### PR TITLE
fix: Limit Bedrock GPT models to default service tier

### DIFF
--- a/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
+++ b/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
@@ -9,7 +9,7 @@ const GPT_5_5_OPENAI_MODEL_ID: &str = "gpt-5.5";
 const GPT_5_4_OPENAI_MODEL_ID: &str = "gpt-5.4";
 
 pub(crate) fn static_model_catalog() -> ModelsResponse {
-    ModelsResponse {
+    without_service_tiers(ModelsResponse {
         models: vec![
             gpt_5_bedrock_model(
                 GPT_5_5_OPENAI_MODEL_ID,
@@ -22,16 +22,22 @@ pub(crate) fn static_model_catalog() -> ModelsResponse {
                 /*priority*/ 1,
             ),
         ],
+    })
+}
+
+pub(crate) fn without_service_tiers(mut catalog: ModelsResponse) -> ModelsResponse {
+    for model in &mut catalog.models {
+        model.additional_speed_tiers.clear();
+        model.service_tiers.clear();
+        model.default_service_tier = None;
     }
+    catalog
 }
 
 fn gpt_5_bedrock_model(openai_slug: &str, bedrock_slug: &str, priority: i32) -> ModelInfo {
     let mut model = bundled_openai_model(openai_slug);
     model.slug = bedrock_slug.to_string();
     model.priority = priority;
-    model.additional_speed_tiers.clear();
-    model.service_tiers.clear();
-    model.default_service_tier = None;
     model.context_window = Some(GPT_5_BEDROCK_CONTEXT_WINDOW);
     model.max_context_window = Some(GPT_5_BEDROCK_CONTEXT_WINDOW);
     model

--- a/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
+++ b/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
@@ -9,7 +9,7 @@ const GPT_5_5_OPENAI_MODEL_ID: &str = "gpt-5.5";
 const GPT_5_4_OPENAI_MODEL_ID: &str = "gpt-5.4";
 
 pub(crate) fn static_model_catalog() -> ModelsResponse {
-    without_service_tiers(ModelsResponse {
+    with_default_only_service_tier(ModelsResponse {
         models: vec![
             gpt_5_bedrock_model(
                 GPT_5_5_OPENAI_MODEL_ID,
@@ -25,8 +25,9 @@ pub(crate) fn static_model_catalog() -> ModelsResponse {
     })
 }
 
-pub(crate) fn without_service_tiers(mut catalog: ModelsResponse) -> ModelsResponse {
+pub(crate) fn with_default_only_service_tier(mut catalog: ModelsResponse) -> ModelsResponse {
     for model in &mut catalog.models {
+        // Amazon Bedrock currently only supports the implicit "default" tier for GPT models.
         model.additional_speed_tiers.clear();
         model.service_tiers.clear();
         model.default_service_tier = None;
@@ -54,6 +55,7 @@ fn bundled_openai_model(slug: &str) -> ModelInfo {
 
 #[cfg(test)]
 mod tests {
+    use codex_protocol::config_types::SERVICE_TIER_DEFAULT_REQUEST_VALUE;
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -98,7 +100,7 @@ mod tests {
     }
 
     #[test]
-    fn gpt_5_bedrock_models_do_not_advertise_service_tiers() {
+    fn gpt_5_bedrock_models_only_allow_default_service_tier() {
         let catalog = static_model_catalog();
 
         for model in catalog.models {
@@ -107,6 +109,11 @@ mod tests {
             assert_eq!(model.default_service_tier, None);
             assert_eq!(
                 model.service_tier_for_request(Some("priority".to_string())),
+                None
+            );
+            assert_eq!(
+                model
+                    .service_tier_for_request(Some(SERVICE_TIER_DEFAULT_REQUEST_VALUE.to_string())),
                 None
             );
         }

--- a/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
+++ b/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
@@ -29,6 +29,9 @@ fn gpt_5_bedrock_model(openai_slug: &str, bedrock_slug: &str, priority: i32) -> 
     let mut model = bundled_openai_model(openai_slug);
     model.slug = bedrock_slug.to_string();
     model.priority = priority;
+    model.additional_speed_tiers.clear();
+    model.service_tiers.clear();
+    model.default_service_tier = None;
     model.context_window = Some(GPT_5_BEDROCK_CONTEXT_WINDOW);
     model.max_context_window = Some(GPT_5_BEDROCK_CONTEXT_WINDOW);
     model
@@ -86,5 +89,20 @@ mod tests {
                 Some(GPT_5_BEDROCK_CONTEXT_WINDOW)
             )
         );
+    }
+
+    #[test]
+    fn gpt_5_bedrock_models_do_not_advertise_service_tiers() {
+        let catalog = static_model_catalog();
+
+        for model in catalog.models {
+            assert_eq!(model.additional_speed_tiers, Vec::<String>::new());
+            assert_eq!(model.service_tiers, Vec::new());
+            assert_eq!(model.default_service_tier, None);
+            assert_eq!(
+                model.service_tier_for_request(Some("priority".to_string())),
+                None
+            );
+        }
     }
 }

--- a/codex-rs/model-provider/src/amazon_bedrock/mod.rs
+++ b/codex-rs/model-provider/src/amazon_bedrock/mod.rs
@@ -24,7 +24,7 @@ use crate::provider::ProviderAccountState;
 use crate::provider::ProviderCapabilities;
 use auth::resolve_provider_auth;
 pub(crate) use catalog::static_model_catalog;
-use catalog::without_service_tiers;
+use catalog::with_default_only_service_tier;
 use mantle::runtime_base_url;
 
 /// Runtime provider for Amazon Bedrock's OpenAI-compatible Mantle endpoint.
@@ -104,7 +104,7 @@ impl ModelProvider for AmazonBedrockModelProvider {
     ) -> SharedModelsManager {
         Arc::new(StaticModelsManager::new(
             /*auth_manager*/ None,
-            config_model_catalog.map_or_else(static_model_catalog, without_service_tiers),
+            config_model_catalog.map_or_else(static_model_catalog, with_default_only_service_tier),
         ))
     }
 }

--- a/codex-rs/model-provider/src/amazon_bedrock/mod.rs
+++ b/codex-rs/model-provider/src/amazon_bedrock/mod.rs
@@ -24,6 +24,7 @@ use crate::provider::ProviderAccountState;
 use crate::provider::ProviderCapabilities;
 use auth::resolve_provider_auth;
 pub(crate) use catalog::static_model_catalog;
+use catalog::without_service_tiers;
 use mantle::runtime_base_url;
 
 /// Runtime provider for Amazon Bedrock's OpenAI-compatible Mantle endpoint.
@@ -103,7 +104,7 @@ impl ModelProvider for AmazonBedrockModelProvider {
     ) -> SharedModelsManager {
         Arc::new(StaticModelsManager::new(
             /*auth_manager*/ None,
-            config_model_catalog.unwrap_or_else(static_model_catalog),
+            config_model_catalog.map_or_else(static_model_catalog, without_service_tiers),
         ))
     }
 }

--- a/codex-rs/model-provider/src/provider.rs
+++ b/codex-rs/model-provider/src/provider.rs
@@ -520,7 +520,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn amazon_bedrock_provider_strips_service_tiers_from_configured_static_catalog() {
+    async fn configured_bedrock_catalog_only_allows_default_service_tier() {
         let configured_model = codex_models_manager::bundled_models_response()
             .expect("bundled models should parse")
             .models

--- a/codex-rs/model-provider/src/provider.rs
+++ b/codex-rs/model-provider/src/provider.rs
@@ -520,9 +520,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn amazon_bedrock_provider_uses_configured_static_catalog_when_present() {
-        let custom_model =
-            codex_models_manager::model_info::model_info_from_slug("custom-bedrock-model");
+    async fn amazon_bedrock_provider_strips_service_tiers_from_configured_static_catalog() {
+        let configured_model = codex_models_manager::bundled_models_response()
+            .expect("bundled models should parse")
+            .models
+            .into_iter()
+            .find(|model| model.slug == "gpt-5.5")
+            .expect("bundled models should include GPT-5.5");
+        assert!(!configured_model.additional_speed_tiers.is_empty());
+        assert!(!configured_model.service_tiers.is_empty());
 
         let provider = create_model_provider(
             ModelProviderInfo::create_amazon_bedrock_provider(/*aws*/ None),
@@ -531,14 +537,20 @@ mod tests {
         let manager = provider.models_manager(
             test_codex_home(),
             Some(ModelsResponse {
-                models: vec![custom_model],
+                models: vec![configured_model],
             }),
         );
 
         let catalog = manager.raw_model_catalog(RefreshStrategy::Online).await;
 
         assert_eq!(catalog.models.len(), 1);
-        assert_eq!(catalog.models[0].slug, "custom-bedrock-model");
+        assert_eq!(catalog.models[0].slug, "gpt-5.5");
+        assert_eq!(
+            catalog.models[0].additional_speed_tiers,
+            Vec::<String>::new()
+        );
+        assert_eq!(catalog.models[0].service_tiers, Vec::new());
+        assert_eq!(catalog.models[0].default_service_tier, None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Description

Bedrock currently only supports the implicit `default` service tier for GPT models. This PR strips non-default service tier metadata from Bedrock model catalogs so Codex does not advertise or send unsupported tiers.

## What changed

- Normalize both built-in and configured Bedrock catalogs to default-only service tier behavior.
- Add regression coverage for built-in and configured Bedrock catalogs.

## Validation

- `just fmt`
- `just test -p codex-model-provider`