### PR TITLE
[codex] Filter plugin install suggestions by active app

### DIFF
--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -117,7 +117,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.0"
+version = "0.136.0"
 # Track the edition for all workspace crates in one place. Individual
 # crates can still override this value, but keeping it here means new
 # crates created with `cargo new -w ...` automatically inherit the 2024

--- a/codex-rs/core/src/connectors.rs
+++ b/codex-rs/core/src/connectors.rs
@@ -129,10 +129,21 @@ pub(crate) async fn list_tool_suggest_discoverable_tools_with_auth(
         )
         .into_iter()
         .map(DiscoverableTool::from);
+    let accessible_enabled_connector_ids = accessible_connectors
+        .iter()
+        .filter(|connector| connector.is_accessible && connector.is_enabled)
+        .map(|connector| connector.id.as_str())
+        .collect::<HashSet<_>>();
     let discoverable_plugins =
         list_tool_suggest_discoverable_plugins(config, loaded_plugin_app_connector_ids)
             .await?
             .into_iter()
+            .filter(|plugin| {
+                plugin.app_connector_ids.is_empty()
+                    || plugin.app_connector_ids.iter().any(|connector_id| {
+                        accessible_enabled_connector_ids.contains(connector_id.as_str())
+                    })
+            })
             .map(DiscoverableTool::from);
     Ok(discoverable_connectors
         .chain(discoverable_plugins)

--- a/codex-rs/core/src/connectors_tests.rs
+++ b/codex-rs/core/src/connectors_tests.rs
@@ -16,6 +16,7 @@ use codex_config::types::AppsDefaultConfig;
 use codex_connectors::merge::plugin_connector_to_app_info;
 use codex_connectors::metadata::connector_install_url;
 use codex_connectors::metadata::sanitize_name;
+use codex_core_plugins::startup_sync::curated_plugins_repo_path;
 use codex_features::Feature;
 use codex_login::CodexAuth;
 use codex_mcp::CODEX_APPS_MCP_SERVER_NAME;
@@ -1283,5 +1284,86 @@ apps = true
         vec![DiscoverableTool::from(plugin_connector_to_app_info(
             "asdk_app_databricks_workspace".to_string(),
         ))]
+    );
+}
+
+#[tokio::test]
+async fn tool_suggest_omits_plugin_candidates_without_accessible_enabled_app() {
+    let codex_home = tempdir().expect("tempdir should succeed");
+    let curated_root = curated_plugins_repo_path(codex_home.path());
+    crate::plugins::test_support::write_openai_curated_marketplace(&curated_root, &["hubspot"]);
+    std::fs::write(
+        codex_home.path().join(CONFIG_TOML_FILE),
+        r#"[features]
+apps = true
+plugins = true
+"#,
+    )
+    .expect("write config");
+    let config = ConfigBuilder::default()
+        .codex_home(codex_home.path().to_path_buf())
+        .build()
+        .await
+        .expect("config should load");
+    let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
+    let loaded_plugin_app_connector_ids = vec!["connector_calendar".to_string()];
+
+    let discoverable_tools = list_tool_suggest_discoverable_tools_with_auth(
+        &config,
+        Some(&auth),
+        &[],
+        &loaded_plugin_app_connector_ids,
+    )
+    .await
+    .expect("discoverable tools should load");
+
+    assert_eq!(
+        discoverable_tools,
+        vec![DiscoverableTool::from(plugin_connector_to_app_info(
+            "connector_calendar".to_string(),
+        ))]
+    );
+}
+
+#[tokio::test]
+async fn tool_suggest_includes_plugin_candidates_with_accessible_enabled_app() {
+    let codex_home = tempdir().expect("tempdir should succeed");
+    let curated_root = curated_plugins_repo_path(codex_home.path());
+    crate::plugins::test_support::write_openai_curated_marketplace(&curated_root, &["hubspot"]);
+    std::fs::write(
+        codex_home.path().join(CONFIG_TOML_FILE),
+        r#"[features]
+apps = true
+plugins = true
+"#,
+    )
+    .expect("write config");
+    let config = ConfigBuilder::default()
+        .codex_home(codex_home.path().to_path_buf())
+        .build()
+        .await
+        .expect("config should load");
+    let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
+    let loaded_plugin_app_connector_ids = vec!["connector_calendar".to_string()];
+
+    let discoverable_tools = list_tool_suggest_discoverable_tools_with_auth(
+        &config,
+        Some(&auth),
+        &[AppInfo {
+            is_accessible: true,
+            is_enabled: true,
+            ..app("connector_calendar")
+        }],
+        &loaded_plugin_app_connector_ids,
+    )
+    .await
+    .expect("discoverable tools should load");
+
+    assert_eq!(
+        discoverable_tools
+            .iter()
+            .map(DiscoverableTool::id)
+            .collect::<Vec<_>>(),
+        vec!["hubspot@openai-curated"]
     );
 }


### PR DESCRIPTION
## Summary

Fixes the in-conversation plugin install elicitation list so app-backed plugin candidates are only offered when at least one backing app connector is currently accessible and enabled for Codex.

This keeps connector suggestions available, but prevents the model from offering plugin installs whose underlying connector is unavailable to the user.

## Problem

The bug was in the join between two discovery systems:

- Connector suggestions already filtered candidate connector IDs against current connector state, including whether the connector is accessible to this user.
- Plugin suggestions loaded marketplace/plugin metadata and could offer a plugin when its `app_connector_ids` matched loaded plugin app IDs, but did not verify that those connector IDs were actually accessible and enabled for the current user.

That allowed Codex to list or install-suggest plugins like Alpaca/Otter/Actively even when the backing connector was admin-disabled or otherwise unavailable.

## Fix

In the combined tool-suggest discovery path, this now builds the set of connector IDs where `is_accessible && is_enabled`, then filters plugin candidates as follows:

- keep plugins with no `app_connector_ids`, because they are not app-backed;
- keep app-backed plugins only when at least one of their `app_connector_ids` is in the accessible+enabled connector set.

The rule is intentionally `any`, not `all`: a single-app plugin like Datadog should be hidden if that one app is unavailable, but a broad plugin like Sales should remain suggestible when at least one of its underlying apps is available to the user.

So Codex no longer offers app-backed plugin installs that cannot complete or be useful through any backing connector, while preserving non-app-backed plugin suggestions, multi-app plugin suggestions with at least one usable app, and connector suggestions.

## Validation

- `just test -p codex-core tool_suggest_omits_plugin_candidates_without_accessible_enabled_app tool_suggest_includes_plugin_candidates_with_accessible_enabled_app tool_suggest_includes_connectors_from_loaded_plugin_apps`
- `git diff --check`

## Scope

This intentionally scopes to elicitation/listing correctness only. It does not change broader plugin invocation behavior when a plugin is already installed.