### PR TITLE
[codex] Add managed macOS sandbox capabilities

### DIFF
--- a/codex-rs/cli/src/debug_sandbox.rs
+++ b/codex-rs/cli/src/debug_sandbox.rs
@@ -49,6 +49,9 @@ pub async fn run_command_under_seatbelt(
         config_profile: _,
         cwd,
         include_managed_config,
+        allow_mach_services,
+        allow_appleevent_bundle_ids,
+        allow_lsopen,
         allow_unix_sockets,
         log_denials,
         config_overrides,
@@ -58,8 +61,8 @@ pub async fn run_command_under_seatbelt(
         &permissions_profile,
         include_managed_config,
     );
-    run_command_under_sandbox(
-        DebugSandboxConfigOptions {
+    run_command_under_sandbox(RunCommandUnderSandboxParams {
+        config_options: DebugSandboxConfigOptions {
             permissions_profile,
             cwd,
             managed_requirements_mode,
@@ -68,10 +71,13 @@ pub async fn run_command_under_seatbelt(
         command,
         config_overrides,
         codex_linux_sandbox_exe,
-        SandboxType::Seatbelt,
+        sandbox_type: SandboxType::Seatbelt,
         log_denials,
-        &allow_unix_sockets,
-    )
+        allow_mach_services: &allow_mach_services,
+        allow_appleevent_bundle_ids: &allow_appleevent_bundle_ids,
+        allow_lsopen,
+        allow_unix_sockets: &allow_unix_sockets,
+    })
     .await
 }
 
@@ -101,8 +107,8 @@ pub async fn run_command_under_landlock(
         &permissions_profile,
         include_managed_config,
     );
-    run_command_under_sandbox(
-        DebugSandboxConfigOptions {
+    run_command_under_sandbox(RunCommandUnderSandboxParams {
+        config_options: DebugSandboxConfigOptions {
             permissions_profile,
             cwd,
             managed_requirements_mode,
@@ -111,10 +117,13 @@ pub async fn run_command_under_landlock(
         command,
         config_overrides,
         codex_linux_sandbox_exe,
-        SandboxType::Landlock,
-        /*log_denials*/ false,
-        &[],
-    )
+        sandbox_type: SandboxType::Landlock,
+        log_denials: false,
+        allow_mach_services: &[],
+        allow_appleevent_bundle_ids: &[],
+        allow_lsopen: false,
+        allow_unix_sockets: &[],
+    })
     .await
 }
 
@@ -135,8 +144,8 @@ pub async fn run_command_under_windows_sandbox(
         &permissions_profile,
         include_managed_config,
     );
-    run_command_under_sandbox(
-        DebugSandboxConfigOptions {
+    run_command_under_sandbox(RunCommandUnderSandboxParams {
+        config_options: DebugSandboxConfigOptions {
             permissions_profile,
             cwd,
             managed_requirements_mode,
@@ -145,10 +154,13 @@ pub async fn run_command_under_windows_sandbox(
         command,
         config_overrides,
         codex_linux_sandbox_exe,
-        SandboxType::Windows,
-        /*log_denials*/ false,
-        &[],
-    )
+        sandbox_type: SandboxType::Windows,
+        log_denials: false,
+        allow_mach_services: &[],
+        allow_appleevent_bundle_ids: &[],
+        allow_lsopen: false,
+        allow_unix_sockets: &[],
+    })
     .await
 }
 
@@ -186,16 +198,43 @@ impl ManagedRequirementsMode {
     }
 }
 
-async fn run_command_under_sandbox(
+struct RunCommandUnderSandboxParams<'a> {
     config_options: DebugSandboxConfigOptions,
     command: Vec<String>,
     config_overrides: CliConfigOverrides,
     codex_linux_sandbox_exe: Option<PathBuf>,
     sandbox_type: SandboxType,
     log_denials: bool,
-    #[cfg_attr(not(target_os = "macos"), allow(unused_variables))]
-    allow_unix_sockets: &[AbsolutePathBuf],
-) -> anyhow::Result<()> {
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+    allow_mach_services: &'a [String],
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+    allow_appleevent_bundle_ids: &'a [String],
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+    allow_lsopen: bool,
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+    allow_unix_sockets: &'a [AbsolutePathBuf],
+}
+
+async fn run_command_under_sandbox(params: RunCommandUnderSandboxParams<'_>) -> anyhow::Result<()> {
+    let RunCommandUnderSandboxParams {
+        config_options,
+        command,
+        config_overrides,
+        codex_linux_sandbox_exe,
+        sandbox_type,
+        log_denials,
+        allow_mach_services,
+        allow_appleevent_bundle_ids,
+        allow_lsopen,
+        allow_unix_sockets,
+    } = params;
+    #[cfg(not(target_os = "macos"))]
+    let _ = (
+        allow_mach_services,
+        allow_appleevent_bundle_ids,
+        allow_lsopen,
+        allow_unix_sockets,
+    );
     let config = load_debug_sandbox_config(
         config_overrides
             .parse_overrides()
@@ -280,6 +319,9 @@ async fn run_command_under_sandbox(
                 sandbox_policy_cwd: sandbox_policy_cwd.as_path(),
                 enforce_managed_network: false,
                 network: network.as_ref(),
+                extra_mach_services: allow_mach_services,
+                extra_appleevent_bundle_ids: allow_appleevent_bundle_ids,
+                allow_lsopen,
                 extra_allow_unix_sockets: allow_unix_sockets,
             });
             spawn_debug_sandbox_child(

--- a/codex-rs/cli/src/debug_sandbox.rs
+++ b/codex-rs/cli/src/debug_sandbox.rs
@@ -873,7 +873,7 @@ mod tests {
                 &permission_profile,
                 &["com.apple.lsd".to_string()],
                 &["com.apple.finder".to_string()],
-                true,
+                /*allow_lsopen*/ true,
             ),
             Some(MacOsSandboxCapabilities {
                 mach_lookup_services: vec![

--- a/codex-rs/cli/src/debug_sandbox.rs
+++ b/codex-rs/cli/src/debug_sandbox.rs
@@ -16,6 +16,8 @@ use codex_core::exec_env::create_env;
 use codex_core::spawn::CODEX_SANDBOX_ENV_VAR;
 use codex_core::spawn::CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR;
 use codex_protocol::config_types::SandboxMode;
+#[cfg(target_os = "macos")]
+use codex_protocol::models::MacOsSandboxCapabilities;
 use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_sandboxing::landlock::allow_network_for_proxy;
 use codex_sandboxing::landlock::create_linux_sandbox_command_args_for_permission_profile;
@@ -312,6 +314,12 @@ async fn run_command_under_sandbox(params: RunCommandUnderSandboxParams<'_>) -> 
         SandboxType::Seatbelt => {
             let (file_system_sandbox_policy, network_sandbox_policy) =
                 runtime_permission_profile.to_runtime_permissions();
+            let macos_sandbox_capabilities = merge_macos_sandbox_capabilities(
+                &runtime_permission_profile,
+                allow_mach_services,
+                allow_appleevent_bundle_ids,
+                allow_lsopen,
+            );
             let args = create_seatbelt_command_args(CreateSeatbeltCommandArgsParams {
                 command,
                 file_system_sandbox_policy: &file_system_sandbox_policy,
@@ -319,9 +327,7 @@ async fn run_command_under_sandbox(params: RunCommandUnderSandboxParams<'_>) -> 
                 sandbox_policy_cwd: sandbox_policy_cwd.as_path(),
                 enforce_managed_network: false,
                 network: network.as_ref(),
-                extra_mach_services: allow_mach_services,
-                extra_appleevent_bundle_ids: allow_appleevent_bundle_ids,
-                allow_lsopen,
+                macos_sandbox_capabilities: macos_sandbox_capabilities.as_ref(),
                 extra_allow_unix_sockets: allow_unix_sockets,
             });
             spawn_debug_sandbox_child(
@@ -396,6 +402,27 @@ async fn run_command_under_sandbox(params: RunCommandUnderSandboxParams<'_>) -> 
     }
 
     handle_exit_status(status);
+}
+
+#[cfg(target_os = "macos")]
+fn merge_macos_sandbox_capabilities(
+    permission_profile: &codex_protocol::models::PermissionProfile,
+    allow_mach_services: &[String],
+    allow_appleevent_bundle_ids: &[String],
+    allow_lsopen: bool,
+) -> Option<MacOsSandboxCapabilities> {
+    let mut macos_sandbox_capabilities = permission_profile
+        .macos_sandbox_capabilities()
+        .cloned()
+        .unwrap_or_default();
+    macos_sandbox_capabilities
+        .mach_lookup_services
+        .extend(allow_mach_services.iter().cloned());
+    macos_sandbox_capabilities
+        .apple_event_destinations
+        .extend(allow_appleevent_bundle_ids.iter().cloned());
+    macos_sandbox_capabilities.launch_services_open |= allow_lsopen;
+    (!macos_sandbox_capabilities.is_empty()).then_some(macos_sandbox_capabilities)
 }
 
 #[cfg(target_os = "windows")]
@@ -829,6 +856,37 @@ mod tests {
 
     fn escape_toml_path(path: &std::path::Path) -> String {
         path.display().to_string().replace('\\', "\\\\")
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn merge_macos_sandbox_capabilities_adds_debug_allowances_to_profile() {
+        let permission_profile = codex_protocol::models::PermissionProfile::read_only()
+            .with_macos_sandbox_capabilities(Some(MacOsSandboxCapabilities {
+                mach_lookup_services: vec!["com.apple.coreservices.appleevents".to_string()],
+                apple_event_destinations: vec!["com.openai.sky.CUAService".to_string()],
+                launch_services_open: false,
+            }));
+
+        assert_eq!(
+            merge_macos_sandbox_capabilities(
+                &permission_profile,
+                &["com.apple.lsd".to_string()],
+                &["com.apple.finder".to_string()],
+                true,
+            ),
+            Some(MacOsSandboxCapabilities {
+                mach_lookup_services: vec![
+                    "com.apple.coreservices.appleevents".to_string(),
+                    "com.apple.lsd".to_string(),
+                ],
+                apple_event_destinations: vec![
+                    "com.openai.sky.CUAService".to_string(),
+                    "com.apple.finder".to_string(),
+                ],
+                launch_services_open: true,
+            })
+        );
     }
 
     fn write_permissions_profile_config(

--- a/codex-rs/cli/src/lib.rs
+++ b/codex-rs/cli/src/lib.rs
@@ -50,6 +50,18 @@ pub struct SeatbeltCommand {
     )]
     pub include_managed_config: bool,
 
+    /// Allow the sandboxed command to look up this Mach service name. Repeat to allow multiple services.
+    #[arg(long = "allow-mach-service", value_name = "SERVICE", value_parser = parse_non_empty_string)]
+    pub allow_mach_services: Vec<String>,
+
+    /// Allow the sandboxed command to send AppleEvents to this destination bundle ID. Repeat to allow multiple destinations.
+    #[arg(long = "allow-appleevent-destination", value_name = "BUNDLE_ID", value_parser = parse_non_empty_string)]
+    pub allow_appleevent_bundle_ids: Vec<String>,
+
+    /// Allow the sandboxed command to use LaunchServices open APIs.
+    #[arg(long = "allow-lsopen", default_value_t = false)]
+    pub allow_lsopen: bool,
+
     /// Allow the sandboxed command to bind/connect AF_UNIX sockets rooted at this path. Relative paths are resolved against the current directory. Repeat to allow multiple paths.
     #[arg(long = "allow-unix-socket", value_parser = parse_allow_unix_socket_path)]
     pub allow_unix_sockets: Vec<AbsolutePathBuf>,
@@ -69,6 +81,15 @@ pub struct SeatbeltCommand {
 fn parse_allow_unix_socket_path(raw: &str) -> Result<AbsolutePathBuf, String> {
     AbsolutePathBuf::relative_to_current_dir(raw)
         .map_err(|err| format!("invalid path {raw}: {err}"))
+}
+
+fn parse_non_empty_string(raw: &str) -> Result<String, String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        Err("value must not be empty".to_string())
+    } else {
+        Ok(trimmed.to_string())
+    }
 }
 
 #[derive(Debug, Parser)]
@@ -139,4 +160,46 @@ pub struct WindowsCommand {
     /// Full command args to run under Windows restricted token sandbox.
     #[arg(trailing_var_arg = true)]
     pub command: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SeatbeltCommand;
+    use clap::Parser;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn seatbelt_command_parses_additional_allowlist_flags() {
+        let command = SeatbeltCommand::try_parse_from([
+            "seatbelt",
+            "--allow-mach-service",
+            "com.apple.foo",
+            "--allow-mach-service",
+            "com.apple.bar",
+            "--allow-appleevent-destination",
+            "com.apple.finder",
+            "--allow-lsopen",
+            "--allow-unix-socket",
+            "/tmp/codex.sock",
+            "--",
+            "/bin/echo",
+            "hi",
+        ])
+        .expect("parse");
+
+        assert_eq!(
+            command.allow_mach_services,
+            vec!["com.apple.foo".to_string(), "com.apple.bar".to_string()]
+        );
+        assert_eq!(
+            command.allow_appleevent_bundle_ids,
+            vec!["com.apple.finder".to_string()]
+        );
+        assert!(command.allow_lsopen);
+        assert_eq!(command.allow_unix_sockets.len(), 1);
+        assert_eq!(
+            command.command,
+            vec!["/bin/echo".to_string(), "hi".to_string()]
+        );
+    }
 }

--- a/codex-rs/codex-mcp/src/mcp/mod_tests.rs
+++ b/codex-rs/codex-mcp/src/mcp/mod_tests.rs
@@ -50,6 +50,7 @@ fn mcp_prompt_auto_approval_honors_unrestricted_managed_profiles() {
         &PermissionProfile::Managed {
             file_system: ManagedFileSystemPermissions::Unrestricted,
             network: NetworkSandboxPolicy::Enabled,
+            macos: None,
         },
         McpPermissionPromptAutoApproveContext::default(),
     ));
@@ -58,6 +59,7 @@ fn mcp_prompt_auto_approval_honors_unrestricted_managed_profiles() {
         &PermissionProfile::Managed {
             file_system: ManagedFileSystemPermissions::Unrestricted,
             network: NetworkSandboxPolicy::Restricted,
+            macos: None,
         },
         McpPermissionPromptAutoApproveContext::default(),
     ));
@@ -71,6 +73,7 @@ fn mcp_prompt_auto_approval_honors_unrestricted_managed_profiles() {
         &PermissionProfile::Managed {
             file_system: ManagedFileSystemPermissions::Unrestricted,
             network: NetworkSandboxPolicy::Enabled,
+            macos: None,
         },
         McpPermissionPromptAutoApproveContext::default(),
     ));

--- a/codex-rs/config/src/permissions_toml.rs
+++ b/codex-rs/config/src/permissions_toml.rs
@@ -11,6 +11,7 @@ use codex_network_proxy::NetworkMode;
 use codex_network_proxy::NetworkProxyConfig;
 use codex_network_proxy::NetworkUnixSocketPermission as ProxyNetworkUnixSocketPermission;
 use codex_network_proxy::normalize_host;
+use codex_protocol::models::MacOsSandboxCapabilities;
 use codex_protocol::permissions::FileSystemAccessMode;
 use indexmap::IndexMap;
 use schemars::JsonSchema;
@@ -116,6 +117,25 @@ pub struct PermissionProfileToml {
     pub workspace_roots: Option<WorkspaceRootsToml>,
     pub filesystem: Option<FilesystemPermissionsToml>,
     pub network: Option<NetworkToml>,
+    pub macos: Option<MacOsSandboxCapabilitiesToml>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, JsonSchema)]
+#[schemars(deny_unknown_fields, rename = "MacOsSandboxCapabilities")]
+pub struct MacOsSandboxCapabilitiesToml {
+    pub mach_lookup_services: Option<Vec<String>>,
+    pub apple_event_destinations: Option<Vec<String>>,
+    pub launch_services_open: Option<bool>,
+}
+
+impl From<MacOsSandboxCapabilitiesToml> for MacOsSandboxCapabilities {
+    fn from(value: MacOsSandboxCapabilitiesToml) -> Self {
+        Self {
+            mach_lookup_services: value.mach_lookup_services.unwrap_or_default(),
+            apple_event_destinations: value.apple_event_destinations.unwrap_or_default(),
+            launch_services_open: value.launch_services_open.unwrap_or_default(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -1214,6 +1214,27 @@
       ],
       "description": "One action binding value in config.\n\nThis accepts either:\n\n1. A single key spec string (`\"ctrl-a\"`). 2. A list of key spec strings (`[\"ctrl-a\", \"alt-a\"]`).\n\nAn empty list explicitly unbinds the action in that scope. Because an explicit empty list is still a configured value, runtime resolution must not fall through to global or built-in defaults for that action."
     },
+    "MacOsSandboxCapabilities": {
+      "additionalProperties": false,
+      "properties": {
+        "apple_event_destinations": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "launch_services_open": {
+          "type": "boolean"
+        },
+        "mach_lookup_services": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
     "MarketplaceConfig": {
       "additionalProperties": false,
       "properties": {
@@ -2184,6 +2205,9 @@
         },
         "filesystem": {
           "$ref": "#/definitions/FilesystemPermissionsToml"
+        },
+        "macos": {
+          "$ref": "#/definitions/MacOsSandboxCapabilities"
         },
         "network": {
           "$ref": "#/definitions/NetworkToml"

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -945,6 +945,7 @@ strip_request_headers = ["authorization"]
                             )])),
                         }),
                     }),
+                    macos: None,
                 },
             )]),
         }
@@ -1113,6 +1114,7 @@ async fn permissions_profiles_proxy_policy_does_not_start_managed_network_proxy_
                             enabled: Some(true),
                             ..Default::default()
                         }),
+                        macos: None,
                     },
                 )]),
             }),
