### PR TITLE
session: keep startup prewarm aligned with resolved multi-agent runtime

### DIFF
--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -757,8 +757,9 @@ impl Session {
             TurnMultiAgentRuntime::ResolveAndStore => {
                 self.resolve_multi_agent_version_for_model(&model_info, &per_turn_config)
             }
-            TurnMultiAgentRuntime::Preview => model_info
-                .multi_agent_version
+            TurnMultiAgentRuntime::Preview => self
+                .multi_agent_version()
+                .or(model_info.multi_agent_version)
                 .unwrap_or_else(|| per_turn_config.multi_agent_version_from_features()),
         };
         let plugin_outcome = self


### PR DESCRIPTION
## Why

Follow-up to #25722. Startup prewarm builds a preview `TurnContext` before the first real turn so it can precompute the initial prompt and tool surface. After the per-thread runtime work landed, that preview path still recomputed multi-agent mode from `model_info` and feature defaults instead of reusing the runtime the session had already resolved from persisted metadata or inheritance.

That could leave the prewarmed session primed for a different multi-agent mode than the first real turn, which is especially risky because collaboration tool exposure depends on `turn_context.multi_agent_version`.

## What changed

- In the `TurnMultiAgentRuntime::Preview` path, prefer `Session::multi_agent_version()` when it is already known.
- Only fall back to `model_info.multi_agent_version` and feature defaults when the session has not resolved a runtime yet.
- Keep preview mode read-only: this still avoids storing a runtime during startup prewarm.

## Testing

- Not run (small runtime-selection follow-up)
