### PR TITLE
refactor: separate turn submissions from thread setting overrides

### DIFF
--- a/codex-rs/analytics/src/analytics_client_tests.rs
+++ b/codex-rs/analytics/src/analytics_client_tests.rs
@@ -122,6 +122,7 @@ use codex_app_server_protocol::TurnStartedNotification;
 use codex_app_server_protocol::TurnStatus as AppServerTurnStatus;
 use codex_app_server_protocol::TurnSteerParams;
 use codex_app_server_protocol::TurnSteerResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput;
 use codex_login::default_client::DEFAULT_ORIGINATOR;
 use codex_login::default_client::originator;
@@ -273,16 +274,19 @@ fn sample_turn_start_request(thread_id: &str, request_id: i64) -> ClientRequest 
         params: TurnStartParams {
             thread_id: thread_id.to_string(),
             client_user_message_id: None,
-            input: vec![
-                UserInput::Text {
-                    text: "hello".to_string(),
-                    text_elements: vec![],
-                },
-                UserInput::Image {
-                    url: "https://example.com/a.png".to_string(),
-                    detail: None,
-                },
-            ],
+            submission: TurnSubmissionParams {
+                input: vec![
+                    UserInput::Text {
+                        text: "hello".to_string(),
+                        text_elements: vec![],
+                    },
+                    UserInput::Image {
+                        url: "https://example.com/a.png".to_string(),
+                        detail: None,
+                    },
+                ],
+                ..Default::default()
+            },
             ..Default::default()
         },
     }

--- a/codex-rs/analytics/src/client_tests.rs
+++ b/codex-rs/analytics/src/client_tests.rs
@@ -90,7 +90,6 @@ fn sample_turn_start_request() -> ClientRequest {
         params: TurnStartParams {
             thread_id: "thread-1".to_string(),
             client_user_message_id: None,
-            input: Vec::new(),
             ..Default::default()
         },
     }

--- a/codex-rs/analytics/src/reducer.rs
+++ b/codex-rs/analytics/src/reducer.rs
@@ -577,7 +577,7 @@ impl AnalyticsReducer {
                     (connection_id, request_id),
                     RequestState::TurnStart(PendingTurnStartState {
                         thread_id: params.thread_id,
-                        num_input_images: num_input_images(&params.input),
+                        num_input_images: num_input_images(&params.submission.input),
                     }),
                 );
             }

--- a/codex-rs/app-server-protocol/schema/typescript/v2/TurnStartParams.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/TurnStartParams.ts
@@ -11,6 +11,10 @@ import type { SandboxPolicy } from "./SandboxPolicy";
 import type { UserInput } from "./UserInput";
 
 export type TurnStartParams = {threadId: string, clientUserMessageId?: string | null, input: Array<UserInput>, /**
+ * Optional JSON Schema used to constrain the final assistant message for
+ * this turn.
+ */
+outputSchema?: JsonValue | null, /**
  * Override the working directory for this turn and subsequent turns.
  */
 cwd?: string | null, /**
@@ -38,8 +42,4 @@ effort?: ReasoningEffort | null, /**
 summary?: ReasoningSummary | null, /**
  * Override the personality for this turn and subsequent turns.
  */
-personality?: Personality | null, /**
- * Optional JSON Schema used to constrain the final assistant message for
- * this turn.
- */
-outputSchema?: JsonValue | null};
+personality?: Personality | null};

