### PR TITLE
[codex] enable parallel standalone web search calls

### DIFF
--- a/codex-rs/ext/web-search/src/extension.rs
+++ b/codex-rs/ext/web-search/src/extension.rs
@@ -169,12 +169,12 @@ mod tests {
             .tool_contributors()
             .iter()
             .flat_map(|contributor| contributor.tools(&session_store, &thread_store))
-            .map(|tool| tool.tool_name())
+            .map(|tool| (tool.tool_name(), tool.supports_parallel_tool_calls()))
             .collect::<Vec<_>>();
 
         assert_eq!(
             tool_names,
-            vec![ToolName::namespaced(WEB_NAMESPACE, RUN_TOOL_NAME)]
+            vec![(ToolName::namespaced(WEB_NAMESPACE, RUN_TOOL_NAME), true)]
         );
     }
 }

--- a/codex-rs/ext/web-search/src/tool.rs
+++ b/codex-rs/ext/web-search/src/tool.rs
@@ -70,6 +70,10 @@ impl ToolExecutor<ToolCall> for WebSearchTool {
         ToolExposure::DirectModelOnly
     }
 
+    fn supports_parallel_tool_calls(&self) -> bool {
+        true
+    }
+
     async fn handle(&self, call: ToolCall) -> Result<Box<dyn ToolOutput>, FunctionCallError> {
         let commands = parse_commands(&call)?;
         let command_action = command_action(&commands);


### PR DESCRIPTION
## Summary
- opt the extension-backed standalone `web.run` tool into parallel tool execution
- update the existing extension registration test to assert that the tool advertises parallel-call support

## Why
The standalone web-search API endpoint now supports parallel requests. The extension executor still inherited the shared serial default, causing multiple `web.run` calls to acquire the exclusive runtime lock.

## Impact
Models that emit multiple standalone web-search calls can now execute them concurrently when model-level parallel tool calls are enabled.

## Validation
- `just fmt`
- `just test -p codex-web-search-extension`
- `git diff --check origin/main...HEAD`