### PR TITLE
feat(core): enforce workspace mutation ordering [2 of 5]

### DIFF
--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -1979,7 +1979,13 @@ async fn try_run_sampling_request(
                         Err(err) => break Err(err),
                     };
                 if let Some(tool_future) = output_result.tool_future {
-                    in_flight.push_back(tool_future);
+                    if output_result.tool_is_execution_barrier {
+                        drain_in_flight(&mut in_flight, sess.clone(), turn_context.clone()).await?;
+                        in_flight.push_back(tool_future);
+                        drain_in_flight(&mut in_flight, sess.clone(), turn_context.clone()).await?;
+                    } else {
+                        in_flight.push_back(tool_future);
+                    }
                 }
                 if let Some(agent_message) = output_result.last_agent_message {
                     last_agent_message = Some(agent_message);

--- a/codex-rs/core/src/stream_events_utils.rs
+++ b/codex-rs/core/src/stream_events_utils.rs
@@ -311,6 +311,7 @@ pub(crate) struct OutputItemResult {
     pub last_agent_message: Option<String>,
     pub needs_follow_up: bool,
     pub tool_future: Option<InFlightFuture<'static>>,
+    pub tool_is_execution_barrier: bool,
 }
 
 pub(crate) struct HandleOutputCtx {
@@ -432,6 +433,7 @@ pub(crate) async fn handle_output_item_done(
             record_completed_response_item(ctx.sess.as_ref(), ctx.turn_context.as_ref(), &item)
                 .await;
 
+            output.tool_is_execution_barrier = ctx.tool_runtime.tool_is_execution_barrier(&call);
             let cancellation_token = ctx.cancellation_token.child_token();
             let tool_future: InFlightFuture<'static> = Box::pin(
                 ctx.tool_runtime

--- a/codex-rs/core/src/tools/parallel.rs
+++ b/codex-rs/core/src/tools/parallel.rs
@@ -67,7 +67,7 @@ impl ToolCallRuntime {
     }
 
     pub(crate) fn tool_is_execution_barrier(&self, call: &ToolCall) -> bool {
-        self.router.tool_is_execution_barrier(call)
+        self.router.tool_execution_policy(call).is_barrier()
     }
 
     pub(crate) fn create_diff_consumer(
@@ -85,7 +85,10 @@ impl ToolCallRuntime {
     ) -> impl std::future::Future<Output = Result<ResponseInputItem, CodexErr>> {
         let error_call = call.clone();
         let dependency_failure = Arc::clone(&self.dependency_failure);
-        let cancel_suffix_on_failure = self.router.tool_cancels_suffix_on_failure(&call);
+        let cancel_suffix_on_failure = self
+            .router
+            .tool_execution_policy(&call)
+            .cancels_suffix_on_failure();
         let prior_dependency_failure = dependency_failure
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -112,37 +115,31 @@ impl ToolCallRuntime {
                 Ok(response) => {
                     let response = response.into_response();
                     if cancel_suffix_on_failure && !response_input_succeeded(&response) {
-                        *dependency_failure
-                            .lock()
-                            .unwrap_or_else(std::sync::PoisonError::into_inner) =
-                            Some(DependencyFailure {
-                                call_id: error_call.call_id.clone(),
-                                code: response_input_error_code(&response),
-                            });
+                        record_dependency_failure(
+                            dependency_failure.as_ref(),
+                            &error_call.call_id,
+                            response_input_error_code(&response),
+                        );
                     }
                     Ok(response)
                 }
                 Err(FunctionCallError::Fatal(message)) => {
                     if cancel_suffix_on_failure {
-                        *dependency_failure
-                            .lock()
-                            .unwrap_or_else(std::sync::PoisonError::into_inner) =
-                            Some(DependencyFailure {
-                                call_id: error_call.call_id.clone(),
-                                code: "tool_error".to_string(),
-                            });
+                        record_dependency_failure(
+                            dependency_failure.as_ref(),
+                            &error_call.call_id,
+                            "tool_error",
+                        );
                     }
                     Err(CodexErr::Fatal(message))
                 }
                 Err(other) => {
                     if cancel_suffix_on_failure {
-                        *dependency_failure
-                            .lock()
-                            .unwrap_or_else(std::sync::PoisonError::into_inner) =
-                            Some(DependencyFailure {
-                                call_id: error_call.call_id.clone(),
-                                code: "tool_error".to_string(),
-                            });
+                        record_dependency_failure(
+                            dependency_failure.as_ref(),
+                            &error_call.call_id,
+                            "tool_error",
+                        );
                     }
                     Ok(Self::failure_response(error_call, other))
                 }
@@ -355,6 +352,19 @@ fn response_input_succeeded(response: &ResponseInputItem) -> bool {
     }
 }
 
+fn record_dependency_failure(
+    state: &Mutex<Option<DependencyFailure>>,
+    call_id: &str,
+    code: impl Into<String>,
+) {
+    *state
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(DependencyFailure {
+        call_id: call_id.to_string(),
+        code: code.into(),
+    });
+}
+
 fn response_input_error_code(response: &ResponseInputItem) -> String {
     let output = match response {
         ResponseInputItem::FunctionCallOutput { output, .. }
@@ -415,13 +425,11 @@ mod tests {
 
         fn handle(&self, _invocation: ToolInvocation) -> codex_tools::ToolExecutorFuture<'_> {
             Box::pin(async {
-                Ok(
-                    Box::new(FunctionToolOutput::from_text(
-                        "ok".to_string(),
-                        /*success*/ Some(true),
-                    ))
-                        as Box<dyn crate::tools::context::ToolOutput>,
-                )
+                Ok(Box::new(FunctionToolOutput::from_text(
+                    "ok".to_string(),
+                    /*success*/ Some(true),
+                ))
+                    as Box<dyn crate::tools::context::ToolOutput>)
             })
         }
     }
@@ -465,18 +473,15 @@ mod tests {
                 Ok(Box::new(FunctionToolOutput::from_text(
                     serde_json::json!({ "code": "path_not_found" }).to_string(),
                     /*success*/ Some(false),
-                )) as Box<dyn crate::tools::context::ToolOutput>)
+                ))
+                    as Box<dyn crate::tools::context::ToolOutput>)
             })
         }
     }
 
     impl CoreToolRuntime for FailingBarrierHandler {
-        fn execution_barrier(&self) -> bool {
-            true
-        }
-
-        fn cancel_suffix_on_failure(&self) -> bool {
-            true
+        fn execution_policy(&self) -> crate::tools::registry::ToolExecutionPolicy {
+            crate::tools::registry::ToolExecutionPolicy::BarrierAndCancelSuffix
         }
     }
 
@@ -507,7 +512,8 @@ mod tests {
                 Ok(Box::new(FunctionToolOutput::from_text(
                     "ok".to_string(),
                     /*success*/ Some(true),
-                )) as Box<dyn crate::tools::context::ToolOutput>)
+                ))
+                    as Box<dyn crate::tools::context::ToolOutput>)
             })
         }
     }