@@ -1165,6 +1167,7 @@ async fn permissions_profiles_proxy_policy_starts_managed_network_proxy() -> std
                             enable_socks5: Some(false),
                             ..Default::default()
                         }),
+                        macos: None,
                     },
                 )]),
             }),
@@ -1319,6 +1322,7 @@ async fn network_proxy_feature_matrix_preserves_sandbox_network_semantics() -> s
                                 enabled: Some(case.network_enabled),
                                 ..Default::default()
                             }),
+                            macos: None,
                         },
                     )]),
                 }),
@@ -1473,6 +1477,7 @@ async fn network_proxy_feature_uses_profile_network_proxy_settings() -> std::io:
                             enable_socks5: Some(false),
                             ..Default::default()
                         }),
+                        macos: None,
                     },
                 )]),
             }),
@@ -1537,6 +1542,7 @@ enabled = false
                             enable_socks5: Some(false),
                             ..Default::default()
                         }),
+                        macos: None,
                     },
                 )]),
             }),
@@ -1591,6 +1597,7 @@ async fn permissions_profiles_network_disabled_by_default_does_not_start_proxy()
                             }),
                             ..Default::default()
                         }),
+                        macos: None,
                     },
                 )]),
             }),
@@ -1641,6 +1648,7 @@ async fn default_permissions_profile_populates_runtime_sandbox_policy() -> std::
                         ]),
                     }),
                     network: None,
+                    macos: None,
                 },
             )]),
         }),
@@ -1736,6 +1744,7 @@ async fn default_permissions_extended_profile_preserves_parent_metadata() -> std
                                 )]),
                             }),
                             network: None,
+                            macos: None,
                         },
                     ),
                     (
@@ -1746,6 +1755,7 @@ async fn default_permissions_extended_profile_preserves_parent_metadata() -> std
                             workspace_roots: None,
                             filesystem: None,
                             network: None,
+                            macos: None,
                         },
                     ),
                 ]),
@@ -1831,6 +1841,7 @@ async fn permission_profile_override_preserves_managed_unrestricted_filesystem()
     let permission_profile = PermissionProfile::Managed {
         file_system: ManagedFileSystemPermissions::Unrestricted,
         network: NetworkSandboxPolicy::Restricted,
+        macos: None,
     };
 
     let config = Config::load_from_base_config_with_overrides(
@@ -1865,6 +1876,7 @@ async fn managed_unrestricted_permission_profile_still_enables_network_requireme
     let permission_profile = PermissionProfile::Managed {
         file_system: ManagedFileSystemPermissions::Unrestricted,
         network: NetworkSandboxPolicy::Enabled,
+        macos: None,
     };
 
     let mut config = Config::load_from_base_config_with_overrides(
@@ -2002,6 +2014,7 @@ async fn permission_profile_override_preserves_configured_network_policy_without
                             }),
                             ..Default::default()
                         }),
+                        macos: None,
                     },
                 )]),
             }),
@@ -2055,6 +2068,7 @@ async fn workspace_root_glob_none_compiles_to_filesystem_pattern_entry() -> std:
                             )]),
                         }),
                         network: None,
+                        macos: None,
                     },
                 )]),
             }),
@@ -2133,6 +2147,7 @@ async fn permissions_profiles_require_default_permissions() -> std::io::Result<(
                             )]),
                         }),
                         network: None,
+                        macos: None,
                     },
                 )]),
             }),
@@ -2271,6 +2286,7 @@ async fn workspace_profile_applies_rules_to_runtime_and_profile_workspace_roots(
                             )]),
                         }),
                         network: None,
+                        macos: None,
                     },
                 )]),
             }),
@@ -2399,6 +2415,7 @@ async fn default_permissions_profile_can_extend_builtin_workspace() -> std::io::
                             enabled: Some(true),
                             ..Default::default()
                         }),
+                        macos: None,
                     },
                 )]),
             }),
@@ -2491,6 +2508,7 @@ async fn default_permissions_profile_can_extend_builtin_read_only() -> std::io::
                             enabled: Some(true),
                             ..Default::default()
                         }),
+                        macos: None,
                     },
                 )]),
             }),
@@ -2935,6 +2953,7 @@ async fn permissions_profiles_allow_direct_write_roots_outside_workspace_root()
                             )]),
                         }),
                         network: None,
+                        macos: None,
                     },
                 )]),
             }),
@@ -3001,6 +3020,7 @@ async fn permissions_profiles_reject_nested_entries_for_non_workspace_roots() ->
                             )]),
                         }),
                         network: None,
+                        macos: None,
                     },
                 )]),
             }),
@@ -3061,6 +3081,7 @@ async fn permissions_profiles_allow_unknown_special_paths() -> std::io::Result<(
             )]),
         }),
         network: None,
+        macos: None,
     })
     .await?;
 
@@ -3110,6 +3131,7 @@ async fn permissions_profiles_allow_unknown_special_paths_with_nested_entries()
             )]),
         }),
         network: None,
+        macos: None,
     })
     .await?;
 
@@ -3140,6 +3162,7 @@ async fn permissions_profiles_allow_missing_filesystem_with_warning() -> std::io
         workspace_roots: None,
         filesystem: None,
         network: None,
+        macos: None,
     })
     .await?;
 
@@ -3174,6 +3197,7 @@ async fn permissions_profiles_allow_empty_filesystem_with_warning() -> std::io::
             entries: BTreeMap::new(),
         }),
         network: None,
+        macos: None,
     })
     .await?;
 
@@ -3218,6 +3242,7 @@ async fn permissions_profiles_reject_workspace_root_parent_traversal() -> std::i
                             )]),
                         }),
                         network: None,
+                        macos: None,
                     },
                 )]),
             }),
@@ -3267,6 +3292,7 @@ async fn permissions_profiles_allow_network_enablement() -> std::io::Result<()> 
                             enabled: Some(true),
                             ..Default::default()
                         }),
