### PR TITLE
fix: update image generation test helper rename

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/image_generation.rs
+++ b/codex-rs/app-server/tests/suite/v2/image_generation.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use anyhow::Context;
 use anyhow::Result;
 use app_test_support::ChatGptAuthFixture;
-use app_test_support::McpProcess;
+use app_test_support::TestAppServer;
 use app_test_support::to_response;
 use app_test_support::write_chatgpt_auth;
 use codex_app_server_protocol::ItemCompletedNotification;
@@ -76,7 +76,8 @@ async fn standalone_image_generation_persists_image_and_returns_it_to_model() ->
         AuthCredentialsStoreMode::File,
     )?;
 
-    let mut mcp = McpProcess::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)]).await?;
+    let mut mcp =
+        TestAppServer::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)]).await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
 
     let thread_req = mcp
@@ -157,7 +158,7 @@ async fn standalone_image_generation_persists_image_and_returns_it_to_model() ->
 }
 
 async fn wait_for_image_generation_completed(
-    mcp: &mut McpProcess,
+    mcp: &mut TestAppServer,
 ) -> Result<ItemCompletedNotification> {
     loop {
         let notification = mcp


### PR DESCRIPTION
## Summary
- update the app-server image generation integration test to use `TestAppServer`
- completes the test helper rename from #25701 for this newer test file

## Validation
- `cargo fmt -- --config imports_granularity=Item`
- `cargo check -p codex-app-server --test all`

Note: `just fmt` ran Rust formatting but failed on Python/SDK formatting because the sandbox could not access the local `uv` cache.