### PR TITLE
[codex] Use git CLI for release Cargo fetches

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -149,6 +149,11 @@ jobs:
       # 2026-03-04: temporarily change releases to use thin LTO because
       # Ubuntu ARM is timing out at 60 minutes.
       CARGO_PROFILE_RELEASE_LTO: ${{ contains(github.ref_name, '-alpha') && 'thin' || 'thin' }}
+      # Use the git CLI instead of Cargo's libgit2 path for git dependencies.
+      # macOS release runners have intermittently failed to fetch nested
+      # submodules through SecureTransport/libgit2, especially libwebrtc's
+      # libyuv submodule from chromium.googlesource.com.
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
       SIGN_MACOS: ${{ github.event_name != 'workflow_dispatch' }}
 
     strategy:


### PR DESCRIPTION
## Summary
- Configure the rust-release build job with `CARGO_NET_GIT_FETCH_WITH_CLI=true`
- Document the macOS SecureTransport/libgit2 failure mode that hit the `libwebrtc`/`libyuv` git submodule fetch

## Root cause
The release run at https://github.com/openai/codex/actions/runs/26717498860/job/78745156683 repeatedly failed before compilation because Cargo's libgit2 fetch path could not clone the nested `yuv-sys/libyuv` submodule from `chromium.googlesource.com`, ending with `SecureTransport error: connection closed via error`.

## Validation
- `git diff --check`

This is a workflow-only change, so I did not run Rust package tests.