+                        macos: None,
                     },
                 )]),
             }),

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -121,7 +121,6 @@ use std::sync::Arc;
 
 use crate::config::permissions::BUILT_IN_WORKSPACE_PROFILE;
 use crate::config::permissions::apply_network_proxy_feature_config;
-use crate::config::permissions::builtin_permission_profile;
 use crate::config::permissions::compile_permission_profile_selection;
 use crate::config::permissions::compile_permission_profile_workspace_roots;
 use crate::config::permissions::default_builtin_permission_profile_name;
@@ -2892,14 +2891,15 @@ impl Config {
                 effective_permission_selection.profiles.as_ref(),
                 default_permissions,
             )?;
+            let permission_profile = compile_permission_profile_selection(
+                effective_permission_selection.profiles.as_ref(),
+                default_permissions,
+                builtin_workspace_write_settings,
+                resolved_cwd.as_path(),
+                &mut startup_warnings,
+            )?;
             let (mut file_system_sandbox_policy, network_sandbox_policy) =
-                compile_permission_profile_selection(
-                    effective_permission_selection.profiles.as_ref(),
-                    default_permissions,
-                    builtin_workspace_write_settings,
-                    resolved_cwd.as_path(),
-                    &mut startup_warnings,
-                )?;
+                permission_profile.to_runtime_permissions();
             let mut configured_workspace_roots = compile_permission_profile_workspace_roots(
                 effective_permission_selection.profiles.as_ref(),
                 default_permissions,
@@ -2914,16 +2914,8 @@ impl Config {
             dedupe_absolute_paths(&mut configured_workspace_roots);
             file_system_sandbox_policy = file_system_sandbox_policy
                 .with_materialized_project_roots_for_workspace_roots(&configured_workspace_roots);
-            let permission_profile = if let Some(permission_profile) =
-                builtin_permission_profile(default_permissions, builtin_workspace_write_settings)
-            {
-                permission_profile
-            } else {
-                PermissionProfile::from_runtime_permissions(
-                    &file_system_sandbox_policy,
-                    network_sandbox_policy,
-                )
-            };
+            let permission_profile = permission_profile
+                .with_runtime_permissions(&file_system_sandbox_policy, network_sandbox_policy);
             let active_permission_profile = if using_implicit_builtin_profile
                 && default_permissions == BUILT_IN_WORKSPACE_PROFILE
                 && cfg.sandbox_workspace_write.is_some()
@@ -3412,8 +3404,7 @@ impl Config {
         }
         let effective_file_system_sandbox_policy = effective_file_system_sandbox_policy
             .with_additional_readable_roots(resolved_cwd.as_path(), &helper_readable_roots);
-        let effective_permission_profile = PermissionProfile::from_runtime_permissions_with_enforcement(
-            effective_permission_profile.enforcement(),
+        let effective_permission_profile = effective_permission_profile.with_runtime_permissions(
             &effective_file_system_sandbox_policy,
             effective_network_sandbox_policy,
         );

--- a/codex-rs/core/src/config/network_proxy_spec_tests.rs
+++ b/codex-rs/core/src/config/network_proxy_spec_tests.rs
@@ -163,6 +163,7 @@ fn managed_unrestricted_profile_allows_domain_expansion() {
     let permission_profile = PermissionProfile::Managed {
         file_system: ManagedFileSystemPermissions::Unrestricted,
         network: NetworkSandboxPolicy::Restricted,
+        macos: None,
     };
 
     let spec = NetworkProxySpec::from_config_and_constraints(

--- a/codex-rs/core/src/config/permissions.rs
+++ b/codex-rs/core/src/config/permissions.rs
@@ -229,6 +229,7 @@ fn permission_profile_toml_from_file_system_policy(
         workspace_roots: None,
         filesystem: Some(filesystem),
         network: None,
+        macos: None,
     }
 }
 
@@ -348,7 +349,7 @@ pub(crate) fn compile_permission_profile(
     profile_name: &str,
     policy_cwd: &Path,
     startup_warnings: &mut Vec<String>,
-) -> io::Result<(FileSystemSandboxPolicy, NetworkSandboxPolicy)> {
+) -> io::Result<PermissionProfile> {
     let profile = resolve_permission_profile(permissions, profile_name)?;
     let mut file_system_sandbox_policy = FileSystemSandboxPolicy::restricted(Vec::new());
     let base_network_sandbox_policy = NetworkSandboxPolicy::Restricted;
@@ -405,7 +406,11 @@ pub(crate) fn compile_permission_profile(
     }
     let network_sandbox_policy =
         compile_network_sandbox_policy(profile.network.as_ref(), base_network_sandbox_policy);
-    Ok((file_system_sandbox_policy, network_sandbox_policy))
+    Ok(PermissionProfile::from_runtime_permissions(
+        &file_system_sandbox_policy,
+        network_sandbox_policy,
+    )
+    .with_macos_sandbox_capabilities(profile.macos.map(Into::into)))
 }
 
 pub(crate) fn compile_permission_profile_selection(
@@ -414,9 +419,9 @@ pub(crate) fn compile_permission_profile_selection(
     workspace_write: Option<&SandboxWorkspaceWrite>,
     policy_cwd: &Path,
     startup_warnings: &mut Vec<String>,
-) -> io::Result<(FileSystemSandboxPolicy, NetworkSandboxPolicy)> {
+) -> io::Result<PermissionProfile> {
     if let Some(permission_profile) = builtin_permission_profile(profile_name, workspace_write) {
-        return Ok(permission_profile.to_runtime_permissions());
+        return Ok(permission_profile);
     }
     reject_unknown_builtin_permission_profile(profile_name)?;
 

--- a/codex-rs/core/src/config/permissions_tests.rs
+++ b/codex-rs/core/src/config/permissions_tests.rs
@@ -4,6 +4,7 @@ use crate::config::ConfigOverrides;
 use codex_config::config_toml::ConfigToml;
 use codex_config::permissions_toml::FilesystemPermissionToml;
 use codex_config::permissions_toml::FilesystemPermissionsToml;
+use codex_config::permissions_toml::MacOsSandboxCapabilitiesToml;
 use codex_config::permissions_toml::NetworkDomainPermissionToml;
 use codex_config::permissions_toml::NetworkDomainPermissionsToml;
 use codex_config::permissions_toml::NetworkToml;
@@ -12,6 +13,7 @@ use codex_config::permissions_toml::NetworkUnixSocketPermissionsToml;
 use codex_config::permissions_toml::PermissionProfileToml;
 use codex_config::permissions_toml::PermissionsToml;
 use codex_config::permissions_toml::WorkspaceRootsToml;
+use codex_protocol::models::MacOsSandboxCapabilities;
 use codex_protocol::permissions::FileSystemAccessMode;
 use codex_protocol::permissions::FileSystemPath;
 use codex_protocol::permissions::FileSystemSandboxEntry;
@@ -75,6 +77,7 @@ async fn restricted_read_implicitly_allows_helper_executables() -> std::io::Resu
                             entries: BTreeMap::new(),
                         }),
                         network: None,
+                        macos: None,
                     },
                 )]),
             }),
@@ -330,6 +333,56 @@ allow_local_binding = true
 }
 
 #[test]
+fn permissions_profiles_macos_capabilities_preserve_partial_overrides_and_explicit_revocations() {
+    let permissions = toml::from_str::<PermissionsToml>(
+        r#"
+[base.macos]
+mach_lookup_services = ["com.example.parent"]
+apple_event_destinations = ["com.example.Parent"]
+launch_services_open = true
+
+[child]
+extends = "base"
+
+[child.macos]
+mach_lookup_services = []
+launch_services_open = false
+
+[grandchild]
+extends = "child"
+
+[grandchild.macos]
+apple_event_destinations = []
+"#,
+    )
+    .expect("permissions should deserialize");
+
+    let child = permissions
+        .resolve_profile("child", |_| None)
+        .expect("child profile should resolve");
+    assert_eq!(
+        child.macos,
+        Some(MacOsSandboxCapabilitiesToml {
+            mach_lookup_services: Some(Vec::new()),
+            apple_event_destinations: Some(vec!["com.example.Parent".to_string()]),
+            launch_services_open: Some(false),
+        })
+    );
+
+    let grandchild = permissions
+        .resolve_profile("grandchild", |_| None)
+        .expect("grandchild profile should resolve");
+    assert_eq!(
+        grandchild.macos,
+        Some(MacOsSandboxCapabilitiesToml {
+            mach_lookup_services: Some(Vec::new()),
+            apple_event_destinations: Some(Vec::new()),
+            launch_services_open: Some(false),
+        })
+    );
+}
+
+#[test]
 fn permissions_profiles_reject_undefined_extends_parent() {
     let permissions = toml::from_str::<PermissionsToml>(
         r#"
@@ -449,6 +502,7 @@ fn compile_permission_profile_workspace_roots_resolves_enabled_entries() -> std:
                     }),
                     filesystem: None,
                     network: None,
+                    macos: None,
                 },
             )]),
         }),
@@ -545,7 +599,7 @@ fn glob_scan_max_depth_must_be_positive() {
 fn read_write_trailing_glob_suffix_compiles_as_subpath() -> std::io::Result<()> {
     let cwd = TempDir::new()?;
     let mut startup_warnings = Vec::new();
-    let (file_system_policy, _) = compile_permission_profile(
+    let permission_profile = compile_permission_profile(
         &PermissionsToml {
             entries: BTreeMap::from([(
                 "workspace".to_string(),
@@ -564,6 +618,7 @@ fn read_write_trailing_glob_suffix_compiles_as_subpath() -> std::io::Result<()> 
                         )]),
                     }),
                     network: None,
+                    macos: None,
                 },
             )]),
         },
@@ -571,6 +626,7 @@ fn read_write_trailing_glob_suffix_compiles_as_subpath() -> std::io::Result<()> 
         cwd.path(),
         &mut startup_warnings,
     )?;
+    let file_system_policy = permission_profile.file_system_sandbox_policy();
 
     assert_eq!(
         file_system_policy,
@@ -581,6 +637,60 @@ fn read_write_trailing_glob_suffix_compiles_as_subpath() -> std::io::Result<()> 
             access: FileSystemAccessMode::Read,
         }]),
         "trailing /** should compile as a subtree path instead of a glob pattern"
+    );
+    Ok(())
+}
+
+#[test]
+fn compile_permission_profile_preserves_macos_sandbox_capabilities() -> std::io::Result<()> {
+    let cwd = TempDir::new()?;
+    let macos = MacOsSandboxCapabilities {
+        mach_lookup_services: vec!["com.apple.coreservices.appleevents".to_string()],
+        apple_event_destinations: vec!["com.openai.sky.CUAService".to_string()],
+        launch_services_open: true,
+    };
+    let permission_profile = compile_permission_profile(
+        &PermissionsToml {
+            entries: BTreeMap::from([(
+                "cua".to_string(),
+                PermissionProfileToml {
+                    description: None,
+                    extends: Some(BUILT_IN_WORKSPACE_PROFILE.to_string()),
+                    workspace_roots: None,
+                    filesystem: None,
+                    network: None,
+                    macos: Some(MacOsSandboxCapabilitiesToml {
+                        mach_lookup_services: Some(macos.mach_lookup_services.clone()),
+                        apple_event_destinations: Some(macos.apple_event_destinations.clone()),
+                        launch_services_open: Some(macos.launch_services_open),
+                    }),
+                },
+            )]),
+        },
+        "cua",
+        cwd.path(),
+        &mut Vec::new(),
+    )?;
+
+    assert!(
+        permission_profile
+            .file_system_sandbox_policy()
+            .entries
+            .iter()
+            .any(|entry| matches!(
+                entry,
+                FileSystemSandboxEntry {
+                    path: FileSystemPath::Special {
+                        value: FileSystemSpecialPath::ProjectRoots { subpath: None },
+                    },
+                    access: FileSystemAccessMode::Write,
+                }
+            )),
+        "profile extending :workspace should preserve inherited workspace writes"
+    );
+    assert_eq!(
+        permission_profile.macos_sandbox_capabilities(),
+        Some(&macos)
     );
     Ok(())
 }

