### PR TITLE
Skip startup prewarm when websockets are disabled

### DIFF
--- a/codex-rs/core/src/session_startup_prewarm.rs
+++ b/codex-rs/core/src/session_startup_prewarm.rs
@@ -172,6 +172,10 @@ impl SessionStartupPrewarmHandle {
 
 impl Session {
     pub(crate) async fn schedule_startup_prewarm(self: &Arc<Self>, base_instructions: String) {
+        if !self.services.model_client.responses_websocket_enabled() {
+            return;
+        }
+
         let session_telemetry = self.services.session_telemetry.clone();
         let websocket_connect_timeout = self.provider().await.websocket_connect_timeout();
         let started_at = Instant::now();


### PR DESCRIPTION
## Summary
- skip startup websocket prewarm setup when the model client has Responses-over-WebSocket disabled
- avoid making HTTP-only sessions build prewarm prompt/tool state that cannot produce a reusable websocket session

## Why
Recent macOS timing flakes were timing out while waiting for first-turn events in HTTP-only core tests. Startup prewarm is only useful for websocket-capable providers, but it was scheduled for every session. For HTTP-only test providers this added unnecessary async startup work before the regular turn could reach the mocked response flow.

## Testing
- bazel test //codex-rs/core:core-all-test --test_filter=suite::auto_review::remote_model_override_uses_catalog_model_for_strict_auto_review --test_output=errors
- bazel test //codex-rs/core:core-all-test --test_filter=suite::request_permissions_tool::approved_folder_write_request_permissions_unblocks_later_apply_patch --test_output=errors