### PR TITLE
fix: reject symlinked --output-last-message paths

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2751,6 +2751,7 @@ dependencies = [
  "codex-utils-cargo-bin",
  "codex-utils-cli",
  "codex-utils-oss",
+ "codex-utils-path",
  "codex-utils-sandbox-summary",
  "core_test_support",
  "libc",
@@ -4088,6 +4089,7 @@ version = "0.0.0"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
+ "libc",
  "pretty_assertions",
  "tempfile",
 ]

--- a/codex-rs/exec/Cargo.toml
+++ b/codex-rs/exec/Cargo.toml
@@ -39,6 +39,7 @@ codex-protocol = { workspace = true }
 codex-utils-absolute-path = { workspace = true }
 codex-utils-cli = { workspace = true }
 codex-utils-oss = { workspace = true }
+codex-utils-path = { workspace = true }
 codex-utils-sandbox-summary = { workspace = true }
 owo-colors = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/codex-rs/exec/src/event_processor.rs
+++ b/codex-rs/exec/src/event_processor.rs
@@ -1,3 +1,5 @@
+#[cfg(unix)]
+use std::io::Write;
 use std::path::Path;
 
 use codex_app_server_protocol::ServerNotification;
@@ -41,8 +43,23 @@ pub(crate) fn handle_last_message(last_agent_message: Option<&str>, output_file:
 
 fn write_last_message_file(contents: &str, last_message_path: Option<&Path>) {
     if let Some(path) = last_message_path
-        && let Err(e) = std::fs::write(path, contents)
+        && let Err(e) = write_last_message_to_path(path, contents)
     {
         eprintln!("Failed to write last message file {path:?}: {e}");
     }
 }
+
+#[cfg(unix)]
+fn write_last_message_to_path(path: &Path, contents: &str) -> std::io::Result<()> {
+    let mut file = codex_utils_path::open_file_for_write_no_follow(path)?;
+    file.write_all(contents.as_bytes())
+}
+
+#[cfg(not(unix))]
+fn write_last_message_to_path(path: &Path, contents: &str) -> std::io::Result<()> {
+    std::fs::write(path, contents)
+}
+
+#[cfg(test)]
+#[path = "event_processor_tests.rs"]
+mod tests;

--- a/codex-rs/exec/src/event_processor_tests.rs
+++ b/codex-rs/exec/src/event_processor_tests.rs
@@ -1,0 +1,60 @@
+use super::write_last_message_to_path;
+use pretty_assertions::assert_eq;
+use tempfile::tempdir;
+
+#[test]
+fn writes_last_message_to_regular_file() {
+    let temp_dir = tempdir().expect("tempdir");
+    let output_path = temp_dir
+        .path()
+        .canonicalize()
+        .expect("canonical tempdir")
+        .join("output.md");
+
+    write_last_message_to_path(&output_path, "hello").expect("write output");
+
+    assert_eq!(
+        std::fs::read_to_string(&output_path).expect("read output"),
+        "hello"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn rejects_symlinked_last_message_path() {
+    let temp_dir = tempdir().expect("tempdir");
+    let temp_dir = temp_dir.path().canonicalize().expect("canonical tempdir");
+    let target_path = temp_dir.join("target.md");
+    let output_path = temp_dir.join("output.md");
+    std::fs::write(&target_path, "original").expect("write target");
+    std::os::unix::fs::symlink(&target_path, &output_path).expect("create symlink");
+
+    let err = write_last_message_to_path(&output_path, "hello").expect_err("symlink should fail");
+
+    assert_eq!(err.raw_os_error(), Some(libc::ELOOP));
+    assert_eq!(
+        std::fs::read_to_string(&target_path).expect("read target"),
+        "original"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn rejects_symlinked_last_message_parent_directory() {
+    let temp_dir = tempdir().expect("tempdir");
+    let temp_dir = temp_dir.path().canonicalize().expect("canonical tempdir");
+    let target_dir = temp_dir.join("target");
+    let symlinked_dir = temp_dir.join("link");
+    std::fs::create_dir(&target_dir).expect("create target directory");
+    let target_path = target_dir.join("output.md");
+    std::fs::write(&target_path, "original").expect("write target");
+    std::os::unix::fs::symlink(&target_dir, &symlinked_dir).expect("create symlink");
+
+    write_last_message_to_path(&symlinked_dir.join("output.md"), "hello")
+        .expect_err("symlinked parent should fail");
+
+    assert_eq!(
+        std::fs::read_to_string(&target_path).expect("read target"),
+        "original"
+    );
+}

--- a/codex-rs/exec/tests/suite/mod.rs
+++ b/codex-rs/exec/tests/suite/mod.rs
@@ -6,6 +6,7 @@ mod auth_env;
 mod ephemeral;
 mod mcp_required_exit;
 mod originator;
+mod output_last_message;
 mod output_schema;
 mod prompt_stdin;
 mod resume;

--- a/codex-rs/exec/tests/suite/output_last_message.rs
+++ b/codex-rs/exec/tests/suite/output_last_message.rs
@@ -1,0 +1,35 @@
+#![cfg(unix)]
+
+use core_test_support::responses;
+use core_test_support::test_codex_exec::test_codex_exec;
+use predicates::str::contains;
+use pretty_assertions::assert_eq;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn output_last_message_does_not_follow_symlink() -> anyhow::Result<()> {
+    let test = test_codex_exec();
+    let target_path = test.cwd_path().join("target.md");
+    let output_path = test.cwd_path().join("output.md");
+    std::fs::write(&target_path, "original")?;
+    std::os::unix::fs::symlink(&target_path, &output_path)?;
+
+    let server = responses::start_mock_server().await;
+    let body = responses::sse(vec![
+        responses::ev_response_created("resp1"),
+        responses::ev_assistant_message("m1", "replacement"),
+        responses::ev_completed("resp1"),
+    ]);
+    let _response_mock = responses::mount_sse_once(&server, body).await;
+
+    test.cmd_with_server(&server)
+        .arg("--skip-git-repo-check")
+        .arg("--output-last-message")
+        .arg(&output_path)
+        .arg("write a response")
+        .assert()
+        .success()
+        .stderr(contains("Failed to write last message file"));
+
+    assert_eq!(std::fs::read_to_string(&target_path)?, "original");
+    Ok(())
+}

--- a/codex-rs/utils/path-utils/Cargo.toml
+++ b/codex-rs/utils/path-utils/Cargo.toml
@@ -12,6 +12,9 @@ codex-utils-absolute-path = { workspace = true }
 dunce = { workspace = true }
 tempfile = { workspace = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 tempfile = { workspace = true }

--- a/codex-rs/utils/path-utils/src/lib.rs
+++ b/codex-rs/utils/path-utils/src/lib.rs
@@ -144,7 +144,10 @@ pub fn write_atomically(write_path: &Path, contents: &str) -> io::Result<()> {
     Ok(())
 }
 
-/// Opens a file for writing without following symlinks in any path component.
+/// Creates or truncates a file for writing without following symlinks in any path component.
+///
+/// Relative paths are resolved from the process's current directory. The returned file uses mode
+/// `0o666`, subject to the process umask.
 #[cfg(unix)]
 pub fn open_file_for_write_no_follow(path: &Path) -> io::Result<File> {
     open_file_no_follow(

--- a/codex-rs/utils/path-utils/src/lib.rs
+++ b/codex-rs/utils/path-utils/src/lib.rs
@@ -5,7 +5,19 @@ pub use env::is_wsl;
 
 use codex_utils_absolute_path::AbsolutePathBuf;
 use std::collections::HashSet;
+#[cfg(unix)]
+use std::ffi::CString;
+#[cfg(unix)]
+use std::fs::File;
 use std::io;
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(unix)]
+use std::os::fd::FromRawFd;
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
+#[cfg(unix)]
+use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
 use tempfile::NamedTempFile;
@@ -130,6 +142,84 @@ pub fn write_atomically(write_path: &Path, contents: &str) -> io::Result<()> {
     std::fs::write(tmp.path(), contents)?;
     tmp.persist(write_path)?;
     Ok(())
+}
+
+/// Opens a file for writing without following symlinks in any path component.
+#[cfg(unix)]
+pub fn open_file_for_write_no_follow(path: &Path) -> io::Result<File> {
+    open_file_no_follow(
+        path,
+        libc::O_WRONLY | libc::O_CREAT | libc::O_TRUNC,
+        /*mode*/ 0o666,
+    )
+}
+
+#[cfg(unix)]
+fn open_file_no_follow(path: &Path, flags: libc::c_int, mode: libc::mode_t) -> io::Result<File> {
+    let components = path
+        .components()
+        .filter_map(|component| match component {
+            Component::RootDir | Component::CurDir => None,
+            Component::ParentDir => Some(Ok(std::ffi::OsStr::new(".."))),
+            Component::Normal(component) => Some(Ok(component)),
+            Component::Prefix(_) => Some(Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("unsupported path prefix in {}", path.display()),
+            ))),
+        })
+        .collect::<io::Result<Vec<_>>>()?;
+    let Some((file_name, parent_components)) = components.split_last() else {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("path {} does not name a file", path.display()),
+        ));
+    };
+
+    let mut current_dir = if path.is_absolute() {
+        File::open("/")?
+    } else {
+        File::open(".")?
+    };
+    for component in parent_components {
+        current_dir = openat(
+            &current_dir,
+            component,
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW,
+            /*mode*/ 0,
+        )?;
+    }
+    openat(
+        &current_dir,
+        file_name,
+        flags | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        mode,
+    )
+}
+
+#[cfg(unix)]
+fn openat(
+    directory: &File,
+    path: &std::ffi::OsStr,
+    flags: libc::c_int,
+    mode: libc::mode_t,
+) -> io::Result<File> {
+    let path = CString::new(path.as_bytes())
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;
+    // SAFETY: `path` is NUL-terminated, `directory` owns a valid fd, and the
+    // returned fd is transferred into a `File` exactly once.
+    let fd = unsafe {
+        libc::openat(
+            directory.as_raw_fd(),
+            path.as_ptr(),
+            flags,
+            libc::c_uint::from(mode),
+        )
+    };
+    if fd == -1 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: `openat` returned a new owned file descriptor.
+    Ok(unsafe { File::from_raw_fd(fd) })
 }
 
 fn normalize_for_wsl(path: PathBuf) -> PathBuf {

--- a/codex-rs/utils/path-utils/src/lib.rs
+++ b/codex-rs/utils/path-utils/src/lib.rs
@@ -150,15 +150,6 @@ pub fn write_atomically(write_path: &Path, contents: &str) -> io::Result<()> {
 /// `0o666`, subject to the process umask.
 #[cfg(unix)]
 pub fn open_file_for_write_no_follow(path: &Path) -> io::Result<File> {
-    open_file_no_follow(
-        path,
-        libc::O_WRONLY | libc::O_CREAT | libc::O_TRUNC,
-        /*mode*/ 0o666,
-    )
-}
-
-#[cfg(unix)]
-fn open_file_no_follow(path: &Path, flags: libc::c_int, mode: libc::mode_t) -> io::Result<File> {
     let components = path
         .components()
         .filter_map(|component| match component {
@@ -194,8 +185,8 @@ fn open_file_no_follow(path: &Path, flags: libc::c_int, mode: libc::mode_t) -> i
     openat(
         &current_dir,
         file_name,
-        flags | libc::O_CLOEXEC | libc::O_NOFOLLOW,
-        mode,
+        libc::O_WRONLY | libc::O_CREAT | libc::O_TRUNC | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        /*mode*/ 0o666,
     )
 }
 

--- a/codex-rs/utils/path-utils/src/path_utils_tests.rs
+++ b/codex-rs/utils/path-utils/src/path_utils_tests.rs
@@ -1,7 +1,9 @@
 #[cfg(unix)]
 mod symlinks {
+    use super::super::open_file_for_write_no_follow;
     use super::super::resolve_symlink_write_paths;
     use pretty_assertions::assert_eq;
+    use std::io::Write;
     use std::os::unix::fs::symlink;
 
     #[test]
@@ -17,6 +19,40 @@ mod symlinks {
 
         assert_eq!(resolved.read_path, None);
         assert_eq!(resolved.write_path, a);
+        Ok(())
+    }
+
+    #[test]
+    fn no_follow_write_rejects_symlinked_parent_directory() -> std::io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let dir = dir.path().canonicalize()?;
+        let target_dir = dir.join("target");
+        let symlinked_dir = dir.join("link");
+        std::fs::create_dir(&target_dir)?;
+        std::fs::write(target_dir.join("payload"), "original")?;
+        symlink(&target_dir, &symlinked_dir)?;
+
+        let err = open_file_for_write_no_follow(&symlinked_dir.join("payload"))
+            .expect_err("symlinked parent should fail");
+
+        assert!(err.raw_os_error().is_some());
+        assert_eq!(
+            std::fs::read_to_string(target_dir.join("payload"))?,
+            "original"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn no_follow_write_writes_regular_file() -> std::io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let path = dir.path().canonicalize()?.join("payload");
+
+        let mut writer = open_file_for_write_no_follow(&path)?;
+        writer.write_all(b"hello")?;
+        drop(writer);
+
+        assert_eq!(std::fs::read_to_string(&path)?, "hello");
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- Replace the Unix `--output-last-message` writer's plain `std::fs::write` call with an `openat` walk that uses `O_NOFOLLOW` for every path component.
- Reject both symlinked output files and symlinked parent directories without modifying the symlink target.
- Keep the existing `std::fs::write` behavior on non-Unix platforms.

## Root Cause
`codex exec --output-last-message` wrote the final message with plain `std::fs::write`. When a caller placed the output path in a sandbox-writable location, that write followed symlinks and could modify a different writable target.

## Scope
This PR is intentionally independent and based directly on `main`. It contains only the output-file hardening. The `.codex/config.toml` protections remain in #15730.

## Validation
- `just fmt`
- `just test -p codex-utils-path`
- `just test -p codex-exec last_message`
- `just bazel-lock-update`
- `just bazel-lock-check`
- `just fix -p codex-utils-path -p codex-exec`