--- a/codex-rs/core/src/sandbox_tags.rs
+++ b/codex-rs/core/src/sandbox_tags.rs
@@ -16,6 +16,7 @@ pub(crate) fn permission_profile_sandbox_tag(
         PermissionProfile::Managed {
             file_system,
             network,
+            ..
         } => {
             let file_system_policy = file_system.to_sandbox_policy();
             if !should_require_platform_sandbox(

--- a/codex-rs/core/src/sandbox_tags_tests.rs
+++ b/codex-rs/core/src/sandbox_tags_tests.rs
@@ -77,6 +77,7 @@ fn unrestricted_managed_profile_with_enabled_network_is_untagged() {
     let profile = PermissionProfile::Managed {
         file_system: ManagedFileSystemPermissions::Unrestricted,
         network: NetworkSandboxPolicy::Enabled,
+        macos: None,
     };
 
     assert_eq!(
@@ -102,6 +103,7 @@ fn root_write_managed_profile_with_enabled_network_is_untagged() {
             glob_scan_max_depth: None,
         },
         network: NetworkSandboxPolicy::Enabled,
+        macos: None,
     };
 
     assert_eq!(
@@ -119,6 +121,7 @@ fn managed_network_enforcement_tags_unrestricted_profiles_as_sandboxed() {
     let profile = PermissionProfile::Managed {
         file_system: ManagedFileSystemPermissions::Unrestricted,
         network: NetworkSandboxPolicy::Enabled,
+        macos: None,
     };
     let expected = get_platform_sandbox(/*windows_sandbox_enabled*/ false)
         .map(SandboxType::as_metric_tag)

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -383,19 +383,14 @@ impl SessionConfiguration {
         profile_workspace_roots: Vec<AbsolutePathBuf>,
         preserve_deny_reads_from: Option<&FileSystemSandboxPolicy>,
     ) -> ConstraintResult<()> {
-        let enforcement = permission_profile.enforcement();
         let (mut file_system_sandbox_policy, network_sandbox_policy) =
             permission_profile.to_runtime_permissions();
         if let Some(existing_file_system_policy) = preserve_deny_reads_from {
             file_system_sandbox_policy
                 .preserve_deny_read_restrictions_from(existing_file_system_policy);
         }
-        let effective_permission_profile =
-            PermissionProfile::from_runtime_permissions_with_enforcement(
-                enforcement,
-                &file_system_sandbox_policy,
-                network_sandbox_policy,
-            );
+        let effective_permission_profile = permission_profile
+            .with_runtime_permissions(&file_system_sandbox_policy, network_sandbox_policy);
 
         let permission_snapshot = match active_permission_profile {
             Some(active_permission_profile) => {

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -4187,6 +4187,7 @@ async fn active_profile_update_rebuilds_network_proxy_config() -> std::io::Resul
                         )]),
                     }),
                     network: None,
+                    macos: None,
                 },
             ),
             (
@@ -4208,6 +4209,7 @@ async fn active_profile_update_rebuilds_network_proxy_config() -> std::io::Resul
                         enable_socks5: Some(false),
                         ..Default::default()
                     }),
+                    macos: None,
                 },
             ),
         ]),

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -307,11 +307,9 @@ impl TurnContext {
             base_network_sandbox_policy,
             additional_permissions.as_ref(),
         );
-        let permissions = PermissionProfile::from_runtime_permissions_with_enforcement(
-            self.permission_profile.enforcement(),
-            &file_system_sandbox_policy,
-            network_sandbox_policy,
-        );
+        let permissions = self
+            .permission_profile
+            .with_runtime_permissions(&file_system_sandbox_policy, network_sandbox_policy);
         FileSystemSandboxContext {
             permissions,
             cwd: Some(cwd.clone()),

--- a/codex-rs/core/tests/suite/mod.rs
+++ b/codex-rs/core/tests/suite/mod.rs
@@ -7,13 +7,56 @@ use codex_test_binary_support::TestBinaryDispatchMode;
 use codex_test_binary_support::configure_test_binary_dispatch;
 use ctor::ctor;
 
+#[cfg(target_os = "macos")]
+pub(crate) const MACOS_SANDBOX_CAPABILITY_PROBE_ARG: &str =
+    "--codex-test-macos-sandbox-capability-probe";
+#[cfg(target_os = "macos")]
+pub(crate) const MACOS_SANDBOX_CAPABILITY_PROBE_MACH_SERVICE: &str =
+    "com.apple.coreservices.appleevents";
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+    static bootstrap_port: libc::c_uint;
+    fn bootstrap_look_up(
+        bootstrap_port: libc::c_uint,
+        service_name: *const libc::c_char,
+        service_port: *mut libc::c_uint,
+    ) -> libc::c_int;
+}
+
+#[cfg(target_os = "macos")]
+fn maybe_run_macos_sandbox_capability_probe() {
+    if std::env::args().nth(1).as_deref() != Some(MACOS_SANDBOX_CAPABILITY_PROBE_ARG) {
+        return;
+    }
+
+    let mut service_port = 0;
+    // SAFETY: the service name and output port pointers remain valid for the duration of the call.
+    let result = unsafe {
+        bootstrap_look_up(
+            bootstrap_port,
+            c"com.apple.coreservices.appleevents".as_ptr(),
+            &mut service_port,
+        )
+    };
+    if result != 0 {
+        eprintln!("Mach lookup failed with result {result}");
+        std::process::exit(1);
+    }
+    std::process::exit(0);
+}
+
 // This code runs before any other tests are run.
 // It allows the test binary to behave like codex and dispatch to apply_patch and codex-linux-sandbox
 // based on the arg0.
 // NOTE: this doesn't work on ARM
 #[ctor]
 pub static CODEX_ALIASES_TEMP_DIR: Option<TestBinaryDispatchGuard> = {
-    configure_test_binary_dispatch("codex-core-tests", |exe_name, argv1| {
+    let guard = configure_test_binary_dispatch("codex-core-tests", |exe_name, argv1| {
+        #[cfg(target_os = "macos")]
+        if argv1 == Some(MACOS_SANDBOX_CAPABILITY_PROBE_ARG) {
+            return TestBinaryDispatchMode::Skip;
+        }
         if argv1 == Some(CODEX_CORE_APPLY_PATCH_ARG1) {
             return TestBinaryDispatchMode::DispatchArg0Only;
         }
@@ -24,7 +67,10 @@ pub static CODEX_ALIASES_TEMP_DIR: Option<TestBinaryDispatchGuard> = {
             return TestBinaryDispatchMode::DispatchArg0Only;
         }
         TestBinaryDispatchMode::InstallAliases
-    })
+    });
+    #[cfg(target_os = "macos")]
+    maybe_run_macos_sandbox_capability_probe();
+    guard
 };
 
 #[cfg(not(target_os = "windows"))]

--- a/codex-rs/core/tests/suite/request_permissions.rs
+++ b/codex-rs/core/tests/suite/request_permissions.rs
@@ -7,6 +7,8 @@ use codex_features::Feature;
 use codex_protocol::config_types::ApprovalsReviewer;
 use codex_protocol::models::AdditionalPermissionProfile as PermissionProfile;
 use codex_protocol::models::FileSystemPermissions;
+#[cfg(target_os = "macos")]
+use codex_protocol::models::MacOsSandboxCapabilities;
 use codex_protocol::models::PermissionProfile as CorePermissionProfile;
 use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_protocol::protocol::AskForApproval;
@@ -502,6 +504,90 @@ async fn request_permissions_tool_is_auto_denied_when_granular_request_permissio
             scope: PermissionGrantScope::Turn,
             strict_auto_review: false,
         }
+    );
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test(flavor = "current_thread")]
+async fn managed_macos_capability_survives_additional_permissions_tool_execution() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+    skip_if_sandbox!(Ok(()));
+
+    let server = start_mock_server().await;
+    let approval_policy = AskForApproval::OnRequest;
+    let macos = MacOsSandboxCapabilities {
+        mach_lookup_services: vec![super::MACOS_SANDBOX_CAPABILITY_PROBE_MACH_SERVICE.to_string()],
+        apple_event_destinations: Vec::new(),
+        launch_services_open: false,
+    };
+    let permission_profile =
+        CorePermissionProfile::read_only().with_macos_sandbox_capabilities(Some(macos));
+    let permission_profile_for_config = permission_profile.clone();
+
+    let mut builder = test_codex().with_config(move |config| {
+        config.permissions.approval_policy = Constrained::allow_any(approval_policy);
+        config
+            .permissions
+            .set_permission_profile(permission_profile_for_config)
+            .expect("set permission profile");
+        config
+            .features
+            .enable(Feature::ExecPermissionApprovals)
+            .expect("test config should allow feature update");
+    });
+    let test = builder.build(&server).await?;
+
+    let requested_dir = test.workspace_path("macos-capability-probe-grant");
+    fs::create_dir_all(&requested_dir)?;
+    let requested_permissions = requested_directory_write_permissions(&requested_dir);
+    let normalized_requested_permissions = normalized_directory_write_permissions(&requested_dir)?;
+    let test_exe = std::env::current_exe()?;
+    let probe_arg = super::MACOS_SANDBOX_CAPABILITY_PROBE_ARG;
+    let command = format!("{test_exe:?} {probe_arg}");
+    let call_id = "managed-macos-capability-with-additional-permissions";
+    let event = shell_event_with_request_permissions(call_id, &command, &requested_permissions)?;
+
+    let _ = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-macos-capability-1"),
+            event,
+            ev_completed("resp-macos-capability-1"),
+        ]),
+    )
+    .await;
+    let results = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_assistant_message("msg-macos-capability-1", "done"),
+            ev_completed("resp-macos-capability-2"),
+        ]),
+    )
+    .await;
+
+    submit_turn(&test, call_id, approval_policy, permission_profile).await?;
+    let approval = expect_exec_approval(&test, &command).await;
+    assert_eq!(
+        approval.additional_permissions,
+        Some(normalized_requested_permissions.into())
+    );
+    test.codex
+        .submit(Op::ExecApproval {
+            id: approval.effective_approval_id(),
+            turn_id: None,
+            decision: ReviewDecision::Approved,
+        })
+        .await?;
+    wait_for_completion(&test).await;
+
+    let result = parse_result(&results.single_request().function_call_output(call_id));
+    assert_eq!(
+        result.exit_code,
+        Some(0),
+        "capability probe should succeed after applying additional permissions: {}",
+        result.stdout
     );
 
     Ok(())

--- a/codex-rs/core/tests/suite/request_permissions.rs
+++ b/codex-rs/core/tests/suite/request_permissions.rs
@@ -96,9 +96,23 @@ fn shell_event_with_request_permissions<S: serde::Serialize>(
     command: &str,
     additional_permissions: &S,
 ) -> Result<Value> {
+    shell_event_with_request_permissions_and_timeout(
+        call_id,
+        command,
+        additional_permissions,
+        /*timeout_ms*/ 1_000,
+    )
+}
+
+fn shell_event_with_request_permissions_and_timeout<S: serde::Serialize>(
+    call_id: &str,
+    command: &str,
+    additional_permissions: &S,
+    timeout_ms: u64,
+) -> Result<Value> {
     let args = json!({
         "command": command,
-        "timeout_ms": 1_000_u64,
+        "timeout_ms": timeout_ms,
         "sandbox_permissions": SandboxPermissions::WithAdditionalPermissions,
         "additional_permissions": additional_permissions,
     });
@@ -547,7 +561,12 @@ async fn managed_macos_capability_survives_additional_permissions_tool_execution
     let probe_arg = super::MACOS_SANDBOX_CAPABILITY_PROBE_ARG;
     let command = format!("{test_exe:?} {probe_arg}");
     let call_id = "managed-macos-capability-with-additional-permissions";
-    let event = shell_event_with_request_permissions(call_id, &command, &requested_permissions)?;
+    let event = shell_event_with_request_permissions_and_timeout(
+        call_id,
+        &command,
+        &requested_permissions,
+        /*timeout_ms*/ 5_000,
+    )?;
 
     let _ = mount_sse_once(
         &server,

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -224,6 +224,24 @@ impl AdditionalPermissionProfile {
     }
 }
 
+#[derive(Debug, Clone, Default, Eq, PartialEq, Serialize, Deserialize, JsonSchema, TS)]
+pub struct MacOsSandboxCapabilities {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub mach_lookup_services: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub apple_event_destinations: Vec<String>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub launch_services_open: bool,
+}
+
+impl MacOsSandboxCapabilities {
+    pub fn is_empty(&self) -> bool {
+        self.mach_lookup_services.is_empty()
+            && self.apple_event_destinations.is_empty()
+            && !self.launch_services_open
+    }
+}
+
 #[derive(
     Debug, Clone, Copy, Default, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, TS,
 )]
