### PR TITLE
[codex] DNS: exercise codex-core CI failure

### DIFF
--- a/codex-rs/core/src/util_tests.rs
+++ b/codex-rs/core/src/util_tests.rs
@@ -16,6 +16,12 @@ use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::util::SubscriberInitExt;
 
 #[test]
+fn ci_test_intentionally_fails() {
+    println!("running intentionally failing codex-core CI test");
+    panic!("intentional codex-core CI test failure");
+}
+
+#[test]
 fn feedback_tags_macro_compiles() {
     #[derive(Debug)]
     struct OnlyDebug;

--- a/codex-rs/core/tests/suite/compact.rs
+++ b/codex-rs/core/tests/suite/compact.rs
@@ -538,7 +538,7 @@ async fn summarize_context_three_requests_and_instructions() {
     wait_for_event(&codex, |ev| matches!(ev, EventMsg::ShutdownComplete)).await;
 
     // Verify rollout contains user-turn TurnContext entries and a Compacted entry.
-    println!("rollout path: {}", rollout_path.display());
+    println!("compacted rollout path: {}", rollout_path.display());
     let text = std::fs::read_to_string(&rollout_path).unwrap_or_else(|e| {
         panic!(
             "failed to read rollout file {}: {e}",


### PR DESCRIPTION
DO NOT SUBMIT. This draft PR exists only to verify CI failure reporting for `codex-core`.

It adds a clearly named, intentionally failing `codex-core` unit test and updates a test-only rollout `println!` label.

The local `codex-core` test run was interrupted before completion at the user's request. CI is expected to fail at `util::tests::ci_test_intentionally_fails`.