### PR TITLE
[codex] Don't propagate RUST_LOG to subprocesses by default

### DIFF
--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -854,6 +854,7 @@ impl Session {
                 ShellSnapshot::new(
                     config.codex_home.clone(),
                     thread_id,
+                    config.permissions.shell_environment_policy.clone(),
                     session_telemetry.clone(),
                     state_db_ctx.clone(),
                 )

--- a/codex-rs/core/src/shell_snapshot.rs
+++ b/codex-rs/core/src/shell_snapshot.rs
@@ -43,7 +43,8 @@ pub(crate) struct ShellSnapshotFile {
 const SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(10);
 const SNAPSHOT_RETENTION: Duration = Duration::from_secs(60 * 60 * 24 * 3); // 3 days retention.
 const SNAPSHOT_DIR: &str = "shell_snapshots";
-const EXCLUDED_EXPORT_VARS: &[&str] = &["PWD", "OLDPWD", "RUST_LOG"];
+const EXCLUDED_EXPORT_VARS: &[&str] = &["PWD", "OLDPWD"];
+const EXCLUDED_INHERITED_VARS: &[&str] = &["RUST_LOG"];
 
 impl ShellSnapshot {
     pub(crate) fn new(
@@ -287,6 +288,7 @@ async fn run_script_with_timeout(
     // returns a ref of handler.
     let mut handler = Command::new(&args[0]);
     handler.args(&args[1..]);
+    remove_inherited_snapshot_vars(&mut handler);
     handler.stdin(Stdio::null());
     handler.current_dir(cwd);
     #[cfg(unix)]
@@ -309,6 +311,12 @@ async fn run_script_with_timeout(
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+fn remove_inherited_snapshot_vars(handler: &mut Command) {
+    for name in EXCLUDED_INHERITED_VARS {
+        handler.env_remove(name);
+    }
 }
 
 fn excluded_exports_regex() -> String {

--- a/codex-rs/core/src/shell_snapshot.rs
+++ b/codex-rs/core/src/shell_snapshot.rs
@@ -17,6 +17,8 @@ use anyhow::anyhow;
 use anyhow::bail;
 use codex_otel::SessionTelemetry;
 use codex_protocol::ThreadId;
+use codex_protocol::config_types::ShellEnvironmentPolicy;
+use codex_protocol::shell_environment::policy_explicitly_includes_inherited_rust_log;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use tokio::fs;
 use tokio::process::Command;
@@ -32,6 +34,7 @@ pub(crate) struct ShellSnapshot {
 struct ShellSnapshotConfig {
     codex_home: AbsolutePathBuf,
     session_id: ThreadId,
+    shell_environment_policy: ShellEnvironmentPolicy,
     session_telemetry: SessionTelemetry,
     state_db: Option<StateDbHandle>,
 }
@@ -44,12 +47,12 @@ const SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(10);
 const SNAPSHOT_RETENTION: Duration = Duration::from_secs(60 * 60 * 24 * 3); // 3 days retention.
 const SNAPSHOT_DIR: &str = "shell_snapshots";
 const EXCLUDED_EXPORT_VARS: &[&str] = &["PWD", "OLDPWD"];
-const EXCLUDED_INHERITED_VARS: &[&str] = &["RUST_LOG"];
 
 impl ShellSnapshot {
     pub(crate) fn new(
         codex_home: AbsolutePathBuf,
         session_id: ThreadId,
+        shell_environment_policy: ShellEnvironmentPolicy,
         session_telemetry: SessionTelemetry,
         state_db: Option<StateDbHandle>,
     ) -> Self {
@@ -57,6 +60,7 @@ impl ShellSnapshot {
             config: Some(Arc::new(ShellSnapshotConfig {
                 codex_home,
                 session_id,
+                shell_environment_policy,
                 session_telemetry,
                 state_db,
             })),
@@ -98,6 +102,7 @@ impl ShellSnapshot {
                 config.session_id,
                 &cwd,
                 &shell,
+                &config.shell_environment_policy,
                 config.state_db.clone(),
             )
             .await;
@@ -121,6 +126,7 @@ impl ShellSnapshot {
         session_id: ThreadId,
         session_cwd: &AbsolutePathBuf,
         shell: &Shell,
+        shell_environment_policy: &ShellEnvironmentPolicy,
         state_db: Option<StateDbHandle>,
     ) -> std::result::Result<ShellSnapshotFile, &'static str> {
         // File to store the snapshot
@@ -151,7 +157,14 @@ impl ShellSnapshot {
         });
 
         // Make the new snapshot.
-        if let Err(err) = write_shell_snapshot(shell.shell_type, &temp_path, session_cwd).await {
+        if let Err(err) = write_shell_snapshot(
+            shell.shell_type,
+            &temp_path,
+            session_cwd,
+            shell_environment_policy,
+        )
+        .await
+        {
             tracing::warn!(
                 "Failed to create shell snapshot for {}: {err:?}",
                 shell.name()
@@ -163,7 +176,9 @@ impl ShellSnapshot {
             temp_path.display()
         );
 
-        if let Err(err) = validate_snapshot(shell, &temp_path, session_cwd).await {
+        if let Err(err) =
+            validate_snapshot(shell, &temp_path, session_cwd, shell_environment_policy).await
+        {
             tracing::error!("Shell snapshot validation failed: {err:?}");
             remove_snapshot_file(&temp_path).await;
             return Err("validation_failed");
@@ -200,6 +215,7 @@ async fn write_shell_snapshot(
     shell_type: ShellType,
     output_path: &AbsolutePathBuf,
     cwd: &AbsolutePathBuf,
+    shell_environment_policy: &ShellEnvironmentPolicy,
 ) -> Result<()> {
     if shell_type == ShellType::PowerShell || shell_type == ShellType::Cmd {
         bail!("Shell snapshot not supported yet for {shell_type:?}");
@@ -207,7 +223,7 @@ async fn write_shell_snapshot(
     let shell = get_shell(shell_type, /*path*/ None)
         .with_context(|| format!("No available shell for {shell_type:?}"))?;
 
-    let raw_snapshot = capture_snapshot(&shell, cwd).await?;
+    let raw_snapshot = capture_snapshot(&shell, cwd, shell_environment_policy).await?;
     let snapshot = strip_snapshot_preamble(&raw_snapshot)?;
 
     if let Some(parent) = output_path.parent() {
@@ -225,13 +241,37 @@ async fn write_shell_snapshot(
     Ok(())
 }
 
-async fn capture_snapshot(shell: &Shell, cwd: &AbsolutePathBuf) -> Result<String> {
+async fn capture_snapshot(
+    shell: &Shell,
+    cwd: &AbsolutePathBuf,
+    shell_environment_policy: &ShellEnvironmentPolicy,
+) -> Result<String> {
     let shell_type = shell.shell_type;
     match shell_type {
-        ShellType::Zsh => run_shell_script(shell, &zsh_snapshot_script(), cwd).await,
-        ShellType::Bash => run_shell_script(shell, &bash_snapshot_script(), cwd).await,
-        ShellType::Sh => run_shell_script(shell, &sh_snapshot_script(), cwd).await,
-        ShellType::PowerShell => run_shell_script(shell, powershell_snapshot_script(), cwd).await,
+        ShellType::Zsh => {
+            run_shell_script(shell, &zsh_snapshot_script(), cwd, shell_environment_policy).await
+        }
+        ShellType::Bash => {
+            run_shell_script(
+                shell,
+                &bash_snapshot_script(),
+                cwd,
+                shell_environment_policy,
+            )
+            .await
+        }
+        ShellType::Sh => {
+            run_shell_script(shell, &sh_snapshot_script(), cwd, shell_environment_policy).await
+        }
+        ShellType::PowerShell => {
+            run_shell_script(
+                shell,
+                powershell_snapshot_script(),
+                cwd,
+                shell_environment_policy,
+            )
+            .await
+        }
         ShellType::Cmd => bail!("Shell snapshotting is not yet supported for {shell_type:?}"),
     }
 }
@@ -249,12 +289,14 @@ async fn validate_snapshot(
     shell: &Shell,
     snapshot_path: &AbsolutePathBuf,
     cwd: &AbsolutePathBuf,
+    shell_environment_policy: &ShellEnvironmentPolicy,
 ) -> Result<()> {
     let snapshot_path_display = snapshot_path.display();
     let script = format!("set -e; . \"{snapshot_path_display}\"");
     run_script_with_timeout(
         shell,
         &script,
+        shell_environment_policy,
         SNAPSHOT_TIMEOUT,
         /*use_login_shell*/ false,
         cwd,
@@ -263,10 +305,16 @@ async fn validate_snapshot(
     .map(|_| ())
 }
 
-async fn run_shell_script(shell: &Shell, script: &str, cwd: &AbsolutePathBuf) -> Result<String> {
+async fn run_shell_script(
+    shell: &Shell,
+    script: &str,
+    cwd: &AbsolutePathBuf,
+    shell_environment_policy: &ShellEnvironmentPolicy,
+) -> Result<String> {
     run_script_with_timeout(
         shell,
         script,
+        shell_environment_policy,
         SNAPSHOT_TIMEOUT,
         /*use_login_shell*/ true,
         cwd,
@@ -277,6 +325,7 @@ async fn run_shell_script(shell: &Shell, script: &str, cwd: &AbsolutePathBuf) ->
 async fn run_script_with_timeout(
     shell: &Shell,
     script: &str,
+    shell_environment_policy: &ShellEnvironmentPolicy,
     snapshot_timeout: Duration,
     use_login_shell: bool,
     cwd: &AbsolutePathBuf,
@@ -288,7 +337,7 @@ async fn run_script_with_timeout(
     // returns a ref of handler.
     let mut handler = Command::new(&args[0]);
     handler.args(&args[1..]);
-    remove_inherited_snapshot_vars(&mut handler);
+    apply_inherited_rust_log_policy(&mut handler, shell_environment_policy);
     handler.stdin(Stdio::null());
     handler.current_dir(cwd);
     #[cfg(unix)]
@@ -313,9 +362,12 @@ async fn run_script_with_timeout(
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
-fn remove_inherited_snapshot_vars(handler: &mut Command) {
-    for name in EXCLUDED_INHERITED_VARS {
-        handler.env_remove(name);
+fn apply_inherited_rust_log_policy(
+    handler: &mut Command,
+    shell_environment_policy: &ShellEnvironmentPolicy,
+) {
+    if !policy_explicitly_includes_inherited_rust_log(shell_environment_policy) {
+        handler.env_remove("RUST_LOG");
     }
 }
 

--- a/codex-rs/core/src/shell_snapshot.rs
+++ b/codex-rs/core/src/shell_snapshot.rs
@@ -43,7 +43,7 @@ pub(crate) struct ShellSnapshotFile {
 const SNAPSHOT_TIMEOUT: Duration = Duration::from_secs(10);
 const SNAPSHOT_RETENTION: Duration = Duration::from_secs(60 * 60 * 24 * 3); // 3 days retention.
 const SNAPSHOT_DIR: &str = "shell_snapshots";
-const EXCLUDED_EXPORT_VARS: &[&str] = &["PWD", "OLDPWD"];
+const EXCLUDED_EXPORT_VARS: &[&str] = &["PWD", "OLDPWD", "RUST_LOG"];
 
 impl ShellSnapshot {
     pub(crate) fn new(

--- a/codex-rs/core/src/shell_snapshot_tests.rs
+++ b/codex-rs/core/src/shell_snapshot_tests.rs
@@ -148,44 +148,85 @@ fn bash_snapshot_filters_invalid_exports() -> Result<()> {
 }
 
 #[cfg(unix)]
-fn assert_snapshot_filters_rust_log(shell: &str, snapshot_script: String) -> Result<()> {
+fn assert_snapshot_preserves_profile_rust_log(
+    shell: &str,
+    snapshot_script: String,
+    profile_name: &str,
+) -> Result<()> {
     let home = tempdir()?;
-    let output = Command::new(shell)
+    let profile_path = home.path().join(profile_name);
+    std::fs::write(&profile_path, "export RUST_LOG=profile\n")?;
+
+    let mut snapshot = Command::new(shell);
+    snapshot
         .arg("-c")
         .arg(snapshot_script)
         .env("HOME", home.path())
-        .env("BASH_ENV", "/dev/null")
+        .env_remove("BASH_ENV")
         .env_remove("ENV")
         .env("RUST_LOG", "warn")
-        .output()?;
+        .env("RUST_LOG_STYLE", "always");
+    if shell == "/bin/sh" {
+        snapshot.env("ENV", &profile_path);
+    }
+    for name in EXCLUDED_INHERITED_VARS {
+        snapshot.env_remove(name);
+    }
+    let output = snapshot.output()?;
 
     assert!(output.status.success());
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        !stdout.contains("RUST_LOG"),
-        "snapshot should not capture app-server logging configuration"
-    );
+    let snapshot_path = home.path().join("snapshot.sh");
+    std::fs::write(&snapshot_path, &output.stdout)?;
+    let validate = Command::new(shell)
+        .arg("-c")
+        .arg(". \"$1\"; printf '%s' \"$RUST_LOG\"")
+        .arg(shell)
+        .arg(&snapshot_path)
+        .env("HOME", home.path())
+        .env("BASH_ENV", "/dev/null")
+        .env_remove("ENV")
+        .env_remove("RUST_LOG")
+        .output()?;
 
+    assert!(validate.status.success());
+    assert_eq!(String::from_utf8_lossy(&validate.stdout), "profile");
     Ok(())
 }
 
 #[cfg(unix)]
 #[test]
-fn bash_snapshot_filters_rust_log() -> Result<()> {
-    assert_snapshot_filters_rust_log("/bin/bash", bash_snapshot_script())
+fn bash_snapshot_preserves_profile_rust_log() -> Result<()> {
+    assert_snapshot_preserves_profile_rust_log("/bin/bash", bash_snapshot_script(), ".bashrc")
 }
 
 #[cfg(unix)]
 #[test]
-fn sh_snapshot_filters_rust_log() -> Result<()> {
-    assert_snapshot_filters_rust_log("/bin/sh", sh_snapshot_script())
+fn sh_snapshot_preserves_profile_rust_log() -> Result<()> {
+    assert_snapshot_preserves_profile_rust_log("/bin/sh", sh_snapshot_script(), ".profile")
 }
 
 #[cfg(target_os = "macos")]
 #[test]
-fn zsh_snapshot_filters_rust_log() -> Result<()> {
-    assert_snapshot_filters_rust_log("/bin/zsh", zsh_snapshot_script())
+fn zsh_snapshot_preserves_profile_rust_log() -> Result<()> {
+    assert_snapshot_preserves_profile_rust_log("/bin/zsh", zsh_snapshot_script(), ".zshrc")
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn snapshot_shell_does_not_inherit_rust_log() -> Result<()> {
+    let mut command = tokio::process::Command::new("/bin/sh");
+    command
+        .arg("-c")
+        .arg("printf '%s' \"${RUST_LOG-unset}\"")
+        .env("RUST_LOG", "warn");
+    remove_inherited_snapshot_vars(&mut command);
+
+    let output = command.output().await?;
+
+    assert!(output.status.success());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "unset");
+    Ok(())
 }
 
 #[cfg(unix)]

--- a/codex-rs/core/src/shell_snapshot_tests.rs
+++ b/codex-rs/core/src/shell_snapshot_tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+#[cfg(unix)]
+use codex_protocol::config_types::EnvironmentVariablePattern;
 use core_test_support::PathBufExt;
 use core_test_support::PathExt;
 use pretty_assertions::assert_eq;
@@ -83,7 +85,14 @@ fn assert_posix_snapshot_sections(snapshot: &str) {
 async fn get_snapshot(shell_type: ShellType) -> Result<String> {
     let dir = tempdir()?;
     let path = dir.path().join("snapshot.sh");
-    write_shell_snapshot(shell_type, &path.abs(), &dir.path().abs()).await?;
+    let shell_environment_policy = ShellEnvironmentPolicy::default();
+    write_shell_snapshot(
+        shell_type,
+        &path.abs(),
+        &dir.path().abs(),
+        &shell_environment_policy,
+    )
+    .await?;
     let content = fs::read_to_string(&path).await?;
     Ok(content)
 }
@@ -169,9 +178,7 @@ fn assert_snapshot_preserves_profile_rust_log(
     if shell == "/bin/sh" {
         snapshot.env("ENV", &profile_path);
     }
-    for name in EXCLUDED_INHERITED_VARS {
-        snapshot.env_remove(name);
-    }
+    snapshot.env_remove("RUST_LOG");
     let output = snapshot.output()?;
 
     assert!(output.status.success());
@@ -220,12 +227,56 @@ async fn snapshot_shell_does_not_inherit_rust_log() -> Result<()> {
         .arg("-c")
         .arg("printf '%s' \"${RUST_LOG-unset}\"")
         .env("RUST_LOG", "warn");
-    remove_inherited_snapshot_vars(&mut command);
+    apply_inherited_rust_log_policy(&mut command, &ShellEnvironmentPolicy::default());
 
     let output = command.output().await?;
 
     assert!(output.status.success());
     assert_eq!(String::from_utf8_lossy(&output.stdout), "unset");
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn explicitly_included_rust_log_is_visible_to_snapshot_profile() -> Result<()> {
+    let home = tempdir()?;
+    let profile_path = home.path().join(".bashrc");
+    std::fs::write(
+        &profile_path,
+        "if [ \"${RUST_LOG-}\" = warn ]; then export PROFILE_SAW_RUST_LOG=yes; fi\n",
+    )?;
+    let shell_environment_policy = ShellEnvironmentPolicy {
+        include_only: vec![EnvironmentVariablePattern::new_case_insensitive("RUST_LOG")],
+        ..Default::default()
+    };
+
+    let mut snapshot = tokio::process::Command::new("/bin/bash");
+    snapshot
+        .arg("-c")
+        .arg(bash_snapshot_script())
+        .env("HOME", home.path())
+        .env_remove("BASH_ENV")
+        .env("RUST_LOG", "warn");
+    apply_inherited_rust_log_policy(&mut snapshot, &shell_environment_policy);
+    let output = snapshot.output().await?;
+
+    assert!(output.status.success());
+
+    let snapshot_path = home.path().join("snapshot.sh");
+    std::fs::write(&snapshot_path, &output.stdout)?;
+    let validate = tokio::process::Command::new("/bin/bash")
+        .arg("-c")
+        .arg(". \"$1\"; printf '%s' \"${PROFILE_SAW_RUST_LOG-unset}\"")
+        .arg("bash")
+        .arg(&snapshot_path)
+        .env("HOME", home.path())
+        .env("BASH_ENV", "/dev/null")
+        .env_remove("RUST_LOG")
+        .output()
+        .await?;
+
+    assert!(validate.status.success());
+    assert_eq!(String::from_utf8_lossy(&validate.stdout), "yes");
     Ok(())
 }
 
@@ -277,12 +328,14 @@ async fn try_create_creates_and_deletes_snapshot_file() -> Result<()> {
         shell_type: ShellType::Bash,
         shell_path: PathBuf::from("/bin/bash"),
     };
+    let shell_environment_policy = ShellEnvironmentPolicy::default();
 
     let snapshot = ShellSnapshot::try_create(
         &dir.path().abs(),
         ThreadId::new(),
         &dir.path().abs(),
         &shell,
+        &shell_environment_policy,
         /*state_db*/ None,
     )
     .await
@@ -306,12 +359,14 @@ async fn try_create_uses_distinct_generation_paths() -> Result<()> {
         shell_type: ShellType::Bash,
         shell_path: PathBuf::from("/bin/bash"),
     };
+    let shell_environment_policy = ShellEnvironmentPolicy::default();
 
     let initial_snapshot = ShellSnapshot::try_create(
         &dir.path().abs(),
         session_id,
         &dir.path().abs(),
         &shell,
+        &shell_environment_policy,
         /*state_db*/ None,
     )
     .await
@@ -321,6 +376,7 @@ async fn try_create_uses_distinct_generation_paths() -> Result<()> {
         session_id,
         &dir.path().abs(),
         &shell,
+        &shell_environment_policy,
         /*state_db*/ None,
     )
     .await
@@ -367,9 +423,11 @@ async fn snapshot_shell_does_not_inherit_stdin() -> Result<()> {
         "HOME=\"{home_display}\"; export HOME; {}",
         bash_snapshot_script()
     );
+    let shell_environment_policy = ShellEnvironmentPolicy::default();
     let output = run_script_with_timeout(
         &shell,
         &script,
+        &shell_environment_policy,
         Duration::from_secs(2),
         /*use_login_shell*/ true,
         &home,
@@ -409,10 +467,12 @@ async fn timed_out_snapshot_shell_is_terminated() -> Result<()> {
         shell_type: ShellType::Sh,
         shell_path: PathBuf::from("/bin/sh"),
     };
+    let shell_environment_policy = ShellEnvironmentPolicy::default();
 
     let err = run_script_with_timeout(
         &shell,
         &script,
+        &shell_environment_policy,
         Duration::from_secs(1),
         /*use_login_shell*/ true,
         &dir.path().abs(),

--- a/codex-rs/core/src/shell_snapshot_tests.rs
+++ b/codex-rs/core/src/shell_snapshot_tests.rs
@@ -148,6 +148,47 @@ fn bash_snapshot_filters_invalid_exports() -> Result<()> {
 }
 
 #[cfg(unix)]
+fn assert_snapshot_filters_rust_log(shell: &str, snapshot_script: String) -> Result<()> {
+    let home = tempdir()?;
+    let output = Command::new(shell)
+        .arg("-c")
+        .arg(snapshot_script)
+        .env("HOME", home.path())
+        .env("BASH_ENV", "/dev/null")
+        .env_remove("ENV")
+        .env("RUST_LOG", "warn")
+        .output()?;
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("RUST_LOG"),
+        "snapshot should not capture app-server logging configuration"
+    );
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn bash_snapshot_filters_rust_log() -> Result<()> {
+    assert_snapshot_filters_rust_log("/bin/bash", bash_snapshot_script())
+}
+
+#[cfg(unix)]
+#[test]
+fn sh_snapshot_filters_rust_log() -> Result<()> {
+    assert_snapshot_filters_rust_log("/bin/sh", sh_snapshot_script())
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn zsh_snapshot_filters_rust_log() -> Result<()> {
+    assert_snapshot_filters_rust_log("/bin/zsh", zsh_snapshot_script())
+}
+
+#[cfg(unix)]
 #[test]
 fn bash_snapshot_preserves_multiline_exports() -> Result<()> {
     let multiline_cert = "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----";

--- a/codex-rs/protocol/src/config_types.rs
+++ b/codex-rs/protocol/src/config_types.rs
@@ -203,11 +203,12 @@ pub type EnvironmentVariablePattern = WildMatchPattern<'*', '?'>;
 
 /// Deriving the `env` based on this policy works as follows:
 /// 1. Create an initial map based on the `inherit` policy.
-/// 2. If `ignore_default_excludes` is false, filter the map using the default
+/// 2. Remove inherited `RUST_LOG` unless `include_only` explicitly retains it.
+/// 3. If `ignore_default_excludes` is false, filter the map using the default
 ///    exclude pattern(s), which are: `"*KEY*"`, `"*SECRET*"`, and `"*TOKEN*"`.
-/// 3. If `exclude` is not empty, filter the map using the provided patterns.
-/// 4. Insert any entries from `r#set` into the map.
-/// 5. If non-empty, filter the map using the `include_only` patterns.
+/// 4. If `exclude` is not empty, filter the map using the provided patterns.
+/// 5. Insert any entries from `r#set` into the map.
+/// 6. If non-empty, filter the map using the `include_only` patterns.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ShellEnvironmentPolicy {
     /// Starting point when building the environment.

--- a/codex-rs/protocol/src/shell_environment.rs
+++ b/codex-rs/protocol/src/shell_environment.rs
@@ -43,6 +43,15 @@ where
     env_map
 }
 
+/// Returns whether the policy explicitly opts into inheriting `RUST_LOG`.
+pub fn policy_explicitly_includes_inherited_rust_log(policy: &ShellEnvironmentPolicy) -> bool {
+    !policy.include_only.is_empty()
+        && policy
+            .include_only
+            .iter()
+            .any(|pattern| pattern.matches("RUST_LOG"))
+}
+
 pub fn populate_env<I>(
     vars: I,
     policy: &ShellEnvironmentPolicy,
@@ -79,9 +88,7 @@ where
     // Step 2 - Harnesses like Codex Desktop and the VS Code extension spawn the
     // app-server with `RUST_LOG=warn` by default. Do not pass that inherited
     // value to subprocesses unless the user explicitly includes it.
-    let include_inherited_rust_log =
-        !policy.include_only.is_empty() && matches_any("RUST_LOG", &policy.include_only);
-    if !include_inherited_rust_log {
+    if !policy_explicitly_includes_inherited_rust_log(policy) {
         env_map.retain(|key, _| !is_rust_log(key));
     }
 

--- a/codex-rs/protocol/src/shell_environment.rs
+++ b/codex-rs/protocol/src/shell_environment.rs
@@ -72,6 +72,13 @@ where
         }
     };
 
+    // Remove RUST_LOG if present.
+    // Harnesses like Codex Desktop and the VS Code extension will
+    // spawn the app-server with `RUST_LOG=warn` by default, which can then cause
+    // unexpected behavior in subprocesses. Users can still explicitly include
+    // it via overrides.
+    env_map.remove("RUST_LOG");
+
     let matches_any = |name: &str, patterns: &[EnvironmentVariablePattern]| -> bool {
         patterns.iter().any(|pattern| pattern.matches(name))
     };
@@ -82,12 +89,6 @@ where
             EnvironmentVariablePattern::new_case_insensitive("*KEY*"),
             EnvironmentVariablePattern::new_case_insensitive("*SECRET*"),
             EnvironmentVariablePattern::new_case_insensitive("*TOKEN*"),
-            // Harnesses like Codex Desktop and the VS Code extension
-            // will spawn the app-server with `RUST_LOG=warn` by default,
-            // which can then cause unexpected behavior in subprocesses.
-            // This removes it by default; users can still explicitly
-            // include it via overrides.
-            EnvironmentVariablePattern::new("RUST_LOG"),
         ];
         env_map.retain(|k, _| !matches_any(k, &default_excludes));
     }

--- a/codex-rs/protocol/src/shell_environment.rs
+++ b/codex-rs/protocol/src/shell_environment.rs
@@ -72,18 +72,20 @@ where
         }
     };
 
-    // Remove RUST_LOG if present.
-    // Harnesses like Codex Desktop and the VS Code extension will
-    // spawn the app-server with `RUST_LOG=warn` by default, which can then cause
-    // unexpected behavior in subprocesses. Users can still explicitly include
-    // it via overrides.
-    env_map.retain(|key, _| !key.eq_ignore_ascii_case("RUST_LOG"));
-
     let matches_any = |name: &str, patterns: &[EnvironmentVariablePattern]| -> bool {
         patterns.iter().any(|pattern| pattern.matches(name))
     };
 
-    // Step 2 - Apply the default exclude if not disabled.
+    // Step 2 - Harnesses like Codex Desktop and the VS Code extension spawn the
+    // app-server with `RUST_LOG=warn` by default. Do not pass that inherited
+    // value to subprocesses unless the user explicitly includes it.
+    let include_inherited_rust_log =
+        !policy.include_only.is_empty() && matches_any("RUST_LOG", &policy.include_only);
+    if !include_inherited_rust_log {
+        env_map.retain(|key, _| !is_rust_log(key));
+    }
+
+    // Step 3 - Apply the default exclude if not disabled.
     if !policy.ignore_default_excludes {
         let default_excludes = vec![
             EnvironmentVariablePattern::new_case_insensitive("*KEY*"),
@@ -93,27 +95,35 @@ where
         env_map.retain(|k, _| !matches_any(k, &default_excludes));
     }
 
-    // Step 3 - Apply custom excludes.
+    // Step 4 - Apply custom excludes.
     if !policy.exclude.is_empty() {
         env_map.retain(|k, _| !matches_any(k, &policy.exclude));
     }
 
-    // Step 4 - Apply user-provided overrides.
+    // Step 5 - Apply user-provided overrides.
     for (key, val) in &policy.r#set {
         env_map.insert(key.clone(), val.clone());
     }
 
-    // Step 5 - If include_only is non-empty, keep only the matching vars.
+    // Step 6 - If include_only is non-empty, keep only the matching vars.
     if !policy.include_only.is_empty() {
         env_map.retain(|k, _| matches_any(k, &policy.include_only));
     }
 
-    // Step 6 - Populate the thread ID environment variable when provided.
+    // Step 7 - Populate the thread ID environment variable when provided.
     if let Some(thread_id) = thread_id {
         env_map.insert(CODEX_THREAD_ID_ENV_VAR.to_string(), thread_id.to_string());
     }
 
     env_map
+}
+
+fn is_rust_log(name: &str) -> bool {
+    if cfg!(target_os = "windows") {
+        name.eq_ignore_ascii_case("RUST_LOG")
+    } else {
+        name == "RUST_LOG"
+    }
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -163,7 +173,7 @@ mod tests {
     fn inherited_rust_log_is_removed() {
         let vars = vec![
             ("PATH".to_string(), "/usr/bin".to_string()),
-            ("rust_log".to_string(), "warn".to_string()),
+            ("RUST_LOG".to_string(), "warn".to_string()),
         ];
 
         let result = populate_env(
@@ -176,6 +186,19 @@ mod tests {
             result,
             HashMap::from([("PATH".to_string(), "/usr/bin".to_string())])
         );
+    }
+
+    #[test]
+    fn explicitly_included_rust_log_is_preserved() {
+        let vars = vec![("RUST_LOG".to_string(), "codex_core=trace".to_string())];
+        let policy = ShellEnvironmentPolicy {
+            include_only: vec![EnvironmentVariablePattern::new_case_insensitive("RUST_LOG")],
+            ..Default::default()
+        };
+
+        let result = populate_env(vars.clone(), &policy, /*thread_id*/ None);
+
+        assert_eq!(result, vars.into_iter().collect());
     }
 
     #[test]
@@ -293,5 +316,18 @@ mod non_windows_tests {
         ]);
 
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn similarly_named_unix_env_vars_are_preserved() {
+        let vars = make_vars(&[("rust_log", "warn"), ("Rust_Log", "debug")]);
+
+        let result = populate_env(
+            vars.clone(),
+            &ShellEnvironmentPolicy::default(),
+            /*thread_id*/ None,
+        );
+
+        assert_eq!(result, vars.into_iter().collect());
     }
 }

--- a/codex-rs/protocol/src/shell_environment.rs
+++ b/codex-rs/protocol/src/shell_environment.rs
@@ -82,6 +82,12 @@ where
             EnvironmentVariablePattern::new_case_insensitive("*KEY*"),
             EnvironmentVariablePattern::new_case_insensitive("*SECRET*"),
             EnvironmentVariablePattern::new_case_insensitive("*TOKEN*"),
+            // Harnesses like Codex Desktop and the VS Code extension
+            // will spawn the app-server with `RUST_LOG=warn` by default,
+            // which can then cause unexpected behavior in subprocesses.
+            // This removes it by default; users can still explicitly
+            // include it via overrides.
+            EnvironmentVariablePattern::new("RUST_LOG"),
         ];
         env_map.retain(|k, _| !matches_any(k, &default_excludes));
     }

--- a/codex-rs/protocol/src/shell_environment.rs
+++ b/codex-rs/protocol/src/shell_environment.rs
@@ -77,7 +77,7 @@ where
     // spawn the app-server with `RUST_LOG=warn` by default, which can then cause
     // unexpected behavior in subprocesses. Users can still explicitly include
     // it via overrides.
-    env_map.remove("RUST_LOG");
+    env_map.retain(|key, _| !key.eq_ignore_ascii_case("RUST_LOG"));
 
     let matches_any = |name: &str, patterns: &[EnvironmentVariablePattern]| -> bool {
         patterns.iter().any(|pattern| pattern.matches(name))
@@ -154,6 +154,46 @@ pub const WINDOWS_CORE_ENV_VARS: &[&str] = &[
     "POWERSHELL",
     "PWSH",
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inherited_rust_log_is_removed() {
+        let vars = vec![
+            ("PATH".to_string(), "/usr/bin".to_string()),
+            ("rust_log".to_string(), "warn".to_string()),
+        ];
+
+        let result = populate_env(
+            vars,
+            &ShellEnvironmentPolicy::default(),
+            /*thread_id*/ None,
+        );
+
+        assert_eq!(
+            result,
+            HashMap::from([("PATH".to_string(), "/usr/bin".to_string())])
+        );
+    }
+
+    #[test]
+    fn explicit_rust_log_override_is_preserved() {
+        let vars = vec![("RUST_LOG".to_string(), "warn".to_string())];
+        let policy = ShellEnvironmentPolicy {
+            r#set: HashMap::from([("RUST_LOG".to_string(), "codex_core=trace".to_string())]),
+            ..Default::default()
+        };
+
+        let result = populate_env(vars, &policy, /*thread_id*/ None);
+
+        assert_eq!(
+            result,
+            HashMap::from([("RUST_LOG".to_string(), "codex_core=trace".to_string())])
+        );
+    }
+}
 
 #[cfg(all(test, target_os = "windows"))]
 mod windows_tests {


### PR DESCRIPTION
I noticed this as a downstream effect of how the appserver gets spawned in Codex Desktop, etc. In general this doesn't cause problems, but it _can_ result in unexpected test/snapshot skew e.g. when an agent runs `cargo test`.

Note: I'm only medium-confidence on this being the "right" way to do things. I think another option would be for Codex to not use `RUST_LOG` at all, but instead a custom variable (like `CODEX_LOG`?) that wouldn't directly affect subprocesses that are spawned with the default environment inheritance policy.

~~Edit: there's already a `CODEX_LOG` but I haven't fully traced it yet.~~ Never mind, test only.