### PR TITLE
feat(app-server): project workspace mutation approvals [4 of 5]

### DIFF
--- a/codex-rs/app-server-protocol/schema/typescript/v2/ThreadSettings.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/ThreadSettings.ts
@@ -11,4 +11,4 @@ import type { ApprovalsReviewer } from "./ApprovalsReviewer";
 import type { AskForApproval } from "./AskForApproval";
 import type { SandboxPolicy } from "./SandboxPolicy";
 
-export type ThreadSettings = { cwd: AbsolutePathBuf, approvalPolicy: AskForApproval, approvalsReviewer: ApprovalsReviewer, sandboxPolicy: SandboxPolicy, activePermissionProfile: ActivePermissionProfile | null, model: string, modelProvider: string, serviceTier: string | null, effort: ReasoningEffort | null, summary: ReasoningSummary | null, collaborationMode: CollaborationMode, personality: Personality | null, };
+export type ThreadSettings = {cwd: AbsolutePathBuf, approvalPolicy: AskForApproval, approvalsReviewer: ApprovalsReviewer, sandboxPolicy: SandboxPolicy, activePermissionProfile: ActivePermissionProfile | null, model: string, modelProvider: string, serviceTier: string | null, effort: ReasoningEffort | null, summary: ReasoningSummary | null, collaborationMode: CollaborationMode, personality: Personality | null};

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -3340,6 +3340,7 @@ mod tests {
                 thread_id: "thr_123".to_string(),
                 thread_settings: v2::ThreadSettings {
                     cwd: absolute_path("/tmp/repo"),
+                    runtime_workspace_roots: vec![absolute_path("/tmp/repo")],
                     approval_policy: v2::AskForApproval::Never,
                     approvals_reviewer: v2::ApprovalsReviewer::User,
                     sandbox_policy: v2::SandboxPolicy::DangerFullAccess,

--- a/codex-rs/app-server-protocol/src/protocol/v2/thread.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2/thread.rs
@@ -281,11 +281,13 @@ pub struct ThreadSettingsUpdateParams {
 #[ts(export_to = "v2/")]
 pub struct ThreadSettingsUpdateResponse {}
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS, ExperimentalApi)]
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
 pub struct ThreadSettings {
     pub cwd: AbsolutePathBuf,
+    #[experimental("thread/settings/updated.runtimeWorkspaceRoots")]
+    pub runtime_workspace_roots: Vec<AbsolutePathBuf>,
     pub approval_policy: AskForApproval,
     pub approvals_reviewer: ApprovalsReviewer,
     pub sandbox_policy: SandboxPolicy,

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -148,7 +148,7 @@ Example with notification opt-out:
 - `thread/goal/clear` — clear the current persisted goal for a materialized thread; returns whether a goal was removed and emits `thread/goal/cleared` when state changes.
 - `thread/goal/updated` — notification emitted whenever a thread goal changes; includes the full current goal.
 - `thread/goal/cleared` — notification emitted whenever a thread goal is removed.
-- `thread/settings/updated` — experimental notification emitted to subscribed clients when a loaded thread’s effective next-turn settings change; includes `threadId` and the full `threadSettings`.
+- `thread/settings/updated` — experimental notification emitted to subscribed clients when a loaded thread’s effective next-turn settings change; includes `threadId` and the full `threadSettings`. Experimental clients also receive `threadSettings.runtimeWorkspaceRoots`, including roots added by model workspace mutations.
 - `thread/status/changed` — notification emitted when a loaded thread’s status changes (`threadId` + new `status`).
 - `thread/archive` — move a thread’s rollout file into the archived directory and attempt to move any spawned descendant thread rollout files; returns `{}` on success and emits `thread/archived` for each archived thread.
 - `thread/delete` — hard-delete an active or archived thread and any spawned descendant threads; returns `{}` on success and emits `thread/deleted` for each deleted thread.
@@ -1438,6 +1438,10 @@ the client can offer session-scoped and/or persistent approval choices.
 
 The built-in `request_permissions` tool sends an `item/permissions/requestApproval` JSON-RPC request to the client with the requested permission profile. This v2 payload mirrors the command-execution `additionalPermissions` shape: it can request network access and additional filesystem access. The `environmentId` and `cwd` fields identify the environment and directory used to resolve project-root permissions and relative deny globs.
 
+The model-facing `set_working_directory` and `add_workspace_root` tools use the same request when a mutation would widen persistent filesystem access. These requests include `workspaceMutation` with the operation, canonical target, and resulting workspace roots. Clients must grant workspace-mutation requests with `scope: "session"`; a turn-scoped grant is rejected because the mutation changes persistent thread state.
+
+A workspace-mutation request looks like:
+
 ```json
 {
   "method": "item/permissions/requestApproval",
@@ -1453,6 +1457,11 @@ The built-in `request_permissions` tool sends an `item/permissions/requestApprov
       "fileSystem": {
         "write": ["/Users/me/project", "/Users/me/shared"]
       }
+    },
+    "workspaceMutation": {
+      "operation": "addWorkspaceRoot",
+      "target": "/Users/me/shared",
+      "resultingWorkspaceRoots": ["/Users/me/project", "/Users/me/shared"]
     }
   }
 }

