### PR TITLE
Remove Plan-mode gate from idle turn injection

### DIFF
--- a/codex-rs/core/src/session/inject.rs
+++ b/codex-rs/core/src/session/inject.rs
@@ -4,7 +4,6 @@ use super::turn_context::TurnContext;
 use crate::state::ActiveTurn;
 use crate::state::TurnState;
 use crate::tasks::RegularTask;
-use codex_protocol::config_types::ModeKind;
 use codex_protocol::models::ResponseItem;
 use std::sync::Arc;
 
@@ -40,9 +39,6 @@ impl Session {
     ) -> Result<(), Vec<ResponseItem>> {
         if input.is_empty() {
             return Ok(());
-        }
-        if self.collaboration_mode().await.mode == ModeKind::Plan {
-            return Err(input);
         }
         if self.input_queue.has_trigger_turn_mailbox_items().await {
             return Err(input);


### PR DESCRIPTION
## Why

`try_start_turn_if_idle` is the core helper for starting injected input only when the session is actually idle. It should stay focused on generic turn-lifecycle safety. The previous `ModeKind::Plan` guard mixed caller policy into that helper: Plan mode may choose not to auto-start some extension work, but that decision belongs at the extension or caller boundary rather than in the session injection primitive.

## What changed

- Removed the `ModeKind::Plan` early return from `Session::try_start_turn_if_idle`.
- Removed the now-unused `ModeKind` import from `core/src/session/inject.rs`.

## Testing

Not run locally.
