### PR TITLE
Use extension lifecycle for goal resume continuation

### DIFF
--- a/codex-rs/app-server/src/request_processors/thread_goal_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_goal_processor.rs
@@ -74,10 +74,8 @@ impl ThreadGoalRequestProcessor {
         }
         self.emit_thread_goal_snapshot(thread_id).await;
         // App-server owns resume response and snapshot ordering, so wait until
-        // those are sent before letting core start goal continuation.
-        if let Err(err) = thread.continue_active_goal_if_idle().await {
-            tracing::warn!("failed to continue active goal after resume: {err}");
-        }
+        // those are sent before letting extensions schedule idle work.
+        thread.emit_thread_idle_lifecycle_if_idle().await;
     }
 
     pub(crate) async fn pending_resume_goal_state(

--- a/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
+++ b/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
@@ -616,10 +616,8 @@ pub(super) async fn handle_pending_thread_resume_request(
         }
     }
 
-    if pending.emit_thread_goal_update
-        && let Err(err) = conversation.apply_goal_resume_runtime_effects().await
-    {
-        tracing::warn!("failed to apply goal resume runtime effects: {err}");
+    if pending.emit_thread_goal_update {
+        conversation.emit_thread_resume_lifecycle().await;
     }
 
     let ThreadConfigSnapshot {
@@ -691,11 +689,9 @@ pub(super) async fn handle_pending_thread_resume_request(
         .replay_requests_to_connection_for_thread(connection_id, conversation_id)
         .await;
     // App-server owns resume response and snapshot ordering, so wait until
-    // replay completes before letting core start goal continuation.
-    if pending.emit_thread_goal_update
-        && let Err(err) = conversation.continue_active_goal_if_idle().await
-    {
-        tracing::warn!("failed to continue active goal after running-thread resume: {err}");
+    // replay completes before letting extensions schedule idle work.
+    if pending.emit_thread_goal_update {
+        conversation.emit_thread_idle_lifecycle_if_idle().await;
     }
 }
 

--- a/codex-rs/core/src/codex_thread.rs
+++ b/codex-rs/core/src/codex_thread.rs
@@ -148,7 +148,7 @@ impl CodexThread {
         self.codex.session_loop_termination.clone().await;
     }
 
-    pub(crate) async fn emit_thread_resume_lifecycle(&self) {
+    pub async fn emit_thread_resume_lifecycle(&self) {
         for contributor in self
             .codex
             .session
@@ -163,6 +163,13 @@ impl CodexThread {
                 })
                 .await;
         }
+    }
+
+    pub async fn emit_thread_idle_lifecycle_if_idle(&self) {
+        self.codex
+            .session
+            .emit_thread_idle_lifecycle_if_idle()
+            .await;
     }
 
     pub async fn apply_goal_resume_runtime_effects(&self) -> anyhow::Result<()> {

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -1296,9 +1296,6 @@ impl ThreadManagerState {
             .await?;
         if is_resumed_thread {
             new_thread.thread.emit_thread_resume_lifecycle().await;
-            if let Err(err) = new_thread.thread.apply_goal_resume_runtime_effects().await {
-                warn!("failed to apply goal resume runtime effects: {err}");
-            }
         }
         Ok(new_thread)
     }


### PR DESCRIPTION
## Summary
- expose generic thread resume/idle lifecycle methods on `CodexThread`
- route app-server resume goal snapshot continuation through extension idle lifecycle
- stop invoking legacy goal resume runtime effects after extension resume lifecycle

## Testing
- `just fmt`
- `just test -p codex-core` (fails locally: sandbox/tooling environment failures, including missing `test_stdio_server` and `sandbox-exec: sandbox_apply: Operation not permitted`)
- `just test -p codex-app-server` (fails locally: sandbox/process-exec environment failures and timeouts, including `sandbox-exec: sandbox_apply: Operation not permitted`)
