### PR TITLE
[codex] Use git CLI for Cargo fetches across Rust workflows

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -6,6 +6,11 @@ on:
     branches:
       - main
 
+# Cargo's libgit2 transport has been flaky when fetching git dependencies with
+# nested submodules. Prefer the system git CLI across every Cargo invocation.
+env:
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+
 jobs:
   cargo-deny:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -3,6 +3,11 @@ on:
   pull_request: {}
   workflow_dispatch:
 
+# Cargo's libgit2 transport has been flaky when fetching git dependencies with
+# nested submodules. Prefer the system git CLI across every Cargo invocation.
+env:
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+
 jobs:
   # --- Detect what changed so the fast PR workflow only runs relevant jobs ----
   changed:

--- a/.github/workflows/rust-release-argument-comment-lint.yml
+++ b/.github/workflows/rust-release-argument-comment-lint.yml
@@ -7,6 +7,11 @@ on:
         required: true
         type: boolean
 
+# Cargo's libgit2 transport has been flaky when fetching git dependencies with
+# nested submodules. Prefer the system git CLI across every Cargo invocation.
+env:
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+
 jobs:
   skip:
     if: ${{ !inputs.publish }}

--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -20,6 +20,11 @@ on:
       AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME:
         required: true
 
+# Cargo's libgit2 transport has been flaky when fetching git dependencies with
+# nested submodules. Prefer the system git CLI across every Cargo invocation.
+env:
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+
 jobs:
   build-windows-binaries:
     name: Build Windows binaries - ${{ matrix.runner }} - ${{ matrix.target }} - ${{ matrix.bundle }}

--- a/.github/workflows/rusty-v8-release.yml
+++ b/.github/workflows/rusty-v8-release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "rusty-v8-v*.*.*"
 
+# Cargo's libgit2 transport has been flaky when fetching git dependencies with
+# nested submodules. Prefer the system git CLI for Cargo smoke tests.
+env:
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+
 concurrency:
   group: ${{ github.workflow }}::${{ github.ref_name }}
   cancel-in-progress: false

--- a/.github/workflows/v8-canary.yml
+++ b/.github/workflows/v8-canary.yml
@@ -37,6 +37,11 @@ on:
       - "third_party/v8/**"
   workflow_dispatch:
 
+# Cargo's libgit2 transport has been flaky when fetching git dependencies with
+# nested submodules. Prefer the system git CLI for Cargo builds and smoke tests.
+env:
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+
 concurrency:
   group: ${{ github.workflow }}::${{ github.event.pull_request.number > 0 && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}
   cancel-in-progress: ${{ github.ref_name != 'main' }}


### PR DESCRIPTION
## Why
Cargo's libgit2 transport has intermittently failed while fetching git dependencies with nested submodules. [#25644](https://github.com/openai/codex/pull/25644) applied `CARGO_NET_GIT_FETCH_WITH_CLI=true` to the main Rust release build after macOS SecureTransport/libgit2 failures while cloning `libwebrtc`'s nested `libyuv` submodule. Similar flakes can affect other Cargo-bearing Rust jobs.

## What changed
Configure `CARGO_NET_GIT_FETCH_WITH_CLI=true` at workflow scope for the remaining Cargo-bearing Rust workflows:

- fast Rust CI and `cargo-deny`
- reusable Windows and argument-comment-lint release workflows
- `rusty-v8-release` and `v8-canary` Cargo builds and smoke tests

The full Rust CI, reusable nextest workflow, and primary Rust release build already had the override. Bazel-only workflows are unchanged because they use a different dependency fetch path.

## Validation
- Parsed all `.github/workflows/*.yml` files as YAML.
- Scanned Cargo-bearing workflows to confirm they configure `CARGO_NET_GIT_FETCH_WITH_CLI`.