--- a/codex-rs/app-server-protocol/src/export.rs
+++ b/codex-rs/app-server-protocol/src/export.rs
@@ -49,6 +49,10 @@ const FLAT_V2_SHARED_DEFINITIONS: &[&str] = &["ClientRequest", "ServerNotificati
 const V1_CLIENT_REQUEST_METHODS: &[&str] =
     &["getConversationSummary", "gitDiffToRemote", "getAuthStatus"];
 const EXCLUDED_SERVER_NOTIFICATION_METHODS_FOR_JSON: &[&str] = &["rawResponseItem/completed"];
+const FLATTENED_EXPERIMENTAL_FIELD_SOURCES: &[(&str, &[&str])] = &[(
+    "TurnStartParams",
+    &["TurnSubmission", "ThreadSettingsOverrides"],
+)];
 
 #[derive(Clone)]
 pub struct GeneratedSchema {
@@ -264,10 +268,7 @@ pub(crate) fn filter_experimental_ts_tree(tree: &mut BTreeMap<PathBuf, String>) 
 
     let mut fields_by_type_name: HashMap<String, HashSet<String>> = HashMap::new();
     for field in registered_fields {
-        fields_by_type_name
-            .entry(field.type_name.to_string())
-            .or_default()
-            .insert(field.field_name.to_string());
+        register_experimental_field(&mut fields_by_type_name, field);
     }
 
     for (path, content) in tree.iter_mut() {
@@ -334,10 +335,7 @@ fn filter_experimental_type_fields_ts(
 ) -> Result<()> {
     let mut fields_by_type_name: HashMap<String, HashSet<String>> = HashMap::new();
     for field in experimental_fields {
-        fields_by_type_name
-            .entry(field.type_name.to_string())
-            .or_default()
-            .insert(field.field_name.to_string());
+        register_experimental_field(&mut fields_by_type_name, field);
     }
     if fields_by_type_name.is_empty() {
         return Ok(());
@@ -394,6 +392,36 @@ fn filter_experimental_type_fields_ts_contents(
     prune_unused_type_imports(content, &import_usage_scope)
 }
 
+fn register_experimental_field(
+    fields_by_type_name: &mut HashMap<String, HashSet<String>>,
+    field: &crate::experimental_api::ExperimentalField,
+) {
+    fields_by_type_name
+        .entry(field.type_name.to_string())
+        .or_default()
+        .insert(field.field_name.to_string());
+    for (flattened_type, sources) in FLATTENED_EXPERIMENTAL_FIELD_SOURCES {
+        if sources.contains(&field.type_name) {
+            fields_by_type_name
+                .entry((*flattened_type).to_string())
+                .or_default()
+                .insert(field.field_name.to_string());
+        }
+    }
+}
+
+fn experimental_field_applies_to_type(
+    field: &crate::experimental_api::ExperimentalField,
+    type_name: &str,
+) -> bool {
+    field.type_name == type_name
+        || FLATTENED_EXPERIMENTAL_FIELD_SOURCES
+            .iter()
+            .any(|(flattened_type, sources)| {
+                *flattened_type == type_name && sources.contains(&field.type_name)
+            })
+}
+
 fn filter_experimental_schema(bundle: &mut Value) -> Result<()> {
     let registered_fields = experimental_fields();
     filter_experimental_fields_in_root(bundle, &registered_fields);
@@ -413,7 +441,7 @@ fn filter_experimental_fields_in_root(
     let title = title.to_string();
 
     for field in experimental_fields {
-        if title != field.type_name {
+        if !experimental_field_applies_to_type(field, &title) {
             continue;
         }
         remove_property_from_schema(schema, field.field_name);
@@ -444,7 +472,14 @@ fn filter_experimental_fields_in_definitions_map(
         }
 
         for field in experimental_fields {
-            if !definition_matches_type(def_name, field.type_name) {
+            if !definition_matches_type(def_name, field.type_name)
+                && !FLATTENED_EXPERIMENTAL_FIELD_SOURCES
+                    .iter()
+                    .any(|(flattened_type, sources)| {
+                        definition_matches_type(def_name, flattened_type)
+                            && sources.contains(&field.type_name)
+                    })
+            {
                 continue;
             }
             remove_property_from_schema(def_schema, field.field_name);
@@ -2157,6 +2192,7 @@ mod tests {
                                 | "CollabCloseEndEvent"
                                 | "CollabResumeBeginEvent"
                                 | "CollabResumeEndEvent"
+                                | "TurnSubmission"
                         )
                 });
 
@@ -2680,6 +2716,42 @@ mod tests {
     }
 
     #[test]
+    fn experimental_type_fields_ts_filter_handles_flattened_sources() -> Result<()> {
+        let output_dir = std::env::temp_dir().join(format!("codex_ts_filter_{}", Uuid::now_v7()));
+        fs::create_dir_all(&output_dir)?;
+
+        struct TempDirGuard(PathBuf);
+
+        impl Drop for TempDirGuard {
+            fn drop(&mut self) {
+                let _ = fs::remove_dir_all(&self.0);
+            }
+        }
+
+        let _guard = TempDirGuard(output_dir.clone());
+        let path = output_dir.join("TurnStartParams.ts");
+        let content = r#"export type TurnStartParams = {
+  input: Array<string>;
+  environments?: Array<string> | null;
+}
+"#;
+        fs::write(&path, content)?;
+
+        static TURN_SUBMISSION_FIELD: crate::experimental_api::ExperimentalField =
+            crate::experimental_api::ExperimentalField {
+                type_name: "TurnSubmission",
+                field_name: "environments",
+                reason: "turn/start.environments",
+            };
+        filter_experimental_type_fields_ts(&output_dir, &[&TURN_SUBMISSION_FIELD])?;
+
+        let filtered = fs::read_to_string(&path)?;
+        assert_eq!(filtered.contains("environments"), false);
+        assert_eq!(filtered.contains("input"), true);
+        Ok(())
+    }
+
+    #[test]
     fn experimental_type_fields_ts_filter_keeps_imports_used_in_intersection_suffix() -> Result<()>
     {
         let output_dir = std::env::temp_dir().join(format!("codex_ts_filter_{}", Uuid::now_v7()));
@@ -2809,9 +2881,11 @@ permissionProfile?: string | null};
         fs::create_dir(&output_dir)?;
         generate_json_with_experimental(&output_dir, /*experimental_api*/ false)?;
 
-        let thread_start_json =
-            fs::read_to_string(output_dir.join("v2").join("ThreadStartParams.json"))?;
-        assert_eq!(thread_start_json.contains("mockExperimentalField"), false);
+        let turn_start_json =
+            fs::read_to_string(output_dir.join("v2").join("TurnStartParams.json"))?;
+        assert_eq!(turn_start_json.contains("mockExperimentalField"), false);
+        assert_eq!(turn_start_json.contains("\"environments\""), false);
+        assert_eq!(turn_start_json.contains("\"runtimeWorkspaceRoots\""), false);
         let command_execution_request_approval_json =
             fs::read_to_string(output_dir.join("CommandExecutionRequestApprovalParams.json"))?;
         assert_eq!(

--- a/codex-rs/app-server-protocol/src/protocol/v2/tests.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2/tests.rs
@@ -711,7 +711,7 @@ fn permission_profile_selection_uses_id_string() {
         "permissions": "dev",
     }))
     .expect("turn/start params deserialize");
-    assert_eq!(turn.permissions, Some("dev".to_string()));
+    assert_eq!(turn.thread_settings.permissions, Some("dev".to_string()));
 
     let command: CommandExecParams = serde_json::from_value(json!({
         "command": ["echo", "hello"],
@@ -1757,14 +1757,16 @@ fn client_request_turn_start_granular_approval_policy_is_marked_experimental() {
             params: TurnStartParams {
                 thread_id: "thr_123".to_string(),
                 client_user_message_id: None,
-                input: Vec::new(),
-                approval_policy: Some(AskForApproval::Granular {
-                    sandbox_approval: false,
-                    rules: true,
-                    skill_approval: false,
-                    request_permissions: false,
-                    mcp_elicitations: true,
-                }),
+                thread_settings: ThreadSettingsOverrides {
+                    approval_policy: Some(AskForApproval::Granular {
+                        sandbox_approval: false,
+                        rules: true,
+                        skill_approval: false,
+                        request_permissions: false,
+                        mcp_elicitations: true,
+                    }),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
         },
@@ -3596,7 +3598,7 @@ fn turn_start_params_preserve_explicit_null_service_tier() {
         "serviceTier": null
     }))
     .expect("params should deserialize");
-    assert_eq!(params.service_tier, Some(None));
+    assert_eq!(params.thread_settings.service_tier, Some(None));
 
     let serialized = serde_json::to_value(&params).expect("params should serialize");
     assert_eq!(
@@ -3607,23 +3609,8 @@ fn turn_start_params_preserve_explicit_null_service_tier() {
     let without_override = TurnStartParams {
         thread_id: "thread_123".to_string(),
         client_user_message_id: None,
-        input: vec![],
-        responsesapi_client_metadata: None,
-        additional_context: None,
-        environments: None,
-        cwd: None,
-        runtime_workspace_roots: None,
-        approval_policy: None,
-        approvals_reviewer: None,
-        sandbox_policy: None,
-        permissions: None,
-        model: None,
-        service_tier: None,
-        effort: None,
-        summary: None,
-        output_schema: None,
-        collaboration_mode: None,
-        personality: None,
+        submission: TurnSubmissionParams::default(),
+        thread_settings: ThreadSettingsOverrides::default(),
     };
     let serialized_without_override =
         serde_json::to_value(&without_override).expect("params should serialize");
@@ -3717,7 +3704,7 @@ fn turn_start_params_round_trip_environments() {
     .expect("params should deserialize");
 
     assert_eq!(
-        params.environments,
+        params.submission.environments,
         Some(vec![TurnEnvironmentParams {
             environment_id: "local".to_string(),
             cwd: cwd.clone(),
@@ -3749,7 +3736,7 @@ fn turn_start_params_preserve_empty_environments() {
     }))
     .expect("params should deserialize");
 
-    assert_eq!(params.environments, Some(Vec::new()));
+    assert_eq!(params.submission.environments, Some(Vec::new()));
     assert_eq!(
         crate::experimental_api::ExperimentalApi::experimental_reason(&params),
         Some("turn/start.environments")
@@ -3773,8 +3760,8 @@ fn turn_start_params_treat_null_or_omitted_environments_as_default() {
     }))
     .expect("params should deserialize");
 
-    assert_eq!(null_environments.environments, None);
-    assert_eq!(omitted_environments.environments, None);
+    assert_eq!(null_environments.submission.environments, None);
+    assert_eq!(omitted_environments.submission.environments, None);
     assert_eq!(
         crate::experimental_api::ExperimentalApi::experimental_reason(&null_environments),
         None

--- a/codex-rs/app-server-protocol/src/protocol/v2/turn.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2/turn.rs
@@ -140,28 +140,7 @@ impl From<TurnSubmission> for TurnSubmissionParams {
     Serialize, Deserialize, Debug, Default, Clone, PartialEq, JsonSchema, TS, ExperimentalApi,
 )]
 #[serde(rename_all = "camelCase")]
-#[ts(export_to = "v2/")]
-pub struct TurnStartParams {
-    pub thread_id: String,
-    #[ts(optional = nullable)]
-    pub client_user_message_id: Option<String>,
-    pub input: Vec<UserInput>,
-    /// Optional turn-scoped Responses API client metadata.
-    #[experimental("turn/start.responsesapiClientMetadata")]
-    #[ts(optional = nullable)]
-    pub responsesapi_client_metadata: Option<HashMap<String, String>>,
-    /// Optional client-provided context fragments keyed by an opaque source identifier.
-    #[experimental("turn/start.additionalContext")]
-    #[ts(optional = nullable)]
-    pub additional_context: Option<HashMap<String, AdditionalContextEntry>>,
-    /// Optional turn-scoped environments.
-    ///
-    /// Omitted uses the thread sticky environments. Empty disables
-    /// environment access for this turn. Non-empty selects the first
-    /// environment as the current turn environment for this turn.
-    #[experimental("turn/start.environments")]
-    #[ts(optional = nullable)]
-    pub environments: Option<Vec<TurnEnvironmentParams>>,
+pub struct ThreadSettingsOverrides {
     /// Override the working directory for this turn and subsequent turns.
     #[ts(optional = nullable)]
     pub cwd: Option<PathBuf>,
@@ -208,11 +187,6 @@ pub struct TurnStartParams {
     /// Override the personality for this turn and subsequent turns.
     #[ts(optional = nullable)]
     pub personality: Option<Personality>,
-    /// Optional JSON Schema used to constrain the final assistant message for
-    /// this turn.
-    #[ts(optional = nullable)]
-    pub output_schema: Option<JsonValue>,
-
     /// EXPERIMENTAL - Set a pre-set collaboration mode.
     /// Takes precedence over model, reasoning_effort, and developer instructions if set.
     ///
@@ -221,6 +195,25 @@ pub struct TurnStartParams {
     #[experimental("turn/start.collaborationMode")]
     #[ts(optional = nullable)]
     pub collaboration_mode: Option<CollaborationMode>,
+}
+
+#[derive(
+    Serialize, Deserialize, Debug, Default, Clone, PartialEq, JsonSchema, TS, ExperimentalApi,
+)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
+pub struct TurnStartParams {
+    pub thread_id: String,
+    #[ts(optional = nullable)]
+    pub client_user_message_id: Option<String>,
+    #[serde(flatten)]
+    #[ts(flatten)]
+    #[experimental(nested)]
+    pub submission: TurnSubmissionParams,
+    #[serde(flatten)]
+    #[ts(flatten)]
+    #[experimental(nested)]
+    pub thread_settings: ThreadSettingsOverrides,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]

--- a/codex-rs/app-server-test-client/src/lib.rs
+++ b/codex-rs/app-server-test-client/src/lib.rs
@@ -61,11 +61,13 @@ use codex_app_server_protocol::ThreadListParams;
 use codex_app_server_protocol::ThreadListResponse;
 use codex_app_server_protocol::ThreadResumeParams;
 use codex_app_server_protocol::ThreadResumeResponse;
+use codex_app_server_protocol::ThreadSettingsOverrides;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
 use codex_app_server_protocol::TurnStatus;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_core::config::Config;
 use codex_otel::OtelProvider;
@@ -735,14 +737,17 @@ async fn trigger_zsh_fork_multi_cmd_approval(
             let mut turn_params = TurnStartParams {
                 thread_id: thread_response.thread.id.clone(),
                 client_user_message_id: None,
-                input: vec![V2UserInput::Text {
-                    text: message,
-                    text_elements: Vec::new(),
-                }],
+                submission: TurnSubmissionParams {
+                    input: vec![V2UserInput::Text {
+                        text: message,
+                        text_elements: Vec::new(),
+                    }],
+                    ..Default::default()
+                },
                 ..Default::default()
             };
-            turn_params.approval_policy = Some(AskForApproval::OnRequest);
-            turn_params.sandbox_policy = Some(SandboxPolicy::ReadOnly {
+            turn_params.thread_settings.approval_policy = Some(AskForApproval::OnRequest);
+            turn_params.thread_settings.sandbox_policy = Some(SandboxPolicy::ReadOnly {
                 network_access: false,
             });
 
@@ -820,10 +825,13 @@ async fn resume_message_v2(
         let turn_response = client.turn_start(TurnStartParams {
             thread_id: resume_response.thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: user_message,
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: user_message,
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })?;
         println!("< turn/start response: {turn_response:?}");
@@ -962,15 +970,18 @@ async fn send_message_v2_with_policies(
             let mut turn_params = TurnStartParams {
                 thread_id: thread_response.thread.id.clone(),
                 client_user_message_id: None,
-                input: vec![V2UserInput::Text {
-                    text: user_message,
-                    // Test client sends plain text without UI element ranges.
-                    text_elements: Vec::new(),
-                }],
+                submission: TurnSubmissionParams {
+                    input: vec![V2UserInput::Text {
+                        text: user_message,
+                        // Test client sends plain text without UI element ranges.
+                        text_elements: Vec::new(),
+                    }],
+                    ..Default::default()
+                },
                 ..Default::default()
             };
-            turn_params.approval_policy = policies.approval_policy;
-            turn_params.sandbox_policy = policies.sandbox_policy;
+            turn_params.thread_settings.approval_policy = policies.approval_policy;
+            turn_params.thread_settings.sandbox_policy = policies.sandbox_policy;
 
             let turn_response = client.turn_start(turn_params)?;
             println!("< turn/start response: {turn_response:?}");
@@ -1003,11 +1014,14 @@ async fn send_follow_up_v2(
         let first_turn_params = TurnStartParams {
             thread_id: thread_response.thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: first_message,
-                // Test client sends plain text without UI element ranges.
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: first_message,
+                    // Test client sends plain text without UI element ranges.
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         };
         let first_turn_response = client.turn_start(first_turn_params)?;
@@ -1017,11 +1031,14 @@ async fn send_follow_up_v2(
         let follow_up_params = TurnStartParams {
             thread_id: thread_response.thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: follow_up_message,
-                // Test client sends plain text without UI element ranges.
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: follow_up_message,
+                    // Test client sends plain text without UI element ranges.
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         };
         let follow_up_response = client.turn_start(follow_up_params)?;
@@ -1261,15 +1278,20 @@ fn live_elicitation_timeout_pause(
     let turn_response = client.turn_start(TurnStartParams {
         thread_id: thread_id.clone(),
         client_user_message_id: None,
-        input: vec![V2UserInput::Text {
-            text: prompt,
-            text_elements: Vec::new(),
-        }],
-        approval_policy: Some(AskForApproval::Never),
-        sandbox_policy: Some(SandboxPolicy::DangerFullAccess),
-        effort: Some(ReasoningEffort::High),
-        cwd: Some(workspace),
-        ..Default::default()
+        submission: TurnSubmissionParams {
+            input: vec![V2UserInput::Text {
+                text: prompt,
+                text_elements: Vec::new(),
+            }],
+            ..Default::default()
+        },
+        thread_settings: ThreadSettingsOverrides {
+            approval_policy: Some(AskForApproval::Never),
+            sandbox_policy: Some(SandboxPolicy::DangerFullAccess),
+            effort: Some(ReasoningEffort::High),
+            cwd: Some(workspace),
+            ..Default::default()
+        },
     })?;
     println!("< turn/start response: {turn_response:?}");
 

--- a/codex-rs/app-server/src/message_processor_tracing_tests.rs
+++ b/codex-rs/app-server/src/message_processor_tracing_tests.rs
@@ -17,10 +17,12 @@ use codex_app_server_protocol::InitializeParams;
 use codex_app_server_protocol::InitializeResponse;
 use codex_app_server_protocol::JSONRPCRequest;
 use codex_app_server_protocol::RequestId;
+use codex_app_server_protocol::ThreadSettingsOverrides;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput;
 use codex_arg0::Arg0DispatchPaths;
 use codex_config::CloudRequirementsLoader;
@@ -651,28 +653,32 @@ async fn turn_start_jsonrpc_span_parents_core_turn_spans() -> Result<()> {
             ClientRequest::TurnStart {
                 request_id: RequestId::Integer(3),
                 params: TurnStartParams {
-                    environments: None,
+                    submission: TurnSubmissionParams {
+                        environments: None,
+                        input: vec![UserInput::Text {
+                            text: "hello".to_string(),
+                            text_elements: Vec::new(),
+                        }],
+                        responsesapi_client_metadata: None,
+                        additional_context: None,
+                        output_schema: None,
+                    },
                     thread_id,
                     client_user_message_id: None,
-                    input: vec![UserInput::Text {
-                        text: "hello".to_string(),
-                        text_elements: Vec::new(),
-                    }],
-                    responsesapi_client_metadata: None,
-                    additional_context: None,
-                    cwd: None,
-                    runtime_workspace_roots: None,
-                    approval_policy: None,
-                    sandbox_policy: None,
-                    permissions: None,
-                    approvals_reviewer: None,
-                    model: None,
-                    service_tier: None,
-                    effort: None,
-                    summary: None,
-                    personality: None,
-                    output_schema: None,
-                    collaboration_mode: None,
+                    thread_settings: ThreadSettingsOverrides {
+                        cwd: None,
+                        runtime_workspace_roots: None,
+                        approval_policy: None,
+                        sandbox_policy: None,
+                        permissions: None,
+                        approvals_reviewer: None,
+                        model: None,
+                        service_tier: None,
+                        effort: None,
+                        summary: None,
+                        personality: None,
+                        collaboration_mode: None,
+                    },
                 },
             },
             Some(remote_trace),

--- a/codex-rs/app-server/src/request_processors.rs
+++ b/codex-rs/app-server/src/request_processors.rs
@@ -267,6 +267,7 @@ use codex_app_server_protocol::TurnStatus;
 use codex_app_server_protocol::TurnSteerParams;
 use codex_app_server_protocol::TurnSteerResponse;
 use codex_app_server_protocol::TurnSubmission;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_app_server_protocol::WindowsSandboxReadiness;
 use codex_app_server_protocol::WindowsSandboxReadinessResponse;

--- a/codex-rs/app-server/src/request_processors/turn_processor.rs
+++ b/codex-rs/app-server/src/request_processors/turn_processor.rs
@@ -1,4 +1,5 @@
 use super::*;
+use codex_app_server_protocol::ThreadSettingsOverrides;
 use codex_protocol::protocol::AdditionalContextEntry as CoreAdditionalContextEntry;
 use codex_protocol::protocol::AdditionalContextKind as CoreAdditionalContextKind;
 
@@ -133,11 +134,7 @@ impl TurnRequestProcessor {
         let (_, thread) = self.load_thread(&thread_id_string).await?;
         let params = TurnStartParams {
             thread_id: thread_id_string,
-            input: submission.input,
-            responsesapi_client_metadata: submission.responsesapi_client_metadata,
-            additional_context: submission.additional_context,
-            environments: submission.environments,
-            output_schema: submission.output_schema,
+            submission: submission.into(),
             ..Default::default()
         };
         self.start_turn_from_params(thread_id, thread, params, /*trace_context*/ None)
@@ -408,7 +405,7 @@ impl TurnRequestProcessor {
         app_server_client_name: Option<String>,
         app_server_client_version: Option<String>,
     ) -> Result<TurnStartResponse, JSONRPCErrorError> {
-        if let Err(error) = Self::validate_v2_input_limit(&params.input) {
+        if let Err(error) = Self::validate_v2_input_limit(&params.submission.input) {
             self.track_error_response(
                 &request_id,
                 &error,
@@ -473,34 +470,57 @@ impl TurnRequestProcessor {
         params: TurnStartParams,
         trace_context: Option<W3cTraceContext>,
     ) -> Result<TurnStartResponse, JSONRPCErrorError> {
-        let environment_selections = self.parse_environment_selections(params.environments)?;
+        let TurnStartParams {
+            client_user_message_id,
+            submission:
+                TurnSubmissionParams {
+                    input,
+                    responsesapi_client_metadata,
+                    additional_context,
+                    environments,
+                    output_schema,
+                },
+            thread_settings:
+                ThreadSettingsOverrides {
+                    cwd,
+                    runtime_workspace_roots,
+                    approval_policy,
+                    approvals_reviewer,
+                    sandbox_policy,
+                    permissions,
+                    model,
+                    service_tier,
+                    effort,
+                    summary,
+                    personality,
+                    collaboration_mode,
+                },
+            ..
+        } = params;
+        let environment_selections = self.parse_environment_selections(environments)?;
 
         // Map v2 input items to core input items.
-        let mapped_items: Vec<CoreInputItem> = params
-            .input
-            .into_iter()
-            .map(V2UserInput::into_core)
-            .collect();
-        let client_user_message_id = params.client_user_message_id;
-        let additional_context = map_additional_context(params.additional_context);
+        let mapped_items: Vec<CoreInputItem> =
+            input.into_iter().map(V2UserInput::into_core).collect();
+        let additional_context = map_additional_context(additional_context);
         let turn_has_input = !mapped_items.is_empty();
         let thread_settings = self
             .build_thread_settings_overrides(
                 thread.as_ref(),
                 ThreadSettingsBuildParams {
                     method: "turn/start",
-                    cwd: params.cwd,
-                    runtime_workspace_roots: params.runtime_workspace_roots,
-                    approval_policy: params.approval_policy,
-                    approvals_reviewer: params.approvals_reviewer,
-                    sandbox_policy: params.sandbox_policy,
-                    permissions: params.permissions,
-                    model: params.model,
-                    service_tier: params.service_tier,
-                    effort: params.effort,
-                    summary: params.summary,
-                    collaboration_mode: params.collaboration_mode,
-                    personality: params.personality,
+                    cwd,
+                    runtime_workspace_roots,
+                    approval_policy,
+                    approvals_reviewer,
+                    sandbox_policy,
+                    permissions,
+                    model,
+                    service_tier,
+                    effort,
+                    summary,
+                    collaboration_mode,
+                    personality,
                 },
             )
             .await?;
@@ -509,8 +529,8 @@ impl TurnRequestProcessor {
         let turn_op = Op::UserInput {
             items: mapped_items,
             environments: environment_selections,
-            final_output_json_schema: params.output_schema,
-            responsesapi_client_metadata: params.responsesapi_client_metadata,
+            final_output_json_schema: output_schema,
+            responsesapi_client_metadata,
             additional_context,
             thread_settings,
         };

--- a/codex-rs/app-server/tests/suite/v2/account.rs
+++ b/codex-rs/app-server/tests/suite/v2/account.rs
@@ -32,6 +32,7 @@ use codex_app_server_protocol::ServerNotification;
 use codex_app_server_protocol::ServerRequest;
 use codex_app_server_protocol::TurnCompletedNotification;
 use codex_app_server_protocol::TurnStatus;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_config::types::AuthCredentialsStoreMode;
 use codex_login::REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR;
 use codex_login::login_with_api_key;
@@ -507,10 +508,13 @@ async fn external_auth_refreshes_on_unauthorized() -> Result<()> {
         .send_turn_start_request(codex_app_server_protocol::TurnStartParams {
             thread_id: thread.thread.id,
             client_user_message_id: None,
-            input: vec![codex_app_server_protocol::UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![codex_app_server_protocol::UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -614,10 +618,13 @@ async fn external_auth_refresh_error_fails_turn() -> Result<()> {
         .send_turn_start_request(codex_app_server_protocol::TurnStartParams {
             thread_id: thread.thread.id.clone(),
             client_user_message_id: None,
-            input: vec![codex_app_server_protocol::UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![codex_app_server_protocol::UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -737,10 +744,13 @@ async fn external_auth_refresh_mismatched_workspace_fails_turn() -> Result<()> {
         .send_turn_start_request(codex_app_server_protocol::TurnStartParams {
             thread_id: thread.thread.id.clone(),
             client_user_message_id: None,
-            input: vec![codex_app_server_protocol::UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![codex_app_server_protocol::UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -853,10 +863,13 @@ async fn external_auth_refresh_invalid_access_token_fails_turn() -> Result<()> {
         .send_turn_start_request(codex_app_server_protocol::TurnStartParams {
             thread_id: thread.thread.id.clone(),
             client_user_message_id: None,
-            input: vec![codex_app_server_protocol::UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![codex_app_server_protocol::UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/attestation.rs
+++ b/codex-rs/app-server/tests/suite/v2/attestation.rs
@@ -15,6 +15,7 @@ use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_config::types::AuthCredentialsStoreMode;
 use core_test_support::responses;
@@ -111,10 +112,13 @@ async fn attestation_generate_round_trip_adds_header_to_responses_websocket_hand
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/client_metadata.rs
+++ b/codex-rs/app-server/tests/suite/v2/client_metadata.rs
@@ -20,6 +20,7 @@ use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
 use codex_app_server_protocol::TurnSteerParams;
 use codex_app_server_protocol::TurnSteerResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_protocol::ThreadId as CoreThreadId;
 use codex_protocol::protocol::SessionSource;
@@ -80,11 +81,14 @@ async fn turn_start_forwards_client_metadata_to_responses_request_v2() -> Result
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
-            responsesapi_client_metadata: Some(client_metadata.clone()),
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                responsesapi_client_metadata: Some(client_metadata.clone()),
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -161,10 +165,13 @@ async fn turn_start_sends_fork_lineage_in_turn_metadata_for_thread_fork_v2() -> 
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Continue".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Continue".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -356,10 +363,13 @@ async fn turn_start_sends_subagent_lineage_after_cold_thread_resume_v2() -> Resu
     let turn_req = mcp
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
-            input: vec![V2UserInput::Text {
-                text: "Continue".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Continue".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -440,11 +450,14 @@ async fn turn_steer_updates_client_metadata_on_follow_up_responses_request_v2() 
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Run sleep".to_string(),
-                text_elements: Vec::new(),
-            }],
-            responsesapi_client_metadata: Some(start_metadata.clone()),
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Run sleep".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                responsesapi_client_metadata: Some(start_metadata.clone()),
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -567,11 +580,14 @@ async fn turn_start_forwards_client_metadata_to_responses_websocket_request_body
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
-            responsesapi_client_metadata: Some(client_metadata),
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                responsesapi_client_metadata: Some(client_metadata),
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/compaction.rs
+++ b/codex-rs/app-server/tests/suite/v2/compaction.rs
@@ -27,6 +27,7 @@ use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnCompletedNotification;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_config::types::AuthCredentialsStoreMode;
 use codex_protocol::models::ContentItem;
@@ -395,10 +396,13 @@ async fn send_turn_and_wait(mcp: &mut McpProcess, thread_id: &str, text: &str) -
         .send_turn_start_request(TurnStartParams {
             thread_id: thread_id.to_string(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: text.to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: text.to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/connection_handling_websocket_unix.rs
+++ b/codex-rs/app-server/tests/suite/v2/connection_handling_websocket_unix.rs
@@ -15,6 +15,7 @@ use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnStartParams;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use core_test_support::responses;
 use futures::SinkExt;
@@ -227,10 +228,13 @@ async fn send_turn_start_request(stream: &mut WsClient, id: i64, thread_id: &str
         Some(serde_json::to_value(TurnStartParams {
             thread_id: thread_id.to_string(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })?),
     )

--- a/codex-rs/app-server/tests/suite/v2/dynamic_tools.rs
+++ b/codex-rs/app-server/tests/suite/v2/dynamic_tools.rs
@@ -20,6 +20,7 @@ use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_protocol::models::DEFAULT_IMAGE_DETAIL;
 use codex_protocol::models::FunctionCallOutputBody;
@@ -90,10 +91,13 @@ async fn thread_start_injects_dynamic_tools_into_model_requests() -> Result<()> 
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -170,10 +174,13 @@ async fn thread_start_keeps_hidden_dynamic_tools_out_of_model_requests() -> Resu
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -350,10 +357,13 @@ async fn dynamic_tool_call_round_trip_sends_text_content_items_to_model() -> Res
         .send_turn_start_request(TurnStartParams {
             thread_id: thread_id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Run the tool".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Run the tool".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -525,10 +535,13 @@ async fn dynamic_tool_call_round_trip_sends_content_items_to_model() -> Result<(
         .send_turn_start_request(TurnStartParams {
             thread_id: thread_id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Run the tool".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Run the tool".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/external_agent_config.rs
+++ b/codex-rs/app-server/tests/suite/v2/external_agent_config.rs
@@ -21,6 +21,7 @@ use codex_app_server_protocol::ThreadReadResponse;
 use codex_app_server_protocol::ThreadResumeParams;
 use codex_app_server_protocol::ThreadResumeResponse;
 use codex_app_server_protocol::TurnStartParams;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput;
 use core_test_support::responses;
 use pretty_assertions::assert_eq;
@@ -392,10 +393,13 @@ async fn external_agent_config_import_creates_session_rollouts() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "follow up".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "follow up".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -966,10 +970,13 @@ async fn external_agent_config_import_compacts_huge_session_before_first_follow_
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "follow up".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "follow up".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/hooks_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/hooks_list.rs
@@ -21,6 +21,7 @@ use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnStartParams;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_core::config::set_project_trust_level;
 use codex_protocol::config_types::TrustLevel;
@@ -663,10 +664,13 @@ command = "python3 {hook_script_path}"
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "first turn".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "first turn".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -725,10 +729,13 @@ command = "python3 {hook_script_path}"
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "second turn".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "second turn".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -795,10 +802,13 @@ command = "python3 {hook_script_path}"
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "third turn".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "third turn".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -936,10 +946,13 @@ command = "python3 {hook_script_path}"
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "first turn".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "first turn".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -988,10 +1001,13 @@ command = "python3 {hook_script_path}"
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "second turn".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "second turn".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/initialize.rs
+++ b/codex-rs/app-server/tests/suite/v2/initialize.rs
@@ -13,6 +13,7 @@ use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_cargo_bin::cargo_bin;
@@ -307,10 +308,13 @@ async fn turn_start_notify_payload_includes_initialize_client_name() -> Result<(
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/mcp_server_elicitation.rs
+++ b/codex-rs/app-server/tests/suite/v2/mcp_server_elicitation.rs
@@ -24,12 +24,14 @@ use codex_app_server_protocol::McpServerElicitationRequestResponse;
 use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ServerRequest;
 use codex_app_server_protocol::ServerRequestResolvedNotification;
+use codex_app_server_protocol::ThreadSettingsOverrides;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnCompletedNotification;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
 use codex_app_server_protocol::TurnStatus;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_config::types::AuthCredentialsStoreMode;
 use core_test_support::assert_regex_match;
@@ -136,12 +138,17 @@ async fn mcp_server_elicitation_round_trip() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Warm up connectors.".to_string(),
-                text_elements: Vec::new(),
-            }],
-            model: Some("mock-model".to_string()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Warm up connectors.".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                model: Some("mock-model".to_string()),
+                ..Default::default()
+            },
         })
         .await?;
     let warmup_turn_start_resp: JSONRPCResponse = timeout(
@@ -169,12 +176,17 @@ async fn mcp_server_elicitation_round_trip() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Use [$calendar](app://calendar) to run the calendar tool.".to_string(),
-                text_elements: Vec::new(),
-            }],
-            model: Some("mock-model".to_string()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Use [$calendar](app://calendar) to run the calendar tool.".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                model: Some("mock-model".to_string()),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_start_resp: JSONRPCResponse = timeout(

--- a/codex-rs/app-server/tests/suite/v2/mcp_tool.rs
+++ b/codex-rs/app-server/tests/suite/v2/mcp_tool.rs
@@ -28,6 +28,7 @@ use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_utils_pty::DEFAULT_OUTPUT_BYTES_CAP;
 use core_test_support::responses;
@@ -462,10 +463,13 @@ url = "{mcp_server_url}/mcp"
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Call the large MCP tool".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Call the large MCP tool".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/output_schema.rs
+++ b/codex-rs/app-server/tests/suite/v2/output_schema.rs
@@ -7,6 +7,7 @@ use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use core_test_support::responses;
 use core_test_support::skip_if_no_network;
@@ -60,11 +61,14 @@ async fn turn_start_accepts_output_schema_v2() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
-            output_schema: Some(output_schema.clone()),
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                output_schema: Some(output_schema.clone()),
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -143,11 +147,14 @@ async fn turn_start_output_schema_is_per_turn_v2() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
-            output_schema: Some(output_schema.clone()),
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                output_schema: Some(output_schema.clone()),
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -186,11 +193,14 @@ async fn turn_start_output_schema_is_per_turn_v2() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello again".to_string(),
-                text_elements: Vec::new(),
-            }],
-            output_schema: None,
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello again".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                output_schema: None,
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/plan_item.rs
+++ b/codex-rs/app-server/tests/suite/v2/plan_item.rs
@@ -11,12 +11,14 @@ use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::PlanDeltaNotification;
 use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ThreadItem;
+use codex_app_server_protocol::ThreadSettingsOverrides;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnCompletedNotification;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
 use codex_app_server_protocol::TurnStatus;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_features::FEATURES;
 use codex_features::Feature;
@@ -153,12 +155,17 @@ async fn start_plan_mode_turn(mcp: &mut McpProcess) -> Result<codex_app_server_p
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Plan this".to_string(),
-                text_elements: Vec::new(),
-            }],
-            collaboration_mode: Some(collaboration_mode),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Plan this".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                collaboration_mode: Some(collaboration_mode),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(

--- a/codex-rs/app-server/tests/suite/v2/remote_thread_store.rs
+++ b/codex-rs/app-server/tests/suite/v2/remote_thread_store.rs
@@ -32,6 +32,7 @@ use codex_app_server_protocol::ThreadListResponse;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnStartParams;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_arg0::Arg0DispatchPaths;
 use codex_config::CloudRequirementsLoader;
@@ -114,10 +115,13 @@ async fn thread_start_with_non_local_thread_store_does_not_create_local_persiste
             params: TurnStartParams {
                 thread_id: thread.id.clone(),
                 client_user_message_id: None,
-                input: vec![V2UserInput::Text {
-                    text: "Hello".to_string(),
-                    text_elements: Vec::new(),
-                }],
+                submission: TurnSubmissionParams {
+                    input: vec![V2UserInput::Text {
+                        text: "Hello".to_string(),
+                        text_elements: Vec::new(),
+                    }],
+                    ..Default::default()
+                },
                 ..Default::default()
             },
         })

--- a/codex-rs/app-server/tests/suite/v2/request_permissions.rs
+++ b/codex-rs/app-server/tests/suite/v2/request_permissions.rs
@@ -11,10 +11,12 @@ use codex_app_server_protocol::PermissionsRequestApprovalResponse;
 use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ServerRequest;
 use codex_app_server_protocol::ServerRequestResolvedNotification;
+use codex_app_server_protocol::ThreadSettingsOverrides;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use tokio::time::timeout;
 
@@ -50,12 +52,17 @@ async fn request_permissions_round_trip() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "pick a directory".to_string(),
-                text_elements: Vec::new(),
-            }],
-            model: Some("mock-model".to_string()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "pick a directory".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                model: Some("mock-model".to_string()),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_start_resp: JSONRPCResponse = timeout(

--- a/codex-rs/app-server/tests/suite/v2/request_user_input.rs
+++ b/codex-rs/app-server/tests/suite/v2/request_user_input.rs
@@ -9,10 +9,12 @@ use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ServerRequest;
 use codex_app_server_protocol::ServerRequestResolvedNotification;
+use codex_app_server_protocol::ThreadSettingsOverrides;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_protocol::config_types::CollaborationMode;
 use codex_protocol::config_types::ModeKind;
@@ -52,21 +54,26 @@ async fn request_user_input_round_trip() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "ask something".to_string(),
-                text_elements: Vec::new(),
-            }],
-            model: Some("mock-model".to_string()),
-            effort: Some(ReasoningEffort::Medium),
-            collaboration_mode: Some(CollaborationMode {
-                mode: ModeKind::Plan,
-                settings: Settings {
-                    model: "mock-model".to_string(),
-                    reasoning_effort: Some(ReasoningEffort::Medium),
-                    developer_instructions: None,
-                },
-            }),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "ask something".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                model: Some("mock-model".to_string()),
+                effort: Some(ReasoningEffort::Medium),
+                collaboration_mode: Some(CollaborationMode {
+                    mode: ModeKind::Plan,
+                    settings: Settings {
+                        model: "mock-model".to_string(),
+                        reasoning_effort: Some(ReasoningEffort::Medium),
+                        developer_instructions: None,
+                    },
+                }),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_start_resp: JSONRPCResponse = timeout(

--- a/codex-rs/app-server/tests/suite/v2/review.rs
+++ b/codex-rs/app-server/tests/suite/v2/review.rs
@@ -25,6 +25,7 @@ use codex_app_server_protocol::ThreadStatusChangedNotification;
 use codex_app_server_protocol::TurnItemsView;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStatus;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use pretty_assertions::assert_eq;
 use serde_json::json;
@@ -469,10 +470,13 @@ async fn materialize_thread_rollout(mcp: &mut McpProcess, thread_id: &str) -> Re
         .send_turn_start_request(TurnStartParams {
             thread_id: thread_id.to_string(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "materialize rollout".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "materialize rollout".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/safety_check_downgrade.rs
+++ b/codex-rs/app-server/tests/suite/v2/safety_check_downgrade.rs
@@ -17,6 +17,7 @@ use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput;
 use core_test_support::responses;
 use core_test_support::skip_if_no_network;
@@ -68,10 +69,13 @@ async fn openai_model_header_mismatch_emits_model_rerouted_notification_v2() -> 
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "trigger safeguard".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "trigger safeguard".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -135,10 +139,13 @@ async fn cyber_policy_response_emits_typed_error_notification_v2() -> Result<()>
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "trigger cyber policy error".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "trigger cyber policy error".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -212,10 +219,13 @@ async fn response_model_field_mismatch_emits_model_rerouted_notification_v2_when
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "trigger response model check".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "trigger response model check".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -281,10 +291,13 @@ async fn model_verification_emits_typed_notification_and_warning_v2() -> Result<
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "trigger model verification".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "trigger model verification".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_archive.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_archive.rs
@@ -18,6 +18,7 @@ use codex_app_server_protocol::ThreadUnarchiveParams;
 use codex_app_server_protocol::ThreadUnarchiveResponse;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput;
 use codex_core::ARCHIVED_SESSIONS_SUBDIR;
 use codex_core::find_archived_thread_path_by_id_str;
@@ -94,10 +95,13 @@ async fn thread_archive_requires_materialized_rollout() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "materialize".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "materialize".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -519,10 +523,13 @@ async fn thread_archive_clears_stale_subscriptions_before_resume() -> Result<()>
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "materialize".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "materialize".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -597,10 +604,13 @@ async fn thread_archive_clears_stale_subscriptions_before_resume() -> Result<()>
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "secondary turn".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "secondary turn".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_fork.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_fork.rs
@@ -26,6 +26,7 @@ use codex_app_server_protocol::ThreadStatusChangedNotification;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
 use codex_app_server_protocol::TurnStatus;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput;
 use codex_config::types::AuthCredentialsStoreMode;
 use codex_login::REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR;
@@ -748,10 +749,13 @@ async fn thread_fork_ephemeral_remains_pathless_and_omits_listing() -> Result<()
         .send_turn_start_request(TurnStartParams {
             thread_id: fork_thread_id,
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "continue".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "continue".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_inject_items.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_inject_items.rs
@@ -9,6 +9,7 @@ use codex_app_server_protocol::ThreadInjectItemsResponse;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnStartParams;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_core::RolloutRecorder;
 use codex_protocol::models::ContentItem;
@@ -93,10 +94,13 @@ async fn thread_inject_items_adds_raw_response_items_to_thread_history() -> Resu
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -172,10 +176,13 @@ async fn thread_inject_items_adds_raw_response_items_after_a_turn() -> Result<()
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "First turn".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "First turn".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -218,10 +225,13 @@ async fn thread_inject_items_adds_raw_response_items_after_a_turn() -> Result<()
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Second turn".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Second turn".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_list.rs
@@ -25,6 +25,7 @@ use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::ThreadStatus;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput;
 use codex_core::ARCHIVED_SESSIONS_SUBDIR;
 use codex_git_utils::GitSha;
@@ -228,10 +229,13 @@ async fn thread_list_reports_system_error_idle_flag_after_failed_turn() -> Resul
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "seed history".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "seed history".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -251,10 +255,13 @@ async fn thread_list_reports_system_error_idle_flag_after_failed_turn() -> Resul
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "fail turn".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "fail turn".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_queue.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_queue.rs
@@ -27,10 +27,13 @@ use codex_app_server_protocol::ThreadQueueListParams;
 use codex_app_server_protocol::ThreadQueueListResponse;
 use codex_app_server_protocol::ThreadQueueReorderParams;
 use codex_app_server_protocol::ThreadQueueReorderResponse;
+use codex_app_server_protocol::ThreadSettingsUpdateParams;
+use codex_app_server_protocol::ThreadSettingsUpdateResponse;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnSubmission;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -636,6 +639,97 @@ async fn queued_turns_wait_for_a_just_accepted_direct_turn_to_become_visible() -
 }
 
 #[tokio::test]
+async fn queued_turn_uses_current_thread_settings_when_dispatched() -> Result<()> {
+    let responses = vec![
+        create_shell_command_sse_response(
+            vec![
+                "python3".to_string(),
+                "-c".to_string(),
+                "print(42)".to_string(),
+            ],
+            /*workdir*/ None,
+            Some(5000),
+            "queued-settings-blocker",
+        )?,
+        create_final_assistant_message_sse_response("direct turn done")?,
+        create_final_assistant_message_sse_response("queued follow-up done")?,
+    ];
+    let server = create_mock_responses_server_sequence_unchecked(responses).await;
+    let codex_home = TempDir::new()?;
+    write_queue_test_config(codex_home.path(), &server.uri(), "untrusted")?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    initialize_experimental(&mut mcp).await?;
+    let thread = start_thread(&mut mcp).await?;
+
+    let direct_turn_request_id = mcp
+        .send_turn_start_request(text_turn(&thread.id, "direct turn first"))
+        .await?;
+    timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(direct_turn_request_id)),
+    )
+    .await??;
+
+    let approval_request = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_request_message(),
+    )
+    .await??;
+    let ServerRequest::CommandExecutionRequestApproval { request_id, .. } = approval_request else {
+        panic!("expected direct turn approval request to keep the direct turn open");
+    };
+
+    queue_turn(&mut mcp, &thread.id, "queued turn after settings update").await?;
+    let settings_request_id = mcp
+        .send_thread_settings_update_request(ThreadSettingsUpdateParams {
+            thread_id: thread.id.clone(),
+            model: Some("updated-queued-model".to_string()),
+            ..Default::default()
+        })
+        .await?;
+    let settings_response: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(settings_request_id)),
+    )
+    .await??;
+    let _: ThreadSettingsUpdateResponse = to_response(settings_response)?;
+
+    mcp.send_response(
+        request_id,
+        serde_json::to_value(CommandExecutionRequestApprovalResponse {
+            decision: CommandExecutionApprovalDecision::Accept,
+        })?,
+    )
+    .await?;
+    timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_notification_message("turn/completed"),
+    )
+    .await??;
+    timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_notification_message("turn/completed"),
+    )
+    .await??;
+
+    let requests = server
+        .received_requests()
+        .await
+        .expect("failed to fetch received requests");
+    assert_eq!(requests.len(), 3);
+    let queued_request: serde_json::Value = serde_json::from_slice(&requests[2].body)?;
+    assert_eq!(
+        queued_request
+            .get("model")
+            .and_then(serde_json::Value::as_str),
+        Some("updated-queued-model")
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn queued_turns_drain_after_a_direct_turn_has_already_completed() -> Result<()> {
     let responses = vec![
         create_final_assistant_message_sse_response("direct turn done")?,
@@ -825,7 +919,10 @@ fn text_submission(text: &str) -> TurnSubmission {
 fn text_turn(thread_id: &str, text: &str) -> TurnStartParams {
     TurnStartParams {
         thread_id: thread_id.to_string(),
-        input: text_submission(text).input,
+        submission: TurnSubmissionParams {
+            input: text_submission(text).input,
+            ..Default::default()
+        },
         ..Default::default()
     }
 }

--- a/codex-rs/app-server/tests/suite/v2/thread_read.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_read.rs
@@ -39,6 +39,7 @@ use codex_app_server_protocol::TurnItemsView;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
 use codex_app_server_protocol::TurnStatus;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput;
 use codex_arg0::Arg0DispatchPaths;
 use codex_config::CloudRequirementsLoader;
@@ -1199,10 +1200,13 @@ async fn thread_read_reports_system_error_idle_flag_after_failed_turn() -> Resul
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "fail this turn".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "fail this turn".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_resume.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_resume.rs
@@ -40,6 +40,7 @@ use codex_app_server_protocol::ThreadReadResponse;
 use codex_app_server_protocol::ThreadResumeInitialTurnsPageParams;
 use codex_app_server_protocol::ThreadResumeParams;
 use codex_app_server_protocol::ThreadResumeResponse;
+use codex_app_server_protocol::ThreadSettingsOverrides;
 use codex_app_server_protocol::ThreadSource;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
@@ -49,6 +50,7 @@ use codex_app_server_protocol::TurnItemsView;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
 use codex_app_server_protocol::TurnStatus;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput;
 use codex_config::types::AuthCredentialsStoreMode;
 use codex_login::REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR;
@@ -212,10 +214,13 @@ async fn thread_resume_with_empty_path_uses_running_thread_id() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "materialize rollout".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "materialize rollout".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -281,12 +286,17 @@ async fn turn_start_updates_runtime_workspace_roots_for_loaded_thread() -> Resul
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
-            runtime_workspace_roots: Some(vec![extra_root.clone(), extra_root.join(".")]),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                runtime_workspace_roots: Some(vec![extra_root.clone(), extra_root.join(".")]),
+                ..Default::default()
+            },
         })
         .await?;
     timeout(
@@ -812,10 +822,13 @@ async fn thread_resume_keeps_paused_goal_paused() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "materialize this thread".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "materialize this thread".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -917,10 +930,13 @@ async fn thread_goal_set_preserves_budget_limited_same_objective() -> Result<()>
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "materialize this thread".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "materialize this thread".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -1016,10 +1032,13 @@ async fn thread_goal_set_persists_resumable_stopped_statuses() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "materialize this thread".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "materialize this thread".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -1212,10 +1231,13 @@ async fn thread_goal_clear_deletes_goal_and_notifies() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "materialize this thread".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "materialize this thread".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -2031,10 +2053,13 @@ async fn thread_resume_defers_updated_at_until_turn_start() -> Result<()> {
     let turn_id = mcp
         .send_turn_start_request(TurnStartParams {
             thread_id,
-            input: vec![UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -2081,10 +2106,13 @@ async fn thread_resume_keeps_in_flight_turn_streaming() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "seed history".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "seed history".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -2107,10 +2135,13 @@ async fn thread_resume_keeps_in_flight_turn_streaming() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "respond with docs".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "respond with docs".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -2190,10 +2221,13 @@ async fn thread_resume_rejects_history_when_thread_is_running() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "seed history".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "seed history".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -2214,10 +2248,13 @@ async fn thread_resume_rejects_history_when_thread_is_running() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread_id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "keep running".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "keep running".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -2308,10 +2345,13 @@ async fn thread_resume_rejects_mismatched_path_for_running_thread_id() -> Result
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "seed history".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "seed history".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -2332,10 +2372,13 @@ async fn thread_resume_rejects_mismatched_path_for_running_thread_id() -> Result
         .send_turn_start_request(TurnStartParams {
             thread_id: thread_id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "keep running".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "keep running".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -2446,10 +2489,13 @@ async fn thread_resume_rejoins_running_thread_even_with_override_mismatch() -> R
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "seed history".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "seed history".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -2469,10 +2515,13 @@ async fn thread_resume_rejoins_running_thread_even_with_override_mismatch() -> R
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "keep running".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "keep running".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -2577,10 +2626,13 @@ async fn thread_resume_can_skip_turns_when_thread_is_running() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "seed history".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "seed history".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -2661,10 +2713,13 @@ async fn thread_resume_replays_pending_command_execution_request_approval() -> R
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "seed history".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "seed history".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -2684,12 +2739,17 @@ async fn thread_resume_replays_pending_command_execution_request_approval() -> R
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "run command".to_string(),
-                text_elements: Vec::new(),
-            }],
-            approval_policy: Some(AskForApproval::UnlessTrusted),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "run command".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                approval_policy: Some(AskForApproval::UnlessTrusted),
+                ..Default::default()
+            },
         })
         .await?;
     timeout(
@@ -2801,12 +2861,17 @@ async fn thread_resume_replays_pending_file_change_request_approval() -> Result<
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "seed history".to_string(),
-                text_elements: Vec::new(),
-            }],
-            cwd: Some(workspace.clone()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "seed history".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(workspace.clone()),
+                ..Default::default()
+            },
         })
         .await?;
     timeout(
@@ -2825,13 +2890,18 @@ async fn thread_resume_replays_pending_file_change_request_approval() -> Result<
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "apply patch".to_string(),
-                text_elements: Vec::new(),
-            }],
-            cwd: Some(workspace.clone()),
-            approval_policy: Some(AskForApproval::UnlessTrusted),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "apply patch".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(workspace.clone()),
+                approval_policy: Some(AskForApproval::UnlessTrusted),
+                ..Default::default()
+            },
         })
         .await?;
     timeout(
@@ -2970,10 +3040,13 @@ async fn thread_resume_with_overrides_defers_updated_at_until_turn_start() -> Re
         .send_turn_start_request(TurnStartParams {
             thread_id: resumed_thread.id,
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -3283,10 +3356,13 @@ async fn start_materialized_thread_and_restart(
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: seed_text.to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: seed_text.to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -3373,10 +3449,13 @@ async fn thread_resume_accepts_personality_override() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "seed history".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "seed history".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -3414,10 +3493,13 @@ async fn thread_resume_accepts_personality_override() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: resume.thread.id,
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_rollback.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_rollback.rs
@@ -14,6 +14,7 @@ use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::ThreadStatus;
 use codex_app_server_protocol::TurnStartParams;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
@@ -58,10 +59,13 @@ async fn thread_rollback_drops_last_turns_and_persists_to_rollout() -> Result<()
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: first_text.to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: first_text.to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -80,10 +84,13 @@ async fn thread_rollback_drops_last_turns_and_persists_to_rollout() -> Result<()
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Second".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Second".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_settings_update.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_settings_update.rs
@@ -13,6 +13,7 @@ use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::SandboxPolicy;
 use codex_app_server_protocol::ThreadReadParams;
 use codex_app_server_protocol::ThreadReadResponse;
+use codex_app_server_protocol::ThreadSettingsOverrides;
 use codex_app_server_protocol::ThreadSettingsUpdateParams;
 use codex_app_server_protocol::ThreadSettingsUpdateResponse;
 use codex_app_server_protocol::ThreadSettingsUpdatedNotification;
@@ -20,6 +21,7 @@ use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_core::test_support::all_model_presets;
 use codex_protocol::config_types::SERVICE_TIER_DEFAULT_REQUEST_VALUE;
@@ -260,12 +262,17 @@ async fn turn_start_settings_override_emits_thread_settings_updated() -> Result<
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "hello".to_string(),
-                text_elements: Vec::new(),
-            }],
-            model: Some("mock-model-3".to_string()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                model: Some("mock-model-3".to_string()),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_response: JSONRPCResponse = timeout(
@@ -306,10 +313,13 @@ async fn start_text_turn(mcp: &mut McpProcess, thread_id: String) -> Result<()> 
     let turn_request_id = mcp
         .send_turn_start_request(TurnStartParams {
             thread_id,
-            input: vec![V2UserInput::Text {
-                text: "hello".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_shell_command.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_shell_command.rs
@@ -21,6 +21,7 @@ use codex_app_server_protocol::ThreadForkResponse;
 use codex_app_server_protocol::ThreadItem;
 use codex_app_server_protocol::ThreadReadParams;
 use codex_app_server_protocol::ThreadReadResponse;
+use codex_app_server_protocol::ThreadSettingsOverrides;
 use codex_app_server_protocol::ThreadShellCommandParams;
 use codex_app_server_protocol::ThreadShellCommandResponse;
 use codex_app_server_protocol::ThreadStartParams;
@@ -30,6 +31,7 @@ use codex_app_server_protocol::ThreadTurnsListResponse;
 use codex_app_server_protocol::TurnCompletedNotification;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_core::shell::default_user_shell;
 use codex_exec_server::CODEX_EXEC_SERVER_URL_ENV_VAR;
@@ -276,12 +278,17 @@ async fn thread_shell_command_uses_existing_active_turn() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "run python".to_string(),
-                text_elements: Vec::new(),
-            }],
-            cwd: Some(workspace.clone()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "run python".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(workspace.clone()),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(

--- a/codex-rs/app-server/tests/suite/v2/thread_status.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_status.rs
@@ -9,12 +9,14 @@ use codex_app_server_protocol::JSONRPCMessage;
 use codex_app_server_protocol::JSONRPCNotification;
 use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::RequestId;
+use codex_app_server_protocol::ThreadSettingsOverrides;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::ThreadStatus;
 use codex_app_server_protocol::ThreadStatusChangedNotification;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use tempfile::TempDir;
 use tokio::time::timeout;
@@ -49,12 +51,17 @@ async fn thread_status_changed_emits_runtime_updates() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "collect status updates".to_string(),
-                text_elements: Vec::new(),
-            }],
-            model: Some("mock-model".to_string()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "collect status updates".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                model: Some("mock-model".to_string()),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_start_resp: JSONRPCResponse = timeout(
@@ -173,12 +180,17 @@ async fn thread_status_changed_can_be_opted_out() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "run once".to_string(),
-                text_elements: Vec::new(),
-            }],
-            model: Some("mock-model".to_string()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "run once".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                model: Some("mock-model".to_string()),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_start_resp: JSONRPCResponse = timeout(

--- a/codex-rs/app-server/tests/suite/v2/thread_unarchive.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_unarchive.rs
@@ -20,6 +20,7 @@ use codex_app_server_protocol::ThreadUnarchiveResponse;
 use codex_app_server_protocol::ThreadUnarchivedNotification;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput;
 use codex_arg0::Arg0DispatchPaths;
 use codex_config::CloudRequirementsLoader;
@@ -82,10 +83,13 @@ async fn thread_unarchive_moves_rollout_back_into_sessions_directory() -> Result
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![UserInput::Text {
-                text: "materialize".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![UserInput::Text {
+                    text: "materialize".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_unsubscribe.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_unsubscribe.rs
@@ -17,6 +17,7 @@ use codex_app_server_protocol::ThreadReadParams;
 use codex_app_server_protocol::ThreadReadResponse;
 use codex_app_server_protocol::ThreadResumeParams;
 use codex_app_server_protocol::ThreadResumeResponse;
+use codex_app_server_protocol::ThreadSettingsOverrides;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::ThreadStatus;
@@ -25,6 +26,7 @@ use codex_app_server_protocol::ThreadUnsubscribeResponse;
 use codex_app_server_protocol::ThreadUnsubscribeStatus;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use core_test_support::responses;
 use core_test_support::streaming_sse::StreamingSseChunk;
@@ -152,12 +154,17 @@ async fn thread_unsubscribe_during_turn_keeps_turn_running() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread_id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "run deterministic tool".to_string(),
-                text_elements: Vec::new(),
-            }],
-            cwd: Some(working_directory),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "run deterministic tool".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(working_directory),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(
@@ -262,10 +269,13 @@ async fn thread_unsubscribe_preserves_cached_status_before_idle_unload() -> Resu
         .send_turn_start_request(TurnStartParams {
             thread_id: thread_id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "fail this turn".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "fail this turn".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/turn_interrupt.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_interrupt.rs
@@ -13,6 +13,7 @@ use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ServerRequest;
 use codex_app_server_protocol::ServerRequestResolvedNotification;
+use codex_app_server_protocol::ThreadSettingsOverrides;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnCompletedNotification;
@@ -21,6 +22,7 @@ use codex_app_server_protocol::TurnInterruptResponse;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
 use codex_app_server_protocol::TurnStatus;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use tempfile::TempDir;
 use tokio::time::timeout;
@@ -79,12 +81,17 @@ async fn turn_interrupt_aborts_running_turn() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "run sleep".to_string(),
-                text_elements: Vec::new(),
-            }],
-            cwd: Some(working_directory.clone()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "run sleep".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(working_directory.clone()),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(
@@ -161,10 +168,13 @@ async fn turn_interrupt_rejects_completed_turn() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "say done".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "say done".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -256,13 +266,18 @@ async fn turn_interrupt_resolves_pending_command_approval_request() -> Result<()
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "run python".to_string(),
-                text_elements: Vec::new(),
-            }],
-            cwd: Some(working_directory),
-            approval_policy: Some(codex_app_server_protocol::AskForApproval::UnlessTrusted),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "run python".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(working_directory),
+                approval_policy: Some(codex_app_server_protocol::AskForApproval::UnlessTrusted),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(

--- a/codex-rs/app-server/tests/suite/v2/turn_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start.rs
@@ -42,6 +42,7 @@ use codex_app_server_protocol::ServerRequest;
 use codex_app_server_protocol::ServerRequestResolvedNotification;
 use codex_app_server_protocol::TextElement;
 use codex_app_server_protocol::ThreadItem;
+use codex_app_server_protocol::ThreadSettingsOverrides;
 use codex_app_server_protocol::ThreadSource;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
@@ -52,6 +53,7 @@ use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
 use codex_app_server_protocol::TurnStartedNotification;
 use codex_app_server_protocol::TurnStatus;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_app_server_protocol::WarningNotification;
 use codex_config::config_toml::ConfigToml;
@@ -142,10 +144,13 @@ async fn run_local_image_turn(detail: Option<ImageDetail>) -> Result<Vec<Value>>
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::LocalImage {
-                path: image_path,
-                detail,
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::LocalImage {
+                    path: image_path,
+                    detail,
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -237,7 +242,10 @@ async fn turn_start_with_empty_input_runs_model_request() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: Vec::new(),
+            submission: TurnSubmissionParams {
+                input: Vec::new(),
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -338,17 +346,20 @@ async fn turn_start_additional_context_flows_to_model_input() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "inspect tab".to_string(),
-                text_elements: Vec::new(),
-            }],
-            additional_context: Some(HashMap::from([(
-                "custom_source".to_string(),
-                AdditionalContextEntry {
-                    value: "source value".to_string(),
-                    kind: AdditionalContextKind::Untrusted,
-                },
-            )])),
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "inspect tab".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                additional_context: Some(HashMap::from([(
+                    "custom_source".to_string(),
+                    AdditionalContextEntry {
+                        value: "source value".to_string(),
+                        kind: AdditionalContextKind::Untrusted,
+                    },
+                )])),
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -424,10 +435,13 @@ async fn turn_start_sends_originator_header() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -497,10 +511,13 @@ async fn turn_start_emits_user_message_item_with_text_elements() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: Some("client-message-1".to_string()),
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: text_elements.clone(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: text_elements.clone(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -604,10 +621,13 @@ async fn turn_start_emits_thread_scoped_warning_notification_for_trimmed_skills(
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -699,11 +719,17 @@ async fn turn_start_sends_service_tier_id_to_model_request() -> Result<()> {
     let turn_req = mcp
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
-            service_tier: Some(Some(service_tier_id.clone())),
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
+            thread_settings: ThreadSettingsOverrides {
+                service_tier: Some(Some(service_tier_id.clone())),
+                ..Default::default()
+            },
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -771,10 +797,13 @@ async fn thread_start_omits_empty_instruction_overrides_from_model_request() -> 
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -851,10 +880,13 @@ async fn turn_start_tracks_turn_event_analytics() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Image {
-                url: "https://example.com/a.png".to_string(),
-                detail: None,
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Image {
+                    url: "https://example.com/a.png".to_string(),
+                    detail: None,
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -940,16 +972,19 @@ async fn turn_start_accepts_text_at_limit_with_mention_item() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
             client_user_message_id: None,
-            input: vec![
-                V2UserInput::Text {
-                    text: "x".repeat(MAX_USER_INPUT_TEXT_CHARS),
-                    text_elements: Vec::new(),
-                },
-                V2UserInput::Mention {
-                    name: "Demo App".to_string(),
-                    path: "app://demo-app".to_string(),
-                },
-            ],
+            submission: TurnSubmissionParams {
+                input: vec![
+                    V2UserInput::Text {
+                        text: "x".repeat(MAX_USER_INPUT_TEXT_CHARS),
+                        text_elements: Vec::new(),
+                    },
+                    V2UserInput::Mention {
+                        name: "Demo App".to_string(),
+                        path: "app://demo-app".to_string(),
+                    },
+                ],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -1004,16 +1039,19 @@ async fn turn_start_rejects_combined_oversized_text_input() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
             client_user_message_id: None,
-            input: vec![
-                V2UserInput::Text {
-                    text: first,
-                    text_elements: Vec::new(),
-                },
-                V2UserInput::Text {
-                    text: second,
-                    text_elements: Vec::new(),
-                },
-            ],
+            submission: TurnSubmissionParams {
+                input: vec![
+                    V2UserInput::Text {
+                        text: first,
+                        text_elements: Vec::new(),
+                    },
+                    V2UserInput::Text {
+                        text: second,
+                        text_elements: Vec::new(),
+                    },
+                ],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -1079,12 +1117,17 @@ async fn turn_start_rejects_invalid_permission_selection_before_starting_turn() 
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
-            permissions: Some(BUILT_IN_PERMISSION_PROFILE_DANGER_FULL_ACCESS.to_string()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                permissions: Some(BUILT_IN_PERMISSION_PROFILE_DANGER_FULL_ACCESS.to_string()),
+                ..Default::default()
+            },
         })
         .await?;
     let err: JSONRPCError = timeout(
@@ -1152,14 +1195,17 @@ async fn turn_start_rejects_unknown_environment_before_starting_turn() -> Result
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
-            environments: Some(vec![TurnEnvironmentParams {
-                environment_id: "missing".to_string(),
-                cwd: codex_home.path().to_path_buf().try_into()?,
-            }]),
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                environments: Some(vec![TurnEnvironmentParams {
+                    environment_id: "missing".to_string(),
+                    cwd: codex_home.path().to_path_buf().try_into()?,
+                }]),
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -1226,10 +1272,13 @@ async fn turn_start_emits_notifications_and_accepts_model_override() -> Result<(
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -1279,12 +1328,17 @@ async fn turn_start_emits_notifications_and_accepts_model_override() -> Result<(
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Second".to_string(),
-                text_elements: Vec::new(),
-            }],
-            model: Some("mock-model-override".to_string()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Second".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                model: Some("mock-model-override".to_string()),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp2: JSONRPCResponse = timeout(
@@ -1378,16 +1432,21 @@ async fn turn_start_accepts_collaboration_mode_override_v2() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
-            model: Some("mock-model-override".to_string()),
-            effort: Some(ReasoningEffort::Low),
-            summary: Some(ReasoningSummary::Auto),
-            output_schema: None,
-            collaboration_mode: Some(collaboration_mode),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                output_schema: None,
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                model: Some("mock-model-override".to_string()),
+                effort: Some(ReasoningEffort::Low),
+                summary: Some(ReasoningSummary::Auto),
+                collaboration_mode: Some(collaboration_mode),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(
@@ -1468,16 +1527,21 @@ async fn turn_start_uses_thread_feature_overrides_for_request_user_input_tool_de
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
-            model: Some("mock-model-override".to_string()),
-            effort: Some(ReasoningEffort::Low),
-            summary: Some(ReasoningSummary::Auto),
-            output_schema: None,
-            collaboration_mode: Some(collaboration_mode),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                output_schema: None,
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                model: Some("mock-model-override".to_string()),
+                effort: Some(ReasoningEffort::Low),
+                summary: Some(ReasoningSummary::Auto),
+                collaboration_mode: Some(collaboration_mode),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(
@@ -1540,12 +1604,17 @@ async fn turn_start_accepts_personality_override_v2() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
-            personality: Some(Personality::Friendly),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                personality: Some(Personality::Friendly),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(
@@ -1622,12 +1691,17 @@ async fn turn_start_change_personality_mid_thread_v2() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
-            personality: None,
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                personality: None,
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(
@@ -1647,12 +1721,17 @@ async fn turn_start_change_personality_mid_thread_v2() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello again".to_string(),
-                text_elements: Vec::new(),
-            }],
-            personality: Some(Personality::Friendly),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello again".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                personality: Some(Personality::Friendly),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp2: JSONRPCResponse = timeout(
@@ -1750,12 +1829,17 @@ async fn turn_start_uses_migrated_pragmatic_personality_without_override_v2() ->
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
-            personality: None,
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                personality: None,
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(
@@ -1871,10 +1955,13 @@ async fn turn_start_exec_approval_toggle_v2() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "run python".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "run python".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -1936,16 +2023,21 @@ async fn turn_start_exec_approval_toggle_v2() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "run python again".to_string(),
-                text_elements: Vec::new(),
-            }],
-            approval_policy: Some(codex_app_server_protocol::AskForApproval::Never),
-            sandbox_policy: Some(codex_app_server_protocol::SandboxPolicy::DangerFullAccess),
-            model: Some("mock-model".to_string()),
-            effort: Some(ReasoningEffort::Medium),
-            summary: Some(ReasoningSummary::Auto),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "run python again".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                approval_policy: Some(codex_app_server_protocol::AskForApproval::Never),
+                sandbox_policy: Some(codex_app_server_protocol::SandboxPolicy::DangerFullAccess),
+                model: Some("mock-model".to_string()),
+                effort: Some(ReasoningEffort::Medium),
+                summary: Some(ReasoningSummary::Auto),
+                ..Default::default()
+            },
         })
         .await?;
     timeout(
@@ -2014,12 +2106,17 @@ async fn turn_start_exec_approval_decline_v2() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "run python".to_string(),
-                text_elements: Vec::new(),
-            }],
-            cwd: Some(workspace.clone()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "run python".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(workspace.clone()),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(
@@ -2167,33 +2264,37 @@ async fn turn_start_updates_sandbox_and_cwd_between_turns_v2() -> Result<()> {
     // first turn with workspace-write sandbox and first_cwd
     let first_turn = mcp
         .send_turn_start_request(TurnStartParams {
-            environments: None,
+            submission: TurnSubmissionParams {
+                environments: None,
+                input: vec![V2UserInput::Text {
+                    text: "first turn".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                responsesapi_client_metadata: None,
+                additional_context: None,
+                output_schema: None,
+            },
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "first turn".to_string(),
-                text_elements: Vec::new(),
-            }],
-            responsesapi_client_metadata: None,
-            additional_context: None,
-            cwd: Some(first_cwd.clone()),
-            runtime_workspace_roots: None,
-            approval_policy: Some(codex_app_server_protocol::AskForApproval::Never),
-            approvals_reviewer: None,
-            sandbox_policy: Some(codex_app_server_protocol::SandboxPolicy::WorkspaceWrite {
-                writable_roots: vec![first_cwd.try_into()?],
-                network_access: false,
-                exclude_tmpdir_env_var: true,
-                exclude_slash_tmp: true,
-            }),
-            permissions: None,
-            model: Some("mock-model".to_string()),
-            effort: Some(ReasoningEffort::Medium),
-            summary: Some(ReasoningSummary::Auto),
-            service_tier: None,
-            personality: None,
-            output_schema: None,
-            collaboration_mode: None,
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(first_cwd.clone()),
+                runtime_workspace_roots: None,
+                approval_policy: Some(codex_app_server_protocol::AskForApproval::Never),
+                approvals_reviewer: None,
+                sandbox_policy: Some(codex_app_server_protocol::SandboxPolicy::WorkspaceWrite {
+                    writable_roots: vec![first_cwd.try_into()?],
+                    network_access: false,
+                    exclude_tmpdir_env_var: true,
+                    exclude_slash_tmp: true,
+                }),
+                permissions: None,
+                model: Some("mock-model".to_string()),
+                effort: Some(ReasoningEffort::Medium),
+                summary: Some(ReasoningSummary::Auto),
+                service_tier: None,
+                personality: None,
+                collaboration_mode: None,
+            },
         })
         .await?;
     timeout(
@@ -2211,28 +2312,32 @@ async fn turn_start_updates_sandbox_and_cwd_between_turns_v2() -> Result<()> {
     // second turn with workspace-write and second_cwd, ensure exec begins in second_cwd
     let second_turn = mcp
         .send_turn_start_request(TurnStartParams {
-            environments: None,
+            submission: TurnSubmissionParams {
+                environments: None,
+                input: vec![V2UserInput::Text {
+                    text: "second turn".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                responsesapi_client_metadata: None,
+                additional_context: None,
+                output_schema: None,
+            },
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "second turn".to_string(),
-                text_elements: Vec::new(),
-            }],
-            responsesapi_client_metadata: None,
-            additional_context: None,
-            cwd: Some(second_cwd.clone()),
-            runtime_workspace_roots: None,
-            approval_policy: Some(codex_app_server_protocol::AskForApproval::Never),
-            approvals_reviewer: None,
-            sandbox_policy: Some(codex_app_server_protocol::SandboxPolicy::DangerFullAccess),
-            permissions: None,
-            model: Some("mock-model".to_string()),
-            effort: Some(ReasoningEffort::Medium),
-            summary: Some(ReasoningSummary::Auto),
-            service_tier: None,
-            personality: None,
-            output_schema: None,
-            collaboration_mode: None,
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(second_cwd.clone()),
+                runtime_workspace_roots: None,
+                approval_policy: Some(codex_app_server_protocol::AskForApproval::Never),
+                approvals_reviewer: None,
+                sandbox_policy: Some(codex_app_server_protocol::SandboxPolicy::DangerFullAccess),
+                permissions: None,
+                model: Some("mock-model".to_string()),
+                effort: Some(ReasoningEffort::Medium),
+                summary: Some(ReasoningSummary::Auto),
+                service_tier: None,
+                personality: None,
+                collaboration_mode: None,
+            },
         })
         .await?;
     timeout(
@@ -2357,13 +2462,18 @@ stream_max_retries = 0
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "select dev profile".to_string(),
-                text_elements: Vec::new(),
-            }],
-            runtime_workspace_roots: Some(vec![old_root]),
-            permissions: Some("dev".to_string()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "select dev profile".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                runtime_workspace_roots: Some(vec![old_root]),
+                permissions: Some("dev".to_string()),
+                ..Default::default()
+            },
         })
         .await?;
     timeout(
@@ -2381,12 +2491,17 @@ stream_max_retries = 0
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "write in new root".to_string(),
-                text_elements: Vec::new(),
-            }],
-            runtime_workspace_roots: Some(vec![new_root]),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "write in new root".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                runtime_workspace_roots: Some(vec![new_root]),
+                ..Default::default()
+            },
         })
         .await?;
     timeout(
@@ -2514,14 +2629,19 @@ async fn run_environment_selection_case(
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: format!("run {}", case.name),
-                text_elements: Vec::new(),
-            }],
-            environments: environment_params(case.turn, workspace)?,
-            cwd: Some(workspace.to_path_buf()),
-            model: Some("mock-model".to_string()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: format!("run {}", case.name),
+                    text_elements: Vec::new(),
+                }],
+                environments: environment_params(case.turn, workspace)?,
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(workspace.to_path_buf()),
+                model: Some("mock-model".to_string()),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(
@@ -2630,12 +2750,17 @@ async fn turn_start_file_change_approval_v2() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "apply patch".into(),
-                text_elements: Vec::new(),
-            }],
-            cwd: Some(workspace.clone()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "apply patch".into(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(workspace.clone()),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(
@@ -2821,12 +2946,17 @@ async fn turn_start_does_not_stream_apply_patch_change_updates_without_feature_v
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "apply patch".into(),
-                text_elements: Vec::new(),
-            }],
-            cwd: Some(workspace),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "apply patch".into(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(workspace),
+                ..Default::default()
+            },
         })
         .await?;
     timeout(
@@ -2959,12 +3089,17 @@ async fn turn_start_streams_apply_patch_change_updates_v2() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "apply patch".into(),
-                text_elements: Vec::new(),
-            }],
-            cwd: Some(workspace.clone()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "apply patch".into(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(workspace.clone()),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(
@@ -3090,10 +3225,13 @@ async fn turn_start_emits_spawn_agent_item_with_model_metadata_v2() -> Result<()
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: PARENT_PROMPT.to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: PARENT_PROMPT.to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -3310,10 +3448,13 @@ config_file = "./custom-role.toml"
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: PARENT_PROMPT.to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: PARENT_PROMPT.to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;
@@ -3456,12 +3597,17 @@ async fn turn_start_file_change_approval_accept_for_session_persists_v2() -> Res
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "apply patch 1".into(),
-                text_elements: Vec::new(),
-            }],
-            cwd: Some(workspace.clone()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "apply patch 1".into(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(workspace.clone()),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_1_resp: JSONRPCResponse = timeout(
@@ -3529,12 +3675,17 @@ async fn turn_start_file_change_approval_accept_for_session_persists_v2() -> Res
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "apply patch 2".into(),
-                text_elements: Vec::new(),
-            }],
-            cwd: Some(workspace.clone()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "apply patch 2".into(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(workspace.clone()),
+                ..Default::default()
+            },
         })
         .await?;
     timeout(
@@ -3628,12 +3779,17 @@ async fn turn_start_file_change_approval_decline_v2() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "apply patch".into(),
-                text_elements: Vec::new(),
-            }],
-            cwd: Some(workspace.clone()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "apply patch".into(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(workspace.clone()),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(
@@ -3774,12 +3930,17 @@ async fn command_execution_notifications_include_process_id() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "run a command".to_string(),
-                text_elements: Vec::new(),
-            }],
-            sandbox_policy: Some(codex_app_server_protocol::SandboxPolicy::DangerFullAccess),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "run a command".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                sandbox_policy: Some(codex_app_server_protocol::SandboxPolicy::DangerFullAccess),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(
@@ -3907,12 +4068,18 @@ async fn turn_start_with_elevated_override_does_not_persist_project_trust() -> R
     let turn_request = mcp
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id,
-            cwd: Some(workspace.path().to_path_buf()),
-            sandbox_policy: Some(codex_app_server_protocol::SandboxPolicy::DangerFullAccess),
-            input: vec![V2UserInput::Text {
-                text: "Hello".to_string(),
-                text_elements: Vec::new(),
-            }],
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(workspace.path().to_path_buf()),
+                sandbox_policy: Some(codex_app_server_protocol::SandboxPolicy::DangerFullAccess),
+                ..Default::default()
+            },
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Hello".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/app-server/tests/suite/v2/turn_start_zsh_fork.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start_zsh_fork.rs
@@ -23,12 +23,14 @@ use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ServerRequest;
 use codex_app_server_protocol::ThreadItem;
+use codex_app_server_protocol::ThreadSettingsOverrides;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnCompletedNotification;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
 use codex_app_server_protocol::TurnStatus;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_features::FEATURES;
 use codex_features::Feature;
@@ -118,17 +120,22 @@ async fn turn_start_shell_zsh_fork_executes_command_v2() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "run echo hi".to_string(),
-                text_elements: Vec::new(),
-            }],
-            cwd: Some(workspace.clone()),
-            approval_policy: Some(codex_app_server_protocol::AskForApproval::Never),
-            sandbox_policy: Some(codex_app_server_protocol::SandboxPolicy::DangerFullAccess),
-            model: Some("mock-model".to_string()),
-            effort: Some(codex_protocol::openai_models::ReasoningEffort::Medium),
-            summary: Some(codex_protocol::config_types::ReasoningSummary::Auto),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "run echo hi".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(workspace.clone()),
+                approval_policy: Some(codex_app_server_protocol::AskForApproval::Never),
+                sandbox_policy: Some(codex_app_server_protocol::SandboxPolicy::DangerFullAccess),
+                model: Some("mock-model".to_string()),
+                effort: Some(codex_protocol::openai_models::ReasoningEffort::Medium),
+                summary: Some(codex_protocol::config_types::ReasoningSummary::Auto),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(
@@ -237,12 +244,17 @@ async fn turn_start_shell_zsh_fork_exec_approval_decline_v2() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "run python".to_string(),
-                text_elements: Vec::new(),
-            }],
-            cwd: Some(workspace.clone()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "run python".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(workspace.clone()),
+                ..Default::default()
+            },
         })
         .await?;
     timeout(
@@ -370,12 +382,17 @@ async fn turn_start_shell_zsh_fork_exec_approval_cancel_v2() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "run python".to_string(),
-                text_elements: Vec::new(),
-            }],
-            cwd: Some(workspace.clone()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "run python".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(workspace.clone()),
+                ..Default::default()
+            },
         })
         .await?;
     timeout(
@@ -529,22 +546,27 @@ async fn turn_start_shell_zsh_fork_subcommand_decline_marks_parent_declined_v2()
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "remove both files".to_string(),
-                text_elements: Vec::new(),
-            }],
-            cwd: Some(workspace.clone()),
-            approval_policy: Some(codex_app_server_protocol::AskForApproval::UnlessTrusted),
-            sandbox_policy: Some(codex_app_server_protocol::SandboxPolicy::WorkspaceWrite {
-                writable_roots: vec![workspace.clone().try_into()?],
-                network_access: false,
-                exclude_tmpdir_env_var: true,
-                exclude_slash_tmp: true,
-            }),
-            model: Some("mock-model".to_string()),
-            effort: Some(codex_protocol::openai_models::ReasoningEffort::Medium),
-            summary: Some(codex_protocol::config_types::ReasoningSummary::Auto),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "remove both files".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(workspace.clone()),
+                approval_policy: Some(codex_app_server_protocol::AskForApproval::UnlessTrusted),
+                sandbox_policy: Some(codex_app_server_protocol::SandboxPolicy::WorkspaceWrite {
+                    writable_roots: vec![workspace.clone().try_into()?],
+                    network_access: false,
+                    exclude_tmpdir_env_var: true,
+                    exclude_slash_tmp: true,
+                }),
+                model: Some("mock-model".to_string()),
+                effort: Some(codex_protocol::openai_models::ReasoningEffort::Medium),
+                summary: Some(codex_protocol::config_types::ReasoningSummary::Auto),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(

--- a/codex-rs/app-server/tests/suite/v2/turn_steer.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_steer.rs
@@ -18,12 +18,14 @@ use codex_app_server_protocol::JSONRPCNotification;
 use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ThreadItem;
+use codex_app_server_protocol::ThreadSettingsOverrides;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
 use codex_app_server_protocol::TurnSteerParams;
 use codex_app_server_protocol::TurnSteerResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_protocol::user_input::MAX_USER_INPUT_TEXT_CHARS;
 use serde_json::Value;
@@ -156,12 +158,17 @@ async fn turn_steer_rejects_oversized_text_input() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "run sleep".to_string(),
-                text_elements: Vec::new(),
-            }],
-            cwd: Some(working_directory.clone()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "run sleep".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(working_directory.clone()),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(
@@ -270,12 +277,17 @@ async fn turn_steer_returns_active_turn_id() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "run sleep".to_string(),
-                text_elements: Vec::new(),
-            }],
-            cwd: Some(working_directory.clone()),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "run sleep".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(working_directory.clone()),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(
@@ -407,12 +419,17 @@ async fn turn_steer_rejects_context_only_input_without_merging_context() -> Resu
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "run sleep".to_string(),
-                text_elements: Vec::new(),
-            }],
-            cwd: Some(working_directory),
-            ..Default::default()
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "run sleep".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
+            thread_settings: ThreadSettingsOverrides {
+                cwd: Some(working_directory),
+                ..Default::default()
+            },
         })
         .await?;
     let turn_resp: JSONRPCResponse = timeout(

--- a/codex-rs/app-server/tests/suite/v2/web_search.rs
+++ b/codex-rs/app-server/tests/suite/v2/web_search.rs
@@ -18,6 +18,7 @@ use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_app_server_protocol::WebSearchAction;
 use codex_config::types::AuthCredentialsStoreMode;
@@ -96,10 +97,13 @@ async fn standalone_web_search_round_trips_encrypted_output() -> Result<()> {
         .send_turn_start_request(TurnStartParams {
             thread_id: thread_id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::Text {
-                text: "Search the web".to_string(),
-                text_elements: Vec::new(),
-            }],
+            submission: TurnSubmissionParams {
+                input: vec![V2UserInput::Text {
+                    text: "Search the web".to_string(),
+                    text_elements: Vec::new(),
+                }],
+                ..Default::default()
+            },
             ..Default::default()
         })
         .await?;

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -38,6 +38,7 @@ use codex_app_server_protocol::ThreadReadParams;
 use codex_app_server_protocol::ThreadReadResponse;
 use codex_app_server_protocol::ThreadResumeParams;
 use codex_app_server_protocol::ThreadResumeResponse;
+use codex_app_server_protocol::ThreadSettingsOverrides;
 use codex_app_server_protocol::ThreadSortKey;
 use codex_app_server_protocol::ThreadSource;
 use codex_app_server_protocol::ThreadSourceKind;
@@ -50,6 +51,7 @@ use codex_app_server_protocol::TurnInterruptResponse;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
 use codex_app_server_protocol::TurnStartedNotification;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_arg0::Arg0DispatchPaths;
 use codex_cloud_requirements::cloud_requirements_loader_for_storage;
 use codex_config::ConfigLoadError;
@@ -780,23 +782,17 @@ async fn run_exec_session(args: ExecRunArgs) -> anyhow::Result<()> {
                     params: TurnStartParams {
                         thread_id: primary_thread_id_for_span.clone(),
                         client_user_message_id: None,
-                        input: items.into_iter().map(Into::into).collect(),
-                        responsesapi_client_metadata: None,
-                        additional_context: None,
-                        environments: None,
-                        cwd: Some(default_cwd),
-                        runtime_workspace_roots: None,
-                        approval_policy: Some(default_approval_policy.into()),
-                        approvals_reviewer: None,
-                        sandbox_policy: None,
-                        permissions: None,
-                        model: None,
-                        service_tier: None,
-                        effort: default_effort,
-                        summary: None,
-                        personality: None,
-                        output_schema,
-                        collaboration_mode: None,
+                        submission: TurnSubmissionParams {
+                            input: items.into_iter().map(Into::into).collect(),
+                            output_schema,
+                            ..Default::default()
+                        },
+                        thread_settings: ThreadSettingsOverrides {
+                            cwd: Some(default_cwd),
+                            approval_policy: Some(default_approval_policy.into()),
+                            effort: default_effort,
+                            ..Default::default()
+                        },
                     },
                 },
                 "turn/start",

--- a/codex-rs/tui/src/app_server_session.rs
+++ b/codex-rs/tui/src/app_server_session.rs
@@ -91,6 +91,7 @@ use codex_app_server_protocol::ThreadRollbackParams;
 use codex_app_server_protocol::ThreadRollbackResponse;
 use codex_app_server_protocol::ThreadSetNameParams;
 use codex_app_server_protocol::ThreadSetNameResponse;
+use codex_app_server_protocol::ThreadSettingsOverrides;
 use codex_app_server_protocol::ThreadSettingsUpdateParams;
 use codex_app_server_protocol::ThreadSettingsUpdateResponse;
 use codex_app_server_protocol::ThreadShellCommandParams;
@@ -109,6 +110,7 @@ use codex_app_server_protocol::TurnStartResponse;
 use codex_app_server_protocol::TurnSteerParams;
 use codex_app_server_protocol::TurnSteerResponse;
 use codex_app_server_protocol::TurnSubmission;
+use codex_app_server_protocol::TurnSubmissionParams;
 use codex_app_server_protocol::UserInput;
 use codex_otel::TelemetryAuthMode;
 use codex_protocol::ThreadId;
@@ -707,28 +709,30 @@ impl AppServerSession {
                 params: TurnStartParams {
                     thread_id: thread_id.to_string(),
                     client_user_message_id: None,
-                    input: items,
-                    responsesapi_client_metadata: None,
-                    additional_context: None,
-                    environments: None,
-                    cwd: Some(cwd),
-                    runtime_workspace_roots: Some(
-                        workspace_roots
-                            .iter()
-                            .map(AbsolutePathBuf::to_path_buf)
-                            .collect(),
-                    ),
-                    approval_policy: Some(approval_policy),
-                    approvals_reviewer: Some(approvals_reviewer.into()),
-                    sandbox_policy,
-                    permissions,
-                    model: Some(model),
-                    service_tier,
-                    effort,
-                    summary,
-                    personality,
-                    output_schema,
-                    collaboration_mode,
+                    submission: TurnSubmissionParams {
+                        input: items,
+                        output_schema,
+                        ..Default::default()
+                    },
+                    thread_settings: ThreadSettingsOverrides {
+                        cwd: Some(cwd),
+                        runtime_workspace_roots: Some(
+                            workspace_roots
+                                .iter()
+                                .map(AbsolutePathBuf::to_path_buf)
+                                .collect(),
+                        ),
+                        approval_policy: Some(approval_policy),
+                        approvals_reviewer: Some(approvals_reviewer.into()),
+                        sandbox_policy,
+                        permissions,
+                        model: Some(model),
+                        service_tier,
+                        effort,
+                        summary,
+                        personality,
+                        collaboration_mode,
+                    },
                 },
             })
             .await


### PR DESCRIPTION
## Summary

Queued follow-ups need the message part of a turn without copying the session-setting overrides that belong to direct turn startup. This PR separates those concepts in the app-server protocol.

`TurnSubmission` is the concrete message payload stored in queued records and returned in responses:

- `input`
- `responsesapiClientMetadata`
- `additionalContext`
- `environments`
- `outputSchema`

`TurnSubmissionParams` is the client request form of the same payload. Its optional fields preserve omission semantics for TypeScript clients.

`ThreadSettingsOverrides` carries the persistent or per-turn execution settings:

- `cwd`
- `runtimeWorkspaceRoots`
- approval, sandbox, and permission settings
- model, service tier, reasoning effort, personality, and collaboration mode

`TurnStartParams` still owns routing fields such as `threadId` and `clientUserMessageId`, then flattens `TurnSubmissionParams` and `ThreadSettingsOverrides`. The JSON-RPC wire shape stays flat and compatible.

## Important call sites

| Area | Change |
| --- | --- |
| App-server protocol | Add `TurnSubmission`, request-only `TurnSubmissionParams`, and `ThreadSettingsOverrides`; flatten request params and overrides into `TurnStartParams`. |
| App-server turn processor | Read submission data and thread-setting overrides from their typed groups. |
| Queue RPCs | Accept request params while storing and returning concrete submissions. |
| TUI | Build reusable concrete submissions for durable queued follow-ups and request params for direct turns. |
| Exec client | Build direct `TurnStartParams` from submission params plus settings overrides. |
| App-server test client and integration tests | Update constructors to express the same split explicitly. |
| Schema exporter | Preserve stable-schema filtering for fields generated through flattened sources. |

## Design decisions

- Name the concrete message payload `TurnSubmission` because it is the reusable value stored by queue RPCs.
- Use a separate `TurnSubmissionParams` request type because TypeScript optionality belongs to client request payloads.
- Keep settings overrides as a distinct type because queue entries intentionally omit them. Dispatch uses the thread's current settings.
- Preserve the flat JSON-RPC shape with serde and TypeScript flattening so clients do not need a wire migration.

## Stack

1. [#23618](https://github.com/openai/codex/pull/23618) - add the durable queued-turn store.
2. [#23619](https://github.com/openai/codex/pull/23619) - expose experimental app-server queue RPCs.
3. [#23620](https://github.com/openai/codex/pull/23620) - dispatch queued turns from app-server.
4. [#25258](https://github.com/openai/codex/pull/25258) - route TUI follow-ups through app-server behind the rollout flag.
5. **Current PR:** [#25276](https://github.com/openai/codex/pull/25276) - separate turn submissions from thread-setting overrides.
6. [#25283](https://github.com/openai/codex/pull/25283) - synchronize runtime workspace roots through thread settings.

## Testing

Tests: protocol schema fixtures, app-server and analytics compile coverage, targeted queue tests, formatter, Clippy cleanup pass, and targeted local CI.