@@ -764,8 +770,10 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn failed_barrier_cancels_suffix_without_dispatching_it() -> anyhow::Result<()> {
+    async fn assert_failed_barrier_cancels_suffix(
+        fatal: bool,
+        expected_code: &str,
+    ) -> anyhow::Result<ToolCallRuntime> {
         let (session, turn_context) = crate::session::tests::make_session_and_context().await;
         let barrier_name = codex_tools::ToolName::plain("barrier");
         let suffix_name = codex_tools::ToolName::plain("suffix");
@@ -774,7 +782,7 @@ mod tests {
             ToolRegistry::from_tools([
                 Arc::new(FailingBarrierHandler {
                     tool_name: barrier_name.clone(),
-                    fatal: false,
+                    fatal,
                 }) as Arc<dyn CoreToolRuntime>,
                 Arc::new(RecordingHandler {
                     tool_name: suffix_name.clone(),
@@ -792,7 +800,7 @@ mod tests {
         let payload = ToolPayload::Function {
             arguments: "{}".to_string(),
         };
-        runtime
+        let barrier_response = runtime
             .clone()
             .handle_tool_call(
                 ToolCall {
@@ -802,7 +810,15 @@ mod tests {
                 },
                 CancellationToken::new(),
             )
-            .await?;
+            .await;
+        if fatal {
+            assert!(matches!(
+                barrier_response,
+                Err(CodexErr::Fatal(message)) if message == "fatal barrier"
+            ));
+        } else {
+            barrier_response?;
+        }
         let response = runtime
             .clone()
             .handle_tool_call(
@@ -828,10 +844,21 @@ mod tests {
                 "code": "dependency_cancelled",
                 "message": "cancelled because workspace mutation `barrier-call` failed",
                 "failed_mutation_call_id": "barrier-call",
-                "failed_mutation_code": "path_not_found",
+                "failed_mutation_code": expected_code,
             })
         );
         assert!(!suffix_called.load(Ordering::Acquire));
+
+        Ok(runtime)
+    }
+
+    #[tokio::test]
+    async fn failed_barrier_cancels_suffix_without_dispatching_it() -> anyhow::Result<()> {
+        let runtime = assert_failed_barrier_cancels_suffix(
+            /*fatal*/ false,
+            /*expected_code*/ "path_not_found",
+        )
+        .await?;
 
         let tool_search_response = runtime
             .handle_tool_call(
@@ -862,75 +889,11 @@ mod tests {
 
     #[tokio::test]
     async fn fatal_barrier_cancels_suffix_without_dispatching_it() -> anyhow::Result<()> {
-        let (session, turn_context) = crate::session::tests::make_session_and_context().await;
-        let barrier_name = codex_tools::ToolName::plain("barrier");
-        let suffix_name = codex_tools::ToolName::plain("suffix");
-        let suffix_called = Arc::new(AtomicBool::new(/*v*/ false));
-        let router = Arc::new(ToolRouter::from_parts(
-            ToolRegistry::from_tools([
-                Arc::new(FailingBarrierHandler {
-                    tool_name: barrier_name.clone(),
-                    fatal: true,
-                }) as Arc<dyn CoreToolRuntime>,
-                Arc::new(RecordingHandler {
-                    tool_name: suffix_name.clone(),
-                    called: Arc::clone(&suffix_called),
-                }) as Arc<dyn CoreToolRuntime>,
-            ]),
-            Vec::new(),
-        ));
-        let runtime = ToolCallRuntime::new(
-            router,
-            Arc::new(session),
-            Arc::new(turn_context),
-            Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new())),
-        );
-        let payload = ToolPayload::Function {
-            arguments: "{}".to_string(),
-        };
-        let barrier_response = runtime
-            .clone()
-            .handle_tool_call(
-                ToolCall {
-                    tool_name: barrier_name,
-                    call_id: "barrier-call".to_string(),
-                    payload: payload.clone(),
-                },
-                CancellationToken::new(),
-            )
-            .await;
-        assert!(matches!(
-            barrier_response,
-            Err(CodexErr::Fatal(message)) if message == "fatal barrier"
-        ));
-
-        let response = runtime
-            .handle_tool_call(
-                ToolCall {
-                    tool_name: suffix_name,
-                    call_id: "suffix-call".to_string(),
-                    payload,
-                },
-                CancellationToken::new(),
-            )
-            .await?;
-        let ResponseInputItem::FunctionCallOutput { output, .. } = response else {
-            anyhow::bail!("cancelled suffix should return function output");
-        };
-        let FunctionCallOutputBody::Text(text) = output.body else {
-            anyhow::bail!("cancelled suffix output should be text");
-        };
-        assert_eq!(output.success, Some(false));
-        assert_eq!(
-            serde_json::from_str::<serde_json::Value>(&text)?,
-            serde_json::json!({
-                "code": "dependency_cancelled",
-                "message": "cancelled because workspace mutation `barrier-call` failed",
-                "failed_mutation_call_id": "barrier-call",
-                "failed_mutation_code": "tool_error",
-            })
-        );
-        assert!(!suffix_called.load(Ordering::Acquire));
+        assert_failed_barrier_cancels_suffix(
+            /*fatal*/ true,
+            /*expected_code*/ "tool_error",
+        )
+        .await?;
         Ok(())
     }
 }

--- a/codex-rs/core/src/tools/parallel.rs
+++ b/codex-rs/core/src/tools/parallel.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::time::Instant;
 
+use tokio::sync::Mutex;
 use tokio::sync::RwLock;
 use tokio::task::JoinError;
 use tokio_util::either::Either;
@@ -34,6 +35,13 @@ pub(crate) struct ToolCallRuntime {
     turn_context: Arc<TurnContext>,
     tracker: SharedTurnDiffTracker,
     parallel_execution: Arc<RwLock<()>>,
+    dependency_failure: Arc<Mutex<Option<DependencyFailure>>>,
+}
+
+#[derive(Clone)]
+struct DependencyFailure {
+    call_id: String,
+    code: String,
 }
 
 impl ToolCallRuntime {
@@ -49,7 +57,12 @@ impl ToolCallRuntime {
             turn_context,
             tracker,
             parallel_execution: Arc::new(RwLock::new(())),
+            dependency_failure: Arc::new(Mutex::new(/*t*/ None)),
         }
+    }
+
+    pub(crate) fn tool_is_execution_barrier(&self, call: &ToolCall) -> bool {
+        self.router.tool_is_execution_barrier(call)
     }
 
     pub(crate) fn create_diff_consumer(
@@ -66,13 +79,38 @@ impl ToolCallRuntime {
         cancellation_token: CancellationToken,
     ) -> impl std::future::Future<Output = Result<ResponseInputItem, CodexErr>> {
         let error_call = call.clone();
+        let dependency_failure = Arc::clone(&self.dependency_failure);
+        let cancel_suffix_on_failure = self.router.tool_cancels_suffix_on_failure(&call);
         let future =
             self.handle_tool_call_with_source(call, ToolCallSource::Direct, cancellation_token);
         async move {
+            if let Some(dependency_failure) = dependency_failure.lock().await.clone() {
+                return Ok(Self::dependency_cancelled_response(
+                    error_call,
+                    dependency_failure,
+                ));
+            }
             match future.await {
-                Ok(response) => Ok(response.into_response()),
+                Ok(response) => {
+                    let response = response.into_response();
+                    if cancel_suffix_on_failure && !response_input_succeeded(&response) {
+                        *dependency_failure.lock().await = Some(DependencyFailure {
+                            call_id: error_call.call_id.clone(),
+                            code: response_input_error_code(&response),
+                        });
+                    }
+                    Ok(response)
+                }
                 Err(FunctionCallError::Fatal(message)) => Err(CodexErr::Fatal(message)),
-                Err(other) => Ok(Self::failure_response(error_call, other)),
+                Err(other) => {
+                    if cancel_suffix_on_failure {
+                        *dependency_failure.lock().await = Some(DependencyFailure {
+                            call_id: error_call.call_id.clone(),
+                            code: "tool_error".to_string(),
+                        });
+                    }
+                    Ok(Self::failure_response(error_call, other))
+                }
             }
         }
         .in_current_span()
@@ -97,7 +135,7 @@ impl ToolCallRuntime {
         let abort_session = Arc::clone(&session);
         let abort_source = source.clone();
         let abort_turn = Arc::clone(&turn);
-        let terminal_outcome_reached = Arc::new(AtomicBool::new(false));
+        let terminal_outcome_reached = Arc::new(AtomicBool::new(/*v*/ false));
         let dispatch_terminal_outcome_reached = Arc::clone(&terminal_outcome_reached);
         let dispatch_call = call.clone();
 
@@ -210,6 +248,37 @@ impl ToolCallRuntime {
         }
     }
 
+    fn dependency_cancelled_response(
+        call: ToolCall,
+        dependency_failure: DependencyFailure,
+    ) -> ResponseInputItem {
+        let failed_call_id = dependency_failure.call_id;
+        let message = serde_json::json!({
+            "code": "dependency_cancelled",
+            "message": format!("cancelled because workspace mutation `{failed_call_id}` failed"),
+            "failed_mutation_call_id": failed_call_id,
+            "failed_mutation_code": dependency_failure.code,
+        })
+        .to_string();
+        match call.payload {
+            ToolPayload::Custom { .. } => ResponseInputItem::CustomToolCallOutput {
+                call_id: call.call_id,
+                name: None,
+                output: codex_protocol::models::FunctionCallOutputPayload {
+                    body: codex_protocol::models::FunctionCallOutputBody::Text(message),
+                    success: Some(false),
+                },
+            },
+            _ => ResponseInputItem::FunctionCallOutput {
+                call_id: call.call_id,
+                output: codex_protocol::models::FunctionCallOutputPayload {
+                    body: codex_protocol::models::FunctionCallOutputBody::Text(message),
+                    success: Some(false),
+                },
+            },
+        }
+    }
+
     fn aborted_response(call: &ToolCall, secs: f32) -> AnyToolResult {
         AnyToolResult {
             call_id: call.call_id.clone(),
@@ -233,6 +302,36 @@ impl ToolCallRuntime {
             format!("aborted by user after {secs:.1}s")
         }
     }
+}
+
+fn response_input_succeeded(response: &ResponseInputItem) -> bool {
+    match response {
+        ResponseInputItem::FunctionCallOutput { output, .. }
+        | ResponseInputItem::CustomToolCallOutput { output, .. } => {
+            output.success.unwrap_or(/*default*/ true)
+        }
+        _ => true,
+    }
+}
+
+fn response_input_error_code(response: &ResponseInputItem) -> String {
+    let output = match response {
+        ResponseInputItem::FunctionCallOutput { output, .. }
+        | ResponseInputItem::CustomToolCallOutput { output, .. } => output,
+        _ => return "tool_error".to_string(),
+    };
+    let codex_protocol::models::FunctionCallOutputBody::Text(body) = &output.body else {
+        return "tool_error".to_string();
+    };
+    serde_json::from_str::<serde_json::Value>(body)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("code")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "tool_error".to_string())
 }
 
 #[cfg(test)]
@@ -276,7 +375,10 @@ mod tests {
         fn handle(&self, _invocation: ToolInvocation) -> codex_tools::ToolExecutorFuture<'_> {
             Box::pin(async {
                 Ok(
-                    Box::new(FunctionToolOutput::from_text("ok".to_string(), Some(true)))
+                    Box::new(FunctionToolOutput::from_text(
+                        "ok".to_string(),
+                        /*success*/ Some(true),
+                    ))
                         as Box<dyn crate::tools::context::ToolOutput>,
                 )
             })
@@ -291,6 +393,80 @@ mod tests {
         cleanup_started: std::sync::Mutex<Option<oneshot::Sender<()>>>,
         allow_cleanup: Arc<Notify>,
     }
+
+    struct FailingBarrierHandler {
+        tool_name: codex_tools::ToolName,
+    }
+
+    impl ToolExecutor<ToolInvocation> for FailingBarrierHandler {
+        fn tool_name(&self) -> codex_tools::ToolName {
+            self.tool_name.clone()
+        }
+
+        fn spec(&self) -> codex_tools::ToolSpec {
+            codex_tools::ToolSpec::Function(codex_tools::ResponsesApiTool {
+                name: self.tool_name.name.clone(),
+                description: "Failing barrier test tool.".to_string(),
+                strict: false,
+                defer_loading: None,
+                parameters: codex_tools::JsonSchema::default(),
+                output_schema: None,
+            })
+        }
+
+        fn handle(&self, _invocation: ToolInvocation) -> codex_tools::ToolExecutorFuture<'_> {
+            Box::pin(async {
+                Ok(Box::new(FunctionToolOutput::from_text(
+                    serde_json::json!({ "code": "path_not_found" }).to_string(),
+                    /*success*/ Some(false),
+                )) as Box<dyn crate::tools::context::ToolOutput>)
+            })
+        }
+    }
+
+    impl CoreToolRuntime for FailingBarrierHandler {
+        fn execution_barrier(&self) -> bool {
+            true
+        }
+
+        fn cancel_suffix_on_failure(&self) -> bool {
+            true
+        }
+    }
+
+    struct RecordingHandler {
+        tool_name: codex_tools::ToolName,
+        called: Arc<AtomicBool>,
+    }
+
+    impl ToolExecutor<ToolInvocation> for RecordingHandler {
+        fn tool_name(&self) -> codex_tools::ToolName {
+            self.tool_name.clone()
+        }
+
+        fn spec(&self) -> codex_tools::ToolSpec {
+            codex_tools::ToolSpec::Function(codex_tools::ResponsesApiTool {
+                name: self.tool_name.name.clone(),
+                description: "Recording test tool.".to_string(),
+                strict: false,
+                defer_loading: None,
+                parameters: codex_tools::JsonSchema::default(),
+                output_schema: None,
+            })
+        }
+
+        fn handle(&self, _invocation: ToolInvocation) -> codex_tools::ToolExecutorFuture<'_> {
+            self.called.store(/*val*/ true, Ordering::Release);
+            Box::pin(async {
+                Ok(Box::new(FunctionToolOutput::from_text(
+                    "ok".to_string(),
+                    /*success*/ Some(true),
+                )) as Box<dyn crate::tools::context::ToolOutput>)
+            })
+        }
+    }
+
+    impl CoreToolRuntime for RecordingHandler {}
 
     impl ToolExecutor<ToolInvocation> for CancellationCleanupHandler {
         fn tool_name(&self) -> codex_tools::ToolName {
@@ -338,7 +514,7 @@ mod tests {
             self.allow_cleanup.notified().await;
             Ok(Box::new(FunctionToolOutput::from_text(
                 "cleanup complete".to_string(),
-                Some(false),
+                /*success*/ Some(false),
             )) as Box<dyn crate::tools::context::ToolOutput>)
         }
     }
@@ -539,6 +715,75 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(vec![ToolCallOutcome::Aborted], actual);
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn failed_barrier_cancels_suffix_without_dispatching_it() -> anyhow::Result<()> {
+        let (session, turn_context) = crate::session::tests::make_session_and_context().await;
+        let barrier_name = codex_tools::ToolName::plain("barrier");
+        let suffix_name = codex_tools::ToolName::plain("suffix");
+        let suffix_called = Arc::new(AtomicBool::new(/*v*/ false));
+        let router = Arc::new(ToolRouter::from_parts(
+            ToolRegistry::from_tools([
+                Arc::new(FailingBarrierHandler {
+                    tool_name: barrier_name.clone(),
+                }) as Arc<dyn CoreToolRuntime>,
+                Arc::new(RecordingHandler {
+                    tool_name: suffix_name.clone(),
+                    called: Arc::clone(&suffix_called),
+                }) as Arc<dyn CoreToolRuntime>,
+            ]),
+            Vec::new(),
+        ));
+        let runtime = ToolCallRuntime::new(
+            router,
+            Arc::new(session),
+            Arc::new(turn_context),
+            Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new())),
+        );
+        let payload = ToolPayload::Function {
+            arguments: "{}".to_string(),
+        };
+        runtime
+            .clone()
+            .handle_tool_call(
+                ToolCall {
+                    tool_name: barrier_name,
+                    call_id: "barrier-call".to_string(),
+                    payload: payload.clone(),
+                },
+                CancellationToken::new(),
+            )
+            .await?;
+        let response = runtime
+            .handle_tool_call(
+                ToolCall {
+                    tool_name: suffix_name,
+                    call_id: "suffix-call".to_string(),
+                    payload,
+                },
+                CancellationToken::new(),
+            )
+            .await?;
+
+        let ResponseInputItem::FunctionCallOutput { output, .. } = response else {
+            anyhow::bail!("cancelled suffix should return function output");
+        };
+        let FunctionCallOutputBody::Text(text) = output.body else {
+            anyhow::bail!("cancelled suffix output should be text");
+        };
+        assert_eq!(output.success, Some(false));
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&text)?,
+            serde_json::json!({
+                "code": "dependency_cancelled",
+                "message": "cancelled because workspace mutation `barrier-call` failed",
+                "failed_mutation_call_id": "barrier-call",
+                "failed_mutation_code": "path_not_found",
+            })
+        );
+        assert!(!suffix_called.load(Ordering::Acquire));
         Ok(())
     }
 }

--- a/codex-rs/core/src/tools/parallel.rs
+++ b/codex-rs/core/src/tools/parallel.rs
@@ -1,9 +1,9 @@
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::time::Instant;
 
-use tokio::sync::Mutex;
 use tokio::sync::RwLock;
 use tokio::task::JoinError;
 use tokio_util::either::Either;
@@ -44,6 +44,11 @@ struct DependencyFailure {
     code: String,
 }
 
+enum PendingToolCall<F> {
+    Cancelled(DependencyFailure),
+    Dispatch(F),
+}
+
 impl ToolCallRuntime {
     pub(crate) fn new(
         router: Arc<ToolRouter>,
@@ -81,33 +86,63 @@ impl ToolCallRuntime {
         let error_call = call.clone();
         let dependency_failure = Arc::clone(&self.dependency_failure);
         let cancel_suffix_on_failure = self.router.tool_cancels_suffix_on_failure(&call);
-        let future =
-            self.handle_tool_call_with_source(call, ToolCallSource::Direct, cancellation_token);
+        let prior_dependency_failure = dependency_failure
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        let pending_tool_call = match prior_dependency_failure {
+            Some(dependency_failure) => PendingToolCall::Cancelled(dependency_failure),
+            None => PendingToolCall::Dispatch(self.handle_tool_call_with_source(
+                call,
+                ToolCallSource::Direct,
+                cancellation_token,
+            )),
+        };
         async move {
-            if let Some(dependency_failure) = dependency_failure.lock().await.clone() {
-                return Ok(Self::dependency_cancelled_response(
-                    error_call,
-                    dependency_failure,
-                ));
-            }
+            let future = match pending_tool_call {
+                PendingToolCall::Cancelled(dependency_failure) => {
+                    return Ok(Self::dependency_cancelled_response(
+                        error_call,
+                        dependency_failure,
+                    ));
+                }
+                PendingToolCall::Dispatch(future) => future,
+            };
             match future.await {
                 Ok(response) => {
                     let response = response.into_response();
                     if cancel_suffix_on_failure && !response_input_succeeded(&response) {
-                        *dependency_failure.lock().await = Some(DependencyFailure {
-                            call_id: error_call.call_id.clone(),
-                            code: response_input_error_code(&response),
-                        });
+                        *dependency_failure
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+                            Some(DependencyFailure {
+                                call_id: error_call.call_id.clone(),
+                                code: response_input_error_code(&response),
+                            });
                     }
                     Ok(response)
                 }
-                Err(FunctionCallError::Fatal(message)) => Err(CodexErr::Fatal(message)),
+                Err(FunctionCallError::Fatal(message)) => {
+                    if cancel_suffix_on_failure {
+                        *dependency_failure
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+                            Some(DependencyFailure {
+                                call_id: error_call.call_id.clone(),
+                                code: "tool_error".to_string(),
+                            });
+                    }
+                    Err(CodexErr::Fatal(message))
+                }
                 Err(other) => {
                     if cancel_suffix_on_failure {
-                        *dependency_failure.lock().await = Some(DependencyFailure {
-                            call_id: error_call.call_id.clone(),
-                            code: "tool_error".to_string(),
-                        });
+                        *dependency_failure
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner) =
+                            Some(DependencyFailure {
+                                call_id: error_call.call_id.clone(),
+                                code: "tool_error".to_string(),
+                            });
                     }
                     Ok(Self::failure_response(error_call, other))
                 }
@@ -261,6 +296,12 @@ impl ToolCallRuntime {
         })
         .to_string();
         match call.payload {
+            ToolPayload::ToolSearch { .. } => ResponseInputItem::ToolSearchOutput {
+                call_id: call.call_id,
+                status: "completed".to_string(),
+                execution: "client".to_string(),
+                tools: Vec::new(),
+            },
             ToolPayload::Custom { .. } => ResponseInputItem::CustomToolCallOutput {
                 call_id: call.call_id,
                 name: None,
@@ -396,6 +437,7 @@ mod tests {
 
     struct FailingBarrierHandler {
         tool_name: codex_tools::ToolName,
+        fatal: bool,
     }
 
     impl ToolExecutor<ToolInvocation> for FailingBarrierHandler {
@@ -415,7 +457,11 @@ mod tests {
         }
 
         fn handle(&self, _invocation: ToolInvocation) -> codex_tools::ToolExecutorFuture<'_> {
-            Box::pin(async {
+            let fatal = self.fatal;
+            Box::pin(async move {
+                if fatal {
+                    return Err(FunctionCallError::Fatal("fatal barrier".to_string()));
+                }
                 Ok(Box::new(FunctionToolOutput::from_text(
                     serde_json::json!({ "code": "path_not_found" }).to_string(),
                     /*success*/ Some(false),
@@ -728,6 +774,7 @@ mod tests {
             ToolRegistry::from_tools([
                 Arc::new(FailingBarrierHandler {
                     tool_name: barrier_name.clone(),
+                    fatal: false,
                 }) as Arc<dyn CoreToolRuntime>,
                 Arc::new(RecordingHandler {
                     tool_name: suffix_name.clone(),
@@ -757,6 +804,7 @@ mod tests {
             )
             .await?;
         let response = runtime
+            .clone()
             .handle_tool_call(
                 ToolCall {
                     tool_name: suffix_name,
@@ -781,6 +829,105 @@ mod tests {
                 "message": "cancelled because workspace mutation `barrier-call` failed",
                 "failed_mutation_call_id": "barrier-call",
                 "failed_mutation_code": "path_not_found",
+            })
+        );
+        assert!(!suffix_called.load(Ordering::Acquire));
+
+        let tool_search_response = runtime
+            .handle_tool_call(
+                ToolCall {
+                    tool_name: codex_tools::ToolName::plain("suffix"),
+                    call_id: "tool-search-call".to_string(),
+                    payload: ToolPayload::ToolSearch {
+                        arguments: codex_protocol::models::SearchToolCallParams {
+                            query: "suffix".to_string(),
+                            limit: None,
+                        },
+                    },
+                },
+                CancellationToken::new(),
+            )
+            .await?;
+        assert_eq!(
+            tool_search_response,
+            ResponseInputItem::ToolSearchOutput {
+                call_id: "tool-search-call".to_string(),
+                status: "completed".to_string(),
+                execution: "client".to_string(),
+                tools: Vec::new(),
+            }
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn fatal_barrier_cancels_suffix_without_dispatching_it() -> anyhow::Result<()> {
+        let (session, turn_context) = crate::session::tests::make_session_and_context().await;
+        let barrier_name = codex_tools::ToolName::plain("barrier");
+        let suffix_name = codex_tools::ToolName::plain("suffix");
+        let suffix_called = Arc::new(AtomicBool::new(/*v*/ false));
+        let router = Arc::new(ToolRouter::from_parts(
+            ToolRegistry::from_tools([
+                Arc::new(FailingBarrierHandler {
+                    tool_name: barrier_name.clone(),
+                    fatal: true,
+                }) as Arc<dyn CoreToolRuntime>,
+                Arc::new(RecordingHandler {
+                    tool_name: suffix_name.clone(),
+                    called: Arc::clone(&suffix_called),
+                }) as Arc<dyn CoreToolRuntime>,
+            ]),
+            Vec::new(),
+        ));
+        let runtime = ToolCallRuntime::new(
+            router,
+            Arc::new(session),
+            Arc::new(turn_context),
+            Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new())),
+        );
+        let payload = ToolPayload::Function {
+            arguments: "{}".to_string(),
+        };
+        let barrier_response = runtime
+            .clone()
+            .handle_tool_call(
+                ToolCall {
+                    tool_name: barrier_name,
+                    call_id: "barrier-call".to_string(),
+                    payload: payload.clone(),
+                },
+                CancellationToken::new(),
+            )
+            .await;
+        assert!(matches!(
+            barrier_response,
+            Err(CodexErr::Fatal(message)) if message == "fatal barrier"
+        ));
+
+        let response = runtime
+            .handle_tool_call(
+                ToolCall {
+                    tool_name: suffix_name,
+                    call_id: "suffix-call".to_string(),
+                    payload,
+                },
+                CancellationToken::new(),
+            )
+            .await?;
+        let ResponseInputItem::FunctionCallOutput { output, .. } = response else {
+            anyhow::bail!("cancelled suffix should return function output");
+        };
+        let FunctionCallOutputBody::Text(text) = output.body else {
+            anyhow::bail!("cancelled suffix output should be text");
+        };
+        assert_eq!(output.success, Some(false));
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&text)?,
+            serde_json::json!({
+                "code": "dependency_cancelled",
+                "message": "cancelled because workspace mutation `barrier-call` failed",
+                "failed_mutation_call_id": "barrier-call",
+                "failed_mutation_code": "tool_error",
             })
         );
         assert!(!suffix_called.load(Ordering::Acquire));

--- a/codex-rs/core/src/tools/registry.rs
+++ b/codex-rs/core/src/tools/registry.rs
@@ -45,6 +45,14 @@ pub use codex_tools::ToolExposure;
 /// Implementers provide the shared `ToolExecutor` behavior plus optional
 /// core-owned metadata for hooks, telemetry, tool search, and argument diffs.
 pub(crate) trait CoreToolRuntime: ToolExecutor<ToolInvocation> {
+    fn execution_barrier(&self) -> bool {
+        false
+    }
+
+    fn cancel_suffix_on_failure(&self) -> bool {
+        false
+    }
+
     fn matches_kind(&self, payload: &ToolPayload) -> bool {
         matches!(
             payload,
@@ -277,6 +285,14 @@ impl ToolExecutor<ToolInvocation> for ExposureOverride {
 }
 
 impl CoreToolRuntime for ExposureOverride {
+    fn execution_barrier(&self) -> bool {
+        self.handler.execution_barrier()
+    }
+
+    fn cancel_suffix_on_failure(&self) -> bool {
+        self.handler.cancel_suffix_on_failure()
+    }
+
     fn matches_kind(&self, payload: &ToolPayload) -> bool {
         self.handler.matches_kind(payload)
     }
@@ -385,6 +401,16 @@ impl ToolRegistry {
     pub(crate) fn waits_for_runtime_cancellation(&self, name: &ToolName) -> Option<bool> {
         let tool = self.tool(name)?;
         Some(tool.waits_for_runtime_cancellation())
+    }
+
+    pub(crate) fn execution_barrier(&self, name: &ToolName) -> Option<bool> {
+        let tool = self.tool(name)?;
+        Some(tool.execution_barrier())
+    }
+
+    pub(crate) fn cancel_suffix_on_failure(&self, name: &ToolName) -> Option<bool> {
+        let tool = self.tool(name)?;
+        Some(tool.cancel_suffix_on_failure())
     }
 
     #[allow(dead_code)]

--- a/codex-rs/core/src/tools/registry.rs
+++ b/codex-rs/core/src/tools/registry.rs
@@ -40,17 +40,32 @@ pub(crate) type ToolTelemetryTags = Vec<(&'static str, String)>;
 pub use codex_tools::ToolExecutor;
 pub use codex_tools::ToolExposure;
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) enum ToolExecutionPolicy {
+    #[default]
+    Parallel,
+    // Constructed by workspace mutation tools in the next stack layer.
+    #[allow(dead_code)]
+    BarrierAndCancelSuffix,
+}
+
+impl ToolExecutionPolicy {
+    pub(crate) fn is_barrier(self) -> bool {
+        !matches!(self, Self::Parallel)
+    }
+
+    pub(crate) fn cancels_suffix_on_failure(self) -> bool {
+        matches!(self, Self::BarrierAndCancelSuffix)
+    }
+}
+
 /// Typed runtime contract for locally executed tools.
 ///
 /// Implementers provide the shared `ToolExecutor` behavior plus optional
 /// core-owned metadata for hooks, telemetry, tool search, and argument diffs.
 pub(crate) trait CoreToolRuntime: ToolExecutor<ToolInvocation> {
-    fn execution_barrier(&self) -> bool {
-        false
-    }
-
-    fn cancel_suffix_on_failure(&self) -> bool {
-        false
+    fn execution_policy(&self) -> ToolExecutionPolicy {
+        ToolExecutionPolicy::Parallel
     }
 
     fn matches_kind(&self, payload: &ToolPayload) -> bool {
@@ -285,12 +300,8 @@ impl ToolExecutor<ToolInvocation> for ExposureOverride {
 }
 
 impl CoreToolRuntime for ExposureOverride {
-    fn execution_barrier(&self) -> bool {
-        self.handler.execution_barrier()
-    }
-
-    fn cancel_suffix_on_failure(&self) -> bool {
-        self.handler.cancel_suffix_on_failure()
+    fn execution_policy(&self) -> ToolExecutionPolicy {
+        self.handler.execution_policy()
     }
 
     fn matches_kind(&self, payload: &ToolPayload) -> bool {
@@ -403,14 +414,9 @@ impl ToolRegistry {
         Some(tool.waits_for_runtime_cancellation())
     }
 
-    pub(crate) fn execution_barrier(&self, name: &ToolName) -> Option<bool> {
+    pub(crate) fn execution_policy(&self, name: &ToolName) -> Option<ToolExecutionPolicy> {
         let tool = self.tool(name)?;
-        Some(tool.execution_barrier())
-    }
-
-    pub(crate) fn cancel_suffix_on_failure(&self, name: &ToolName) -> Option<bool> {
-        let tool = self.tool(name)?;
-        Some(tool.cancel_suffix_on_failure())
+        Some(tool.execution_policy())
     }
 
     #[allow(dead_code)]

--- a/codex-rs/core/src/tools/router.rs
+++ b/codex-rs/core/src/tools/router.rs
@@ -92,6 +92,18 @@ impl ToolRouter {
             .unwrap_or(false)
     }
 
+    pub fn tool_is_execution_barrier(&self, call: &ToolCall) -> bool {
+        self.registry
+            .execution_barrier(&call.tool_name)
+            .unwrap_or(/*default*/ false)
+    }
+
+    pub fn tool_cancels_suffix_on_failure(&self, call: &ToolCall) -> bool {
+        self.registry
+            .cancel_suffix_on_failure(&call.tool_name)
+            .unwrap_or(/*default*/ false)
+    }
+
     #[instrument(level = "trace", skip_all, err)]
     pub fn build_tool_call(item: ResponseItem) -> Result<Option<ToolCall>, FunctionCallError> {
         match item {

--- a/codex-rs/core/src/tools/router.rs
+++ b/codex-rs/core/src/tools/router.rs
@@ -92,16 +92,13 @@ impl ToolRouter {
             .unwrap_or(false)
     }
 
-    pub fn tool_is_execution_barrier(&self, call: &ToolCall) -> bool {
+    pub(crate) fn tool_execution_policy(
+        &self,
+        call: &ToolCall,
+    ) -> crate::tools::registry::ToolExecutionPolicy {
         self.registry
-            .execution_barrier(&call.tool_name)
-            .unwrap_or(/*default*/ false)
-    }
-
-    pub fn tool_cancels_suffix_on_failure(&self, call: &ToolCall) -> bool {
-        self.registry
-            .cancel_suffix_on_failure(&call.tool_name)
-            .unwrap_or(/*default*/ false)
+            .execution_policy(&call.tool_name)
+            .unwrap_or_default()
     }
 
     #[instrument(level = "trace", skip_all, err)]


### PR DESCRIPTION
## Why

A directory mutation cannot execute like an ordinary parallel tool call. Calls after it must observe the updated cwd and permission context, and they must not run against stale state if the mutation fails.

## What Changed

- Add an explicit `ToolExecutionPolicy` with parallel and barrier-and-cancel-suffix modes.
- Execute preceding calls before a barrier, run the barrier exclusively, and release later calls only after success.
- Emit `dependency_cancelled` outputs for calls skipped behind a failed mutation barrier.
- Preserve ordinary parallel execution between barriers.
- Share dependency-failure construction and test setup across the ordering paths.

## How to Test

1. Submit a batch with ordinary calls before and after a successful barrier.
2. Confirm calls before the barrier complete first and suffix calls start only after success.
3. Repeat with a failed barrier.
4. Confirm suffix calls are not dispatched and receive `dependency_cancelled` outputs.

Targeted tests:
- `failed_barrier_cancels_suffix_without_dispatching_it`
- The focused tests in `core/src/tools/parallel.rs`

## Stack

1. [#25336](https://github.com/openai/codex/pull/25336) runtime workspace state
2. #25339(https://github.com/openai/codex/pull/25339) ordered mutation barriers (this PR)
3. [#25334](https://github.com/openai/codex/pull/25334) model workspace tools
4. [#25338](https://github.com/openai/codex/pull/25338) approval projection
5. [#25335](https://github.com/openai/codex/pull/25335) TUI workspace commands