### PR TITLE
[codex-rs] Enable Codex Apps auth elicitations safely

### DIFF
--- a/codex-rs/codex-mcp/src/rmcp_client.rs
+++ b/codex-rs/codex-mcp/src/rmcp_client.rs
@@ -481,13 +481,7 @@ async fn start_server_task(
         codex_apps_tools_cache_context,
         client_elicitation_capability,
     } = params;
-    let mut capabilities = ClientCapabilities::default();
-    capabilities.elicitation = Some(client_elicitation_capability);
-    let params = InitializeRequestParams::new(
-        capabilities,
-        Implementation::new("codex-mcp-client", env!("CARGO_PKG_VERSION")).with_title("Codex"),
-    )
-    .with_protocol_version(ProtocolVersion::V_2025_06_18);
+    let params = initialize_request_params(client_elicitation_capability);
 
     let send_elicitation = elicitation_requests.make_sender(server_name.clone(), tx_event);
 
@@ -571,6 +565,18 @@ struct StartServerTaskParams {
     elicitation_requests: ElicitationRequestManager,
     codex_apps_tools_cache_context: Option<CodexAppsToolsCacheContext>,
     client_elicitation_capability: ElicitationCapability,
+}
+
+fn initialize_request_params(
+    client_elicitation_capability: ElicitationCapability,
+) -> InitializeRequestParams {
+    let mut capabilities = ClientCapabilities::default();
+    capabilities.elicitation = Some(client_elicitation_capability);
+    InitializeRequestParams::new(
+        capabilities,
+        Implementation::new("codex-mcp-client", env!("CARGO_PKG_VERSION")).with_title("Codex"),
+    )
+    .with_protocol_version(ProtocolVersion::V_2025_06_18)
 }
 
 async fn make_rmcp_client(
@@ -660,8 +666,11 @@ async fn make_rmcp_client(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
+    use rmcp::model::ElicitationCapability;
     use rmcp::model::JsonObject;
     use rmcp::model::Meta;
+    use serde_json::json;
 
     fn tool_with_connector_meta() -> RmcpTool {
         RmcpTool::new(
@@ -685,6 +694,26 @@ mod tests {
             .expect("object")
             .clone(),
         ))
+    }
+
+    #[test]
+    fn initialize_request_uses_2025_06_18_elicitation_capability_by_default() {
+        let params = initialize_request_params(ElicitationCapability::default());
+
+        assert_eq!(
+            serde_json::to_value(params).expect("serialize initialize params"),
+            json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": {
+                    "elicitation": {},
+                },
+                "clientInfo": {
+                    "name": "codex-mcp-client",
+                    "title": "Codex",
+                    "version": env!("CARGO_PKG_VERSION"),
+                },
+            })
+        );
     }
 
     #[test]

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -488,6 +488,9 @@
             "local_thread_store_compression": {
               "type": "boolean"
             },
+            "mcp_url_elicitation_capability": {
+              "type": "boolean"
+            },
             "memories": {
               "type": "boolean"
             },
