### PR TITLE
Restore Windows coverage for code-mode image generation exposure

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/imagegen_extension.rs
+++ b/codex-rs/app-server/tests/suite/v2/imagegen_extension.rs
@@ -136,7 +136,50 @@ async fn standalone_image_generation_persists_image_and_returns_it_to_model() ->
     Ok(())
 }
 
-#[cfg_attr(windows, ignore = "covered by Linux and macOS CI")]
+#[tokio::test]
+async fn standalone_image_generation_is_exposed_in_code_mode_only() -> Result<()> {
+    let server = responses::start_mock_server().await;
+    let response_mock = responses::mount_sse_once(
+        &server,
+        responses::sse(vec![
+            responses::ev_assistant_message("msg-1", "Done"),
+            responses::ev_completed("resp-1"),
+        ]),
+    )
+    .await;
+
+    let codex_home = TempDir::new()?;
+    create_config_toml(
+        codex_home.path(),
+        &server.uri(),
+        ImagegenTestMode::CodeModeOnly,
+    )?;
+    write_chatgpt_auth(
+        codex_home.path(),
+        ChatGptAuthFixture::new("access-chatgpt"),
+        AuthCredentialsStoreMode::File,
+    )?;
+
+    let mut mcp =
+        TestAppServer::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)]).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+    start_image_generation_turn(&mut mcp).await?;
+    timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_notification_message("turn/completed"),
+    )
+    .await??;
+
+    assert!(
+        response_mock
+            .single_request()
+            .body_contains_text("image_gen__imagegen")
+    );
+
+    Ok(())
+}
+
+#[cfg(not(windows))]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn standalone_image_generation_is_callable_from_code_mode_only() -> Result<()> {
     let call_id = "code-mode-image-run-1";


### PR DESCRIPTION
## Summary

Restore Windows coverage for standalone image generation in code mode.

The previous test executed a V8-backed code-mode cell on Windows CI, where that runtime path is intentionally excluded because it is unreliable. The test was then ignored entirely on Windows, removing useful coverage.

This splits the test into two checks:

- All platforms verify that `image_gen__imagegen` is exposed to the model when image generation is configured for code mode only.
- Non-Windows platforms continue to execute the full V8-backed flow and verify that the nested image-generation call succeeds.

## Verification

- `just fmt`
- `git diff --check`
- `just test -p codex-app-server standalone_image_generation`

Result: 3 tests passed, plus the required bench smoke check.