### PR TITLE
core: stop passing legacy SandboxPolicy to guardian reviews

### DIFF
--- a/codex-rs/core/src/guardian/review_session.rs
+++ b/codex-rs/core/src/guardian/review_session.rs
@@ -20,7 +20,6 @@ use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::InitialHistory;
 use codex_protocol::protocol::Op;
 use codex_protocol::protocol::RolloutItem;
-use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SubAgentSource;
 use codex_protocol::protocol::TokenUsage;
@@ -719,9 +718,7 @@ async fn run_review_on_session(
         .total_token_usage()
         .await
         .unwrap_or_default();
-    // The legacy SandboxPolicy should match the PermissionProfile.
     let guardian_permission_profile = PermissionProfile::read_only();
-    let legacy_sandbox_policy = SandboxPolicy::new_read_only_policy();
 
     let submit_result = run_before_review_deadline(
         deadline,
@@ -736,7 +733,7 @@ async fn run_review_on_session(
                 #[allow(deprecated)]
                 cwd: Some(params.parent_turn.cwd.to_path_buf()),
                 approval_policy: Some(AskForApproval::Never),
-                sandbox_policy: Some(legacy_sandbox_policy),
+                sandbox_policy: None,
                 permission_profile: Some(guardian_permission_profile),
                 summary: Some(params.reasoning_summary),
                 personality: params.personality,


### PR DESCRIPTION
## Why

Guardian review turns already submit a read-only `PermissionProfile`, which is the permissions model the runtime should honor. Passing the equivalent legacy `SandboxPolicy` through `ThreadSettingsOverrides` keeps two representations of the same read-only constraint alive on this path and makes the guardian flow depend on compatibility plumbing that is being phased out.

## What Changed

- Set `sandbox_policy` to `None` when the guardian review session submits its child `Op::UserInput`.
- Keep `permission_profile: Some(PermissionProfile::read_only())` and `approval_policy: Some(AskForApproval::Never)`, so the guardian review remains read-only and cannot request approvals.
- Remove the now-unused `SandboxPolicy` import and redundant comment from `codex-rs/core/src/guardian/review_session.rs`.

## Verification

Not run locally; this is a narrow cleanup of redundant thread-settings override state.