### PR TITLE
[codex] Expose local image paths to models

### DIFF
--- a/codex-rs/core/src/event_mapping_tests.rs
+++ b/codex-rs/core/src/event_mapping_tests.rs
@@ -67,7 +67,7 @@ fn parses_user_message_with_text_and_two_images() {
 #[test]
 fn skips_local_image_label_text() {
     let image_url = "data:image/png;base64,abc".to_string();
-    let label = codex_protocol::models::local_image_open_tag_text(/*label_number*/ 1);
+    let label = r#"<image name=[Image #1] path="/tmp/local.png">"#.to_string();
     let user_text = "Please review this image.".to_string();
 
     let item = ResponseItem::Message {

--- a/codex-rs/core/tests/suite/image_rollout.rs
+++ b/codex-rs/core/tests/suite/image_rollout.rs
@@ -161,7 +161,9 @@ async fn copy_paste_local_image_persists_rollout_request_shape() -> anyhow::Resu
         role: "user".to_string(),
         content: vec![
             ContentItem::InputText {
-                text: codex_protocol::models::local_image_open_tag_text(/*label_number*/ 1),
+                text: codex_protocol::models::local_image_open_tag_text_with_path(
+                    /*label_number*/ 1, &abs_path,
+                ),
             },
             ContentItem::InputImage {
                 image_url,

--- a/codex-rs/core/tests/suite/image_rollout.rs
+++ b/codex-rs/core/tests/suite/image_rollout.rs
@@ -161,9 +161,7 @@ async fn copy_paste_local_image_persists_rollout_request_shape() -> anyhow::Resu
         role: "user".to_string(),
         content: vec![
             ContentItem::InputText {
-                text: codex_protocol::models::local_image_open_tag_text_with_path(
-                    /*label_number*/ 1, &abs_path,
-                ),
+                text: format!(r#"<image name=[Image #1] path="{}">"#, abs_path.display()),
             },
             ContentItem::InputImage {
                 image_url,

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -1026,12 +1026,7 @@ pub fn local_image_label_text(label_number: usize) -> String {
     format!("[Image #{label_number}]")
 }
 
-pub fn local_image_open_tag_text(label_number: usize) -> String {
-    let label = local_image_label_text(label_number);
-    format!("{LOCAL_IMAGE_OPEN_TAG_PREFIX}{label}{LOCAL_IMAGE_OPEN_TAG_SUFFIX}")
-}
-
-pub fn local_image_open_tag_text_with_path(label_number: usize, path: &std::path::Path) -> String {
+fn local_image_open_tag_text_with_path(label_number: usize, path: &std::path::Path) -> String {
     let label = local_image_label_text(label_number);
     let path = path
         .display()

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -1031,6 +1031,18 @@ pub fn local_image_open_tag_text(label_number: usize) -> String {
     format!("{LOCAL_IMAGE_OPEN_TAG_PREFIX}{label}{LOCAL_IMAGE_OPEN_TAG_SUFFIX}")
 }
 
+pub fn local_image_open_tag_text_with_path(label_number: usize, path: &std::path::Path) -> String {
+    let label = local_image_label_text(label_number);
+    let path = path
+        .display()
+        .to_string()
+        .replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;");
+    format!("{LOCAL_IMAGE_OPEN_TAG_PREFIX}{label} path=\"{path}\"{LOCAL_IMAGE_OPEN_TAG_SUFFIX}")
+}
+
 pub fn is_local_image_open_tag_text(text: &str) -> bool {
     text.strip_prefix(LOCAL_IMAGE_OPEN_TAG_PREFIX)
         .is_some_and(|rest| rest.ends_with(LOCAL_IMAGE_OPEN_TAG_SUFFIX))
@@ -1087,7 +1099,7 @@ pub fn local_image_content_items_with_label_number(
             let mut items = Vec::with_capacity(3);
             if let Some(label_number) = label_number {
                 items.push(ContentItem::InputText {
-                    text: local_image_open_tag_text(label_number),
+                    text: local_image_open_tag_text_with_path(label_number, path),
                 });
             }
             items.push(ContentItem::InputImage {
@@ -2873,7 +2885,7 @@ mod tests {
                 detail: None,
             },
             UserInput::LocalImage {
-                path: local_path,
+                path: local_path.clone(),
                 detail: None,
             },
         ]);
@@ -2890,7 +2902,10 @@ mod tests {
                 assert_eq!(
                     content.get(1),
                     Some(&ContentItem::InputText {
-                        text: local_image_open_tag_text(/*label_number*/ 2),
+                        text: local_image_open_tag_text_with_path(
+                            /*label_number*/ 2,
+                            &local_path
+                        ),
                     })
                 );
                 assert!(matches!(
@@ -2908,6 +2923,14 @@ mod tests {
         }
 
         Ok(())
+    }
+
+    #[test]
+    fn local_image_open_tag_escapes_path() {
+        assert_eq!(
+            local_image_open_tag_text_with_path(1, std::path::Path::new(r#"/tmp/a&"<b>.png"#)),
+            r#"<image name=[Image #1] path="/tmp/a&amp;&quot;&lt;b&gt;.png">"#
+        );
     }
 
     #[test]

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -2180,8 +2180,9 @@ pub struct UserMessageEvent {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub image_details: Vec<Option<ImageDetail>>,
     /// Local file paths sourced from `UserInput::LocalImage`. These are kept so
-    /// the UI can reattach images when editing history, and should not be sent
-    /// to the model or treated as API-ready URLs.
+    /// the UI can reattach images when editing history. Local image prompts may
+    /// include a display form of the path, but these should not be treated as
+    /// API-ready URLs.
     #[serde(default)]
     pub local_images: Vec<std::path::PathBuf>,
     /// Detail hints for `local_images`, indexed in parallel. Missing entries


### PR DESCRIPTION
## Why

Local image attachments include the image bytes, but the adjacent model-visible label omits the source path. Exposing the path lets model-selected workflows refer back to the intended local image explicitly.

## What changed

- Include an escaped `path` attribute in model-visible local image opening tags.
- Keep the existing pathless helper for callers that do not have a local path.
- Update protocol and rollout coverage for the new request shape.

## Validation

- `just fmt`
- `just test -p codex-protocol`
- `just test -p codex-core --test all image_rollout::copy_paste_local_image_persists_rollout_request_shape`
- `git diff --check origin/main...HEAD`