@@ -317,6 +335,9 @@ pub enum PermissionProfile {
     Managed {
         file_system: ManagedFileSystemPermissions,
         network: NetworkSandboxPolicy,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[ts(optional)]
+        macos: Option<MacOsSandboxCapabilities>,
     },
     /// Do not apply an outer sandbox.
     Disabled,
@@ -367,6 +388,7 @@ impl Default for PermissionProfile {
                 glob_scan_max_depth: None,
             },
             network: NetworkSandboxPolicy::Restricted,
+            macos: None,
         }
     }
 }
@@ -378,6 +400,7 @@ impl PermissionProfile {
         Self::Managed {
             file_system: ManagedFileSystemPermissions::from_sandbox_policy(&file_system),
             network: NetworkSandboxPolicy::Restricted,
+            macos: None,
         }
     }
 
@@ -414,6 +437,7 @@ impl PermissionProfile {
         Self::Managed {
             file_system: ManagedFileSystemPermissions::from_sandbox_policy(&file_system),
             network,
+            macos: None,
         }
     }
 
@@ -425,6 +449,7 @@ impl PermissionProfile {
             Self::Managed {
                 file_system,
                 network,
+                macos,
             } => {
                 let file_system = file_system
                     .to_sandbox_policy()
@@ -432,6 +457,7 @@ impl PermissionProfile {
                 Self::Managed {
                     file_system: ManagedFileSystemPermissions::from_sandbox_policy(&file_system),
                     network,
+                    macos,
                 }
             }
             Self::Disabled => Self::Disabled,
@@ -474,6 +500,7 @@ impl PermissionProfile {
                         file_system_sandbox_policy,
                     ),
                     network: network_sandbox_policy,
+                    macos: None,
                 }
             }
         }
@@ -518,11 +545,48 @@ impl PermissionProfile {
         }
     }
 
+    pub fn macos_sandbox_capabilities(&self) -> Option<&MacOsSandboxCapabilities> {
+        match self {
+            Self::Managed { macos, .. } => macos.as_ref(),
+            Self::Disabled | Self::External { .. } => None,
+        }
+    }
+
+    pub fn with_macos_sandbox_capabilities(self, macos: Option<MacOsSandboxCapabilities>) -> Self {
+        match self {
+            Self::Managed {
+                file_system,
+                network,
+                ..
+            } => Self::Managed {
+                file_system,
+                network,
+                macos,
+            },
+            Self::Disabled => Self::Disabled,
+            Self::External { network } => Self::External { network },
+        }
+    }
+
+    pub fn with_runtime_permissions(
+        &self,
+        file_system_sandbox_policy: &FileSystemSandboxPolicy,
+        network_sandbox_policy: NetworkSandboxPolicy,
+    ) -> Self {
+        Self::from_runtime_permissions_with_enforcement(
+            self.enforcement(),
+            file_system_sandbox_policy,
+            network_sandbox_policy,
+        )
+        .with_macos_sandbox_capabilities(self.macos_sandbox_capabilities().cloned())
+    }
+
     pub fn to_legacy_sandbox_policy(&self, cwd: &Path) -> io::Result<SandboxPolicy> {
         match self {
             Self::Managed {
                 file_system,
                 network,
+                ..
             } => file_system
                 .to_sandbox_policy()
                 .to_legacy_sandbox_policy(*network, cwd),
@@ -552,6 +616,8 @@ enum TaggedPermissionProfile {
     Managed {
         file_system: ManagedFileSystemPermissions,
         network: NetworkSandboxPolicy,
+        #[serde(default)]
+        macos: Option<MacOsSandboxCapabilities>,
     },
     Disabled,
     #[serde(rename_all = "snake_case")]
@@ -566,9 +632,11 @@ impl From<TaggedPermissionProfile> for PermissionProfile {
             TaggedPermissionProfile::Managed {
                 file_system,
                 network,
+                macos,
             } => Self::Managed {
                 file_system,
                 network,
+                macos,
             },
             TaggedPermissionProfile::Disabled => Self::Disabled,
             TaggedPermissionProfile::External { network } => Self::External { network },
@@ -1871,6 +1939,7 @@ mod tests {
                     glob_scan_max_depth: NonZeroUsize::new(2),
                 },
                 network: NetworkSandboxPolicy::Enabled,
+                macos: None,
             }
         );
         Ok(())
@@ -1958,6 +2027,7 @@ mod tests {
             PermissionProfile::Managed {
                 file_system: ManagedFileSystemPermissions::Unrestricted,
                 network: NetworkSandboxPolicy::Restricted,
+                macos: None,
             },
             "the legacy ExternalSandbox projection must not hide a split unrestricted filesystem policy"
         );
@@ -1968,6 +2038,33 @@ mod tests {
                 NetworkSandboxPolicy::Restricted,
             )
         );
+    }
+
+    #[test]
+    fn permission_profile_runtime_update_preserves_macos_sandbox_capabilities() -> Result<()> {
+        let macos = MacOsSandboxCapabilities {
+            mach_lookup_services: vec!["com.apple.coreservices.appleevents".to_string()],
+            apple_event_destinations: vec!["com.openai.sky.CUAService".to_string()],
+            launch_services_open: true,
+        };
+        let permission_profile =
+            PermissionProfile::read_only().with_macos_sandbox_capabilities(Some(macos.clone()));
+        let permission_profile = permission_profile.with_runtime_permissions(
+            &FileSystemSandboxPolicy::unrestricted(),
+            NetworkSandboxPolicy::Enabled,
+        );
+
+        assert_eq!(
+            serde_json::from_value::<PermissionProfile>(serde_json::to_value(
+                &permission_profile
+            )?)?,
+            PermissionProfile::Managed {
+                file_system: ManagedFileSystemPermissions::Unrestricted,
+                network: NetworkSandboxPolicy::Enabled,
+                macos: Some(macos),
+            }
+        );
+        Ok(())
     }
 
     #[test]

--- a/codex-rs/sandboxing/src/manager.rs
+++ b/codex-rs/sandboxing/src/manager.rs
@@ -233,6 +233,9 @@ impl SandboxManager {
                     sandbox_policy_cwd,
                     enforce_managed_network,
                     network,
+                    extra_mach_services: &[],
+                    extra_appleevent_bundle_ids: &[],
+                    allow_lsopen: false,
                     extra_allow_unix_sockets: &[],
                 });
                 let mut full_command = Vec::with_capacity(1 + args.len());

--- a/codex-rs/sandboxing/src/manager.rs
+++ b/codex-rs/sandboxing/src/manager.rs
@@ -75,11 +75,7 @@ pub fn with_managed_mitm_ca_readable_root(
         sandbox_policy_cwd,
         std::slice::from_ref(managed_mitm_ca_trust_bundle_path),
     );
-    PermissionProfile::from_runtime_permissions_with_enforcement(
-        permission_profile.enforcement(),
-        &file_system_sandbox_policy,
-        network_sandbox_policy,
-    )
+    permission_profile.with_runtime_permissions(&file_system_sandbox_policy, network_sandbox_policy)
 }
 
 #[derive(Debug)]
@@ -233,9 +229,8 @@ impl SandboxManager {
                     sandbox_policy_cwd,
                     enforce_managed_network,
                     network,
-                    extra_mach_services: &[],
-                    extra_appleevent_bundle_ids: &[],
-                    allow_lsopen: false,
+                    macos_sandbox_capabilities: effective_permission_profile
+                        .macos_sandbox_capabilities(),
                     extra_allow_unix_sockets: &[],
                 });
                 let mut full_command = Vec::with_capacity(1 + args.len());

--- a/codex-rs/sandboxing/src/manager_tests.rs
+++ b/codex-rs/sandboxing/src/manager_tests.rs
@@ -8,6 +8,8 @@ use super::with_managed_mitm_ca_readable_root;
 use codex_protocol::config_types::WindowsSandboxLevel;
 use codex_protocol::models::AdditionalPermissionProfile;
 use codex_protocol::models::FileSystemPermissions;
+#[cfg(target_os = "macos")]
+use codex_protocol::models::MacOsSandboxCapabilities;
 use codex_protocol::models::NetworkPermissions;
 use codex_protocol::models::PermissionProfile;
 use codex_protocol::permissions::FileSystemAccessMode;
