### PR TITLE
[codex] Add comprehensive root formatting check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,13 +81,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.11.3"
-      - name: Prepare Ruff environments
-        run: |
-          uv sync --frozen --project sdk/python --extra dev --no-install-package openai-codex-cli-bin
-          uv sync --frozen --project scripts
       - name: Check formatting (run `just fmt` to fix)
-        env:
-          UV_NO_SYNC: "1"
         run: just fmt-check
 
       - name: Prettier (run `pnpm run format:fix` to fix)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,13 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.11.3"
+      - name: Prepare Ruff environments
+        run: |
+          uv sync --frozen --project sdk/python --extra dev --no-install-package openai-codex-cli-bin
+          uv sync --frozen --project scripts
       - name: Check formatting (run `just fmt` to fix)
+        env:
+          UV_NO_SYNC: "1"
         run: just fmt-check
 
       - name: Prettier (run `pnpm run format:fix` to fix)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,6 @@ jobs:
         with:
           version: "0.11.3"
       - name: Check formatting (run `just fmt` to fix)
-        env:
-          # The SDK runtime publishes musllinux wheels for Linux.
-          CODEX_SDK_PYTHON_PLATFORM: --python-platform x86_64-unknown-linux-musl
         run: just fmt-check
 
       - name: Prettier (run `pnpm run format:fix` to fix)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
         with:
           version: "0.11.3"
       - name: Check formatting (run `just fmt` to fix)
+        env:
+          # The SDK runtime publishes musllinux wheels for Linux.
+          CODEX_SDK_PYTHON_PLATFORM: --python-platform x86_64-unknown-linux-musl
         run: just fmt-check
 
       - name: Prettier (run `pnpm run format:fix` to fix)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
 
       - uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
         with:
-          tool: just
+          tool: just@1.51.0
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,8 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.11.3"
-      - name: Ruff format Python scripts (run `just fmt` to fix)
-        run: just fmt-scripts-check
+      - name: Check formatting (run `just fmt` to fix)
+        run: just fmt-check
 
       - name: Prettier (run `pnpm run format:fix` to fix)
         run: pnpm run format

