### PR TITLE
[codex] Read plugin marketplaces from effective config

### DIFF
--- a/codex-rs/cli/src/plugin_cmd.rs
+++ b/codex-rs/cli/src/plugin_cmd.rs
@@ -552,10 +552,8 @@ pub(crate) fn configured_marketplace_snapshot_issues(
     load_errors: &[MarketplaceListError],
     marketplace_name: Option<&str>,
 ) -> Vec<ConfiguredMarketplaceSnapshotIssue> {
-    let Some(user_config) = plugins_input.config_layer_stack.effective_user_config() else {
-        return Vec::new();
-    };
-    let Some(configured_marketplaces) = user_config
+    let effective_config = plugins_input.config_layer_stack.effective_config();
+    let Some(configured_marketplaces) = effective_config
         .get("marketplaces")
         .and_then(toml::Value::as_table)
     else {

--- a/codex-rs/config/src/config_toml.rs
+++ b/codex-rs/config/src/config_toml.rs
@@ -430,7 +430,8 @@ pub struct ConfigToml {
     #[serde(default)]
     pub plugins: HashMap<String, PluginConfig>,
 
-    /// User-level marketplace entries keyed by marketplace name.
+    /// Plugin marketplace entries keyed by marketplace name. Entries follow
+    /// normal config layer precedence.
     #[serde(default)]
     pub marketplaces: HashMap<String, MarketplaceConfig>,
 

--- a/codex-rs/core-plugins/src/installed_marketplaces.rs
+++ b/codex-rs/core-plugins/src/installed_marketplaces.rs
@@ -18,10 +18,8 @@ pub fn installed_marketplace_roots_from_layer_stack(
     config_layer_stack: &ConfigLayerStack,
     codex_home: &Path,
 ) -> Vec<AbsolutePathBuf> {
-    let Some(user_config) = config_layer_stack.effective_user_config() else {
-        return Vec::new();
-    };
-    let Some(marketplaces_value) = user_config.get("marketplaces") else {
+    let effective_config = config_layer_stack.effective_config();
+    let Some(marketplaces_value) = effective_config.get("marketplaces") else {
         return Vec::new();
     };
     let Some(marketplaces) = marketplaces_value.as_table() else {
@@ -74,3 +72,7 @@ pub fn resolve_configured_marketplace_root(
         _ => Some(default_install_root.join(marketplace_name)),
     }
 }
+
+#[cfg(test)]
+#[path = "installed_marketplaces_tests.rs"]
+mod tests;

--- a/codex-rs/core-plugins/src/installed_marketplaces_tests.rs
+++ b/codex-rs/core-plugins/src/installed_marketplaces_tests.rs
@@ -1,0 +1,132 @@
+use super::*;
+use codex_app_server_protocol::ConfigLayerSource;
+use codex_config::ConfigLayerEntry;
+use codex_config::ConfigRequirements;
+use codex_config::ConfigRequirementsToml;
+use pretty_assertions::assert_eq;
+use tempfile::TempDir;
+
+fn config_layer(source: ConfigLayerSource, contents: &str) -> ConfigLayerEntry {
+    ConfigLayerEntry::new(
+        source,
+        toml::from_str(contents).expect("config TOML should parse"),
+    )
+}
+
+fn write_marketplace_manifest(root: &Path, name: &str) {
+    std::fs::create_dir_all(root.join(".agents/plugins"))
+        .expect("marketplace root should be created");
+    std::fs::write(
+        root.join(".agents/plugins/marketplace.json"),
+        format!(r#"{{"name":"{name}","plugins":[]}}"#),
+    )
+    .expect("marketplace manifest should be written");
+}
+
+#[test]
+fn installed_marketplace_roots_include_mdm_system_and_cloud_config() {
+    let codex_home = TempDir::new().expect("codex home");
+    let install_root = marketplace_install_root(codex_home.path());
+    for name in ["cloud", "mdm", "system"] {
+        write_marketplace_manifest(&install_root.join(name), name);
+    }
+
+    let stack = ConfigLayerStack::new(
+        vec![
+            config_layer(
+                ConfigLayerSource::Mdm {
+                    domain: "com.openai.codex".to_string(),
+                    key: "config".to_string(),
+                },
+                r#"
+[marketplaces.mdm]
+source_type = "git"
+source = "https://example.com/mdm.git"
+"#,
+            ),
+            config_layer(
+                ConfigLayerSource::System {
+                    file: AbsolutePathBuf::try_from(codex_home.path().join("etc/config.toml"))
+                        .expect("system config path should be absolute"),
+                },
+                r#"
+[marketplaces.system]
+source_type = "git"
+source = "https://example.com/system.git"
+"#,
+            ),
+            config_layer(
+                ConfigLayerSource::EnterpriseManaged {
+                    id: "cfg_cloud".to_string(),
+                    name: "Cloud marketplaces".to_string(),
+                },
+                r#"
+[marketplaces.cloud]
+source_type = "git"
+source = "https://example.com/cloud.git"
+"#,
+            ),
+        ],
+        ConfigRequirements::default(),
+        ConfigRequirementsToml::default(),
+    )
+    .expect("config layer stack should build");
+
+    assert_eq!(
+        installed_marketplace_roots_from_layer_stack(&stack, codex_home.path()),
+        ["cloud", "mdm", "system"]
+            .into_iter()
+            .map(|name| AbsolutePathBuf::try_from(install_root.join(name)).unwrap())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn installed_marketplace_roots_use_normal_config_precedence() {
+    let codex_home = TempDir::new().expect("codex home");
+    let system_root = codex_home.path().join("system-marketplace");
+    let user_root = codex_home.path().join("user-marketplace");
+    write_marketplace_manifest(&system_root, "shared");
+    write_marketplace_manifest(&user_root, "shared");
+
+    let stack = ConfigLayerStack::new(
+        vec![
+            config_layer(
+                ConfigLayerSource::System {
+                    file: AbsolutePathBuf::try_from(codex_home.path().join("etc/config.toml"))
+                        .expect("system config path should be absolute"),
+                },
+                &format!(
+                    r#"
+[marketplaces.shared]
+source_type = "local"
+source = "{}"
+"#,
+                    system_root.display()
+                ),
+            ),
+            config_layer(
+                ConfigLayerSource::User {
+                    file: AbsolutePathBuf::try_from(codex_home.path().join("config.toml"))
+                        .expect("user config path should be absolute"),
+                    profile: None,
+                },
+                &format!(
+                    r#"
+[marketplaces.shared]
+source = "{}"
+"#,
+                    user_root.display()
+                ),
+            ),
+        ],
+        ConfigRequirements::default(),
+        ConfigRequirementsToml::default(),
+    )
+    .expect("config layer stack should build");
+
+    assert_eq!(
+        installed_marketplace_roots_from_layer_stack(&stack, codex_home.path()),
+        vec![AbsolutePathBuf::try_from(user_root).unwrap()]
+    );
+}

--- a/codex-rs/core-plugins/src/marketplace_upgrade.rs
+++ b/codex-rs/core-plugins/src/marketplace_upgrade.rs
@@ -45,6 +45,20 @@ struct ConfiguredGitMarketplace {
     ref_name: Option<String>,
     sparse_paths: Vec<String>,
     last_revision: Option<String>,
+    persist_to_user_config: bool,
+}
+
+impl ConfiguredGitMarketplace {
+    fn has_same_source(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.source == other.source
+            && self.ref_name == other.ref_name
+            && self.sparse_paths == other.sparse_paths
+    }
+
+    fn has_same_config(&self, other: &Self) -> bool {
+        self.has_same_source(other) && self.last_revision == other.last_revision
+    }
 }
 
 impl ConfiguredMarketplaceUpgradeOutcome {
@@ -109,29 +123,45 @@ fn marketplace_install_root(codex_home: &Path) -> PathBuf {
 fn configured_git_marketplaces(
     config_layer_stack: &ConfigLayerStack,
 ) -> Vec<ConfiguredGitMarketplace> {
-    let Some(user_config) = config_layer_stack.effective_user_config() else {
-        return Vec::new();
-    };
-    let Some(marketplaces_value) = user_config.get("marketplaces") else {
-        return Vec::new();
-    };
-    let marketplaces = match marketplaces_value
-        .clone()
-        .try_into::<HashMap<String, MarketplaceConfig>>()
-    {
-        Ok(marketplaces) => marketplaces,
+    let user_marketplaces = config_layer_stack
+        .effective_user_config()
+        .and_then(|config| configured_git_marketplaces_from_config(&config).ok())
+        .unwrap_or_default()
+        .into_iter()
+        .map(|marketplace| (marketplace.name.clone(), marketplace))
+        .collect::<HashMap<_, _>>();
+
+    let effective_config = config_layer_stack.effective_config();
+    let mut configured = match configured_git_marketplaces_from_config(&effective_config) {
+        Ok(configured) => configured,
         Err(err) => {
             warn!("invalid marketplaces config while preparing auto-upgrade: {err}");
             return Vec::new();
         }
     };
 
-    let mut configured = marketplaces
-        .into_iter()
-        .filter_map(|(name, marketplace)| configured_git_marketplace_from_config(name, marketplace))
-        .collect::<Vec<_>>();
+    for marketplace in &mut configured {
+        marketplace.persist_to_user_config = user_marketplaces
+            .get(&marketplace.name)
+            .is_some_and(|user_marketplace| user_marketplace.has_same_source(marketplace));
+    }
     configured.sort_unstable_by(|left, right| left.name.cmp(&right.name));
     configured
+}
+
+fn configured_git_marketplaces_from_config(
+    config: &toml::Value,
+) -> Result<Vec<ConfiguredGitMarketplace>, toml::de::Error> {
+    let Some(marketplaces_value) = config.get("marketplaces") else {
+        return Ok(Vec::new());
+    };
+    let marketplaces = marketplaces_value
+        .clone()
+        .try_into::<HashMap<String, MarketplaceConfig>>()?;
+    Ok(marketplaces
+        .into_iter()
+        .filter_map(|(name, marketplace)| configured_git_marketplace_from_config(name, marketplace))
+        .collect())
 }
 
 fn configured_git_marketplace_from_config(
@@ -162,6 +192,7 @@ fn configured_git_marketplace_from_config(
         ref_name,
         sparse_paths: sparse_paths.unwrap_or_default(),
         last_revision,
+        persist_to_user_config: false,
     })
 }
 
@@ -178,7 +209,8 @@ fn upgrade_configured_git_marketplace(
     )?;
     let destination = install_root.join(&marketplace.name);
     if find_marketplace_manifest_path(&destination).is_some()
-        && marketplace.last_revision.as_deref() == Some(remote_revision.as_str())
+        && (!marketplace.persist_to_user_config
+            || marketplace.last_revision.as_deref() == Some(remote_revision.as_str()))
         && installed_marketplace_metadata_matches(&destination, marketplace, &remote_revision)
     {
         return Ok(None);
@@ -228,6 +260,11 @@ fn upgrade_configured_git_marketplace(
         sparse_paths: &marketplace.sparse_paths,
     };
     activate_marketplace_root(&destination, staged_dir, || {
+        // Keep marketplace definitions owned by their original config layer so
+        // future updates are not shadowed by user config.
+        if !marketplace.persist_to_user_config {
+            return Ok(());
+        }
         ensure_configured_git_marketplace_unchanged(codex_home, marketplace)?;
         record_user_marketplace(codex_home, &marketplace.name, &update).map_err(|err| {
             format!(
@@ -247,7 +284,7 @@ fn ensure_configured_git_marketplace_unchanged(
 ) -> Result<(), String> {
     let current = read_configured_git_marketplace(codex_home, &expected.name)?;
     match current {
-        Some(current) if current == *expected => Ok(()),
+        Some(current) if current.has_same_config(expected) => Ok(()),
         Some(_) => Err(format!(
             "configured marketplace `{}` changed while auto-upgrade was in flight",
             expected.name
@@ -295,3 +332,7 @@ fn read_configured_git_marketplace(
         marketplace,
     ))
 }
+
+#[cfg(test)]
+#[path = "marketplace_upgrade_tests.rs"]
+mod tests;

--- a/codex-rs/core-plugins/src/marketplace_upgrade_tests.rs
+++ b/codex-rs/core-plugins/src/marketplace_upgrade_tests.rs
@@ -1,0 +1,220 @@
+use super::*;
+use anyhow::Result;
+use codex_app_server_protocol::ConfigLayerSource;
+use codex_config::ConfigLayerEntry;
+use codex_config::ConfigRequirements;
+use codex_config::ConfigRequirementsToml;
+use pretty_assertions::assert_eq;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+fn config_layer(source: ConfigLayerSource, contents: &str) -> ConfigLayerEntry {
+    ConfigLayerEntry::new(
+        source,
+        toml::from_str(contents).expect("config TOML should parse"),
+    )
+}
+
+fn run_git(cwd: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git").current_dir(cwd).args(args).output()?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "git {} failed in {}: {}",
+            args.join(" "),
+            cwd.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn init_marketplace_repo(root: &Path, marketplace_name: &str, marker: &str) -> Result<()> {
+    run_git(root, &["init"])?;
+    run_git(root, &["config", "user.email", "codex@example.com"])?;
+    run_git(root, &["config", "user.name", "Codex Tests"])?;
+    std::fs::create_dir_all(root.join(".agents/plugins"))?;
+    std::fs::write(
+        root.join(".agents/plugins/marketplace.json"),
+        format!(r#"{{"name":"{marketplace_name}","plugins":[]}}"#),
+    )?;
+    std::fs::write(root.join("marker.txt"), marker)?;
+    run_git(root, &["add", "."])?;
+    run_git(root, &["commit", "-m", "initial marketplace"])?;
+    Ok(())
+}
+
+fn managed_marketplace_stack(source: &Path) -> ConfigLayerStack {
+    ConfigLayerStack::new(
+        vec![config_layer(
+            ConfigLayerSource::EnterpriseManaged {
+                id: "cfg_marketplaces".to_string(),
+                name: "Managed marketplaces".to_string(),
+            },
+            &format!(
+                r#"
+[marketplaces.debug]
+source_type = "git"
+source = "{}"
+"#,
+                source.display()
+            ),
+        )],
+        ConfigRequirements::default(),
+        ConfigRequirementsToml::default(),
+    )
+    .expect("config layer stack should build")
+}
+
+#[test]
+fn configured_git_marketplaces_merge_mdm_system_cloud_and_user_layers() {
+    let temp_dir = TempDir::new().expect("tempdir");
+    let stack = ConfigLayerStack::new(
+        vec![
+            config_layer(
+                ConfigLayerSource::Mdm {
+                    domain: "com.openai.codex".to_string(),
+                    key: "config".to_string(),
+                },
+                r#"
+[marketplaces.mdm]
+source_type = "git"
+source = "https://example.com/mdm.git"
+"#,
+            ),
+            config_layer(
+                ConfigLayerSource::System {
+                    file: AbsolutePathBuf::try_from(temp_dir.path().join("etc/config.toml"))
+                        .expect("system config path should be absolute"),
+                },
+                r#"
+[marketplaces.system]
+source_type = "git"
+source = "https://example.com/system.git"
+"#,
+            ),
+            config_layer(
+                ConfigLayerSource::EnterpriseManaged {
+                    id: "cfg_cloud".to_string(),
+                    name: "Cloud marketplaces".to_string(),
+                },
+                r#"
+[marketplaces.cloud]
+source_type = "git"
+source = "https://example.com/cloud.git"
+"#,
+            ),
+            config_layer(
+                ConfigLayerSource::User {
+                    file: AbsolutePathBuf::try_from(temp_dir.path().join("config.toml"))
+                        .expect("user config path should be absolute"),
+                    profile: None,
+                },
+                r#"
+[marketplaces.user]
+source_type = "git"
+source = "https://example.com/user.git"
+"#,
+            ),
+        ],
+        ConfigRequirements::default(),
+        ConfigRequirementsToml::default(),
+    )
+    .expect("config layer stack should build");
+
+    assert_eq!(
+        configured_git_marketplaces(&stack),
+        vec![
+            ConfiguredGitMarketplace {
+                name: "cloud".to_string(),
+                source: "https://example.com/cloud.git".to_string(),
+                ref_name: None,
+                sparse_paths: Vec::new(),
+                last_revision: None,
+                persist_to_user_config: false,
+            },
+            ConfiguredGitMarketplace {
+                name: "mdm".to_string(),
+                source: "https://example.com/mdm.git".to_string(),
+                ref_name: None,
+                sparse_paths: Vec::new(),
+                last_revision: None,
+                persist_to_user_config: false,
+            },
+            ConfiguredGitMarketplace {
+                name: "system".to_string(),
+                source: "https://example.com/system.git".to_string(),
+                ref_name: None,
+                sparse_paths: Vec::new(),
+                last_revision: None,
+                persist_to_user_config: false,
+            },
+            ConfiguredGitMarketplace {
+                name: "user".to_string(),
+                source: "https://example.com/user.git".to_string(),
+                ref_name: None,
+                sparse_paths: Vec::new(),
+                last_revision: None,
+                persist_to_user_config: true,
+            },
+        ]
+    );
+}
+
+#[test]
+fn managed_marketplace_upgrade_does_not_create_user_override() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    let first_source = TempDir::new()?;
+    let second_source = TempDir::new()?;
+    init_marketplace_repo(first_source.path(), "debug", "first")?;
+    init_marketplace_repo(second_source.path(), "debug", "second")?;
+
+    let first_stack = managed_marketplace_stack(first_source.path());
+    let first_outcome =
+        upgrade_configured_git_marketplaces(codex_home.path(), &first_stack, Some("debug"));
+    let installed_root = marketplace_install_root(codex_home.path()).join("debug");
+
+    assert_eq!(
+        first_outcome,
+        ConfiguredMarketplaceUpgradeOutcome {
+            selected_marketplaces: vec!["debug".to_string()],
+            upgraded_roots: vec![AbsolutePathBuf::try_from(installed_root.clone()).unwrap()],
+            errors: Vec::new(),
+        }
+    );
+    assert_eq!(
+        std::fs::read_to_string(installed_root.join("marker.txt"))?,
+        "first"
+    );
+    assert!(!codex_home.path().join(CONFIG_TOML_FILE).exists());
+
+    let unchanged_outcome =
+        upgrade_configured_git_marketplaces(codex_home.path(), &first_stack, Some("debug"));
+    assert_eq!(
+        unchanged_outcome,
+        ConfiguredMarketplaceUpgradeOutcome {
+            selected_marketplaces: vec!["debug".to_string()],
+            upgraded_roots: Vec::new(),
+            errors: Vec::new(),
+        }
+    );
+
+    let second_stack = managed_marketplace_stack(second_source.path());
+    let second_outcome =
+        upgrade_configured_git_marketplaces(codex_home.path(), &second_stack, Some("debug"));
+    assert_eq!(
+        second_outcome,
+        ConfiguredMarketplaceUpgradeOutcome {
+            selected_marketplaces: vec!["debug".to_string()],
+            upgraded_roots: vec![AbsolutePathBuf::try_from(installed_root.clone()).unwrap()],
+            errors: Vec::new(),
+        }
+    );
+    assert_eq!(
+        std::fs::read_to_string(installed_root.join("marker.txt"))?,
+        "second"
+    );
+    assert!(!codex_home.path().join(CONFIG_TOML_FILE).exists());
+
+    Ok(())
+}

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -4876,7 +4876,7 @@
         "$ref": "#/definitions/MarketplaceConfig"
       },
       "default": {},
-      "description": "User-level marketplace entries keyed by marketplace name.",
+      "description": "Plugin marketplace entries keyed by marketplace name. Entries follow normal config layer precedence.",
       "type": "object"
     },
     "mcp_oauth_callback_port": {

--- a/codex-rs/tui/src/chatwidget/plugins.rs
+++ b/codex-rs/tui/src/chatwidget/plugins.rs
@@ -711,14 +711,18 @@ impl ChatWidget {
         else {
             return false;
         };
-        let Some(marketplace) = plugins_response.marketplaces.iter().find(|marketplace| {
-            marketplace_tab_id(marketplace) == active_tab_id
-                && marketplace_is_user_configured(&self.config, &marketplace.name)
-        }) else {
+        let Some(marketplace) = plugins_response
+            .marketplaces
+            .iter()
+            .find(|marketplace| marketplace_tab_id(marketplace) == active_tab_id)
+        else {
             return false;
         };
 
         if remove_marketplace {
+            if !marketplace_is_user_configured(&self.config, &marketplace.name) {
+                return false;
+            }
             self.open_marketplace_remove_confirmation(
                 marketplace.name.clone(),
                 marketplace_display_name(marketplace),
@@ -726,7 +730,7 @@ impl ChatWidget {
             return true;
         }
         if marketplace.path.is_none()
-            || !marketplace_is_user_configured_git(&self.config, &marketplace.name)
+            || !marketplace_is_configured_git(&self.config, &marketplace.name)
         {
             return false;
         }
@@ -1536,7 +1540,7 @@ impl ChatWidget {
             let can_remove_marketplace =
                 marketplace_is_user_configured(&self.config, &marketplace.name);
             let can_upgrade_marketplace = marketplace.path.is_some()
-                && marketplace_is_user_configured_git(&self.config, &marketplace.name);
+                && marketplace_is_configured_git(&self.config, &marketplace.name);
             if can_remove_marketplace || can_upgrade_marketplace {
                 tab_footer_hints.push((
                     tab_id.clone(),
@@ -2032,11 +2036,11 @@ fn marketplace_is_user_configured(config: &Config, marketplace_name: &str) -> bo
         .is_some_and(|marketplaces| marketplaces.contains_key(marketplace_name))
 }
 
-fn marketplace_is_user_configured_git(config: &Config, marketplace_name: &str) -> bool {
+fn marketplace_is_configured_git(config: &Config, marketplace_name: &str) -> bool {
     config
         .config_layer_stack
-        .get_active_user_layer()
-        .and_then(|user_layer| user_layer.config.get("marketplaces"))
+        .effective_config()
+        .get("marketplaces")
         .and_then(toml::Value::as_table)
         .and_then(|marketplaces| marketplaces.get(marketplace_name))
         .and_then(toml::Value::as_table)

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugins_popup_managed_git_marketplace.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plugins_popup_managed_git_marketplace.snap
@@ -1,0 +1,14 @@
+---
+source: tui/src/chatwidget/tests/popups_and_settings.rs
+expression: popup
+---
+  Plugins
+  Repo Marketplace.
+  Installed 0 of 1 Repo Marketplace plugins.
+
+  All Plugins  Installed (0)  OpenAI Curated  [Repo Marketplace]  Add Marketplace
+
+  Type to search plugins
+› [-] Debug Plugin  Available   Press Enter to install or view plugin details.
+
+  ctrl + u upgrade · space toggle · ←/→ tabs · enter details · esc close

--- a/codex-rs/tui/src/chatwidget/tests/popups_and_settings.rs
+++ b/codex-rs/tui/src/chatwidget/tests/popups_and_settings.rs
@@ -2,10 +2,14 @@ use super::*;
 use crate::app_event::ConnectorsSnapshot;
 use crate::chatwidget::connectors::ConnectorsCacheState;
 use codex_app_server_protocol::AppInfo;
+use codex_app_server_protocol::ConfigLayerSource;
 use codex_app_server_protocol::HookErrorInfo;
 use codex_app_server_protocol::HooksListEntry;
 use codex_app_server_protocol::HooksListResponse;
 use codex_app_server_protocol::MarketplaceRemoveResponse;
+use codex_config::ConfigLayerEntry;
+use codex_config::ConfigRequirements;
+use codex_config::ConfigRequirementsToml;
 use codex_features::Stage;
 use pretty_assertions::assert_eq;
 
@@ -433,6 +437,79 @@ async fn plugins_popup_upgrades_user_configured_git_marketplace_from_marketplace
         no_more_events.is_err(),
         "expected no duplicate marketplace upgrade events, got {no_more_events:?}"
     );
+}
+
+#[tokio::test]
+async fn plugins_popup_upgrades_managed_git_marketplace_without_remove_action() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    chat.set_feature_enabled(Feature::Plugins, /*enabled*/ true);
+
+    let cwd = chat.config.cwd.to_path_buf();
+    chat.config.config_layer_stack = ConfigLayerStack::new(
+        vec![ConfigLayerEntry::new(
+            ConfigLayerSource::EnterpriseManaged {
+                id: "cfg_marketplaces".to_string(),
+                name: "Managed marketplaces".to_string(),
+            },
+            toml::from_str::<TomlValue>(
+                "[marketplaces.repo]\nsource_type = \"git\"\nsource = \"https://github.com/owner/repo.git\"\n",
+            )
+            .expect("marketplace config"),
+        )],
+        ConfigRequirements::default(),
+        ConfigRequirementsToml::default(),
+    )
+    .expect("config layer stack");
+
+    render_loaded_plugins_popup(
+        &mut chat,
+        plugins_test_response(vec![
+            plugins_test_curated_marketplace(Vec::new()),
+            plugins_test_repo_marketplace(vec![plugins_test_summary(
+                "plugin-debug",
+                "debug",
+                Some("Debug Plugin"),
+                Some("Debug marketplace plugin."),
+                /*installed*/ false,
+                /*enabled*/ true,
+                PluginInstallPolicy::Available,
+            )]),
+        ]),
+    );
+
+    while rx.try_recv().is_ok() {}
+    for _ in 0..3 {
+        chat.handle_key_event(KeyEvent::from(KeyCode::Right));
+    }
+
+    let popup = render_bottom_popup(&chat, /*width*/ 100);
+    assert!(
+        popup.contains("Repo Marketplace.")
+            && popup.contains("ctrl + u upgrade")
+            && !popup.contains("ctrl + r remove")
+            && popup.contains("Debug Plugin"),
+        "expected upgradeable managed marketplace tab without remove action, got:\n{popup}"
+    );
+    assert_chatwidget_snapshot!("plugins_popup_managed_git_marketplace", popup);
+
+    chat.handle_key_event(KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL));
+
+    match rx.try_recv() {
+        Ok(AppEvent::OpenMarketplaceUpgradeLoading { marketplace_name }) => {
+            assert_eq!(marketplace_name, Some("repo".to_string()));
+        }
+        other => panic!("expected OpenMarketplaceUpgradeLoading event, got {other:?}"),
+    }
+    match rx.try_recv() {
+        Ok(AppEvent::FetchMarketplaceUpgrade {
+            cwd: event_cwd,
+            marketplace_name,
+        }) => {
+            assert_eq!(event_cwd, cwd);
+            assert_eq!(marketplace_name, Some("repo".to_string()));
+        }
+        other => panic!("expected FetchMarketplaceUpgrade event, got {other:?}"),
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- read `[marketplaces]` from the ordinary effective config stack so MDM, `/etc/codex/config.toml`, cloud-delivered `EnterpriseManaged` config, and other enabled config layers can provide marketplace entries with normal precedence
- keep installed plugin state user-owned, and only persist Git marketplace upgrade metadata to user config when the effective marketplace source is itself user-configured
- make CLI snapshot validation and TUI upgrade controls recognize Git marketplaces supplied by non-user config layers, while keeping user-only marketplace removal behavior

## Root cause

Plugin marketplace discovery, configured Git marketplace upgrades, CLI snapshot validation, and the TUI upgrade gate explicitly read `effective_user_config()` or the active user layer. Cloud config is delivered as a normal `EnterpriseManaged` config layer, so valid `[marketplaces]` entries from cloud config, MDM, and system config were not interpreted like other `config.toml` properties.

## Impact

Enterprises can distribute Git-backed marketplace defaults through their normal Codex config delivery mechanisms. Higher-precedence entries still override lower-precedence entries according to the existing config layer model.

This does not change `[plugins]`: installed and enabled plugin state remains user-owned. A marketplace entry makes plugins available rather than installing them, and each client still needs access to the configured marketplace source.

Managed marketplace upgrades do not copy the source or revision into user config, avoiding a user-layer override that would shadow future administrator changes.

## Validation

- `just write-config-schema`
- `just test -p codex-core-plugins` (`203` passed)
- `just test -p codex-cli` (`262` passed)
- `INSTA_UPDATE=always just test -p codex-tui plugins_popup_upgrades_managed_git_marketplace_without_remove_action`
- `just fix -p codex-core-plugins`
- `just fix -p codex-cli`
- `just fix -p codex-tui`
- `just fix -p codex-config`
- `just fmt`