@@ -106,6 +108,63 @@ fn transform_preserves_unrestricted_file_system_policy_for_restricted_network() 
     assert_eq!(
         exec_request.network_sandbox_policy,
         NetworkSandboxPolicy::Restricted
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn transform_seatbelt_lowers_macos_profile_capabilities() {
+    let manager = SandboxManager::new();
+    let cwd = AbsolutePathBuf::current_dir().expect("current dir");
+    let macos = MacOsSandboxCapabilities {
+        mach_lookup_services: vec!["com.apple.coreservices.appleevents".to_string()],
+        apple_event_destinations: vec!["com.openai.sky.CUAService".to_string()],
+        launch_services_open: true,
+    };
+    let permissions =
+        PermissionProfile::read_only().with_macos_sandbox_capabilities(Some(macos.clone()));
+    let exec_request = manager
+        .transform(SandboxTransformRequest {
+            command: SandboxCommand {
+                program: "true".into(),
+                args: Vec::new(),
+                cwd: cwd.clone(),
+                env: HashMap::new(),
+                additional_permissions: Some(AdditionalPermissionProfile::default()),
+            },
+            permissions: &permissions,
+            sandbox: SandboxType::MacosSeatbelt,
+            enforce_managed_network: false,
+            network: None,
+            sandbox_policy_cwd: cwd.as_path(),
+            codex_linux_sandbox_exe: None,
+            use_legacy_landlock: false,
+            windows_sandbox_level: WindowsSandboxLevel::Disabled,
+            windows_sandbox_private_desktop: false,
+        })
+        .expect("transform");
+
+    assert_eq!(
+        exec_request.permission_profile.macos_sandbox_capabilities(),
+        Some(&macos)
+    );
+    assert!(
+        exec_request
+            .command
+            .iter()
+            .any(|arg| arg.contains("(global-name \"com.apple.coreservices.appleevents\")"))
+    );
+    assert!(
+        exec_request
+            .command
+            .iter()
+            .any(|arg| arg.contains("(appleevent-destination \"com.openai.sky.CUAService\")"))
+    );
+    assert!(
+        exec_request
+            .command
+            .iter()
+            .any(|arg| arg.contains("(allow lsopen)"))
     );
 }
 

--- a/codex-rs/sandboxing/src/policy_transforms.rs
+++ b/codex-rs/sandboxing/src/policy_transforms.rs
@@ -499,11 +499,8 @@ pub fn effective_permission_profile(
         effective_file_system_sandbox_policy(&file_system_policy, additional_permissions);
     let effective_network_policy =
         effective_network_sandbox_policy(network_policy, additional_permissions);
-    PermissionProfile::from_runtime_permissions_with_enforcement(
-        permission_profile.enforcement(),
-        &effective_file_system_policy,
-        effective_network_policy,
-    )
+    permission_profile
+        .with_runtime_permissions(&effective_file_system_policy, effective_network_policy)
 }
 
 pub fn should_require_platform_sandbox(

--- a/codex-rs/sandboxing/src/seatbelt.rs
+++ b/codex-rs/sandboxing/src/seatbelt.rs
@@ -241,6 +241,61 @@ fn unix_socket_policy(proxy: &ProxyPolicyInputs) -> String {
     policy
 }
 
+fn seatbelt_string_literal(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn extra_mach_lookup_policy(extra_mach_services: &[String]) -> String {
+    let services = extra_mach_services
+        .iter()
+        .map(|service| service.trim())
+        .filter(|service| !service.is_empty())
+        .collect::<BTreeSet<_>>();
+    if services.is_empty() {
+        return String::new();
+    }
+
+    let services = services
+        .into_iter()
+        .map(|service| format!("  (global-name \"{}\")", seatbelt_string_literal(service)))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!("(allow mach-lookup\n{services}\n)")
+}
+
+fn extra_appleevent_policy(extra_appleevent_bundle_ids: &[String]) -> String {
+    let bundle_ids = extra_appleevent_bundle_ids
+        .iter()
+        .map(|bundle_id| bundle_id.trim())
+        .filter(|bundle_id| !bundle_id.is_empty())
+        .collect::<BTreeSet<_>>();
+    if bundle_ids.is_empty() {
+        return String::new();
+    }
+
+    let destinations = bundle_ids
+        .into_iter()
+        .map(|bundle_id| {
+            format!(
+                "  (appleevent-destination \"{}\")",
+                seatbelt_string_literal(bundle_id)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "(allow mach-lookup\n  (global-name \"com.apple.coreservices.appleevents\"))\n(allow appleevent-send\n{destinations}\n)"
+    )
+}
+
+fn lsopen_policy(allow_lsopen: bool) -> String {
+    if allow_lsopen {
+        "(allow lsopen)".to_string()
+    } else {
+        String::new()
+    }
+}
+
 #[cfg_attr(not(test), allow(dead_code))]
 fn dynamic_network_policy(
     sandbox_policy: &SandboxPolicy,
@@ -584,6 +639,9 @@ fn create_seatbelt_command_args_for_legacy_policy(
         sandbox_policy_cwd,
         enforce_managed_network,
         network,
+        extra_mach_services: &[],
+        extra_appleevent_bundle_ids: &[],
+        allow_lsopen: false,
         extra_allow_unix_sockets: &[],
     })
 }
@@ -596,6 +654,9 @@ pub struct CreateSeatbeltCommandArgsParams<'a> {
     pub sandbox_policy_cwd: &'a Path,
     pub enforce_managed_network: bool,
     pub network: Option<&'a NetworkProxy>,
+    pub extra_mach_services: &'a [String],
+    pub extra_appleevent_bundle_ids: &'a [String],
+    pub allow_lsopen: bool,
     pub extra_allow_unix_sockets: &'a [AbsolutePathBuf],
 }
 
@@ -607,6 +668,9 @@ pub fn create_seatbelt_command_args(args: CreateSeatbeltCommandArgsParams<'_>) -
         sandbox_policy_cwd,
         enforce_managed_network,
         network,
+        extra_mach_services,
+        extra_appleevent_bundle_ids,
+        allow_lsopen,
         extra_allow_unix_sockets,
     } = args;
 
@@ -704,6 +768,9 @@ pub fn create_seatbelt_command_args(args: CreateSeatbeltCommandArgsParams<'_>) -
     let proxy = proxy_policy_inputs(network, extra_allow_unix_sockets);
     let network_policy =
         dynamic_network_policy_for_network(network_sandbox_policy, enforce_managed_network, &proxy);
+    let mach_lookup_policy = extra_mach_lookup_policy(extra_mach_services);
+    let appleevent_policy = extra_appleevent_policy(extra_appleevent_bundle_ids);
+    let lsopen_policy = lsopen_policy(allow_lsopen);
 
     let include_platform_defaults = file_system_sandbox_policy.include_platform_defaults();
     let deny_read_policy =
@@ -715,6 +782,15 @@ pub fn create_seatbelt_command_args(args: CreateSeatbeltCommandArgsParams<'_>) -
         deny_read_policy,
         network_policy,
     ];
+    if !mach_lookup_policy.is_empty() {
+        policy_sections.push(mach_lookup_policy);
+    }
+    if !appleevent_policy.is_empty() {
+        policy_sections.push(appleevent_policy);
+    }
+    if !lsopen_policy.is_empty() {
+        policy_sections.push(lsopen_policy);
+    }
     if include_platform_defaults {
         policy_sections.push(MACOS_RESTRICTED_READ_ONLY_PLATFORM_DEFAULTS.to_string());
     }

--- a/codex-rs/sandboxing/src/seatbelt.rs
+++ b/codex-rs/sandboxing/src/seatbelt.rs
@@ -2,6 +2,7 @@ use codex_network_proxy::NetworkProxy;
 use codex_network_proxy::PROXY_URL_ENV_KEYS;
 use codex_network_proxy::has_proxy_url_env_vars;
 use codex_network_proxy::proxy_url_env_value;
+use codex_protocol::models::MacOsSandboxCapabilities;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_protocol::permissions::PROTECTED_METADATA_PATH_NAMES;
@@ -245,8 +246,8 @@ fn seatbelt_string_literal(value: &str) -> String {
     value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
-fn extra_mach_lookup_policy(extra_mach_services: &[String]) -> String {
-    let services = extra_mach_services
+fn mach_lookup_policy(mach_lookup_services: &[String]) -> String {
+    let services = mach_lookup_services
         .iter()
         .map(|service| service.trim())
         .filter(|service| !service.is_empty())
@@ -263,8 +264,8 @@ fn extra_mach_lookup_policy(extra_mach_services: &[String]) -> String {
     format!("(allow mach-lookup\n{services}\n)")
 }
 
-fn extra_appleevent_policy(extra_appleevent_bundle_ids: &[String]) -> String {
-    let bundle_ids = extra_appleevent_bundle_ids
+fn appleevent_policy(apple_event_destinations: &[String]) -> String {
+    let bundle_ids = apple_event_destinations
         .iter()
         .map(|bundle_id| bundle_id.trim())
         .filter(|bundle_id| !bundle_id.is_empty())
@@ -283,13 +284,11 @@ fn extra_appleevent_policy(extra_appleevent_bundle_ids: &[String]) -> String {
         })
         .collect::<Vec<_>>()
         .join("\n");
-    format!(
-        "(allow mach-lookup\n  (global-name \"com.apple.coreservices.appleevents\"))\n(allow appleevent-send\n{destinations}\n)"
-    )
+    format!("(allow appleevent-send\n{destinations}\n)")
 }
 
-fn lsopen_policy(allow_lsopen: bool) -> String {
-    if allow_lsopen {
+fn launch_services_open_policy(launch_services_open: bool) -> String {
+    if launch_services_open {
         "(allow lsopen)".to_string()
     } else {
         String::new()
@@ -639,9 +638,7 @@ fn create_seatbelt_command_args_for_legacy_policy(
         sandbox_policy_cwd,
         enforce_managed_network,
         network,
-        extra_mach_services: &[],
-        extra_appleevent_bundle_ids: &[],
-        allow_lsopen: false,
+        macos_sandbox_capabilities: None,
         extra_allow_unix_sockets: &[],
     })
 }
@@ -654,9 +651,7 @@ pub struct CreateSeatbeltCommandArgsParams<'a> {
     pub sandbox_policy_cwd: &'a Path,
     pub enforce_managed_network: bool,
     pub network: Option<&'a NetworkProxy>,
-    pub extra_mach_services: &'a [String],
-    pub extra_appleevent_bundle_ids: &'a [String],
-    pub allow_lsopen: bool,
+    pub macos_sandbox_capabilities: Option<&'a MacOsSandboxCapabilities>,
     pub extra_allow_unix_sockets: &'a [AbsolutePathBuf],
 }
 
@@ -668,9 +663,7 @@ pub fn create_seatbelt_command_args(args: CreateSeatbeltCommandArgsParams<'_>) -
         sandbox_policy_cwd,
         enforce_managed_network,
         network,
-        extra_mach_services,
-        extra_appleevent_bundle_ids,
-        allow_lsopen,
+        macos_sandbox_capabilities,
         extra_allow_unix_sockets,
     } = args;
 
@@ -768,9 +761,17 @@ pub fn create_seatbelt_command_args(args: CreateSeatbeltCommandArgsParams<'_>) -
     let proxy = proxy_policy_inputs(network, extra_allow_unix_sockets);
     let network_policy =
         dynamic_network_policy_for_network(network_sandbox_policy, enforce_managed_network, &proxy);
-    let mach_lookup_policy = extra_mach_lookup_policy(extra_mach_services);
-    let appleevent_policy = extra_appleevent_policy(extra_appleevent_bundle_ids);
-    let lsopen_policy = lsopen_policy(allow_lsopen);
+    let mach_lookup_policy =
+        mach_lookup_policy(macos_sandbox_capabilities.map_or(&[], |capabilities| {
+            capabilities.mach_lookup_services.as_slice()
+        }));
+    let appleevent_policy =
+        appleevent_policy(macos_sandbox_capabilities.map_or(&[], |capabilities| {
+            capabilities.apple_event_destinations.as_slice()
+        }));
+    let launch_services_open_policy = launch_services_open_policy(
+        macos_sandbox_capabilities.is_some_and(|capabilities| capabilities.launch_services_open),
+    );
 
     let include_platform_defaults = file_system_sandbox_policy.include_platform_defaults();
     let deny_read_policy =
@@ -788,8 +789,8 @@ pub fn create_seatbelt_command_args(args: CreateSeatbeltCommandArgsParams<'_>) -
     if !appleevent_policy.is_empty() {
         policy_sections.push(appleevent_policy);
     }
-    if !lsopen_policy.is_empty() {
-        policy_sections.push(lsopen_policy);
+    if !launch_services_open_policy.is_empty() {
+        policy_sections.push(launch_services_open_policy);
     }
     if include_platform_defaults {
         policy_sections.push(MACOS_RESTRICTED_READ_ONLY_PLATFORM_DEFAULTS.to_string());

--- a/codex-rs/sandboxing/src/seatbelt_tests.rs
+++ b/codex-rs/sandboxing/src/seatbelt_tests.rs
@@ -206,6 +206,9 @@ fn explicit_unreadable_paths_are_excluded_from_full_disk_read_and_write_access()
         sandbox_policy_cwd: Path::new("/"),
         enforce_managed_network: false,
         network: None,
+        extra_mach_services: &[],
+        extra_appleevent_bundle_ids: &[],
+        allow_lsopen: false,
         extra_allow_unix_sockets: &[],
     });
 
@@ -278,6 +281,9 @@ fn explicit_unreadable_paths_are_excluded_from_readable_roots() {
         sandbox_policy_cwd: Path::new("/"),
         enforce_managed_network: false,
         network: None,
+        extra_mach_services: &[],
+        extra_appleevent_bundle_ids: &[],
+        allow_lsopen: false,
         extra_allow_unix_sockets: &[],
     });
 
@@ -581,6 +587,9 @@ fn create_seatbelt_args_allowlists_explicit_unix_socket_paths_without_proxy() {
         sandbox_policy_cwd: cwd.path(),
         enforce_managed_network: false,
         network: None,
+        extra_mach_services: &[],
+        extra_appleevent_bundle_ids: &[],
+        allow_lsopen: false,
         extra_allow_unix_sockets: &extra_allow_unix_sockets,
     });
     let policy = seatbelt_policy_arg(&args);
@@ -639,6 +648,9 @@ async fn create_seatbelt_args_merges_proxy_and_explicit_unix_socket_paths() -> a
         sandbox_policy_cwd: cwd.path(),
         enforce_managed_network: false,
         network: Some(&network_proxy),
+        extra_mach_services: &[],
+        extra_appleevent_bundle_ids: &[],
+        allow_lsopen: false,
         extra_allow_unix_sockets: &extra_allow_unix_sockets,
     });
 
@@ -680,6 +692,9 @@ fn create_seatbelt_args_preserves_full_network_with_explicit_unix_socket_paths()
         sandbox_policy_cwd: cwd.path(),
         enforce_managed_network: false,
         network: None,
+        extra_mach_services: &[],
+        extra_appleevent_bundle_ids: &[],
+        allow_lsopen: false,
         extra_allow_unix_sockets: &extra_allow_unix_sockets,
     });
     let policy = seatbelt_policy_arg(&args);
@@ -721,6 +736,134 @@ fn unix_socket_policy_non_empty_output_is_newline_terminated() {
         allow_all_policy.ends_with('\n'),
         "allow-all unix socket policy should end with a newline:\n{allow_all_policy}"
     );
+}
+
+#[test]
+fn create_seatbelt_args_allowlists_extra_mach_services() {
+    let cwd = TempDir::new().expect("temp cwd");
+    let file_system_policy = FileSystemSandboxPolicy::from_legacy_sandbox_policy_for_cwd(
+        &SandboxPolicy::new_read_only_policy(),
+        cwd.path(),
+    );
+    let extra_mach_services = vec![
+        "com.apple.beta".to_string(),
+        "com.apple.alpha".to_string(),
+        "com.apple.beta".to_string(),
+    ];
+    let args = create_seatbelt_command_args(CreateSeatbeltCommandArgsParams {
+        command: vec!["/usr/bin/true".to_string()],
+        file_system_sandbox_policy: &file_system_policy,
+        network_sandbox_policy: NetworkSandboxPolicy::Restricted,
+        sandbox_policy_cwd: cwd.path(),
+        enforce_managed_network: false,
+        network: None,
+        extra_mach_services: &extra_mach_services,
+        extra_appleevent_bundle_ids: &[],
+        allow_lsopen: false,
+        extra_allow_unix_sockets: &[],
+    });
+    let policy = seatbelt_policy_arg(&args);
+
+    assert!(
+        policy.contains(
+            "(allow mach-lookup\n  (global-name \"com.apple.alpha\")\n  (global-name \"com.apple.beta\")\n)"
+        ),
+        "policy should allow the requested Mach services in stable order:\n{policy}"
+    );
+    assert_eq!(
+        policy.matches("(global-name \"com.apple.alpha\")").count(),
+        1
+    );
+    assert_eq!(
+        policy.matches("(global-name \"com.apple.beta\")").count(),
+        1
+    );
+}
+
+#[test]
+fn create_seatbelt_args_allowlists_appleevent_destinations() {
+    let cwd = TempDir::new().expect("temp cwd");
+    let file_system_policy = FileSystemSandboxPolicy::from_legacy_sandbox_policy_for_cwd(
+        &SandboxPolicy::new_read_only_policy(),
+        cwd.path(),
+    );
+    let extra_appleevent_bundle_ids = vec![
+        "com.apple.mail".to_string(),
+        "com.apple.finder".to_string(),
+        "com.apple.mail".to_string(),
+    ];
+    let args = create_seatbelt_command_args(CreateSeatbeltCommandArgsParams {
+        command: vec!["/usr/bin/true".to_string()],
+        file_system_sandbox_policy: &file_system_policy,
+        network_sandbox_policy: NetworkSandboxPolicy::Restricted,
+        sandbox_policy_cwd: cwd.path(),
+        enforce_managed_network: false,
+        network: None,
+        extra_mach_services: &[],
+        extra_appleevent_bundle_ids: &extra_appleevent_bundle_ids,
+        allow_lsopen: false,
+        extra_allow_unix_sockets: &[],
+    });
+    let policy = seatbelt_policy_arg(&args);
+
+    assert!(
+        policy.contains(
+            "(allow mach-lookup\n  (global-name \"com.apple.coreservices.appleevents\"))"
+        ),
+        "policy should allow lookup of the AppleEvents service:\n{policy}"
+    );
+    assert!(
+        policy.contains(
+            "(allow appleevent-send\n  (appleevent-destination \"com.apple.finder\")\n  (appleevent-destination \"com.apple.mail\")\n)"
+        ),
+        "policy should allow the requested AppleEvent destinations in stable order:\n{policy}"
+    );
+    assert_eq!(
+        policy
+            .matches("(global-name \"com.apple.coreservices.appleevents\")")
+            .count(),
+        1
+    );
+    assert_eq!(
+        policy
+            .matches("(appleevent-destination \"com.apple.finder\")")
+            .count(),
+        1
+    );
+    assert_eq!(
+        policy
+            .matches("(appleevent-destination \"com.apple.mail\")")
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn create_seatbelt_args_allows_lsopen_when_requested() {
+    let cwd = TempDir::new().expect("temp cwd");
+    let file_system_policy = FileSystemSandboxPolicy::from_legacy_sandbox_policy_for_cwd(
+        &SandboxPolicy::new_read_only_policy(),
+        cwd.path(),
+    );
+    let args = create_seatbelt_command_args(CreateSeatbeltCommandArgsParams {
+        command: vec!["/usr/bin/true".to_string()],
+        file_system_sandbox_policy: &file_system_policy,
+        network_sandbox_policy: NetworkSandboxPolicy::Restricted,
+        sandbox_policy_cwd: cwd.path(),
+        enforce_managed_network: false,
+        network: None,
+        extra_mach_services: &[],
+        extra_appleevent_bundle_ids: &[],
+        allow_lsopen: true,
+        extra_allow_unix_sockets: &[],
+    });
+    let policy = seatbelt_policy_arg(&args);
+
+    assert!(
+        policy.contains("(allow lsopen)"),
+        "policy should allow lsopen when requested:\n{policy}"
+    );
+    assert_eq!(policy.matches("(allow lsopen)").count(), 1);
 }
 
 #[test]

--- a/codex-rs/sandboxing/src/seatbelt_tests.rs
+++ b/codex-rs/sandboxing/src/seatbelt_tests.rs
@@ -19,6 +19,7 @@ use codex_network_proxy::NetworkProxyConfig;
 use codex_network_proxy::NetworkProxyConstraints;
 use codex_network_proxy::NetworkProxyState;
 use codex_network_proxy::build_config_state;
+use codex_protocol::models::MacOsSandboxCapabilities;
 use codex_protocol::permissions::FileSystemAccessMode;
 use codex_protocol::permissions::FileSystemPath;
 use codex_protocol::permissions::FileSystemSandboxEntry;
@@ -206,9 +207,7 @@ fn explicit_unreadable_paths_are_excluded_from_full_disk_read_and_write_access()
         sandbox_policy_cwd: Path::new("/"),
         enforce_managed_network: false,
         network: None,
-        extra_mach_services: &[],
-        extra_appleevent_bundle_ids: &[],
-        allow_lsopen: false,
+        macos_sandbox_capabilities: None,
         extra_allow_unix_sockets: &[],
     });
 
@@ -281,9 +280,7 @@ fn explicit_unreadable_paths_are_excluded_from_readable_roots() {
         sandbox_policy_cwd: Path::new("/"),
         enforce_managed_network: false,
         network: None,
-        extra_mach_services: &[],
-        extra_appleevent_bundle_ids: &[],
-        allow_lsopen: false,
+        macos_sandbox_capabilities: None,
         extra_allow_unix_sockets: &[],
     });
 
@@ -587,9 +584,7 @@ fn create_seatbelt_args_allowlists_explicit_unix_socket_paths_without_proxy() {
         sandbox_policy_cwd: cwd.path(),
         enforce_managed_network: false,
         network: None,
-        extra_mach_services: &[],
-        extra_appleevent_bundle_ids: &[],
-        allow_lsopen: false,
+        macos_sandbox_capabilities: None,
         extra_allow_unix_sockets: &extra_allow_unix_sockets,
     });
     let policy = seatbelt_policy_arg(&args);
@@ -648,9 +643,7 @@ async fn create_seatbelt_args_merges_proxy_and_explicit_unix_socket_paths() -> a
         sandbox_policy_cwd: cwd.path(),
         enforce_managed_network: false,
         network: Some(&network_proxy),
-        extra_mach_services: &[],
-        extra_appleevent_bundle_ids: &[],
-        allow_lsopen: false,
+        macos_sandbox_capabilities: None,
         extra_allow_unix_sockets: &extra_allow_unix_sockets,
     });
 
