### PR TITLE
Disable SQLite intrinsics for Windows x64 releases

### DIFF
--- a/.github/scripts/run-bazel-ci.sh
+++ b/.github/scripts/run-bazel-ci.sh
@@ -423,10 +423,14 @@ else
   #   clear remote cache/execution endpoints configured in .bazelrc.
   #   https://bazel.build/reference/command-line-reference#common_options-flag--remote_cache
   #   https://bazel.build/reference/command-line-reference#common_options-flag--remote_executor
+  # --experimental_remote_downloader=:
+  #   clear the remote downloader endpoint configured in .bazelrc. Bazel 9
+  #   rejects a remote downloader without a gRPC remote cache.
   bazel_run_args=(
     "${bazel_args[@]}"
     --remote_cache=
     --remote_executor=
+    --experimental_remote_downloader=
   )
   if (( ${#post_config_bazel_args[@]} > 0 )); then
     bazel_run_args+=("${post_config_bazel_args[@]}")

--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -107,11 +107,15 @@ jobs:
       - name: Cargo build (Windows binaries)
         shell: bash
         run: |
+          target="${{ matrix.target }}"
+          if [[ "$target" == "x86_64-pc-windows-msvc" ]]; then
+            export LIBSQLITE3_FLAGS=SQLITE_DISABLE_INTRINSIC
+          fi
           build_args=()
           for binary in ${{ matrix.binaries }}; do
             build_args+=(--bin "$binary")
           done
-          cargo build --target ${{ matrix.target }} --release --timings "${build_args[@]}"
+          cargo build --target "$target" --release --timings "${build_args[@]}"
 
       - name: Upload Cargo timings
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -310,12 +310,16 @@ jobs:
       - name: Cargo build
         shell: bash
         run: |
+          target="${{ matrix.target }}"
+          if [[ "$target" == "x86_64-pc-windows-msvc" ]]; then
+            export LIBSQLITE3_FLAGS=SQLITE_DISABLE_INTRINSIC
+          fi
           build_args=()
           for binary in ${{ matrix.binaries }}; do
             build_args+=(--bin "$binary")
           done
           echo "CARGO_PROFILE_RELEASE_LTO: ${CARGO_PROFILE_RELEASE_LTO}"
-          cargo build --target ${{ matrix.target }} --release --timings "${build_args[@]}"
+          cargo build --target "$target" --release --timings "${build_args[@]}"
 
       - name: Upload Cargo timings
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0


### PR DESCRIPTION
## Why

Codex 0.135.0 started shipping bundled SQLite 3.51.x via SQLx 0.9.0 to avoid the older WAL corruption bug fixed by #24728. On Windows x64, #25367 reports an immediate `STATUS_ILLEGAL_INSTRUCTION` crash on a Haswell CPU when starting normal Codex paths.

Rather than downgrading SQLite, this keeps the newer bundled SQLite source and removes SQLite compiler-intrinsic code paths from the Windows x64 release build.

This PR also fixes the fork/no-secret Bazel CI fallback exposed while validating this change. Without `BUILDBUDDY_API_KEY`, `.github/scripts/run-bazel-ci.sh` already clears the remote cache and executor, but Bazel 9 also requires clearing the remote downloader configured in `.bazelrc`.

## What changed

For `x86_64-pc-windows-msvc` release builds, export `LIBSQLITE3_FLAGS=SQLITE_DISABLE_INTRINSIC` before `cargo build` in:

- `.github/workflows/rust-release.yml`
- `.github/workflows/rust-release-windows.yml`

For Bazel CI without BuildBuddy credentials, also pass `--experimental_remote_downloader=` in `.github/scripts/run-bazel-ci.sh` so fork PRs can fall back to local Bazel cleanly.

Other targets keep their current SQLite build flags.

## Verification

- `git diff --check`
- `bash -n .github/scripts/run-bazel-ci.sh`
- Confirmed Bazel 9 accepts `--experimental_remote_downloader=` as a build flag via `bazel help build` with local cache paths. The local sandbox prevents a full Bazel run here, so GitHub Actions remains the end-to-end validation.