--- a/justfile
+++ b/justfile
@@ -6,6 +6,8 @@ set windows-shell := ["python", "-c", 'import os, runpy; runpy.run_path(os.envir
 
 rust_min_stack := "8388608" # 8 MiB
 python := if os_family() == "windows" { "python" } else { "python3" }
+# Linux SDK runtime wheels target musllinux, including on glibc development hosts.
+sdk_python_platform := if os() == "linux" { "--python-platform " + arch() + "-unknown-linux-musl" } else { "" }
 
 # Display help
 help:
@@ -38,18 +40,18 @@ app-server-test-client *args:
 
 # Format the justfile, Rust, Python SDK code, and Python scripts.
 fmt:
-    just --fmt
+    just --unstable --fmt
     cargo fmt -- --config imports_granularity=Item {stderr-null}
-    # Python formatting uses the scripts project's locked Ruff environment.
-    uv run --frozen --project ../scripts ruff check --fix --fix-only ../sdk/python
-    uv run --frozen --project ../scripts ruff format ../sdk/python
+    # The SDK and internal scripts use separate project roots for their Ruff environments.
+    uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff check --fix --fix-only ../sdk/python
+    uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff format ../sdk/python
     uv run --frozen --project ../scripts ruff format ../scripts
 
 fmt-check:
-    just --fmt --check
+    just --unstable --fmt --check
     cargo fmt -- --config imports_granularity=Item --check {stderr-null}
-    uv run --frozen --project ../scripts ruff check ../sdk/python
-    uv run --frozen --project ../scripts ruff format --check ../sdk/python
+    uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff check ../sdk/python
+    uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff format --check ../sdk/python
     uv run --frozen --project ../scripts ruff format --check ../scripts
 
 fix *args:

--- a/justfile
+++ b/justfile
@@ -46,11 +46,11 @@ fmt:
     uv run --frozen --project ../scripts ruff format ../scripts
 
 fmt-check:
+    # Keep this recipe in sync with `fmt` above.
     just --unstable --fmt --check
     cargo fmt -- --config imports_granularity=Item --check {stderr-null}
-    uv sync --frozen --project ../sdk/python --extra dev --no-install-package openai-codex-cli-bin
-    uv run --frozen --project ../sdk/python --extra dev --no-sync ruff check --diff ../sdk/python
-    uv run --frozen --project ../sdk/python --extra dev --no-sync ruff format --check ../sdk/python
+    uv run --frozen --project ../sdk/python --extra dev ruff check --diff ../sdk/python
+    uv run --frozen --project ../sdk/python --extra dev ruff format --check ../sdk/python
     uv run --frozen --project ../scripts ruff format --check ../scripts
 
 fix *args:

--- a/justfile
+++ b/justfile
@@ -38,20 +38,11 @@ app-server-test-client *args:
 
 # Format the justfile, Rust, Python SDK code, and Python scripts.
 fmt:
-    just --unstable --fmt
-    cargo fmt -- --config imports_granularity=Item {stderr-null}
-    uv run --frozen --project ../sdk/python --extra dev ruff check --fix --fix-only ../sdk/python
-    uv run --frozen --project ../sdk/python --extra dev ruff format ../sdk/python
-    # Root scripts have their own locked Ruff environment.
-    uv run --frozen --project ../scripts ruff format ../scripts
+    {{ python }} ../scripts/format.py
 
+# Check formatting without modifying files.
 fmt-check:
-    # Keep this recipe in sync with `fmt` above.
-    just --unstable --fmt --check
-    cargo fmt -- --config imports_granularity=Item --check {stderr-null}
-    uv run --frozen --project ../sdk/python --extra dev ruff check --diff ../sdk/python
-    uv run --frozen --project ../sdk/python --extra dev ruff format --check ../sdk/python
-    uv run --frozen --project ../scripts ruff format --check ../scripts
+    {{ python }} ../scripts/format.py --check
 
 fix *args:
     cargo clippy --fix --tests --allow-dirty {args}

--- a/justfile
+++ b/justfile
@@ -40,10 +40,9 @@ app-server-test-client *args:
 fmt:
     just --unstable --fmt
     cargo fmt -- --config imports_granularity=Item {stderr-null}
-    # The SDK and internal scripts use separate project roots for their Ruff environments.
-    uv sync --frozen --project ../sdk/python --extra dev --no-install-package openai-codex-cli-bin
-    uv run --frozen --project ../sdk/python --extra dev --no-sync ruff check --fix --fix-only ../sdk/python
-    uv run --frozen --project ../sdk/python --extra dev --no-sync ruff format ../sdk/python
+    uv run --frozen --project ../sdk/python --extra dev ruff check --fix --fix-only ../sdk/python
+    uv run --frozen --project ../sdk/python --extra dev ruff format ../sdk/python
+    # Root scripts have their own locked Ruff environment.
     uv run --frozen --project ../scripts ruff format ../scripts
 
 fmt-check:

--- a/justfile
+++ b/justfile
@@ -49,7 +49,7 @@ fmt:
 fmt-check:
     just --unstable --fmt --check
     cargo fmt -- --config imports_granularity=Item --check {stderr-null}
-    uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff check ../sdk/python
+    uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff check --diff ../sdk/python
     uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff format --check ../sdk/python
     uv run --frozen --project ../scripts ruff format --check ../scripts
 

--- a/justfile
+++ b/justfile
@@ -21,9 +21,9 @@ exec *args:
     cargo run --bin codex -- exec {args}
 
 # Start `codex exec-server` and run codex-tui.
-[unix]
 [no-cd]
 [positional-arguments]
+[unix]
 tui-with-exec-server *args:
     {{ justfile_directory() }}/scripts/run_tui_with_exec_server.sh "$@"
 
@@ -36,15 +36,20 @@ app-server-test-client *args:
     cargo build -p codex-cli
     cargo run -p codex-app-server-test-client -- --codex-bin ./target/debug/codex {args}
 
-# Format Rust, Python SDK code, and Python scripts.
+# Format the justfile, Rust, Python SDK code, and Python scripts.
 fmt:
+    just --fmt
     cargo fmt -- --config imports_granularity=Item {stderr-null}
-    uv run --frozen --project ../sdk/python --extra dev ruff check --fix --fix-only ../sdk/python
-    uv run --frozen --project ../sdk/python --extra dev ruff format ../sdk/python
-    # Root scripts have their own locked Ruff environment.
+    # Python formatting uses the scripts project's locked Ruff environment.
+    uv run --frozen --project ../scripts ruff check --fix --fix-only ../sdk/python
+    uv run --frozen --project ../scripts ruff format ../sdk/python
     uv run --frozen --project ../scripts ruff format ../scripts
 
-fmt-scripts-check:
+fmt-check:
+    just --fmt --check
+    cargo fmt -- --config imports_granularity=Item --check {stderr-null}
+    uv run --frozen --project ../scripts ruff check ../sdk/python
+    uv run --frozen --project ../scripts ruff format --check ../sdk/python
     uv run --frozen --project ../scripts ruff format --check ../scripts
 
 fix *args:
@@ -97,21 +102,21 @@ bench-smoke:
 # Build and run Codex from source using Bazel.
 # On Unix, use `[no-cd]` and `--run_under="cd $PWD &&"` to ensure Bazel runs
 # the command in the current working directory.
-[unix]
 [no-cd]
+[unix]
 bazel-codex *args:
     bazel run //codex-rs/cli:codex --run_under="cd $PWD &&" -- "$@"
 
 [windows]
 bazel-codex *args:
-    bazel run //codex-rs/cli:codex --run_under='cd /d "{{invocation_directory_native()}}" &&' -- @($args | Select-Object -Skip 1)
+    bazel run //codex-rs/cli:codex --run_under='cd /d "{{ invocation_directory_native() }}" &&' -- @($args | Select-Object -Skip 1)
 
 [no-cd]
 bazel-lock-update:
     bazel mod deps --lockfile_mode=update
 
-[unix]
 [no-cd]
+[unix]
 bazel-lock-check:
     {{ justfile_directory() }}/scripts/check-module-bazel-lock.sh
 
@@ -122,13 +127,13 @@ bazel-lock-check:
 bazel-test:
     bazel test --test_tag_filters=-argument-comment-lint //... --keep_going
 
-[unix]
 [no-cd]
+[unix]
 bazel-clippy:
     bazel_targets="$({{ justfile_directory() }}/scripts/list-bazel-clippy-targets.sh)" && bazel build --config=clippy -- ${bazel_targets}
 
-[unix]
 [no-cd]
+[unix]
 bazel-argument-comment-lint:
     bazel build --config=argument-comment-lint -- $({{ justfile_directory() }}/tools/argument-comment-lint/list-bazel-targets.sh)
 
@@ -155,8 +160,8 @@ write-hooks-schema:
     cargo run --manifest-path {{ justfile_directory() }}/codex-rs/Cargo.toml -p codex-hooks --bin write_hooks_schema_fixtures
 
 # Run the argument-comment Dylint checks across codex-rs.
-[unix]
 [no-cd]
+[unix]
 argument-comment-lint *args:
     if [ "$#" -eq 0 ]; then \
       bazel build --config=argument-comment-lint -- $({{ justfile_directory() }}/tools/argument-comment-lint/list-bazel-targets.sh); \

--- a/justfile
+++ b/justfile
@@ -6,8 +6,7 @@ set windows-shell := ["python", "-c", 'import os, runpy; runpy.run_path(os.envir
 
 rust_min_stack := "8388608" # 8 MiB
 python := if os_family() == "windows" { "python" } else { "python3" }
-# Linux SDK runtime wheels target musllinux, including on glibc development hosts.
-sdk_python_platform := if os() == "linux" { "--python-platform " + arch() + "-unknown-linux-musl" } else { "" }
+sdk_python_platform := env_var_or_default("CODEX_SDK_PYTHON_PLATFORM", "")
 
 # Display help
 help:

--- a/justfile
+++ b/justfile
@@ -6,7 +6,6 @@ set windows-shell := ["python", "-c", 'import os, runpy; runpy.run_path(os.envir
 
 rust_min_stack := "8388608" # 8 MiB
 python := if os_family() == "windows" { "python" } else { "python3" }
-sdk_python_platform := env_var_or_default("CODEX_SDK_PYTHON_PLATFORM", "")
 
 # Display help
 help:
@@ -42,15 +41,17 @@ fmt:
     just --unstable --fmt
     cargo fmt -- --config imports_granularity=Item {stderr-null}
     # The SDK and internal scripts use separate project roots for their Ruff environments.
-    uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff check --fix --fix-only ../sdk/python
-    uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff format ../sdk/python
+    uv sync --frozen --project ../sdk/python --extra dev --no-install-package openai-codex-cli-bin
+    uv run --frozen --project ../sdk/python --extra dev --no-sync ruff check --fix --fix-only ../sdk/python
+    uv run --frozen --project ../sdk/python --extra dev --no-sync ruff format ../sdk/python
     uv run --frozen --project ../scripts ruff format ../scripts
 
 fmt-check:
     just --unstable --fmt --check
     cargo fmt -- --config imports_granularity=Item --check {stderr-null}
-    uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff check --diff ../sdk/python
-    uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff format --check ../sdk/python
+    uv sync --frozen --project ../sdk/python --extra dev --no-install-package openai-codex-cli-bin
+    uv run --frozen --project ../sdk/python --extra dev --no-sync ruff check --diff ../sdk/python
+    uv run --frozen --project ../sdk/python --extra dev --no-sync ruff format --check ../sdk/python
     uv run --frozen --project ../scripts ruff format --check ../scripts
 
 fix *args:

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -87,6 +87,8 @@ def formatter_groups(*, check: bool) -> tuple[FormatterGroup, ...]:
         FormatterGroup("Just", (Command(tuple(just_args)),)),
         FormatterGroup(
             "Rust",
+            # Stable rustfmt repeats a nightly-only `imports_granularity` warning
+            # for each crate, so suppress that expected stderr noise.
             (Command(tuple(cargo_args), CODEX_RS_ROOT, discard_stderr=True),),
         ),
         FormatterGroup(

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Format repository sources or check that they are already formatted."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CODEX_RS_ROOT = REPO_ROOT / "codex-rs"
+SDK_RUNTIME_PACKAGE = "openai-codex-cli-bin"
+
+
+@dataclass(frozen=True)
+class Command:
+    args: tuple[str, ...]
+    cwd: Path = REPO_ROOT
+    discard_stderr: bool = False
+
+
+@dataclass(frozen=True)
+class FormatterGroup:
+    name: str
+    commands: tuple[Command, ...]
+
+
+@dataclass(frozen=True)
+class FormatterResult:
+    name: str
+    output: str
+    returncode: int
+
+
+def formatter_groups(*, check: bool) -> tuple[FormatterGroup, ...]:
+    just_args = ["just", "--unstable", "--fmt"]
+    cargo_args = ["cargo", "fmt", "--", "--config", "imports_granularity=Item"]
+    sdk_format_args = [
+        "uv",
+        "run",
+        "--frozen",
+        "--project",
+        "sdk/python",
+        "--extra",
+        "dev",
+        "--no-sync",
+        "ruff",
+        "format",
+    ]
+    scripts_format_args = [
+        "uv",
+        "run",
+        "--frozen",
+        "--project",
+        "scripts",
+        "--no-sync",
+        "ruff",
+        "format",
+    ]
+
+    if check:
+        just_args.append("--check")
+        cargo_args.append("--check")
+        # `ruff check --diff` reports lint-driven rewrites without changing files.
+        # It is the check-mode counterpart of `--fix --fix-only`, not a full lint gate.
+        sdk_lint_args = ["ruff", "check", "--diff"]
+        sdk_format_args.append("--check")
+        scripts_format_args.append("--check")
+    else:
+        # Ruff's lint fixer and formatter are separate passes: the first applies
+        # fixable lint rewrites, while the second formats source layout.
+        sdk_lint_args = ["ruff", "check", "--fix", "--fix-only"]
+
+    return (
+        FormatterGroup("Just", (Command(tuple(just_args)),)),
+        FormatterGroup(
+            "Rust",
+            (Command(tuple(cargo_args), CODEX_RS_ROOT, discard_stderr=True),),
+        ),
+        FormatterGroup(
+            "Python SDK",
+            (
+                Command(
+                    (
+                        "uv",
+                        "sync",
+                        "--frozen",
+                        "--project",
+                        "sdk/python",
+                        "--extra",
+                        "dev",
+                        "--inexact",
+                        "--no-install-package",
+                        SDK_RUNTIME_PACKAGE,
+                    )
+                ),
+                Command(
+                    (
+                        "uv",
+                        "run",
+                        "--frozen",
+                        "--project",
+                        "sdk/python",
+                        "--extra",
+                        "dev",
+                        "--no-sync",
+                        *sdk_lint_args,
+                        "sdk/python",
+                    )
+                ),
+                Command((*sdk_format_args, "sdk/python")),
+            ),
+        ),
+        FormatterGroup(
+            "Python scripts",
+            (
+                # The SDK and internal scripts intentionally use separate project
+                # roots so each uses its own locked Ruff environment.
+                Command(("uv", "sync", "--frozen", "--project", "scripts")),
+                Command((*scripts_format_args, "scripts")),
+            ),
+        ),
+    )
+
+
+def run_formatter_group(group: FormatterGroup) -> FormatterResult:
+    output: list[str] = []
+    for command in group.commands:
+        output.append(f"$ {shlex.join(command.args)}\n")
+        try:
+            process = subprocess.run(
+                command.args,
+                cwd=command.cwd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL
+                if command.discard_stderr
+                else subprocess.STDOUT,
+                text=True,
+                check=False,
+            )
+        except OSError as error:
+            output.append(f"{error}\n")
+            return FormatterResult(group.name, "".join(output), 1)
+
+        output.append(process.stdout)
+        if process.stdout and not process.stdout.endswith("\n"):
+            output.append("\n")
+        if process.returncode != 0:
+            return FormatterResult(group.name, "".join(output), process.returncode)
+
+    return FormatterResult(group.name, "".join(output), 0)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="check formatting without modifying files",
+    )
+    args = parser.parse_args()
+    groups = formatter_groups(check=args.check)
+
+    failures: list[str] = []
+    with ThreadPoolExecutor(max_workers=len(groups)) as executor:
+        futures = {
+            executor.submit(run_formatter_group, group): group.name for group in groups
+        }
+        for future in as_completed(futures):
+            result = future.result()
+            print(f"==> {result.name}")
+            print(result.output, end="")
+            if result.returncode != 0:
+                failures.append(result.name)
+
+    if failures:
+        print(f"Formatting failed: {', '.join(failures)}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CODEX_RS_ROOT = REPO_ROOT / "codex-rs"
-SDK_RUNTIME_PACKAGE = "openai-codex-cli-bin"
+RUFF_REQUIREMENT = "ruff>=0.15.8"
 
 
 @dataclass(frozen=True)
@@ -40,25 +40,33 @@ class FormatterResult:
 def formatter_groups(*, check: bool) -> tuple[FormatterGroup, ...]:
     just_args = ["just", "--unstable", "--fmt"]
     cargo_args = ["cargo", "fmt", "--", "--config", "imports_granularity=Item"]
-    sdk_format_args = [
+    sdk_uv_run_args = [
         "uv",
         "run",
         "--frozen",
         "--project",
         "sdk/python",
-        "--extra",
-        "dev",
         "--no-sync",
-        "ruff",
-        "format",
+        "--with",
+        RUFF_REQUIREMENT,
     ]
-    scripts_format_args = [
+    scripts_uv_run_args = [
         "uv",
         "run",
         "--frozen",
         "--project",
         "scripts",
         "--no-sync",
+        "--with",
+        RUFF_REQUIREMENT,
+    ]
+    sdk_format_args = [
+        *sdk_uv_run_args,
+        "ruff",
+        "format",
+    ]
+    scripts_format_args = [
+        *scripts_uv_run_args,
         "ruff",
         "format",
     ]
@@ -68,9 +76,9 @@ def formatter_groups(*, check: bool) -> tuple[FormatterGroup, ...]:
         cargo_args.append("--check")
         # `ruff check --diff` reports lint-driven rewrites without changing files.
         # It is the check-mode counterpart of `--fix --fix-only`, not a full lint gate.
-        sdk_lint_args = ["ruff", "check", "--diff"]
         sdk_format_args.append("--check")
         scripts_format_args.append("--check")
+        sdk_lint_args = ["ruff", "check", "--diff"]
     else:
         # Ruff's lint fixer and formatter are separate passes: the first applies
         # fixable lint rewrites, while the second formats source layout.
@@ -87,28 +95,7 @@ def formatter_groups(*, check: bool) -> tuple[FormatterGroup, ...]:
             (
                 Command(
                     (
-                        "uv",
-                        "sync",
-                        "--frozen",
-                        "--project",
-                        "sdk/python",
-                        "--extra",
-                        "dev",
-                        "--inexact",
-                        "--no-install-package",
-                        SDK_RUNTIME_PACKAGE,
-                    )
-                ),
-                Command(
-                    (
-                        "uv",
-                        "run",
-                        "--frozen",
-                        "--project",
-                        "sdk/python",
-                        "--extra",
-                        "dev",
-                        "--no-sync",
+                        *sdk_uv_run_args,
                         *sdk_lint_args,
                         "sdk/python",
                     )
@@ -120,8 +107,7 @@ def formatter_groups(*, check: bool) -> tuple[FormatterGroup, ...]:
             "Python scripts",
             (
                 # The SDK and internal scripts intentionally use separate project
-                # roots so each uses its own locked Ruff environment.
-                Command(("uv", "sync", "--frozen", "--project", "scripts")),
+                # roots so uv and Ruff retain each project's configuration context.
                 Command((*scripts_format_args, "scripts")),
             ),
         ),
@@ -129,6 +115,7 @@ def formatter_groups(*, check: bool) -> tuple[FormatterGroup, ...]:
 
 
 def run_formatter_group(group: FormatterGroup) -> FormatterResult:
+    """Run one formatter group sequentially and return its buffered output."""
     output: list[str] = []
     for command in group.commands:
         output.append(f"$ {shlex.join(command.args)}\n")
@@ -168,12 +155,13 @@ def main() -> int:
 
     failures: list[str] = []
     with ThreadPoolExecutor(max_workers=len(groups)) as executor:
-        futures = {
-            executor.submit(run_formatter_group, group): group.name for group in groups
-        }
+        futures = {}
+        for group in groups:
+            print(f"Starting {group.name} formatter...", flush=True)
+            futures[executor.submit(run_formatter_group, group)] = group.name
         for future in as_completed(futures):
             result = future.result()
-            print(f"==> {result.name}")
+            print(f"==> {result.name} formatter finished")
             print(result.output, end="")
             if result.returncode != 0:
                 failures.append(result.name)

--- a/scripts/format.py
+++ b/scripts/format.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 """Format repository sources or check that they are already formatted."""
 
-from __future__ import annotations
-
 import argparse
 import shlex
 import subprocess
@@ -14,7 +12,6 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CODEX_RS_ROOT = REPO_ROOT / "codex-rs"
-RUFF_REQUIREMENT = "ruff>=0.15.8"
 
 
 @dataclass(frozen=True)
@@ -40,6 +37,8 @@ class FormatterResult:
 def formatter_groups(*, check: bool) -> tuple[FormatterGroup, ...]:
     just_args = ["just", "--unstable", "--fmt"]
     cargo_args = ["cargo", "fmt", "--", "--config", "imports_granularity=Item"]
+    # Use an unpinned overlay so Ruff is available without syncing project
+    # dependencies. Each `--project` still retains its local configuration context.
     sdk_uv_run_args = [
         "uv",
         "run",
@@ -48,7 +47,7 @@ def formatter_groups(*, check: bool) -> tuple[FormatterGroup, ...]:
         "sdk/python",
         "--no-sync",
         "--with",
-        RUFF_REQUIREMENT,
+        "ruff",
     ]
     scripts_uv_run_args = [
         "uv",
@@ -58,7 +57,7 @@ def formatter_groups(*, check: bool) -> tuple[FormatterGroup, ...]:
         "scripts",
         "--no-sync",
         "--with",
-        RUFF_REQUIREMENT,
+        "ruff",
     ]
     sdk_format_args = [
         *sdk_uv_run_args,
@@ -74,10 +73,10 @@ def formatter_groups(*, check: bool) -> tuple[FormatterGroup, ...]:
     if check:
         just_args.append("--check")
         cargo_args.append("--check")
-        # `ruff check --diff` reports lint-driven rewrites without changing files.
-        # It is the check-mode counterpart of `--fix --fix-only`, not a full lint gate.
         sdk_format_args.append("--check")
         scripts_format_args.append("--check")
+        # `ruff check --diff` reports lint-driven rewrites without changing files.
+        # It is the check-mode counterpart of `--fix --fix-only`, not a full lint gate.
         sdk_lint_args = ["ruff", "check", "--diff"]
     else:
         # Ruff's lint fixer and formatter are separate passes: the first applies

--- a/sdk/python/tests/test_artifact_workflow_and_binaries.py
+++ b/sdk/python/tests/test_artifact_workflow_and_binaries.py
@@ -135,31 +135,48 @@ def test_root_format_driver_covers_all_formatter_groups() -> None:
         "Python scripts",
     ]
     assert [group.name for group in checks] == [group.name for group in formatters]
-    assert [len(group.commands) for group in formatters] == [1, 1, 3, 2]
+    assert [len(group.commands) for group in formatters] == [1, 1, 2, 1]
     assert [len(group.commands) for group in checks] == [
         len(group.commands) for group in formatters
     ]
-    assert formatters[2].commands[0] == checks[2].commands[0]
-    assert formatters[2].commands[0].args == (
+    sdk_uv_run_args = (
         "uv",
-        "sync",
+        "run",
         "--frozen",
         "--project",
         "sdk/python",
-        "--extra",
-        "dev",
-        "--inexact",
-        "--no-install-package",
-        "openai-codex-cli-bin",
+        "--no-sync",
+        "--with",
+        "ruff>=0.15.8",
     )
-    assert formatters[2].commands[1].args[-5:] == (
+    scripts_uv_run_args = (
+        "uv",
+        "run",
+        "--frozen",
+        "--project",
+        "scripts",
+        "--no-sync",
+        "--with",
+        "ruff>=0.15.8",
+    )
+    assert all(
+        command.args[: len(sdk_uv_run_args)] == sdk_uv_run_args
+        for group in (formatters[2], checks[2])
+        for command in group.commands
+    )
+    assert all(
+        command.args[: len(scripts_uv_run_args)] == scripts_uv_run_args
+        for group in (formatters[3], checks[3])
+        for command in group.commands
+    )
+    assert formatters[2].commands[0].args[-5:] == (
         "ruff",
         "check",
         "--fix",
         "--fix-only",
         "sdk/python",
     )
-    assert checks[2].commands[1].args[-4:] == (
+    assert checks[2].commands[0].args[-4:] == (
         "ruff",
         "check",
         "--diff",

--- a/sdk/python/tests/test_artifact_workflow_and_binaries.py
+++ b/sdk/python/tests/test_artifact_workflow_and_binaries.py
@@ -122,7 +122,7 @@ def test_root_fmt_check_recipe_checks_all_formatters() -> None:
     assert [line.strip() for line in fmt_check_recipe[1:] if line.strip()] == [
         "just --unstable --fmt --check",
         "cargo fmt -- --config imports_granularity=Item --check {stderr-null}",
-        "uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff check ../sdk/python",
+        "uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff check --diff ../sdk/python",
         "uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff format --check ../sdk/python",
         "uv run --frozen --project ../scripts ruff format --check ../scripts",
     ]

--- a/sdk/python/tests/test_artifact_workflow_and_binaries.py
+++ b/sdk/python/tests/test_artifact_workflow_and_binaries.py
@@ -125,26 +125,18 @@ def test_root_fmt_check_recipe_checks_all_formatters() -> None:
         if line.strip() and not line.strip().startswith("#")
     ]
     fmt_to_fmt_check = {
-        "just --unstable --fmt": ["just --unstable --fmt --check"],
-        "cargo fmt -- --config imports_granularity=Item {stderr-null}": [
-            "cargo fmt -- --config imports_granularity=Item --check {stderr-null}"
-        ],
-        "uv run --frozen --project ../sdk/python --extra dev ruff check --fix --fix-only ../sdk/python": [
-            "uv sync --frozen --project ../sdk/python --extra dev --no-install-package openai-codex-cli-bin",
-            "uv run --frozen --project ../sdk/python --extra dev --no-sync ruff check --diff ../sdk/python",
-        ],
-        "uv run --frozen --project ../sdk/python --extra dev ruff format ../sdk/python": [
-            "uv run --frozen --project ../sdk/python --extra dev --no-sync ruff format --check ../sdk/python"
-        ],
-        "uv run --frozen --project ../scripts ruff format ../scripts": [
-            "uv run --frozen --project ../scripts ruff format --check ../scripts"
-        ],
+        "just --unstable --fmt": "just --unstable --fmt --check",
+        "cargo fmt -- --config imports_granularity=Item {stderr-null}": "cargo fmt -- --config imports_granularity=Item --check {stderr-null}",
+        "uv run --frozen --project ../sdk/python --extra dev ruff check --fix --fix-only ../sdk/python": "uv run --frozen --project ../sdk/python --extra dev ruff check --diff ../sdk/python",
+        "uv run --frozen --project ../sdk/python --extra dev ruff format ../sdk/python": "uv run --frozen --project ../sdk/python --extra dev ruff format --check ../sdk/python",
+        "uv run --frozen --project ../scripts ruff format ../scripts": "uv run --frozen --project ../scripts ruff format --check ../scripts",
     }
-    assert [line.strip() for line in fmt_check_recipe[1:] if line.strip()] == [
-        fmt_check_command
-        for command in fmt_commands
-        for fmt_check_command in fmt_to_fmt_check[command]
-    ]
+    assert fmt_check_recipe[1] == "    # Keep this recipe in sync with `fmt` above."
+    assert [
+        line.strip()
+        for line in fmt_check_recipe[1:]
+        if line.strip() and not line.strip().startswith("#")
+    ] == [fmt_to_fmt_check[command] for command in fmt_commands]
 
 
 def test_generate_types_wires_all_generation_steps() -> None:

--- a/sdk/python/tests/test_artifact_workflow_and_binaries.py
+++ b/sdk/python/tests/test_artifact_workflow_and_binaries.py
@@ -92,10 +92,9 @@ def test_root_fmt_recipe_formats_justfile_rust_python_sdk_and_scripts() -> None:
         "commands": [
             "just --unstable --fmt",
             "cargo fmt -- --config imports_granularity=Item {stderr-null}",
-            "# The SDK and internal scripts use separate project roots for their Ruff environments.",
-            "uv sync --frozen --project ../sdk/python --extra dev --no-install-package openai-codex-cli-bin",
-            "uv run --frozen --project ../sdk/python --extra dev --no-sync ruff check --fix --fix-only ../sdk/python",
-            "uv run --frozen --project ../sdk/python --extra dev --no-sync ruff format ../sdk/python",
+            "uv run --frozen --project ../sdk/python --extra dev ruff check --fix --fix-only ../sdk/python",
+            "uv run --frozen --project ../sdk/python --extra dev ruff format ../sdk/python",
+            "# Root scripts have their own locked Ruff environment.",
             "uv run --frozen --project ../scripts ruff format ../scripts",
         ],
     }
@@ -126,15 +125,25 @@ def test_root_fmt_check_recipe_checks_all_formatters() -> None:
         if line.strip() and not line.strip().startswith("#")
     ]
     fmt_to_fmt_check = {
-        "just --unstable --fmt": "just --unstable --fmt --check",
-        "cargo fmt -- --config imports_granularity=Item {stderr-null}": "cargo fmt -- --config imports_granularity=Item --check {stderr-null}",
-        "uv sync --frozen --project ../sdk/python --extra dev --no-install-package openai-codex-cli-bin": "uv sync --frozen --project ../sdk/python --extra dev --no-install-package openai-codex-cli-bin",
-        "uv run --frozen --project ../sdk/python --extra dev --no-sync ruff check --fix --fix-only ../sdk/python": "uv run --frozen --project ../sdk/python --extra dev --no-sync ruff check --diff ../sdk/python",
-        "uv run --frozen --project ../sdk/python --extra dev --no-sync ruff format ../sdk/python": "uv run --frozen --project ../sdk/python --extra dev --no-sync ruff format --check ../sdk/python",
-        "uv run --frozen --project ../scripts ruff format ../scripts": "uv run --frozen --project ../scripts ruff format --check ../scripts",
+        "just --unstable --fmt": ["just --unstable --fmt --check"],
+        "cargo fmt -- --config imports_granularity=Item {stderr-null}": [
+            "cargo fmt -- --config imports_granularity=Item --check {stderr-null}"
+        ],
+        "uv run --frozen --project ../sdk/python --extra dev ruff check --fix --fix-only ../sdk/python": [
+            "uv sync --frozen --project ../sdk/python --extra dev --no-install-package openai-codex-cli-bin",
+            "uv run --frozen --project ../sdk/python --extra dev --no-sync ruff check --diff ../sdk/python",
+        ],
+        "uv run --frozen --project ../sdk/python --extra dev ruff format ../sdk/python": [
+            "uv run --frozen --project ../sdk/python --extra dev --no-sync ruff format --check ../sdk/python"
+        ],
+        "uv run --frozen --project ../scripts ruff format ../scripts": [
+            "uv run --frozen --project ../scripts ruff format --check ../scripts"
+        ],
     }
     assert [line.strip() for line in fmt_check_recipe[1:] if line.strip()] == [
-        fmt_to_fmt_check[command] for command in fmt_commands
+        fmt_check_command
+        for command in fmt_commands
+        for fmt_check_command in fmt_to_fmt_check[command]
     ]
 
 

--- a/sdk/python/tests/test_artifact_workflow_and_binaries.py
+++ b/sdk/python/tests/test_artifact_workflow_and_binaries.py
@@ -93,8 +93,9 @@ def test_root_fmt_recipe_formats_justfile_rust_python_sdk_and_scripts() -> None:
             "just --unstable --fmt",
             "cargo fmt -- --config imports_granularity=Item {stderr-null}",
             "# The SDK and internal scripts use separate project roots for their Ruff environments.",
-            "uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff check --fix --fix-only ../sdk/python",
-            "uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff format ../sdk/python",
+            "uv sync --frozen --project ../sdk/python --extra dev --no-install-package openai-codex-cli-bin",
+            "uv run --frozen --project ../sdk/python --extra dev --no-sync ruff check --fix --fix-only ../sdk/python",
+            "uv run --frozen --project ../sdk/python --extra dev --no-sync ruff format ../sdk/python",
             "uv run --frozen --project ../scripts ruff format ../scripts",
         ],
     }
@@ -119,12 +120,21 @@ def test_root_fmt_check_recipe_checks_all_formatters() -> None:
     )
     fmt_check_recipe = lines[fmt_check_index:next_recipe_index]
 
+    fmt_commands = [
+        line.strip()
+        for line in lines[lines.index("fmt:") + 1 : fmt_check_index]
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    fmt_to_fmt_check = {
+        "just --unstable --fmt": "just --unstable --fmt --check",
+        "cargo fmt -- --config imports_granularity=Item {stderr-null}": "cargo fmt -- --config imports_granularity=Item --check {stderr-null}",
+        "uv sync --frozen --project ../sdk/python --extra dev --no-install-package openai-codex-cli-bin": "uv sync --frozen --project ../sdk/python --extra dev --no-install-package openai-codex-cli-bin",
+        "uv run --frozen --project ../sdk/python --extra dev --no-sync ruff check --fix --fix-only ../sdk/python": "uv run --frozen --project ../sdk/python --extra dev --no-sync ruff check --diff ../sdk/python",
+        "uv run --frozen --project ../sdk/python --extra dev --no-sync ruff format ../sdk/python": "uv run --frozen --project ../sdk/python --extra dev --no-sync ruff format --check ../sdk/python",
+        "uv run --frozen --project ../scripts ruff format ../scripts": "uv run --frozen --project ../scripts ruff format --check ../scripts",
+    }
     assert [line.strip() for line in fmt_check_recipe[1:] if line.strip()] == [
-        "just --unstable --fmt --check",
-        "cargo fmt -- --config imports_granularity=Item --check {stderr-null}",
-        "uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff check --diff ../sdk/python",
-        "uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff format --check ../sdk/python",
-        "uv run --frozen --project ../scripts ruff format --check ../scripts",
+        fmt_to_fmt_check[command] for command in fmt_commands
     ]
 
 

--- a/sdk/python/tests/test_artifact_workflow_and_binaries.py
+++ b/sdk/python/tests/test_artifact_workflow_and_binaries.py
@@ -90,11 +90,11 @@ def test_root_fmt_recipe_formats_justfile_rust_python_sdk_and_scripts() -> None:
         "working_directory": 'set working-directory := "codex-rs"',
         "previous_comment": "# Format the justfile, Rust, Python SDK code, and Python scripts.",
         "commands": [
-            "just --fmt",
+            "just --unstable --fmt",
             "cargo fmt -- --config imports_granularity=Item {stderr-null}",
-            "# Python formatting uses the scripts project's locked Ruff environment.",
-            "uv run --frozen --project ../scripts ruff check --fix --fix-only ../sdk/python",
-            "uv run --frozen --project ../scripts ruff format ../sdk/python",
+            "# The SDK and internal scripts use separate project roots for their Ruff environments.",
+            "uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff check --fix --fix-only ../sdk/python",
+            "uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff format ../sdk/python",
             "uv run --frozen --project ../scripts ruff format ../scripts",
         ],
     }
@@ -120,10 +120,10 @@ def test_root_fmt_check_recipe_checks_all_formatters() -> None:
     fmt_check_recipe = lines[fmt_check_index:next_recipe_index]
 
     assert [line.strip() for line in fmt_check_recipe[1:] if line.strip()] == [
-        "just --fmt --check",
+        "just --unstable --fmt --check",
         "cargo fmt -- --config imports_granularity=Item --check {stderr-null}",
-        "uv run --frozen --project ../scripts ruff check ../sdk/python",
-        "uv run --frozen --project ../scripts ruff format --check ../sdk/python",
+        "uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff check ../sdk/python",
+        "uv run --frozen --project ../sdk/python --extra dev {{ sdk_python_platform }} ruff format --check ../sdk/python",
         "uv run --frozen --project ../scripts ruff format --check ../scripts",
     ]
 

--- a/sdk/python/tests/test_artifact_workflow_and_binaries.py
+++ b/sdk/python/tests/test_artifact_workflow_and_binaries.py
@@ -147,7 +147,7 @@ def test_root_format_driver_covers_all_formatter_groups() -> None:
         "sdk/python",
         "--no-sync",
         "--with",
-        "ruff>=0.15.8",
+        "ruff",
     )
     scripts_uv_run_args = (
         "uv",
@@ -157,7 +157,7 @@ def test_root_format_driver_covers_all_formatter_groups() -> None:
         "scripts",
         "--no-sync",
         "--with",
-        "ruff>=0.15.8",
+        "ruff",
     )
     assert all(
         command.args[: len(sdk_uv_run_args)] == sdk_uv_run_args

--- a/sdk/python/tests/test_artifact_workflow_and_binaries.py
+++ b/sdk/python/tests/test_artifact_workflow_and_binaries.py
@@ -14,6 +14,18 @@ import tomllib
 ROOT = Path(__file__).resolve().parents[1]
 
 
+def _load_root_format_script_module():
+    """Load the root formatter driver so tests exercise its real command graph."""
+    script_path = ROOT.parents[1] / "scripts" / "format.py"
+    spec = importlib.util.spec_from_file_location("format_repo", script_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"Failed to load script module: {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 def _load_update_script_module():
     """Load the maintenance script as a module so tests exercise real helpers."""
     script_path = ROOT / "scripts" / "update_sdk_artifacts.py"
@@ -68,75 +80,116 @@ def test_generation_has_single_maintenance_entrypoint_script() -> None:
     assert scripts == ["update_sdk_artifacts.py"]
 
 
-def test_root_fmt_recipe_formats_justfile_rust_python_sdk_and_scripts() -> None:
-    """The repo fmt command should format the justfile, Rust, the Python SDK, and scripts."""
+def test_root_fmt_recipes_use_shared_formatter_driver() -> None:
+    """The root formatting recipes should use the shared cross-platform driver."""
     justfile = ROOT.parents[1] / "justfile"
     lines = justfile.read_text().splitlines()
     fmt_index = lines.index("fmt:")
-    next_recipe_index = next(
-        index
-        for index in range(fmt_index + 1, len(lines))
-        if lines[index] and not lines[index].startswith((" ", "\t", "#"))
-    )
-    fmt_recipe = lines[fmt_index:next_recipe_index]
-    actual = {
-        "working_directory": lines[0],
-        "previous_comment": next(
-            line for line in reversed(lines[:fmt_index]) if line.startswith("#")
-        ),
-        "commands": [line.strip() for line in fmt_recipe[1:] if line.strip()],
-    }
-    expected = {
-        "working_directory": 'set working-directory := "codex-rs"',
-        "previous_comment": "# Format the justfile, Rust, Python SDK code, and Python scripts.",
-        "commands": [
-            "just --unstable --fmt",
-            "cargo fmt -- --config imports_granularity=Item {stderr-null}",
-            "uv run --frozen --project ../sdk/python --extra dev ruff check --fix --fix-only ../sdk/python",
-            "uv run --frozen --project ../sdk/python --extra dev ruff format ../sdk/python",
-            "# Root scripts have their own locked Ruff environment.",
-            "uv run --frozen --project ../scripts ruff format ../scripts",
-        ],
-    }
-
-    assert actual == expected, (
-        "The root `just fmt` recipe must run Just fmt, Rust fmt, and Ruff for Python SDK code and scripts. "
-        "Fix the `fmt` recipe in `justfile`, then run `just fmt`.\n"
-        f"Expected: {json.dumps(expected, indent=2)}\n"
-        f"Actual: {json.dumps(actual, indent=2)}"
-    )
-
-
-def test_root_fmt_check_recipe_checks_all_formatters() -> None:
-    """The repo fmt check should validate everything formatted by the fmt recipe."""
-    justfile = ROOT.parents[1] / "justfile"
-    lines = justfile.read_text().splitlines()
     fmt_check_index = lines.index("fmt-check:")
     next_recipe_index = next(
         index
         for index in range(fmt_check_index + 1, len(lines))
         if lines[index] and not lines[index].startswith((" ", "\t", "#"))
     )
-    fmt_check_recipe = lines[fmt_check_index:next_recipe_index]
-
-    fmt_commands = [
-        line.strip()
-        for line in lines[lines.index("fmt:") + 1 : fmt_check_index]
-        if line.strip() and not line.strip().startswith("#")
-    ]
-    fmt_to_fmt_check = {
-        "just --unstable --fmt": "just --unstable --fmt --check",
-        "cargo fmt -- --config imports_granularity=Item {stderr-null}": "cargo fmt -- --config imports_granularity=Item --check {stderr-null}",
-        "uv run --frozen --project ../sdk/python --extra dev ruff check --fix --fix-only ../sdk/python": "uv run --frozen --project ../sdk/python --extra dev ruff check --diff ../sdk/python",
-        "uv run --frozen --project ../sdk/python --extra dev ruff format ../sdk/python": "uv run --frozen --project ../sdk/python --extra dev ruff format --check ../sdk/python",
-        "uv run --frozen --project ../scripts ruff format ../scripts": "uv run --frozen --project ../scripts ruff format --check ../scripts",
+    actual = {
+        "working_directory": lines[0],
+        "fmt_comment": next(line for line in reversed(lines[:fmt_index]) if line.startswith("#")),
+        "fmt_commands": [
+            line.strip()
+            for line in lines[fmt_index + 1 : fmt_check_index]
+            if line.strip() and not line.startswith("#")
+        ],
+        "fmt_check_comment": next(
+            line for line in reversed(lines[:fmt_check_index]) if line.startswith("#")
+        ),
+        "fmt_check_commands": [
+            line.strip() for line in lines[fmt_check_index + 1 : next_recipe_index] if line.strip()
+        ],
     }
-    assert fmt_check_recipe[1] == "    # Keep this recipe in sync with `fmt` above."
-    assert [
-        line.strip()
-        for line in fmt_check_recipe[1:]
-        if line.strip() and not line.strip().startswith("#")
-    ] == [fmt_to_fmt_check[command] for command in fmt_commands]
+    expected = {
+        "working_directory": 'set working-directory := "codex-rs"',
+        "fmt_comment": "# Format the justfile, Rust, Python SDK code, and Python scripts.",
+        "fmt_commands": ["{{ python }} ../scripts/format.py"],
+        "fmt_check_comment": "# Check formatting without modifying files.",
+        "fmt_check_commands": ["{{ python }} ../scripts/format.py --check"],
+    }
+
+    assert actual == expected, (
+        "The root formatting recipes must use the shared formatter driver. "
+        "Fix the recipes in `justfile`, then run `just fmt`.\n"
+        f"Expected: {json.dumps(expected, indent=2)}\n"
+        f"Actual: {json.dumps(actual, indent=2)}"
+    )
+
+
+def test_root_format_driver_covers_all_formatter_groups() -> None:
+    """The shared driver should retain every formatter in both modes."""
+    script = _load_root_format_script_module()
+    formatters = script.formatter_groups(check=False)
+    checks = script.formatter_groups(check=True)
+
+    assert [group.name for group in formatters] == [
+        "Just",
+        "Rust",
+        "Python SDK",
+        "Python scripts",
+    ]
+    assert [group.name for group in checks] == [group.name for group in formatters]
+    assert [len(group.commands) for group in formatters] == [1, 1, 3, 2]
+    assert [len(group.commands) for group in checks] == [
+        len(group.commands) for group in formatters
+    ]
+    assert formatters[2].commands[0] == checks[2].commands[0]
+    assert formatters[2].commands[0].args == (
+        "uv",
+        "sync",
+        "--frozen",
+        "--project",
+        "sdk/python",
+        "--extra",
+        "dev",
+        "--inexact",
+        "--no-install-package",
+        "openai-codex-cli-bin",
+    )
+    assert formatters[2].commands[1].args[-5:] == (
+        "ruff",
+        "check",
+        "--fix",
+        "--fix-only",
+        "sdk/python",
+    )
+    assert checks[2].commands[1].args[-4:] == (
+        "ruff",
+        "check",
+        "--diff",
+        "sdk/python",
+    )
+    assert formatters[0].commands[-1].args == ("just", "--unstable", "--fmt")
+    assert checks[0].commands[-1].args == ("just", "--unstable", "--fmt", "--check")
+    assert formatters[1].commands[-1].args == (
+        "cargo",
+        "fmt",
+        "--",
+        "--config",
+        "imports_granularity=Item",
+    )
+    assert checks[1].commands[-1].args == (
+        "cargo",
+        "fmt",
+        "--",
+        "--config",
+        "imports_granularity=Item",
+        "--check",
+    )
+    assert [group.commands[-1].args[-3:] for group in formatters[2:]] == [
+        ("ruff", "format", "sdk/python"),
+        ("ruff", "format", "scripts"),
+    ]
+    assert [group.commands[-1].args[-4:] for group in checks[2:]] == [
+        ("ruff", "format", "--check", "sdk/python"),
+        ("ruff", "format", "--check", "scripts"),
+    ]
 
 
 def test_generate_types_wires_all_generation_steps() -> None:

--- a/sdk/python/tests/test_artifact_workflow_and_binaries.py
+++ b/sdk/python/tests/test_artifact_workflow_and_binaries.py
@@ -68,8 +68,8 @@ def test_generation_has_single_maintenance_entrypoint_script() -> None:
     assert scripts == ["update_sdk_artifacts.py"]
 
 
-def test_root_fmt_recipe_formats_rust_python_sdk_and_scripts() -> None:
-    """The repo fmt command should format Rust, the Python SDK, and scripts."""
+def test_root_fmt_recipe_formats_justfile_rust_python_sdk_and_scripts() -> None:
+    """The repo fmt command should format the justfile, Rust, the Python SDK, and scripts."""
     justfile = ROOT.parents[1] / "justfile"
     lines = justfile.read_text().splitlines()
     fmt_index = lines.index("fmt:")
@@ -88,22 +88,44 @@ def test_root_fmt_recipe_formats_rust_python_sdk_and_scripts() -> None:
     }
     expected = {
         "working_directory": 'set working-directory := "codex-rs"',
-        "previous_comment": "# Format Rust, Python SDK code, and Python scripts.",
+        "previous_comment": "# Format the justfile, Rust, Python SDK code, and Python scripts.",
         "commands": [
+            "just --fmt",
             "cargo fmt -- --config imports_granularity=Item {stderr-null}",
-            "uv run --frozen --project ../sdk/python --extra dev ruff check --fix --fix-only ../sdk/python",
-            "uv run --frozen --project ../sdk/python --extra dev ruff format ../sdk/python",
-            "# Root scripts have their own locked Ruff environment.",
+            "# Python formatting uses the scripts project's locked Ruff environment.",
+            "uv run --frozen --project ../scripts ruff check --fix --fix-only ../sdk/python",
+            "uv run --frozen --project ../scripts ruff format ../sdk/python",
             "uv run --frozen --project ../scripts ruff format ../scripts",
         ],
     }
 
     assert actual == expected, (
-        "The root `just fmt` recipe must run Rust fmt and Ruff for Python SDK code and scripts. "
+        "The root `just fmt` recipe must run Just fmt, Rust fmt, and Ruff for Python SDK code and scripts. "
         "Fix the `fmt` recipe in `justfile`, then run `just fmt`.\n"
         f"Expected: {json.dumps(expected, indent=2)}\n"
         f"Actual: {json.dumps(actual, indent=2)}"
     )
+
+
+def test_root_fmt_check_recipe_checks_all_formatters() -> None:
+    """The repo fmt check should validate everything formatted by the fmt recipe."""
+    justfile = ROOT.parents[1] / "justfile"
+    lines = justfile.read_text().splitlines()
+    fmt_check_index = lines.index("fmt-check:")
+    next_recipe_index = next(
+        index
+        for index in range(fmt_check_index + 1, len(lines))
+        if lines[index] and not lines[index].startswith((" ", "\t", "#"))
+    )
+    fmt_check_recipe = lines[fmt_check_index:next_recipe_index]
+
+    assert [line.strip() for line in fmt_check_recipe[1:] if line.strip()] == [
+        "just --fmt --check",
+        "cargo fmt -- --config imports_granularity=Item --check {stderr-null}",
+        "uv run --frozen --project ../scripts ruff check ../sdk/python",
+        "uv run --frozen --project ../scripts ruff format --check ../sdk/python",
+        "uv run --frozen --project ../scripts ruff format --check ../scripts",
+    ]
 
 
 def test_generate_types_wires_all_generation_steps() -> None:


### PR DESCRIPTION
## Why

The root formatting entrypoints could drift: `just fmt` did not format the Justfile itself, and the CI-facing check recipe only checked Python scripts instead of matching everything formatted by `just fmt`.

## What changed

- Add a shared cross-platform Python formatter driver used by both `just fmt` and `just fmt-check`.
- Run Justfile, Rust, Python SDK, and internal-script formatter groups concurrently while buffering each formatter group's output until it finishes.
- Log formatter starts immediately, then print each formatter group's labeled output when it completes.
- Keep the SDK lint-fix and Ruff formatting passes ordered, with source comments explaining their distinct roles and the check-mode equivalents.
- Run Ruff through shared `uv run --no-sync --with ruff` overlays so formatting works on clean glibc Linux checkouts without installing the platform-specific SDK runtime wheel.
- Show `fmt-check` help text in `just -l` and simplify CI to call the shared driver through `just fmt-check`.
- Pin the general CI workflow to `just@1.51.0` so its formatter agrees with the checked-in Justfile.
- Add regression coverage for the thin Just recipes and the driver's formatter graph.

## Validation

- `just fmt`
- `just fmt-check`
- `python3 -m pytest sdk/python/tests/test_artifact_workflow_and_binaries.py -k 'root_fmt or root_format' -q`
- `pnpm run format`
- `git diff --check`
- `just -l | rg -n '^    fmt|fmt-check'`
- `uvx --from uv==0.7.22 uv run --frozen --project sdk/python --no-sync --with ruff ruff check --diff sdk/python`