### PR TITLE
Fix stale TestAppServer rename in plugin_list test

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/plugin_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_list.rs
@@ -231,10 +231,10 @@ enabled = true
     mount_remote_installed_plugins(&server, "WORKSPACE", empty_remote_installed_plugins_body())
         .await;
 
-    let mut mcp = McpProcess::new(codex_home.path()).await?;
-    timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;
+    let mut app_server = TestAppServer::new(codex_home.path()).await?;
+    timeout(DEFAULT_TIMEOUT, app_server.initialize()).await??;
 
-    let request_id = mcp
+    let request_id = app_server
         .send_plugin_installed_request(PluginInstalledParams {
             cwds: None,
             install_suggestion_plugin_names: None,
@@ -243,7 +243,7 @@ enabled = true
 
     let response: JSONRPCResponse = timeout(
         DEFAULT_TIMEOUT,
-        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+        app_server.read_stream_until_response_message(RequestId::Integer(request_id)),
     )
     .await??;
     let response: PluginInstalledResponse = to_response(response)?;


### PR DESCRIPTION
## Why

#25701 renamed the app-server test harness to `TestAppServer`, but it raced with #25681, which added a new `plugin_list` test call site still using the old `McpProcess` name. Once both changes met on `main`, app-server test builds failed before running the suite because `McpProcess` no longer exists in that scope.

This PR fixes that CI break by updating the remaining stale call site to the renamed helper.

## What Changed

- Replaced the `McpProcess::new(...)` use in `codex-rs/app-server/tests/suite/v2/plugin_list.rs` with `TestAppServer::new(...)`.
- Renamed the local variable from `mcp` to `app_server` at the same call site to match the helper rename.

Relevant code: https://github.com/openai/codex/blob/aadd9c999b4e0789f7afb2b9b8cc43000bb47e86/codex-rs/app-server/tests/suite/v2/plugin_list.rs#L234-L246

## Verification

Not run locally; this is a compile fix for the app-server test harness rename.
