### PR TITLE
[codex] document out-of-line test module convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,19 @@ See `codex-rs/tui/styles.md`.
 
 ## Tests
 
+### Test module organization
+
+- When adding a new test module, define its contents in a separate sibling file rather than inline in the implementation file.
+- Use an explicit `#[path = "..._tests.rs"]` attribute so the test filename is descriptive and easy to locate:
+
+  ```rust
+  #[cfg(test)]
+  #[path = "parser_tests.rs"]
+  mod tests;
+  ```
+
+- This applies only when introducing a new test module. Do not move or rewrite existing inline `#[cfg(test)] mod tests { ... }` modules solely to follow this convention.
+
 ### Snapshot tests
 
 This repo uses snapshot tests (via `insta`), especially in `codex-rs/tui`, to validate rendered output.


### PR DESCRIPTION
## Why

New unit test modules should follow one consistent layout so implementation files stay focused and test suites remain easy to locate, without creating cleanup churn in existing inline test modules.

## What changed

- Added `AGENTS.md` guidance requiring new test modules to use separate sibling `*_tests.rs` files with an explicit `#[path = "..._tests.rs"]` attribute.
- Clarified that existing inline `#[cfg(test)] mod tests { ... }` modules should not be moved solely to follow the new convention.

## Validation

- Ran `git diff --check`.