### PR TITLE
fix(tui): space multiline list siblings

### DIFF
--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -5,6 +5,7 @@
 
 use super::resize_reflow::trailing_run_start;
 use super::*;
+use crate::app_event::ConsolidationScrollbackReflow;
 
 const SHUTDOWN_FIRST_EXIT_TIMEOUT: Duration = Duration::from_secs(/*secs*/ 2);
 
@@ -234,11 +235,10 @@ impl App {
                     deferred_history_cell,
                 )?;
             }
-            AppEvent::ConsolidateProposedPlan(source) => {
-                if !self.terminal_resize_reflow_enabled() {
-                    self.transcript_reflow.clear();
-                    return Ok(AppRunControl::Continue);
-                }
+            AppEvent::ConsolidateProposedPlan {
+                source,
+                scrollback_reflow,
+            } => {
                 let end = self.transcript_cells.len();
                 let start = trailing_run_start::<history_cell::ProposedPlanStreamCell>(
                     &self.transcript_cells,
@@ -255,7 +255,22 @@ impl App {
                         tui.frame_requester().schedule_frame();
                     }
 
-                    self.finish_required_stream_reflow(tui)?;
+                    match scrollback_reflow {
+                        ConsolidationScrollbackReflow::IfResizeReflowRan => {
+                            self.maybe_finish_stream_reflow(tui)?;
+                        }
+                        ConsolidationScrollbackReflow::Required
+                            if self.terminal_resize_reflow_enabled() =>
+                        {
+                            self.finish_required_stream_reflow(tui)?;
+                        }
+                        ConsolidationScrollbackReflow::Required => {
+                            // The already-emitted stream prefix cannot be removed without reflow.
+                            // Keep terminal scrollback as-is instead of appending a duplicate full
+                            // plan if the feature was disabled before this queued event arrived.
+                            self.maybe_finish_stream_reflow(tui)?;
+                        }
+                    }
                 } else {
                     self.transcript_cells.push(consolidated.clone());
                     if let Some(Overlay::Transcript(t)) = &mut self.overlay {

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -602,8 +602,12 @@ pub(crate) enum AppEvent {
     /// end of the transcript with a single source-backed `ProposedPlanCell`.
     ///
     /// Emitted by `ChatWidget::on_plan_item_completed` after plan stream
-    /// finalization.
-    ConsolidateProposedPlan(String),
+    /// finalization. `scrollback_reflow` lets table-tail finalization and
+    /// authoritative plan corrections refresh already-emitted scrollback.
+    ConsolidateProposedPlan {
+        source: String,
+        scrollback_reflow: ConsolidationScrollbackReflow,
+    },
 
     /// Apply rollback semantics to local transcript cells.
     ///

--- a/codex-rs/tui/src/chatwidget/streaming.rs
+++ b/codex-rs/tui/src/chatwidget/streaming.rs
@@ -4,6 +4,7 @@
 //! cells, commit ticks, and interrupt deferral.
 
 use super::*;
+use crate::app_event::ConsolidationScrollbackReflow;
 
 impl ChatWidget {
     pub(super) fn restore_reasoning_status_header(&mut self) {
@@ -19,7 +20,7 @@ impl ChatWidget {
     pub(super) fn flush_answer_stream_with_separator(&mut self) {
         let had_stream_controller = self.stream_controller.is_some();
         if let Some(mut controller) = self.stream_controller.take() {
-            let scrollback_reflow = if controller.has_live_tail()
+            let scrollback_reflow = if controller.requires_forced_reflow_on_finalize()
                 && self.config.features.enabled(Feature::TerminalResizeReflow)
             {
                 crate::app_event::ConsolidationScrollbackReflow::Required
@@ -140,10 +141,11 @@ impl ChatWidget {
 
     pub(super) fn on_plan_item_completed(&mut self, text: String) {
         let streamed_plan = self.transcript.plan_delta_buffer.trim().to_string();
-        let plan_text = if text.trim().is_empty() {
-            streamed_plan
-        } else {
+        let has_authoritative_plan_text = !text.trim().is_empty();
+        let plan_text = if has_authoritative_plan_text {
             text
+        } else {
+            streamed_plan
         };
         if !plan_text.trim().is_empty() {
             self.record_agent_markdown(&plan_text);
@@ -155,32 +157,49 @@ impl ChatWidget {
         self.transcript.plan_delta_buffer.clear();
         self.transcript.plan_item_active = false;
         self.transcript.saw_plan_item_this_turn = true;
-        let (finalized_streamed_cell, consolidated_plan_source) =
+        let (finalized_streamed_cell, consolidated_plan_source, scrollback_reflow) =
             if let Some(mut controller) = self.plan_stream_controller.take() {
-                let had_live_tail = controller.has_live_tail();
+                let requires_forced_reflow = controller.requires_forced_reflow_on_finalize()
+                    && self.config.features.enabled(Feature::TerminalResizeReflow);
                 self.clear_active_stream_tail();
                 let (cell, source) = controller.finalize();
-                if had_live_tail {
-                    (None, source)
+                let requires_authoritative_refresh = source
+                    .as_ref()
+                    .is_some_and(|source| has_authoritative_plan_text && source != &plan_text)
+                    && self.config.features.enabled(Feature::TerminalResizeReflow);
+                let scrollback_reflow = if requires_forced_reflow || requires_authoritative_refresh
+                {
+                    ConsolidationScrollbackReflow::Required
                 } else {
-                    (cell, source)
+                    ConsolidationScrollbackReflow::IfResizeReflowRan
+                };
+                let source = source.map(|source| {
+                    if has_authoritative_plan_text {
+                        plan_text.clone()
+                    } else {
+                        source
+                    }
+                });
+                let hold_live_tail_for_reflow =
+                    scrollback_reflow == ConsolidationScrollbackReflow::Required;
+                if hold_live_tail_for_reflow {
+                    (None, source, scrollback_reflow)
+                } else {
+                    (cell, source, scrollback_reflow)
                 }
             } else {
-                (None, None)
+                (None, None, ConsolidationScrollbackReflow::IfResizeReflowRan)
             };
         if let Some(cell) = finalized_streamed_cell {
             self.add_boxed_history(cell);
-            // TODO: Replace streamed output with the final plan item text if plan streaming is
-            // removed or if we need to reconcile mismatches between streamed and final content.
-            if let Some(source) = consolidated_plan_source {
-                self.app_event_tx
-                    .send(AppEvent::ConsolidateProposedPlan(source));
-            }
+        }
+        if let Some(source) = consolidated_plan_source {
+            self.app_event_tx.send(AppEvent::ConsolidateProposedPlan {
+                source,
+                scrollback_reflow,
+            });
         } else if !plan_text.is_empty() {
             self.add_to_history(history_cell::new_proposed_plan(plan_text, &self.config.cwd));
-        } else if let Some(source) = consolidated_plan_source {
-            self.app_event_tx
-                .send(AppEvent::ConsolidateProposedPlan(source));
         }
         if should_restore_after_stream {
             self.status_state.pending_status_indicator_restore = true;

--- a/codex-rs/tui/src/chatwidget/streaming.rs
+++ b/codex-rs/tui/src/chatwidget/streaming.rs
@@ -19,7 +19,9 @@ impl ChatWidget {
     pub(super) fn flush_answer_stream_with_separator(&mut self) {
         let had_stream_controller = self.stream_controller.is_some();
         if let Some(mut controller) = self.stream_controller.take() {
-            let scrollback_reflow = if controller.has_live_tail() {
+            let scrollback_reflow = if controller.has_live_tail()
+                && self.config.features.enabled(Feature::TerminalResizeReflow)
+            {
                 crate::app_event::ConsolidationScrollbackReflow::Required
             } else {
                 crate::app_event::ConsolidationScrollbackReflow::IfResizeReflowRan

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -408,7 +408,60 @@ async fn flush_answer_stream_inserts_live_list_tail_when_resize_reflow_disabled(
 }
 
 #[tokio::test]
-async fn completed_plan_table_tail_skips_provisional_history_insert() {
+async fn flush_answer_stream_inserts_live_list_tail_without_forced_reflow() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    let cwd = chat.config.cwd.to_path_buf();
+
+    let mut controller = crate::streaming::controller::StreamController::new(
+        Some(/*width*/ 80),
+        cwd.as_path(),
+        HistoryRenderMode::Rich,
+    );
+    controller.push("- first\n");
+    controller.push("- second\n");
+    assert!(
+        controller.has_live_tail(),
+        "expected trailing list holdback to leave a live tail for this regression",
+    );
+    chat.stream_controller = Some(controller);
+
+    while rx.try_recv().is_ok() {}
+
+    chat.flush_answer_stream_with_separator();
+
+    let mut saw_consolidate = false;
+    let mut saw_insert_history = false;
+    while let Ok(event) = rx.try_recv() {
+        match event {
+            AppEvent::InsertHistoryCell(_) => saw_insert_history = true,
+            AppEvent::ConsolidateAgentMessage {
+                scrollback_reflow,
+                deferred_history_cell,
+                ..
+            } => {
+                saw_consolidate = true;
+                assert_eq!(
+                    scrollback_reflow,
+                    crate::app_event::ConsolidationScrollbackReflow::IfResizeReflowRan
+                );
+                assert!(deferred_history_cell.is_none());
+            }
+            _ => {}
+        }
+    }
+
+    assert!(
+        saw_consolidate,
+        "expected stream finalization to consolidate"
+    );
+    assert!(
+        saw_insert_history,
+        "live list tail should insert history directly without forced reflow"
+    );
+}
+
+#[tokio::test]
+async fn completed_plan_table_tail_uses_consolidation_without_provisional_history_insert() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
     let cwd = chat.config.cwd.to_path_buf();
 
@@ -432,27 +485,241 @@ async fn completed_plan_table_tail_skips_provisional_history_insert() {
 
     chat.on_plan_item_completed(String::new());
 
-    let mut saw_source_backed_plan = false;
+    let mut saw_consolidate = false;
     let mut saw_stream_plan = false;
-    let mut rendered_plan = String::new();
+    while let Ok(event) = rx.try_recv() {
+        match event {
+            AppEvent::ConsolidateProposedPlan {
+                source,
+                scrollback_reflow,
+            } => {
+                saw_consolidate = true;
+                assert!(source.contains("| Verify | Codex |"));
+                assert_eq!(
+                    scrollback_reflow,
+                    crate::app_event::ConsolidationScrollbackReflow::Required
+                );
+            }
+            AppEvent::InsertHistoryCell(cell) => {
+                saw_stream_plan |= cell.as_any().is::<history_cell::ProposedPlanStreamCell>();
+            }
+            _ => {}
+        }
+    }
+
+    assert!(saw_consolidate, "expected source-backed plan consolidation");
+    assert!(
+        !saw_stream_plan,
+        "live plan table tail should not be inserted provisionally"
+    );
+}
+
+#[tokio::test]
+async fn completed_plan_list_tail_consolidates_emitted_prefix() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    let cwd = chat.config.cwd.to_path_buf();
+    let completed_plan = "Plan intro.\n\n- Revised first step\n- Revised second step\n";
+
+    let mut controller = crate::streaming::controller::PlanStreamController::new(
+        Some(/*width*/ 80),
+        cwd.as_path(),
+        HistoryRenderMode::Rich,
+    );
+    controller.push("Plan intro.\n\n");
+    let (prefix, _) = controller.on_commit_tick_batch(usize::MAX);
+    chat.add_boxed_history(prefix.expect("expected emitted plan prefix"));
+    controller.push("- First step\n");
+    controller.push("- Second step\n");
+    assert!(
+        controller.has_live_tail(),
+        "expected trailing list holdback to leave a live tail",
+    );
+    chat.plan_stream_controller = Some(controller);
+    chat.transcript.plan_delta_buffer = "Plan intro.\n\n- First step\n- Second step\n".to_string();
+
+    while rx.try_recv().is_ok() {}
+
+    chat.on_plan_item_completed(completed_plan.to_string());
+
+    let mut saw_consolidate = false;
+    let mut saw_direct_plan_insert = false;
+    while let Ok(event) = rx.try_recv() {
+        match event {
+            AppEvent::ConsolidateProposedPlan {
+                source,
+                scrollback_reflow,
+            } => {
+                saw_consolidate = true;
+                assert_eq!(source, completed_plan);
+                assert_eq!(
+                    scrollback_reflow,
+                    crate::app_event::ConsolidationScrollbackReflow::Required
+                );
+            }
+            AppEvent::InsertHistoryCell(cell) => {
+                saw_direct_plan_insert |= cell.as_any().is::<history_cell::ProposedPlanCell>();
+            }
+            _ => {}
+        }
+    }
+
+    assert!(saw_consolidate, "expected emitted prefix consolidation");
+    assert!(
+        !saw_direct_plan_insert,
+        "held list should consolidate instead of duplicating the emitted prefix",
+    );
+}
+
+#[tokio::test]
+async fn completed_plan_list_tail_inserts_stream_tail_without_forced_reflow() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    let cwd = chat.config.cwd.to_path_buf();
+
+    let mut controller = crate::streaming::controller::PlanStreamController::new(
+        Some(/*width*/ 80),
+        cwd.as_path(),
+        HistoryRenderMode::Rich,
+    );
+    controller.push("- First step\n");
+    controller.push("- Second step\n");
+    assert!(
+        controller.has_live_tail(),
+        "expected trailing list holdback to leave a live tail",
+    );
+    chat.plan_stream_controller = Some(controller);
+    chat.transcript.plan_delta_buffer = "- First step\n- Second step\n".to_string();
+
+    while rx.try_recv().is_ok() {}
+
+    chat.on_plan_item_completed(String::new());
+
+    let mut saw_consolidate = false;
+    let mut saw_stream_plan = false;
+    while let Ok(event) = rx.try_recv() {
+        match event {
+            AppEvent::ConsolidateProposedPlan {
+                source,
+                scrollback_reflow,
+            } => {
+                saw_consolidate = true;
+                assert_eq!(source, "- First step\n- Second step\n");
+                assert_eq!(
+                    scrollback_reflow,
+                    crate::app_event::ConsolidationScrollbackReflow::IfResizeReflowRan
+                );
+            }
+            AppEvent::InsertHistoryCell(cell) => {
+                saw_stream_plan |= cell.as_any().is::<history_cell::ProposedPlanStreamCell>();
+            }
+            _ => {}
+        }
+    }
+
+    assert!(saw_consolidate, "expected source-backed plan consolidation");
+    assert!(
+        saw_stream_plan,
+        "live plan list tail should insert history directly without forced reflow",
+    );
+}
+
+#[tokio::test]
+async fn completed_plan_list_tail_inserts_stream_tail_when_resize_reflow_disabled() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    let cwd = chat.config.cwd.to_path_buf();
+    let completed_plan = "Plan intro.\n\n- Revised first step\n- Revised second step\n";
+    chat.set_feature_enabled(Feature::TerminalResizeReflow, /*enabled*/ false);
+
+    let mut controller = crate::streaming::controller::PlanStreamController::new(
+        Some(/*width*/ 80),
+        cwd.as_path(),
+        HistoryRenderMode::Rich,
+    );
+    controller.push("Plan intro.\n\n");
+    let (prefix, _) = controller.on_commit_tick_batch(usize::MAX);
+    chat.add_boxed_history(prefix.expect("expected emitted plan prefix"));
+    controller.push("- First step\n");
+    controller.push("- Second step\n");
+    assert!(
+        controller.has_live_tail(),
+        "expected trailing list holdback to leave a live tail",
+    );
+    chat.plan_stream_controller = Some(controller);
+    chat.transcript.plan_delta_buffer = "Plan intro.\n\n- First step\n- Second step\n".to_string();
+
+    while rx.try_recv().is_ok() {}
+
+    chat.on_plan_item_completed(completed_plan.to_string());
+
+    let mut saw_consolidate = false;
+    let mut saw_stream_plan = false;
+    let mut saw_direct_plan_insert = false;
+    while let Ok(event) = rx.try_recv() {
+        match event {
+            AppEvent::ConsolidateProposedPlan {
+                source,
+                scrollback_reflow,
+            } => {
+                saw_consolidate = true;
+                assert_eq!(source, completed_plan);
+                assert_eq!(
+                    scrollback_reflow,
+                    crate::app_event::ConsolidationScrollbackReflow::IfResizeReflowRan
+                );
+            }
+            AppEvent::InsertHistoryCell(cell) => {
+                saw_stream_plan |= cell.as_any().is::<history_cell::ProposedPlanStreamCell>();
+                saw_direct_plan_insert |= cell.as_any().is::<history_cell::ProposedPlanCell>();
+            }
+            _ => {}
+        }
+    }
+
+    assert!(saw_consolidate, "expected source-backed plan consolidation");
+    assert!(
+        saw_stream_plan,
+        "authoritative correction should finish the streamed plan when resize reflow is disabled",
+    );
+    assert!(
+        !saw_direct_plan_insert,
+        "held list should not duplicate the emitted prefix with a full plan insert",
+    );
+}
+
+#[tokio::test]
+async fn task_completion_inserts_live_plan_list_tail_when_resize_reflow_disabled() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    let cwd = chat.config.cwd.to_path_buf();
+    chat.set_feature_enabled(Feature::TerminalResizeReflow, /*enabled*/ false);
+
+    let mut controller = crate::streaming::controller::PlanStreamController::new(
+        Some(/*width*/ 80),
+        cwd.as_path(),
+        HistoryRenderMode::Rich,
+    );
+    controller.push("- First step\n");
+    controller.push("- Second step\n");
+    assert!(
+        controller.has_live_tail(),
+        "expected trailing list holdback to leave a live tail",
+    );
+    chat.plan_stream_controller = Some(controller);
+
+    while rx.try_recv().is_ok() {}
+
+    chat.on_task_complete(
+        /*last_agent_message*/ None, /*duration_ms*/ None, /*from_replay*/ false,
+    );
+
+    let mut saw_stream_plan = false;
     while let Ok(event) = rx.try_recv() {
         if let AppEvent::InsertHistoryCell(cell) = event {
-            if cell.as_any().is::<history_cell::ProposedPlanCell>() {
-                saw_source_backed_plan = true;
-                rendered_plan = lines_to_single_string(&cell.display_lines(/*width*/ 80));
-            }
             saw_stream_plan |= cell.as_any().is::<history_cell::ProposedPlanStreamCell>();
         }
     }
 
-    assert!(saw_source_backed_plan, "expected source-backed plan insert");
     assert!(
-        rendered_plan.contains('━'),
-        "expected completed plan table to render with separators, got: {rendered_plan:?}"
-    );
-    assert!(
-        !saw_stream_plan,
-        "live plan table tail should not be inserted provisionally"
+        saw_stream_plan,
+        "live plan list tail should insert history directly without resize reflow",
     );
 }
 

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -354,6 +354,60 @@ async fn flush_answer_stream_requests_scrollback_reflow_for_live_table_tail() {
 }
 
 #[tokio::test]
+async fn flush_answer_stream_inserts_live_list_tail_when_resize_reflow_disabled() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    let cwd = chat.config.cwd.to_path_buf();
+    chat.set_feature_enabled(Feature::TerminalResizeReflow, /*enabled*/ false);
+
+    let mut controller = crate::streaming::controller::StreamController::new(
+        Some(/*width*/ 80),
+        cwd.as_path(),
+        HistoryRenderMode::Rich,
+    );
+    controller.push("- first\n");
+    controller.push("- second\n");
+    assert!(
+        controller.has_live_tail(),
+        "expected trailing list holdback to leave a live tail for this regression",
+    );
+    chat.stream_controller = Some(controller);
+
+    while rx.try_recv().is_ok() {}
+
+    chat.flush_answer_stream_with_separator();
+
+    let mut saw_consolidate = false;
+    let mut saw_insert_history = false;
+    while let Ok(event) = rx.try_recv() {
+        match event {
+            AppEvent::InsertHistoryCell(_) => saw_insert_history = true,
+            AppEvent::ConsolidateAgentMessage {
+                scrollback_reflow,
+                deferred_history_cell,
+                ..
+            } => {
+                saw_consolidate = true;
+                assert_eq!(
+                    scrollback_reflow,
+                    crate::app_event::ConsolidationScrollbackReflow::IfResizeReflowRan
+                );
+                assert!(deferred_history_cell.is_none());
+            }
+            _ => {}
+        }
+    }
+
+    assert!(
+        saw_consolidate,
+        "expected stream finalization to consolidate"
+    );
+    assert!(
+        saw_insert_history,
+        "live list tail should insert history directly without resize reflow"
+    );
+}
+
+#[tokio::test]
 async fn completed_plan_table_tail_skips_provisional_history_insert() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
     let cwd = chat.config.cwd.to_path_buf();

--- a/codex-rs/tui/src/chatwidget/turn_runtime.rs
+++ b/codex-rs/tui/src/chatwidget/turn_runtime.rs
@@ -4,6 +4,7 @@
 //! and final-message separator handling.
 
 use super::*;
+use crate::app_event::ConsolidationScrollbackReflow;
 
 impl ChatWidget {
     /// Synchronize the bottom-pane "task running" indicator with the current lifecycles.
@@ -117,15 +118,25 @@ impl ChatWidget {
         // If a stream is currently active, finalize it.
         self.flush_answer_stream_with_separator();
         if let Some(mut controller) = self.plan_stream_controller.take() {
-            let had_live_tail = controller.has_live_tail();
+            let scrollback_reflow = if controller.requires_forced_reflow_on_finalize()
+                && self.config.features.enabled(Feature::TerminalResizeReflow)
+            {
+                ConsolidationScrollbackReflow::Required
+            } else {
+                ConsolidationScrollbackReflow::IfResizeReflowRan
+            };
+            let hold_live_tail_for_reflow =
+                scrollback_reflow == ConsolidationScrollbackReflow::Required;
             self.clear_active_stream_tail();
             let (cell, source) = controller.finalize();
-            if !had_live_tail && let Some(cell) = cell {
+            if !hold_live_tail_for_reflow && let Some(cell) = cell {
                 self.add_boxed_history(cell);
             }
             if let Some(source) = source {
-                self.app_event_tx
-                    .send(AppEvent::ConsolidateProposedPlan(source));
+                self.app_event_tx.send(AppEvent::ConsolidateProposedPlan {
+                    source,
+                    scrollback_reflow,
+                });
             }
         }
         self.flush_unified_exec_wait_streak();

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -376,7 +376,7 @@ where
     indent_stack: Vec<IndentContext>,
     list_indices: Vec<Option<u64>>,
     list_needs_blank_before_next_item: Vec<bool>,
-    list_item_start_line_counts: Vec<usize>,
+    list_item_has_multiline_content: Vec<bool>,
     link: Option<LinkState>,
     needs_newline: bool,
     pending_marker_line: bool,
@@ -410,7 +410,7 @@ where
             indent_stack: Vec::new(),
             list_indices: Vec::new(),
             list_needs_blank_before_next_item: Vec::new(),
-            list_item_start_line_counts: Vec::new(),
+            list_item_has_multiline_content: Vec::new(),
             link: None,
             needs_newline: false,
             pending_marker_line: false,
@@ -448,6 +448,7 @@ where
             Event::SoftBreak => self.soft_break(),
             Event::HardBreak => self.hard_break(),
             Event::Rule => {
+                self.mark_open_list_items_multiline();
                 self.flush_current_line();
                 if !self.text.is_empty() {
                     self.push_blank_line();
@@ -476,6 +477,7 @@ where
         }
 
         self.pending_local_link_soft_break = false;
+        self.mark_open_list_items_multiline();
         self.push_line(Line::default());
     }
 
@@ -520,9 +522,10 @@ where
             TagEnd::CodeBlock => self.end_codeblock(),
             TagEnd::List(_) => self.end_list(),
             TagEnd::Item => {
-                self.flush_current_line();
-                let start_line_count = self.list_item_start_line_counts.pop().unwrap_or_default();
-                if self.text.len().saturating_sub(start_line_count) > 1
+                if self
+                    .list_item_has_multiline_content
+                    .pop()
+                    .unwrap_or(/*default*/ false)
                     && let Some(needs_blank) = self.list_needs_blank_before_next_item.last_mut()
                 {
                     *needs_blank = true;
@@ -548,6 +551,7 @@ where
             return;
         }
         if self.needs_newline {
+            self.mark_open_list_items_multiline();
             self.push_blank_line();
         }
         self.push_line(Line::default());
@@ -568,6 +572,7 @@ where
         if self.in_table_cell() {
             return;
         }
+        self.mark_open_list_items_multiline();
         if self.needs_newline {
             self.push_line(Line::default());
             self.needs_newline = false;
@@ -598,6 +603,7 @@ where
         if self.in_table_cell() {
             return;
         }
+        self.mark_open_list_items_multiline();
         if self.needs_newline {
             self.push_blank_line();
             self.needs_newline = false;
@@ -707,6 +713,9 @@ where
             }
             return;
         }
+        if !inline || html.lines().count() > 1 {
+            self.mark_open_list_items_multiline();
+        }
         self.pending_marker_line = false;
         for (i, line) in html.lines().enumerate() {
             if self.needs_newline {
@@ -731,6 +740,7 @@ where
             self.push_table_cell_hard_break();
             return;
         }
+        self.mark_open_list_items_multiline();
         self.push_line(Line::default());
     }
 
@@ -749,10 +759,12 @@ where
             return;
         }
         self.line_ends_with_local_link_target = false;
+        self.mark_open_list_items_multiline();
         self.push_line(Line::default());
     }
 
     fn start_list(&mut self, index: Option<u64>) {
+        self.mark_open_list_items_multiline();
         if self.list_indices.is_empty() && self.needs_newline {
             self.push_line(Line::default());
         }
@@ -776,7 +788,7 @@ where
             self.push_blank_line();
         }
         self.flush_current_line();
-        self.list_item_start_line_counts.push(self.text.len());
+        self.list_item_has_multiline_content.push(/*value*/ false);
         self.pending_marker_line = true;
         let depth = self.list_indices.len();
         let is_ordered = self
@@ -817,6 +829,7 @@ where
     }
 
     fn start_codeblock(&mut self, lang: Option<String>, indent: Option<Span<'static>>) {
+        self.mark_open_list_items_multiline();
         self.flush_current_line();
         if !self.text.is_empty() {
             self.push_blank_line();
@@ -864,6 +877,7 @@ where
     }
 
     fn start_table(&mut self, alignments: Vec<Alignment>) {
+        self.mark_open_list_items_multiline();
         self.flush_current_line();
         if self.needs_newline {
             self.push_blank_line();
@@ -1947,6 +1961,12 @@ where
         } else {
             self.push_line(Line::default());
             self.flush_current_line();
+        }
+    }
+
+    fn mark_open_list_items_multiline(&mut self) {
+        for has_multiline_content in &mut self.list_item_has_multiline_content {
+            *has_multiline_content = true;
         }
     }
 

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -319,13 +319,177 @@ pub(crate) fn render_markdown_lines_with_width_and_cwd(
     width: Option<usize>,
     cwd: Option<&Path>,
 ) -> Vec<HyperlinkLine> {
+    let options = markdown_options();
+    let list_spacing = analyze_list_spacing(input, options);
+    let parser = Parser::new_ext(input, options).into_offset_iter();
+    let mut w = Writer::new(input, parser, list_spacing, width, cwd);
+    w.run();
+    w.text
+}
+
+fn markdown_options() -> Options {
     let mut options = Options::empty();
     options.insert(Options::ENABLE_STRIKETHROUGH);
     options.insert(Options::ENABLE_TABLES);
-    let parser = Parser::new_ext(input, options).into_offset_iter();
-    let mut w = Writer::new(input, parser, width, cwd);
-    w.run();
-    w.text
+    options
+}
+
+#[derive(Default)]
+struct ListSpacingAnalysis {
+    list_spacing: Vec<bool>,
+    active_lists: Vec<usize>,
+    open_items: Vec<OpenListItem>,
+    active_links: Vec<bool>,
+    line_ends_with_local_link_target: bool,
+    pending_local_link_soft_break: bool,
+}
+
+struct OpenListItem {
+    list_index: usize,
+    paragraph_count: usize,
+}
+
+impl ListSpacingAnalysis {
+    fn analyze<'a>(events: impl Iterator<Item = Event<'a>>) -> Vec<bool> {
+        let mut analysis = Self::default();
+        for event in events {
+            analysis.prepare_for_event(&event);
+            analysis.handle_event(event);
+        }
+        analysis.finish_pending_soft_break();
+        analysis.list_spacing
+    }
+
+    fn prepare_for_event(&mut self, event: &Event<'_>) {
+        if !self.pending_local_link_soft_break {
+            return;
+        }
+
+        self.pending_local_link_soft_break = false;
+        if !matches!(event, Event::Text(text) if text.trim_start().starts_with(':')) {
+            self.mark_open_list_items_multiline();
+        }
+    }
+
+    fn handle_event(&mut self, event: Event<'_>) {
+        match event {
+            Event::Start(Tag::List(_)) => {
+                self.mark_open_list_items_multiline();
+                self.active_lists.push(self.list_spacing.len());
+                self.list_spacing.push(/*value*/ false);
+            }
+            Event::Start(Tag::Item) => {
+                if let Some(&list_index) = self.active_lists.last() {
+                    self.open_items.push(OpenListItem {
+                        list_index,
+                        paragraph_count: 0,
+                    });
+                }
+            }
+            Event::Start(Tag::Paragraph) => {
+                if self
+                    .open_items
+                    .last()
+                    .is_some_and(|item| item.paragraph_count > 0)
+                {
+                    self.mark_open_list_items_multiline();
+                }
+                if let Some(item) = self.open_items.last_mut() {
+                    item.paragraph_count += 1;
+                }
+            }
+            Event::Start(Tag::Heading { .. })
+            | Event::Start(Tag::BlockQuote)
+            | Event::Start(Tag::CodeBlock(_))
+            | Event::Start(Tag::Table(_))
+            | Event::Rule
+            | Event::HardBreak => {
+                self.line_ends_with_local_link_target = false;
+                self.mark_open_list_items_multiline();
+            }
+            Event::Start(Tag::Link { dest_url, .. }) => {
+                self.active_links
+                    .push(is_local_path_like_link(dest_url.as_ref()));
+            }
+            Event::End(TagEnd::Link) => {
+                self.line_ends_with_local_link_target =
+                    self.active_links.pop().unwrap_or(/*default*/ false);
+            }
+            Event::End(TagEnd::Item) => {
+                self.open_items.pop();
+            }
+            Event::End(TagEnd::List(_)) => {
+                self.active_lists.pop();
+            }
+            Event::SoftBreak => {
+                if self.line_ends_with_local_link_target {
+                    self.pending_local_link_soft_break = true;
+                } else {
+                    self.mark_open_list_items_multiline();
+                }
+                self.line_ends_with_local_link_target = false;
+            }
+            Event::Html(_) => {
+                self.line_ends_with_local_link_target = false;
+                self.mark_open_list_items_multiline();
+            }
+            Event::InlineHtml(html) => {
+                self.line_ends_with_local_link_target = false;
+                if html.lines().count() > 1 {
+                    self.mark_open_list_items_multiline();
+                }
+            }
+            Event::Text(_) | Event::Code(_) => {
+                self.line_ends_with_local_link_target = false;
+            }
+            Event::Start(_)
+            | Event::End(_)
+            | Event::FootnoteReference(_)
+            | Event::TaskListMarker(_) => {}
+        }
+    }
+
+    fn finish_pending_soft_break(&mut self) {
+        if self.pending_local_link_soft_break {
+            self.mark_open_list_items_multiline();
+        }
+    }
+
+    fn mark_open_list_items_multiline(&mut self) {
+        for item in &self.open_items {
+            self.list_spacing[item.list_index] = true;
+        }
+    }
+}
+
+fn analyze_list_spacing(input: &str, options: Options) -> Vec<bool> {
+    ListSpacingAnalysis::analyze(Parser::new_ext(input, options))
+}
+
+pub(crate) fn trailing_list_holdback_start(input: &str) -> Option<usize> {
+    let mut list_starts = Vec::new();
+    let mut trailing_list_start = None;
+
+    for (event, range) in Parser::new_ext(input, markdown_options()).into_offset_iter() {
+        match event {
+            Event::Start(Tag::List(_)) => list_starts.push(range.start),
+            Event::End(TagEnd::List(_)) => {
+                if let Some(list_start) = list_starts.pop()
+                    && input[range.end..].trim().is_empty()
+                {
+                    trailing_list_start = Some(list_start);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    trailing_list_start
+}
+
+struct ActiveListSpacing {
+    spacious: bool,
+    started_item: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -375,8 +539,8 @@ where
     inline_styles: Vec<Style>,
     indent_stack: Vec<IndentContext>,
     list_indices: Vec<Option<u64>>,
-    list_needs_blank_before_next_item: Vec<bool>,
-    list_item_has_multiline_content: Vec<bool>,
+    list_spacing: std::vec::IntoIter<bool>,
+    active_list_spacing: Vec<ActiveListSpacing>,
     link: Option<LinkState>,
     needs_newline: bool,
     pending_marker_line: bool,
@@ -400,7 +564,13 @@ impl<'a, I> Writer<'a, I>
 where
     I: Iterator<Item = (Event<'a>, Range<usize>)>,
 {
-    fn new(input: &'a str, iter: I, wrap_width: Option<usize>, cwd: Option<&Path>) -> Self {
+    fn new(
+        input: &'a str,
+        iter: I,
+        list_spacing: Vec<bool>,
+        wrap_width: Option<usize>,
+        cwd: Option<&Path>,
+    ) -> Self {
         Self {
             input,
             iter,
@@ -409,8 +579,8 @@ where
             inline_styles: Vec::new(),
             indent_stack: Vec::new(),
             list_indices: Vec::new(),
-            list_needs_blank_before_next_item: Vec::new(),
-            list_item_has_multiline_content: Vec::new(),
+            list_spacing: list_spacing.into_iter(),
+            active_list_spacing: Vec::new(),
             link: None,
             needs_newline: false,
             pending_marker_line: false,
@@ -448,7 +618,6 @@ where
             Event::SoftBreak => self.soft_break(),
             Event::HardBreak => self.hard_break(),
             Event::Rule => {
-                self.mark_open_list_items_multiline();
                 self.flush_current_line();
                 if !self.text.is_empty() {
                     self.push_blank_line();
@@ -477,7 +646,6 @@ where
         }
 
         self.pending_local_link_soft_break = false;
-        self.mark_open_list_items_multiline();
         self.push_line(Line::default());
     }
 
@@ -522,14 +690,6 @@ where
             TagEnd::CodeBlock => self.end_codeblock(),
             TagEnd::List(_) => self.end_list(),
             TagEnd::Item => {
-                if self
-                    .list_item_has_multiline_content
-                    .pop()
-                    .unwrap_or(/*default*/ false)
-                    && let Some(needs_blank) = self.list_needs_blank_before_next_item.last_mut()
-                {
-                    *needs_blank = true;
-                }
                 self.indent_stack.pop();
                 self.pending_marker_line = false;
             }
@@ -551,7 +711,6 @@ where
             return;
         }
         if self.needs_newline {
-            self.mark_open_list_items_multiline();
             self.push_blank_line();
         }
         self.push_line(Line::default());
@@ -572,7 +731,6 @@ where
         if self.in_table_cell() {
             return;
         }
-        self.mark_open_list_items_multiline();
         if self.needs_newline {
             self.push_line(Line::default());
             self.needs_newline = false;
@@ -603,7 +761,6 @@ where
         if self.in_table_cell() {
             return;
         }
-        self.mark_open_list_items_multiline();
         if self.needs_newline {
             self.push_blank_line();
             self.needs_newline = false;
@@ -713,9 +870,6 @@ where
             }
             return;
         }
-        if !inline || html.lines().count() > 1 {
-            self.mark_open_list_items_multiline();
-        }
         self.pending_marker_line = false;
         for (i, line) in html.lines().enumerate() {
             if self.needs_newline {
@@ -740,7 +894,6 @@ where
             self.push_table_cell_hard_break();
             return;
         }
-        self.mark_open_list_items_multiline();
         self.push_line(Line::default());
     }
 
@@ -759,36 +912,40 @@ where
             return;
         }
         self.line_ends_with_local_link_target = false;
-        self.mark_open_list_items_multiline();
         self.push_line(Line::default());
     }
 
     fn start_list(&mut self, index: Option<u64>) {
-        self.mark_open_list_items_multiline();
         if self.list_indices.is_empty() && self.needs_newline {
             self.push_line(Line::default());
         }
         self.list_indices.push(index);
-        self.list_needs_blank_before_next_item.push(false);
+        self.active_list_spacing.push(ActiveListSpacing {
+            spacious: self.list_spacing.next().unwrap_or(/*default*/ false),
+            started_item: false,
+        });
     }
 
     fn end_list(&mut self) {
         self.list_indices.pop();
-        self.list_needs_blank_before_next_item.pop();
+        self.active_list_spacing.pop();
         self.needs_newline = true;
     }
 
     fn start_item(&mut self) {
-        if self
-            .list_needs_blank_before_next_item
+        let needs_blank = self
+            .active_list_spacing
             .last_mut()
-            .map(std::mem::take)
-            .unwrap_or(false)
-        {
+            .map(|spacing| {
+                let needs_blank = spacing.spacious && spacing.started_item;
+                spacing.started_item = true;
+                needs_blank
+            })
+            .unwrap_or(/*default*/ false);
+        if needs_blank {
             self.push_blank_line();
         }
         self.flush_current_line();
-        self.list_item_has_multiline_content.push(/*value*/ false);
         self.pending_marker_line = true;
         let depth = self.list_indices.len();
         let is_ordered = self
@@ -829,7 +986,6 @@ where
     }
 
     fn start_codeblock(&mut self, lang: Option<String>, indent: Option<Span<'static>>) {
-        self.mark_open_list_items_multiline();
         self.flush_current_line();
         if !self.text.is_empty() {
             self.push_blank_line();
@@ -877,7 +1033,6 @@ where
     }
 
     fn start_table(&mut self, alignments: Vec<Alignment>) {
-        self.mark_open_list_items_multiline();
         self.flush_current_line();
         if self.needs_newline {
             self.push_blank_line();
@@ -1964,12 +2119,6 @@ where
         }
     }
 
-    fn mark_open_list_items_multiline(&mut self) {
-        for has_multiline_content in &mut self.list_item_has_multiline_content {
-            *has_multiline_content = true;
-        }
-    }
-
     fn push_output_line(&mut self, line: HyperlinkLine) {
         self.text.push(line);
     }
@@ -2423,7 +2572,13 @@ mod tests {
         cell.hard_break();
         cell.push_span("second line".into());
 
-        let writer = W::new("", std::iter::empty(), Some(80), /*cwd*/ None);
+        let writer = W::new(
+            "",
+            std::iter::empty(),
+            Vec::new(),
+            Some(/*wrap_width*/ 80),
+            /*cwd*/ None,
+        );
         let wrapped = writer.wrap_cell(&cell, /*width*/ 40);
         let rendered = wrapped
             .iter()

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -568,11 +568,13 @@ fn loose_list_item_multiple_paragraphs() {
 
 #[test]
 fn tight_item_with_soft_break() {
-    let md = "- item line1\n  item line2\n";
+    let md = "- item line1\n  item line2\n- next item\n";
     let text = render_markdown_text(md);
     let expected = Text::from_iter([
         Line::from_iter(["- ", "item line1"]),
         Line::from_iter(["  ", "item line2"]),
+        Line::default(),
+        Line::from_iter(["- ", "next item"]),
     ]);
     assert_eq!(text, expected);
 }
@@ -1207,7 +1209,7 @@ fn multiline_finding_items_are_separated_snapshot() {
 }
 
 #[test]
-fn wrapped_list_item_is_separated_from_next_sibling() {
+fn wrapped_list_item_stays_compact_before_next_sibling() {
     let md = "1. This item wraps onto another visible rendered line\n2. Next item\n";
     let text = render_markdown_text_with_width(md, Some(/*width*/ 24));
     assert_eq!(
@@ -1216,10 +1218,10 @@ fn wrapped_list_item_is_separated_from_next_sibling() {
             "1. This item wraps onto",
             "   another visible",
             "   rendered line",
-            "",
             "2. Next item",
         ]
     );
+    assert_snapshot!(plain_lines(&text).join("\n"));
 }
 
 #[test]

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -580,6 +580,18 @@ fn tight_item_with_soft_break() {
 }
 
 #[test]
+fn spacious_outer_list_separates_all_siblings_snapshot() {
+    let md = r#"1. Parent item contains nested details:
+   - first nested detail
+   - second nested detail
+2. Next outer item should be visually separated.
+3. Final outer item stays compact.
+"#;
+    let text = render_markdown_text(md);
+    assert_snapshot!(plain_lines(&text).join("\n"));
+}
+
+#[test]
 fn deeply_nested_mixed_three_levels() {
     let md = "1. A\n    - B\n        1. C\n2. D\n";
     let text = render_markdown_text(md);
@@ -1320,6 +1332,7 @@ fn ordered_item_with_code_block_and_nested_bullet() {
         lines,
         vec![
             "1. item 1".to_string(),
+            String::new(),
             "2. item 2".to_string(),
             String::new(),
             "   code".to_string(),

--- a/codex-rs/tui/src/markdown_stream.rs
+++ b/codex-rs/tui/src/markdown_stream.rs
@@ -133,7 +133,20 @@ impl MarkdownStreamCollector {
         let source = self.buffer[..commit_end].to_string();
         let mut rendered: Vec<Line<'static>> = Vec::new();
         markdown::append_markdown(&source, self.width, Some(self.cwd.as_path()), &mut rendered);
-        let mut complete_line_count = rendered.len();
+        let mut complete_line_count = if let Some(list_start) =
+            crate::markdown_render::trailing_list_holdback_start(&source)
+        {
+            let mut stable_prefix = Vec::new();
+            markdown::append_markdown(
+                &source[..list_start],
+                self.width,
+                Some(self.cwd.as_path()),
+                &mut stable_prefix,
+            );
+            stable_prefix.len()
+        } else {
+            rendered.len()
+        };
         if complete_line_count > 0
             && crate::render::line_utils::is_blank_line_spaces_only(
                 &rendered[complete_line_count - 1],
@@ -785,7 +798,9 @@ mod tests {
             "Loose vs. tight list items:".to_string(),
             "".to_string(),
             "1. Tight item".to_string(),
+            "".to_string(),
             "2. Another tight item".to_string(),
+            "".to_string(),
             "3. Loose item with its own paragraph.".to_string(),
             "".to_string(),
             "   This paragraph belongs to the same list item.".to_string(),

--- a/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__markdown_render_complex_snapshot.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__markdown_render_complex_snapshot.snap
@@ -20,6 +20,7 @@ Image: alt text
 - Unordered list item 2 with strikethrough
 
 1. Ordered item one
+
 2. Ordered item two with sublist:
     1. Alt-numbered subitem
 

--- a/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__spacious_outer_list_separates_all_siblings_snapshot.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__spacious_outer_list_separates_all_siblings_snapshot.snap
@@ -1,0 +1,11 @@
+---
+source: tui/src/markdown_render_tests.rs
+expression: "plain_lines(&text).join(\"\\n\")"
+---
+1. Parent item contains nested details:
+    - first nested detail
+    - second nested detail
+
+2. Next outer item should be visually separated.
+
+3. Final outer item stays compact.

--- a/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__wrapped_list_item_stays_compact_before_next_sibling.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__wrapped_list_item_stays_compact_before_next_sibling.snap
@@ -1,0 +1,8 @@
+---
+source: tui/src/markdown_render_tests.rs
+expression: "plain_lines(&text).join(\"\\n\")"
+---
+1. This item wraps onto
+   another visible
+   rendered line
+2. Next item

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -376,26 +376,36 @@ impl StreamCore {
     /// table region is held as tail because adding a row can reshape table
     /// column widths. For `PendingHeader`, only content from the speculative
     /// header line onward is kept mutable so earlier prose can continue
-    /// streaming. When no table is detected, everything flows directly to
-    /// stable. This is the core decision point for the holdback mechanism.
+    /// streaming. A trailing list is also held because a later multiline item
+    /// can make all of its siblings spacious. This is the core decision point
+    /// for the holdback mechanism.
     fn active_tail_budget_lines(&mut self) -> usize {
         if self.render_mode == HistoryRenderMode::Raw {
             return 0;
         }
         let scan_start = Instant::now();
         let holdback_state = self.holdback_scanner.state();
-        let tail_budget = match holdback_state {
+        let table_holdback_start = match holdback_state {
             TableHoldbackState::Confirmed { table_start: start }
             | TableHoldbackState::PendingHeader {
                 header_start: start,
-            } => self.tail_budget_from_source_start(start),
-            TableHoldbackState::None => 0,
+            } => Some(start),
+            TableHoldbackState::None => None,
         };
+        let list_holdback_start =
+            crate::markdown_render::trailing_list_holdback_start(&self.raw_source);
+        let tail_budget = table_holdback_start
+            .into_iter()
+            .chain(list_holdback_start)
+            .min()
+            .map(|start| self.tail_budget_from_source_start(start))
+            .unwrap_or(/*default*/ 0);
         tracing::trace!(
             state = ?holdback_state,
+            list_holdback_start,
             tail_budget,
             elapsed_us = scan_start.elapsed().as_micros(),
-            "table holdback decision",
+            "markdown holdback decision",
         );
         tail_budget
     }
@@ -1189,7 +1199,9 @@ mod tests {
             "Loose vs. tight list items:".to_string(),
             "".to_string(),
             "1. Tight item".to_string(),
+            "".to_string(),
             "2. Another tight item".to_string(),
+            "".to_string(),
             "3. Loose item with its own paragraph.".to_string(),
             "".to_string(),
             "   This paragraph belongs to the same list item.".to_string(),

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -221,6 +221,10 @@ impl StreamCore {
         self.enqueued_stable_len < self.rendered_lines.len()
     }
 
+    fn requires_forced_reflow_on_finalize(&self) -> bool {
+        self.has_tail() && !matches!(self.holdback_scanner.state(), TableHoldbackState::None)
+    }
+
     /// Update rendering width and rebuild queued stable lines for the new layout.
     ///
     /// Re-renders once at the new width and rebuilds queue state from the
@@ -542,9 +546,15 @@ impl StreamController {
         !self.header_emitted && self.core.enqueued_stable_len == 0
     }
 
+    #[cfg(test)]
     #[inline]
     pub(crate) fn has_live_tail(&self) -> bool {
         self.core.has_tail()
+    }
+
+    #[inline]
+    pub(crate) fn requires_forced_reflow_on_finalize(&self) -> bool {
+        self.core.requires_forced_reflow_on_finalize()
     }
 
     pub(crate) fn clear_queue(&mut self) {
@@ -645,9 +655,15 @@ impl PlanStreamController {
         self.core.queued_lines()
     }
 
+    #[cfg(test)]
     #[inline]
     pub(crate) fn has_live_tail(&self) -> bool {
         self.core.has_tail()
+    }
+
+    #[inline]
+    pub(crate) fn requires_forced_reflow_on_finalize(&self) -> bool {
+        self.core.requires_forced_reflow_on_finalize()
     }
 
     #[inline]


### PR DESCRIPTION
## Why

Markdown list items that contain authored multiline structure are hard to scan when the next sibling starts immediately after the final nested or continuation line. Width-only wrapping should remain compact, but nested blocks, explicit line breaks, and multiple paragraphs need visual separation.

[PR #24351](https://github.com/openai/codex/pull/24351) introduced the initial general-purpose list-spacing heuristic. After rendering each list item, it counted the item's rendered output lines and inserted a blank separator before the next sibling when that count was greater than one.

That improved findings-style lists with explanatory paragraphs, but rendered line count is not the right signal:

- A structurally compact item can occupy multiple rendered rows only because the terminal is narrow. The old heuristic added spacing for that viewport-dependent wrapping.
- Spacing was decided after each item independently. A list could remain compact before a multiline item but gain a separator after it, producing inconsistent sibling spacing.

This follow-up bases spacing on authored Markdown structure instead. If any item in a list needs separation, all of that list's siblings use the spacious layout.

## What Changed

- Detect authored multiline content structurally before rendering list items.
- Space every sibling in a list when any item needs separation, while leaving nested lists independent.
- Keep naturally wrapped single-paragraph items compact.
- Preserve the local-file-link `: ...` soft-break exception.
- Hold trailing lists as mutable streaming tails so later multiline siblings cannot invalidate already-emitted spacing.
- Add snapshot and streaming regression coverage.

## How to Test

1. Start Codex and ask it to reply with a compact numbered list. Confirm the siblings remain adjacent.
2. Ask it to reply with a numbered list where one item contains nested bullets. Confirm each outer sibling is separated by one blank line and the nested bullets remain compact.
3. Resize the terminal so a compact list item wraps naturally. Confirm wrapping alone does not add spacing between siblings.

Targeted tests:

- `just test -p codex-tui markdown_render`
- `just test -p codex-tui loose_vs_tight`
