### PR TITLE
Add Python version compatibility guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,3 +232,12 @@ These guidelines apply to app-server protocol work in `codex-rs`, especially:
 - Validate with `just test -p codex-app-server-protocol`.
 - Avoid boilerplate tests that only assert experimental field markers for individual
   request fields in `common.rs`; rely on schema generation/tests and behavioral coverage instead.
+
+## Python Development Best Practices
+
+### Ignore Python 2 compatibility
+
+This project uses Python 3+. You should not use the `__future__` module.
+
+If you need to worry about feature compatibility between different 3.xx point releases, check the
+closest `pyproject.toml`'s `requires-python` field to see what minimum runtime version is supported.


### PR DESCRIPTION
## Why

Python contributions in this repository should target the declared Python 3 runtime instead of carrying Python 2 compatibility patterns forward. When compatibility across Python 3 point releases matters, contributors need a consistent source of truth for the minimum supported version.

## What changed

- Added Python development guidance to `AGENTS.md` stating that the repository uses Python 3+ and should not use the `__future__` module.
- Documented that contributors should check the nearest `pyproject.toml` `requires-python` field when evaluating Python 3 point-release compatibility.

## Testing

Not run (guidance-only change).