### PR TITLE
flake: Keep plugin test homes alive

### DIFF
--- a/codex-rs/core/tests/suite/plugins.rs
+++ b/codex-rs/core/tests/suite/plugins.rs
@@ -18,6 +18,7 @@ use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
 use core_test_support::stdio_server_bin;
+use core_test_support::test_codex::TestCodex;
 use core_test_support::test_codex::test_codex;
 use core_test_support::wait_for_event;
 use core_test_support::wait_for_mcp_server;
@@ -101,7 +102,7 @@ fn write_plugin_app_plugin(home: &TempDir) {
 async fn build_analytics_plugin_test_codex(
     server: &MockServer,
     codex_home: Arc<TempDir>,
-) -> Result<Arc<codex_core::CodexThread>> {
+) -> Result<TestCodex> {
     let chatgpt_base_url = server.uri();
     let mut builder = test_codex()
         .with_home(codex_home)
@@ -113,15 +114,14 @@ async fn build_analytics_plugin_test_codex(
     Ok(builder
         .build(server)
         .await
-        .expect("create new conversation")
-        .codex)
+        .expect("create new conversation"))
 }
 
 async fn build_apps_enabled_plugin_test_codex(
     server: &MockServer,
     codex_home: Arc<TempDir>,
     chatgpt_base_url: String,
-) -> Result<Arc<codex_core::CodexThread>> {
+) -> Result<TestCodex> {
     let mut builder = test_codex()
         .with_home(codex_home)
         .with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing())
@@ -135,8 +135,7 @@ async fn build_apps_enabled_plugin_test_codex(
     Ok(builder
         .build(server)
         .await
-        .expect("create new conversation")
-        .codex)
+        .expect("create new conversation"))
 }
 
 fn tool_names(body: &serde_json::Value) -> Vec<String> {
@@ -171,12 +170,13 @@ async fn capability_sections_render_in_developer_message_in_order() -> Result<()
     let codex_home = Arc::new(TempDir::new()?);
     write_plugin_skill_plugin(codex_home.as_ref());
     write_plugin_app_plugin(codex_home.as_ref());
-    let codex = build_apps_enabled_plugin_test_codex(
+    let test_codex = build_apps_enabled_plugin_test_codex(
         &server,
         Arc::clone(&codex_home),
         apps_server.chatgpt_base_url,
     )
     .await?;
+    let codex = Arc::clone(&test_codex.codex);
 
     codex
         .submit(Op::UserInput {
@@ -253,9 +253,10 @@ async fn explicit_plugin_mentions_inject_plugin_guidance() -> Result<()> {
     write_plugin_mcp_plugin(codex_home.as_ref(), &rmcp_test_server_bin);
     write_plugin_app_plugin(codex_home.as_ref());
 
-    let codex =
+    let test_codex =
         build_apps_enabled_plugin_test_codex(&server, codex_home, apps_server.chatgpt_base_url)
             .await?;
+    let codex = Arc::clone(&test_codex.codex);
     wait_for_mcp_server(&codex, "sample").await?;
 
     codex
@@ -339,7 +340,8 @@ async fn explicit_plugin_mentions_track_plugin_used_analytics() -> Result<()> {
 
     let codex_home = Arc::new(TempDir::new()?);
     write_plugin_skill_plugin(codex_home.as_ref());
-    let codex = build_analytics_plugin_test_codex(&server, codex_home).await?;
+    let test_codex = build_analytics_plugin_test_codex(&server, codex_home).await?;
+    let codex = Arc::clone(&test_codex.codex);
 
     codex
         .submit(Op::UserInput {


### PR DESCRIPTION
## Summary

Keep the full `TestCodex` harness alive in plugin integration tests instead of returning only the `CodexThread`.

## Why

The helper was moving a temporary `codex_home` into `TestCodex`, then immediately dropping the harness and returning only the thread. For plugin MCP tests, the MCP server cwd is inside that temporary home. If the temp directory is removed while MCP startup is still racing, the server launch can fail with `No such file or directory`.

Keeping the harness in scope keeps the temp home alive for the test duration and removes the lifetime race behind the recent `explicit_plugin_mentions_inject_plugin_guidance` flake.

## Validation

- `just fmt`
- `just test -p codex-core explicit_plugin_mentions_inject_plugin_guidance`
