### PR TITLE
Normalize Codex images for Responses strict mode

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/turn_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start.rs
@@ -103,7 +103,58 @@ fn body_contains(req: &wiremock::Request, text: &str) -> bool {
         .is_some_and(|body| body.contains(text))
 }
 
+struct ImageTurnResult {
+    input_images: Vec<Value>,
+    response_request_bodies: Vec<Value>,
+    completed: TurnCompletedNotification,
+}
+
+#[derive(Clone, Copy)]
+enum ImageTurnMode {
+    Default,
+    ResponsesLite,
+}
+
 async fn run_local_image_turn(detail: Option<ImageDetail>) -> Result<Vec<Value>> {
+    Ok(
+        run_local_image_turn_with_options(detail, ImageTurnMode::Default)
+            .await?
+            .input_images,
+    )
+}
+
+async fn run_local_image_turn_with_options(
+    detail: Option<ImageDetail>,
+    mode: ImageTurnMode,
+) -> Result<ImageTurnResult> {
+    run_image_turn_with_options(mode, move |codex_home, _server| {
+        let image_path = codex_home.join("image.png");
+        std::fs::write(&image_path, TINY_PNG_BYTES)?;
+        Ok(V2UserInput::LocalImage {
+            path: image_path,
+            detail,
+        })
+    })
+    .await
+}
+
+async fn run_url_image_turn_with_options(
+    detail: Option<ImageDetail>,
+    mode: ImageTurnMode,
+) -> Result<ImageTurnResult> {
+    run_image_turn_with_options(mode, move |_codex_home, server| {
+        Ok(V2UserInput::Image {
+            url: format!("{}/responses-lite-image.png", server.uri()),
+            detail,
+        })
+    })
+    .await
+}
+
+async fn run_image_turn_with_options(
+    mode: ImageTurnMode,
+    make_input: impl FnOnce(&Path, &wiremock::MockServer) -> Result<V2UserInput> + Send,
+) -> Result<ImageTurnResult> {
     // Two Codex turns hit the mock model (session start + turn/start).
     let responses = vec![
         create_final_assistant_message_sse_response("Done")?,
@@ -120,6 +171,18 @@ async fn run_local_image_turn(detail: Option<ImageDetail>) -> Result<Vec<Value>>
         "never",
         &BTreeMap::default(),
     )?;
+    if matches!(mode, ImageTurnMode::ResponsesLite) {
+        write_models_cache(codex_home.path())?;
+        let cache_path = codex_home.path().join("models_cache.json");
+        let mut cache: Value = serde_json::from_str(&std::fs::read_to_string(&cache_path)?)?;
+        let model = cache["models"]
+            .as_array_mut()
+            .and_then(|models| models.first_mut())
+            .context("models cache should contain a model")?;
+        model["slug"] = Value::String("mock-model".to_string());
+        model["use_responses_lite"] = Value::Bool(true);
+        std::fs::write(cache_path, serde_json::to_string_pretty(&cache)?)?;
+    }
 
     let mut mcp = TestAppServer::new(codex_home.path()).await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
@@ -137,17 +200,11 @@ async fn run_local_image_turn(detail: Option<ImageDetail>) -> Result<Vec<Value>>
     .await??;
     let ThreadStartResponse { thread, .. } = to_response::<ThreadStartResponse>(thread_resp)?;
 
-    let image_path = codex_home.path().join("image.png");
-    std::fs::write(&image_path, TINY_PNG_BYTES)?;
-
     let turn_req = mcp
         .send_turn_start_request(TurnStartParams {
             thread_id: thread.id.clone(),
             client_user_message_id: None,
-            input: vec![V2UserInput::LocalImage {
-                path: image_path,
-                detail,
-            }],
+            input: vec![make_input(codex_home.path(), &server)?],
             ..Default::default()
         })
         .await?;
@@ -159,21 +216,35 @@ async fn run_local_image_turn(detail: Option<ImageDetail>) -> Result<Vec<Value>>
     let TurnStartResponse { turn } = to_response::<TurnStartResponse>(turn_resp)?;
     assert!(!turn.id.is_empty());
 
-    timeout(
+    let completed_notif: JSONRPCNotification = timeout(
         DEFAULT_READ_TIMEOUT,
         mcp.read_stream_until_notification_message("turn/completed"),
     )
     .await??;
+    let completed = serde_json::from_value(
+        completed_notif
+            .params
+            .context("turn/completed params must be present")?,
+    )?;
 
-    received_response_input_images(&server).await
+    let response_request_bodies = received_response_request_bodies(&server).await?;
+    let input_images = response_request_bodies
+        .iter()
+        .flat_map(input_images_from_response_request)
+        .collect();
+    Ok(ImageTurnResult {
+        input_images,
+        response_request_bodies,
+        completed,
+    })
 }
 
-async fn received_response_input_images(server: &wiremock::MockServer) -> Result<Vec<Value>> {
+async fn received_response_request_bodies(server: &wiremock::MockServer) -> Result<Vec<Value>> {
     let requests = server
         .received_requests()
         .await
         .context("failed to fetch received requests")?;
-    let mut input_images = Vec::new();
+    let mut response_request_bodies = Vec::new();
 
     for request in requests {
         if !request.url.path().ends_with("/responses") {
@@ -182,27 +253,28 @@ async fn received_response_input_images(server: &wiremock::MockServer) -> Result
         let body = request
             .body_json::<Value>()
             .context("request body should be JSON")?;
-        let Some(input) = body.get("input").and_then(Value::as_array) else {
-            continue;
-        };
-
-        for item in input {
-            if item.get("type").and_then(Value::as_str) != Some("message") {
-                continue;
-            }
-            let Some(content) = item.get("content").and_then(Value::as_array) else {
-                continue;
-            };
-            input_images.extend(
-                content
-                    .iter()
-                    .filter(|span| span.get("type").and_then(Value::as_str) == Some("input_image"))
-                    .cloned(),
-            );
-        }
+        response_request_bodies.push(body);
     }
 
-    Ok(input_images)
+    Ok(response_request_bodies)
+}
+
+fn input_images_from_response_request(body: &Value) -> Vec<Value> {
+    let Some(input) = body.get("input").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+
+    input
+        .iter()
+        .filter(|item| item.get("type").and_then(Value::as_str) == Some("message"))
+        .filter_map(|item| item.get("content").and_then(Value::as_array))
+        .flat_map(|content| {
+            content
+                .iter()
+                .filter(|span| span.get("type").and_then(Value::as_str) == Some("input_image"))
+                .cloned()
+        })
+        .collect()
 }
 
 #[tokio::test]
@@ -1954,6 +2026,75 @@ async fn turn_start_forwards_custom_local_image_detail() -> Result<()> {
     assert_eq!(input_images.len(), 1);
     assert_eq!(
         input_images[0].get("detail").and_then(Value::as_str),
+        Some("original")
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn turn_start_responses_lite_prepares_local_image() -> Result<()> {
+    let result =
+        run_local_image_turn_with_options(Some(ImageDetail::High), ImageTurnMode::ResponsesLite)
+            .await?;
+
+    assert_eq!(result.input_images.len(), 1);
+    assert!(
+        result.input_images[0]
+            .get("image_url")
+            .and_then(Value::as_str)
+            .is_some_and(|image_url| image_url.starts_with("data:image/png;base64,"))
+    );
+    assert_eq!(result.input_images[0].get("detail"), None);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn turn_start_responses_lite_replaces_http_image_url() -> Result<()> {
+    let result =
+        run_url_image_turn_with_options(Some(ImageDetail::High), ImageTurnMode::ResponsesLite)
+            .await?;
+
+    assert_eq!(result.completed.turn.status, TurnStatus::Completed);
+    assert!(result.completed.turn.error.is_none());
+    assert!(result.input_images.is_empty());
+    assert!(
+        result
+            .response_request_bodies
+            .iter()
+            .all(|body| !body.to_string().contains("/responses-lite-image.png")),
+        "HTTP image URL should not be forwarded to /responses: {:?}",
+        result.response_request_bodies
+    );
+    assert!(
+        result.response_request_bodies.iter().any(|body| body
+            .to_string()
+            .contains("image content omitted because it could not be processed")),
+        "expected image placeholder in /responses request: {:?}",
+        result.response_request_bodies
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn turn_start_non_responses_lite_forwards_http_image_url_and_detail() -> Result<()> {
+    let result =
+        run_url_image_turn_with_options(Some(ImageDetail::Original), ImageTurnMode::Default)
+            .await?;
+
+    assert_eq!(result.input_images.len(), 1);
+    let image_url = result.input_images[0]
+        .get("image_url")
+        .and_then(Value::as_str)
+        .context("input image should have image_url")?;
+    assert!(
+        image_url.ends_with("/responses-lite-image.png") && !image_url.starts_with("data:"),
+        "expected forwarded remote URL, got {image_url}"
+    );
+    assert_eq!(
+        result.input_images[0].get("detail").and_then(Value::as_str),
         Some("original")
     );
 

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -762,7 +762,10 @@ impl ModelClient {
         service_tier: Option<String>,
     ) -> Result<ResponsesApiRequest> {
         let instructions = &prompt.base_instructions.text;
-        let input = prompt.get_formatted_input();
+        let mut input = prompt.get_formatted_input();
+        if model_info.use_responses_lite {
+            crate::responses_lite_images::prepare_response_items_for_responses_lite(&mut input);
+        }
         let tools = create_tools_json_for_responses_api(&prompt.tools)?;
         let reasoning = Self::build_reasoning(model_info, effort, summary);
         let include = if reasoning.is_some() {

--- a/codex-rs/core/src/client_tests.rs
+++ b/codex-rs/core/src/client_tests.rs
@@ -10,6 +10,7 @@ use super::X_OPENAI_SUBAGENT_HEADER;
 use crate::AttestationContext;
 use crate::AttestationProvider;
 use crate::GenerateAttestationFuture;
+use crate::client_common::Prompt;
 use codex_api::ApiError;
 use codex_api::ResponseEvent;
 use codex_app_server_protocol::AuthMode;
@@ -23,6 +24,7 @@ use codex_model_provider_info::create_oss_provider_with_base_url;
 use codex_otel::SessionTelemetry;
 use codex_protocol::SessionId;
 use codex_protocol::ThreadId;
+use codex_protocol::config_types::ReasoningSummary as ReasoningSummaryConfig;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::openai_models::ModelInfo;
@@ -322,6 +324,70 @@ fn build_ws_client_metadata_includes_window_lineage_and_turn_metadata() {
                 r#"{"turn_id":"turn-123"}"#.to_string(),
             ),
         ])
+    );
+}
+
+#[tokio::test]
+async fn build_responses_request_replaces_invalid_historical_image_for_responses_lite() {
+    let client = test_model_client(SessionSource::Cli);
+    let provider = client
+        .state
+        .provider
+        .api_provider()
+        .await
+        .expect("resolve API provider");
+    let prompt = Prompt {
+        input: vec![ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![
+                ContentItem::InputText {
+                    text: "before".to_string(),
+                },
+                ContentItem::InputImage {
+                    image_url: "https://example.com/historical.png".to_string(),
+                    detail: None,
+                },
+                ContentItem::InputText {
+                    text: "after".to_string(),
+                },
+            ],
+            phase: None,
+        }],
+        ..Prompt::default()
+    };
+
+    let mut model_info = test_model_info();
+    model_info.use_responses_lite = true;
+    let request = client
+        .build_responses_request(
+            &provider,
+            &prompt,
+            &model_info,
+            /*effort*/ None,
+            ReasoningSummaryConfig::None,
+            /*service_tier*/ None,
+        )
+        .expect("build Responses Lite request");
+
+    assert_eq!(
+        request.input,
+        vec![ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![
+                ContentItem::InputText {
+                    text: "before".to_string(),
+                },
+                ContentItem::InputText {
+                    text: "image content omitted because it could not be processed".to_string(),
+                },
+                ContentItem::InputText {
+                    text: "after".to_string(),
+                },
+            ],
+            phase: None,
+        }]
     );
 }
 

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -28,7 +28,6 @@ use codex_protocol::error::Result as CodexResult;
 use codex_protocol::items::ContextCompactionItem;
 use codex_protocol::items::TurnItem;
 use codex_protocol::models::ContentItem;
-use codex_protocol::models::ResponseInputItem;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::CompactedItem;
 use codex_protocol::protocol::EventMsg;
@@ -201,11 +200,15 @@ async fn run_compact_task_inner_impl(
     let compaction_item = TurnItem::ContextCompaction(ContextCompactionItem::new());
     sess.emit_turn_item_started(&turn_context, &compaction_item)
         .await;
-    let initial_input_for_turn: ResponseInputItem = ResponseInputItem::from(input);
+    let initial_response_item = sess.response_item_from_user_input(turn_context.as_ref(), input);
+    let prepared_initial_response_item = sess.prepare_conversation_items_for_history(
+        turn_context.as_ref(),
+        std::slice::from_ref(&initial_response_item),
+    );
 
     let mut history = sess.clone_history().await;
     history.record_items(
-        &[initial_input_for_turn.into()],
+        prepared_initial_response_item.as_ref(),
         turn_context.truncation_policy,
     );
 

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -3,8 +3,6 @@ use crate::event_mapping::has_non_contextual_dev_message_content;
 use crate::event_mapping::is_contextual_dev_message_content;
 use crate::event_mapping::is_contextual_user_message_content;
 use crate::session::turn_context::TurnContext;
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use codex_protocol::models::BaseInstructions;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::FunctionCallOutputBody;
@@ -19,6 +17,11 @@ use codex_protocol::protocol::TokenUsageInfo;
 use codex_protocol::protocol::TurnContextItem;
 use codex_utils_cache::BlockingLruCache;
 use codex_utils_cache::sha1_digest;
+use codex_utils_image::ORIGINAL_DETAIL_MAX_PATCHES;
+use codex_utils_image::PromptImageMode;
+use codex_utils_image::image_dimensions_from_base64_payload;
+use codex_utils_image::prompt_image_output_dimensions;
+use codex_utils_image::prompt_image_patch_count;
 use codex_utils_output_truncation::TruncationPolicy;
 use codex_utils_output_truncation::approx_bytes_for_tokens;
 use codex_utils_output_truncation::approx_token_count;
@@ -487,13 +490,12 @@ fn estimate_item_token_count(item: &ResponseItem) -> i64 {
 /// with ceiling division, so 7,373 bytes maps to approximately 1,844 tokens.
 const RESIZED_IMAGE_BYTES_ESTIMATE: i64 = 7373;
 // See https://platform.openai.com/docs/guides/images-vision#calculating-costs.
-// Use a direct 32px patch count only for `detail: "original"`;
-// all other image inputs continue to use `RESIZED_IMAGE_BYTES_ESTIMATE`.
-const ORIGINAL_IMAGE_PATCH_SIZE: u32 = 32;
+// GPT-5.5 sizes omitted, auto, and original image details with the original-detail budget.
+// Other image inputs continue to use `RESIZED_IMAGE_BYTES_ESTIMATE`.
 // See https://platform.openai.com/docs/guides/images-vision#model-sizing-behavior.
 // Keep this hard-coded for now; move it into model capabilities if the patch
 // budget starts changing often across model releases.
-const ORIGINAL_IMAGE_MAX_PATCHES: usize = 10_000;
+const ORIGINAL_IMAGE_MAX_PATCHES: usize = ORIGINAL_DETAIL_MAX_PATCHES;
 const ORIGINAL_IMAGE_ESTIMATE_CACHE_SIZE: usize = 32;
 
 static ORIGINAL_IMAGE_ESTIMATE_CACHE: LazyLock<BlockingLruCache<[u8; 20], Option<i64>>> =
@@ -579,27 +581,24 @@ fn estimate_original_image_bytes(image_url: &str) -> Option<i64> {
                 return None;
             }
         };
-        let bytes = match BASE64_STANDARD.decode(payload) {
-            Ok(bytes) => bytes,
+        let (width, height) = match image_dimensions_from_base64_payload(payload) {
+            Ok(dimensions) => dimensions,
             Err(error) => {
-                tracing::trace!("failed to decode original-detail image payload: {error}");
+                tracing::trace!("failed to read original-detail image dimensions: {error}");
                 return None;
             }
         };
-        let dynamic = match image::load_from_memory(&bytes) {
-            Ok(dynamic) => dynamic,
-            Err(error) => {
-                tracing::trace!("failed to decode original-detail image bytes: {error}");
-                return None;
-            }
-        };
-        let width = i64::from(dynamic.width());
-        let height = i64::from(dynamic.height());
-        let patch_size = i64::from(ORIGINAL_IMAGE_PATCH_SIZE);
-        let patches_wide = width.saturating_add(patch_size.saturating_sub(1)) / patch_size;
-        let patches_high = height.saturating_add(patch_size.saturating_sub(1)) / patch_size;
-        let patch_count = patches_wide.saturating_mul(patches_high);
-        let patch_count = usize::try_from(patch_count).unwrap_or(usize::MAX);
+        // This is token accounting, not client-side image preparation. We
+        // intentionally use `ResponsesLiteOriginal` here even for the legacy
+        // non-Responses-Lite path: legacy accounting already capped
+        // original-detail images at 10K patches, so this preserves the
+        // effective behavior of the previous logic while also modeling the
+        // 6000px maximum dimension that production Responses applies before
+        // counting patches. This does not resize or otherwise modify the image
+        // in history.
+        let (width, height) =
+            prompt_image_output_dimensions(width, height, PromptImageMode::ResponsesLiteOriginal);
+        let patch_count = prompt_image_patch_count(width, height);
         let patch_count = patch_count.min(ORIGINAL_IMAGE_MAX_PATCHES);
         Some(i64::try_from(approx_bytes_for_tokens(patch_count)).unwrap_or(i64::MAX))
     })
@@ -618,7 +617,7 @@ fn image_data_url_estimate_adjustment(item: &ResponseItem) -> (i64, i64) {
             payload_bytes =
                 payload_bytes.saturating_add(i64::try_from(payload_len).unwrap_or(i64::MAX));
             replacement_bytes = replacement_bytes.saturating_add(match detail {
-                Some(ImageDetail::Original) => {
+                None | Some(ImageDetail::Auto | ImageDetail::Original) => {
                     estimate_original_image_bytes(image_url).unwrap_or(RESIZED_IMAGE_BYTES_ESTIMATE)
                 }
                 _ => RESIZED_IMAGE_BYTES_ESTIMATE,

--- a/codex-rs/core/src/context_manager/history_tests.rs
+++ b/codex-rs/core/src/context_manager/history_tests.rs
@@ -1847,7 +1847,7 @@ fn multiple_inline_images_apply_multiple_fixed_costs() {
 }
 
 #[test]
-fn original_detail_images_scale_with_dimensions() {
+fn original_sized_image_details_scale_with_dimensions() {
     // 2304x864 at 32px patches yields 72 * 27 = 1,944 patches.
     // The byte heuristic uses 4 bytes per token, so the replacement cost is 7,776 bytes.
     const EXPECTED_ORIGINAL_DETAIL_IMAGE_BYTES: i64 = 7_776;
@@ -1861,21 +1861,28 @@ fn original_detail_images_scale_with_dimensions() {
         .expect("encode png");
     let payload = BASE64_STANDARD.encode(bytes.get_ref());
     let image_url = format!("data:image/png;base64,{payload}");
-    let item = ResponseItem::FunctionCallOutput {
-        call_id: "call-original".to_string(),
-        output: FunctionCallOutputPayload::from_content_items(vec![
-            FunctionCallOutputContentItem::InputImage {
-                image_url,
-                detail: Some(ImageDetail::Original),
-            },
-        ]),
-    };
 
-    let raw_len = serde_json::to_string(&item).unwrap().len() as i64;
-    let estimated = estimate_response_item_model_visible_bytes(&item);
-    let expected = raw_len - payload.len() as i64 + EXPECTED_ORIGINAL_DETAIL_IMAGE_BYTES;
+    for (detail, name) in [
+        (None, "missing"),
+        (Some(ImageDetail::Auto), "auto"),
+        (Some(ImageDetail::Original), "original"),
+    ] {
+        let item = ResponseItem::FunctionCallOutput {
+            call_id: format!("call-{name}"),
+            output: FunctionCallOutputPayload::from_content_items(vec![
+                FunctionCallOutputContentItem::InputImage {
+                    image_url: image_url.clone(),
+                    detail,
+                },
+            ]),
+        };
 
-    assert_eq!(estimated, expected);
+        let raw_len = serde_json::to_string(&item).unwrap().len() as i64;
+        let estimated = estimate_response_item_model_visible_bytes(&item);
+        let expected = raw_len - payload.len() as i64 + EXPECTED_ORIGINAL_DETAIL_IMAGE_BYTES;
+
+        assert_eq!(estimated, expected);
+    }
 }
 
 #[test]
@@ -1906,6 +1913,37 @@ fn original_detail_images_are_capped_at_max_patch_count() {
     let capped_original_detail_image_bytes =
         i64::try_from(approx_bytes_for_tokens(ORIGINAL_IMAGE_MAX_PATCHES)).unwrap();
     let expected = raw_len - payload.len() as i64 + capped_original_detail_image_bytes;
+
+    assert_eq!(estimated, expected);
+}
+
+#[test]
+fn original_detail_images_apply_max_dimension_before_patch_count() {
+    // 6401x100 first scales to 6000x94. At 32px patches that is 188 * 3 = 564.
+    const EXPECTED_MAX_DIMENSION_IMAGE_BYTES: i64 = 2_256;
+
+    let width = 6401;
+    let height = 100;
+    let image = ImageBuffer::from_pixel(width, height, Rgba([12u8, 34, 56, 255]));
+    let mut bytes = std::io::Cursor::new(Vec::new());
+    image
+        .write_to(&mut bytes, ImageFormat::Png)
+        .expect("encode png");
+    let payload = BASE64_STANDARD.encode(bytes.get_ref());
+    let image_url = format!("data:image/png;base64,{payload}");
+    let item = ResponseItem::FunctionCallOutput {
+        call_id: "call-original-max-dimension".to_string(),
+        output: FunctionCallOutputPayload::from_content_items(vec![
+            FunctionCallOutputContentItem::InputImage {
+                image_url,
+                detail: Some(ImageDetail::Original),
+            },
+        ]),
+    };
+
+    let raw_len = serde_json::to_string(&item).unwrap().len() as i64;
+    let estimated = estimate_response_item_model_visible_bytes(&item);
+    let expected = raw_len - payload.len() as i64 + EXPECTED_MAX_DIMENSION_IMAGE_BYTES;
 
     assert_eq!(estimated, expected);
 }

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -12,6 +12,7 @@ mod client_common;
 mod realtime_context;
 mod realtime_conversation;
 mod realtime_prompt;
+mod responses_lite_images;
 mod responses_retry;
 pub(crate) mod session;
 pub use session::SteerInputError;

--- a/codex-rs/core/src/prompt_debug.rs
+++ b/codex-rs/core/src/prompt_debug.rs
@@ -5,7 +5,6 @@ use codex_exec_server::ExecServerRuntimePaths;
 use codex_login::AuthManager;
 use codex_protocol::error::CodexErr;
 use codex_protocol::error::Result as CodexResult;
-use codex_protocol::models::ResponseInputItem;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::user_input::UserInput;
@@ -78,8 +77,7 @@ pub(crate) async fn build_prompt_input_from_session(
         .await;
 
     if !input.is_empty() {
-        let input_item = ResponseInputItem::from(input);
-        let response_item = ResponseItem::from(input_item);
+        let response_item = sess.response_item_from_user_input(turn_context.as_ref(), input);
         sess.record_conversation_items(turn_context.as_ref(), std::slice::from_ref(&response_item))
             .await;
     }

--- a/codex-rs/core/src/responses_lite_images.rs
+++ b/codex-rs/core/src/responses_lite_images.rs
@@ -1,0 +1,106 @@
+use codex_protocol::models::ContentItem;
+use codex_protocol::models::FunctionCallOutputContentItem;
+use codex_protocol::models::ImageDetail;
+use codex_protocol::models::ResponseItem;
+use codex_utils_image::ImageProcessingError;
+use codex_utils_image::PromptImageMode;
+use codex_utils_image::load_data_url_for_prompt;
+use tracing::warn;
+
+const IMAGE_PROCESSING_ERROR_PLACEHOLDER: &str =
+    "image content omitted because it could not be processed";
+
+#[derive(Debug, thiserror::Error)]
+enum ResponsesLiteImagePreparationError {
+    #[error("Responses Lite image detail only supports `original`, `high`, or `auto`; got `low`")]
+    UnsupportedLowDetail,
+    #[error("Responses Lite failed to prepare image: {0}")]
+    ImageProcessing(#[from] ImageProcessingError),
+}
+
+pub(crate) fn prepare_response_items_for_responses_lite(items: &mut [ResponseItem]) {
+    for item in items {
+        prepare_response_item(item);
+    }
+}
+
+fn prepare_response_item(item: &mut ResponseItem) {
+    match item {
+        ResponseItem::Message { content, .. } => prepare_content_items(content),
+        ResponseItem::FunctionCallOutput { output, .. }
+        | ResponseItem::CustomToolCallOutput { output, .. } => {
+            if let Some(content_items) = output.content_items_mut() {
+                prepare_function_call_output_content_items(content_items);
+            }
+        }
+        ResponseItem::Reasoning { .. }
+        | ResponseItem::AgentMessage { .. }
+        | ResponseItem::LocalShellCall { .. }
+        | ResponseItem::FunctionCall { .. }
+        | ResponseItem::ToolSearchCall { .. }
+        | ResponseItem::CustomToolCall { .. }
+        | ResponseItem::ToolSearchOutput { .. }
+        | ResponseItem::WebSearchCall { .. }
+        | ResponseItem::ImageGenerationCall { .. }
+        | ResponseItem::Compaction { .. }
+        | ResponseItem::CompactionTrigger
+        | ResponseItem::ContextCompaction { .. }
+        | ResponseItem::Other => {}
+    }
+}
+
+fn prepare_content_items(items: &mut [ContentItem]) {
+    for item in items {
+        if let ContentItem::InputImage { image_url, detail } = item
+            && let Err(err) = prepare_image_url_for_responses_lite(image_url, detail)
+        {
+            warn!(error = %err, "failed to prepare Responses Lite message image");
+            *item = ContentItem::InputText {
+                text: IMAGE_PROCESSING_ERROR_PLACEHOLDER.to_string(),
+            };
+        }
+    }
+}
+
+fn prepare_function_call_output_content_items(items: &mut [FunctionCallOutputContentItem]) {
+    for item in items {
+        if let FunctionCallOutputContentItem::InputImage { image_url, detail } = item
+            && let Err(err) = prepare_image_url_for_responses_lite(image_url, detail)
+        {
+            warn!(error = %err, "failed to prepare Responses Lite tool output image");
+            *item = FunctionCallOutputContentItem::InputText {
+                text: IMAGE_PROCESSING_ERROR_PLACEHOLDER.to_string(),
+            };
+        }
+    }
+}
+
+fn prepare_image_url_for_responses_lite(
+    image_url: &mut String,
+    detail: &mut Option<ImageDetail>,
+) -> Result<(), ResponsesLiteImagePreparationError> {
+    // Local-image and view_image producers may have already prepared their data URLs.
+    // Keep this pass as the Responses Lite image contract; the shared image cache
+    // and preserve-within-bounds path avoid a second lossy encode for common formats.
+    let mode = prompt_image_mode_for_responses_lite_detail(*detail)?;
+    let image = load_data_url_for_prompt(image_url, mode)?;
+    *image_url = image.into_data_url();
+    *detail = None;
+    Ok(())
+}
+
+fn prompt_image_mode_for_responses_lite_detail(
+    detail: Option<ImageDetail>,
+) -> Result<PromptImageMode, ResponsesLiteImagePreparationError> {
+    match detail {
+        None | Some(ImageDetail::Auto | ImageDetail::Original) => {
+            Ok(PromptImageMode::ResponsesLiteOriginal)
+        }
+        Some(ImageDetail::High) => Ok(PromptImageMode::ResizeToFit),
+        Some(ImageDetail::Low) => Err(ResponsesLiteImagePreparationError::UnsupportedLowDetail),
+    }
+}
+
+#[cfg(test)]
+#[path = "responses_lite_images_tests.rs"]
+mod tests;

--- a/codex-rs/core/src/responses_lite_images_tests.rs
+++ b/codex-rs/core/src/responses_lite_images_tests.rs
@@ -1,0 +1,157 @@
+use super::*;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use codex_protocol::models::ContentItem;
+use codex_protocol::models::FunctionCallOutputPayload;
+use pretty_assertions::assert_eq;
+
+const TINY_PNG_BYTES: &[u8] = &[
+    137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 6, 0,
+    0, 0, 31, 21, 196, 137, 0, 0, 0, 11, 73, 68, 65, 84, 120, 156, 99, 96, 0, 2, 0, 0, 5, 0, 1,
+    122, 94, 171, 63, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+];
+
+fn tiny_png_data_url() -> String {
+    format!(
+        "data:image/png;base64,{}",
+        BASE64_STANDARD.encode(TINY_PNG_BYTES)
+    )
+}
+
+fn assert_message_image_is_replaced(image_url: String, detail: Option<ImageDetail>) {
+    let mut items = vec![ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputImage { image_url, detail }],
+        phase: None,
+    }];
+
+    prepare_response_items_for_responses_lite(&mut items);
+
+    assert_eq!(
+        items,
+        vec![ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: IMAGE_PROCESSING_ERROR_PLACEHOLDER.to_string(),
+            }],
+            phase: None,
+        }]
+    );
+}
+
+#[test]
+fn responses_lite_preparation_strips_detail_from_message_images() {
+    let mut items = vec![ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputImage {
+            image_url: tiny_png_data_url(),
+            detail: Some(ImageDetail::High),
+        }],
+        phase: None,
+    }];
+
+    prepare_response_items_for_responses_lite(&mut items);
+
+    let ResponseItem::Message { content, .. } = &items[0] else {
+        panic!("expected message item");
+    };
+    let [ContentItem::InputImage { image_url, detail }] = content.as_slice() else {
+        panic!("expected one input image");
+    };
+    assert!(image_url.starts_with("data:image/png;base64,"));
+    assert_eq!(*detail, None);
+}
+
+#[test]
+fn responses_lite_detail_modes_match_responses_defaults() {
+    assert_eq!(
+        prompt_image_mode_for_responses_lite_detail(/*detail*/ None)
+            .expect("missing detail should default to original"),
+        PromptImageMode::ResponsesLiteOriginal
+    );
+    assert_eq!(
+        prompt_image_mode_for_responses_lite_detail(Some(ImageDetail::Auto))
+            .expect("auto detail should use original"),
+        PromptImageMode::ResponsesLiteOriginal
+    );
+    assert_eq!(
+        prompt_image_mode_for_responses_lite_detail(Some(ImageDetail::High))
+            .expect("high detail should use high"),
+        PromptImageMode::ResizeToFit
+    );
+    assert_eq!(
+        prompt_image_mode_for_responses_lite_detail(Some(ImageDetail::Original))
+            .expect("original detail should use original"),
+        PromptImageMode::ResponsesLiteOriginal
+    );
+}
+
+#[test]
+fn responses_lite_preparation_replaces_only_failed_tool_images() {
+    let valid_image_url = tiny_png_data_url();
+    let mut items = vec![ResponseItem::FunctionCallOutput {
+        call_id: "call-1".to_string(),
+        output: FunctionCallOutputPayload {
+            body: codex_protocol::models::FunctionCallOutputBody::ContentItems(vec![
+                FunctionCallOutputContentItem::InputText {
+                    text: "before".to_string(),
+                },
+                FunctionCallOutputContentItem::InputImage {
+                    image_url: "https://example.com/image.png".to_string(),
+                    detail: Some(ImageDetail::Original),
+                },
+                FunctionCallOutputContentItem::InputImage {
+                    image_url: valid_image_url.clone(),
+                    detail: Some(ImageDetail::High),
+                },
+            ]),
+            success: Some(true),
+        },
+    }];
+
+    prepare_response_items_for_responses_lite(&mut items);
+
+    assert_eq!(
+        items,
+        vec![ResponseItem::FunctionCallOutput {
+            call_id: "call-1".to_string(),
+            output: FunctionCallOutputPayload {
+                body: codex_protocol::models::FunctionCallOutputBody::ContentItems(vec![
+                    FunctionCallOutputContentItem::InputText {
+                        text: "before".to_string(),
+                    },
+                    FunctionCallOutputContentItem::InputText {
+                        text: IMAGE_PROCESSING_ERROR_PLACEHOLDER.to_string(),
+                    },
+                    FunctionCallOutputContentItem::InputImage {
+                        image_url: valid_image_url,
+                        detail: None,
+                    },
+                ]),
+                success: Some(true),
+            },
+        }]
+    );
+}
+
+#[test]
+fn responses_lite_preparation_replaces_low_detail_images() {
+    assert_message_image_is_replaced(tiny_png_data_url(), Some(ImageDetail::Low));
+}
+
+#[test]
+fn responses_lite_preparation_replaces_invalid_data_urls() {
+    for image_url in [
+        "data:image/png;base64,%%%".to_string(),
+        format!(
+            "data:image/png;base64,{}",
+            BASE64_STANDARD.encode("not an image")
+        ),
+    ] {
+        assert_message_image_is_replaced(image_url, Some(ImageDetail::High));
+    }
+}

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -327,6 +328,7 @@ use codex_protocol::config_types::ReasoningSummary as ReasoningSummaryConfig;
 use codex_protocol::config_types::WindowsSandboxLevel;
 use codex_protocol::models::ResponseInputItem;
 use codex_protocol::models::ResponseItem;
+use codex_protocol::models::response_input_item_from_user_input;
 use codex_protocol::openai_models::ReasoningEffort as ReasoningEffortConfig;
 use codex_protocol::protocol::ApplyPatchApprovalRequestEvent;
 use codex_protocol::protocol::AskForApproval;
@@ -2579,11 +2581,42 @@ impl Session {
 
     /// Records conversation items: append to history, persist to rollout, and
     /// notify clients observing raw response items.
+    pub(crate) fn prepare_conversation_items_for_history<'a>(
+        &self,
+        turn_context: &TurnContext,
+        items: &'a [ResponseItem],
+    ) -> Cow<'a, [ResponseItem]> {
+        if !turn_context.model_info.use_responses_lite {
+            return Cow::Borrowed(items);
+        }
+
+        let mut prepared_items = items.to_vec();
+        crate::responses_lite_images::prepare_response_items_for_responses_lite(
+            &mut prepared_items,
+        );
+        Cow::Owned(prepared_items)
+    }
+
+    pub(crate) fn response_item_from_user_input(
+        &self,
+        turn_context: &TurnContext,
+        input: Vec<UserInput>,
+    ) -> ResponseItem {
+        let input = if turn_context.model_info.use_responses_lite {
+            response_input_item_from_user_input(input, /*use_responses_lite*/ true)
+        } else {
+            ResponseInputItem::from(input)
+        };
+        ResponseItem::from(input)
+    }
+
     pub(crate) async fn record_conversation_items(
         &self,
         turn_context: &TurnContext,
         items: &[ResponseItem],
     ) {
+        let items = self.prepare_conversation_items_for_history(turn_context, items);
+        let items = items.as_ref();
         {
             let mut state = self.state.lock().await;
             state.record_items(items.iter(), turn_context.truncation_policy);
@@ -3197,7 +3230,7 @@ impl Session {
         // Persist the user message to history, but emit the turn item from `UserInput` so
         // UI-only `text_elements` are preserved. `ResponseItem::Message` does not carry
         // those spans, and `record_response_item_and_emit_turn_item` would drop them.
-        let response_item = ResponseItem::from(ResponseInputItem::from(input.to_vec()));
+        let response_item = self.response_item_from_user_input(turn_context, input.to_vec());
         self.record_conversation_items(turn_context, std::slice::from_ref(&response_item))
             .await;
         let mut user_message_item = UserMessageItem::new(input);

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -43,6 +43,7 @@ use codex_protocol::models::BUILT_IN_PERMISSION_PROFILE_WORKSPACE;
 use codex_protocol::models::FileSystemPermissions;
 use codex_protocol::models::FunctionCallOutputBody;
 use codex_protocol::models::FunctionCallOutputPayload;
+use codex_protocol::models::ImageDetail;
 use codex_protocol::models::PermissionProfile;
 use codex_protocol::models::SandboxEnforcement;
 use codex_protocol::openai_models::ModelServiceTier;
@@ -1879,6 +1880,68 @@ async fn recompute_token_usage_uses_session_base_instructions() {
         .last_token_usage
         .total_tokens;
     assert_eq!(actual_tokens, expected_tokens.max(0));
+}
+
+#[tokio::test]
+async fn record_conversation_items_replaces_failed_responses_lite_image_before_history_insertion() {
+    let (session, turn_context, _rx) = make_session_and_context_with_auth_and_config_and_rx(
+        CodexAuth::from_api_key("Test API Key"),
+        Vec::new(),
+        |config| {
+            let model = get_model_offline_for_tests(config.model.as_deref());
+            let mut model_catalog = bundled_models_response()
+                .unwrap_or_else(|err| panic!("bundled models.json should parse: {err}"));
+            model_catalog
+                .models
+                .iter_mut()
+                .find(|model_info| model_info.slug == model)
+                .unwrap_or_else(|| panic!("{model} should exist in the bundled model catalog"))
+                .use_responses_lite = true;
+            config.model_catalog = Some(model_catalog);
+        },
+    )
+    .await;
+    let item = ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![
+            ContentItem::InputText {
+                text: "before".to_string(),
+            },
+            ContentItem::InputImage {
+                image_url: "data:image/png;base64,%%%".to_string(),
+                detail: Some(ImageDetail::High),
+            },
+            ContentItem::InputText {
+                text: "after".to_string(),
+            },
+        ],
+        phase: None,
+    };
+
+    session
+        .record_conversation_items(turn_context.as_ref(), std::slice::from_ref(&item))
+        .await;
+
+    assert_eq!(
+        session.clone_history().await.raw_items(),
+        &[ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![
+                ContentItem::InputText {
+                    text: "before".to_string(),
+                },
+                ContentItem::InputText {
+                    text: "image content omitted because it could not be processed".to_string(),
+                },
+                ContentItem::InputText {
+                    text: "after".to_string(),
+                },
+            ],
+            phase: None,
+        }]
+    );
 }
 
 #[tokio::test]

--- a/codex-rs/core/tests/suite/code_mode.rs
+++ b/codex-rs/core/tests/suite/code_mode.rs
@@ -57,6 +57,8 @@ use wiremock::ResponseTemplate;
 use wiremock::matchers::method;
 use wiremock::matchers::path;
 
+const TINY_PNG_BASE64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg==";
+
 fn custom_tool_output_items(req: &ResponsesRequest, call_id: &str) -> Vec<Value> {
     match req.custom_tool_call_output(call_id).get("output") {
         Some(Value::Array(items)) => items.clone(),
@@ -175,7 +177,31 @@ async fn run_code_mode_turn_with_config(
             configure(config);
         });
     let test = builder.build(server).await?;
+    run_code_mode_turn_with_test(server, prompt, code, test).await
+}
 
+async fn run_code_mode_turn_with_responses_lite(
+    server: &MockServer,
+    prompt: &str,
+    code: &str,
+) -> Result<(TestCodex, ResponseMock)> {
+    let mut builder = test_codex()
+        .with_model_info_override("gpt-5.4", |model_info| {
+            model_info.use_responses_lite = true;
+        })
+        .with_config(|config| {
+            let _ = config.features.enable(Feature::CodeMode);
+        });
+    let test = builder.build(server).await?;
+    run_code_mode_turn_with_test(server, prompt, code, test).await
+}
+
+async fn run_code_mode_turn_with_test(
+    server: &MockServer,
+    prompt: &str,
+    code: &str,
+    test: TestCodex,
+) -> Result<(TestCodex, ResponseMock)> {
     responses::mount_sse_once(
         server,
         sse(vec![
@@ -2537,6 +2563,73 @@ image("data:image/png;base64,AAA");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn code_mode_responses_lite_prepares_global_helper_image_output() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = responses::start_mock_server().await;
+    let (_test, second_mock) = run_code_mode_turn_with_responses_lite(
+        &server,
+        "use exec to return a Responses Lite image",
+        &format!(
+            r#"
+image("data:image/png;base64,{TINY_PNG_BASE64}", "high");
+"#
+        ),
+    )
+    .await?;
+
+    let req = second_mock.single_request();
+    let items = custom_tool_output_items(&req, "call-1");
+    let (_, success) = custom_tool_output_body_and_success(&req, "call-1");
+    assert_ne!(
+        success,
+        Some(false),
+        "code_mode image output failed unexpectedly"
+    );
+    assert_eq!(items.len(), 2);
+    assert_eq!(
+        items[1].get("type").and_then(Value::as_str),
+        Some("input_image")
+    );
+    assert!(
+        items[1]
+            .get("image_url")
+            .and_then(Value::as_str)
+            .is_some_and(|image_url| image_url.starts_with("data:image/png;base64,"))
+    );
+    assert_eq!(items[1].get("detail"), None);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn code_mode_responses_lite_replaces_invalid_image_output() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = responses::start_mock_server().await;
+    let (_test, second_mock) = run_code_mode_turn_with_responses_lite(
+        &server,
+        "use exec to return an invalid Responses Lite image",
+        r#"
+image("data:image/png;base64,AAA", "high");
+"#,
+    )
+    .await?;
+
+    let req = second_mock.single_request();
+    let items = custom_tool_output_items(&req, "call-1");
+    let (_, success) = custom_tool_output_body_and_success(&req, "call-1");
+    assert_ne!(success, Some(false));
+    assert_eq!(items.len(), 2);
+    assert_eq!(
+        text_item(&items, /*index*/ 1),
+        "image content omitted because it could not be processed"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn code_mode_can_use_view_image_result_with_image_helper() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
@@ -2548,9 +2641,7 @@ async fn code_mode_can_use_view_image_result_with_image_helper() -> Result<()> {
         });
     let test = builder.build(&server).await?;
 
-    let image_bytes = BASE64_STANDARD.decode(
-        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/iZk9HQAAAABJRU5ErkJggg==",
-    )?;
+    let image_bytes = BASE64_STANDARD.decode(TINY_PNG_BASE64)?;
     let image_path = test.cwd_path().join("code_mode_view_image.png");
     fs::write(&image_path, image_bytes)?;
 

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -1087,6 +1087,22 @@ pub fn local_image_content_items_with_label_number(
         ImageDetail::Auto | ImageDetail::Low | ImageDetail::High => PromptImageMode::ResizeToFit,
     };
 
+    local_image_content_items_with_label_number_and_mode(
+        path,
+        file_bytes,
+        label_number,
+        Some(detail),
+        mode,
+    )
+}
+
+fn local_image_content_items_with_label_number_and_mode(
+    path: &std::path::Path,
+    file_bytes: Vec<u8>,
+    label_number: Option<usize>,
+    detail: Option<ImageDetail>,
+    mode: PromptImageMode,
+) -> Vec<ContentItem> {
     match load_for_prompt_bytes(path, file_bytes, mode) {
         Ok(image) => {
             let mut items = Vec::with_capacity(3);
@@ -1097,7 +1113,7 @@ pub fn local_image_content_items_with_label_number(
             }
             items.push(ContentItem::InputImage {
                 image_url: image.into_data_url(),
-                detail: Some(detail),
+                detail,
             });
             if label_number.is_some() {
                 items.push(ContentItem::InputText {
@@ -1119,7 +1135,72 @@ pub fn local_image_content_items_with_label_number(
             ImageProcessingError::UnsupportedImageFormat { mime } => {
                 vec![unsupported_image_error_placeholder(path, mime)]
             }
+            ImageProcessingError::InvalidDataUrl { .. } => {
+                vec![local_image_error_placeholder(path, &err)]
+            }
+            ImageProcessingError::ImageTooLarge { .. } => {
+                vec![local_image_error_placeholder(path, &err)]
+            }
         },
+    }
+}
+
+pub fn response_input_item_from_user_input(
+    items: Vec<UserInput>,
+    use_responses_lite: bool,
+) -> ResponseInputItem {
+    let mut image_index = 0;
+    ResponseInputItem::Message {
+        role: "user".to_string(),
+        content: items
+            .into_iter()
+            .flat_map(|c| match c {
+                UserInput::Text { text, .. } => vec![ContentItem::InputText { text }],
+                UserInput::Image {
+                    image_url, detail, ..
+                } => {
+                    image_index += 1;
+                    vec![ContentItem::InputImage {
+                        image_url,
+                        detail: if use_responses_lite {
+                            detail
+                        } else {
+                            Some(detail.unwrap_or(DEFAULT_IMAGE_DETAIL))
+                        },
+                    }]
+                }
+                UserInput::LocalImage { path, detail, .. } => {
+                    image_index += 1;
+                    let mode = if use_responses_lite {
+                        // The centralized Responses Lite pass owns detail-specific resizing.
+                        PromptImageMode::Original
+                    } else {
+                        match detail.unwrap_or(DEFAULT_IMAGE_DETAIL) {
+                            ImageDetail::Original => PromptImageMode::Original,
+                            ImageDetail::Auto | ImageDetail::Low | ImageDetail::High => {
+                                PromptImageMode::ResizeToFit
+                            }
+                        }
+                    };
+                    match std::fs::read(&path) {
+                        Ok(file_bytes) => local_image_content_items_with_label_number_and_mode(
+                            &path,
+                            file_bytes,
+                            Some(image_index),
+                            if use_responses_lite {
+                                detail
+                            } else {
+                                Some(detail.unwrap_or(DEFAULT_IMAGE_DETAIL))
+                            },
+                            mode,
+                        ),
+                        Err(err) => vec![local_image_error_placeholder(&path, err)],
+                    }
+                }
+                UserInput::Skill { .. } | UserInput::Mention { .. } => Vec::new(), // Tool bodies are injected later in core
+            })
+            .collect::<Vec<ContentItem>>(),
+        phase: None,
     }
 }
 
@@ -1235,41 +1316,7 @@ pub enum ReasoningItemContent {
 
 impl From<Vec<UserInput>> for ResponseInputItem {
     fn from(items: Vec<UserInput>) -> Self {
-        let mut image_index = 0;
-        Self::Message {
-            role: "user".to_string(),
-            content: items
-                .into_iter()
-                .flat_map(|c| match c {
-                    UserInput::Text { text, .. } => vec![ContentItem::InputText { text }],
-                    UserInput::Image {
-                        image_url, detail, ..
-                    } => {
-                        image_index += 1;
-                        let detail = detail.unwrap_or(DEFAULT_IMAGE_DETAIL);
-                        vec![ContentItem::InputImage {
-                            image_url,
-                            detail: Some(detail),
-                        }]
-                    }
-                    UserInput::LocalImage { path, detail, .. } => {
-                        image_index += 1;
-                        let detail = detail.unwrap_or(DEFAULT_IMAGE_DETAIL);
-                        match std::fs::read(&path) {
-                            Ok(file_bytes) => local_image_content_items_with_label_number(
-                                &path,
-                                file_bytes,
-                                Some(image_index),
-                                detail,
-                            ),
-                            Err(err) => vec![local_image_error_placeholder(&path, err)],
-                        }
-                    }
-                    UserInput::Skill { .. } | UserInput::Mention { .. } => Vec::new(), // Tool bodies are injected later in core
-                })
-                .collect::<Vec<ContentItem>>(),
-            phase: None,
-        }
+        response_input_item_from_user_input(items, /*use_responses_lite*/ false)
     }
 }
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]

--- a/codex-rs/utils/image/src/error.rs
+++ b/codex-rs/utils/image/src/error.rs
@@ -25,6 +25,14 @@ pub enum ImageProcessingError {
     },
     #[error("unsupported image `{mime}`")]
     UnsupportedImageFormat { mime: String },
+    #[error("invalid image data URL: {reason}")]
+    InvalidDataUrl { reason: String },
+    #[error("image {representation} is too large ({size} bytes; max {max} bytes)")]
+    ImageTooLarge {
+        representation: &'static str,
+        size: usize,
+        max: usize,
+    },
 }
 
 impl ImageProcessingError {

--- a/codex-rs/utils/image/src/image_tests.rs
+++ b/codex-rs/utils/image/src/image_tests.rs
@@ -1,0 +1,418 @@
+use std::io::Cursor;
+
+use super::*;
+use image::GenericImageView;
+use image::ImageBuffer;
+use image::ImageDecoder;
+use image::Rgba;
+use image::metadata::Orientation;
+
+const TEST_ICC_PROFILE: &[u8] = b"codex test icc profile";
+const ROTATE_90_EXIF: &[u8] = &[
+    0x49, 0x49, 0x2a, 0x00, 0x08, 0x00, 0x00, 0x00, 0x01, 0x00, 0x12, 0x01, 0x03, 0x00, 0x01, 0x00,
+    0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+];
+
+fn image_bytes(image: &ImageBuffer<Rgba<u8>, Vec<u8>>, format: ImageFormat) -> Vec<u8> {
+    let mut encoded = Cursor::new(Vec::new());
+    DynamicImage::ImageRgba8(image.clone())
+        .write_to(&mut encoded, format)
+        .expect("encode image to bytes");
+    encoded.into_inner()
+}
+
+fn image_bytes_with_metadata(
+    image: &ImageBuffer<Rgba<u8>, Vec<u8>>,
+    format: ImageFormat,
+) -> Vec<u8> {
+    let mut encoded = Vec::new();
+    match format {
+        ImageFormat::Png => {
+            let mut encoder = PngEncoder::new(&mut encoded);
+            encoder
+                .set_icc_profile(TEST_ICC_PROFILE.to_vec())
+                .expect("set PNG ICC profile");
+            encoder
+                .set_exif_metadata(ROTATE_90_EXIF.to_vec())
+                .expect("set PNG EXIF metadata");
+            encoder
+                .write_image(
+                    image.as_raw(),
+                    image.width(),
+                    image.height(),
+                    ColorType::Rgba8.into(),
+                )
+                .expect("encode PNG with metadata");
+        }
+        ImageFormat::Jpeg => {
+            let mut encoder = JpegEncoder::new_with_quality(&mut encoded, 90);
+            encoder
+                .set_icc_profile(TEST_ICC_PROFILE.to_vec())
+                .expect("set JPEG ICC profile");
+            encoder
+                .set_exif_metadata(ROTATE_90_EXIF.to_vec())
+                .expect("set JPEG EXIF metadata");
+            encoder
+                .encode_image(&DynamicImage::ImageRgba8(image.clone()))
+                .expect("encode JPEG with metadata");
+        }
+        ImageFormat::WebP => {
+            let mut encoder = WebPEncoder::new_lossless(&mut encoded);
+            encoder
+                .set_icc_profile(TEST_ICC_PROFILE.to_vec())
+                .expect("set WebP ICC profile");
+            encoder
+                .set_exif_metadata(ROTATE_90_EXIF.to_vec())
+                .expect("set WebP EXIF metadata");
+            encoder
+                .write_image(
+                    image.as_raw(),
+                    image.width(),
+                    image.height(),
+                    ColorType::Rgba8.into(),
+                )
+                .expect("encode WebP with metadata");
+        }
+        _ => panic!("unsupported test format"),
+    }
+    encoded
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn preserves_supported_source_bytes_when_within_bounds() {
+    for (format, mime) in [
+        (ImageFormat::Png, "image/png"),
+        (ImageFormat::WebP, "image/webp"),
+    ] {
+        let image = ImageBuffer::from_pixel(64, 32, Rgba([10u8, 20, 30, 255]));
+        let original_bytes = image_bytes(&image, format);
+
+        let encoded = load_for_prompt_bytes(
+            Path::new("in-memory-image"),
+            original_bytes.clone(),
+            PromptImageMode::ResizeToFit,
+        )
+        .expect("process image");
+
+        assert_eq!(encoded.width, 64);
+        assert_eq!(encoded.height, 32);
+        assert_eq!(encoded.mime, mime);
+        assert_eq!(encoded.bytes, original_bytes);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn downscales_large_image() {
+    for (format, mime) in [
+        (ImageFormat::Png, "image/png"),
+        (ImageFormat::WebP, "image/webp"),
+    ] {
+        let image = ImageBuffer::from_pixel(2050, 1025, Rgba([200u8, 10, 10, 255]));
+        let original_bytes = image_bytes(&image, format);
+
+        let processed = load_for_prompt_bytes(
+            Path::new("in-memory-image"),
+            original_bytes,
+            PromptImageMode::ResizeToFit,
+        )
+        .expect("process image");
+
+        assert!(processed.width <= MAX_DIMENSION);
+        assert!(processed.height <= MAX_DIMENSION);
+        assert_eq!(processed.mime, mime);
+
+        let detected_format =
+            image::guess_format(&processed.bytes).expect("detect resized output format");
+        assert_eq!(detected_format, format);
+
+        let loaded =
+            image::load_from_memory(&processed.bytes).expect("read resized bytes back into image");
+        assert_eq!(loaded.dimensions(), (processed.width, processed.height));
+        assert!(
+            prompt_image_patch_count(processed.width, processed.height) <= HIGH_DETAIL_MAX_PATCHES
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn applies_calculated_dimensions_exactly() {
+    let image = ImageBuffer::from_pixel(2050, 2, Rgba([200u8, 10, 10, 255]));
+    let original_bytes = image_bytes(&image, ImageFormat::Png);
+
+    let processed = load_for_prompt_bytes(
+        Path::new("in-memory-image"),
+        original_bytes,
+        PromptImageMode::ResizeToFit,
+    )
+    .expect("process image");
+
+    assert_eq!((processed.width, processed.height), (2048, 2));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn resizing_applies_orientation_and_preserves_supported_metadata() {
+    for format in [ImageFormat::Png, ImageFormat::Jpeg, ImageFormat::WebP] {
+        let image = ImageBuffer::from_pixel(2050, 2, Rgba([200u8, 10, 10, 255]));
+        let original_bytes = image_bytes_with_metadata(&image, format);
+
+        let processed = load_for_prompt_bytes(
+            Path::new("in-memory-image"),
+            original_bytes,
+            PromptImageMode::ResizeToFit,
+        )
+        .expect("process image");
+
+        assert_eq!((processed.width, processed.height), (2, 2048));
+
+        let mut decoder = ImageReader::with_format(Cursor::new(&processed.bytes), format)
+            .into_decoder()
+            .expect("create decoder");
+        assert_eq!(
+            (
+                decoder.dimensions(),
+                decoder.orientation().expect("read orientation"),
+                decoder.icc_profile().expect("read ICC profile"),
+                decoder.exif_metadata().expect("read EXIF metadata"),
+            ),
+            (
+                (2, 2048),
+                Orientation::NoTransforms,
+                Some(TEST_ICC_PROFILE.to_vec()),
+                Some({
+                    let mut exif = ROTATE_90_EXIF.to_vec();
+                    let _ = Orientation::remove_from_exif_chunk(&mut exif);
+                    exif
+                }),
+            )
+        );
+    }
+}
+
+#[test]
+fn prompt_image_output_dimensions_respect_high_detail_limits() {
+    assert_eq!(
+        prompt_image_output_dimensions(
+            /*width*/ 2048,
+            /*height*/ 1024,
+            PromptImageMode::ResizeToFit,
+        ),
+        (2048, 1024)
+    );
+    assert_eq!(
+        prompt_image_output_dimensions(
+            /*width*/ 4096,
+            /*height*/ 2048,
+            PromptImageMode::ResizeToFit,
+        ),
+        (2048, 1024)
+    );
+    assert_eq!(
+        prompt_image_output_dimensions(
+            /*width*/ 2048,
+            /*height*/ 2048,
+            PromptImageMode::ResizeToFit,
+        ),
+        (1600, 1600)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn load_data_url_for_prompt_accepts_case_insensitive_markers() {
+    let image = ImageBuffer::from_pixel(64, 32, Rgba([10u8, 20, 30, 255]));
+    let original_bytes = image_bytes(&image, ImageFormat::Png);
+    let image_url = EncodedImage {
+        bytes: original_bytes.clone(),
+        mime: "image/png".to_string(),
+        width: 64,
+        height: 32,
+    }
+    .into_data_url()
+    .replacen("data:", "DATA:", 1)
+    .replacen(";base64,", ";BASE64,", 1);
+
+    let processed = load_data_url_for_prompt(&image_url, PromptImageMode::Original)
+        .expect("process data URL image");
+
+    assert_eq!(processed.width, 64);
+    assert_eq!(processed.height, 32);
+    assert_eq!(processed.bytes, original_bytes);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn second_pass_preserves_prepared_jpeg_bytes_when_within_bounds() {
+    let image = ImageBuffer::from_pixel(1601, 1601, Rgba([200u8, 10, 10, 255]));
+    let original_bytes = image_bytes(&image, ImageFormat::Jpeg);
+
+    let first = load_for_prompt_bytes(
+        Path::new("in-memory-image"),
+        original_bytes,
+        PromptImageMode::ResizeToFit,
+    )
+    .expect("process image");
+
+    assert_eq!((first.width, first.height), (1600, 1600));
+    assert_eq!(first.mime, "image/jpeg");
+
+    let prepared_image_url = first.clone().into_data_url();
+    let second = load_data_url_for_prompt(&prepared_image_url, PromptImageMode::ResizeToFit)
+        .expect("process prepared data URL image");
+
+    assert_eq!(second.width, first.width);
+    assert_eq!(second.height, first.height);
+    assert_eq!(second.mime, first.mime);
+    assert_eq!(second.bytes, first.bytes);
+}
+
+#[test]
+fn image_dimensions_from_base64_payload_reads_image_header() {
+    let image = ImageBuffer::from_pixel(320, 240, Rgba([10u8, 20, 30, 255]));
+    let original_bytes = image_bytes(&image, ImageFormat::Png);
+    let payload = BASE64_STANDARD.encode(original_bytes);
+
+    let dimensions = image_dimensions_from_base64_payload(&payload)
+        .expect("read dimensions from base64 image payload");
+
+    assert_eq!(dimensions, (320, 240));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn downscales_tall_image_to_fit_square_bounds() {
+    let image = ImageBuffer::from_pixel(512, 4096, Rgba([200u8, 10, 10, 255]));
+    let original_bytes = image_bytes(&image, ImageFormat::Png);
+
+    let processed = load_for_prompt_bytes(
+        Path::new("in-memory-image"),
+        original_bytes,
+        PromptImageMode::ResizeToFit,
+    )
+    .expect("process image");
+
+    assert_eq!(processed.width, 256);
+    assert_eq!(processed.height, MAX_DIMENSION);
+    assert_eq!(processed.mime, "image/png");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn preserves_large_image_in_original_mode() {
+    let image = ImageBuffer::from_pixel(6401, 100, Rgba([180u8, 30, 30, 255]));
+    let original_bytes = image_bytes(&image, ImageFormat::Png);
+
+    let processed = load_for_prompt_bytes(
+        Path::new("in-memory-image"),
+        original_bytes.clone(),
+        PromptImageMode::Original,
+    )
+    .expect("process image");
+
+    assert_eq!(processed.width, 6401);
+    assert_eq!(processed.height, 100);
+    assert_eq!(processed.mime, "image/png");
+    assert_eq!(processed.bytes, original_bytes);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn responses_lite_original_downscales_to_dimension_budget() {
+    let image = ImageBuffer::from_pixel(6401, 100, Rgba([180u8, 30, 30, 255]));
+    let original_bytes = image_bytes(&image, ImageFormat::Png);
+
+    let processed = load_for_prompt_bytes(
+        Path::new("in-memory-image"),
+        original_bytes,
+        PromptImageMode::ResponsesLiteOriginal,
+    )
+    .expect("process image");
+
+    assert!(processed.width < 6401);
+    assert!(processed.width <= ORIGINAL_DETAIL_MAX_DIMENSION);
+    assert!(processed.height <= ORIGINAL_DETAIL_MAX_DIMENSION);
+    assert!(
+        prompt_image_patch_count(processed.width, processed.height) <= ORIGINAL_DETAIL_MAX_PATCHES
+    );
+}
+
+#[test]
+fn prompt_image_output_dimensions_respect_responses_lite_original_limits() {
+    assert_eq!(
+        prompt_image_output_dimensions(
+            /*width*/ 6401,
+            /*height*/ 100,
+            PromptImageMode::ResponsesLiteOriginal,
+        ),
+        (6000, 94)
+    );
+    assert_eq!(
+        prompt_image_output_dimensions(
+            /*width*/ 3201,
+            /*height*/ 3201,
+            PromptImageMode::ResponsesLiteOriginal,
+        ),
+        (3200, 3200)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fails_cleanly_for_invalid_images() {
+    let err = load_for_prompt_bytes(
+        Path::new("in-memory-image"),
+        b"not an image".to_vec(),
+        PromptImageMode::ResizeToFit,
+    )
+    .expect_err("invalid image should fail");
+    assert!(matches!(
+        err,
+        ImageProcessingError::Decode { .. } | ImageProcessingError::UnsupportedImageFormat { .. }
+    ));
+}
+
+#[test]
+fn prompt_image_input_size_limit_is_inclusive_for_each_representation() {
+    let size = MAX_PROMPT_IMAGE_INPUT_BYTES + 1;
+    for representation in ["base64 payload", "decoded input"] {
+        ensure_prompt_image_input_size(representation, MAX_PROMPT_IMAGE_INPUT_BYTES)
+            .expect("input at the limit should be accepted");
+        let err = ensure_prompt_image_input_size(representation, size)
+            .expect_err("input over the limit should fail");
+
+        assert!(matches!(
+            err,
+            ImageProcessingError::ImageTooLarge {
+                representation: got_representation,
+                size: got_size,
+                max: MAX_PROMPT_IMAGE_INPUT_BYTES,
+            } if got_representation == representation && got_size == size
+        ));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reprocesses_updated_file_contents() {
+    {
+        IMAGE_CACHE.clear();
+    }
+
+    let first_image = ImageBuffer::from_pixel(32, 16, Rgba([20u8, 120, 220, 255]));
+    let first_bytes = image_bytes(&first_image, ImageFormat::Png);
+
+    let first = load_for_prompt_bytes(
+        Path::new("in-memory-image"),
+        first_bytes,
+        PromptImageMode::ResizeToFit,
+    )
+    .expect("process first image");
+
+    let second_image = ImageBuffer::from_pixel(96, 48, Rgba([50u8, 60, 70, 255]));
+    let second_bytes = image_bytes(&second_image, ImageFormat::Png);
+
+    let second = load_for_prompt_bytes(
+        Path::new("in-memory-image"),
+        second_bytes,
+        PromptImageMode::ResizeToFit,
+    )
+    .expect("process updated image");
+
+    assert_eq!(first.width, 32);
+    assert_eq!(first.height, 16);
+    assert_eq!(second.width, 96);
+    assert_eq!(second.height, 48);
+    assert_ne!(second.bytes, first.bytes);
+}

--- a/codex-rs/utils/image/src/lib.rs
+++ b/codex-rs/utils/image/src/lib.rs
@@ -1,3 +1,4 @@
+use std::io::Cursor;
 use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::LazyLock;
@@ -9,14 +10,28 @@ use codex_utils_cache::sha1_digest;
 use image::ColorType;
 use image::DynamicImage;
 use image::GenericImageView;
+use image::ImageDecoder;
 use image::ImageEncoder;
 use image::ImageFormat;
+use image::ImageReader;
 use image::codecs::jpeg::JpegEncoder;
 use image::codecs::png::PngEncoder;
 use image::codecs::webp::WebPEncoder;
 use image::imageops::FilterType;
-/// Maximum width or height used when resizing images before uploading.
-pub const MAX_DIMENSION: u32 = 2048;
+use image::metadata::Orientation;
+const DATA_URL_PREFIX: &str = "data:";
+pub const PROMPT_IMAGE_PATCH_SIZE: u32 = 32;
+pub const HIGH_DETAIL_MAX_DIMENSION: u32 = 2048;
+pub const HIGH_DETAIL_MAX_PATCHES: usize = 2_500;
+pub const ORIGINAL_DETAIL_MAX_DIMENSION: u32 = 6000;
+pub const ORIGINAL_DETAIL_MAX_PATCHES: usize = 10_000;
+/// Maximum width or height used when resizing high-detail images before uploading.
+pub const MAX_DIMENSION: u32 = HIGH_DETAIL_MAX_DIMENSION;
+/// Maximum accepted byte length for prompt image input representations.
+///
+/// This is a high sanity guard against pathological inputs, not a protocol
+/// requirement or target upload size.
+pub const MAX_PROMPT_IMAGE_INPUT_BYTES: usize = 1024 * 1024 * 1024;
 
 pub mod error;
 
@@ -39,8 +54,40 @@ impl EncodedImage {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PromptImageMode {
+    /// Resize using the high-detail local upload budget.
     ResizeToFit,
+    /// Preserve legacy original-detail behavior: validate the image, but do not resize locally.
     Original,
+    /// Resize using Responses Lite's original-detail budget.
+    ResponsesLiteOriginal,
+}
+
+impl PromptImageMode {
+    fn resize_limits(self) -> Option<PromptImageResizeLimits> {
+        match self {
+            PromptImageMode::ResizeToFit => Some(PromptImageResizeLimits {
+                max_dimension: HIGH_DETAIL_MAX_DIMENSION,
+                max_patches: HIGH_DETAIL_MAX_PATCHES,
+            }),
+            PromptImageMode::Original => None,
+            PromptImageMode::ResponsesLiteOriginal => Some(PromptImageResizeLimits {
+                max_dimension: ORIGINAL_DETAIL_MAX_DIMENSION,
+                max_patches: ORIGINAL_DETAIL_MAX_PATCHES,
+            }),
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct PromptImageResizeLimits {
+    max_dimension: u32,
+    max_patches: usize,
+}
+
+#[derive(Default)]
+struct ImageMetadata {
+    icc_profile: Option<Vec<u8>>,
+    exif: Option<Vec<u8>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -57,6 +104,8 @@ pub fn load_for_prompt_bytes(
     file_bytes: Vec<u8>,
     mode: PromptImageMode,
 ) -> Result<EncodedImage, ImageProcessingError> {
+    ensure_prompt_image_input_size("decoded input", file_bytes.len())?;
+
     let path_buf = path.to_path_buf();
 
     let key = ImageCacheKey {
@@ -65,22 +114,40 @@ pub fn load_for_prompt_bytes(
     };
 
     IMAGE_CACHE.get_or_try_insert_with(key, move || {
-        let format = match image::guess_format(&file_bytes) {
-            Ok(ImageFormat::Png) => Some(ImageFormat::Png),
-            Ok(ImageFormat::Jpeg) => Some(ImageFormat::Jpeg),
-            Ok(ImageFormat::Gif) => Some(ImageFormat::Gif),
-            Ok(ImageFormat::WebP) => Some(ImageFormat::WebP),
+        let guessed_format = image::guess_format(&file_bytes)
+            .map_err(|source| ImageProcessingError::decode_error(&path_buf, source))?;
+        let format = match guessed_format {
+            ImageFormat::Png => Some(ImageFormat::Png),
+            ImageFormat::Jpeg => Some(ImageFormat::Jpeg),
+            ImageFormat::Gif => Some(ImageFormat::Gif),
+            ImageFormat::WebP => Some(ImageFormat::WebP),
             _ => None,
         };
 
-        let dynamic = image::load_from_memory(&file_bytes)
+        let mut decoder = ImageReader::with_format(Cursor::new(&file_bytes), guessed_format)
+            .into_decoder()
             .map_err(|source| ImageProcessingError::decode_error(&path_buf, source))?;
+        let orientation = decoder.orientation().unwrap_or(Orientation::NoTransforms);
+        let metadata = ImageMetadata {
+            icc_profile: decoder.icc_profile().ok().flatten(),
+            exif: decoder.exif_metadata().ok().flatten().map(|mut exif| {
+                if orientation != Orientation::NoTransforms {
+                    let _ = Orientation::remove_from_exif_chunk(&mut exif);
+                }
+                exif
+            }),
+        };
+        let mut dynamic = DynamicImage::from_decoder(decoder)
+            .map_err(|source| ImageProcessingError::decode_error(&path_buf, source))?;
+        dynamic.apply_orientation(orientation);
 
         let (width, height) = dynamic.dimensions();
 
-        let encoded = if mode == PromptImageMode::Original
-            || (width <= MAX_DIMENSION && height <= MAX_DIMENSION)
-        {
+        let (target_width, target_height) = match mode.resize_limits() {
+            Some(limits) => prompt_image_output_dimensions_for_limits(width, height, limits),
+            None => (width, height),
+        };
+        let encoded = if (target_width, target_height) == (width, height) {
             if let Some(format) = format.filter(|format| can_preserve_source_bytes(*format)) {
                 let mime = format_to_mime(format);
                 EncodedImage {
@@ -90,7 +157,7 @@ pub fn load_for_prompt_bytes(
                     height,
                 }
             } else {
-                let (bytes, output_format) = encode_image(&dynamic, ImageFormat::Png)?;
+                let (bytes, output_format) = encode_image(&dynamic, ImageFormat::Png, metadata)?;
                 let mime = format_to_mime(output_format);
                 EncodedImage {
                     bytes,
@@ -100,11 +167,11 @@ pub fn load_for_prompt_bytes(
                 }
             }
         } else {
-            let resized = dynamic.resize(MAX_DIMENSION, MAX_DIMENSION, FilterType::Triangle);
+            let resized = dynamic.resize_exact(target_width, target_height, FilterType::Triangle);
             let target_format = format
                 .filter(|format| can_preserve_source_bytes(*format))
                 .unwrap_or(ImageFormat::Png);
-            let (bytes, output_format) = encode_image(&resized, target_format)?;
+            let (bytes, output_format) = encode_image(&resized, target_format, metadata)?;
             let mime = format_to_mime(output_format);
             EncodedImage {
                 bytes,
@@ -116,6 +183,161 @@ pub fn load_for_prompt_bytes(
 
         Ok(encoded)
     })
+}
+
+pub fn load_data_url_for_prompt(
+    image_url: &str,
+    mode: PromptImageMode,
+) -> Result<EncodedImage, ImageProcessingError> {
+    let rest =
+        strip_data_url_prefix(image_url).ok_or_else(|| ImageProcessingError::InvalidDataUrl {
+            reason: "missing data: prefix".to_string(),
+        })?;
+    let (metadata, encoded) =
+        rest.split_once(',')
+            .ok_or_else(|| ImageProcessingError::InvalidDataUrl {
+                reason: "missing comma separator".to_string(),
+            })?;
+    let is_base64 = metadata
+        .split(';')
+        .any(|part| part.eq_ignore_ascii_case("base64"));
+    if !is_base64 {
+        return Err(ImageProcessingError::InvalidDataUrl {
+            reason: "only base64 data URLs are supported".to_string(),
+        });
+    }
+
+    ensure_prompt_image_input_size("base64 payload", encoded.len())?;
+
+    let file_bytes =
+        BASE64_STANDARD
+            .decode(encoded)
+            .map_err(|source| ImageProcessingError::InvalidDataUrl {
+                reason: format!("invalid base64 payload: {source}"),
+            })?;
+    load_for_prompt_bytes(Path::new("<data-url-image>"), file_bytes, mode)
+}
+
+fn strip_data_url_prefix(image_url: &str) -> Option<&str> {
+    image_url
+        .get(..DATA_URL_PREFIX.len())
+        .filter(|prefix| prefix.eq_ignore_ascii_case(DATA_URL_PREFIX))?;
+    image_url.get(DATA_URL_PREFIX.len()..)
+}
+
+pub fn image_dimensions_from_base64_payload(
+    payload: &str,
+) -> Result<(u32, u32), ImageProcessingError> {
+    ensure_prompt_image_input_size("base64 payload", payload.len())?;
+
+    let file_bytes =
+        BASE64_STANDARD
+            .decode(payload)
+            .map_err(|source| ImageProcessingError::InvalidDataUrl {
+                reason: format!("invalid base64 payload: {source}"),
+            })?;
+    image_dimensions_for_prompt_bytes(Path::new("<data-url-image>"), &file_bytes)
+}
+
+pub fn image_dimensions_for_prompt_bytes(
+    path: &Path,
+    file_bytes: &[u8],
+) -> Result<(u32, u32), ImageProcessingError> {
+    ensure_prompt_image_input_size("decoded input", file_bytes.len())?;
+
+    let format = image::guess_format(file_bytes)
+        .map_err(|source| ImageProcessingError::decode_error(path, source))?;
+    ImageReader::with_format(Cursor::new(file_bytes), format)
+        .into_dimensions()
+        .map_err(|source| ImageProcessingError::decode_error(path, source))
+}
+
+fn ensure_prompt_image_input_size(
+    representation: &'static str,
+    size: usize,
+) -> Result<(), ImageProcessingError> {
+    if size > MAX_PROMPT_IMAGE_INPUT_BYTES {
+        return Err(ImageProcessingError::ImageTooLarge {
+            representation,
+            size,
+            max: MAX_PROMPT_IMAGE_INPUT_BYTES,
+        });
+    }
+    Ok(())
+}
+
+pub fn prompt_image_output_dimensions(
+    width: u32,
+    height: u32,
+    mode: PromptImageMode,
+) -> (u32, u32) {
+    let Some(limits) = mode.resize_limits() else {
+        return (width.max(1), height.max(1));
+    };
+    prompt_image_output_dimensions_for_limits(width, height, limits)
+}
+
+fn prompt_image_output_dimensions_for_limits(
+    width: u32,
+    height: u32,
+    limits: PromptImageResizeLimits,
+) -> (u32, u32) {
+    let width = width.max(1);
+    let height = height.max(1);
+    if prompt_image_dimensions_fit(width, height, limits) {
+        return (width, height);
+    }
+    prompt_image_resize_dimensions(width, height, limits)
+}
+
+fn prompt_image_dimensions_fit(width: u32, height: u32, limits: PromptImageResizeLimits) -> bool {
+    width <= limits.max_dimension
+        && height <= limits.max_dimension
+        && prompt_image_patch_count(width, height) <= limits.max_patches
+}
+
+fn prompt_image_resize_dimensions(
+    width: u32,
+    height: u32,
+    limits: PromptImageResizeLimits,
+) -> (u32, u32) {
+    let max_dimension_scale = f64::from(limits.max_dimension) / f64::from(width.max(height));
+    let max_dimension_scale = max_dimension_scale.min(1.0);
+    let width = ((f64::from(width) * max_dimension_scale).round() as u32).max(1);
+    let height = ((f64::from(height) * max_dimension_scale).round() as u32).max(1);
+    if prompt_image_dimensions_fit(width, height, limits) {
+        return (width, height);
+    }
+
+    let patch_budget_scale = prompt_image_patch_budget_scale(width, height, limits.max_patches);
+    prompt_image_dimensions_at_scale(width, height, patch_budget_scale)
+}
+
+fn prompt_image_patch_budget_scale(width: u32, height: u32, max_patches: usize) -> f64 {
+    let width = f64::from(width);
+    let height = f64::from(height);
+    let patch_size = f64::from(PROMPT_IMAGE_PATCH_SIZE);
+    let mut scale = (patch_size * patch_size * max_patches as f64 / width / height).sqrt();
+    // Match the Responses/LPE patch-budget math: shrink by area, then round the
+    // scaled patch grid down so ceil(width / patch_size) * ceil(height / patch_size)
+    // stays within the budget after integer dimensions are chosen.
+    let scaled_patches_wide = width * scale / patch_size;
+    let scaled_patches_high = height * scale / patch_size;
+    scale *= (scaled_patches_wide.floor() / scaled_patches_wide)
+        .min(scaled_patches_high.floor() / scaled_patches_high);
+    scale
+}
+
+fn prompt_image_dimensions_at_scale(width: u32, height: u32, scale: f64) -> (u32, u32) {
+    let scaled_width = (f64::from(width) * scale).floor() as u32;
+    let scaled_height = (f64::from(height) * scale).floor() as u32;
+    (scaled_width.max(1), scaled_height.max(1))
+}
+
+pub fn prompt_image_patch_count(width: u32, height: u32) -> usize {
+    let patches_wide = width.div_ceil(PROMPT_IMAGE_PATCH_SIZE);
+    let patches_high = height.div_ceil(PROMPT_IMAGE_PATCH_SIZE);
+    usize::try_from(u64::from(patches_wide) * u64::from(patches_high)).unwrap_or(usize::MAX)
 }
 
 fn can_preserve_source_bytes(format: ImageFormat) -> bool {
@@ -130,6 +352,7 @@ fn can_preserve_source_bytes(format: ImageFormat) -> bool {
 fn encode_image(
     image: &DynamicImage,
     preferred_format: ImageFormat,
+    metadata: ImageMetadata,
 ) -> Result<(Vec<u8>, ImageFormat), ImageProcessingError> {
     let target_format = match preferred_format {
         ImageFormat::Jpeg => ImageFormat::Jpeg,
@@ -138,11 +361,13 @@ fn encode_image(
     };
 
     let mut buffer = Vec::new();
+    let ImageMetadata { icc_profile, exif } = metadata;
 
     match target_format {
         ImageFormat::Png => {
             let rgba = image.to_rgba8();
-            let encoder = PngEncoder::new(&mut buffer);
+            let mut encoder = PngEncoder::new(&mut buffer);
+            apply_image_metadata(&mut encoder, icc_profile, exif, target_format)?;
             encoder
                 .write_image(
                     rgba.as_raw(),
@@ -157,6 +382,7 @@ fn encode_image(
         }
         ImageFormat::Jpeg => {
             let mut encoder = JpegEncoder::new_with_quality(&mut buffer, 85);
+            apply_image_metadata(&mut encoder, icc_profile, exif, target_format)?;
             encoder
                 .encode_image(image)
                 .map_err(|source| ImageProcessingError::Encode {
@@ -166,7 +392,8 @@ fn encode_image(
         }
         ImageFormat::WebP => {
             let rgba = image.to_rgba8();
-            let encoder = WebPEncoder::new_lossless(&mut buffer);
+            let mut encoder = WebPEncoder::new_lossless(&mut buffer);
+            apply_image_metadata(&mut encoder, icc_profile, exif, target_format)?;
             encoder
                 .write_image(
                     rgba.as_raw(),
@@ -185,6 +412,31 @@ fn encode_image(
     Ok((buffer, target_format))
 }
 
+fn apply_image_metadata(
+    encoder: &mut impl ImageEncoder,
+    icc_profile: Option<Vec<u8>>,
+    exif: Option<Vec<u8>>,
+    format: ImageFormat,
+) -> Result<(), ImageProcessingError> {
+    if let Some(icc_profile) = icc_profile {
+        encoder
+            .set_icc_profile(icc_profile)
+            .map_err(|source| ImageProcessingError::Encode {
+                format,
+                source: image::ImageError::Unsupported(source),
+            })?;
+    }
+    if let Some(exif) = exif {
+        encoder
+            .set_exif_metadata(exif)
+            .map_err(|source| ImageProcessingError::Encode {
+                format,
+                source: image::ImageError::Unsupported(source),
+            })?;
+    }
+    Ok(())
+}
+
 fn format_to_mime(format: ImageFormat) -> String {
     match format {
         ImageFormat::Jpeg => "image/jpeg".to_string(),
@@ -195,155 +447,5 @@ fn format_to_mime(format: ImageFormat) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use std::io::Cursor;
-
-    use super::*;
-    use image::GenericImageView;
-    use image::ImageBuffer;
-    use image::Rgba;
-
-    fn image_bytes(image: &ImageBuffer<Rgba<u8>, Vec<u8>>, format: ImageFormat) -> Vec<u8> {
-        let mut encoded = Cursor::new(Vec::new());
-        DynamicImage::ImageRgba8(image.clone())
-            .write_to(&mut encoded, format)
-            .expect("encode image to bytes");
-        encoded.into_inner()
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn returns_original_image_when_within_bounds() {
-        for (format, mime) in [
-            (ImageFormat::Png, "image/png"),
-            (ImageFormat::WebP, "image/webp"),
-        ] {
-            let image = ImageBuffer::from_pixel(64, 32, Rgba([10u8, 20, 30, 255]));
-            let original_bytes = image_bytes(&image, format);
-
-            let encoded = load_for_prompt_bytes(
-                Path::new("in-memory-image"),
-                original_bytes.clone(),
-                PromptImageMode::ResizeToFit,
-            )
-            .expect("process image");
-
-            assert_eq!(encoded.width, 64);
-            assert_eq!(encoded.height, 32);
-            assert_eq!(encoded.mime, mime);
-            assert_eq!(encoded.bytes, original_bytes);
-        }
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn downscales_large_image() {
-        for (format, mime) in [
-            (ImageFormat::Png, "image/png"),
-            (ImageFormat::WebP, "image/webp"),
-        ] {
-            let image = ImageBuffer::from_pixel(4096, 2048, Rgba([200u8, 10, 10, 255]));
-            let original_bytes = image_bytes(&image, format);
-
-            let processed = load_for_prompt_bytes(
-                Path::new("in-memory-image"),
-                original_bytes,
-                PromptImageMode::ResizeToFit,
-            )
-            .expect("process image");
-
-            assert!(processed.width <= MAX_DIMENSION);
-            assert!(processed.height <= MAX_DIMENSION);
-            assert_eq!(processed.mime, mime);
-
-            let detected_format =
-                image::guess_format(&processed.bytes).expect("detect resized output format");
-            assert_eq!(detected_format, format);
-
-            let loaded = image::load_from_memory(&processed.bytes)
-                .expect("read resized bytes back into image");
-            assert_eq!(loaded.dimensions(), (processed.width, processed.height));
-        }
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn downscales_tall_image_to_fit_square_bounds() {
-        let image = ImageBuffer::from_pixel(1024, 4096, Rgba([200u8, 10, 10, 255]));
-        let original_bytes = image_bytes(&image, ImageFormat::Png);
-
-        let processed = load_for_prompt_bytes(
-            Path::new("in-memory-image"),
-            original_bytes,
-            PromptImageMode::ResizeToFit,
-        )
-        .expect("process image");
-
-        assert_eq!(processed.width, 512);
-        assert_eq!(processed.height, MAX_DIMENSION);
-        assert_eq!(processed.mime, "image/png");
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn preserves_large_image_in_original_mode() {
-        let image = ImageBuffer::from_pixel(4096, 2048, Rgba([180u8, 30, 30, 255]));
-        let original_bytes = image_bytes(&image, ImageFormat::Png);
-
-        let processed = load_for_prompt_bytes(
-            Path::new("in-memory-image"),
-            original_bytes.clone(),
-            PromptImageMode::Original,
-        )
-        .expect("process image");
-
-        assert_eq!(processed.width, 4096);
-        assert_eq!(processed.height, 2048);
-        assert_eq!(processed.mime, "image/png");
-        assert_eq!(processed.bytes, original_bytes);
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn fails_cleanly_for_invalid_images() {
-        let err = load_for_prompt_bytes(
-            Path::new("in-memory-image"),
-            b"not an image".to_vec(),
-            PromptImageMode::ResizeToFit,
-        )
-        .expect_err("invalid image should fail");
-        assert!(matches!(
-            err,
-            ImageProcessingError::Decode { .. }
-                | ImageProcessingError::UnsupportedImageFormat { .. }
-        ));
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn reprocesses_updated_file_contents() {
-        {
-            IMAGE_CACHE.clear();
-        }
-
-        let first_image = ImageBuffer::from_pixel(32, 16, Rgba([20u8, 120, 220, 255]));
-        let first_bytes = image_bytes(&first_image, ImageFormat::Png);
-
-        let first = load_for_prompt_bytes(
-            Path::new("in-memory-image"),
-            first_bytes,
-            PromptImageMode::ResizeToFit,
-        )
-        .expect("process first image");
-
-        let second_image = ImageBuffer::from_pixel(96, 48, Rgba([50u8, 60, 70, 255]));
-        let second_bytes = image_bytes(&second_image, ImageFormat::Png);
-
-        let second = load_for_prompt_bytes(
-            Path::new("in-memory-image"),
-            second_bytes,
-            PromptImageMode::ResizeToFit,
-        )
-        .expect("process updated image");
-
-        assert_eq!(first.width, 32);
-        assert_eq!(first.height, 16);
-        assert_eq!(second.width, 96);
-        assert_eq!(second.height, 48);
-        assert_ne!(second.bytes, first.bytes);
-    }
-}
+#[path = "image_tests.rs"]
+mod tests;


### PR DESCRIPTION
## Summary

Adds a feature-flagged Responses API strict-mode image path for Codex.

When `responses_api_codex_strict_mode` is enabled, Codex prepares image inputs before recording them into history and sending them to `/responses`:

- converts supported local/data URL images into prepared data URLs
- strips `detail` after preparation to match the strict contract
- maps `high` to the high-detail resize budget
- maps omitted/`auto`/`original` to the Responses Lite original-detail budget
- rejects `low` detail and non-data URL image inputs, including HTTP(S) URLs

This also centralizes prompt-image processing in `codex-utils-image`, adds shared data URL parsing/dimension/token helpers, and updates original-image token accounting to use the same patch-budget logic.
