### PR TITLE
Simplify MCP approvals reviewer routing

### DIFF
--- a/codex-rs/codex-mcp/src/codex_apps.rs
+++ b/codex-rs/codex-mcp/src/codex_apps.rs
@@ -5,7 +5,6 @@
 //! connector allow-list filtering, and the normalization that turns app
 //! connector/tool metadata into model-visible MCP callable names.
 
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Instant;
 
@@ -14,7 +13,6 @@ use crate::runtime::emit_duration;
 use crate::tools::MCP_TOOLS_CACHE_WRITE_DURATION_METRIC;
 use crate::tools::ToolInfo;
 use anyhow::Context;
-use codex_config::types::ApprovalsReviewer;
 use codex_login::CodexAuth;
 use codex_protocol::mcp::McpServerInfo;
 use codex_utils_plugins::mcp_connector::is_connector_id_allowed;
@@ -23,41 +21,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use sha1::Digest;
 use sha1::Sha1;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct McpApprovalsReviewerPolicy {
-    default: ApprovalsReviewer,
-    codex_apps_by_connector_id: HashMap<String, ApprovalsReviewer>,
-}
-
-impl McpApprovalsReviewerPolicy {
-    pub fn new(
-        default: ApprovalsReviewer,
-        codex_apps_by_connector_id: HashMap<String, ApprovalsReviewer>,
-    ) -> Self {
-        Self {
-            default,
-            codex_apps_by_connector_id,
-        }
-    }
-
-    pub fn resolve(&self, server_name: &str, connector_id: Option<&str>) -> ApprovalsReviewer {
-        if server_name == CODEX_APPS_MCP_SERVER_NAME
-            && let Some(reviewer) = connector_id
-                .and_then(|connector_id| self.codex_apps_by_connector_id.get(connector_id))
-        {
-            return *reviewer;
-        }
-
-        self.default
-    }
-}
-
-impl Default for McpApprovalsReviewerPolicy {
-    fn default() -> Self {
-        Self::new(ApprovalsReviewer::User, HashMap::new())
-    }
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CodexAppsToolsCacheKey {
@@ -350,30 +313,4 @@ fn sha1_hex(s: &str) -> String {
     hasher.update(s.as_bytes());
     let sha1 = hasher.finalize();
     format!("{sha1:x}")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn mcp_approvals_reviewer_policy_only_applies_connector_overrides_to_codex_apps() {
-        let policy = McpApprovalsReviewerPolicy::new(
-            ApprovalsReviewer::User,
-            HashMap::from([("calendar".to_string(), ApprovalsReviewer::AutoReview)]),
-        );
-
-        assert_eq!(
-            policy.resolve(CODEX_APPS_MCP_SERVER_NAME, Some("calendar")),
-            ApprovalsReviewer::AutoReview
-        );
-        assert_eq!(
-            policy.resolve("custom_server", Some("calendar")),
-            ApprovalsReviewer::User
-        );
-        assert_eq!(
-            policy.resolve(CODEX_APPS_MCP_SERVER_NAME, Some("drive")),
-            ApprovalsReviewer::User
-        );
-    }
 }

--- a/codex-rs/codex-mcp/src/connection_manager.rs
+++ b/codex-rs/codex-mcp/src/connection_manager.rs
@@ -16,7 +16,6 @@ use std::time::Instant;
 use crate::McpAuthStatusEntry;
 use crate::codex_apps::CodexAppsToolsCacheContext;
 use crate::codex_apps::CodexAppsToolsCacheKey;
-use crate::codex_apps::McpApprovalsReviewerPolicy;
 use crate::codex_apps::write_cached_codex_apps_tools_if_needed;
 use crate::elicitation::ElicitationRequestManager;
 use crate::elicitation::ElicitationReviewerHandle;
@@ -140,7 +139,6 @@ impl McpConnectionManager {
             elicitation_requests: ElicitationRequestManager::new(
                 approval_policy.value(),
                 permission_profile.clone(),
-                McpApprovalsReviewerPolicy::default(),
                 /*reviewer*/ None,
             ),
             startup_cancellation_token: CancellationToken::new(),
@@ -203,25 +201,6 @@ impl McpConnectionManager {
         }
     }
 
-    /// Replaces the MCP reviewer policy used for subsequent approval requests.
-    pub fn set_approvals_reviewer_policy(
-        &self,
-        approvals_reviewer_policy: McpApprovalsReviewerPolicy,
-    ) {
-        self.elicitation_requests
-            .set_approvals_reviewer_policy(approvals_reviewer_policy);
-    }
-
-    /// Resolves the reviewer for an MCP request using the server and optional connector identity.
-    pub fn approvals_reviewer(
-        &self,
-        server_name: &str,
-        connector_id: Option<&str>,
-    ) -> codex_config::types::ApprovalsReviewer {
-        self.elicitation_requests
-            .approvals_reviewer(server_name, connector_id)
-    }
-
     pub fn elicitations_auto_deny(&self) -> bool {
         self.elicitation_requests.auto_deny()
     }
@@ -246,7 +225,6 @@ impl McpConnectionManager {
         prefix_mcp_tool_names: bool,
         client_elicitation_capability: ElicitationCapability,
         tool_plugin_provenance: ToolPluginProvenance,
-        approvals_reviewer_policy: McpApprovalsReviewerPolicy,
         auth: Option<&CodexAuth>,
         elicitation_reviewer: Option<ElicitationReviewerHandle>,
     ) -> (Self, CancellationToken) {
@@ -257,7 +235,6 @@ impl McpConnectionManager {
         let elicitation_requests = ElicitationRequestManager::new(
             approval_policy.value(),
             initial_permission_profile,
-            approvals_reviewer_policy,
             elicitation_reviewer,
         );
         let tool_plugin_provenance = Arc::new(tool_plugin_provenance);

--- a/codex-rs/codex-mcp/src/connection_manager_tests.rs
+++ b/codex-rs/codex-mcp/src/connection_manager_tests.rs
@@ -239,7 +239,6 @@ async fn disabled_permissions_auto_accept_elicitation_with_empty_form_schema() {
     let manager = ElicitationRequestManager::new(
         AskForApproval::Never,
         PermissionProfile::Disabled,
-        McpApprovalsReviewerPolicy::default(),
         /*reviewer*/ None,
     );
     let (tx_event, _rx_event) = async_channel::bounded(1);
@@ -273,7 +272,6 @@ async fn disabled_permissions_do_not_auto_accept_elicitation_with_requested_fiel
     let manager = ElicitationRequestManager::new(
         AskForApproval::Never,
         PermissionProfile::Disabled,
-        McpApprovalsReviewerPolicy::default(),
         /*reviewer*/ None,
     );
     let (tx_event, _rx_event) = async_channel::bounded(1);
@@ -1191,7 +1189,6 @@ async fn no_local_runtime_fails_local_stdio_but_keeps_local_http_server() {
         /*prefix_mcp_tool_names*/ true,
         ElicitationCapability::default(),
         ToolPluginProvenance::default(),
-        McpApprovalsReviewerPolicy::default(),
         /*auth*/ None,
         /*elicitation_reviewer*/ None,
     )

--- a/codex-rs/codex-mcp/src/elicitation.rs
+++ b/codex-rs/codex-mcp/src/elicitation.rs
@@ -9,7 +9,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 
-use crate::McpApprovalsReviewerPolicy;
 use crate::mcp::McpPermissionPromptAutoApproveContext;
 use crate::mcp::mcp_permission_prompt_is_auto_approved;
 use anyhow::Context;
@@ -19,7 +18,6 @@ use async_channel::Sender;
 use codex_protocol::approvals::ElicitationRequest;
 use codex_protocol::approvals::ElicitationRequestEvent;
 use codex_protocol::mcp::RequestId as ProtocolRequestId;
-use codex_protocol::mcp_approval_meta::CONNECTOR_ID_KEY;
 use codex_protocol::models::PermissionProfile;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::Event;
@@ -39,7 +37,6 @@ pub struct ElicitationReviewRequest {
     pub server_name: String,
     pub request_id: RequestId,
     pub elicitation: CreateElicitationRequestParams,
-    pub approvals_reviewer: codex_config::types::ApprovalsReviewer,
 }
 
 pub trait ElicitationReviewer: Send + Sync {
@@ -57,7 +54,6 @@ pub(crate) struct ElicitationRequestManager {
     pub(crate) approval_policy: Arc<StdMutex<AskForApproval>>,
     pub(crate) permission_profile: Arc<StdMutex<PermissionProfile>>,
     auto_deny: Arc<StdMutex<bool>>,
-    approvals_reviewer_policy: Arc<StdMutex<McpApprovalsReviewerPolicy>>,
     reviewer: Option<ElicitationReviewerHandle>,
 }
 
@@ -65,7 +61,6 @@ impl ElicitationRequestManager {
     pub(crate) fn new(
         approval_policy: AskForApproval,
         permission_profile: PermissionProfile,
-        approvals_reviewer_policy: McpApprovalsReviewerPolicy,
         reviewer: Option<ElicitationReviewerHandle>,
     ) -> Self {
         Self {
@@ -73,7 +68,6 @@ impl ElicitationRequestManager {
             approval_policy: Arc::new(StdMutex::new(approval_policy)),
             permission_profile: Arc::new(StdMutex::new(permission_profile)),
             auto_deny: Arc::new(StdMutex::new(false)),
-            approvals_reviewer_policy: Arc::new(StdMutex::new(approvals_reviewer_policy)),
             reviewer,
         }
     }
@@ -89,26 +83,6 @@ impl ElicitationRequestManager {
         if let Ok(mut current) = self.auto_deny.lock() {
             *current = auto_deny;
         }
-    }
-
-    pub(crate) fn set_approvals_reviewer_policy(
-        &self,
-        approvals_reviewer_policy: McpApprovalsReviewerPolicy,
-    ) {
-        if let Ok(mut current) = self.approvals_reviewer_policy.lock() {
-            *current = approvals_reviewer_policy;
-        }
-    }
-
-    pub(crate) fn approvals_reviewer(
-        &self,
-        server_name: &str,
-        connector_id: Option<&str>,
-    ) -> codex_config::types::ApprovalsReviewer {
-        self.approvals_reviewer_policy
-            .lock()
-            .map(|reviewers| reviewers.resolve(server_name, connector_id))
-            .unwrap_or_default()
     }
 
     pub(crate) async fn resolve(
@@ -135,7 +109,6 @@ impl ElicitationRequestManager {
         let approval_policy = self.approval_policy.clone();
         let permission_profile = self.permission_profile.clone();
         let auto_deny = self.auto_deny.clone();
-        let approvals_reviewer_policy = self.approvals_reviewer_policy.clone();
         let reviewer = self.reviewer.clone();
         Box::new(move |id, elicitation| {
             let elicitation_requests = elicitation_requests.clone();
@@ -144,7 +117,6 @@ impl ElicitationRequestManager {
             let approval_policy = approval_policy.clone();
             let permission_profile = permission_profile.clone();
             let auto_deny = auto_deny.clone();
-            let approvals_reviewer_policy = approvals_reviewer_policy.clone();
             let reviewer = reviewer.clone();
             async move {
                 let auto_deny = auto_deny
@@ -189,20 +161,10 @@ impl ElicitationRequestManager {
                 }
 
                 if let Some(reviewer) = reviewer.as_ref() {
-                    let approvals_reviewer = approvals_reviewer_policy
-                        .lock()
-                        .map(|reviewers| {
-                            reviewers.resolve(
-                                server_name.as_str(),
-                                elicitation_connector_id(&elicitation),
-                            )
-                        })
-                        .unwrap_or_default();
                     let request = ElicitationReviewRequest {
                         server_name: server_name.clone(),
                         request_id: id.clone(),
                         elicitation: elicitation.clone(),
-                        approvals_reviewer,
                     };
                     if let Some(response) = reviewer.review(request).await? {
                         return Ok(response);
@@ -266,16 +228,6 @@ impl ElicitationRequestManager {
             }
             .boxed()
         })
-    }
-}
-
-fn elicitation_connector_id(elicitation: &CreateElicitationRequestParams) -> Option<&str> {
-    match elicitation {
-        CreateElicitationRequestParams::FormElicitationParams { meta, .. }
-        | CreateElicitationRequestParams::UrlElicitationParams { meta, .. } => meta
-            .as_ref()
-            .and_then(|meta| meta.0.get(CONNECTOR_ID_KEY))
-            .and_then(serde_json::Value::as_str),
     }
 }
 

--- a/codex-rs/codex-mcp/src/lib.rs
+++ b/codex-rs/codex-mcp/src/lib.rs
@@ -23,7 +23,6 @@ pub use auth_elicitation::build_auth_elicitation;
 pub use auth_elicitation::build_auth_elicitation_plan;
 pub use auth_elicitation::connector_auth_failure_from_tool_result;
 pub use codex_apps::CodexAppsToolsCacheKey;
-pub use codex_apps::McpApprovalsReviewerPolicy;
 pub use codex_apps::codex_apps_tools_cache_key;
 pub use mcp::configured_mcp_servers;
 pub use mcp::effective_mcp_servers;

--- a/codex-rs/codex-mcp/src/mcp/mod.rs
+++ b/codex-rs/codex-mcp/src/mcp/mod.rs
@@ -293,7 +293,6 @@ pub async fn read_mcp_resource(
         config.prefix_mcp_tool_names,
         config.client_elicitation_capability.clone(),
         tool_plugin_provenance(config),
-        crate::McpApprovalsReviewerPolicy::default(),
         auth,
         /*elicitation_reviewer*/ None,
     )
@@ -364,7 +363,6 @@ pub async fn collect_mcp_server_status_snapshot_with_detail(
         config.prefix_mcp_tool_names,
         config.client_elicitation_capability.clone(),
         tool_plugin_provenance,
-        crate::McpApprovalsReviewerPolicy::default(),
         auth,
         /*elicitation_reviewer*/ None,
     )

--- a/codex-rs/core/src/connectors.rs
+++ b/codex-rs/core/src/connectors.rs
@@ -26,6 +26,7 @@ use crate::plugins::list_tool_suggest_discoverable_plugins;
 use crate::session::INITIAL_SUBMIT_ID;
 use codex_config::AppsRequirementsToml;
 use codex_config::types::AppToolApproval;
+use codex_config::types::ApprovalsReviewer;
 use codex_config::types::AppsConfigToml;
 use codex_config::types::ToolSuggestDiscoverableType;
 use codex_core_plugins::PluginsManager;
@@ -34,7 +35,6 @@ use codex_login::AuthManager;
 use codex_login::CodexAuth;
 use codex_login::default_client::originator;
 use codex_mcp::CODEX_APPS_MCP_SERVER_NAME;
-use codex_mcp::McpApprovalsReviewerPolicy;
 use codex_mcp::McpConnectionManager;
 use codex_mcp::McpRuntimeContext;
 use codex_mcp::ToolInfo;
@@ -282,7 +282,6 @@ pub async fn list_accessible_connectors_from_mcp_tools_with_environment_manager(
         mcp_config.prefix_mcp_tool_names,
         mcp_config.client_elicitation_capability,
         ToolPluginProvenance::default(),
-        mcp_approvals_reviewer_policy(config),
         auth.as_ref(),
         /*elicitation_reviewer*/ None,
     )
@@ -568,29 +567,33 @@ pub(crate) fn codex_app_tool_is_enabled(config: &Config, tool_info: &ToolInfo) -
     .enabled
 }
 
-pub(crate) fn mcp_approvals_reviewer_policy(config: &Config) -> McpApprovalsReviewerPolicy {
-    let codex_apps_by_connector_id = read_user_apps_config(config)
-        .map(|apps_config| {
-            apps_config
-                .apps
-                .into_iter()
-                .filter_map(|(connector_id, app)| {
-                    app.approvals_reviewer
-                        .filter(|reviewer| {
-                            config
-                                .config_layer_stack
-                                .requirements()
-                                .approvals_reviewer
-                                .can_set(reviewer)
-                                .is_ok()
-                        })
-                        .map(|reviewer| (connector_id, reviewer))
-                })
-                .collect()
+pub(crate) fn mcp_approvals_reviewer(
+    config: &Config,
+    server_name: &str,
+    connector_id: Option<&str>,
+) -> ApprovalsReviewer {
+    let app_reviewer = if server_name == CODEX_APPS_MCP_SERVER_NAME {
+        read_user_apps_config(config).and_then(|apps_config| {
+            connector_id
+                .and_then(|connector_id| apps_config.apps.get(connector_id))
+                .and_then(|app| app.approvals_reviewer)
         })
-        .unwrap_or_default();
+    } else {
+        None
+    };
 
-    McpApprovalsReviewerPolicy::new(config.approvals_reviewer, codex_apps_by_connector_id)
+    if let Some(reviewer) = app_reviewer
+        && config
+            .config_layer_stack
+            .requirements()
+            .approvals_reviewer
+            .can_set(&reviewer)
+            .is_ok()
+    {
+        return reviewer;
+    }
+
+    config.approvals_reviewer
 }
 
 fn read_apps_config(config: &Config) -> Option<AppsConfigToml> {

--- a/codex-rs/core/src/connectors_tests.rs
+++ b/codex-rs/core/src/connectors_tests.rs
@@ -427,13 +427,16 @@ approvals_reviewer = "{app}"
             .await
             .expect("config should build");
 
-        let policy = mcp_approvals_reviewer_policy(&config);
         assert_eq!(
-            policy.resolve(CODEX_APPS_MCP_SERVER_NAME, Some("calendar")),
+            mcp_approvals_reviewer(&config, CODEX_APPS_MCP_SERVER_NAME, Some("calendar")),
             expected_app
         );
         assert_eq!(
-            policy.resolve(CODEX_APPS_MCP_SERVER_NAME, Some("drive")),
+            mcp_approvals_reviewer(&config, CODEX_APPS_MCP_SERVER_NAME, Some("drive")),
+            expected_global
+        );
+        assert_eq!(
+            mcp_approvals_reviewer(&config, "custom_server", Some("calendar")),
             expected_global
         );
     }
@@ -465,9 +468,8 @@ approvals_reviewer = "user"
         .await
         .expect("config should build");
 
-    let policy = mcp_approvals_reviewer_policy(&config);
     assert_eq!(
-        policy.resolve(CODEX_APPS_MCP_SERVER_NAME, Some("calendar")),
+        mcp_approvals_reviewer(&config, CODEX_APPS_MCP_SERVER_NAME, Some("calendar")),
         ApprovalsReviewer::AutoReview
     );
 }

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -1431,7 +1431,11 @@ pub(crate) async fn lookup_mcp_tool_metadata(
     let tool_info = tools
         .into_iter()
         .find(|tool_info| tool_info.server_name == server && tool_info.tool.name == tool_name)?;
-    let approvals_reviewer = manager.approvals_reviewer(server, tool_info.connector_id.as_deref());
+    let approvals_reviewer = connectors::mcp_approvals_reviewer(
+        turn_context.config.as_ref(),
+        server,
+        tool_info.connector_id.as_deref(),
+    );
     let connector_description = if server == CODEX_APPS_MCP_SERVER_NAME {
         let connectors = match connectors::list_cached_accessible_connectors_from_mcp_tools(
             turn_context.config.as_ref(),

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -1276,7 +1276,6 @@ async fn install_host_owned_codex_apps_manager(session: &Session, turn_context: 
         turn_context.config.prefix_mcp_tool_names(),
         rmcp::model::ElicitationCapability::default(),
         codex_mcp::ToolPluginProvenance::default(),
-        crate::connectors::mcp_approvals_reviewer_policy(&turn_context.config),
         auth.as_ref(),
         /*elicitation_reviewer*/ None,
     )

--- a/codex-rs/core/src/session/mcp.rs
+++ b/codex-rs/core/src/session/mcp.rs
@@ -356,7 +356,6 @@ impl Session {
             mcp_config.prefix_mcp_tool_names,
             mcp_config.client_elicitation_capability,
             tool_plugin_provenance,
-            crate::connectors::mcp_approvals_reviewer_policy(turn_context.config.as_ref()),
             auth.as_ref(),
             elicitation_reviewer,
         )
@@ -456,9 +455,14 @@ async fn review_guardian_mcp_elicitation(
         return Ok(None);
     };
 
+    let approvals_reviewer = crate::connectors::mcp_approvals_reviewer(
+        turn_context.config.as_ref(),
+        request.server_name.as_str(),
+        elicitation_connector_id(&request.elicitation),
+    );
     if !crate::guardian::routes_approval_to_guardian_with_reviewer(
         turn_context.as_ref(),
-        request.approvals_reviewer,
+        approvals_reviewer,
     ) {
         return Ok(None);
     }
@@ -569,6 +573,15 @@ fn guardian_elicitation_review_request(
             annotations: None,
         },
     ))
+}
+
+fn elicitation_connector_id(elicitation: &CreateElicitationRequestParams) -> Option<&str> {
+    match elicitation {
+        CreateElicitationRequestParams::FormElicitationParams { meta, .. }
+        | CreateElicitationRequestParams::UrlElicitationParams { meta, .. } => meta
+            .as_ref()
+            .and_then(|meta| metadata_str(&meta.0, MCP_ELICITATION_CONNECTOR_ID_KEY)),
+    }
 }
 
 fn meta_requests_approval_request(meta: &Option<Meta>) -> bool {

--- a/codex-rs/core/src/session/mcp_tests.rs
+++ b/codex-rs/core/src/session/mcp_tests.rs
@@ -30,7 +30,6 @@ fn form_request(meta: Option<Meta>) -> ElicitationReviewRequest {
     ElicitationReviewRequest {
         server_name: "browser-use".to_string(),
         request_id: rmcp::model::NumberOrString::Number(7),
-        approvals_reviewer: ApprovalsReviewer::AutoReview,
         elicitation: CreateElicitationRequestParams::FormElicitationParams {
             meta,
             message: "Allow origin?".to_string(),
@@ -172,7 +171,6 @@ fn guardian_elicitation_review_request_declines_unsupported_opt_in_shapes() {
     let url_request = ElicitationReviewRequest {
         server_name: "browser-use".to_string(),
         request_id: rmcp::model::NumberOrString::Number(8),
-        approvals_reviewer: ApprovalsReviewer::AutoReview,
         elicitation: CreateElicitationRequestParams::UrlElicitationParams {
             meta: guardian_meta(Some(json!({}))),
             message: "Open URL".to_string(),
@@ -188,7 +186,6 @@ fn guardian_elicitation_review_request_declines_unsupported_opt_in_shapes() {
     let non_empty_schema_request = ElicitationReviewRequest {
         server_name: "browser-use".to_string(),
         request_id: rmcp::model::NumberOrString::Number(9),
-        approvals_reviewer: ApprovalsReviewer::AutoReview,
         elicitation: CreateElicitationRequestParams::FormElicitationParams {
             meta: guardian_meta(Some(json!({}))),
             message: "Allow origin?".to_string(),

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -1183,7 +1183,6 @@ impl Session {
                 config.prefix_mcp_tool_names(),
                 client_elicitation_capability,
                 tool_plugin_provenance,
-                crate::connectors::mcp_approvals_reviewer_policy(config.as_ref()),
                 auth,
                 Some(sess.mcp_elicitation_reviewer()),
             )

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -696,9 +696,6 @@ impl Session {
             mcp_connection_manager.set_approval_policy(&session_configuration.approval_policy);
             mcp_connection_manager
                 .set_permission_profile(session_configuration.permission_profile());
-            mcp_connection_manager.set_approvals_reviewer_policy(
-                crate::connectors::mcp_approvals_reviewer_policy(&per_turn_config),
-            );
         }
 
         let model_info = self


### PR DESCRIPTION
## Summary
- resolve app-specific MCP approval reviewers in core from the active turn config
- remove the MCP-side approvals reviewer policy object and per-turn policy syncing
- keep direct MCP calls and MCP elicitations on the same reviewer-resolution path

## Tests
- `just fmt`
- `just fix -p codex-core`
- `just fix -p codex-mcp`
- `just test -p codex-mcp`
- `just test -p codex-core` started and reached a finished test build; final nextest summary was not captured before wrapping up