### PR TITLE
[codex] Fix fork Bazel remote downloader fallback

### DIFF
--- a/.github/scripts/run-bazel-ci.sh
+++ b/.github/scripts/run-bazel-ci.sh
@@ -419,14 +419,16 @@ else
   # --noexperimental_remote_repo_contents_cache:
   #   disable remote repo contents cache enabled in .bazelrc startup options.
   #   https://bazel.build/reference/command-line-reference#startup_options-flag--experimental_remote_repo_contents_cache
-  # --remote_cache= and --remote_executor=:
-  #   clear remote cache/execution endpoints configured in .bazelrc.
+  # --remote_cache=, --remote_executor=, and --experimental_remote_downloader=:
+  #   clear remote cache/execution/downloader endpoints configured in .bazelrc.
   #   https://bazel.build/reference/command-line-reference#common_options-flag--remote_cache
   #   https://bazel.build/reference/command-line-reference#common_options-flag--remote_executor
+  #   https://bazel.build/reference/command-line-reference#common_options-flag--experimental_remote_downloader
   bazel_run_args=(
     "${bazel_args[@]}"
     --remote_cache=
     --remote_executor=
+    --experimental_remote_downloader=
   )
   if (( ${#post_config_bazel_args[@]} > 0 )); then
     bazel_run_args+=("${post_config_bazel_args[@]}")


### PR DESCRIPTION
## Summary

- clear `--experimental_remote_downloader` with the other BuildBuddy endpoints when `BUILDBUDDY_API_KEY` is absent
- keep the authenticated BuildBuddy configuration unchanged

## Root cause

Fork pull requests do not receive `BUILDBUDDY_API_KEY`. The local Bazel fallback cleared `--remote_cache` and `--remote_executor`, but `.bazelrc` still configured `--experimental_remote_downloader=grpcs://remote.buildbuddy.io`. Bazel rejects that combination because the remote downloader requires gRPC caching.

This caused the [macOS release-build job](https://github.com/openai/codex/actions/runs/26799371025/job/79002549445) to fail while testing [#25773](https://github.com/openai/codex/pull/25773). The failure is unrelated to the image-generation changes in #25773.

## Validation

- `bash -n .github/scripts/run-bazel-ci.sh`
- `git diff --check`
- ran `.github/scripts/run-bazel-ci.sh` against a fake `bazel` executable without `BUILDBUDDY_API_KEY`; the invocation includes `--remote_cache=`, `--remote_executor=`, and `--experimental_remote_downloader=`
- ran the same fake-Bazel check with `BUILDBUDDY_API_KEY=test-key`; the invocation retains `--config=ci-linux` and the BuildBuddy remote header