@@ -692,9 +685,7 @@ fn create_seatbelt_args_preserves_full_network_with_explicit_unix_socket_paths()
         sandbox_policy_cwd: cwd.path(),
         enforce_managed_network: false,
         network: None,
-        extra_mach_services: &[],
-        extra_appleevent_bundle_ids: &[],
-        allow_lsopen: false,
+        macos_sandbox_capabilities: None,
         extra_allow_unix_sockets: &extra_allow_unix_sockets,
     });
     let policy = seatbelt_policy_arg(&args);
@@ -739,17 +730,20 @@ fn unix_socket_policy_non_empty_output_is_newline_terminated() {
 }
 
 #[test]
-fn create_seatbelt_args_allowlists_extra_mach_services() {
+fn create_seatbelt_args_allowlists_mach_lookup_services() {
     let cwd = TempDir::new().expect("temp cwd");
     let file_system_policy = FileSystemSandboxPolicy::from_legacy_sandbox_policy_for_cwd(
         &SandboxPolicy::new_read_only_policy(),
         cwd.path(),
     );
-    let extra_mach_services = vec![
-        "com.apple.beta".to_string(),
-        "com.apple.alpha".to_string(),
-        "com.apple.beta".to_string(),
-    ];
+    let macos_sandbox_capabilities = MacOsSandboxCapabilities {
+        mach_lookup_services: vec![
+            "com.apple.beta".to_string(),
+            "com.apple.alpha".to_string(),
+            "com.apple.beta".to_string(),
+        ],
+        ..Default::default()
+    };
     let args = create_seatbelt_command_args(CreateSeatbeltCommandArgsParams {
         command: vec!["/usr/bin/true".to_string()],
         file_system_sandbox_policy: &file_system_policy,
@@ -757,9 +751,7 @@ fn create_seatbelt_args_allowlists_extra_mach_services() {
         sandbox_policy_cwd: cwd.path(),
         enforce_managed_network: false,
         network: None,
-        extra_mach_services: &extra_mach_services,
-        extra_appleevent_bundle_ids: &[],
-        allow_lsopen: false,
+        macos_sandbox_capabilities: Some(&macos_sandbox_capabilities),
         extra_allow_unix_sockets: &[],
     });
     let policy = seatbelt_policy_arg(&args);
@@ -787,11 +779,15 @@ fn create_seatbelt_args_allowlists_appleevent_destinations() {
         &SandboxPolicy::new_read_only_policy(),
         cwd.path(),
     );
-    let extra_appleevent_bundle_ids = vec![
-        "com.apple.mail".to_string(),
-        "com.apple.finder".to_string(),
-        "com.apple.mail".to_string(),
-    ];
+    let macos_sandbox_capabilities = MacOsSandboxCapabilities {
+        mach_lookup_services: vec!["com.apple.coreservices.appleevents".to_string()],
+        apple_event_destinations: vec![
+            "com.apple.mail".to_string(),
+            "com.apple.finder".to_string(),
+            "com.apple.mail".to_string(),
+        ],
+        launch_services_open: false,
+    };
     let args = create_seatbelt_command_args(CreateSeatbeltCommandArgsParams {
         command: vec!["/usr/bin/true".to_string()],
         file_system_sandbox_policy: &file_system_policy,
@@ -799,16 +795,14 @@ fn create_seatbelt_args_allowlists_appleevent_destinations() {
         sandbox_policy_cwd: cwd.path(),
         enforce_managed_network: false,
         network: None,
-        extra_mach_services: &[],
-        extra_appleevent_bundle_ids: &extra_appleevent_bundle_ids,
-        allow_lsopen: false,
+        macos_sandbox_capabilities: Some(&macos_sandbox_capabilities),
         extra_allow_unix_sockets: &[],
     });
     let policy = seatbelt_policy_arg(&args);
 
     assert!(
         policy.contains(
-            "(allow mach-lookup\n  (global-name \"com.apple.coreservices.appleevents\"))"
+            "(allow mach-lookup\n  (global-name \"com.apple.coreservices.appleevents\")\n)"
         ),
         "policy should allow lookup of the AppleEvents service:\n{policy}"
     );
@@ -839,12 +833,16 @@ fn create_seatbelt_args_allowlists_appleevent_destinations() {
 }
 
 #[test]
-fn create_seatbelt_args_allows_lsopen_when_requested() {
+fn create_seatbelt_args_appleevent_destinations_do_not_imply_mach_lookup_services() {
     let cwd = TempDir::new().expect("temp cwd");
     let file_system_policy = FileSystemSandboxPolicy::from_legacy_sandbox_policy_for_cwd(
         &SandboxPolicy::new_read_only_policy(),
         cwd.path(),
     );
+    let macos_sandbox_capabilities = MacOsSandboxCapabilities {
+        apple_event_destinations: vec!["com.apple.finder".to_string()],
+        ..Default::default()
+    };
     let args = create_seatbelt_command_args(CreateSeatbeltCommandArgsParams {
         command: vec!["/usr/bin/true".to_string()],
         file_system_sandbox_policy: &file_system_policy,
@@ -852,9 +850,41 @@ fn create_seatbelt_args_allows_lsopen_when_requested() {
         sandbox_policy_cwd: cwd.path(),
         enforce_managed_network: false,
         network: None,
-        extra_mach_services: &[],
-        extra_appleevent_bundle_ids: &[],
-        allow_lsopen: true,
+        macos_sandbox_capabilities: Some(&macos_sandbox_capabilities),
+        extra_allow_unix_sockets: &[],
+    });
+    let policy = seatbelt_policy_arg(&args);
+
+    assert!(
+        policy
+            .contains("(allow appleevent-send\n  (appleevent-destination \"com.apple.finder\")\n)"),
+        "policy should allow the requested AppleEvent destination:\n{policy}"
+    );
+    assert!(
+        !policy.contains("com.apple.coreservices.appleevents"),
+        "AppleEvent destinations should not imply a Mach lookup allowance:\n{policy}"
+    );
+}
+
+#[test]
+fn create_seatbelt_args_allows_lsopen_when_requested() {
+    let cwd = TempDir::new().expect("temp cwd");
+    let file_system_policy = FileSystemSandboxPolicy::from_legacy_sandbox_policy_for_cwd(
+        &SandboxPolicy::new_read_only_policy(),
+        cwd.path(),
+    );
+    let macos_sandbox_capabilities = MacOsSandboxCapabilities {
+        launch_services_open: true,
+        ..Default::default()
+    };
+    let args = create_seatbelt_command_args(CreateSeatbeltCommandArgsParams {
+        command: vec!["/usr/bin/true".to_string()],
+        file_system_sandbox_policy: &file_system_policy,
+        network_sandbox_policy: NetworkSandboxPolicy::Restricted,
+        sandbox_policy_cwd: cwd.path(),
+        enforce_managed_network: false,
+        network: None,
+        macos_sandbox_capabilities: Some(&macos_sandbox_capabilities),
         extra_allow_unix_sockets: &[],
     });
     let policy = seatbelt_policy_arg(&args);

--- a/codex-rs/tui/src/additional_dirs.rs
+++ b/codex-rs/tui/src/additional_dirs.rs
@@ -122,6 +122,7 @@ mod tests {
                 ],
                 glob_scan_max_depth: None,
             },
+            macos: None,
         };
         let dirs = vec![PathBuf::from("/tmp/extra")];
 

--- a/codex-rs/tui/src/app/thread_session_state.rs
+++ b/codex-rs/tui/src/app/thread_session_state.rs
@@ -310,6 +310,7 @@ mod tests {
                 ],
                 glob_scan_max_depth: None,
             },
+            macos: None,
         };
         let session = ThreadSessionState {
             permission_profile: profile.clone(),

--- a/codex-rs/tui/src/app_server_session.rs
+++ b/codex-rs/tui/src/app_server_session.rs
@@ -2085,6 +2085,7 @@ mod tests {
                 ],
                 glob_scan_max_depth: None,
             },
+            macos: None,
         };
 
         assert_eq!(
@@ -2115,6 +2116,7 @@ mod tests {
                 ],
                 glob_scan_max_depth: None,
             },
+            macos: None,
         };
 
         assert_eq!(

--- a/codex-rs/tui/src/chatwidget/tests/composer_submission.rs
+++ b/codex-rs/tui/src/chatwidget/tests/composer_submission.rs
@@ -121,6 +121,7 @@ async fn submission_includes_configured_active_permission_profile() {
             ],
             glob_scan_max_depth: None,
         },
+        macos: None,
     };
     let expected_active_permission_profile = ActivePermissionProfile::new("custom");
     let configured = crate::session_state::ThreadSessionState {
@@ -177,6 +178,7 @@ async fn submission_omits_active_permission_profile_for_legacy_snapshot() {
     let expected_permission_profile: PermissionProfile = PermissionProfile::Managed {
         network: NetworkSandboxPolicy::Restricted,
         file_system: ManagedFileSystemPermissions::Unrestricted,
+        macos: None,
     };
     let configured = crate::session_state::ThreadSessionState {
         thread_id,

--- a/codex-rs/tui/src/chatwidget/tests/history_replay.rs
+++ b/codex-rs/tui/src/chatwidget/tests/history_replay.rs
@@ -371,6 +371,7 @@ async fn session_configured_syncs_widget_config_permissions_and_cwd() {
             ],
             glob_scan_max_depth: None,
         },
+        macos: None,
     };
     let expected_permission_profile = expected_app_server_permission_profile.clone();
     let expected_core_sandbox = expected_permission_profile

--- a/codex-rs/tui/src/chatwidget/tests/permissions.rs
+++ b/codex-rs/tui/src/chatwidget/tests/permissions.rs
@@ -45,6 +45,7 @@ fn app_server_workspace_write_profile(extra_root: AbsolutePathBuf) -> Permission
             ],
             glob_scan_max_depth: None,
         },
