### PR TITLE
fix(core): disable git editors in unified exec

### DIFF
--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -110,6 +110,19 @@ fn unified_exec_options(
     }
 }
 
+fn guard_git_editors_after_login_profiles(command: &[String]) -> Vec<String> {
+    let [_, flag, script, ..] = command else {
+        return command.to_vec();
+    };
+    if flag != "-lc" {
+        return command.to_vec();
+    }
+
+    let mut command = command.to_vec();
+    command[2] = format!("export GIT_EDITOR=: GIT_SEQUENCE_EDITOR=:;\n{script}");
+    command
+}
+
 impl<'a> UnifiedExecRuntime<'a> {
     /// Creates a runtime bound to the shared unified-exec process manager.
     pub fn new(manager: &'a UnifiedExecProcessManager, shell_mode: UnifiedExecShellMode) -> Self {
@@ -303,6 +316,7 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
                 &env,
             )
         };
+        let command = guard_git_editors_after_login_profiles(&command);
         let command = disable_powershell_profile_for_elevated_windows_sandbox(
             &command,
             Some(&req.shell_type),
@@ -402,8 +416,40 @@ mod tests {
     use crate::exec::DEFAULT_EXEC_COMMAND_TIMEOUT_MS;
     use crate::tools::sandboxing::ToolRuntime;
     use codex_exec_server::Environment;
+    use pretty_assertions::assert_eq;
     use std::time::Duration;
     use tempfile::tempdir;
+
+    #[test]
+    fn guard_git_editors_after_login_profiles_prefixes_login_shell_script() {
+        let command = vec![
+            "/bin/sh".to_string(),
+            "-lc".to_string(),
+            "printf ok".to_string(),
+            "arg0".to_string(),
+        ];
+
+        assert_eq!(
+            guard_git_editors_after_login_profiles(&command),
+            vec![
+                "/bin/sh".to_string(),
+                "-lc".to_string(),
+                "export GIT_EDITOR=: GIT_SEQUENCE_EDITOR=:;\nprintf ok".to_string(),
+                "arg0".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn guard_git_editors_after_login_profiles_leaves_non_login_shell_script_unchanged() {
+        let command = vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            "printf ok".to_string(),
+        ];
+
+        assert_eq!(guard_git_editors_after_login_profiles(&command), command);
+    }
 
     #[test]
     fn unified_exec_options_combines_default_timeout_with_network_denial_cancellation() {

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -110,16 +110,35 @@ fn unified_exec_options(
     }
 }
 
-fn guard_git_editors_after_login_profiles(command: &[String]) -> Vec<String> {
-    let [_, flag, script, ..] = command else {
-        return command.to_vec();
-    };
-    if flag != "-lc" {
-        return command.to_vec();
-    }
-
+fn guard_git_editors_after_shell_startup(
+    command: &[String],
+    shell_type: &ShellType,
+) -> Vec<String> {
     let mut command = command.to_vec();
-    command[2] = format!("export GIT_EDITOR=: GIT_SEQUENCE_EDITOR=:;\n{script}");
+    let (script, guard) = match (shell_type, command.as_mut_slice()) {
+        (ShellType::Zsh | ShellType::Bash | ShellType::Sh, [_, flag, script, ..])
+            if flag == "-lc" || flag == "-c" =>
+        {
+            (script, "export GIT_EDITOR=: GIT_SEQUENCE_EDITOR=:;\n")
+        }
+        (ShellType::PowerShell, [_, flag, script, ..]) if flag.eq_ignore_ascii_case("-Command") => {
+            (
+                script,
+                "$env:GIT_EDITOR = ':'; $env:GIT_SEQUENCE_EDITOR = ':';\n",
+            )
+        }
+        (ShellType::PowerShell, [_, no_profile, flag, script, ..])
+            if no_profile.eq_ignore_ascii_case("-NoProfile")
+                && flag.eq_ignore_ascii_case("-Command") =>
+        {
+            (
+                script,
+                "$env:GIT_EDITOR = ':'; $env:GIT_SEQUENCE_EDITOR = ':';\n",
+            )
+        }
+        _ => return command,
+    };
+    *script = format!("{guard}{script}");
     command
 }
 
@@ -274,7 +293,7 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
         attempt: &SandboxAttempt<'_>,
         ctx: &ToolCtx,
     ) -> Result<UnifiedExecProcess, ToolError> {
-        let base_command = &req.command;
+        let base_command = guard_git_editors_after_shell_startup(&req.command, &req.shell_type);
         let session_shell = ctx.session.user_shell();
         let (file_system_sandbox_policy, _) = attempt.permissions.to_runtime_permissions();
         let sandbox_permissions = sandbox_permissions_preserving_denied_reads(
@@ -306,17 +325,16 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
         };
         let environment_is_remote = req.environment.is_remote();
         let command = if environment_is_remote {
-            base_command.to_vec()
+            base_command
         } else {
             maybe_wrap_shell_lc_with_snapshot(
-                base_command,
+                &base_command,
                 session_shell.as_ref(),
                 &req.cwd,
                 &explicit_env_overrides,
                 &env,
             )
         };
-        let command = guard_git_editors_after_login_profiles(&command);
         let command = disable_powershell_profile_for_elevated_windows_sandbox(
             &command,
             Some(&req.shell_type),
@@ -421,7 +439,7 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
-    fn guard_git_editors_after_login_profiles_prefixes_login_shell_script() {
+    fn guard_git_editors_after_shell_startup_prefixes_login_shell_script() {
         let command = vec![
             "/bin/sh".to_string(),
             "-lc".to_string(),
@@ -430,7 +448,7 @@ mod tests {
         ];
 
         assert_eq!(
-            guard_git_editors_after_login_profiles(&command),
+            guard_git_editors_after_shell_startup(&command, &ShellType::Sh),
             vec![
                 "/bin/sh".to_string(),
                 "-lc".to_string(),
@@ -441,14 +459,61 @@ mod tests {
     }
 
     #[test]
-    fn guard_git_editors_after_login_profiles_leaves_non_login_shell_script_unchanged() {
+    fn guard_git_editors_after_shell_startup_prefixes_non_login_shell_script() {
         let command = vec![
             "/bin/sh".to_string(),
             "-c".to_string(),
             "printf ok".to_string(),
         ];
 
-        assert_eq!(guard_git_editors_after_login_profiles(&command), command);
+        assert_eq!(
+            guard_git_editors_after_shell_startup(&command, &ShellType::Sh),
+            vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                "export GIT_EDITOR=: GIT_SEQUENCE_EDITOR=:;\nprintf ok".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn guard_git_editors_after_shell_startup_prefixes_powershell_script() {
+        let command = vec![
+            "pwsh".to_string(),
+            "-Command".to_string(),
+            "Write-Output ok".to_string(),
+        ];
+
+        assert_eq!(
+            guard_git_editors_after_shell_startup(&command, &ShellType::PowerShell),
+            vec![
+                "pwsh".to_string(),
+                "-Command".to_string(),
+                "$env:GIT_EDITOR = ':'; $env:GIT_SEQUENCE_EDITOR = ':';\nWrite-Output ok"
+                    .to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn guard_git_editors_after_shell_startup_prefixes_profile_free_powershell_script() {
+        let command = vec![
+            "pwsh".to_string(),
+            "-NoProfile".to_string(),
+            "-Command".to_string(),
+            "Write-Output ok".to_string(),
+        ];
+
+        assert_eq!(
+            guard_git_editors_after_shell_startup(&command, &ShellType::PowerShell),
+            vec![
+                "pwsh".to_string(),
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                "$env:GIT_EDITOR = ':'; $env:GIT_SEQUENCE_EDITOR = ':';\nWrite-Output ok"
+                    .to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -115,27 +115,32 @@ fn guard_git_editors_after_shell_startup(
     shell_type: &ShellType,
 ) -> Vec<String> {
     let mut command = command.to_vec();
+    if matches!(shell_type, ShellType::PowerShell) {
+        return match command.as_mut_slice() {
+            [_, no_profile, ..] if no_profile.eq_ignore_ascii_case("-NoProfile") => command,
+            [_, flag, script, ..] if flag.eq_ignore_ascii_case("-Command") => {
+                // Keep leading declarations first when PowerShell parses the original script.
+                let escaped_script = script.replace('\'', "''");
+                *script = format!(
+                    "$env:GIT_EDITOR = ':'; $env:GIT_SEQUENCE_EDITOR = ':';\n\
+                    . ([scriptblock]::Create('{escaped_script}'))"
+                );
+                command
+            }
+            _ => command,
+        };
+    }
+
     let (script, guard) = match (shell_type, command.as_mut_slice()) {
         (ShellType::Zsh | ShellType::Bash | ShellType::Sh, [_, flag, script, ..])
             if flag == "-lc" || flag == "-c" =>
         {
             (script, "export GIT_EDITOR=: GIT_SEQUENCE_EDITOR=:;\n")
         }
-        (ShellType::PowerShell, [_, flag, script, ..]) if flag.eq_ignore_ascii_case("-Command") => {
-            (
-                script,
-                "$env:GIT_EDITOR = ':'; $env:GIT_SEQUENCE_EDITOR = ':';\n",
-            )
-        }
-        (ShellType::PowerShell, [_, no_profile, flag, script, ..])
-            if no_profile.eq_ignore_ascii_case("-NoProfile")
-                && flag.eq_ignore_ascii_case("-Command") =>
-        {
-            (
-                script,
-                "$env:GIT_EDITOR = ':'; $env:GIT_SEQUENCE_EDITOR = ':';\n",
-            )
-        }
+        (ShellType::Cmd, [_, flag, script, ..]) if flag.eq_ignore_ascii_case("/c") => (
+            script,
+            "set \"GIT_EDITOR=:\" && set \"GIT_SEQUENCE_EDITOR=:\" && ",
+        ),
         _ => return command,
     };
     *script = format!("{guard}{script}");
@@ -481,7 +486,8 @@ mod tests {
         let command = vec![
             "pwsh".to_string(),
             "-Command".to_string(),
-            "Write-Output ok".to_string(),
+            "using namespace System.Text; [Encoding]::UTF8.WebName".to_string(),
+            "arg0".to_string(),
         ];
 
         assert_eq!(
@@ -489,14 +495,14 @@ mod tests {
             vec![
                 "pwsh".to_string(),
                 "-Command".to_string(),
-                "$env:GIT_EDITOR = ':'; $env:GIT_SEQUENCE_EDITOR = ':';\nWrite-Output ok"
-                    .to_string(),
+                "$env:GIT_EDITOR = ':'; $env:GIT_SEQUENCE_EDITOR = ':';\n. ([scriptblock]::Create('using namespace System.Text; [Encoding]::UTF8.WebName'))".to_string(),
+                "arg0".to_string(),
             ]
         );
     }
 
     #[test]
-    fn guard_git_editors_after_shell_startup_prefixes_profile_free_powershell_script() {
+    fn guard_git_editors_after_shell_startup_leaves_profile_free_powershell_script_unchanged() {
         let command = vec![
             "pwsh".to_string(),
             "-NoProfile".to_string(),
@@ -506,12 +512,42 @@ mod tests {
 
         assert_eq!(
             guard_git_editors_after_shell_startup(&command, &ShellType::PowerShell),
+            command
+        );
+    }
+
+    #[test]
+    fn guard_git_editors_after_shell_startup_escapes_powershell_script_quotes() {
+        let command = vec![
+            "pwsh".to_string(),
+            "-Command".to_string(),
+            "Write-Output 'ok'".to_string(),
+        ];
+
+        assert_eq!(
+            guard_git_editors_after_shell_startup(&command, &ShellType::PowerShell),
             vec![
                 "pwsh".to_string(),
-                "-NoProfile".to_string(),
                 "-Command".to_string(),
-                "$env:GIT_EDITOR = ':'; $env:GIT_SEQUENCE_EDITOR = ':';\nWrite-Output ok"
-                    .to_string(),
+                "$env:GIT_EDITOR = ':'; $env:GIT_SEQUENCE_EDITOR = ':';\n. ([scriptblock]::Create('Write-Output ''ok'''))".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn guard_git_editors_after_shell_startup_prefixes_cmd_script() {
+        let command = vec![
+            "cmd.exe".to_string(),
+            "/c".to_string(),
+            "echo ok".to_string(),
+        ];
+
+        assert_eq!(
+            guard_git_editors_after_shell_startup(&command, &ShellType::Cmd),
+            vec![
+                "cmd.exe".to_string(),
+                "/c".to_string(),
+                "set \"GIT_EDITOR=:\" && set \"GIT_SEQUENCE_EDITOR=:\" && echo ok".to_string(),
             ]
         );
     }

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -1007,6 +1007,8 @@ impl UnifiedExecProcessManager {
             context.session.conversation_id.to_string(),
         );
         let env = apply_unified_exec_env(env);
+        let explicit_env_overrides =
+            apply_unified_exec_env(context.turn.shell_environment_policy.r#set.clone());
         let exec_server_env_config = ExecServerEnvConfig {
             policy: exec_env_policy_from_shell_policy(&context.turn.shell_environment_policy),
             local_policy_env,
@@ -1045,7 +1047,7 @@ impl UnifiedExecProcessManager {
             environment: Arc::clone(&request.environment),
             env,
             exec_server_env_config: Some(exec_server_env_config),
-            explicit_env_overrides: context.turn.shell_environment_policy.r#set.clone(),
+            explicit_env_overrides,
             network: request.network.clone(),
             tty: request.tty,
             sandbox_permissions: request.sandbox_permissions,

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -57,7 +57,7 @@ use codex_tools::ToolName;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_output_truncation::approx_token_count;
 
-const UNIFIED_EXEC_ENV: [(&str, &str); 11] = [
+const UNIFIED_EXEC_ENV: [(&str, &str); 12] = [
     ("NO_COLOR", "1"),
     ("TERM", "dumb"),
     ("LANG", "C.UTF-8"),
@@ -67,6 +67,7 @@ const UNIFIED_EXEC_ENV: [(&str, &str); 11] = [
     ("PAGER", "cat"),
     ("GIT_PAGER", "cat"),
     ("GIT_EDITOR", ":"),
+    ("GIT_SEQUENCE_EDITOR", ":"),
     ("GH_PAGER", "cat"),
     ("CODEX_CI", "1"),
 ];

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -57,7 +57,7 @@ use codex_tools::ToolName;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_output_truncation::approx_token_count;
 
-const UNIFIED_EXEC_ENV: [(&str, &str); 10] = [
+const UNIFIED_EXEC_ENV: [(&str, &str); 11] = [
     ("NO_COLOR", "1"),
     ("TERM", "dumb"),
     ("LANG", "C.UTF-8"),
@@ -66,6 +66,7 @@ const UNIFIED_EXEC_ENV: [(&str, &str); 10] = [
     ("COLORTERM", ""),
     ("PAGER", "cat"),
     ("GIT_PAGER", "cat"),
+    ("GIT_EDITOR", ":"),
     ("GH_PAGER", "cat"),
     ("CODEX_CI", "1"),
 ];

--- a/codex-rs/core/src/unified_exec/process_manager_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_manager_tests.rs
@@ -16,6 +16,7 @@ fn unified_exec_env_injects_defaults() {
         ("PAGER".to_string(), "cat".to_string()),
         ("GIT_PAGER".to_string(), "cat".to_string()),
         ("GIT_EDITOR".to_string(), ":".to_string()),
+        ("GIT_SEQUENCE_EDITOR".to_string(), ":".to_string()),
         ("GH_PAGER".to_string(), "cat".to_string()),
         ("CODEX_CI".to_string(), "1".to_string()),
     ]);
@@ -28,12 +29,14 @@ fn unified_exec_env_overrides_existing_values() {
     let mut base = HashMap::new();
     base.insert("NO_COLOR".to_string(), "0".to_string());
     base.insert("GIT_EDITOR".to_string(), "nvim".to_string());
+    base.insert("GIT_SEQUENCE_EDITOR".to_string(), "nvim".to_string());
     base.insert("PATH".to_string(), "/usr/bin".to_string());
 
     let env = apply_unified_exec_env(base);
 
     assert_eq!(env.get("NO_COLOR"), Some(&"1".to_string()));
     assert_eq!(env.get("GIT_EDITOR"), Some(&":".to_string()));
+    assert_eq!(env.get("GIT_SEQUENCE_EDITOR"), Some(&":".to_string()));
     assert_eq!(env.get("PATH"), Some(&"/usr/bin".to_string()));
 }
 

--- a/codex-rs/core/src/unified_exec/process_manager_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_manager_tests.rs
@@ -15,6 +15,7 @@ fn unified_exec_env_injects_defaults() {
         ("COLORTERM".to_string(), String::new()),
         ("PAGER".to_string(), "cat".to_string()),
         ("GIT_PAGER".to_string(), "cat".to_string()),
+        ("GIT_EDITOR".to_string(), ":".to_string()),
         ("GH_PAGER".to_string(), "cat".to_string()),
         ("CODEX_CI".to_string(), "1".to_string()),
     ]);
@@ -26,11 +27,13 @@ fn unified_exec_env_injects_defaults() {
 fn unified_exec_env_overrides_existing_values() {
     let mut base = HashMap::new();
     base.insert("NO_COLOR".to_string(), "0".to_string());
+    base.insert("GIT_EDITOR".to_string(), "nvim".to_string());
     base.insert("PATH".to_string(), "/usr/bin".to_string());
 
     let env = apply_unified_exec_env(base);
 
     assert_eq!(env.get("NO_COLOR"), Some(&"1".to_string()));
+    assert_eq!(env.get("GIT_EDITOR"), Some(&":".to_string()));
     assert_eq!(env.get("PATH"), Some(&"/usr/bin".to_string()));
 }
 

--- a/codex-rs/core/tests/suite/shell_snapshot.rs
+++ b/codex-rs/core/tests/suite/shell_snapshot.rs
@@ -516,9 +516,19 @@ async fn linux_unified_exec_snapshot_preserves_shell_environment_policy_set() ->
     )
     .await?;
     let snapshot_path = wait_for_snapshot(&codex_home).await?;
-    fs::write(&snapshot_path, snapshot_override_content_for_policy_test()).await?;
+    fs::write(
+        &snapshot_path,
+        format!(
+            "{}export GIT_EDITOR='nvim'\nexport GIT_SEQUENCE_EDITOR='nvim'\n",
+            snapshot_override_content_for_policy_test()
+        ),
+    )
+    .await?;
 
-    let command = command_asserting_policy_after_snapshot();
+    let command = format!(
+        "{}; printf '|git_editor=%s|git_sequence_editor=%s' \"$GIT_EDITOR\" \"$GIT_SEQUENCE_EDITOR\"",
+        command_asserting_policy_after_snapshot()
+    );
     let end = run_tool_turn_on_harness(
         &harness,
         "verify unified exec policy after snapshot",
@@ -533,7 +543,7 @@ async fn linux_unified_exec_snapshot_preserves_shell_environment_policy_set() ->
 
     assert_eq!(
         normalize_newlines(&end.stdout).trim(),
-        POLICY_SUCCESS_OUTPUT
+        "policy-after-snapshot|git_editor=:|git_sequence_editor=:"
     );
     assert_eq!(end.exit_code, 0);
     assert!(snapshot_path.starts_with(codex_home));


### PR DESCRIPTION
## Why

Unified exec already normalizes shell behavior for unattended commands by disabling pagers and color output, but it still allowed Git to launch configured editors. Commands such as `git rebase --continue` can therefore open an interactive editor and leave an agent-driven shell blocked.

This also needs to hold after shell startup files and shell snapshots are applied: a user profile or restored snapshot can reintroduce `GIT_EDITOR` and `GIT_SEQUENCE_EDITOR` values after the initial process environment is constructed.

https://x.com/aofeisheng/status/2060969491174183296

The report points out that `UNIFIED_EXEC_ENV` already sets non-interactive defaults such as `PAGER=cat`, `GIT_PAGER=cat`, `TERM=dumb`, and `CODEX_CI=1`, but omitted `GIT_EDITOR`. That omission matters because Git may invoke an editor during `git rebase --continue`; in an agent-driven shell, there is no user available to close it.

The repro also exposed two adjacent cases. Interactive rebases use `GIT_SEQUENCE_EDITOR`, and user shell startup files or restored shell snapshots can overwrite the initial process environment. This PR sets both editor variables to the shell-native no-op `:` and reapplies them after shell startup. Using `:` instead of `true` also keeps the guard working when `PATH` is minimal.

## What Changed

- Set `GIT_EDITOR=:` and `GIT_SEQUENCE_EDITOR=:` in the unified exec environment so Git accepts existing commit and sequence-edit content without opening an editor.
- Reassert those values after startup hooks for POSIX shells, Cmd, and PowerShell.
- Preserve PowerShell leading declarations while applying the guard.
- Keep unified exec environment overrides authoritative when shell snapshots are restored.
- Add focused unit and integration coverage for editor guards, snapshot precedence, and shell-specific command rewriting.

## How to Test

1. Create a repository with a rebase conflict and configure an interactive Git editor, for example `GIT_EDITOR=false` or a local editor command.
2. Start Codex with unified exec enabled, resolve the conflict, and allow Codex to run `git rebase --continue`.
3. Confirm that the rebase continues without opening an editor or blocking the shell.
4. As a regression check, export `GIT_EDITOR=nvim` and `GIT_SEQUENCE_EDITOR=nvim` from a shell startup file or shell snapshot and confirm unified exec still runs with both values set to `:`.

Targeted tests:

```shell
CARGO_TARGET_DIR=/private/tmp/codex-fix-unified-exec-git-editor-target just test -p codex-core -E 'test(guard_git_editors_after_shell_startup) | test(unified_exec_env) | test(maybe_wrap_shell_lc_with_snapshot_restores_explicit_override_precedence)'
```

Manual repro checks covered `git rebase --continue`, interactive rebase sequence editing, minimal-`PATH` behavior, and zsh startup-file overrides. Live PowerShell smoke testing was not available locally because `pwsh` is not installed.
