### PR TITLE
[codex] Stop asking before running required Rust tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ Run `just fmt` (in the `codex-rs` directory) automatically after you have finish
 
 1. Do not run `cargo test` directly. Use `just test` so test execution follows the repo defaults.
 2. Run the test for the specific project that was changed. For example, if changes were made in `codex-rs/tui`, run `just test -p codex-tui`.
-3. Once those pass, if any changes were made in common, core, or protocol, run the complete test suite with `just test`. Avoid `--all-features` for routine local runs because it expands the build matrix and can significantly increase `target/` disk usage; use it only when you specifically need full feature coverage. project-specific or individual tests can be run without asking the user, but do ask the user before running the complete test suite.
+3. Once those pass, if any changes were made in common, core, or protocol, run the complete test suite with `just test`. Avoid `--all-features` for routine local runs because it expands the build matrix and can significantly increase `target/` disk usage; use it only when you specifically need full feature coverage.
 
 Before finalizing a large change to `codex-rs`, run `just fix -p <project>` (in `codex-rs` directory) to fix any linter issues in the code. Prefer scoping with `-p` to avoid slow workspace‑wide Clippy builds; only run `just fix` without `-p` if you changed shared crates. Do not re-run tests after running `fix` or `fmt`.
 


### PR DESCRIPTION
## Summary
- remove the `AGENTS.md` instruction to ask the user before running the complete Rust test suite
- keep the existing guidance to run the full suite after project-specific checks when common, core, or protocol changes require it

## Motivation
The repository instructions already define when the full Rust suite is required. Asking for an extra user confirmation before running that required validation adds an unnecessary round trip and can leave changes only partially verified.

## Impact
Agents can run the required full Rust suite autonomously after relevant shared-crate changes, while routine project-specific test guidance remains unchanged.

## Validation
- not run (instruction-only change)