+        macos: None,
     }
 }
 
@@ -342,6 +343,7 @@ async fn preset_matching_does_not_treat_non_cwd_writable_profile_as_read_only() 
             ],
             glob_scan_max_depth: None,
         },
+        macos: None,
     };
     let cwd = test_path_buf("/tmp/project").abs();
 

--- a/codex-rs/tui/src/history_cell/session.rs
+++ b/codex-rs/tui/src/history_cell/session.rs
@@ -234,6 +234,7 @@ pub(crate) fn has_yolo_permissions(
                 | PermissionProfile::Managed {
                     file_system: ManagedFileSystemPermissions::Unrestricted,
                     network: NetworkSandboxPolicy::Enabled,
+                    ..
                 }
         )
 }

--- a/codex-rs/tui/src/history_cell/tests.rs
+++ b/codex-rs/tui/src/history_cell/tests.rs
@@ -1519,6 +1519,7 @@ fn yolo_mode_includes_managed_full_access_profiles() {
     let permission_profile: PermissionProfile = PermissionProfile::Managed {
         network: NetworkSandboxPolicy::Enabled,
         file_system: ManagedFileSystemPermissions::Unrestricted,
+        macos: None,
     };
 
     assert!(has_yolo_permissions(

--- a/codex-rs/tui/src/permission_compat.rs
+++ b/codex-rs/tui/src/permission_compat.rs
@@ -75,6 +75,7 @@ mod tests {
                 ],
                 glob_scan_max_depth: None,
             },
+            macos: None,
         };
 
         let compatibility_profile =

--- a/codex-rs/tui/src/status/tests.rs
+++ b/codex-rs/tui/src/status/tests.rs
@@ -113,6 +113,7 @@ fn app_server_workspace_write_profile(network_enabled: bool) -> PermissionProfil
             ],
             glob_scan_max_depth: None,
         },
+        macos: None,
     }
 }
 
@@ -800,6 +801,7 @@ async fn status_permissions_full_disk_managed_with_network_is_danger_full_access
         .set_permission_profile(PermissionProfile::Managed {
             network: NetworkSandboxPolicy::Enabled,
             file_system: ManagedFileSystemPermissions::Unrestricted,
+            macos: None,
         })
         .expect("set permission profile");
 
@@ -823,6 +825,7 @@ async fn status_permissions_full_disk_managed_without_network_is_external_sandbo
         .set_permission_profile(PermissionProfile::Managed {
             network: NetworkSandboxPolicy::Restricted,
             file_system: ManagedFileSystemPermissions::Unrestricted,
+            macos: None,
         })
         .expect("set permission profile");
 

--- a/codex-rs/windows-sandbox-rs/src/resolved_permissions.rs
+++ b/codex-rs/windows-sandbox-rs/src/resolved_permissions.rs
@@ -262,6 +262,7 @@ mod tests {
                 glob_scan_max_depth: None,
             },
             network: NetworkSandboxPolicy::Restricted,
+            macos: None,
         };
         let workspace_roots = workspace_roots_for(workspace_root.as_path());
         let permissions =
@@ -315,6 +316,7 @@ mod tests {
                 glob_scan_max_depth: None,
             },
             network: NetworkSandboxPolicy::Restricted,
+            macos: None,
         };
 
         let permissions =
@@ -431,6 +433,7 @@ mod tests {
         let permission_profile = PermissionProfile::Managed {
             file_system: ManagedFileSystemPermissions::Unrestricted,
             network: NetworkSandboxPolicy::Restricted,
+            macos: None,
         };
 
         let err =
@@ -459,6 +462,7 @@ mod tests {
                 glob_scan_max_depth: None,
             },
             network: NetworkSandboxPolicy::Restricted,
+            macos: None,
         };
         let workspace_roots = workspace_roots_for(cwd.as_path());
 


### PR DESCRIPTION
## Summary

- add typed, optional macOS Seatbelt capabilities to managed permission profiles
- preserve those capabilities across runtime permission transformations and lower them into Seatbelt policy
- retain targeted `codex sandbox macos` debug flags as an additive diagnostic overlay
- preserve explicit capability revocations through permission-profile inheritance

## Why

Sandboxed node REPL processes need narrowly scoped macOS capabilities to communicate with and launch local services without requiring full-access mode. This builds on and supersedes #19218 by moving the allowances into the governed permission-profile path while retaining the useful debug CLI surface.

The capabilities remain opt-in. This does not grant anything by default, hardcode a CUA service in production code, change TCC or entitlement behavior, or affect Windows/Linux sandbox behavior.

## Validation

- `just write-config-schema`
- `just fmt`
- `just test -p codex-config` (177 passed)
- focused `codex-core` tests for capability inheritance/revocation, runtime lowering, and built-in profile extension
- `just test -p codex-sandboxing` (69 passed)
- focused `codex-protocol` capability preservation test
- focused `codex-cli` debug flag parsing test
- `just fix -p codex-protocol -p codex-config -p codex-core -p codex-sandboxing -p codex-cli`
- `git diff --check origin/main..HEAD -- codex-rs`

## Known test issue

A full `just test -p codex-core` run before the latest rebase reported 2612 passing tests plus two unrelated local-environment failures: one test inherited `CODEX_SANDBOX_NETWORK_DISABLED=1` from the outer Codex sandbox and passed when rerun without that variable; `thread_manager::tests::start_thread_uses_all_default_environments_from_codex_home` timed out both in the suite and alone. This patch does not touch those paths.