### PR TITLE
fix(tui): render token activity inline without clearing [bundled into #25345]

### DIFF
--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -215,6 +215,7 @@ impl App {
                     scrollback_reflow,
                     deferred_history_cell,
                 )?;
+                self.chat_widget.note_stream_consolidation_completed();
                 self.insert_completed_token_activity_output_after_stream_shutdown(tui);
             }
             AppEvent::ConsolidateProposedPlan(source) => {
@@ -222,6 +223,7 @@ impl App {
                     if !self.transcript_reflow.history_cell_refresh_requested() {
                         self.transcript_reflow.clear();
                     }
+                    self.chat_widget.note_stream_consolidation_completed();
                     self.insert_completed_token_activity_output_after_stream_shutdown(tui);
                     return Ok(AppRunControl::Continue);
                 }
@@ -257,6 +259,7 @@ impl App {
 
                     self.maybe_finish_stream_reflow(tui)?;
                 }
+                self.chat_widget.note_stream_consolidation_completed();
                 self.insert_completed_token_activity_output_after_stream_shutdown(tui);
             }
             AppEvent::ApplyThreadRollback { num_turns } => {

--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -215,12 +215,14 @@ impl App {
                     scrollback_reflow,
                     deferred_history_cell,
                 )?;
+                self.insert_completed_token_activity_output_if_ready(tui);
             }
             AppEvent::ConsolidateProposedPlan(source) => {
                 if !self.terminal_resize_reflow_enabled() {
                     if !self.transcript_reflow.history_cell_refresh_requested() {
                         self.transcript_reflow.clear();
                     }
+                    self.insert_completed_token_activity_output(tui);
                     return Ok(AppRunControl::Continue);
                 }
                 let end = self.transcript_cells.len();
@@ -255,6 +257,7 @@ impl App {
 
                     self.maybe_finish_stream_reflow(tui)?;
                 }
+                self.insert_completed_token_activity_output_if_ready(tui);
             }
             AppEvent::ApplyThreadRollback { num_turns } => {
                 if self.apply_non_pending_thread_rollback(num_turns) {
@@ -728,14 +731,16 @@ impl App {
                 if let Err(err) = &result {
                     tracing::warn!("account/tokenUsage/read failed during TUI refresh: {err}");
                 }
-                if let Some(cell) = self
+                if self
                     .chat_widget
                     .finish_token_activity_refresh(request_id, result)
                 {
                     // Commit synchronously so an already queued /clear cannot overtake this card.
                     // Do not route through ChatWidget::add_to_history: /tokens may complete during
                     // active work, and flushing an in-progress tool cell would corrupt its lifecycle.
-                    self.insert_history_cell(tui, Box::new(cell));
+                    // If an answer stream is active, keep the settled card transient until its
+                    // provisional transcript cells have been consolidated.
+                    self.insert_completed_token_activity_output_if_ready(tui);
                 }
             }
             AppEvent::ConnectorsLoaded { result, is_final } => {

--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -215,14 +215,14 @@ impl App {
                     scrollback_reflow,
                     deferred_history_cell,
                 )?;
-                self.insert_completed_token_activity_output_if_ready(tui);
+                self.insert_completed_token_activity_output_after_stream_shutdown(tui);
             }
             AppEvent::ConsolidateProposedPlan(source) => {
                 if !self.terminal_resize_reflow_enabled() {
                     if !self.transcript_reflow.history_cell_refresh_requested() {
                         self.transcript_reflow.clear();
                     }
-                    self.insert_completed_token_activity_output(tui);
+                    self.insert_completed_token_activity_output_after_stream_shutdown(tui);
                     return Ok(AppRunControl::Continue);
                 }
                 let end = self.transcript_cells.len();
@@ -257,7 +257,7 @@ impl App {
 
                     self.maybe_finish_stream_reflow(tui)?;
                 }
-                self.insert_completed_token_activity_output_if_ready(tui);
+                self.insert_completed_token_activity_output_after_stream_shutdown(tui);
             }
             AppEvent::ApplyThreadRollback { num_turns } => {
                 if self.apply_non_pending_thread_rollback(num_turns) {
@@ -742,6 +742,9 @@ impl App {
                     // provisional transcript cells have been consolidated.
                     self.insert_completed_token_activity_output_if_ready(tui);
                 }
+            }
+            AppEvent::CommitCompletedTokenActivityOutput => {
+                self.insert_completed_token_activity_output_after_stream_shutdown(tui);
             }
             AppEvent::ConnectorsLoaded { result, is_final } => {
                 self.chat_widget.on_connectors_loaded(result, is_final);

--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -732,6 +732,9 @@ impl App {
                     .chat_widget
                     .finish_token_activity_refresh(request_id, result)
                 {
+                    // Commit synchronously so an already queued /clear cannot overtake this card.
+                    // Do not route through ChatWidget::add_to_history: /tokens may complete during
+                    // active work, and flushing an in-progress tool cell would corrupt its lifecycle.
                     self.insert_history_cell(tui, Box::new(cell));
                 }
             }

--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -197,27 +197,7 @@ impl App {
                 self.begin_thread_switch_history_replay_buffer();
             }
             AppEvent::InsertHistoryCell(cell) => {
-                let cell: Arc<dyn HistoryCell> = cell.into();
-                if let Some(Overlay::Transcript(t)) = &mut self.overlay {
-                    t.insert_cell(cell.clone());
-                    tui.frame_requester().schedule_frame();
-                }
-                self.transcript_cells.push(cell.clone());
-                if self.initial_history_replay_buffer.as_ref().is_some() {
-                    self.insert_history_cell_lines_with_initial_replay_buffer(
-                        tui,
-                        cell.as_ref(),
-                        self.chat_widget
-                            .history_wrap_width(tui.terminal.last_known_screen_size.width),
-                    );
-                } else {
-                    self.insert_history_cell_lines(
-                        tui,
-                        cell.as_ref(),
-                        self.chat_widget
-                            .history_wrap_width(tui.terminal.last_known_screen_size.width),
-                    );
-                }
+                self.insert_history_cell(tui, cell);
             }
             AppEvent::EndInitialHistoryReplayBuffer => {
                 self.finish_initial_history_replay_buffer(tui);
@@ -748,8 +728,12 @@ impl App {
                 if let Err(err) = &result {
                     tracing::warn!("account/tokenUsage/read failed during TUI refresh: {err}");
                 }
-                self.chat_widget
-                    .finish_token_activity_refresh(request_id, result);
+                if let Some(cell) = self
+                    .chat_widget
+                    .finish_token_activity_refresh(request_id, result)
+                {
+                    self.insert_history_cell(tui, Box::new(cell));
+                }
             }
             AppEvent::ConnectorsLoaded { result, is_final } => {
                 self.chat_widget.on_connectors_loaded(result, is_final);

--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -748,12 +748,8 @@ impl App {
                 if let Err(err) = &result {
                     tracing::warn!("account/tokenUsage/read failed during TUI refresh: {err}");
                 }
-                if self
-                    .chat_widget
-                    .finish_token_activity_refresh(request_id, result)
-                {
-                    self.refresh_updated_history_cell(tui)?;
-                }
+                self.chat_widget
+                    .finish_token_activity_refresh(request_id, result);
             }
             AppEvent::ConnectorsLoaded { result, is_final } => {
                 self.chat_widget.on_connectors_loaded(result, is_final);

--- a/codex-rs/tui/src/app/history_ui.rs
+++ b/codex-rs/tui/src/app/history_ui.rs
@@ -48,6 +48,16 @@ impl App {
         }
     }
 
+    pub(super) fn insert_completed_token_activity_output_after_stream_shutdown(
+        &mut self,
+        tui: &mut tui::Tui,
+    ) {
+        if self.chat_widget.token_activity_history_insertion_blocked() {
+            return;
+        }
+        self.insert_completed_token_activity_output(tui);
+    }
+
     pub(super) fn open_url_in_browser(&mut self, url: String) {
         if let Err(err) = webbrowser::open(&url) {
             self.chat_widget

--- a/codex-rs/tui/src/app/history_ui.rs
+++ b/codex-rs/tui/src/app/history_ui.rs
@@ -30,6 +30,24 @@ impl App {
         }
     }
 
+    pub(super) fn insert_completed_token_activity_output_if_ready(&mut self, tui: &mut tui::Tui) {
+        if self.chat_widget.token_activity_history_insertion_blocked()
+            || self.transcript_cells.last().is_some_and(|cell| {
+                cell.as_any().is::<history_cell::AgentMessageCell>()
+                    || cell.as_any().is::<history_cell::ProposedPlanStreamCell>()
+            })
+        {
+            return;
+        }
+        self.insert_completed_token_activity_output(tui);
+    }
+
+    pub(super) fn insert_completed_token_activity_output(&mut self, tui: &mut tui::Tui) {
+        if let Some(cell) = self.chat_widget.take_completed_token_activity_output() {
+            self.insert_history_cell(tui, Box::new(cell));
+        }
+    }
+
     pub(super) fn open_url_in_browser(&mut self, url: String) {
         if let Err(err) = webbrowser::open(&url) {
             self.chat_widget

--- a/codex-rs/tui/src/app/history_ui.rs
+++ b/codex-rs/tui/src/app/history_ui.rs
@@ -28,6 +28,10 @@ impl App {
                     .history_wrap_width(tui.terminal.last_known_screen_size.width),
             );
         }
+        // A committed cell can unblock a settled /tokens card that was waiting
+        // behind a transient active cell or a provisional stream tail.
+        self.chat_widget
+            .request_completed_token_activity_output_insertion();
     }
 
     pub(super) fn insert_completed_token_activity_output_if_ready(&mut self, tui: &mut tui::Tui) {

--- a/codex-rs/tui/src/app/history_ui.rs
+++ b/codex-rs/tui/src/app/history_ui.rs
@@ -6,6 +6,30 @@
 use super::*;
 
 impl App {
+    pub(super) fn insert_history_cell(&mut self, tui: &mut tui::Tui, cell: Box<dyn HistoryCell>) {
+        let cell: Arc<dyn HistoryCell> = cell.into();
+        if let Some(Overlay::Transcript(t)) = &mut self.overlay {
+            t.insert_cell(cell.clone());
+            tui.frame_requester().schedule_frame();
+        }
+        self.transcript_cells.push(cell.clone());
+        if self.initial_history_replay_buffer.as_ref().is_some() {
+            self.insert_history_cell_lines_with_initial_replay_buffer(
+                tui,
+                cell.as_ref(),
+                self.chat_widget
+                    .history_wrap_width(tui.terminal.last_known_screen_size.width),
+            );
+        } else {
+            self.insert_history_cell_lines(
+                tui,
+                cell.as_ref(),
+                self.chat_widget
+                    .history_wrap_width(tui.terminal.last_known_screen_size.width),
+            );
+        }
+    }
+
     pub(super) fn open_url_in_browser(&mut self, url: String) {
         if let Err(err) = webbrowser::open(&url) {
             self.chat_widget

--- a/codex-rs/tui/src/app/resize_reflow.rs
+++ b/codex-rs/tui/src/app/resize_reflow.rs
@@ -294,15 +294,6 @@ impl App {
         tui.frame_requester().schedule_frame();
     }
 
-    /// Rebuild history after an existing cell's render output changes.
-    ///
-    /// Use the resize-reflow lifecycle so overlays defer the replay and active streams receive the
-    /// same post-consolidation repair as resize-triggered rebuilds.
-    pub(super) fn refresh_updated_history_cell(&mut self, tui: &mut tui::Tui) -> Result<()> {
-        self.schedule_immediate_history_cell_refresh(tui);
-        self.maybe_run_resize_reflow(tui)
-    }
-
     fn schedule_immediate_history_cell_refresh(&mut self, tui: &mut tui::Tui) {
         self.transcript_reflow.schedule_history_cell_refresh();
         tui.frame_requester().schedule_frame();

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -304,6 +304,9 @@ pub(crate) enum AppEvent {
         result: Result<GetAccountTokenUsageResponse, String>,
     },
 
+    /// Commit a settled token activity card after a stream shutdown barrier.
+    CommitCompletedTokenActivityOutput,
+
     /// Send a user-confirmed request to notify the workspace owner.
     SendAddCreditsNudgeEmail {
         credit_type: AddCreditsNudgeCreditType,

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -551,6 +551,7 @@ pub(crate) struct ChatWidget {
     refreshing_status_outputs: Vec<(u64, StatusHistoryHandle)>,
     next_status_refresh_request_id: u64,
     refreshing_token_activity_output: Option<tokens::PendingTokenActivityOutput>,
+    completed_token_activity_output: Option<history_cell::CompositeHistoryCell>,
     next_token_activity_request_id: u64,
     plan_type: Option<PlanType>,
     codex_rate_limit_reached_type: Option<RateLimitReachedType>,

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -550,7 +550,7 @@ pub(crate) struct ChatWidget {
     rate_limit_snapshots_by_limit_id: BTreeMap<String, RateLimitSnapshotDisplay>,
     refreshing_status_outputs: Vec<(u64, StatusHistoryHandle)>,
     next_status_refresh_request_id: u64,
-    refreshing_token_activity_outputs: Vec<tokens::PendingTokenActivityOutput>,
+    refreshing_token_activity_output: Option<tokens::PendingTokenActivityOutput>,
     next_token_activity_request_id: u64,
     plan_type: Option<PlanType>,
     codex_rate_limit_reached_type: Option<RateLimitReachedType>,

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -550,7 +550,7 @@ pub(crate) struct ChatWidget {
     rate_limit_snapshots_by_limit_id: BTreeMap<String, RateLimitSnapshotDisplay>,
     refreshing_status_outputs: Vec<(u64, StatusHistoryHandle)>,
     next_status_refresh_request_id: u64,
-    refreshing_token_activity_outputs: Vec<(u64, tokens::TokenActivityHandle)>,
+    refreshing_token_activity_outputs: Vec<tokens::PendingTokenActivityOutput>,
     next_token_activity_request_id: u64,
     plan_type: Option<PlanType>,
     codex_rate_limit_reached_type: Option<RateLimitReachedType>,

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -564,6 +564,7 @@ pub(crate) struct ChatWidget {
     stream_controller: Option<StreamController>,
     // Stream lifecycle controller for proposed plan output.
     plan_stream_controller: Option<PlanStreamController>,
+    pending_stream_consolidations: usize,
     /// Holds the platform clipboard lease so copied text remains available while supported.
     clipboard_lease: Option<crate::clipboard_copy::ClipboardLease>,
     copy_last_response_binding: Vec<KeyBinding>,

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1177,6 +1177,7 @@ impl ChatWidget {
         if let Some(active) = self.transcript.active_cell.take() {
             self.transcript.needs_final_message_separator = true;
             self.app_event_tx.send(AppEvent::InsertHistoryCell(active));
+            self.request_completed_token_activity_output_insertion();
         }
     }
 
@@ -1388,6 +1389,7 @@ impl ChatWidget {
                 tool.mark_failed();
             }
             self.add_boxed_history(cell);
+            self.request_completed_token_activity_output_insertion();
         }
     }
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1871,12 +1871,12 @@ impl ChatWidget {
         self.current_rollout_path.clone()
     }
 
-    /// Returns a cache key describing the current in-flight active cell for the transcript overlay.
+    /// Returns a cache key describing the current in-flight cells for the transcript overlay.
     ///
     /// `Ctrl+T` renders committed transcript cells plus a render-only live tail derived from the
-    /// current active cell, and the overlay caches that tail; this key is what it uses to decide
-    /// whether it must recompute. When there is no active cell, this returns `None` so the overlay
-    /// can drop the tail entirely.
+    /// current active, hook, and token activity cells, and the overlay caches that tail; this key is
+    /// what it uses to decide whether it must recompute. When there are no live cells, this returns
+    /// `None` so the overlay can drop the tail entirely.
     ///
     /// If callers mutate the active cell's transcript output without bumping the revision (or
     /// providing an appropriate animation tick), the overlay will keep showing a stale tail while
@@ -1884,7 +1884,8 @@ impl ChatWidget {
     pub(crate) fn active_cell_transcript_key(&self) -> Option<ActiveCellTranscriptKey> {
         let cell = self.transcript.active_cell.as_ref();
         let hook_cell = self.active_hook_cell.as_ref();
-        if cell.is_none() && hook_cell.is_none() {
+        let token_activity_cell = self.pending_token_activity_output();
+        if cell.is_none() && hook_cell.is_none() && token_activity_cell.is_none() {
             return None;
         }
         Some(ActiveCellTranscriptKey {
@@ -1921,6 +1922,13 @@ impl ChatWidget {
                 lines.push(HyperlinkLine::from(""));
             }
             lines.extend(hook_lines);
+        }
+        if let Some(token_activity_cell) = self.pending_token_activity_output() {
+            let token_activity_lines = token_activity_cell.transcript_hyperlink_lines(width);
+            if !token_activity_lines.is_empty() && !lines.is_empty() {
+                lines.push(HyperlinkLine::from(""));
+            }
+            lines.extend(token_activity_lines);
         }
         (!lines.is_empty()).then_some(lines)
     }

--- a/codex-rs/tui/src/chatwidget/constructor.rs
+++ b/codex-rs/tui/src/chatwidget/constructor.rs
@@ -136,6 +136,7 @@ impl ChatWidget {
             adaptive_chunking: AdaptiveChunkingPolicy::default(),
             stream_controller: None,
             plan_stream_controller: None,
+            pending_stream_consolidations: 0,
             clipboard_lease: None,
             copy_last_response_binding,
             running_commands: HashMap::new(),

--- a/codex-rs/tui/src/chatwidget/constructor.rs
+++ b/codex-rs/tui/src/chatwidget/constructor.rs
@@ -125,6 +125,7 @@ impl ChatWidget {
             refreshing_status_outputs: Vec::new(),
             next_status_refresh_request_id: 0,
             refreshing_token_activity_output: None,
+            completed_token_activity_output: None,
             next_token_activity_request_id: 0,
             plan_type: initial_plan_type,
             codex_rate_limit_reached_type: None,

--- a/codex-rs/tui/src/chatwidget/constructor.rs
+++ b/codex-rs/tui/src/chatwidget/constructor.rs
@@ -124,7 +124,7 @@ impl ChatWidget {
             rate_limit_snapshots_by_limit_id: BTreeMap::new(),
             refreshing_status_outputs: Vec::new(),
             next_status_refresh_request_id: 0,
-            refreshing_token_activity_outputs: Vec::new(),
+            refreshing_token_activity_output: None,
             next_token_activity_request_id: 0,
             plan_type: initial_plan_type,
             codex_rate_limit_reached_type: None,

--- a/codex-rs/tui/src/chatwidget/rendering.rs
+++ b/codex-rs/tui/src/chatwidget/rendering.rs
@@ -28,7 +28,7 @@ impl ChatWidget {
         flex.push(/*flex*/ 0, active_hook_cell_renderable);
         if let Some(cell) = self.pending_token_activity_output() {
             flex.push(
-                /*flex*/ 0,
+                /*flex*/ 1,
                 RenderableItem::Owned(Box::new(TranscriptAreaRenderable {
                     child: cell,
                     top: 1,

--- a/codex-rs/tui/src/chatwidget/rendering.rs
+++ b/codex-rs/tui/src/chatwidget/rendering.rs
@@ -26,7 +26,7 @@ impl ChatWidget {
         let mut flex = FlexRenderable::new();
         flex.push(/*flex*/ 1, active_cell_renderable);
         flex.push(/*flex*/ 0, active_hook_cell_renderable);
-        for cell in self.pending_token_activity_outputs() {
+        if let Some(cell) = self.pending_token_activity_output() {
             flex.push(
                 /*flex*/ 0,
                 RenderableItem::Owned(Box::new(TranscriptAreaRenderable {

--- a/codex-rs/tui/src/chatwidget/rendering.rs
+++ b/codex-rs/tui/src/chatwidget/rendering.rs
@@ -23,11 +23,11 @@ impl ChatWidget {
             }
             _ => RenderableItem::Owned(Box::new(())),
         };
-        let mut content = FlexRenderable::new();
-        content.push(/*flex*/ 0, active_cell_renderable);
-        content.push(/*flex*/ 0, active_hook_cell_renderable);
+        let mut flex = FlexRenderable::new();
+        flex.push(/*flex*/ 1, active_cell_renderable);
+        flex.push(/*flex*/ 0, active_hook_cell_renderable);
         if let Some(cell) = self.pending_token_activity_output() {
-            content.push(
+            flex.push(
                 /*flex*/ 1,
                 RenderableItem::Owned(Box::new(TranscriptAreaRenderable {
                     child: cell,
@@ -36,8 +36,6 @@ impl ChatWidget {
                 })),
             );
         }
-        let mut flex = FlexRenderable::new();
-        flex.push(/*flex*/ 1, RenderableItem::Owned(Box::new(content)));
         flex.push(
             /*flex*/ 0,
             RenderableItem::Owned(Box::new(BottomPaneComposerReserveRenderable {

--- a/codex-rs/tui/src/chatwidget/rendering.rs
+++ b/codex-rs/tui/src/chatwidget/rendering.rs
@@ -26,6 +26,16 @@ impl ChatWidget {
         let mut flex = FlexRenderable::new();
         flex.push(/*flex*/ 1, active_cell_renderable);
         flex.push(/*flex*/ 0, active_hook_cell_renderable);
+        for cell in self.pending_token_activity_outputs() {
+            flex.push(
+                /*flex*/ 0,
+                RenderableItem::Owned(Box::new(TranscriptAreaRenderable {
+                    child: cell,
+                    top: 1,
+                    right: active_cell_right_reserve,
+                })),
+            );
+        }
         flex.push(
             /*flex*/ 0,
             RenderableItem::Owned(Box::new(BottomPaneComposerReserveRenderable {

--- a/codex-rs/tui/src/chatwidget/rendering.rs
+++ b/codex-rs/tui/src/chatwidget/rendering.rs
@@ -23,11 +23,11 @@ impl ChatWidget {
             }
             _ => RenderableItem::Owned(Box::new(())),
         };
-        let mut flex = FlexRenderable::new();
-        flex.push(/*flex*/ 1, active_cell_renderable);
-        flex.push(/*flex*/ 0, active_hook_cell_renderable);
+        let mut content = FlexRenderable::new();
+        content.push(/*flex*/ 0, active_cell_renderable);
+        content.push(/*flex*/ 0, active_hook_cell_renderable);
         if let Some(cell) = self.pending_token_activity_output() {
-            flex.push(
+            content.push(
                 /*flex*/ 1,
                 RenderableItem::Owned(Box::new(TranscriptAreaRenderable {
                     child: cell,
@@ -36,6 +36,8 @@ impl ChatWidget {
                 })),
             );
         }
+        let mut flex = FlexRenderable::new();
+        flex.push(/*flex*/ 1, RenderableItem::Owned(Box::new(content)));
         flex.push(
             /*flex*/ 0,
             RenderableItem::Owned(Box::new(BottomPaneComposerReserveRenderable {

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__pending_token_activity_refresh_renders_above_composer_snapshot.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__pending_token_activity_refresh_renders_above_composer_snapshot.snap
@@ -1,0 +1,14 @@
+---
+source: tui/src/chatwidget/tests/slash_commands.rs
+expression: normalize_snapshot_paths(term.backend().vt100().screen().contents())
+---
+
+/tokens daily
+
+ Token activity
+   Loading...
+
+
+› Ask Codex to do anything
+
+  gpt-5.5 default · /tmp/project

--- a/codex-rs/tui/src/chatwidget/streaming.rs
+++ b/codex-rs/tui/src/chatwidget/streaming.rs
@@ -51,6 +51,9 @@ impl ChatWidget {
         if had_stream_controller && self.stream_controllers_idle() {
             self.app_event_tx.send(AppEvent::StopCommitAnimation);
         }
+        if had_stream_controller {
+            self.request_completed_token_activity_output_insertion();
+        }
     }
 
     pub(super) fn stream_controllers_idle(&self) -> bool {

--- a/codex-rs/tui/src/chatwidget/streaming.rs
+++ b/codex-rs/tui/src/chatwidget/streaming.rs
@@ -186,6 +186,7 @@ impl ChatWidget {
         if should_restore_after_stream {
             self.status_state.pending_status_indicator_restore = true;
             self.maybe_restore_status_indicator_after_stream_idle();
+            self.request_completed_token_activity_output_insertion();
         }
     }
 

--- a/codex-rs/tui/src/chatwidget/streaming.rs
+++ b/codex-rs/tui/src/chatwidget/streaming.rs
@@ -39,6 +39,7 @@ impl ChatWidget {
             // that can re-render from source on resize.
             if let Some(source) = source {
                 let source = parse_assistant_markdown(&source).visible_markdown;
+                self.note_stream_consolidation_queued();
                 self.app_event_tx.send(AppEvent::ConsolidateAgentMessage {
                     source,
                     cwd: self.config.cwd.to_path_buf(),
@@ -174,12 +175,14 @@ impl ChatWidget {
             // TODO: Replace streamed output with the final plan item text if plan streaming is
             // removed or if we need to reconcile mismatches between streamed and final content.
             if let Some(source) = consolidated_plan_source {
+                self.note_stream_consolidation_queued();
                 self.app_event_tx
                     .send(AppEvent::ConsolidateProposedPlan(source));
             }
         } else if !plan_text.is_empty() {
             self.add_to_history(history_cell::new_proposed_plan(plan_text, &self.config.cwd));
         } else if let Some(source) = consolidated_plan_source {
+            self.note_stream_consolidation_queued();
             self.app_event_tx
                 .send(AppEvent::ConsolidateProposedPlan(source));
         }

--- a/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
+++ b/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
@@ -1299,6 +1299,33 @@ async fn completed_token_activity_refresh_waits_for_active_stream() {
 }
 
 #[tokio::test]
+async fn completed_token_activity_refresh_waits_for_queued_stream_consolidation() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    set_chatgpt_auth(&mut chat);
+
+    chat.dispatch_command(SlashCommand::Tokens);
+    let request_id = match rx.try_recv() {
+        Ok(AppEvent::RefreshTokenActivity { request_id }) => request_id,
+        other => panic!("expected token activity refresh request, got {other:?}"),
+    };
+    chat.on_agent_message_delta("partial response".to_string());
+    chat.finalize_completed_assistant_message(/*message*/ None);
+    assert!(chat.pending_stream_consolidations > 0);
+
+    assert!(
+        chat.finish_token_activity_refresh(
+            request_id,
+            Err("token activity unavailable".to_string()),
+        )
+    );
+    assert!(chat.token_activity_history_insertion_blocked());
+
+    chat.note_stream_consolidation_completed();
+
+    assert!(!chat.token_activity_history_insertion_blocked());
+}
+
+#[tokio::test]
 async fn completed_token_activity_refresh_waits_for_active_history_cell() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
     set_chatgpt_auth(&mut chat);

--- a/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
+++ b/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
@@ -1299,6 +1299,38 @@ async fn completed_token_activity_refresh_waits_for_active_stream() {
 }
 
 #[tokio::test]
+async fn completed_token_activity_refresh_retries_after_plan_item_completion() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    set_chatgpt_auth(&mut chat);
+
+    chat.dispatch_command(SlashCommand::Tokens);
+    let request_id = match rx.try_recv() {
+        Ok(AppEvent::RefreshTokenActivity { request_id }) => request_id,
+        other => panic!("expected token activity refresh request, got {other:?}"),
+    };
+    let mut controller = crate::streaming::controller::PlanStreamController::new(
+        /*width*/ None,
+        &chat.config.cwd,
+        chat.history_render_mode(),
+    );
+    controller.push("Plan details");
+    chat.plan_stream_controller = Some(controller);
+    assert!(
+        chat.finish_token_activity_refresh(
+            request_id,
+            Err("token activity unavailable".to_string()),
+        )
+    );
+
+    chat.on_plan_item_completed("Plan details".to_string());
+
+    assert!(
+        std::iter::from_fn(|| rx.try_recv().ok())
+            .any(|event| matches!(event, AppEvent::CommitCompletedTokenActivityOutput))
+    );
+}
+
+#[tokio::test]
 async fn repeated_token_activity_refreshes_keep_only_latest_card() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
     set_chatgpt_auth(&mut chat);

--- a/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
+++ b/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
@@ -1190,6 +1190,11 @@ async fn clearing_pending_token_activity_refreshes_discards_late_result() {
             .map(|cell| lines_to_single_string(&cell.display_lines(u16::MAX))),
         Some("/tokens daily\n\n Token activity\n   Loading...\n".to_string()),
     );
+    assert_eq!(
+        chat.active_cell_transcript_lines(u16::MAX)
+            .map(|lines| lines_to_single_string(&lines)),
+        Some("/tokens daily\n\n Token activity\n   Loading...\n".to_string()),
+    );
 
     chat.clear_pending_token_activity_refreshes();
 

--- a/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
+++ b/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
@@ -1208,6 +1208,33 @@ async fn clearing_pending_token_activity_refreshes_discards_late_result() {
 }
 
 #[tokio::test]
+async fn pending_token_activity_refresh_renders_above_composer_snapshot() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    set_chatgpt_auth(&mut chat);
+
+    chat.dispatch_command(SlashCommand::Tokens);
+    assert_matches!(
+        rx.try_recv(),
+        Ok(AppEvent::RefreshTokenActivity { .. }),
+        "expected token activity refresh request"
+    );
+
+    let width: u16 = 80;
+    let height = chat.desired_height(width);
+    let backend = VT100Backend::new(width, height);
+    let mut term = crate::custom_terminal::Terminal::with_options(backend).expect("terminal");
+    term.set_viewport_area(Rect::new(/*x*/ 0, /*y*/ 0, width, height));
+    term.draw(|f| {
+        chat.render(f.area(), f.buffer_mut());
+    })
+    .unwrap();
+    assert_chatwidget_snapshot!(
+        "pending_token_activity_refresh_renders_above_composer_snapshot",
+        normalize_snapshot_paths(term.backend().vt100().screen().contents())
+    );
+}
+
+#[tokio::test]
 async fn completed_token_activity_refresh_returns_one_history_cell() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
     set_chatgpt_auth(&mut chat);

--- a/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
+++ b/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
@@ -1186,24 +1186,24 @@ async fn clearing_pending_token_activity_refreshes_discards_late_result() {
         other => panic!("expected token activity refresh request, got {other:?}"),
     };
     assert_eq!(
-        chat.pending_token_activity_outputs()
-            .map(|cell| lines_to_single_string(&cell.display_lines(u16::MAX)))
-            .collect::<Vec<_>>(),
-        vec!["/tokens daily\n\n Token activity\n   Loading...\n".to_string()],
+        chat.pending_token_activity_output()
+            .map(|cell| lines_to_single_string(&cell.display_lines(u16::MAX))),
+        Some("/tokens daily\n\n Token activity\n   Loading...\n".to_string()),
     );
 
     chat.clear_pending_token_activity_refreshes();
 
     assert!(
-        !chat.finish_token_activity_refresh(
+        chat.finish_token_activity_refresh(
             request_id,
             Err("stale token activity result".to_string()),
         )
+        .is_none()
     );
 }
 
 #[tokio::test]
-async fn completed_token_activity_refresh_commits_one_history_cell() {
+async fn completed_token_activity_refresh_returns_one_history_cell() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
     set_chatgpt_auth(&mut chat);
 
@@ -1213,23 +1213,54 @@ async fn completed_token_activity_refresh_commits_one_history_cell() {
         Ok(AppEvent::RefreshTokenActivity { request_id }) => request_id,
         other => panic!("expected token activity refresh request, got {other:?}"),
     };
-    assert_eq!(chat.pending_token_activity_outputs().count(), 1);
+    assert!(chat.pending_token_activity_output().is_some());
 
-    assert!(
-        chat.finish_token_activity_refresh(
-            request_id,
-            Err("token activity unavailable".to_string()),
-        )
-    );
+    let cell = chat
+        .finish_token_activity_refresh(request_id, Err("token activity unavailable".to_string()))
+        .expect("completed token activity cell");
 
-    assert_eq!(chat.pending_token_activity_outputs().count(), 0);
-    let cell = match rx.try_recv() {
-        Ok(AppEvent::InsertHistoryCell(cell)) => cell,
-        other => panic!("expected completed token activity history cell, got {other:?}"),
-    };
+    assert!(chat.pending_token_activity_output().is_none());
     assert_eq!(
         lines_to_single_string(&cell.display_lines(u16::MAX)),
         "/tokens daily\n\n Token activity\n   Token activity unavailable\n",
+    );
+}
+
+#[tokio::test]
+async fn repeated_token_activity_refreshes_keep_only_latest_card() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    set_chatgpt_auth(&mut chat);
+
+    chat.dispatch_command(SlashCommand::Tokens);
+    let first_request_id = match rx.try_recv() {
+        Ok(AppEvent::RefreshTokenActivity { request_id }) => request_id,
+        other => panic!("expected first token activity refresh request, got {other:?}"),
+    };
+
+    chat.dispatch_command_with_args(SlashCommand::Tokens, "weekly".to_string(), Vec::new());
+    let second_request_id = match rx.try_recv() {
+        Ok(AppEvent::RefreshTokenActivity { request_id }) => request_id,
+        other => panic!("expected second token activity refresh request, got {other:?}"),
+    };
+
+    assert_eq!(
+        chat.pending_token_activity_output()
+            .map(|cell| lines_to_single_string(&cell.display_lines(u16::MAX))),
+        Some("/tokens weekly\n\n Token activity\n   Loading...\n".to_string()),
+    );
+    assert!(
+        chat.finish_token_activity_refresh(
+            first_request_id,
+            Err("stale token activity result".to_string()),
+        )
+        .is_none()
+    );
+    assert!(
+        chat.finish_token_activity_refresh(
+            second_request_id,
+            Err("token activity unavailable".to_string()),
+        )
+        .is_some()
     );
 }
 

--- a/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
+++ b/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
@@ -1299,6 +1299,36 @@ async fn completed_token_activity_refresh_waits_for_active_stream() {
 }
 
 #[tokio::test]
+async fn completed_token_activity_refresh_waits_for_active_history_cell() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    set_chatgpt_auth(&mut chat);
+
+    chat.dispatch_command(SlashCommand::Tokens);
+    let request_id = match rx.try_recv() {
+        Ok(AppEvent::RefreshTokenActivity { request_id }) => request_id,
+        other => panic!("expected token activity refresh request, got {other:?}"),
+    };
+    chat.transcript.active_cell = Some(Box::new(PlainHistoryCell::new(vec![Line::from(
+        "active tool",
+    )])));
+    assert!(
+        chat.finish_token_activity_refresh(
+            request_id,
+            Err("token activity unavailable".to_string()),
+        )
+    );
+    assert!(chat.token_activity_history_insertion_blocked());
+
+    chat.flush_active_cell();
+
+    assert_matches!(rx.try_recv(), Ok(AppEvent::InsertHistoryCell(_)));
+    assert_matches!(
+        rx.try_recv(),
+        Ok(AppEvent::CommitCompletedTokenActivityOutput)
+    );
+}
+
+#[tokio::test]
 async fn completed_token_activity_refresh_retries_after_plan_item_completion() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
     set_chatgpt_auth(&mut chat);
@@ -1327,6 +1357,40 @@ async fn completed_token_activity_refresh_retries_after_plan_item_completion() {
     assert!(
         std::iter::from_fn(|| rx.try_recv().ok())
             .any(|event| matches!(event, AppEvent::CommitCompletedTokenActivityOutput))
+    );
+}
+
+#[tokio::test]
+async fn pending_token_activity_refresh_keeps_composer_visible_in_short_viewport() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    set_chatgpt_auth(&mut chat);
+    chat.transcript.active_cell = Some(Box::new(PlainHistoryCell::new(
+        std::iter::repeat_n(Line::from("active output"), /*n*/ 20).collect(),
+    )));
+
+    chat.dispatch_command(SlashCommand::Tokens);
+    assert_matches!(
+        rx.try_recv(),
+        Ok(AppEvent::RefreshTokenActivity { .. }),
+        "expected token activity refresh request"
+    );
+
+    let width: u16 = 80;
+    let height: u16 = 8;
+    let backend = VT100Backend::new(width, height);
+    let mut term = crate::custom_terminal::Terminal::with_options(backend).expect("terminal");
+    term.set_viewport_area(Rect::new(/*x*/ 0, /*y*/ 0, width, height));
+    term.draw(|f| {
+        chat.render(f.area(), f.buffer_mut());
+    })
+    .unwrap();
+
+    assert!(
+        term.backend()
+            .vt100()
+            .screen()
+            .contents()
+            .contains("Ask Codex to do anything")
     );
 }
 

--- a/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
+++ b/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
@@ -1289,8 +1289,12 @@ async fn completed_token_activity_refresh_waits_for_active_stream() {
         Some("/tokens daily\n\n Token activity\n   Token activity unavailable\n".to_string()),
     );
 
-    chat.stream_controller = None;
+    chat.finalize_turn();
     assert!(!chat.token_activity_history_insertion_blocked());
+    assert!(
+        std::iter::from_fn(|| rx.try_recv().ok())
+            .any(|event| matches!(event, AppEvent::CommitCompletedTokenActivityOutput))
+    );
     assert!(chat.take_completed_token_activity_output().is_some());
 }
 

--- a/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
+++ b/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
@@ -1181,11 +1181,16 @@ async fn clearing_pending_token_activity_refreshes_discards_late_result() {
 
     chat.dispatch_command(SlashCommand::Tokens);
 
-    assert_matches!(rx.try_recv(), Ok(AppEvent::InsertHistoryCell(_)));
     let request_id = match rx.try_recv() {
         Ok(AppEvent::RefreshTokenActivity { request_id }) => request_id,
         other => panic!("expected token activity refresh request, got {other:?}"),
     };
+    assert_eq!(
+        chat.pending_token_activity_outputs()
+            .map(|cell| lines_to_single_string(&cell.display_lines(u16::MAX)))
+            .collect::<Vec<_>>(),
+        vec!["/tokens daily\n\n Token activity\n   Loading...\n".to_string()],
+    );
 
     chat.clear_pending_token_activity_refreshes();
 
@@ -1194,6 +1199,37 @@ async fn clearing_pending_token_activity_refreshes_discards_late_result() {
             request_id,
             Err("stale token activity result".to_string()),
         )
+    );
+}
+
+#[tokio::test]
+async fn completed_token_activity_refresh_commits_one_history_cell() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    set_chatgpt_auth(&mut chat);
+
+    chat.dispatch_command(SlashCommand::Tokens);
+
+    let request_id = match rx.try_recv() {
+        Ok(AppEvent::RefreshTokenActivity { request_id }) => request_id,
+        other => panic!("expected token activity refresh request, got {other:?}"),
+    };
+    assert_eq!(chat.pending_token_activity_outputs().count(), 1);
+
+    assert!(
+        chat.finish_token_activity_refresh(
+            request_id,
+            Err("token activity unavailable".to_string()),
+        )
+    );
+
+    assert_eq!(chat.pending_token_activity_outputs().count(), 0);
+    let cell = match rx.try_recv() {
+        Ok(AppEvent::InsertHistoryCell(cell)) => cell,
+        other => panic!("expected completed token activity history cell, got {other:?}"),
+    };
+    assert_eq!(
+        lines_to_single_string(&cell.display_lines(u16::MAX)),
+        "/tokens daily\n\n Token activity\n   Token activity unavailable\n",
     );
 }
 

--- a/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
+++ b/codex-rs/tui/src/chatwidget/tests/slash_commands.rs
@@ -1199,11 +1199,10 @@ async fn clearing_pending_token_activity_refreshes_discards_late_result() {
     chat.clear_pending_token_activity_refreshes();
 
     assert!(
-        chat.finish_token_activity_refresh(
+        !chat.finish_token_activity_refresh(
             request_id,
             Err("stale token activity result".to_string()),
         )
-        .is_none()
     );
 }
 
@@ -1247,8 +1246,15 @@ async fn completed_token_activity_refresh_returns_one_history_cell() {
     };
     assert!(chat.pending_token_activity_output().is_some());
 
+    assert!(
+        chat.finish_token_activity_refresh(
+            request_id,
+            Err("token activity unavailable".to_string()),
+        )
+    );
+    assert!(chat.pending_token_activity_output().is_some());
     let cell = chat
-        .finish_token_activity_refresh(request_id, Err("token activity unavailable".to_string()))
+        .take_completed_token_activity_output()
         .expect("completed token activity cell");
 
     assert!(chat.pending_token_activity_output().is_none());
@@ -1256,6 +1262,36 @@ async fn completed_token_activity_refresh_returns_one_history_cell() {
         lines_to_single_string(&cell.display_lines(u16::MAX)),
         "/tokens daily\n\n Token activity\n   Token activity unavailable\n",
     );
+}
+
+#[tokio::test]
+async fn completed_token_activity_refresh_waits_for_active_stream() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    set_chatgpt_auth(&mut chat);
+
+    chat.dispatch_command(SlashCommand::Tokens);
+    let request_id = match rx.try_recv() {
+        Ok(AppEvent::RefreshTokenActivity { request_id }) => request_id,
+        other => panic!("expected token activity refresh request, got {other:?}"),
+    };
+    chat.on_agent_message_delta("partial response".to_string());
+    assert!(chat.token_activity_history_insertion_blocked());
+
+    assert!(
+        chat.finish_token_activity_refresh(
+            request_id,
+            Err("token activity unavailable".to_string()),
+        )
+    );
+    assert_eq!(
+        chat.pending_token_activity_output()
+            .map(|cell| lines_to_single_string(&cell.display_lines(u16::MAX))),
+        Some("/tokens daily\n\n Token activity\n   Token activity unavailable\n".to_string()),
+    );
+
+    chat.stream_controller = None;
+    assert!(!chat.token_activity_history_insertion_blocked());
+    assert!(chat.take_completed_token_activity_output().is_some());
 }
 
 #[tokio::test]
@@ -1280,20 +1316,14 @@ async fn repeated_token_activity_refreshes_keep_only_latest_card() {
             .map(|cell| lines_to_single_string(&cell.display_lines(u16::MAX))),
         Some("/tokens weekly\n\n Token activity\n   Loading...\n".to_string()),
     );
-    assert!(
-        chat.finish_token_activity_refresh(
-            first_request_id,
-            Err("stale token activity result".to_string()),
-        )
-        .is_none()
-    );
-    assert!(
-        chat.finish_token_activity_refresh(
-            second_request_id,
-            Err("token activity unavailable".to_string()),
-        )
-        .is_some()
-    );
+    assert!(!chat.finish_token_activity_refresh(
+        first_request_id,
+        Err("stale token activity result".to_string()),
+    ));
+    assert!(chat.finish_token_activity_refresh(
+        second_request_id,
+        Err("token activity unavailable".to_string()),
+    ));
 }
 
 #[tokio::test]

--- a/codex-rs/tui/src/chatwidget/tokens.rs
+++ b/codex-rs/tui/src/chatwidget/tokens.rs
@@ -685,7 +685,9 @@ impl ChatWidget {
     }
 
     pub(crate) fn token_activity_history_insertion_blocked(&self) -> bool {
-        self.stream_controller.is_some() || self.plan_stream_controller.is_some()
+        self.stream_controller.is_some()
+            || self.plan_stream_controller.is_some()
+            || self.transcript.active_cell.is_some()
     }
 
     pub(crate) fn take_completed_token_activity_output(&mut self) -> Option<CompositeHistoryCell> {

--- a/codex-rs/tui/src/chatwidget/tokens.rs
+++ b/codex-rs/tui/src/chatwidget/tokens.rs
@@ -647,6 +647,7 @@ impl ChatWidget {
             cell,
             handle,
         });
+        self.bump_active_cell_revision();
         self.request_redraw();
         self.app_event_tx
             .send(AppEvent::RefreshTokenActivity { request_id });
@@ -663,20 +664,20 @@ impl ChatWidget {
         request_id: u64,
         result: Result<GetAccountTokenUsageResponse, String>,
     ) -> Option<CompositeHistoryCell> {
-        let Some(output) = self.refreshing_token_activity_output.take() else {
-            return None;
-        };
+        let output = self.refreshing_token_activity_output.take()?;
         if output.request_id != request_id {
             self.refreshing_token_activity_output = Some(output);
             return None;
         }
         output.handle.finish(result);
+        self.bump_active_cell_revision();
         self.request_redraw();
         Some(output.cell)
     }
 
     pub(crate) fn clear_pending_token_activity_refreshes(&mut self) {
         if self.refreshing_token_activity_output.take().is_some() {
+            self.bump_active_cell_revision();
             self.request_redraw();
         }
     }

--- a/codex-rs/tui/src/chatwidget/tokens.rs
+++ b/codex-rs/tui/src/chatwidget/tokens.rs
@@ -642,6 +642,7 @@ impl ChatWidget {
         self.next_token_activity_request_id =
             self.next_token_activity_request_id.wrapping_add(/*rhs*/ 1);
         let (cell, handle) = new_token_activity_output(view);
+        self.completed_token_activity_output = None;
         self.refreshing_token_activity_output = Some(PendingTokenActivityOutput {
             request_id,
             cell,
@@ -657,26 +658,46 @@ impl ChatWidget {
         self.refreshing_token_activity_output
             .as_ref()
             .map(|output| &output.cell as &dyn HistoryCell)
+            .or_else(|| {
+                self.completed_token_activity_output
+                    .as_ref()
+                    .map(|cell| cell as &dyn HistoryCell)
+            })
     }
 
     pub(crate) fn finish_token_activity_refresh(
         &mut self,
         request_id: u64,
         result: Result<GetAccountTokenUsageResponse, String>,
-    ) -> Option<CompositeHistoryCell> {
-        let output = self.refreshing_token_activity_output.take()?;
+    ) -> bool {
+        let Some(output) = self.refreshing_token_activity_output.take() else {
+            return false;
+        };
         if output.request_id != request_id {
             self.refreshing_token_activity_output = Some(output);
-            return None;
+            return false;
         }
         output.handle.finish(result);
+        self.completed_token_activity_output = Some(output.cell);
         self.bump_active_cell_revision();
         self.request_redraw();
-        Some(output.cell)
+        true
+    }
+
+    pub(crate) fn token_activity_history_insertion_blocked(&self) -> bool {
+        self.stream_controller.is_some() || self.plan_stream_controller.is_some()
+    }
+
+    pub(crate) fn take_completed_token_activity_output(&mut self) -> Option<CompositeHistoryCell> {
+        let output = self.completed_token_activity_output.take()?;
+        self.bump_active_cell_revision();
+        Some(output)
     }
 
     pub(crate) fn clear_pending_token_activity_refreshes(&mut self) {
-        if self.refreshing_token_activity_output.take().is_some() {
+        let cleared_refresh = self.refreshing_token_activity_output.take().is_some();
+        let cleared_completed = self.completed_token_activity_output.take().is_some();
+        if cleared_refresh || cleared_completed {
             self.bump_active_cell_revision();
             self.request_redraw();
         }

--- a/codex-rs/tui/src/chatwidget/tokens.rs
+++ b/codex-rs/tui/src/chatwidget/tokens.rs
@@ -642,20 +642,19 @@ impl ChatWidget {
         self.next_token_activity_request_id =
             self.next_token_activity_request_id.wrapping_add(/*rhs*/ 1);
         let (cell, handle) = new_token_activity_output(view);
-        self.refreshing_token_activity_outputs
-            .push(PendingTokenActivityOutput {
-                request_id,
-                cell,
-                handle,
-            });
+        self.refreshing_token_activity_output = Some(PendingTokenActivityOutput {
+            request_id,
+            cell,
+            handle,
+        });
         self.request_redraw();
         self.app_event_tx
             .send(AppEvent::RefreshTokenActivity { request_id });
     }
 
-    pub(super) fn pending_token_activity_outputs(&self) -> impl Iterator<Item = &dyn HistoryCell> {
-        self.refreshing_token_activity_outputs
-            .iter()
+    pub(super) fn pending_token_activity_output(&self) -> Option<&dyn HistoryCell> {
+        self.refreshing_token_activity_output
+            .as_ref()
             .map(|output| &output.cell as &dyn HistoryCell)
     }
 
@@ -663,24 +662,23 @@ impl ChatWidget {
         &mut self,
         request_id: u64,
         result: Result<GetAccountTokenUsageResponse, String>,
-    ) -> bool {
-        let Some(index) = self
-            .refreshing_token_activity_outputs
-            .iter()
-            .position(|output| output.request_id == request_id)
-        else {
-            return false;
+    ) -> Option<CompositeHistoryCell> {
+        let Some(output) = self.refreshing_token_activity_output.take() else {
+            return None;
         };
-        let output = self.refreshing_token_activity_outputs.remove(index);
+        if output.request_id != request_id {
+            self.refreshing_token_activity_output = Some(output);
+            return None;
+        }
         output.handle.finish(result);
-        self.add_to_history(output.cell);
         self.request_redraw();
-        true
+        Some(output.cell)
     }
 
     pub(crate) fn clear_pending_token_activity_refreshes(&mut self) {
-        self.refreshing_token_activity_outputs.clear();
-        self.request_redraw();
+        if self.refreshing_token_activity_output.take().is_some() {
+            self.request_redraw();
+        }
     }
 }
 

--- a/codex-rs/tui/src/chatwidget/tokens.rs
+++ b/codex-rs/tui/src/chatwidget/tokens.rs
@@ -694,6 +694,13 @@ impl ChatWidget {
         Some(output)
     }
 
+    pub(crate) fn request_completed_token_activity_output_insertion(&self) {
+        if self.completed_token_activity_output.is_some() {
+            self.app_event_tx
+                .send(AppEvent::CommitCompletedTokenActivityOutput);
+        }
+    }
+
     pub(crate) fn clear_pending_token_activity_refreshes(&mut self) {
         let cleared_refresh = self.refreshing_token_activity_output.take().is_some();
         let cleared_completed = self.completed_token_activity_output.take().is_some();

--- a/codex-rs/tui/src/chatwidget/tokens.rs
+++ b/codex-rs/tui/src/chatwidget/tokens.rs
@@ -687,7 +687,18 @@ impl ChatWidget {
     pub(crate) fn token_activity_history_insertion_blocked(&self) -> bool {
         self.stream_controller.is_some()
             || self.plan_stream_controller.is_some()
+            || self.pending_stream_consolidations > 0
             || self.transcript.active_cell.is_some()
+    }
+
+    pub(crate) fn note_stream_consolidation_queued(&mut self) {
+        self.pending_stream_consolidations =
+            self.pending_stream_consolidations.saturating_add(/*rhs*/ 1);
+    }
+
+    pub(crate) fn note_stream_consolidation_completed(&mut self) {
+        self.pending_stream_consolidations =
+            self.pending_stream_consolidations.saturating_sub(/*rhs*/ 1);
     }
 
     pub(crate) fn take_completed_token_activity_output(&mut self) -> Option<CompositeHistoryCell> {

--- a/codex-rs/tui/src/chatwidget/tokens.rs
+++ b/codex-rs/tui/src/chatwidget/tokens.rs
@@ -1,22 +1,3 @@
-//! Renders account token activity and coordinates asynchronous `/tokens` refreshes.
-//!
-//! The slash command inserts a composite history cell immediately so the user sees
-//! a loading state while the account request runs in the background. The returned
-//! [`TokenActivityHandle`] shares the card's state through an `Arc<RwLock<_>>`;
-//! completing the handle updates the existing history cell rather than appending a
-//! second result. [`ChatWidget::finish_token_activity_refresh`] then requests a
-//! redraw after matching the background response to its request ID.
-//!
-//! Chart rendering is intentionally terminal-native. Daily mode displays a
-//! GitHub-style 52-week calendar, while weekly and cumulative modes reuse the same
-//! grid as bottom-aligned bars. Truecolor terminals encode activity intensity with
-//! color. Lower-color terminals fall back to distinct hollow and filled glyphs so
-//! empty days remain legible.
-//!
-//! Backend buckets are normalized before rendering: malformed dates, future dates,
-//! and dates outside the visible window are ignored; duplicate dates are summed;
-//! and negative token counts are clamped to zero.
-
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -60,7 +41,6 @@ const CHART_LEFT_WIDTH: usize = 4;
 const SUMMARY_INDENT: &str = " ";
 const SUMMARY_INDENT_WIDTH: u16 = 1;
 
-/// Selects the aggregation represented by the token activity chart.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum TokenActivityView {
     Daily,
@@ -69,11 +49,6 @@ pub(super) enum TokenActivityView {
 }
 
 impl TokenActivityView {
-    /// Parses the optional `/tokens` argument into a supported chart view.
-    ///
-    /// An empty argument selects the daily view so `/tokens` and `/tokens daily`
-    /// behave identically. Returning `None` lets the slash-command dispatcher
-    /// report unsupported arguments instead of silently choosing a view.
     pub(super) fn parse(value: &str) -> Option<Self> {
         match value.trim().to_ascii_lowercase().as_str() {
             "" | "day" | "daily" => Some(Self::Daily),
@@ -92,7 +67,6 @@ impl TokenActivityView {
     }
 }
 
-/// Tracks the renderable lifecycle of one token activity history cell.
 #[derive(Debug)]
 enum TokenActivityState {
     Loading,
@@ -100,22 +74,18 @@ enum TokenActivityState {
     Error,
 }
 
-/// Completes an asynchronously rendered token activity history cell.
-///
-/// Clones share the same card state, allowing the background request path to
-/// update a cell already owned by transcript history. The widget remains
-/// responsible for requesting a redraw after completion.
 #[derive(Clone, Debug)]
 pub(super) struct TokenActivityHandle {
     state: Arc<RwLock<TokenActivityState>>,
 }
 
+pub(super) struct PendingTokenActivityOutput {
+    request_id: u64,
+    cell: CompositeHistoryCell,
+    handle: TokenActivityHandle,
+}
+
 impl TokenActivityHandle {
-    /// Replaces the loading state with either fetched activity or an unavailable state.
-    ///
-    /// This method intentionally discards the error string because the TUI exposes
-    /// one stable unavailable message. Calling it more than once replaces the prior
-    /// terminal state, so request-ID matching should happen before completion.
     pub(super) fn finish(&self, result: Result<GetAccountTokenUsageResponse, String>) {
         let state = match result {
             Ok(response) => TokenActivityState::Loaded(response),
@@ -127,18 +97,12 @@ impl TokenActivityHandle {
     }
 }
 
-/// Renders one `/tokens` card from shared asynchronous state.
 #[derive(Debug)]
 struct TokenActivityHistoryCell {
     view: TokenActivityView,
     state: Arc<RwLock<TokenActivityState>>,
 }
 
-/// Creates the transcript cell and completion handle for one `/tokens` invocation.
-///
-/// The composite cell includes the echoed slash command and a loading card from
-/// the start. Callers must retain the returned handle and complete it when the
-/// matching background response arrives; otherwise the card remains loading.
 pub(super) fn new_token_activity_output(
     view: TokenActivityView,
 ) -> (CompositeHistoryCell, TokenActivityHandle) {
@@ -496,11 +460,6 @@ fn month_labels(today: NaiveDate, first_column: usize, shown_columns: usize) -> 
     .into()
 }
 
-/// Normalizes backend daily buckets into the fixed 52-week display window.
-///
-/// The returned vector is ordered by chart cell, starting with the oldest Sunday.
-/// Invalid, out-of-window, and future dates are ignored. Duplicate dates are
-/// accumulated and negative token values do not reduce activity.
 fn daily_values(
     buckets: &[codex_app_server_protocol::AccountTokenUsageDailyBucket],
     today: NaiveDate,
@@ -589,7 +548,6 @@ fn cell_date(today: NaiveDate, index: usize) -> Option<NaiveDate> {
     chart_start(today).checked_add_signed(Duration::days(index as i64))
 }
 
-/// Stores the terminal-specific styles and glyph strategy for token activity cells.
 struct TokenActivityPalette {
     styles: [Style; 5],
     bar_style: Style,
@@ -679,58 +637,50 @@ fn theme_anchor_rgb() -> Option<(u8, u8, u8)> {
 }
 
 impl ChatWidget {
-    /// Starts a token activity refresh and inserts its loading card into history.
-    ///
-    /// Each invocation receives a request ID so background responses update only
-    /// their own card. Skipping the request ID when handling the response could
-    /// update the wrong card after repeated `/tokens` commands.
     pub(super) fn add_token_activity_output(&mut self, view: TokenActivityView) {
         let request_id = self.next_token_activity_request_id;
         self.next_token_activity_request_id =
             self.next_token_activity_request_id.wrapping_add(/*rhs*/ 1);
         let (cell, handle) = new_token_activity_output(view);
         self.refreshing_token_activity_outputs
-            .push((request_id, handle));
-        self.add_to_history(cell);
+            .push(PendingTokenActivityOutput {
+                request_id,
+                cell,
+                handle,
+            });
+        self.request_redraw();
         self.app_event_tx
             .send(AppEvent::RefreshTokenActivity { request_id });
     }
 
-    /// Applies a background token activity result to its matching history cell.
-    ///
-    /// Returns `true` when a pending request matched and a redraw was requested.
-    /// Late responses return `false`, including responses for cards cleared during
-    /// backtracking or session replacement.
+    pub(super) fn pending_token_activity_outputs(&self) -> impl Iterator<Item = &dyn HistoryCell> {
+        self.refreshing_token_activity_outputs
+            .iter()
+            .map(|output| &output.cell as &dyn HistoryCell)
+    }
+
     pub(crate) fn finish_token_activity_refresh(
         &mut self,
         request_id: u64,
         result: Result<GetAccountTokenUsageResponse, String>,
     ) -> bool {
-        let mut remaining = Vec::with_capacity(self.refreshing_token_activity_outputs.len());
-        let mut result = Some(result);
-        let mut updated_any = false;
-        for (pending_request_id, handle) in self.refreshing_token_activity_outputs.drain(..) {
-            if pending_request_id == request_id {
-                #[expect(clippy::expect_used)]
-                handle.finish(result.take().expect("token activity result consumed once"));
-                updated_any = true;
-            } else {
-                remaining.push((pending_request_id, handle));
-            }
-        }
-        self.refreshing_token_activity_outputs = remaining;
-        if updated_any {
-            self.request_redraw();
-        }
-        updated_any
+        let Some(index) = self
+            .refreshing_token_activity_outputs
+            .iter()
+            .position(|output| output.request_id == request_id)
+        else {
+            return false;
+        };
+        let output = self.refreshing_token_activity_outputs.remove(index);
+        output.handle.finish(result);
+        self.add_to_history(output.cell);
+        self.request_redraw();
+        true
     }
 
-    /// Drops completion handles for token activity cards that must no longer update.
-    ///
-    /// Existing rendered cells remain in history, but late background responses
-    /// cannot mutate them after a transcript reset or backtrack operation.
     pub(crate) fn clear_pending_token_activity_refreshes(&mut self) {
         self.refreshing_token_activity_outputs.clear();
+        self.request_redraw();
     }
 }
 

--- a/codex-rs/tui/src/chatwidget/tokens.rs
+++ b/codex-rs/tui/src/chatwidget/tokens.rs
@@ -1,3 +1,24 @@
+//! Renders account token activity and coordinates asynchronous `/tokens` cards.
+//!
+//! The slash command builds a composite history cell immediately, but the widget
+//! keeps that cell transient while the account request runs. The transient card is
+//! rendered above the composer through [`ChatWidget::pending_token_activity_output`]
+//! so loading never requires clearing or rewriting transcript history. When the
+//! matching response arrives, [`TokenActivityHandle`] updates the shared card state
+//! and [`ChatWidget::finish_token_activity_refresh`] moves the cell into a completed
+//! slot. Event dispatch commits that completed cell into history only after active
+//! output and stream consolidation no longer block insertion.
+//!
+//! Chart rendering is intentionally terminal-native. Daily mode displays a
+//! GitHub-style 52-week calendar, while weekly and cumulative modes reuse the same
+//! grid as bottom-aligned bars. Truecolor terminals encode activity intensity with
+//! color. Lower-color terminals fall back to distinct hollow and filled glyphs so
+//! empty days remain legible.
+//!
+//! Backend buckets are normalized before rendering: malformed dates, future dates,
+//! and dates outside the visible window are ignored; duplicate dates are summed;
+//! and negative token counts are clamped to zero.
+
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -41,6 +62,7 @@ const CHART_LEFT_WIDTH: usize = 4;
 const SUMMARY_INDENT: &str = " ";
 const SUMMARY_INDENT_WIDTH: u16 = 1;
 
+/// Selects the aggregation represented by the token activity chart.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum TokenActivityView {
     Daily,
@@ -49,6 +71,11 @@ pub(super) enum TokenActivityView {
 }
 
 impl TokenActivityView {
+    /// Parses the optional `/tokens` argument into a supported chart view.
+    ///
+    /// An empty argument selects the daily view so `/tokens` and `/tokens daily`
+    /// behave identically. Returning `None` lets the slash-command dispatcher
+    /// report unsupported arguments instead of silently choosing a view.
     pub(super) fn parse(value: &str) -> Option<Self> {
         match value.trim().to_ascii_lowercase().as_str() {
             "" | "day" | "daily" => Some(Self::Daily),
@@ -67,6 +94,7 @@ impl TokenActivityView {
     }
 }
 
+/// Tracks the renderable lifecycle of one token activity history cell.
 #[derive(Debug)]
 enum TokenActivityState {
     Loading,
@@ -74,11 +102,21 @@ enum TokenActivityState {
     Error,
 }
 
+/// Completes an asynchronously rendered token activity history cell.
+///
+/// Clones share the same card state, allowing the background request path to
+/// update a cell still owned by the widget's transient-output state. The widget
+/// remains responsible for request-ID matching, redraws, and history insertion.
 #[derive(Clone, Debug)]
 pub(super) struct TokenActivityHandle {
     state: Arc<RwLock<TokenActivityState>>,
 }
 
+/// Holds the one transient token activity card waiting on its background response.
+///
+/// The request ID prevents late results from mutating a newer `/tokens` card. The
+/// cell stays out of transcript history until the matching response completes and
+/// the widget confirms that active output no longer blocks insertion.
 pub(super) struct PendingTokenActivityOutput {
     request_id: u64,
     cell: CompositeHistoryCell,
@@ -86,6 +124,11 @@ pub(super) struct PendingTokenActivityOutput {
 }
 
 impl TokenActivityHandle {
+    /// Replaces the loading state with either fetched activity or an unavailable state.
+    ///
+    /// This method intentionally discards the error string because the TUI exposes
+    /// one stable unavailable message. Calling it more than once replaces the prior
+    /// terminal state, so request-ID matching should happen before completion.
     pub(super) fn finish(&self, result: Result<GetAccountTokenUsageResponse, String>) {
         let state = match result {
             Ok(response) => TokenActivityState::Loaded(response),
@@ -97,12 +140,18 @@ impl TokenActivityHandle {
     }
 }
 
+/// Renders one `/tokens` card from shared asynchronous state.
 #[derive(Debug)]
 struct TokenActivityHistoryCell {
     view: TokenActivityView,
     state: Arc<RwLock<TokenActivityState>>,
 }
 
+/// Creates the card contents and completion handle for one `/tokens` invocation.
+///
+/// The composite cell includes the echoed slash command and a loading card from
+/// the start. Callers must retain the returned handle and complete it when the
+/// matching background response arrives; otherwise the transient card stays loading.
 pub(super) fn new_token_activity_output(
     view: TokenActivityView,
 ) -> (CompositeHistoryCell, TokenActivityHandle) {
@@ -460,6 +509,11 @@ fn month_labels(today: NaiveDate, first_column: usize, shown_columns: usize) -> 
     .into()
 }
 
+/// Normalizes backend daily buckets into the fixed 52-week display window.
+///
+/// The returned vector is ordered by chart cell, starting with the oldest Sunday.
+/// Invalid, out-of-window, and future dates are ignored. Duplicate dates are
+/// accumulated and negative token values do not reduce activity.
 fn daily_values(
     buckets: &[codex_app_server_protocol::AccountTokenUsageDailyBucket],
     today: NaiveDate,
@@ -548,6 +602,7 @@ fn cell_date(today: NaiveDate, index: usize) -> Option<NaiveDate> {
     chart_start(today).checked_add_signed(Duration::days(index as i64))
 }
 
+/// Stores the terminal-specific styles and glyph strategy for token activity cells.
 struct TokenActivityPalette {
     styles: [Style; 5],
     bar_style: Style,
@@ -637,6 +692,11 @@ fn theme_anchor_rgb() -> Option<(u8, u8, u8)> {
 }
 
 impl ChatWidget {
+    /// Starts a token activity refresh and replaces the current transient card.
+    ///
+    /// Each invocation receives a request ID so background responses update only
+    /// their own card. The card remains outside transcript history until completion,
+    /// which keeps loading visible without disturbing existing transcript content.
     pub(super) fn add_token_activity_output(&mut self, view: TokenActivityView) {
         let request_id = self.next_token_activity_request_id;
         self.next_token_activity_request_id =
@@ -654,6 +714,11 @@ impl ChatWidget {
             .send(AppEvent::RefreshTokenActivity { request_id });
     }
 
+    /// Returns the transient token activity card that should render above the composer.
+    ///
+    /// A loading card takes precedence over a completed card waiting for history
+    /// insertion. Callers should render the returned cell but leave ownership with
+    /// the widget so completion and insertion can update it safely.
     pub(super) fn pending_token_activity_output(&self) -> Option<&dyn HistoryCell> {
         self.refreshing_token_activity_output
             .as_ref()
@@ -665,6 +730,11 @@ impl ChatWidget {
             })
     }
 
+    /// Applies a background token activity result to its matching transient card.
+    ///
+    /// Returns `true` when the pending request matched and moved into the completed
+    /// slot. Late responses return `false`, including responses for cards replaced
+    /// by a newer `/tokens` invocation or cleared during transcript changes.
     pub(crate) fn finish_token_activity_refresh(
         &mut self,
         request_id: u64,
@@ -684,6 +754,11 @@ impl ChatWidget {
         true
     }
 
+    /// Reports whether a completed token activity card must wait before insertion.
+    ///
+    /// Inserting while a stream, queued consolidation, or active transcript cell is
+    /// present can reorder the card relative to visible output, so callers retry once
+    /// these barriers clear.
     pub(crate) fn token_activity_history_insertion_blocked(&self) -> bool {
         self.stream_controller.is_some()
             || self.plan_stream_controller.is_some()
@@ -691,22 +766,39 @@ impl ChatWidget {
             || self.transcript.active_cell.is_some()
     }
 
+    /// Records a stream consolidation barrier that delays token card insertion.
+    ///
+    /// Each queued consolidation should eventually call
+    /// [`ChatWidget::note_stream_consolidation_completed`].
     pub(crate) fn note_stream_consolidation_queued(&mut self) {
         self.pending_stream_consolidations =
             self.pending_stream_consolidations.saturating_add(/*rhs*/ 1);
     }
 
+    /// Releases one queued stream consolidation barrier.
+    ///
+    /// The counter saturates at zero so an unmatched completion does not underflow,
+    /// but paired queue/completion calls are still the intended contract.
     pub(crate) fn note_stream_consolidation_completed(&mut self) {
         self.pending_stream_consolidations =
             self.pending_stream_consolidations.saturating_sub(/*rhs*/ 1);
     }
 
+    /// Transfers the completed token activity card into the history insertion path.
+    ///
+    /// Callers should use this only after
+    /// [`ChatWidget::token_activity_history_insertion_blocked`] returns `false`;
+    /// taking the card removes it from the transient render area.
     pub(crate) fn take_completed_token_activity_output(&mut self) -> Option<CompositeHistoryCell> {
         let output = self.completed_token_activity_output.take()?;
         self.bump_active_cell_revision();
         Some(output)
     }
 
+    /// Requests another insertion attempt when a completed card is waiting.
+    ///
+    /// This is used after stream or history lifecycle events that may have cleared
+    /// the insertion barriers without directly owning the completed card.
     pub(crate) fn request_completed_token_activity_output_insertion(&self) {
         if self.completed_token_activity_output.is_some() {
             self.app_event_tx
@@ -714,6 +806,10 @@ impl ChatWidget {
         }
     }
 
+    /// Drops transient and completed token cards that must no longer update.
+    ///
+    /// Late background responses cannot mutate cards after a transcript reset,
+    /// backtrack, or replacement flow clears this widget-owned state.
     pub(crate) fn clear_pending_token_activity_refreshes(&mut self) {
         let cleared_refresh = self.refreshing_token_activity_output.take().is_some();
         let cleared_completed = self.completed_token_activity_output.take().is_some();

--- a/codex-rs/tui/src/chatwidget/turn_runtime.rs
+++ b/codex-rs/tui/src/chatwidget/turn_runtime.rs
@@ -126,6 +126,7 @@ impl ChatWidget {
                 self.add_boxed_history(cell);
             }
             if let Some(source) = source {
+                self.note_stream_consolidation_queued();
                 self.app_event_tx
                     .send(AppEvent::ConsolidateProposedPlan(source));
             }

--- a/codex-rs/tui/src/chatwidget/turn_runtime.rs
+++ b/codex-rs/tui/src/chatwidget/turn_runtime.rs
@@ -51,7 +51,9 @@ impl ChatWidget {
         self.turn_lifecycle.start(Instant::now());
         self.transcript.reset_turn_flags();
         self.adaptive_chunking.reset();
-        self.plan_stream_controller = None;
+        if self.plan_stream_controller.take().is_some() {
+            self.request_completed_token_activity_output_insertion();
+        }
         self.turn_runtime_metrics = RuntimeMetricsSummary::default();
         self.session_telemetry.reset_runtime_metrics();
         self.bottom_pane.clear_quit_shortcut_hint();
@@ -127,6 +129,7 @@ impl ChatWidget {
                 self.app_event_tx
                     .send(AppEvent::ConsolidateProposedPlan(source));
             }
+            self.request_completed_token_activity_output_insertion();
         }
         self.flush_unified_exec_wait_streak();
         if !from_replay {
@@ -316,6 +319,7 @@ impl ChatWidget {
         self.adaptive_chunking.reset();
         self.stream_controller = None;
         self.plan_stream_controller = None;
+        self.request_completed_token_activity_output_insertion();
         self.status_state.pending_status_indicator_restore = false;
         self.request_status_line_branch_refresh();
         self.request_status_line_git_summary_refresh();

--- a/codex-rs/tui/src/render/renderable.rs
+++ b/codex-rs/tui/src/render/renderable.rs
@@ -276,15 +276,13 @@ impl<'a> FlexRenderable<'a> {
         let mut allocated_rects = Vec::with_capacity(self.children.len());
         let mut child_sizes = vec![0; self.children.len()];
         let mut allocated_size = 0;
-        let mut total_flex = 0;
+        let mut flex_children = Vec::new();
 
         // 1. Allocate space to non-flex children.
         let max_size = area.height;
-        let mut last_flex_child_idx = 0;
         for (i, FlexChild { flex, child }) in self.children.iter().enumerate() {
             if *flex > 0 {
-                total_flex += flex;
-                last_flex_child_idx = i;
+                flex_children.push((i, *flex as u16, child.desired_height(area.width)));
             } else {
                 child_sizes[i] = child
                     .desired_height(area.width)
@@ -293,24 +291,41 @@ impl<'a> FlexRenderable<'a> {
             }
         }
         let free_space = max_size.saturating_sub(allocated_size);
-        // 2. Allocate space to flex children, proportional to their flex factor.
-        let mut allocated_flex_space = 0;
-        if total_flex > 0 {
-            let space_per_flex = free_space / total_flex as u16;
-            for (i, FlexChild { flex, child }) in self.children.iter().enumerate() {
-                if *flex > 0 {
-                    // Last flex child gets all the remaining space, to prevent a rounding error
-                    // from not allocating all the space.
-                    let max_child_extent = if i == last_flex_child_idx {
-                        free_space - allocated_flex_space
-                    } else {
-                        space_per_flex * *flex as u16
-                    };
-                    let child_size = child.desired_height(area.width).min(max_child_extent);
-                    child_sizes[i] = child_size;
-                    allocated_flex_space += child_size;
+        // 2. Satisfy flex children that need less than their proportional share so their unused
+        // space can be redistributed instead of leaving blank rows.
+        let mut remaining_space = free_space;
+        while !flex_children.is_empty() {
+            let total_flex = flex_children.iter().map(|(_, flex, _)| *flex).sum::<u16>();
+            let mut satisfied_any = false;
+            flex_children.retain(|(i, flex, desired_height)| {
+                let proportional_share =
+                    (u32::from(remaining_space) * u32::from(*flex) / u32::from(total_flex)) as u16;
+                if *desired_height <= proportional_share {
+                    child_sizes[*i] = *desired_height;
+                    remaining_space = remaining_space.saturating_sub(*desired_height);
+                    satisfied_any = true;
+                    false
+                } else {
+                    true
                 }
+            });
+            if !satisfied_any {
+                break;
             }
+        }
+        // 3. Divide the remaining space proportionally. The final child absorbs rounding slack.
+        let total_flex = flex_children.iter().map(|(_, flex, _)| *flex).sum::<u16>();
+        let mut allocated_flex_space = 0;
+        let last_flex_child_idx = flex_children.last().map(|(i, _, _)| *i);
+        for (i, flex, desired_height) in flex_children {
+            let max_child_extent = if Some(i) == last_flex_child_idx {
+                remaining_space.saturating_sub(allocated_flex_space)
+            } else {
+                (u32::from(remaining_space) * u32::from(flex) / u32::from(total_flex)) as u16
+            };
+            let child_size = desired_height.min(max_child_extent);
+            child_sizes[i] = child_size;
+            allocated_flex_space += child_size;
         }
 
         let mut y = area.y;
@@ -480,5 +495,81 @@ where
         let child: RenderableItem<'a> =
             RenderableItem::Owned(Box::new(self) as Box<dyn Renderable + 'a>);
         RenderableItem::Owned(Box::new(InsetRenderable { child, insets }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    struct HeightRenderable(u16);
+
+    impl HeightRenderable {
+        fn with_height(height: u16) -> Self {
+            Self(height)
+        }
+    }
+
+    impl Renderable for HeightRenderable {
+        fn render(&self, _area: Rect, _buf: &mut Buffer) {}
+
+        fn desired_height(&self, _width: u16) -> u16 {
+            self.0
+        }
+    }
+
+    #[test]
+    fn flex_redistributes_space_unused_by_short_children() {
+        let mut flex = FlexRenderable::new();
+        flex.push(
+            /*flex*/ 1,
+            RenderableItem::Owned(Box::new(HeightRenderable::with_height(/*height*/ 20))),
+        );
+        flex.push(
+            /*flex*/ 1,
+            RenderableItem::Owned(Box::new(HeightRenderable::with_height(/*height*/ 2))),
+        );
+
+        let allocated = flex.allocate(Rect::new(
+            /*x*/ 0, /*y*/ 0, /*width*/ 80, /*height*/ 10,
+        ));
+
+        assert_eq!(
+            allocated
+                .into_iter()
+                .map(|area| area.height)
+                .collect::<Vec<_>>(),
+            vec![8, 2],
+        );
+    }
+
+    #[test]
+    fn flex_reserves_non_flex_space_before_flexible_children() {
+        let mut flex = FlexRenderable::new();
+        flex.push(
+            /*flex*/ 1,
+            RenderableItem::Owned(Box::new(HeightRenderable::with_height(/*height*/ 20))),
+        );
+        flex.push(
+            /*flex*/ 0,
+            RenderableItem::Owned(Box::new(HeightRenderable::with_height(/*height*/ 2))),
+        );
+        flex.push(
+            /*flex*/ 1,
+            RenderableItem::Owned(Box::new(HeightRenderable::with_height(/*height*/ 20))),
+        );
+
+        let allocated = flex.allocate(Rect::new(
+            /*x*/ 0, /*y*/ 0, /*width*/ 80, /*height*/ 10,
+        ));
+
+        assert_eq!(
+            allocated
+                .into_iter()
+                .map(|area| area.height)
+                .collect::<Vec<_>>(),
+            vec![4, 2, 4],
+        );
     }
 }


### PR DESCRIPTION
## Why

The initial `/tokens` implementation refreshed transcript history while loading account activity, which could clear the visible terminal content before the final card rendered. Keep the command terminal-native by rendering one bounded transient card inline and replacing it only when the async result is ready.

<img width="1323" height="433" alt="image" src="https://github.com/user-attachments/assets/32d0db80-7d5d-497c-9836-7bf7e00645c0" />

## What Changed

- Render the `/tokens` loading card above the composer without clearing the screen.
- Keep only the latest transient token card when `/tokens` is invoked repeatedly.
- Synchronize the loading card with transcript overlay mode.
- Defer completed-card insertion while active cells or stream consolidation are still in progress, then retry after history updates.
- Preserve composer space in short viewports and redistribute unused flexible layout space.
- Add snapshot and regression coverage for transient card ordering and layout.

## Token Count Semantics

The activity card reports text-token volume, not metered usage or credits. The default and sandbox-backed profile stats include cached input tokens, uncached input tokens, and output tokens. The feature-gated fact-backed source sums total processed context tokens and generated tokens. Neither path applies fast-mode, model, or service-tier usage multipliers.

This means `/tokens` is intentionally a historical activity view rather than a quota-consumption view. If we later add subscription limits, upgrades, or credit-purchase entry points, those should use a separate usage/quota data source rather than reinterpreting this graph.

## Stack

1. [#25344](https://github.com/openai/codex/pull/25344) account token usage app-server API
2. [#25345](https://github.com/openai/codex/pull/25345) base `/tokens` TUI widget
3. inline token activity card UX (this PR)

## How to Test

1. Start Codex with `just codex` while authenticated with ChatGPT.
2. Leave visible transcript content on screen, then run `/tokens daily`.
3. Confirm a single `Loading...` card appears above the composer without clearing the terminal.
4. Confirm the card resolves in place to the activity graph.
5. Run `/tokens` repeatedly and confirm only the latest card remains.
6. Trigger `/tokens` while assistant output is streaming and confirm the completed card appears after active output consolidation.
7. Resize to a short viewport and confirm the composer remains visible.

Targeted tests:
- `just test -p codex-tui token_activity`
- `just test -p codex-tui flex_`