--- a/codex-rs/app-server/src/request_processors.rs
+++ b/codex-rs/app-server/src/request_processors.rs
@@ -290,6 +290,7 @@ use codex_core::CodexThreadSettingsOverrides;
 use codex_core::ForkSnapshot;
 use codex_core::McpManager;
 use codex_core::NewThread;
+use codex_core::RuntimeWorkspaceReplayOverrides;
 #[cfg(test)]
 use codex_core::SessionMeta;
 use codex_core::StartThreadOptions;

--- a/codex-rs/app-server/src/request_processors/thread_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor.rs
@@ -2585,6 +2585,10 @@ impl ThreadRequestProcessor {
 
         let history_cwd = thread_history.session_cwd();
         let runtime_workspace_roots = runtime_workspace_roots.map(resolve_runtime_workspace_roots);
+        let runtime_workspace_replay_overrides = RuntimeWorkspaceReplayOverrides {
+            preserve_cwd: cwd.is_some(),
+            preserve_workspace_roots: runtime_workspace_roots.is_some(),
+        };
         let mut typesafe_overrides = self.build_thread_config_overrides(
             model,
             model_provider,
@@ -2624,11 +2628,12 @@ impl ThreadRequestProcessor {
 
         match self
             .thread_manager
-            .resume_thread_with_history(
+            .resume_thread_with_history_preserving_runtime_workspace_overrides(
                 config,
                 thread_history,
                 self.auth_manager.clone(),
                 self.request_trace_context(&request_id).await,
+                runtime_workspace_replay_overrides,
             )
             .await
         {
@@ -3286,6 +3291,10 @@ impl ThreadRequestProcessor {
                 ))
             })?;
         let history_cwd = Some(source_thread.cwd.clone());
+        let runtime_workspace_replay_overrides = RuntimeWorkspaceReplayOverrides {
+            preserve_cwd: cwd.is_some(),
+            preserve_workspace_roots: runtime_workspace_roots.is_some(),
+        };
 
         // Persist Windows sandbox mode.
         let mut cli_overrides = cli_overrides.unwrap_or_default();
@@ -3341,7 +3350,7 @@ impl ThreadRequestProcessor {
             ..
         } = self
             .thread_manager
-            .fork_thread_from_history(
+            .fork_thread_from_history_preserving_runtime_workspace_overrides(
                 ForkSnapshot::Interrupted,
                 config,
                 InitialHistory::Resumed(ResumedHistory {
@@ -3351,6 +3360,7 @@ impl ThreadRequestProcessor {
                 }),
                 thread_source.map(Into::into),
                 self.request_trace_context(&request_id).await,
+                runtime_workspace_replay_overrides,
             )
             .await
             .map_err(|err| match err {

--- a/codex-rs/app-server/src/request_processors/thread_summary.rs
+++ b/codex-rs/app-server/src/request_processors/thread_summary.rs
@@ -191,6 +191,7 @@ pub(crate) fn thread_settings_from_config_snapshot(
 ) -> ThreadSettings {
     ThreadSettings {
         cwd: config_snapshot.cwd().clone(),
+        runtime_workspace_roots: config_snapshot.workspace_roots.clone(),
         approval_policy: config_snapshot.approval_policy.into(),
         approvals_reviewer: config_snapshot.approvals_reviewer.into(),
         sandbox_policy: thread_response_sandbox_policy(
@@ -222,6 +223,7 @@ pub(crate) fn thread_settings_from_core_snapshot(
         permission_profile,
         active_permission_profile,
         cwd,
+        workspace_roots,
         reasoning_effort,
         reasoning_summary,
         personality,
@@ -231,6 +233,7 @@ pub(crate) fn thread_settings_from_core_snapshot(
     ThreadSettings {
         sandbox_policy,
         cwd,
+        runtime_workspace_roots: workspace_roots,
         approval_policy: approval_policy.into(),
         approvals_reviewer: approvals_reviewer.into(),
         active_permission_profile: thread_response_active_permission_profile(

--- a/codex-rs/app-server/src/thread_state.rs
+++ b/codex-rs/app-server/src/thread_state.rs
@@ -221,6 +221,7 @@ mod tests {
     fn thread_settings(model: &str) -> ThreadSettings {
         ThreadSettings {
             cwd: AbsolutePathBuf::from_absolute_path("/tmp").expect("absolute path"),
+            runtime_workspace_roots: Vec::new(),
             approval_policy: AskForApproval::OnRequest,
             approvals_reviewer: ApprovalsReviewer::User,
             sandbox_policy: SandboxPolicy::ReadOnly {

--- a/codex-rs/tui/src/app/app_server_event_targets.rs
+++ b/codex-rs/tui/src/app/app_server_event_targets.rs
@@ -207,6 +207,7 @@ mod tests {
     fn test_thread_settings() -> ThreadSettings {
         ThreadSettings {
             cwd: test_path_buf("/tmp/thread-settings").abs(),
+            runtime_workspace_roots: vec![test_path_buf("/tmp/thread-settings").abs()],
             approval_policy: codex_app_server_protocol::AskForApproval::Never,
             approvals_reviewer: codex_app_server_protocol::ApprovalsReviewer::User,
             sandbox_policy: codex_app_server_protocol::SandboxPolicy::ReadOnly {

--- a/codex-rs/tui/src/app/tests.rs
+++ b/codex-rs/tui/src/app/tests.rs
@@ -5865,7 +5865,10 @@ async fn inactive_thread_settings_notification_updates_cached_collaboration_mode
         thread_id: inactive_thread_id.to_string(),
         thread_settings: ThreadSettings {
             cwd: test_absolute_path("/tmp/thread-settings"),
-            runtime_workspace_roots: vec![test_absolute_path("/tmp/thread-settings")],
+            runtime_workspace_roots: vec![
+                test_absolute_path("/tmp/thread-settings"),
+                test_absolute_path("/tmp/thread-settings-shared"),
+            ],
             approval_policy: AskForApproval::OnRequest,
             approvals_reviewer: codex_app_server_protocol::ApprovalsReviewer::AutoReview,
             sandbox_policy: codex_app_server_protocol::SandboxPolicy::ReadOnly {
@@ -5902,6 +5905,13 @@ async fn inactive_thread_settings_notification_updates_cached_collaboration_mode
         .expect("inactive session should remain cached");
     assert_eq!(cached_session.model, "gpt-test");
     assert_eq!(cached_session.personality, Some(Personality::Pragmatic));
+    assert_eq!(
+        cached_session.runtime_workspace_roots,
+        vec![
+            test_absolute_path("/tmp/thread-settings"),
+            test_absolute_path("/tmp/thread-settings-shared"),
+        ]
+    );
     assert_eq!(
         cached_session.collaboration_mode.as_deref(),
         Some(&collaboration_mode)

--- a/codex-rs/tui/src/app/tests.rs
+++ b/codex-rs/tui/src/app/tests.rs
@@ -2651,13 +2651,24 @@ async fn inactive_thread_permissions_approval_preserves_file_system_permissions(
                     entries: None,
                 }),
             },
-            workspace_mutation: None,
+            workspace_mutation: Some(
+                codex_app_server_protocol::WorkspaceMutationApprovalRequest {
+                    operation:
+                        codex_app_server_protocol::WorkspaceMutationOperation::AddWorkspaceRoot,
+                    target: test_absolute_path("/tmp/write"),
+                    resulting_workspace_roots: vec![
+                        test_absolute_path("/tmp"),
+                        test_absolute_path("/tmp/write"),
+                    ],
+                },
+            ),
         },
     };
 
     let Some(ThreadInteractiveRequest::Approval(ApprovalRequest::Permissions {
         environment_id,
         permissions,
+        workspace_mutation,
         ..
     })) = app
         .interactive_request_for_thread_request(thread_id, &request)
@@ -2678,6 +2689,20 @@ async fn inactive_thread_permissions_approval_preserves_file_system_permissions(
                 Some(vec![test_absolute_path("/tmp/write")]),
             )),
         }
+    );
+    assert_eq!(
+        workspace_mutation,
+        Some(
+            codex_protocol::request_permissions::WorkspaceMutationApprovalRequest {
+                operation:
+                    codex_protocol::request_permissions::WorkspaceMutationOperation::AddWorkspaceRoot,
+                target: test_absolute_path("/tmp/write"),
+                resulting_workspace_roots: vec![
+                    test_absolute_path("/tmp"),
+                    test_absolute_path("/tmp/write"),
+                ],
+            }
+        )
     );
 }
 
@@ -5840,6 +5865,7 @@ async fn inactive_thread_settings_notification_updates_cached_collaboration_mode
         thread_id: inactive_thread_id.to_string(),
         thread_settings: ThreadSettings {
             cwd: test_absolute_path("/tmp/thread-settings"),
+            runtime_workspace_roots: vec![test_absolute_path("/tmp/thread-settings")],
             approval_policy: AskForApproval::OnRequest,
             approvals_reviewer: codex_app_server_protocol::ApprovalsReviewer::AutoReview,
             sandbox_policy: codex_app_server_protocol::SandboxPolicy::ReadOnly {

--- a/codex-rs/tui/src/app/thread_routing.rs
+++ b/codex-rs/tui/src/app/thread_routing.rs
@@ -313,6 +313,7 @@ impl App {
                     environment_id: params.environment_id.clone(),
                     reason: params.reason.clone(),
                     permissions: params.permissions.clone().into(),
+                    workspace_mutation: params.workspace_mutation.clone().map(Into::into),
                 }),
             ),
             _ => None,

--- a/codex-rs/tui/src/app/thread_settings.rs
+++ b/codex-rs/tui/src/app/thread_settings.rs
@@ -183,7 +183,10 @@ fn apply_thread_settings_to_session(session: &mut ThreadSessionState, settings: 
         settings.cwd.as_path(),
     );
     session.active_permission_profile = settings.active_permission_profile.clone().map(Into::into);
-    session.set_cwd_retargeting_implicit_runtime_workspace_root(settings.cwd.clone());
+    session.cwd.clone_from(&settings.cwd);
+    session
+        .runtime_workspace_roots
+        .clone_from(&settings.runtime_workspace_roots);
     session.personality = settings.personality;
     let mut collaboration_mode = settings.collaboration_mode.clone();
     collaboration_mode

--- a/codex-rs/tui/src/bottom_pane/approval_overlay.rs
+++ b/codex-rs/tui/src/bottom_pane/approval_overlay.rs
@@ -763,7 +763,8 @@ fn build_header(request: &ApprovalRequest) -> Box<dyn Renderable> {
                 ]));
                 header.push(Line::from(""));
                 header.push(
-                    "This grants write access to the directory for the rest of the session.".into(),
+                    "This updates the session workspace and may grant additional filesystem access."
+                        .into(),
                 );
                 header.push(Line::from(""));
             } else if let Some(reason) = reason {

--- a/codex-rs/tui/src/bottom_pane/approval_overlay.rs
+++ b/codex-rs/tui/src/bottom_pane/approval_overlay.rs
@@ -265,7 +265,14 @@ impl ApprovalOverlay {
             ApprovalRequest::Permissions {
                 workspace_mutation, ..
             } => (
-                permissions_options(approval_keymap, workspace_mutation.is_some()),
+                permissions_options(
+                    approval_keymap,
+                    if workspace_mutation.is_some() {
+                        PermissionsApprovalMode::SessionOnly
+                    } else {
+                        PermissionsApprovalMode::AnyScope
+                    },
+                ),
                 workspace_mutation.as_ref().map_or_else(
                     || "Would you like to grant these permissions?".to_string(),
                     |workspace_mutation| match workspace_mutation.operation {
@@ -1079,7 +1086,16 @@ fn patch_options(keymap: &ApprovalKeymap) -> Vec<ApprovalOption> {
     ]
 }
 
-fn permissions_options(keymap: &ApprovalKeymap, session_scope_only: bool) -> Vec<ApprovalOption> {
+#[derive(Clone, Copy)]
+enum PermissionsApprovalMode {
+    AnyScope,
+    SessionOnly,
+}
+
+fn permissions_options(
+    keymap: &ApprovalKeymap,
+    mode: PermissionsApprovalMode,
+) -> Vec<ApprovalOption> {
     let deny_shortcuts = keymap
         .deny
         .iter()
@@ -1087,7 +1103,7 @@ fn permissions_options(keymap: &ApprovalKeymap, session_scope_only: bool) -> Vec
         .filter(|shortcut| shortcut.parts() != (KeyCode::Esc, KeyModifiers::NONE))
         .collect();
 
-    if session_scope_only {
+    if matches!(mode, PermissionsApprovalMode::SessionOnly) {
         let mut approve_shortcuts = keymap.approve.clone();
         for shortcut in &keymap.approve_for_session {
             if !approve_shortcuts.contains(shortcut) {
@@ -1870,7 +1886,7 @@ mod tests {
     fn permissions_options_use_expected_labels() {
         let keymap = crate::keymap::RuntimeKeymap::defaults();
         let labels: Vec<String> =
-            permissions_options(&keymap.approval, /*session_scope_only*/ false)
+            permissions_options(&keymap.approval, PermissionsApprovalMode::AnyScope)
                 .into_iter()
                 .map(|option| option.label)
                 .collect();
@@ -1889,7 +1905,7 @@ mod tests {
     fn workspace_mutation_permissions_options_only_offer_session_scope_or_deny() {
         let keymap = crate::keymap::RuntimeKeymap::defaults();
         let labels: Vec<String> =
-            permissions_options(&keymap.approval, /*session_scope_only*/ true)
+            permissions_options(&keymap.approval, PermissionsApprovalMode::SessionOnly)
                 .into_iter()
                 .map(|option| option.label)
                 .collect();

--- a/codex-rs/tui/src/bottom_pane/approval_overlay.rs
+++ b/codex-rs/tui/src/bottom_pane/approval_overlay.rs
@@ -54,6 +54,8 @@ use codex_features::Features;
 use codex_protocol::ThreadId;
 use codex_protocol::request_permissions::PermissionGrantScope;
 use codex_protocol::request_permissions::RequestPermissionProfile;
+use codex_protocol::request_permissions::WorkspaceMutationApprovalRequest;
+use codex_protocol::request_permissions::WorkspaceMutationOperation;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
@@ -87,6 +89,7 @@ pub(crate) enum ApprovalRequest {
         environment_id: Option<String>,
         reason: Option<String>,
         permissions: RequestPermissionProfile,
+        workspace_mutation: Option<WorkspaceMutationApprovalRequest>,
     },
     ApplyPatch {
         thread_id: ThreadId,
@@ -259,9 +262,22 @@ impl ApprovalOverlay {
                     },
                 ),
             ),
-            ApprovalRequest::Permissions { .. } => (
-                permissions_options(approval_keymap),
-                "Would you like to grant these permissions?".to_string(),
+            ApprovalRequest::Permissions {
+                workspace_mutation, ..
+            } => (
+                permissions_options(approval_keymap, workspace_mutation.is_some()),
+                workspace_mutation.as_ref().map_or_else(
+                    || "Would you like to grant these permissions?".to_string(),
+                    |workspace_mutation| match workspace_mutation.operation {
+                        WorkspaceMutationOperation::SetWorkingDirectory => {
+                            "Would you like to switch this session's working directory?".to_string()
+                        }
+                        WorkspaceMutationOperation::AddWorkspaceRoot => {
+                            "Would you like to add a directory to this session's workspace?"
+                                .to_string()
+                        }
+                    },
+                ),
             ),
             ApprovalRequest::ApplyPatch { .. } => (
                 patch_options(approval_keymap),
@@ -717,6 +733,7 @@ fn build_header(request: &ApprovalRequest) -> Box<dyn Renderable> {
             environment_id,
             reason,
             permissions,
+            workspace_mutation,
             ..
         } => {
             let mut header: Vec<Line<'static>> = Vec::new();
@@ -734,7 +751,22 @@ fn build_header(request: &ApprovalRequest) -> Box<dyn Renderable> {
                 ]));
                 header.push(Line::from(""));
             }
-            if let Some(reason) = reason {
+            if let Some(workspace_mutation) = workspace_mutation {
+                header.push(Line::from(vec![
+                    "Directory: ".into(),
+                    workspace_mutation
+                        .target
+                        .as_path()
+                        .display()
+                        .to_string()
+                        .cyan(),
+                ]));
+                header.push(Line::from(""));
+                header.push(
+                    "This grants write access to the directory for the rest of the session.".into(),
+                );
+                header.push(Line::from(""));
+            } else if let Some(reason) = reason {
                 header.push(Line::from(vec!["Reason: ".into(), reason.clone().italic()]));
                 header.push(Line::from(""));
             }
@@ -1046,13 +1078,34 @@ fn patch_options(keymap: &ApprovalKeymap) -> Vec<ApprovalOption> {
     ]
 }
 
-fn permissions_options(keymap: &ApprovalKeymap) -> Vec<ApprovalOption> {
+fn permissions_options(keymap: &ApprovalKeymap, session_scope_only: bool) -> Vec<ApprovalOption> {
     let deny_shortcuts = keymap
         .deny
         .iter()
         .copied()
         .filter(|shortcut| shortcut.parts() != (KeyCode::Esc, KeyModifiers::NONE))
         .collect();
+
+    if session_scope_only {
+        let mut approve_shortcuts = keymap.approve.clone();
+        for shortcut in &keymap.approve_for_session {
+            if !approve_shortcuts.contains(shortcut) {
+                approve_shortcuts.push(*shortcut);
+            }
+        }
+        return vec![
+            ApprovalOption {
+                label: "Yes, update this session's workspace".to_string(),
+                decision: ApprovalDecision::Permissions(PermissionsDecision::GrantForSession),
+                shortcuts: approve_shortcuts,
+            },
+            ApprovalOption {
+                label: "No, keep the current workspace".to_string(),
+                decision: ApprovalDecision::Permissions(PermissionsDecision::Deny),
+                shortcuts: deny_shortcuts,
+            },
+        ];
+    }
 
     vec![
         ApprovalOption {
@@ -1247,7 +1300,25 @@ mod tests {
                     Some(vec![absolute_path("/tmp/out.txt")]),
                 )),
             },
+            workspace_mutation: None,
         }
+    }
+
+    fn make_workspace_mutation_permissions_request() -> ApprovalRequest {
+        let mut request = make_permissions_request();
+        let ApprovalRequest::Permissions {
+            workspace_mutation, ..
+        } = &mut request
+        else {
+            unreachable!("permissions request helper returned another request type");
+        };
+        *workspace_mutation = Some(WorkspaceMutationApprovalRequest {
+            operation:
+                codex_protocol::request_permissions::WorkspaceMutationOperation::AddWorkspaceRoot,
+            target: absolute_path("/tmp/out.txt"),
+            resulting_workspace_roots: vec![absolute_path("/tmp/out.txt")],
+        });
+        request
     }
 
     fn make_elicitation_request() -> ApprovalRequest {
@@ -1797,10 +1868,11 @@ mod tests {
     #[test]
     fn permissions_options_use_expected_labels() {
         let keymap = crate::keymap::RuntimeKeymap::defaults();
-        let labels: Vec<String> = permissions_options(&keymap.approval)
-            .into_iter()
-            .map(|option| option.label)
-            .collect();
+        let labels: Vec<String> =
+            permissions_options(&keymap.approval, /*session_scope_only*/ false)
+                .into_iter()
+                .map(|option| option.label)
+                .collect();
         assert_eq!(
             labels,
             vec![
@@ -1808,6 +1880,23 @@ mod tests {
                 "Yes, grant for this turn with strict auto review".to_string(),
                 "Yes, grant these permissions for this session".to_string(),
                 "No, continue without permissions".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn workspace_mutation_permissions_options_only_offer_session_scope_or_deny() {
+        let keymap = crate::keymap::RuntimeKeymap::defaults();
+        let labels: Vec<String> =
+            permissions_options(&keymap.approval, /*session_scope_only*/ true)
+                .into_iter()
+                .map(|option| option.label)
+                .collect();
+        assert_eq!(
+            labels,
+            vec![
+                "Yes, update this session's workspace".to_string(),
+                "No, keep the current workspace".to_string(),
             ]
         );
     }
@@ -1891,6 +1980,36 @@ mod tests {
         assert!(
             saw_op,
             "expected permission approval decision to emit a session-scoped response"
+        );
+    }
+
+    #[test]
+    fn workspace_mutation_permissions_approve_shortcut_submits_session_scope() {
+        let (tx, mut rx) = unbounded_channel::<AppEvent>();
+        let tx = AppEventSender::new(tx);
+        let mut view = make_overlay(
+            make_workspace_mutation_permissions_request(),
+            tx,
+            Features::with_defaults(),
+        );
+
+        view.handle_key_event(KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE));
+
+        let mut saw_op = false;
+        while let Ok(ev) = rx.try_recv() {
+            if let AppEvent::SubmitThreadOp {
+                op: Op::RequestPermissionsResponse { response, .. },
+                ..
+            } = ev
+            {
+                assert_eq!(response.scope, PermissionGrantScope::Session);
+                saw_op = true;
+                break;
+            }
+        }
+        assert!(
+            saw_op,
+            "expected workspace mutation approval to emit a session-scoped response"
         );
     }
 
@@ -2057,6 +2176,21 @@ mod tests {
         let view = make_overlay(make_permissions_request(), tx, Features::with_defaults());
         assert_snapshot!(
             "approval_overlay_permissions_prompt",
+            normalize_snapshot_paths(render_overlay_lines(&view, /*width*/ 120))
+        );
+    }
+
+    #[test]
+    fn workspace_mutation_permissions_prompt_snapshot() {
+        let (tx, _rx) = unbounded_channel::<AppEvent>();
+        let tx = AppEventSender::new(tx);
+        let view = make_overlay(
+            make_workspace_mutation_permissions_request(),
+            tx,
+            Features::with_defaults(),
+        );
+        assert_snapshot!(
+            "approval_overlay_workspace_mutation_permissions_prompt",
             normalize_snapshot_paths(render_overlay_lines(&view, /*width*/ 120))
         );
     }

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__approval_overlay__tests__approval_overlay_workspace_mutation_permissions_prompt.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__approval_overlay__tests__approval_overlay_workspace_mutation_permissions_prompt.snap
@@ -1,0 +1,17 @@
+---
+source: tui/src/bottom_pane/approval_overlay.rs
+expression: "normalize_snapshot_paths(render_overlay_lines(&view, 120))"
+---
+
+  Would you like to add a directory to this session's workspace?
+
+  Directory: /tmp/out.txt
+
+  This grants write access to the directory for the rest of the session.
+
+  Permission rule: network; read `/tmp/readme.txt`; write `/tmp/out.txt`
+
+› 1. Yes, update this session's workspace (y)
+  2. No, keep the current workspace (d)
+
+  Press enter to confirm or esc to cancel

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__approval_overlay__tests__approval_overlay_workspace_mutation_permissions_prompt.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__approval_overlay__tests__approval_overlay_workspace_mutation_permissions_prompt.snap
@@ -7,7 +7,7 @@ expression: "normalize_snapshot_paths(render_overlay_lines(&view, 120))"
 
   Directory: /tmp/out.txt
 
-  This grants write access to the directory for the rest of the session.
+  This updates the session workspace and may grant additional filesystem access.
 
   Permission rule: network; read `/tmp/readme.txt`; write `/tmp/out.txt`
 

--- a/codex-rs/tui/src/chatwidget/tests/app_server.rs
+++ b/codex-rs/tui/src/chatwidget/tests/app_server.rs
@@ -9,6 +9,7 @@ fn thread_settings_for_test(
         thread_id: thread_id.to_string(),
         thread_settings: codex_app_server_protocol::ThreadSettings {
             cwd: test_path_buf("/tmp/thread-settings").abs(),
+            runtime_workspace_roots: vec![test_path_buf("/tmp/thread-settings").abs()],
             approval_policy: AskForApproval::OnRequest,
             approvals_reviewer: codex_app_server_protocol::ApprovalsReviewer::AutoReview,
             sandbox_policy: codex_app_server_protocol::SandboxPolicy::ReadOnly {

--- a/codex-rs/tui/src/chatwidget/tests/approval_requests.rs
+++ b/codex-rs/tui/src/chatwidget/tests/approval_requests.rs
@@ -296,7 +296,13 @@ fn app_server_request_permissions_preserves_file_system_permissions() {
                 entries: None,
             }),
         },
-        workspace_mutation: None,
+        workspace_mutation: Some(
+            codex_app_server_protocol::WorkspaceMutationApprovalRequest {
+                operation: codex_app_server_protocol::WorkspaceMutationOperation::AddWorkspaceRoot,
+                target: write_path.clone(),
+                resulting_workspace_roots: vec![cwd.clone(), write_path.clone()],
+            },
+        ),
     });
 
     assert_eq!(
@@ -307,12 +313,23 @@ fn app_server_request_permissions_preserves_file_system_permissions() {
             }),
             file_system: Some(FileSystemPermissions::from_read_write_roots(
                 Some(vec![read_path]),
-                Some(vec![write_path]),
+                Some(vec![write_path.clone()]),
             )),
         }
     );
-    assert_eq!(request.cwd, Some(cwd));
+    assert_eq!(request.cwd, Some(cwd.clone()));
     assert_eq!(request.environment_id.as_deref(), Some("remote"));
+    assert_eq!(
+        request.workspace_mutation,
+        Some(
+            codex_protocol::request_permissions::WorkspaceMutationApprovalRequest {
+                operation:
+                    codex_protocol::request_permissions::WorkspaceMutationOperation::AddWorkspaceRoot,
+                target: write_path.clone(),
+                resulting_workspace_roots: vec![cwd, write_path],
+            }
+        )
+    );
 }
 
 #[tokio::test]

--- a/codex-rs/tui/src/chatwidget/tool_requests.rs
+++ b/codex-rs/tui/src/chatwidget/tool_requests.rs
@@ -444,6 +444,7 @@ impl ChatWidget {
             environment_id: ev.environment_id,
             reason: ev.reason,
             permissions: ev.permissions,
+            workspace_mutation: ev.workspace_mutation,
         };
         self.bottom_pane
             .push_approval_request(request, &self.config.features);


### PR DESCRIPTION
## Why

Persisting a workspace mutation can widen filesystem access. Reviewers need an approval prompt that describes the actual state change instead of presenting it as generic command execution.

## What Changed

- Add dedicated app-server protocol payloads for workspace-mutation approvals.
- Include the mutation operation, canonical target, and resulting workspace-root list in approval requests.
- Project workspace approvals through an explicit permission-approval mode instead of a boolean flag.
- Regenerate the app-server schema and TypeScript fixtures.
- Render a clearer TUI approval prompt for persistent workspace mutations.

## How to Test

1. Trigger a workspace mutation that widens persistent filesystem access.
2. Confirm the approval prompt identifies the target directory and resulting roots.
3. Approve and deny the request in separate runs.
4. Confirm approval persists the mutation and denial leaves workspace state unchanged.

Targeted coverage:
- `overlay_workspace_mutation_permissions_prompt` snapshot
- The workspace-mutation approval request tests in `tui/src/chatwidget/tests/approval_requests.rs`

## Stack

1. [#25336](https://github.com/openai/codex/pull/25336) runtime workspace state
2. [#25339](https://github.com/openai/codex/pull/25339) ordered mutation barriers
3. [#25334](https://github.com/openai/codex/pull/25334) model workspace tools
4. #25338(https://github.com/openai/codex/pull/25338) approval projection (this PR)
5. [#25335](https://github.com/openai/codex/pull/25335) TUI workspace commands