### PR TITLE
feat(tui): restore output-free cancelled prompts

### DIFF
--- a/codex-rs/rollout/src/compression_tests.rs
+++ b/codex-rs/rollout/src/compression_tests.rs
@@ -243,6 +243,7 @@ fn write_rollout(path: &std::path::Path, thread_id: ThreadId, message: &str) -> 
         meta: SessionMeta {
             id: thread_id,
             forked_from_id: None,
+            parent_thread_id: None,
             timestamp: "2025-01-03T12:00:00Z".to_string(),
             cwd: parent.to_path_buf(),
             originator: "test".to_string(),

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -515,7 +515,7 @@ pub(crate) struct App {
 
     // Esc-backtracking state grouped
     pub(crate) backtrack: crate::app_backtrack::BacktrackState,
-    /// When set, the next draw re-renders the transcript into terminal scrollback once.
+    /// When set, the next draw rebuilds terminal scrollback from the retained transcript cells.
     ///
     /// This is used after a confirmed thread rollback to ensure scrollback reflects the trimmed
     /// transcript cells.
@@ -1256,8 +1256,8 @@ See the Codex keymap documentation for supported actions and examples."
                 }
                 TuiEvent::Draw | TuiEvent::Resize => {
                     if self.backtrack_render_pending {
+                        self.rebuild_transcript_after_backtrack(tui)?;
                         self.backtrack_render_pending = false;
-                        self.render_transcript_once(tui);
                     }
                     self.chat_widget.maybe_post_pending_notification(tui);
                     if self

--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -324,7 +324,11 @@ impl App {
                 return Ok(AppRunControl::Exit(ExitReason::Fatal(message)));
             }
             AppEvent::CodexOp(op) => {
+                self.chat_widget.prepare_local_op_submission(&op);
                 self.submit_active_thread_op(app_server, op).await?;
+            }
+            AppEvent::RestoreCancelledTurn(prompt) => {
+                self.apply_cancelled_turn_edit(prompt);
             }
             AppEvent::AppendMessageHistoryEntry { thread_id, text } => {
                 self.append_message_history_entry(thread_id, text);

--- a/codex-rs/tui/src/app/resize_reflow.rs
+++ b/codex-rs/tui/src/app/resize_reflow.rs
@@ -459,6 +459,35 @@ impl App {
         Ok(terminal_width)
     }
 
+    /// Rebuild scrollback after rollback removes transcript cells.
+    ///
+    /// Unlike resize reflow, rollback must clear the terminal even when no cells remain. Otherwise
+    /// the cancelled user prompt stays visible in scrollback despite being removed from the source
+    /// transcript.
+    pub(super) fn rebuild_transcript_after_backtrack(&mut self, tui: &mut tui::Tui) -> Result<()> {
+        let terminal_width = tui.terminal.size()?.width;
+        let width = self.chat_widget.history_wrap_width(terminal_width);
+        let reflowed_lines = if self.transcript_cells.is_empty() {
+            self.reset_history_emission_state();
+            Vec::new()
+        } else {
+            self.render_transcript_lines_for_reflow(width).lines
+        };
+
+        tui.clear_pending_history_lines();
+        self.clear_terminal_for_resize_replay(tui)?;
+
+        self.deferred_history_lines.clear();
+        if !reflowed_lines.is_empty() {
+            tui.insert_history_hyperlink_lines_with_wrap_policy(
+                reflowed_lines,
+                self.history_line_wrap_policy(),
+            );
+        }
+
+        Ok(())
+    }
+
     /// Render transcript cells for the current resize rebuild.
     ///
     /// Rendering walks backward from the transcript tail so row-capped sessions avoid formatting the

--- a/codex-rs/tui/src/app/snapshots/codex_tui__app__tests__cancelled_turn_edit_restores_composer.snap
+++ b/codex-rs/tui/src/app/snapshots/codex_tui__app__tests__cancelled_turn_edit_restores_composer.snap
@@ -1,0 +1,5 @@
+---
+source: tui/src/app/tests.rs
+expression: app.chat_widget.composer_text_with_pending()
+---
+edit me

--- a/codex-rs/tui/src/app/tests.rs
+++ b/codex-rs/tui/src/app/tests.rs
@@ -4638,6 +4638,61 @@ async fn backtrack_remote_image_only_selection_clears_existing_composer_draft() 
 }
 
 #[tokio::test]
+async fn cancelled_turn_edit_restores_prompt_and_rolls_back_latest_turn() {
+    let (mut app, _app_event_rx, mut op_rx) = make_test_app_with_channels().await;
+    app.transcript_cells = vec![Arc::new(UserHistoryCell {
+        message: "original".to_string(),
+        text_elements: Vec::new(),
+        local_image_paths: Vec::new(),
+        remote_image_urls: Vec::new(),
+    }) as Arc<dyn HistoryCell>];
+    let prompt = crate::chatwidget::UserMessage {
+        text: "edit me".to_string(),
+        local_images: Vec::new(),
+        remote_image_urls: vec!["https://example.com/edit.png".to_string()],
+        text_elements: Vec::new(),
+        mention_bindings: Vec::new(),
+    };
+
+    app.apply_cancelled_turn_edit(prompt);
+
+    assert_eq!(app.chat_widget.composer_text_with_pending(), "edit me");
+    assert_snapshot!(
+        "cancelled_turn_edit_restores_composer",
+        app.chat_widget.composer_text_with_pending()
+    );
+    assert_eq!(
+        app.chat_widget.remote_image_urls(),
+        vec!["https://example.com/edit.png".to_string()]
+    );
+    assert_matches!(op_rx.try_recv(), Ok(Op::ThreadRollback { num_turns: 1 }));
+}
+
+#[tokio::test]
+async fn first_cancelled_turn_edit_restores_prompt_without_local_history() {
+    let (mut app, _app_event_rx, mut op_rx) = make_test_app_with_channels().await;
+    let prompt = crate::chatwidget::UserMessage {
+        text: "edit first prompt".to_string(),
+        local_images: Vec::new(),
+        remote_image_urls: vec!["https://example.com/edit.png".to_string()],
+        text_elements: Vec::new(),
+        mention_bindings: Vec::new(),
+    };
+
+    app.apply_cancelled_turn_edit(prompt);
+
+    assert_eq!(
+        app.chat_widget.composer_text_with_pending(),
+        "edit first prompt"
+    );
+    assert_eq!(
+        app.chat_widget.remote_image_urls(),
+        vec!["https://example.com/edit.png".to_string()]
+    );
+    assert_matches!(op_rx.try_recv(), Ok(Op::ThreadRollback { num_turns: 1 }));
+}
+
+#[tokio::test]
 async fn backtrack_resubmit_preserves_data_image_urls_in_user_turn() {
     let (mut app, _app_event_rx, mut op_rx) = make_test_app_with_channels().await;
 

--- a/codex-rs/tui/src/app/thread_routing.rs
+++ b/codex-rs/tui/src/app/thread_routing.rs
@@ -497,7 +497,7 @@ impl App {
         op: &AppCommand,
     ) -> Result<bool> {
         match op {
-            AppCommand::Interrupt => {
+            AppCommand::Interrupt { .. } => {
                 if let Some(turn_id) = self.active_turn_id_for_thread(thread_id).await {
                     app_server.turn_interrupt(thread_id, turn_id).await?;
                 } else {

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -31,6 +31,7 @@ use std::sync::Arc;
 use crate::app::App;
 use crate::app_command::AppCommand;
 use crate::app_event::AppEvent;
+use crate::chatwidget::UserMessage;
 #[cfg(test)]
 use crate::history_cell::AgentMessageCell;
 use crate::history_cell::SessionInfoCell;
@@ -229,6 +230,38 @@ impl App {
         }
     }
 
+    pub(crate) fn apply_cancelled_turn_edit(&mut self, prompt: UserMessage) {
+        let user_total = user_count(&self.transcript_cells);
+        let selection = BacktrackSelection {
+            nth_user_message: user_total.saturating_sub(1),
+            prefill: prompt.text.clone(),
+            text_elements: prompt.text_elements.clone(),
+            local_image_paths: prompt
+                .local_images
+                .iter()
+                .map(|image| image.path.clone())
+                .collect(),
+            remote_image_urls: prompt.remote_image_urls.clone(),
+        };
+        if user_total == 0 {
+            if self.backtrack.pending_rollback.is_some() {
+                self.chat_widget
+                    .add_error_message("Backtrack rollback already in progress.".to_string());
+                return;
+            }
+            self.backtrack.pending_rollback = Some(PendingBacktrackRollback {
+                selection,
+                thread_id: self.chat_widget.thread_id(),
+            });
+            self.chat_widget
+                .submit_op(AppCommand::thread_rollback(/*num_turns*/ 1));
+            self.chat_widget.restore_user_message_to_composer(prompt);
+            return;
+        }
+        self.apply_backtrack_rollback(selection);
+        self.chat_widget.restore_user_message_to_composer(prompt);
+    }
+
     /// Open transcript overlay (enters alternate screen and shows full transcript).
     pub(crate) fn open_transcript_overlay(&mut self, tui: &mut tui::Tui) {
         let _ = tui.enter_alt_screen();
@@ -255,25 +288,6 @@ impl App {
         if was_backtrack {
             // Ensure backtrack state is fully reset when overlay closes (e.g. via 'q').
             self.reset_backtrack_state();
-        }
-    }
-
-    /// Re-render the full transcript into the terminal scrollback in one call.
-    /// Useful when switching sessions to ensure prior history remains visible.
-    pub(crate) fn render_transcript_once(&mut self, tui: &mut tui::Tui) {
-        if !self.transcript_cells.is_empty() {
-            let width = self
-                .chat_widget
-                .history_wrap_width(tui.terminal.last_known_screen_size.width);
-            for cell in &self.transcript_cells {
-                tui.insert_history_hyperlink_lines_with_wrap_policy(
-                    cell.display_hyperlink_lines_for_mode(
-                        width,
-                        self.chat_widget.history_render_mode(),
-                    ),
-                    self.history_line_wrap_policy(),
-                );
-            }
         }
     }
 

--- a/codex-rs/tui/src/app_command.rs
+++ b/codex-rs/tui/src/app_command.rs
@@ -26,7 +26,9 @@ use serde_json::Value;
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub(crate) enum AppCommand {
-    Interrupt,
+    Interrupt {
+        behavior: InterruptBehavior,
+    },
     CleanBackgroundTerminals,
     RealtimeConversationStart {
         transport: Option<ThreadRealtimeStartTransport>,
@@ -110,9 +112,23 @@ pub(crate) enum AppCommand {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub(crate) enum InterruptBehavior {
+    Default,
+    RestorePromptIfNoOutput,
+}
+
 impl AppCommand {
     pub(crate) fn interrupt() -> Self {
-        Self::Interrupt
+        Self::Interrupt {
+            behavior: InterruptBehavior::Default,
+        }
+    }
+
+    pub(crate) fn interrupt_and_restore_prompt_if_no_output() -> Self {
+        Self::Interrupt {
+            behavior: InterruptBehavior::RestorePromptIfNoOutput,
+        }
     }
 
     pub(crate) fn clean_background_terminals() -> Self {

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -234,6 +234,9 @@ pub(crate) enum AppEvent {
     /// bubbling channels through layers of widgets.
     CodexOp(AppCommand),
 
+    /// Restore an output-free interrupted turn into the composer and roll it back.
+    RestoreCancelledTurn(UserMessage),
+
     /// Approve one retry of a recent auto-review denial selected in the TUI.
     ApproveRecentAutoReviewDenial {
         thread_id: ThreadId,

--- a/codex-rs/tui/src/app_event_sender.rs
+++ b/codex-rs/tui/src/app_event_sender.rs
@@ -47,6 +47,12 @@ impl AppEventSender {
         self.send(AppEvent::CodexOp(AppCommand::interrupt()));
     }
 
+    pub(crate) fn interrupt_and_restore_prompt_if_no_output(&self) {
+        self.send(AppEvent::CodexOp(
+            AppCommand::interrupt_and_restore_prompt_if_no_output(),
+        ));
+    }
+
     pub(crate) fn compact(&self) {
         self.send(AppEvent::CodexOp(AppCommand::compact()));
     }

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -2595,7 +2595,7 @@ mod tests {
 
         while let Ok(ev) = rx.try_recv() {
             assert!(
-                !matches!(ev, AppEvent::CodexOp(Op::Interrupt)),
+                !matches!(ev, AppEvent::CodexOp(Op::Interrupt { .. })),
                 "expected Esc to not send Op::Interrupt when dismissing skill popup"
             );
         }
@@ -2633,7 +2633,7 @@ mod tests {
 
         while let Ok(ev) = rx.try_recv() {
             assert!(
-                !matches!(ev, AppEvent::CodexOp(Op::Interrupt)),
+                !matches!(ev, AppEvent::CodexOp(Op::Interrupt { .. })),
                 "expected Esc to not send Op::Interrupt while command popup is active"
             );
         }
@@ -2669,7 +2669,7 @@ mod tests {
 
         while let Ok(ev) = rx.try_recv() {
             assert!(
-                !matches!(ev, AppEvent::CodexOp(Op::Interrupt)),
+                !matches!(ev, AppEvent::CodexOp(Op::Interrupt { .. })),
                 "expected Esc to not send Op::Interrupt while typing `/agent`"
             );
         }
@@ -2714,7 +2714,7 @@ mod tests {
 
         while let Ok(ev) = rx.try_recv() {
             assert!(
-                !matches!(ev, AppEvent::CodexOp(Op::Interrupt)),
+                !matches!(ev, AppEvent::CodexOp(Op::Interrupt { .. })),
                 "expected Esc release after dismissing agent picker to not interrupt"
             );
         }
@@ -2744,7 +2744,7 @@ mod tests {
         pane.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
 
         assert!(
-            matches!(rx.try_recv(), Ok(AppEvent::CodexOp(Op::Interrupt))),
+            matches!(rx.try_recv(), Ok(AppEvent::CodexOp(Op::Interrupt { .. }))),
             "expected Esc to send Op::Interrupt while a task is running"
         );
     }
@@ -2768,7 +2768,7 @@ mod tests {
 
         pane.handle_key_event(KeyEvent::new(KeyCode::F(12), KeyModifiers::NONE));
         assert!(
-            matches!(rx.try_recv(), Ok(AppEvent::CodexOp(Op::Interrupt))),
+            matches!(rx.try_recv(), Ok(AppEvent::CodexOp(Op::Interrupt { .. }))),
             "expected configured key to interrupt while `/agent` is being edited"
         );
     }

--- a/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
@@ -1382,7 +1382,7 @@ mod tests {
         let AppEvent::CodexOp(op) = event else {
             panic!("expected CodexOp");
         };
-        assert_eq!(op, Op::Interrupt);
+        assert_eq!(op, Op::interrupt());
         assert!(
             rx.try_recv().is_err(),
             "unexpected AppEvents before interrupt completion"

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -644,6 +644,7 @@ pub(crate) struct ChatWidget {
     // order.
     suppress_initial_user_message_submit: bool,
     input_queue: InputQueueState,
+    cancel_edit: CancelEditState,
     /// Main chat-surface bindings resolved from `tui.keymap.chat`.
     chat_keymap: ChatKeymap,
     /// Keybinding to show for popping the most-recently queued message back
@@ -755,6 +756,13 @@ pub(crate) enum InterruptedTurnNoticeMode {
     #[default]
     Default,
     Suppress,
+}
+
+#[derive(Debug, Default)]
+struct CancelEditState {
+    prompt: Option<UserMessage>,
+    eligible: bool,
+    armed: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1181,6 +1189,9 @@ impl ChatWidget {
     }
 
     fn add_boxed_history(&mut self, cell: Box<dyn HistoryCell>) {
+        if self.turn_lifecycle.agent_turn_running && !cell.display_lines(u16::MAX).is_empty() {
+            self.record_visible_turn_activity();
+        }
         // Keep the placeholder session header as the active cell until real session info arrives,
         // so we can merge headers instead of committing a duplicate box to history.
         let keep_placeholder_header_active = !self.is_session_configured()
@@ -1799,7 +1810,12 @@ impl ChatWidget {
     }
 
     pub(crate) fn prepare_local_op_submission(&mut self, op: &AppCommand) {
-        if matches!(op, AppCommand::Interrupt) && self.turn_lifecycle.agent_turn_running {
+        if let AppCommand::Interrupt { behavior } = op
+            && self.turn_lifecycle.agent_turn_running
+        {
+            if *behavior == crate::app_command::InterruptBehavior::RestorePromptIfNoOutput {
+                self.arm_cancel_edit();
+            }
             if let Some(controller) = self.stream_controller.as_mut() {
                 controller.clear_queue();
             }

--- a/codex-rs/tui/src/chatwidget/command_lifecycle.rs
+++ b/codex-rs/tui/src/chatwidget/command_lifecycle.rs
@@ -240,6 +240,7 @@ impl ChatWidget {
     }
 
     pub(crate) fn handle_command_execution_started_now(&mut self, item: ThreadItem) {
+        self.record_visible_turn_activity();
         let ThreadItem::CommandExecution {
             id,
             command,

--- a/codex-rs/tui/src/chatwidget/constructor.rs
+++ b/codex-rs/tui/src/chatwidget/constructor.rs
@@ -182,6 +182,7 @@ impl ChatWidget {
             forked_from: None,
             interrupted_turn_notice_mode: InterruptedTurnNoticeMode::Default,
             input_queue: InputQueueState::default(),
+            cancel_edit: CancelEditState::default(),
             chat_keymap,
             queued_message_edit_hint_binding,
             show_welcome_banner: is_first_run,

--- a/codex-rs/tui/src/chatwidget/hook_lifecycle.rs
+++ b/codex-rs/tui/src/chatwidget/hook_lifecycle.rs
@@ -7,6 +7,7 @@ use super::*;
 
 impl ChatWidget {
     pub(super) fn on_hook_started(&mut self, run: codex_app_server_protocol::HookRunSummary) {
+        self.record_visible_turn_activity();
         self.flush_answer_stream_with_separator();
         self.flush_completed_hook_output();
         match self.active_hook_cell.as_mut() {

--- a/codex-rs/tui/src/chatwidget/input_restore.rs
+++ b/codex-rs/tui/src/chatwidget/input_restore.rs
@@ -3,6 +3,38 @@
 use super::*;
 
 impl ChatWidget {
+    pub(super) fn record_cancel_edit_candidate(&mut self, prompt: UserMessage) {
+        self.cancel_edit.prompt = Some(prompt);
+        self.cancel_edit.eligible = true;
+        self.cancel_edit.armed = false;
+    }
+
+    pub(super) fn record_visible_turn_activity(&mut self) {
+        self.cancel_edit.eligible = false;
+        self.cancel_edit.armed = false;
+    }
+
+    pub(super) fn arm_cancel_edit(&mut self) {
+        self.cancel_edit.armed = self.cancel_edit.eligible
+            && self.cancel_edit.prompt.is_some()
+            && self.bottom_pane.composer_is_empty()
+            && self.input_queue.pending_steers.is_empty()
+            && !self.has_queued_follow_up_messages()
+            && !self.active_side_conversation;
+    }
+
+    fn take_armed_cancel_edit_prompt(&mut self, reason: TurnAbortReason) -> Option<UserMessage> {
+        (reason == TurnAbortReason::Interrupted
+            && self.cancel_edit.armed
+            && self.cancel_edit.eligible)
+            .then(|| self.cancel_edit.prompt.take())
+            .flatten()
+    }
+
+    pub(super) fn clear_cancel_edit(&mut self) {
+        self.cancel_edit = CancelEditState::default();
+    }
+
     pub(crate) fn set_initial_user_message_submit_suppressed(&mut self, suppressed: bool) {
         self.suppress_initial_user_message_submit = suppressed;
     }
@@ -104,12 +136,15 @@ impl ChatWidget {
     /// When there are queued user messages, restore them into the composer
     /// separated by newlines rather than auto-submitting the next one.
     pub(super) fn on_interrupted_turn(&mut self, reason: TurnAbortReason) {
+        let cancelled_prompt = self.take_armed_cancel_edit_prompt(reason);
         // Finalize, log a gentle prompt, and clear running state.
         self.finalize_turn();
         let send_pending_steers_immediately =
             self.input_queue.submit_pending_steers_after_interrupt;
         self.input_queue.submit_pending_steers_after_interrupt = false;
-        if self.interrupted_turn_notice_mode != InterruptedTurnNoticeMode::Suppress {
+        if cancelled_prompt.is_none()
+            && self.interrupted_turn_notice_mode != InterruptedTurnNoticeMode::Suppress
+        {
             if send_pending_steers_immediately {
                 self.add_to_history(history_cell::new_info_event(
                     "Model interrupted to submit steer instructions.".to_owned(),
@@ -143,6 +178,10 @@ impl ChatWidget {
             self.restore_user_message_to_composer(combined);
         }
         self.refresh_pending_input_preview();
+        if let Some(prompt) = cancelled_prompt {
+            self.app_event_tx
+                .send(AppEvent::RestoreCancelledTurn(prompt));
+        }
 
         self.request_redraw();
     }

--- a/codex-rs/tui/src/chatwidget/input_submission.rs
+++ b/codex-rs/tui/src/chatwidget/input_submission.rs
@@ -389,6 +389,16 @@ impl ChatWidget {
             self.refresh_pending_input_preview();
         }
 
+        if render_in_history {
+            self.record_cancel_edit_candidate(UserMessage {
+                text: text.clone(),
+                local_images: local_images.clone(),
+                remote_image_urls: remote_image_urls.clone(),
+                text_elements: text_elements.clone(),
+                mention_bindings: mention_bindings.clone(),
+            });
+        }
+
         // Show replayable user content in conversation history.
         let display_user_message = render_in_history.then(|| {
             user_message_display_for_history(

--- a/codex-rs/tui/src/chatwidget/interaction.rs
+++ b/codex-rs/tui/src/chatwidget/interaction.rs
@@ -375,7 +375,7 @@ impl ChatWidget {
                 self.quit_shortcut_key = None;
                 self.bottom_pane.clear_quit_shortcut_hint();
                 self.pause_active_goal_for_interrupt();
-                self.submit_op(AppCommand::interrupt());
+                self.submit_op(AppCommand::interrupt_and_restore_prompt_if_no_output());
             } else {
                 self.request_quit_without_confirmation();
             }
@@ -393,7 +393,7 @@ impl ChatWidget {
 
         if self.is_cancellable_work_active() {
             self.pause_active_goal_for_interrupt();
-            self.submit_op(AppCommand::interrupt());
+            self.submit_op(AppCommand::interrupt_and_restore_prompt_if_no_output());
         }
     }
 

--- a/codex-rs/tui/src/chatwidget/streaming.rs
+++ b/codex-rs/tui/src/chatwidget/streaming.rs
@@ -111,6 +111,9 @@ impl ChatWidget {
         if self.active_mode_kind() != ModeKind::Plan {
             return;
         }
+        if !delta.is_empty() {
+            self.record_visible_turn_activity();
+        }
         if !self.transcript.plan_item_active {
             self.transcript.plan_item_active = true;
             self.transcript.plan_delta_buffer.clear();
@@ -370,6 +373,9 @@ impl ChatWidget {
 
     #[inline]
     pub(super) fn handle_streaming_delta(&mut self, delta: String) {
+        if !delta.is_empty() {
+            self.record_visible_turn_activity();
+        }
         if self.stream_controller.is_none() {
             // Before starting an agent stream, flush any active exec cell group.
             self.flush_unified_exec_wait_streak();

--- a/codex-rs/tui/src/chatwidget/tests/composer_submission.rs
+++ b/codex-rs/tui/src/chatwidget/tests/composer_submission.rs
@@ -7,6 +7,7 @@ use codex_protocol::permissions::FileSystemSandboxEntry;
 use codex_protocol::permissions::FileSystemSpecialPath;
 use codex_protocol::permissions::NetworkSandboxPolicy;
 use pretty_assertions::assert_eq;
+use std::collections::HashMap;
 use std::collections::VecDeque;
 
 #[tokio::test]
@@ -927,6 +928,69 @@ async fn empty_enter_during_task_does_not_queue() {
 }
 
 #[tokio::test]
+async fn output_free_interrupted_turn_requests_prompt_restore() {
+    let (mut chat, mut rx, mut op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    let prompt = UserMessage::from("revise this prompt");
+    chat.record_cancel_edit_candidate(prompt.clone());
+    handle_turn_started(&mut chat, "turn-1");
+
+    chat.submit_op(AppCommand::interrupt_and_restore_prompt_if_no_output());
+    assert_matches!(
+        op_rx.try_recv(),
+        Ok(Op::Interrupt {
+            behavior: crate::app_command::InterruptBehavior::RestorePromptIfNoOutput,
+        })
+    );
+    handle_turn_interrupted(&mut chat, "turn-1");
+
+    assert_matches!(rx.try_recv(), Ok(AppEvent::RestoreCancelledTurn(restored)) if restored == prompt);
+}
+
+#[tokio::test]
+async fn visible_output_prevents_cancelled_turn_prompt_restore() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    chat.record_cancel_edit_candidate(UserMessage::from("revise this prompt"));
+    handle_turn_started(&mut chat, "turn-1");
+    chat.on_agent_message_delta("visible output".to_string());
+    chat.submit_op(AppCommand::interrupt_and_restore_prompt_if_no_output());
+
+    handle_turn_interrupted(&mut chat, "turn-1");
+
+    while let Ok(event) = rx.try_recv() {
+        assert!(!matches!(event, AppEvent::RestoreCancelledTurn(_)));
+    }
+}
+
+#[tokio::test]
+async fn thinking_status_keeps_cancelled_turn_prompt_restore_eligible() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    let prompt = UserMessage::from("revise this prompt");
+    chat.record_cancel_edit_candidate(prompt.clone());
+    handle_turn_started(&mut chat, "turn-1");
+    chat.on_agent_reasoning_delta("**Thinking**".to_string());
+    chat.submit_op(AppCommand::interrupt_and_restore_prompt_if_no_output());
+
+    handle_turn_interrupted(&mut chat, "turn-1");
+
+    assert_matches!(rx.try_recv(), Ok(AppEvent::RestoreCancelledTurn(restored)) if restored == prompt);
+}
+
+#[tokio::test]
+async fn patch_activity_prevents_cancelled_turn_prompt_restore() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    chat.record_cancel_edit_candidate(UserMessage::from("revise this prompt"));
+    handle_turn_started(&mut chat, "turn-1");
+    chat.on_patch_apply_begin(HashMap::new());
+    chat.submit_op(AppCommand::interrupt_and_restore_prompt_if_no_output());
+
+    handle_turn_interrupted(&mut chat, "turn-1");
+
+    while let Ok(event) = rx.try_recv() {
+        assert!(!matches!(event, AppEvent::RestoreCancelledTurn(_)));
+    }
+}
+
+#[tokio::test]
 async fn pending_steer_esc_does_not_steal_vim_insert_escape() {
     let (mut chat, _rx, mut op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
     let esc = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
@@ -949,7 +1013,7 @@ async fn pending_steer_esc_does_not_steal_vim_insert_escape() {
     chat.handle_key_event(esc);
 
     match op_rx.try_recv() {
-        Ok(Op::Interrupt) => {}
+        Ok(Op::Interrupt { .. }) => {}
         other => panic!("expected Op::Interrupt, got {other:?}"),
     }
     assert!(chat.input_queue.submit_pending_steers_after_interrupt);
@@ -975,7 +1039,7 @@ async fn pending_steer_interrupt_uses_remapped_binding() {
     chat.handle_key_event(KeyEvent::new(KeyCode::F(12), KeyModifiers::NONE));
 
     match op_rx.try_recv() {
-        Ok(Op::Interrupt) => {}
+        Ok(Op::Interrupt { .. }) => {}
         other => panic!("expected Op::Interrupt, got {other:?}"),
     }
     assert!(chat.input_queue.submit_pending_steers_after_interrupt);

--- a/codex-rs/tui/src/chatwidget/tests/helpers.rs
+++ b/codex-rs/tui/src/chatwidget/tests/helpers.rs
@@ -208,7 +208,7 @@ pub(super) fn next_submit_op(op_rx: &mut tokio::sync::mpsc::UnboundedReceiver<Op
 pub(super) fn next_interrupt_op(op_rx: &mut tokio::sync::mpsc::UnboundedReceiver<Op>) {
     loop {
         match op_rx.try_recv() {
-            Ok(Op::Interrupt) => return,
+            Ok(Op::Interrupt { .. }) => return,
             Ok(_) => continue,
             Err(TryRecvError::Empty) => panic!("expected interrupt op but queue was empty"),
             Err(TryRecvError::Disconnected) => panic!("expected interrupt op but channel closed"),

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -1351,7 +1351,7 @@ async fn streaming_final_answer_keeps_task_running_state() {
 
     chat.handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
     match op_rx.try_recv() {
-        Ok(Op::Interrupt) => {}
+        Ok(Op::Interrupt { .. }) => {}
         other => panic!("expected Op::Interrupt, got {other:?}"),
     }
     assert!(!chat.bottom_pane.quit_shortcut_hint_visible());
@@ -1384,7 +1384,7 @@ async fn ctrl_c_interrupt_pauses_active_goal_turn() {
     chat.handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
 
     match op_rx.try_recv() {
-        Ok(Op::Interrupt) => {}
+        Ok(Op::Interrupt { .. }) => {}
         other => panic!("expected Op::Interrupt, got {other:?}"),
     }
     assert_matches!(

--- a/codex-rs/tui/src/chatwidget/tool_lifecycle.rs
+++ b/codex-rs/tui/src/chatwidget/tool_lifecycle.rs
@@ -7,10 +7,12 @@ use super::*;
 
 impl ChatWidget {
     pub(super) fn on_patch_apply_begin(&mut self, changes: HashMap<PathBuf, FileChange>) {
+        self.record_visible_turn_activity();
         self.add_to_history(history_cell::new_patch_event(changes, &self.config.cwd));
     }
 
     pub(super) fn on_view_image_tool_call(&mut self, path: AbsolutePathBuf) {
+        self.record_visible_turn_activity();
         self.flush_answer_stream_with_separator();
         self.add_to_history(history_cell::new_view_image_tool_call(
             path,
@@ -20,6 +22,7 @@ impl ChatWidget {
     }
 
     pub(super) fn on_image_generation_begin(&mut self) {
+        self.record_visible_turn_activity();
         self.flush_answer_stream_with_separator();
     }
 
@@ -63,6 +66,7 @@ impl ChatWidget {
     }
 
     pub(super) fn on_web_search_begin(&mut self, call_id: String) {
+        self.record_visible_turn_activity();
         self.flush_answer_stream_with_separator();
         self.flush_active_cell();
         self.transcript.active_cell = Some(Box::new(history_cell::new_active_web_search_call(
@@ -109,6 +113,7 @@ impl ChatWidget {
     }
 
     pub(super) fn on_collab_agent_tool_call(&mut self, item: ThreadItem) {
+        self.record_visible_turn_activity();
         let ThreadItem::CollabAgentToolCall {
             id, tool, status, ..
         } = &item
@@ -153,6 +158,7 @@ impl ChatWidget {
     }
 
     pub(crate) fn handle_mcp_tool_call_started_now(&mut self, item: ThreadItem) {
+        self.record_visible_turn_activity();
         let ThreadItem::McpToolCall {
             id,
             server,

--- a/codex-rs/tui/src/chatwidget/tool_requests.rs
+++ b/codex-rs/tui/src/chatwidget/tool_requests.rs
@@ -7,6 +7,7 @@ use super::*;
 
 impl ChatWidget {
     pub(super) fn on_exec_approval_request(&mut self, _id: String, ev: ExecApprovalRequestEvent) {
+        self.record_visible_turn_activity();
         let ev2 = ev.clone();
         self.defer_or_handle(
             |q| q.push_exec_approval(ev),
@@ -19,6 +20,7 @@ impl ChatWidget {
         _id: String,
         ev: ApplyPatchApprovalRequestEvent,
     ) {
+        self.record_visible_turn_activity();
         let ev2 = ev.clone();
         self.defer_or_handle(
             |q| q.push_apply_patch_approval(ev),
@@ -256,6 +258,7 @@ impl ChatWidget {
         request_id: AppServerRequestId,
         params: McpServerElicitationRequestParams,
     ) {
+        self.record_visible_turn_activity();
         let request_id2 = request_id.clone();
         let params2 = params.clone();
         self.defer_or_handle(
@@ -265,6 +268,7 @@ impl ChatWidget {
     }
 
     pub(super) fn on_request_user_input(&mut self, ev: ToolRequestUserInputParams) {
+        self.record_visible_turn_activity();
         let ev2 = ev.clone();
         self.defer_or_handle(
             |q| q.push_user_input(ev),
@@ -273,6 +277,7 @@ impl ChatWidget {
     }
 
     pub(super) fn on_request_permissions(&mut self, ev: RequestPermissionsEvent) {
+        self.record_visible_turn_activity();
         let ev2 = ev.clone();
         self.defer_or_handle(
             |q| q.push_request_permissions(ev),

--- a/codex-rs/tui/src/chatwidget/turn_runtime.rs
+++ b/codex-rs/tui/src/chatwidget/turn_runtime.rs
@@ -317,6 +317,7 @@ impl ChatWidget {
         self.stream_controller = None;
         self.plan_stream_controller = None;
         self.status_state.pending_status_indicator_restore = false;
+        self.clear_cancel_edit();
         self.request_status_line_branch_refresh();
         self.request_status_line_git_summary_refresh();
         self.maybe_show_pending_rate_limit_prompt();

--- a/codex-rs/tui/src/chatwidget/user_messages.rs
+++ b/codex-rs/tui/src/chatwidget/user_messages.rs
@@ -25,16 +25,16 @@ use super::ChatWidget;
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct UserMessage {
-    pub(super) text: String,
-    pub(super) local_images: Vec<LocalImageAttachment>,
+    pub(crate) text: String,
+    pub(crate) local_images: Vec<LocalImageAttachment>,
     /// Remote image attachments represented as URLs (for example data URLs)
     /// provided by app-server clients.
     ///
     /// Unlike `local_images`, these are not created by TUI image attach/paste
     /// flows. The TUI can restore and remove them while editing/backtracking.
-    pub(super) remote_image_urls: Vec<String>,
-    pub(super) text_elements: Vec<TextElement>,
-    pub(super) mention_bindings: Vec<MentionBinding>,
+    pub(crate) remote_image_urls: Vec<String>,
+    pub(crate) text_elements: Vec<TextElement>,
+    pub(crate) mention_bindings: Vec<MentionBinding>,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/codex-rs/tui/src/status_indicator_widget.rs
+++ b/codex-rs/tui/src/status_indicator_widget.rs
@@ -101,7 +101,8 @@ impl StatusIndicatorWidget {
     }
 
     pub(crate) fn interrupt(&self) {
-        self.app_event_tx.interrupt();
+        self.app_event_tx
+            .interrupt_and_restore_prompt_if_no_output();
     }
 
     /// Update the animated header label (left of the brackets).


### PR DESCRIPTION
## TL;DR

When you press Esc or Ctrl+C after sending a prompt but before any output was rendering, it restores the last composer and the message.

## Summary

Cancelling a prompt immediately after submission should behave like returning to edit that prompt, not like discarding the user's draft. Today, pressing `Esc` or `Ctrl+C` before Codex responds leaves the submitted prompt in the transcript and returns an empty composer, forcing the user to recall or retype it.

When an interrupted turn has not produced substantive visible output, restore its submitted prompt directly into the composer and roll back that latest turn. This also covers the first prompt in a fresh thread, before the TUI has retained a local user-history cell. The restored draft keeps its text, image attachments, and active collaboration mode so it can be edited and resubmitted in place.

Restoration is intentionally suppressed once the turn has produced user-visible activity such as assistant output, tool work, hooks, or patches. A transient thinking status does not make the prompt ineligible. Rollback also rebuilds terminal scrollback from the retained transcript cells so repeated cancellations and terminal resizes do not duplicate history.

## How to Test

1. Start the TUI with `cargo run -p codex-cli --bin codex`.
2. In a fresh thread, submit the first prompt and press `Esc` before Codex emits substantive output. Confirm that the prompt returns to the composer for editing and its submitted transcript row is removed.
3. Repeat with `Ctrl+C`, then repeat after at least one completed turn. Confirm the same behavior.
4. Submit a prompt, wait for assistant output or tool activity, then cancel. Confirm that the transcript remains intact and the prompt is not restored into the composer.
5. Cancel several output-free prompts and resize the terminal between attempts. Confirm that the startup banner, tip, and transcript history do not duplicate in scrollback.

Targeted tests:
- `just test -p codex-tui cancelled_turn_edit_restores_prompt`
- `just test -p codex-tui output_free_interrupted_turn_requests_prompt_restore`
- `just test -p codex-tui visible_output_prevents_cancelled_turn_prompt_restore`
- `just test -p codex-tui thinking_status_keeps_cancelled_turn_prompt_restore_eligible`
- `just test -p codex-tui patch_activity_prevents_cancelled_turn_prompt_restore`

The full `just test -p codex-tui` run completed with `2746` passing tests and two unrelated existing guardian feature-flag failures. `just argument-comment-lint` remains blocked locally by the existing Bazel LLVM `compiler-rt` sanitizer-header glob failure; the touched Rust diff was manually audited for positional literal comments.