### PR TITLE
Build unsigned macOS package archives

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -463,13 +463,14 @@ jobs:
           fi
 
       - name: Build Codex package archive
-        if: ${{ runner.os != 'macOS' || env.SIGN_MACOS == 'true' }}
         shell: bash
         env:
           TARGET: ${{ matrix.target }}
           BUNDLE: ${{ matrix.bundle }}
         run: |
           set -euo pipefail
+          # Build the full package layout for unsigned macOS too so workflow_dispatch
+          # release builds validate packaged Codex without publishing it.
           bash "${GITHUB_WORKSPACE}/.github/scripts/build-codex-package-archive.sh" \
             --target "$TARGET" \
             --bundle "$BUNDLE" \


### PR DESCRIPTION
## Summary
- run the existing Codex package archive build step for unsigned macOS release builds too
- keep the unsigned flow build-only by leaving the unsigned artifact upload path pointed at `unsigned-dist/<target>/*`
- document in the workflow that this is meant to validate the packaged Codex layout during `build_unsigned` runs without publishing it

## Why
Unsigned macOS release runs already build the raw handoff binaries, but they skip the package archive build entirely. That means we do not exercise the full packaged Codex layout in the unsigned path even though the packaging logic can wrap those binaries just fine.

The package helper still produces the normal archive names:
- `codex-package-<target>.tar.gz`
- `codex-package-<target>.tar.zst`
- `codex-app-server-package-<target>.tar.gz`
- `codex-app-server-package-<target>.tar.zst`

Those archives are built under `dist/<target>/`, but they are not uploaded in the unsigned macOS path because the unsigned upload step still only uploads `unsigned-dist/<target>/*`. The release job therefore does not see or publish these unsigned package archives.

## Validation
- `git diff --check -- .github/workflows/rust-release.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/rust-release.yml")'`
- local package builder smoke test against the unsigned `aarch64-apple-darwin` binary to confirm it produces `bin/codex`, `codex-path/rg`, and `codex-resources/zsh/bin/zsh` in the package layout