@@ -4609,6 +4612,9 @@
           "type": "boolean"
         },
         "local_thread_store_compression": {
+          "type": "boolean"
+        },
+        "mcp_url_elicitation_capability": {
           "type": "boolean"
         },
         "memories": {

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -5454,7 +5454,8 @@ async fn to_mcp_config_flows_mcp_tool_prefix_from_feature() -> std::io::Result<(
 }
 
 #[tokio::test]
-async fn to_mcp_config_preserves_auth_elicitation_feature_from_config() -> std::io::Result<()> {
+async fn to_mcp_config_keeps_auth_elicitation_separate_from_mcp_url_capability()
+-> std::io::Result<()> {
     let codex_home = TempDir::new()?;
     let mut config = Config::load_from_base_config_with_overrides(
         ConfigToml::default(),
@@ -5471,6 +5472,13 @@ async fn to_mcp_config_preserves_auth_elicitation_feature_from_config() -> std::
     );
 
     let _ = config.features.enable(Feature::AuthElicitation);
+    let mcp_config = config.to_mcp_config(&plugins_manager).await;
+    assert_eq!(
+        mcp_config.client_elicitation_capability,
+        ElicitationCapability::default()
+    );
+
+    let _ = config.features.enable(Feature::McpUrlElicitationCapability);
     let mcp_config = config.to_mcp_config(&plugins_manager).await;
     assert_eq!(
         mcp_config.client_elicitation_capability,

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -1415,7 +1415,10 @@ impl Config {
             use_legacy_landlock: self.features.use_legacy_landlock(),
             apps_enabled: self.features.enabled(Feature::Apps),
             prefix_mcp_tool_names: self.prefix_mcp_tool_names(),
-            client_elicitation_capability: if self.features.enabled(Feature::AuthElicitation) {
+            client_elicitation_capability: if self
+                .features
+                .enabled(Feature::McpUrlElicitationCapability)
+            {
                 ElicitationCapability {
                     form: Some(FormElicitationCapability::default()),
                     url: Some(UrlElicitationCapability::default()),

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -1283,8 +1283,13 @@ async fn install_host_owned_codex_apps_manager(session: &Session, turn_context: 
 
 #[tokio::test]
 async fn codex_apps_auth_elicitation_feature_disabled_returns_original_result() {
-    let (session, turn_context, rx_event) = make_session_and_context_with_rx().await;
+    let (session, mut turn_context, rx_event) = make_session_and_context_with_rx().await;
     install_host_owned_codex_apps_manager(&session, &turn_context).await;
+    let mut features = Features::with_defaults();
+    features.disable(Feature::AuthElicitation);
+    Arc::get_mut(&mut turn_context)
+        .expect("single turn context ref")
+        .features = ManagedFeatures::from(features);
     let result = codex_apps_auth_failure_result();
     let metadata = codex_apps_auth_failure_metadata();
 
@@ -1392,15 +1397,10 @@ async fn codex_apps_auth_elicitation_granular_mcp_disabled_returns_original_resu
 }
 
 #[tokio::test]
-async fn codex_apps_auth_elicitation_feature_enabled_requests_elicitation() {
-    let (session, mut turn_context, rx_event) = make_session_and_context_with_rx().await;
+async fn codex_apps_auth_elicitation_default_enabled_requests_elicitation() {
+    let (session, turn_context, rx_event) = make_session_and_context_with_rx().await;
     install_host_owned_codex_apps_manager(&session, &turn_context).await;
     *session.active_turn.lock().await = Some(ActiveTurn::default());
-    let mut features = Features::with_defaults();
-    features.enable(Feature::AuthElicitation);
-    Arc::get_mut(&mut turn_context)
-        .expect("single turn context ref")
-        .features = ManagedFeatures::from(features);
     let result = codex_apps_auth_failure_result();
     let metadata = codex_apps_auth_failure_metadata();
 

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -1133,7 +1133,10 @@ impl Session {
             let host_owned_codex_apps_enabled = config
                 .features
                 .apps_enabled_for_auth(auth.as_ref().is_some_and(|auth| auth.uses_codex_backend()));
-            let client_elicitation_capability = if config.features.enabled(Feature::AuthElicitation) {
+            let client_elicitation_capability = if config
+                .features
+                .enabled(Feature::McpUrlElicitationCapability)
+            {
                 ElicitationCapability {
                     form: Some(FormElicitationCapability::default()),
                     url: Some(UrlElicitationCapability::default()),

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -194,8 +194,10 @@ pub enum Feature {
     Goals,
     /// Route MCP tool approval prompts through the MCP elicitation request path.
     ToolCallMcpElicitation,
-    /// Prompt Codex Apps connector auth failures through MCP URL elicitations.
+    /// Prompt host-owned Codex Apps connector auth failures through URL elicitations.
     AuthElicitation,
+    /// Advertise URL elicitation support to configured MCP servers.
+    McpUrlElicitationCapability,
     /// Enable personality selection in the TUI.
     Personality,
     /// Enable native artifact tools.
@@ -1138,6 +1140,12 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::AuthElicitation,
         key: "auth_elicitation",
+        stage: Stage::Stable,
+        default_enabled: true,
+    },
+    FeatureSpec {
+        id: Feature::McpUrlElicitationCapability,
+        key: "mcp_url_elicitation_capability",
         stage: Stage::UnderDevelopment,
         default_enabled: false,
     },

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -302,12 +302,28 @@ fn tool_call_mcp_elicitation_is_stable_and_enabled_by_default() {
 }
 
 #[test]
-fn auth_elicitation_is_under_development() {
-    assert_eq!(Feature::AuthElicitation.stage(), Stage::UnderDevelopment);
-    assert_eq!(Feature::AuthElicitation.default_enabled(), false);
+fn auth_elicitation_is_stable_and_enabled_by_default() {
+    assert_eq!(Feature::AuthElicitation.stage(), Stage::Stable);
+    assert_eq!(Feature::AuthElicitation.default_enabled(), true);
     assert_eq!(
         feature_for_key("auth_elicitation"),
         Some(Feature::AuthElicitation)
+    );
+}
+
+#[test]
+fn mcp_url_elicitation_capability_is_under_development() {
+    assert_eq!(
+        Feature::McpUrlElicitationCapability.stage(),
+        Stage::UnderDevelopment
+    );
+    assert_eq!(
+        Feature::McpUrlElicitationCapability.default_enabled(),
+        false
+    );
+    assert_eq!(
+        feature_for_key("mcp_url_elicitation_capability"),
+        Some(Feature::McpUrlElicitationCapability)
     );
 }
 


### PR DESCRIPTION
[from codex]

Make Codex Apps connector auth recovery safe to enable by default without advertising a newer MCP elicitation capability shape to unrelated custom MCP servers.

`auth_elicitation` previously controlled two separate behaviors:

- synthesizing a host-owned Codex Apps URL elicitation after a connector auth failure
- advertising `elicitation.form` and `elicitation.url` in every MCP client initialize request

Codex still negotiates MCP `2025-06-18`, where strict servers may reject the later `{form, url}` capability shape. The connector auth recovery flow is synthesized by Codex from host-owned tool-result metadata, so it does not require that capability advertisement.

This change makes `auth_elicitation` stable and default-on for the host-owned recovery flow, and moves general URL elicitation capability advertisement behind a separate default-off `mcp_url_elicitation_capability` feature. Default custom MCP initialize requests continue to serialize `elicitation: {}` while negotiating `2025-06-18`.

It also adds regression coverage for the initialize payload, the feature split, and the default-enabled Codex Apps auth recovery path, and regenerates the config schema.

Related:
- https://github.com/openai/codex/pull/19193
- https://github.com/openai/codex/issues/20562

Validation:
- `just fmt`
- `just write-config-schema`
- `just test -p codex-features`
- `just test -p codex-mcp`
- `just test -p codex-core -E 'test(to_mcp_config_keeps_auth_elicitation_separate_from_mcp_url_capability) | test(codex_apps_auth_elicitation)'`
- `just fix -p codex-features`
- `just fix -p codex-mcp`
- `just fix -p codex-core`
- `git diff --check`
