### PR TITLE
Fix multiline paste in /goal edit

### DIFF
--- a/codex-rs/tui/src/bottom_pane/custom_prompt_view.rs
+++ b/codex-rs/tui/src/bottom_pane/custom_prompt_view.rs
@@ -22,7 +22,6 @@ use super::CancellationEvent;
 use super::bottom_pane_view::BottomPaneView;
 use super::bottom_pane_view::ViewCompletion;
 use super::paste_burst::CharDecision;
-use super::paste_burst::FlushResult;
 use super::paste_burst::PasteBurst;
 use super::textarea::TextArea;
 use super::textarea::TextAreaState;
@@ -107,19 +106,13 @@ impl CustomPromptView {
                 modifiers,
                 ..
             } if !has_ctrl_or_alt(modifiers) && self.textarea.allows_paste_burst() => {
-                let burst_retro_chars = match self.paste_burst.on_plain_char_no_hold(now) {
-                    Some(CharDecision::BeginBuffer { retro_chars }) => {
-                        Some(usize::from(retro_chars) + 1)
-                    }
-                    _ => None,
-                };
+                let paste_like_burst = matches!(
+                    self.paste_burst.on_plain_char_no_hold(now),
+                    Some(CharDecision::BeginBuffer { .. })
+                );
                 self.textarea.input(key_event);
-                if let Some(retro_chars) = burst_retro_chars {
-                    let cursor = self.textarea.cursor();
-                    let before_cursor = &self.textarea.text()[..cursor];
-                    let _ = self
-                        .paste_burst
-                        .decide_begin_buffer(now, before_cursor, retro_chars);
+                if paste_like_burst {
+                    self.paste_burst.extend_window(now);
                 }
             }
             other => {
@@ -129,12 +122,8 @@ impl CustomPromptView {
         }
     }
 
-    fn flush_paste_burst_detector(&mut self, now: Instant) -> bool {
-        let flushed = !matches!(self.paste_burst.flush_if_due(now), FlushResult::None);
-        if flushed {
-            self.paste_burst.clear_after_explicit_paste();
-        }
-        flushed
+    fn flush_paste_burst_detector(&mut self, now: Instant) {
+        let _ = self.paste_burst.flush_if_due(now);
     }
 }
 
@@ -166,7 +155,8 @@ impl BottomPaneView for CustomPromptView {
     }
 
     fn flush_paste_burst_if_due(&mut self) -> bool {
-        self.flush_paste_burst_detector(Instant::now())
+        self.flush_paste_burst_detector(Instant::now());
+        false
     }
 
     fn is_in_paste_burst(&self) -> bool {
@@ -175,53 +165,8 @@ impl BottomPaneView for CustomPromptView {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn paste_burst_newline_does_not_submit() {
-        let (submitted, submitted_rx) = std::sync::mpsc::channel();
-        let mut view = CustomPromptView::new(
-            "Edit goal".to_string(),
-            "Type a goal objective and press Enter".to_string(),
-            "existing".to_string(),
-            /*context_label*/ None,
-            Box::new(move |text| {
-                submitted.send(text).expect("send submitted text");
-            }),
-        );
-        let now = Instant::now();
-
-        for (idx, ch) in " first".chars().enumerate() {
-            view.handle_key_event_at(KeyEvent::from(KeyCode::Char(ch)), now + elapsed(idx));
-        }
-        view.handle_key_event_at(KeyEvent::from(KeyCode::Enter), now + elapsed(6));
-        for (idx, ch) in "second".chars().enumerate() {
-            view.handle_key_event_at(KeyEvent::from(KeyCode::Char(ch)), now + elapsed(7 + idx));
-        }
-
-        assert!(submitted_rx.try_recv().is_err());
-        assert!(!view.is_complete());
-
-        view.flush_paste_burst_detector(
-            now + elapsed(40) + PasteBurst::recommended_active_flush_delay(),
-        );
-        view.handle_key_event_at(
-            KeyEvent::from(KeyCode::Enter),
-            now + elapsed(80) + PasteBurst::recommended_active_flush_delay(),
-        );
-
-        assert_eq!(
-            submitted_rx.try_recv(),
-            Ok("existing first\nsecond".to_string())
-        );
-        assert!(view.is_complete());
-    }
-
-    fn elapsed(ms: usize) -> std::time::Duration {
-        std::time::Duration::from_millis(ms as u64)
-    }
-}
+#[path = "custom_prompt_view_tests.rs"]
+mod tests;
 
 impl Renderable for CustomPromptView {
     fn desired_height(&self, width: u16) -> u16 {

--- a/codex-rs/tui/src/bottom_pane/custom_prompt_view.rs
+++ b/codex-rs/tui/src/bottom_pane/custom_prompt_view.rs
@@ -11,7 +11,9 @@ use ratatui::widgets::Paragraph;
 use ratatui::widgets::StatefulWidgetRef;
 use ratatui::widgets::Widget;
 use std::cell::RefCell;
+use std::time::Instant;
 
+use crate::key_hint::has_ctrl_or_alt;
 use crate::render::renderable::Renderable;
 
 use super::popup_consts::standard_popup_hint_line;
@@ -19,6 +21,9 @@ use super::popup_consts::standard_popup_hint_line;
 use super::CancellationEvent;
 use super::bottom_pane_view::BottomPaneView;
 use super::bottom_pane_view::ViewCompletion;
+use super::paste_burst::CharDecision;
+use super::paste_burst::FlushResult;
+use super::paste_burst::PasteBurst;
 use super::textarea::TextArea;
 use super::textarea::TextAreaState;
 
@@ -35,6 +40,7 @@ pub(crate) struct CustomPromptView {
     // UI state
     textarea: TextArea,
     textarea_state: RefCell<TextAreaState>,
+    paste_burst: PasteBurst,
     completion: Option<ViewCompletion>,
 }
 
@@ -59,13 +65,14 @@ impl CustomPromptView {
             on_submit,
             textarea,
             textarea_state: RefCell::new(TextAreaState::default()),
+            paste_burst: PasteBurst::default(),
             completion: None,
         }
     }
-}
 
-impl BottomPaneView for CustomPromptView {
-    fn handle_key_event(&mut self, key_event: KeyEvent) {
+    fn handle_key_event_at(&mut self, key_event: KeyEvent, now: Instant) {
+        // Text is inserted immediately below; flushing only expires Enter suppression.
+        self.flush_paste_burst_detector(now);
         match key_event {
             KeyEvent {
                 code: KeyCode::Esc, ..
@@ -74,25 +81,66 @@ impl BottomPaneView for CustomPromptView {
             }
             KeyEvent {
                 code: KeyCode::Enter,
-                modifiers: KeyModifiers::NONE,
+                modifiers,
                 ..
             } => {
-                let text = self.textarea.text().trim().to_string();
-                if !text.is_empty() {
-                    (self.on_submit)(text);
-                    self.completion = Some(ViewCompletion::Accepted);
+                if self
+                    .paste_burst
+                    .newline_should_insert_instead_of_submit(now)
+                {
+                    self.paste_burst.extend_window(now);
+                    self.textarea.insert_str("\n");
+                    return;
+                }
+                if modifiers == KeyModifiers::NONE {
+                    let text = self.textarea.text().trim().to_string();
+                    if !text.is_empty() {
+                        (self.on_submit)(text);
+                        self.completion = Some(ViewCompletion::Accepted);
+                    }
+                } else {
+                    self.textarea.input(key_event);
                 }
             }
             KeyEvent {
-                code: KeyCode::Enter,
+                code: KeyCode::Char(_),
+                modifiers,
                 ..
-            } => {
+            } if !has_ctrl_or_alt(modifiers) && self.textarea.allows_paste_burst() => {
+                let burst_retro_chars = match self.paste_burst.on_plain_char_no_hold(now) {
+                    Some(CharDecision::BeginBuffer { retro_chars }) => {
+                        Some(usize::from(retro_chars) + 1)
+                    }
+                    _ => None,
+                };
                 self.textarea.input(key_event);
+                if let Some(retro_chars) = burst_retro_chars {
+                    let cursor = self.textarea.cursor();
+                    let before_cursor = &self.textarea.text()[..cursor];
+                    let _ = self
+                        .paste_burst
+                        .decide_begin_buffer(now, before_cursor, retro_chars);
+                }
             }
             other => {
                 self.textarea.input(other);
+                self.paste_burst.clear_after_explicit_paste();
             }
         }
+    }
+
+    fn flush_paste_burst_detector(&mut self, now: Instant) -> bool {
+        let flushed = !matches!(self.paste_burst.flush_if_due(now), FlushResult::None);
+        if flushed {
+            self.paste_burst.clear_after_explicit_paste();
+        }
+        flushed
+    }
+}
+
+impl BottomPaneView for CustomPromptView {
+    fn handle_key_event(&mut self, key_event: KeyEvent) {
+        self.handle_key_event_at(key_event, Instant::now());
     }
 
     fn on_ctrl_c(&mut self) -> CancellationEvent {
@@ -113,7 +161,65 @@ impl BottomPaneView for CustomPromptView {
             return false;
         }
         self.textarea.insert_str(&pasted);
+        self.paste_burst.clear_after_explicit_paste();
         true
+    }
+
+    fn flush_paste_burst_if_due(&mut self) -> bool {
+        self.flush_paste_burst_detector(Instant::now())
+    }
+
+    fn is_in_paste_burst(&self) -> bool {
+        self.paste_burst.is_active()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn paste_burst_newline_does_not_submit() {
+        let (submitted, submitted_rx) = std::sync::mpsc::channel();
+        let mut view = CustomPromptView::new(
+            "Edit goal".to_string(),
+            "Type a goal objective and press Enter".to_string(),
+            "existing".to_string(),
+            /*context_label*/ None,
+            Box::new(move |text| {
+                submitted.send(text).expect("send submitted text");
+            }),
+        );
+        let now = Instant::now();
+
+        for (idx, ch) in " first".chars().enumerate() {
+            view.handle_key_event_at(KeyEvent::from(KeyCode::Char(ch)), now + elapsed(idx));
+        }
+        view.handle_key_event_at(KeyEvent::from(KeyCode::Enter), now + elapsed(6));
+        for (idx, ch) in "second".chars().enumerate() {
+            view.handle_key_event_at(KeyEvent::from(KeyCode::Char(ch)), now + elapsed(7 + idx));
+        }
+
+        assert!(submitted_rx.try_recv().is_err());
+        assert!(!view.is_complete());
+
+        view.flush_paste_burst_detector(
+            now + elapsed(40) + PasteBurst::recommended_active_flush_delay(),
+        );
+        view.handle_key_event_at(
+            KeyEvent::from(KeyCode::Enter),
+            now + elapsed(80) + PasteBurst::recommended_active_flush_delay(),
+        );
+
+        assert_eq!(
+            submitted_rx.try_recv(),
+            Ok("existing first\nsecond".to_string())
+        );
+        assert!(view.is_complete());
+    }
+
+    fn elapsed(ms: usize) -> std::time::Duration {
+        std::time::Duration::from_millis(ms as u64)
     }
 }
 

--- a/codex-rs/tui/src/bottom_pane/custom_prompt_view.rs
+++ b/codex-rs/tui/src/bottom_pane/custom_prompt_view.rs
@@ -118,6 +118,22 @@ impl CustomPromptView {
                     self.paste_burst.extend_window(now);
                 }
             }
+            KeyEvent {
+                code: KeyCode::Tab,
+                modifiers,
+                ..
+            } if !has_ctrl_or_alt(modifiers) && self.textarea.allows_paste_burst() => {
+                let in_paste_burst = self
+                    .paste_burst
+                    .newline_should_insert_instead_of_submit(now)
+                    || self
+                        .paste_burst
+                        .recent_plain_char_was_within_burst_interval(now);
+                self.textarea.input(key_event);
+                if in_paste_burst {
+                    self.paste_burst.extend_window(now);
+                }
+            }
             other => {
                 self.textarea.input(other);
                 self.paste_burst.clear_after_explicit_paste();

--- a/codex-rs/tui/src/bottom_pane/custom_prompt_view.rs
+++ b/codex-rs/tui/src/bottom_pane/custom_prompt_view.rs
@@ -86,6 +86,9 @@ impl CustomPromptView {
                 if self
                     .paste_burst
                     .newline_should_insert_instead_of_submit(now)
+                    || self
+                        .paste_burst
+                        .recent_plain_char_was_within_burst_interval(now)
                 {
                     self.paste_burst.extend_window(now);
                     self.textarea.insert_str("\n");

--- a/codex-rs/tui/src/bottom_pane/custom_prompt_view.rs
+++ b/codex-rs/tui/src/bottom_pane/custom_prompt_view.rs
@@ -21,7 +21,6 @@ use super::popup_consts::standard_popup_hint_line;
 use super::CancellationEvent;
 use super::bottom_pane_view::BottomPaneView;
 use super::bottom_pane_view::ViewCompletion;
-use super::paste_burst::CharDecision;
 use super::paste_burst::PasteBurst;
 use super::textarea::TextArea;
 use super::textarea::TextAreaState;
@@ -70,8 +69,6 @@ impl CustomPromptView {
     }
 
     fn handle_key_event_at(&mut self, key_event: KeyEvent, now: Instant) {
-        // Text is inserted immediately below; flushing only expires Enter suppression.
-        self.flush_paste_burst_detector(now);
         match key_event {
             KeyEvent {
                 code: KeyCode::Esc, ..
@@ -83,13 +80,7 @@ impl CustomPromptView {
                 modifiers,
                 ..
             } => {
-                if self
-                    .paste_burst
-                    .newline_should_insert_instead_of_submit(now)
-                    || self
-                        .paste_burst
-                        .recent_plain_char_was_within_burst_interval(now)
-                {
+                if self.paste_burst.direct_insert_newline_should_insert(now) {
                     self.paste_burst.extend_window(now);
                     self.textarea.insert_str("\n");
                     return;
@@ -109,10 +100,7 @@ impl CustomPromptView {
                 modifiers,
                 ..
             } if !has_ctrl_or_alt(modifiers) && self.textarea.allows_paste_burst() => {
-                let paste_like_burst = matches!(
-                    self.paste_burst.on_plain_char_no_hold(now),
-                    Some(CharDecision::BeginBuffer { .. })
-                );
+                let paste_like_burst = self.paste_burst.on_plain_char_no_hold(now).is_some();
                 self.textarea.input(key_event);
                 if paste_like_burst {
                     self.paste_burst.extend_window(now);
@@ -123,12 +111,7 @@ impl CustomPromptView {
                 modifiers,
                 ..
             } if !has_ctrl_or_alt(modifiers) && self.textarea.allows_paste_burst() => {
-                let in_paste_burst = self
-                    .paste_burst
-                    .newline_should_insert_instead_of_submit(now)
-                    || self
-                        .paste_burst
-                        .recent_plain_char_was_within_burst_interval(now);
+                let in_paste_burst = self.paste_burst.direct_insert_newline_should_insert(now);
                 self.textarea.input(key_event);
                 if in_paste_burst {
                     self.paste_burst.extend_window(now);
@@ -139,10 +122,6 @@ impl CustomPromptView {
                 self.paste_burst.clear_after_explicit_paste();
             }
         }
-    }
-
-    fn flush_paste_burst_detector(&mut self, now: Instant) {
-        let _ = self.paste_burst.flush_if_due(now);
     }
 }
 
@@ -171,15 +150,6 @@ impl BottomPaneView for CustomPromptView {
         self.textarea.insert_str(&pasted);
         self.paste_burst.clear_after_explicit_paste();
         true
-    }
-
-    fn flush_paste_burst_if_due(&mut self) -> bool {
-        self.flush_paste_burst_detector(Instant::now());
-        false
-    }
-
-    fn is_in_paste_burst(&self) -> bool {
-        self.paste_burst.is_active()
     }
 }
 

--- a/codex-rs/tui/src/bottom_pane/custom_prompt_view_tests.rs
+++ b/codex-rs/tui/src/bottom_pane/custom_prompt_view_tests.rs
@@ -7,7 +7,7 @@ fn paste_burst_newline_does_not_submit_short_first_line() {
     let now = Instant::now();
 
     for (first_line, second_line) in [("x", "rest"), ("id", "body"), ("foo", "bar")] {
-        let (mut view, submitted_rx) = custom_prompt_view("");
+        let (mut view, submitted_rx) = custom_prompt_view();
         let mut ms = 0;
 
         for ch in first_line.chars() {
@@ -36,7 +36,7 @@ fn paste_burst_newline_does_not_submit_short_first_line() {
 
 #[test]
 fn paste_burst_newline_after_tab_does_not_submit() {
-    let (mut view, submitted_rx) = custom_prompt_view("");
+    let (mut view, submitted_rx) = custom_prompt_view();
     let now = Instant::now();
     let mut ms = 0;
 
@@ -62,7 +62,7 @@ fn paste_burst_newline_after_tab_does_not_submit() {
 
 #[test]
 fn delayed_enter_after_typing_submits() {
-    let (mut view, submitted_rx) = custom_prompt_view("");
+    let (mut view, submitted_rx) = custom_prompt_view();
     let now = Instant::now();
 
     for (idx, ch) in "foo".chars().enumerate() {
@@ -74,12 +74,12 @@ fn delayed_enter_after_typing_submits() {
     assert!(view.is_complete());
 }
 
-fn custom_prompt_view(initial_text: &str) -> (CustomPromptView, Receiver<String>) {
+fn custom_prompt_view() -> (CustomPromptView, Receiver<String>) {
     let (submitted, submitted_rx) = std::sync::mpsc::channel();
     let view = CustomPromptView::new(
         "Edit goal".to_string(),
         "Type a goal objective and press Enter".to_string(),
-        initial_text.to_string(),
+        String::new(),
         /*context_label*/ None,
         Box::new(move |text| {
             submitted.send(text).expect("send submitted text");

--- a/codex-rs/tui/src/bottom_pane/custom_prompt_view_tests.rs
+++ b/codex-rs/tui/src/bottom_pane/custom_prompt_view_tests.rs
@@ -35,6 +35,32 @@ fn paste_burst_newline_does_not_submit_short_first_line() {
 }
 
 #[test]
+fn paste_burst_newline_after_tab_does_not_submit() {
+    let (mut view, submitted_rx) = custom_prompt_view("");
+    let now = Instant::now();
+    let mut ms = 0;
+
+    view.handle_key_event_at(KeyEvent::from(KeyCode::Char('x')), now + elapsed(ms));
+    ms += 1;
+    view.handle_key_event_at(KeyEvent::from(KeyCode::Tab), now + elapsed(ms));
+    ms += 1;
+    view.handle_key_event_at(KeyEvent::from(KeyCode::Enter), now + elapsed(ms));
+    ms += 1;
+    for ch in "rest".chars() {
+        view.handle_key_event_at(KeyEvent::from(KeyCode::Char(ch)), now + elapsed(ms));
+        ms += 1;
+    }
+
+    assert!(submitted_rx.try_recv().is_err());
+    assert!(!view.is_complete());
+
+    view.handle_key_event_at(KeyEvent::from(KeyCode::Enter), now + elapsed(/*ms*/ 200));
+
+    assert_eq!(submitted_rx.try_recv(), Ok("x\nrest".to_string()));
+    assert!(view.is_complete());
+}
+
+#[test]
 fn delayed_enter_after_typing_submits() {
     let (mut view, submitted_rx) = custom_prompt_view("");
     let now = Instant::now();

--- a/codex-rs/tui/src/bottom_pane/custom_prompt_view_tests.rs
+++ b/codex-rs/tui/src/bottom_pane/custom_prompt_view_tests.rs
@@ -24,7 +24,7 @@ fn paste_burst_newline_does_not_submit_short_first_line() {
         assert!(submitted_rx.try_recv().is_err());
         assert!(!view.is_complete());
 
-        view.handle_key_event_at(KeyEvent::from(KeyCode::Enter), now + elapsed(200));
+        view.handle_key_event_at(KeyEvent::from(KeyCode::Enter), now + elapsed(/*ms*/ 200));
 
         assert_eq!(
             submitted_rx.try_recv(),
@@ -42,7 +42,7 @@ fn delayed_enter_after_typing_submits() {
     for (idx, ch) in "foo".chars().enumerate() {
         view.handle_key_event_at(KeyEvent::from(KeyCode::Char(ch)), now + elapsed(idx * 20));
     }
-    view.handle_key_event_at(KeyEvent::from(KeyCode::Enter), now + elapsed(80));
+    view.handle_key_event_at(KeyEvent::from(KeyCode::Enter), now + elapsed(/*ms*/ 80));
 
     assert_eq!(submitted_rx.try_recv(), Ok("foo".to_string()));
     assert!(view.is_complete());

--- a/codex-rs/tui/src/bottom_pane/custom_prompt_view_tests.rs
+++ b/codex-rs/tui/src/bottom_pane/custom_prompt_view_tests.rs
@@ -4,24 +4,34 @@ use std::sync::mpsc::Receiver;
 
 #[test]
 fn paste_burst_newline_does_not_submit_short_first_line() {
-    let (mut view, submitted_rx) = custom_prompt_view("");
     let now = Instant::now();
 
-    for (idx, ch) in "foo".chars().enumerate() {
-        view.handle_key_event_at(KeyEvent::from(KeyCode::Char(ch)), now + elapsed(idx));
+    for (first_line, second_line) in [("x", "rest"), ("id", "body"), ("foo", "bar")] {
+        let (mut view, submitted_rx) = custom_prompt_view("");
+        let mut ms = 0;
+
+        for ch in first_line.chars() {
+            view.handle_key_event_at(KeyEvent::from(KeyCode::Char(ch)), now + elapsed(ms));
+            ms += 1;
+        }
+        view.handle_key_event_at(KeyEvent::from(KeyCode::Enter), now + elapsed(ms));
+        ms += 1;
+        for ch in second_line.chars() {
+            view.handle_key_event_at(KeyEvent::from(KeyCode::Char(ch)), now + elapsed(ms));
+            ms += 1;
+        }
+
+        assert!(submitted_rx.try_recv().is_err());
+        assert!(!view.is_complete());
+
+        view.handle_key_event_at(KeyEvent::from(KeyCode::Enter), now + elapsed(200));
+
+        assert_eq!(
+            submitted_rx.try_recv(),
+            Ok(format!("{first_line}\n{second_line}"))
+        );
+        assert!(view.is_complete());
     }
-    view.handle_key_event_at(KeyEvent::from(KeyCode::Enter), now + elapsed(3));
-    for (idx, ch) in "bar".chars().enumerate() {
-        view.handle_key_event_at(KeyEvent::from(KeyCode::Char(ch)), now + elapsed(4 + idx));
-    }
-
-    assert!(submitted_rx.try_recv().is_err());
-    assert!(!view.is_complete());
-
-    view.handle_key_event_at(KeyEvent::from(KeyCode::Enter), now + elapsed(200));
-
-    assert_eq!(submitted_rx.try_recv(), Ok("foo\nbar".to_string()));
-    assert!(view.is_complete());
 }
 
 #[test]

--- a/codex-rs/tui/src/bottom_pane/custom_prompt_view_tests.rs
+++ b/codex-rs/tui/src/bottom_pane/custom_prompt_view_tests.rs
@@ -1,0 +1,57 @@
+use super::*;
+use pretty_assertions::assert_eq;
+use std::sync::mpsc::Receiver;
+
+#[test]
+fn paste_burst_newline_does_not_submit_short_first_line() {
+    let (mut view, submitted_rx) = custom_prompt_view("");
+    let now = Instant::now();
+
+    for (idx, ch) in "foo".chars().enumerate() {
+        view.handle_key_event_at(KeyEvent::from(KeyCode::Char(ch)), now + elapsed(idx));
+    }
+    view.handle_key_event_at(KeyEvent::from(KeyCode::Enter), now + elapsed(3));
+    for (idx, ch) in "bar".chars().enumerate() {
+        view.handle_key_event_at(KeyEvent::from(KeyCode::Char(ch)), now + elapsed(4 + idx));
+    }
+
+    assert!(submitted_rx.try_recv().is_err());
+    assert!(!view.is_complete());
+
+    view.handle_key_event_at(KeyEvent::from(KeyCode::Enter), now + elapsed(200));
+
+    assert_eq!(submitted_rx.try_recv(), Ok("foo\nbar".to_string()));
+    assert!(view.is_complete());
+}
+
+#[test]
+fn delayed_enter_after_typing_submits() {
+    let (mut view, submitted_rx) = custom_prompt_view("");
+    let now = Instant::now();
+
+    for (idx, ch) in "foo".chars().enumerate() {
+        view.handle_key_event_at(KeyEvent::from(KeyCode::Char(ch)), now + elapsed(idx * 20));
+    }
+    view.handle_key_event_at(KeyEvent::from(KeyCode::Enter), now + elapsed(80));
+
+    assert_eq!(submitted_rx.try_recv(), Ok("foo".to_string()));
+    assert!(view.is_complete());
+}
+
+fn custom_prompt_view(initial_text: &str) -> (CustomPromptView, Receiver<String>) {
+    let (submitted, submitted_rx) = std::sync::mpsc::channel();
+    let view = CustomPromptView::new(
+        "Edit goal".to_string(),
+        "Type a goal objective and press Enter".to_string(),
+        initial_text.to_string(),
+        /*context_label*/ None,
+        Box::new(move |text| {
+            submitted.send(text).expect("send submitted text");
+        }),
+    );
+    (view, submitted_rx)
+}
+
+fn elapsed(ms: usize) -> std::time::Duration {
+    std::time::Duration::from_millis(ms as u64)
+}

--- a/codex-rs/tui/src/bottom_pane/paste_burst.rs
+++ b/codex-rs/tui/src/bottom_pane/paste_burst.rs
@@ -10,11 +10,16 @@
 //!   paste once enough chars have arrived.
 //!
 //! This module provides the `PasteBurst` state machine. `ChatComposer` feeds it only "plain"
-//! character events (no Ctrl/Alt) and uses its decisions to either:
+//! character events (no Ctrl/Alt) and uses the full buffering decisions to either:
 //!
 //! - briefly hold a first ASCII char (flicker suppression),
 //! - buffer a burst as a single pasted string, or
 //! - let input flow through as normal typing.
+//!
+//! Simpler bottom-pane views can also use the same detector without buffering: insert characters
+//! immediately, call [`PasteBurst::on_plain_char_no_hold`], and use
+//! [`PasteBurst::extend_window`] when a paste-like burst is observed so Enter is treated as a
+//! newline during the burst.
 //!
 //! # Call Pattern
 //!
@@ -32,6 +37,9 @@
 //!   [`PasteBurst::flush_before_modified_input`] to avoid leaving buffered text "stuck", and then
 //!   [`PasteBurst::clear_window_after_non_char`] so subsequent typing does not get grouped into a
 //!   previous burst.
+//! - If the caller inserted every char immediately and is using `PasteBurst` only as an Enter
+//!   suppression detector, it can skip buffering and simply call [`PasteBurst::extend_window`] when
+//!   [`PasteBurst::on_plain_char_no_hold`] returns [`CharDecision::BeginBuffer`].
 //!
 //! # State Variables
 //!
@@ -106,10 +114,10 @@
 //! - [`PasteBurst::on_plain_char_no_hold`] never holds (used for IME/non-ASCII paths), since
 //!   holding a non-ASCII character can feel like dropped input.
 //!
-//! # Contract With `ChatComposer`
+//! # Contract With Callers
 //!
-//! `PasteBurst` does not mutate the UI text buffer on its own. The caller (`ChatComposer`) must
-//! interpret decisions and apply the corresponding UI edits:
+//! `PasteBurst` does not mutate the UI text buffer on its own. Callers must interpret decisions
+//! and apply the corresponding UI edits. `ChatComposer` uses the full buffering contract:
 //!
 //! - For each plain ASCII `KeyCode::Char`, call [`PasteBurst::on_plain_char`].
 //!   - [`CharDecision::RetainFirstChar`]: do **not** insert the char into the textarea yet.

--- a/codex-rs/tui/src/bottom_pane/paste_burst.rs
+++ b/codex-rs/tui/src/bottom_pane/paste_burst.rs
@@ -16,11 +16,6 @@
 //! - buffer a burst as a single pasted string, or
 //! - let input flow through as normal typing.
 //!
-//! Simpler bottom-pane views can also use the same detector without buffering: insert characters
-//! immediately, call [`PasteBurst::on_plain_char_no_hold`], and use
-//! [`PasteBurst::extend_window`] when a paste-like burst is observed so Enter is treated as a
-//! newline during the burst.
-//!
 //! # Call Pattern
 //!
 //! `PasteBurst` is a pure state machine: it never mutates the textarea directly. The caller feeds
@@ -37,11 +32,10 @@
 //!   [`PasteBurst::flush_before_modified_input`] to avoid leaving buffered text "stuck", and then
 //!   [`PasteBurst::clear_window_after_non_char`] so subsequent typing does not get grouped into a
 //!   previous burst.
-//! - If the caller inserted every char immediately and is using `PasteBurst` only as an Enter
-//!   suppression detector, it can skip buffering and simply call [`PasteBurst::extend_window`] when
-//!   [`PasteBurst::on_plain_char_no_hold`] returns [`CharDecision::BeginBuffer`]. Its Enter handler
-//!   can also use [`PasteBurst::recent_plain_char_was_within_burst_interval`] so very short pasted
-//!   first lines still keep the following Enter as a newline.
+//! - Direct-insert callers can skip buffering, use
+//!   [`PasteBurst::direct_insert_newline_should_insert`] in their Enter handler, and call
+//!   [`PasteBurst::extend_window`] when Enter or [`PasteBurst::on_plain_char_no_hold`] reports a
+//!   burst-like stream.
 //!
 //! # State Variables
 //!
@@ -343,10 +337,12 @@ impl PasteBurst {
         self.is_active() || in_burst_window
     }
 
-    /// Returns true when Enter arrives too soon after a plain char to be confident it was typed.
-    pub fn recent_plain_char_was_within_burst_interval(&self, now: Instant) -> bool {
-        self.last_plain_char_time
-            .is_some_and(|t| now.duration_since(t) <= PASTE_BURST_CHAR_INTERVAL)
+    /// Decide if Enter should insert a newline for callers that insert chars immediately.
+    pub fn direct_insert_newline_should_insert(&self, now: Instant) -> bool {
+        self.newline_should_insert_instead_of_submit(now)
+            || self
+                .last_plain_char_time
+                .is_some_and(|t| now.duration_since(t) <= PASTE_BURST_CHAR_INTERVAL)
     }
 
     /// Keep the burst window alive.

--- a/codex-rs/tui/src/bottom_pane/paste_burst.rs
+++ b/codex-rs/tui/src/bottom_pane/paste_burst.rs
@@ -39,7 +39,9 @@
 //!   previous burst.
 //! - If the caller inserted every char immediately and is using `PasteBurst` only as an Enter
 //!   suppression detector, it can skip buffering and simply call [`PasteBurst::extend_window`] when
-//!   [`PasteBurst::on_plain_char_no_hold`] returns [`CharDecision::BeginBuffer`].
+//!   [`PasteBurst::on_plain_char_no_hold`] returns [`CharDecision::BeginBuffer`]. Its Enter handler
+//!   can also use [`PasteBurst::recent_plain_char_was_within_burst_interval`] so very short pasted
+//!   first lines still keep the following Enter as a newline.
 //!
 //! # State Variables
 //!
@@ -339,6 +341,12 @@ impl PasteBurst {
     pub fn newline_should_insert_instead_of_submit(&self, now: Instant) -> bool {
         let in_burst_window = self.burst_window_until.is_some_and(|until| now <= until);
         self.is_active() || in_burst_window
+    }
+
+    /// Returns true when Enter arrives too soon after a plain char to be confident it was typed.
+    pub fn recent_plain_char_was_within_burst_interval(&self, now: Instant) -> bool {
+        self.last_plain_char_time
+            .is_some_and(|t| now.duration_since(t) <= PASTE_BURST_CHAR_INTERVAL)
     }
 
     /// Keep the burst window alive.

--- a/codex-rs/tui/src/chatwidget/tests/popups_and_settings.rs
+++ b/codex-rs/tui/src/chatwidget/tests/popups_and_settings.rs
@@ -333,16 +333,7 @@ async fn plugins_popup_add_marketplace_tab_opens_prompt_and_submits_source() {
         "expected marketplace source prompt, got:\n{prompt}"
     );
 
-    chat.handle_key_event(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE));
-    chat.handle_key_event(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::NONE));
-    chat.handle_key_event(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::NONE));
-    chat.handle_key_event(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE));
-    chat.handle_key_event(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE));
-    chat.handle_key_event(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::NONE));
-    chat.handle_key_event(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::NONE));
-    chat.handle_key_event(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::NONE));
-    chat.handle_key_event(KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE));
-    chat.handle_key_event(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::NONE));
+    chat.handle_paste("owner/repo".to_string());
     chat.handle_key_event(KeyEvent::from(KeyCode::Enter));
 
     match rx.try_recv() {


### PR DESCRIPTION
Fixes #26025.

## Why
`/goal edit` opens `CustomPromptView`, which did not use the paste-burst handling that protects the main composer when terminals deliver paste as rapid key events. On Windows terminals, the first pasted newline could be treated as Enter-to-submit, truncating the goal edit and leaving the rest of the paste behind.

## What
This reuses `PasteBurst` in `CustomPromptView` as a lightweight Enter-suppression detector for paste-like key streams. Characters still insert directly, explicit paste still goes through the view paste path, and ordinary text entry still submits on Enter.