### PR TITLE
Write remaining config TOML updates atomically

### DIFF
--- a/codex-rs/app-server/src/config/external_agent_config.rs
+++ b/codex-rs/app-server/src/config/external_agent_config.rs
@@ -2,6 +2,7 @@ use codex_config::types::PluginConfig;
 use codex_config::with_config_write_lock;
 use codex_core::config::Config;
 use codex_core::config::ConfigBuilder;
+use codex_core::path_utils::write_atomically;
 use codex_core_plugins::PluginInstallRequest;
 use codex_core_plugins::PluginsManager;
 use codex_core_plugins::marketplace::MarketplacePluginInstallPolicy;
@@ -1529,7 +1530,7 @@ fn merge_missing_toml_file(target_config: &Path, incoming: &TomlValue) -> io::Re
 fn write_toml_file(path: &Path, value: &TomlValue) -> io::Result<()> {
     let serialized = toml::to_string_pretty(value)
         .map_err(|err| invalid_data_error(format!("failed to serialize config.toml: {err}")))?;
-    fs::write(path, format!("{}\n", serialized.trim_end()))
+    write_atomically(path, &format!("{}\n", serialized.trim_end()))
 }
 
 fn migrated_mcp_server_names(value: &TomlValue) -> Vec<String> {

--- a/codex-rs/config/src/marketplace_edit.rs
+++ b/codex-rs/config/src/marketplace_edit.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::io::ErrorKind;
 use std::path::Path;
 
+use codex_utils_path::write_atomically;
 use toml_edit::DocumentMut;
 use toml_edit::Item as TomlItem;
 use toml_edit::Table as TomlTable;
@@ -42,7 +43,7 @@ pub fn record_user_marketplace(
         )?;
         upsert_marketplace(&mut doc, marketplace_name, update);
         fs::create_dir_all(codex_home)?;
-        fs::write(&write_paths.write_path, doc.to_string())
+        write_atomically(&write_paths.write_path, &doc.to_string())
     })
 }
 
@@ -78,7 +79,7 @@ pub fn remove_user_marketplace_config(
         }
 
         fs::create_dir_all(codex_home)?;
-        fs::write(&write_paths.write_path, doc.to_string())?;
+        write_atomically(&write_paths.write_path, &doc.to_string())?;
         Ok(RemoveMarketplaceConfigOutcome::Removed)
     })
 }

--- a/codex-rs/config/src/mcp_edit.rs
+++ b/codex-rs/config/src/mcp_edit.rs
@@ -4,6 +4,7 @@ use std::io::ErrorKind;
 use std::path::Path;
 use std::path::PathBuf;
 
+use codex_utils_path::write_atomically;
 use tokio::task;
 use toml::Value as TomlValue;
 use toml_edit::DocumentMut;
@@ -99,7 +100,7 @@ impl ConfigEditsBuilder {
                 replace_mcp_servers(&mut doc, servers);
             }
             fs::create_dir_all(&self.codex_home)?;
-            fs::write(&write_paths.write_path, doc.to_string())
+            write_atomically(&write_paths.write_path, &doc.to_string())
         })
     }
 }


### PR DESCRIPTION
## Summary
- replace direct marketplace config writes with atomic replacement
- replace direct MCP config writes with atomic replacement
- make external-agent migrated TOML persistence atomic

## Why
The shared lock prevents lost updates. Atomic replacement separately prevents readers from seeing partially written TOML.

## Validation
- `just test -p codex-config`
- `just test -p codex-app-server external_agent_config`
- `just fix -p codex-config -p codex-app-server`
- `just fmt`