### PR TITLE
Fix Windows release PDB staging

### DIFF
--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -134,11 +134,22 @@ jobs:
       - name: Stage Windows binaries
         shell: bash
         run: |
-          output_dir="target/${{ matrix.target }}/release/staged-${{ matrix.bundle }}"
+          release_dir="target/${{ matrix.target }}/release"
+          output_dir="$release_dir/staged-${{ matrix.bundle }}"
           mkdir -p "$output_dir"
           for binary in ${{ matrix.binaries }}; do
-            cp "target/${{ matrix.target }}/release/${binary}.exe" "$output_dir/${binary}.exe"
-            cp "target/${{ matrix.target }}/release/${binary}.pdb" "$output_dir/${binary}.pdb"
+            pdb_name="${binary//-/_}"
+            pdb_path="$release_dir/${pdb_name}.pdb"
+            if [[ ! -f "$pdb_path" ]]; then
+              pdb_path="$release_dir/${binary}.pdb"
+            fi
+            if [[ ! -f "$pdb_path" ]]; then
+              echo "PDB for $binary not found at $release_dir/${pdb_name}.pdb or $release_dir/${binary}.pdb" >&2
+              exit 1
+            fi
+
+            cp "$release_dir/${binary}.exe" "$output_dir/${binary}.exe"
+            cp "$pdb_path" "$output_dir/${binary}.pdb"
           done
 
       - name: Upload Windows binaries


### PR DESCRIPTION
## Summary
- Teach the Windows release prebuild staging step to locate Rust/MSVC PDBs emitted with crate-style underscore names.
- Stage PDBs under the shipped hyphenated binary names so the downstream symbol archive step keeps the same artifact contract.
- Keep a fallback for already-hyphenated PDB names and fail with a clear diagnostic if neither form exists.

## Root cause
The recent symbol publishing change in #25649 started copying `${binary}.pdb` from `target/<triple>/release` during Windows prebuild staging. Cargo still emits the `.exe` with the hyphenated binary name, but MSVC PDBs for hyphenated Rust crates are emitted with underscores, for example `codex_app_server.pdb` for `codex-app-server.exe`. The release workflow was still building into the expected directory; the new PDB copy step was looking for the wrong filename.

## Impact
This unblocks the `rust-release` Windows prebuilt-binary jobs for hyphenated binaries while preserving the hyphenated PDB names consumed by the final Windows release packaging and symbol archive steps.

## Validation
- `just fmt` from `codex-rs`
- `git diff --check -- .github/workflows/rust-release-windows.yml`
- Parsed `.github/workflows/rust-release-windows.yml` as YAML locally
- Local bash staging sanity test for both underscore-emitted and hyphenated PDB filenames