### PR TITLE
[codex] Fix app-server image generation Bazel test

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/image_generation.rs
+++ b/codex-rs/app-server/tests/suite/v2/image_generation.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use anyhow::Context;
 use anyhow::Result;
 use app_test_support::ChatGptAuthFixture;
-use app_test_support::McpProcess;
+use app_test_support::TestAppServer;
 use app_test_support::to_response;
 use app_test_support::write_chatgpt_auth;
 use codex_app_server_protocol::ItemCompletedNotification;
@@ -76,7 +76,8 @@ async fn standalone_image_generation_persists_image_and_returns_it_to_model() ->
         AuthCredentialsStoreMode::File,
     )?;
 
-    let mut mcp = McpProcess::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)]).await?;
+    let mut mcp =
+        TestAppServer::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)]).await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
 
     let thread_req = mcp
@@ -157,7 +158,7 @@ async fn standalone_image_generation_persists_image_and_returns_it_to_model() ->
 }
 
 async fn wait_for_image_generation_completed(
-    mcp: &mut McpProcess,
+    mcp: &mut TestAppServer,
 ) -> Result<ItemCompletedNotification> {
     loop {
         let notification = mcp


### PR DESCRIPTION
## What changed
- Replace the stale `McpProcess` helper name with `TestAppServer` in the standalone image-generation app-server integration test.

## Why
PR #25176 added the test after the helper had been renamed. Bazel compiles the test suite and failed on the unresolved `app_test_support::McpProcess` import, breaking `main`.

## Validation
- `UV_CACHE_DIR=/private/tmp/codex-uv-cache just fmt`
- `just test -p codex-app-server standalone_image_generation_persists_image_and_returns_it_to_model`
- `git diff --check`

## Note
A local Bazel retry could not start because the shared Bazel repository cache was locked.