### PR TITLE
fix(git-utils): validate linked worktree trust targets

### DIFF
--- a/codex-rs/core/src/git_info_tests.rs
+++ b/codex-rs/core/src/git_info_tests.rs
@@ -611,6 +611,11 @@ async fn resolve_root_git_project_for_trust_detects_worktree_pointer_without_git
     std::fs::create_dir_all(&worktree_root).unwrap();
     std::fs::create_dir_all(worktree_root.join("nested")).unwrap();
     std::fs::write(
+        worktree_git_dir.join("gitdir"),
+        format!("{}\n", worktree_root.join(".git").display()),
+    )
+    .unwrap();
+    std::fs::write(
         worktree_root.join(".git"),
         format!("gitdir: {}\n", worktree_git_dir.display()),
     )
@@ -626,6 +631,35 @@ async fn resolve_root_git_project_for_trust_detects_worktree_pointer_without_git
     assert_eq!(
         resolve_root_git_project_for_trust(LOCAL_FS.as_ref(), &nested).await,
         Some(expected)
+    );
+}
+
+#[tokio::test]
+async fn resolve_root_git_project_for_trust_rejects_unrelated_worktree_pointer() {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo_root = tmp.path().join("repo");
+    let worktree_git_dir = repo_root.join(".git").join("worktrees").join("feature-x");
+    let trusted_worktree_root = tmp.path().join("trusted-wt");
+    let unrelated_worktree_root = tmp.path().join("unrelated-wt");
+    std::fs::create_dir_all(&worktree_git_dir).unwrap();
+    std::fs::create_dir_all(&trusted_worktree_root).unwrap();
+    std::fs::create_dir_all(&unrelated_worktree_root).unwrap();
+    std::fs::write(trusted_worktree_root.join(".git"), "").unwrap();
+    std::fs::write(
+        worktree_git_dir.join("gitdir"),
+        format!("{}\n", trusted_worktree_root.join(".git").display()),
+    )
+    .unwrap();
+    std::fs::write(
+        unrelated_worktree_root.join(".git"),
+        format!("gitdir: {}\n", worktree_git_dir.display()),
+    )
+    .unwrap();
+
+    assert!(
+        resolve_root_git_project_for_trust(LOCAL_FS.as_ref(), &unrelated_worktree_root.abs())
+            .await
+            .is_none()
     );
 }
 

--- a/codex-rs/git-utils/src/info.rs
+++ b/codex-rs/git-utils/src/info.rs
@@ -769,6 +769,25 @@ pub async fn resolve_root_git_project_for_trust(
         return None;
     }
 
+    let worktree_dot_git_s = fs
+        .read_file_text(&git_dir_path.join("gitdir"), /*sandbox*/ None)
+        .await
+        .ok()?;
+    let worktree_dot_git_rel = worktree_dot_git_s.trim();
+    if worktree_dot_git_rel.is_empty() {
+        return None;
+    }
+    let worktree_dot_git =
+        AbsolutePathBuf::resolve_path_against_base(worktree_dot_git_rel, git_dir_path.as_path());
+    if fs
+        .canonicalize(&worktree_dot_git, /*sandbox*/ None)
+        .await
+        .ok()?
+        != fs.canonicalize(&dot_git, /*sandbox*/ None).await.ok()?
+    {
+        return None;
+    }
+
     let common_dir = worktrees_dir.parent()?;
     common_dir.parent()
 }


### PR DESCRIPTION
## Why

Linked-worktree trust resolution accepted metadata shaped like `.git/worktrees/<name>` without checking that the metadata belonged to the current checkout. That could resolve an unrelated checkout to the main project root.

## What changed

Validate the linked worktree `gitdir` back-reference before returning the main project root. Missing, empty, or mismatched back-references now stop trust-root resolution.

## Test plan

- Added a regression test for an unrelated checkout pointing at existing linked-worktree metadata.
- Ran `just test -p codex-core resolve_root_git_project_for_trust`.
- Ran scoped Clippy for `codex-git-utils` and `codex-core`.