### PR TITLE
[codex] cover attributable backend HTTP state

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2190,6 +2190,7 @@ dependencies = [
  "codex-api",
  "codex-backend-openapi-models",
  "codex-client",
+ "codex-http-state",
  "codex-login",
  "codex-model-provider",
  "codex-protocol",
@@ -2197,6 +2198,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -1313,11 +1313,13 @@ impl MessageProcessor {
                     .await
             }
             ClientRequest::GetAccountRateLimits { .. } => {
-                self.account_processor.get_account_rate_limits().await
+                self.account_processor
+                    .get_account_rate_limits(app_server_client_name.as_deref())
+                    .await
             }
             ClientRequest::SendAddCreditsNudgeEmail { params, .. } => {
                 self.account_processor
-                    .send_add_credits_nudge_email(params)
+                    .send_add_credits_nudge_email(params, app_server_client_name.as_deref())
                     .await
             }
             ClientRequest::GitDiffToRemote { params, .. } => {

--- a/codex-rs/app-server/src/request_processors/account_processor.rs
+++ b/codex-rs/app-server/src/request_processors/account_processor.rs
@@ -1,4 +1,5 @@
 use super::*;
+use codex_http_state::HttpStateContext;
 use codex_http_state::HttpStateSurface;
 
 // Duration before a browser ChatGPT login attempt is abandoned.
@@ -135,8 +136,9 @@ impl AccountRequestProcessor {
 
     pub(crate) async fn get_account_rate_limits(
         &self,
+        app_server_client_name: Option<&str>,
     ) -> Result<Option<ClientResponsePayload>, JSONRPCErrorError> {
-        self.get_account_rate_limits_response()
+        self.get_account_rate_limits_response(Self::http_state_surface(app_server_client_name))
             .await
             .map(|response| Some(response.into()))
     }
@@ -144,10 +146,14 @@ impl AccountRequestProcessor {
     pub(crate) async fn send_add_credits_nudge_email(
         &self,
         params: SendAddCreditsNudgeEmailParams,
+        app_server_client_name: Option<&str>,
     ) -> Result<Option<ClientResponsePayload>, JSONRPCErrorError> {
-        self.send_add_credits_nudge_email_response(params)
-            .await
-            .map(|response| Some(response.into()))
+        self.send_add_credits_nudge_email_response(
+            params,
+            Self::http_state_surface(app_server_client_name),
+        )
+        .await
+        .map(|response| Some(response.into()))
     }
 
     pub(crate) async fn cancel_active_login(&self) {
@@ -876,8 +882,9 @@ impl AccountRequestProcessor {
 
     async fn get_account_rate_limits_response(
         &self,
+        http_state_surface: HttpStateSurface,
     ) -> Result<GetAccountRateLimitsResponse, JSONRPCErrorError> {
-        self.fetch_account_rate_limits()
+        self.fetch_account_rate_limits(http_state_surface)
             .await
             .map(
                 |(rate_limits, rate_limits_by_limit_id)| GetAccountRateLimitsResponse {
@@ -895,8 +902,9 @@ impl AccountRequestProcessor {
     async fn send_add_credits_nudge_email_response(
         &self,
         params: SendAddCreditsNudgeEmailParams,
+        http_state_surface: HttpStateSurface,
     ) -> Result<SendAddCreditsNudgeEmailResponse, JSONRPCErrorError> {
-        self.send_add_credits_nudge_email_inner(params)
+        self.send_add_credits_nudge_email_inner(params, http_state_surface)
             .await
             .map(|status| SendAddCreditsNudgeEmailResponse { status })
     }
@@ -904,6 +912,7 @@ impl AccountRequestProcessor {
     async fn send_add_credits_nudge_email_inner(
         &self,
         params: SendAddCreditsNudgeEmailParams,
+        http_state_surface: HttpStateSurface,
     ) -> Result<AddCreditsNudgeEmailStatus, JSONRPCErrorError> {
         let Some(auth) = self.auth_manager.auth().await else {
             return Err(invalid_request(
@@ -917,8 +926,7 @@ impl AccountRequestProcessor {
             ));
         }
 
-        let client = BackendClient::from_auth(self.config.chatgpt_base_url.clone(), &auth)
-            .map_err(|err| internal_error(format!("failed to construct backend client: {err}")))?;
+        let client = self.backend_client(&auth, http_state_surface)?;
 
         match client
             .send_add_credits_nudge_email(Self::backend_credit_type(params.credit_type))
@@ -943,6 +951,7 @@ impl AccountRequestProcessor {
 
     async fn fetch_account_rate_limits(
         &self,
+        http_state_surface: HttpStateSurface,
     ) -> Result<
         (
             CoreRateLimitSnapshot,
@@ -962,8 +971,7 @@ impl AccountRequestProcessor {
             ));
         }
 
-        let client = BackendClient::from_auth(self.config.chatgpt_base_url.clone(), &auth)
-            .map_err(|err| internal_error(format!("failed to construct backend client: {err}")))?;
+        let client = self.backend_client(&auth, http_state_surface)?;
 
         let snapshots = client
             .get_rate_limits_many()
@@ -994,5 +1002,18 @@ impl AccountRequestProcessor {
             .unwrap_or_else(|| snapshots[0].clone());
 
         Ok((primary, rate_limits_by_limit_id))
+    }
+
+    fn backend_client(
+        &self,
+        auth: &CodexAuth,
+        http_state_surface: HttpStateSurface,
+    ) -> Result<BackendClient, JSONRPCErrorError> {
+        BackendClient::from_auth_with_http_state(
+            self.config.chatgpt_base_url.clone(),
+            auth,
+            HttpStateContext::new(self.config.codex_home.to_path_buf(), http_state_surface),
+        )
+        .map_err(|err| internal_error(format!("failed to construct backend client: {err}")))
     }
 }

--- a/codex-rs/backend-client/Cargo.toml
+++ b/codex-rs/backend-client/Cargo.toml
@@ -20,9 +20,11 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 codex-backend-openapi-models = { path = "../codex-backend-openapi-models" }
 codex-api = { workspace = true }
 codex-client = { workspace = true }
+codex-http-state = { workspace = true }
 codex-login = { workspace = true }
 codex-model-provider = { workspace = true }
 codex-protocol = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = "1"
+tempfile = { workspace = true }

--- a/codex-rs/backend-client/src/client.rs
+++ b/codex-rs/backend-client/src/client.rs
@@ -9,6 +9,7 @@ use anyhow::Result;
 use codex_api::SharedAuthProvider;
 use codex_client::build_reqwest_client_with_custom_ca;
 use codex_client::with_chatgpt_cloudflare_cookie_store;
+use codex_http_state::HttpStateContext;
 use codex_login::CodexAuth;
 use codex_login::default_client::get_codex_user_agent;
 use codex_protocol::account::PlanType as AccountPlanType;
@@ -177,6 +178,20 @@ impl Client {
             .with_auth_provider(codex_model_provider::auth_provider_from_auth(auth)))
     }
 
+    pub fn from_auth_with_http_state(
+        base_url: impl Into<String>,
+        auth: &CodexAuth,
+        http_state: HttpStateContext,
+    ) -> Result<Self> {
+        Ok(Self::new(base_url)?
+            .with_user_agent(get_codex_user_agent())
+            .with_auth_provider(codex_model_provider::with_native_integrity_state(
+                codex_model_provider::auth_provider_from_auth(auth),
+                Some(auth),
+                Some(http_state),
+            )))
+    }
+
     pub fn with_auth_provider(mut self, auth: SharedAuthProvider) -> Self {
         self.auth_provider = auth;
         self
@@ -204,14 +219,14 @@ impl Client {
         self
     }
 
-    fn headers(&self) -> HeaderMap {
+    fn headers(&self, url: &str) -> HeaderMap {
         let mut h = HeaderMap::new();
         if let Some(ua) = &self.user_agent {
             h.insert(USER_AGENT, ua.clone());
         } else {
             h.insert(USER_AGENT, HeaderValue::from_static("codex-cli"));
         }
-        self.auth_provider.add_auth_headers(&mut h);
+        self.auth_provider.add_auth_headers_for_url(url, &mut h);
         if let Some(acc) = &self.chatgpt_account_id
             && let Ok(name) = HeaderName::from_bytes(b"ChatGPT-Account-Id")
             && let Ok(hv) = HeaderValue::from_str(acc)
@@ -232,7 +247,10 @@ impl Client {
         method: &str,
         url: &str,
     ) -> Result<(String, String)> {
-        let res = req.send().await?;
+        let request_headers = self.headers(url);
+        let res = req.headers(request_headers.clone()).send().await?;
+        self.auth_provider
+            .observe_response_headers(url, &request_headers, res.headers());
         let status = res.status();
         let ct = res
             .headers()
@@ -253,7 +271,14 @@ impl Client {
         method: &str,
         url: &str,
     ) -> std::result::Result<(String, String), RequestError> {
-        let res = req.send().await.map_err(anyhow::Error::from)?;
+        let request_headers = self.headers(url);
+        let res = req
+            .headers(request_headers.clone())
+            .send()
+            .await
+            .map_err(anyhow::Error::from)?;
+        self.auth_provider
+            .observe_response_headers(url, &request_headers, res.headers());
         let status = res.status();
         let content_type = res
             .headers()
@@ -297,7 +322,7 @@ impl Client {
             PathStyle::CodexApi => format!("{}/api/codex/usage", self.base_url),
             PathStyle::ChatGptApi => format!("{}/wham/usage", self.base_url),
         };
-        let req = self.http.get(&url).headers(self.headers());
+        let req = self.http.get(&url);
         let (body, ct) = self.exec_request(req, "GET", &url).await?;
         let payload: RateLimitStatusPayload = self.decode_json(&url, &ct, &body)?;
         Ok(Self::rate_limit_snapshots_from_payload(payload))
@@ -311,7 +336,6 @@ impl Client {
         let req = self
             .http
             .post(&url)
-            .headers(self.headers())
             .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
             .json(&SendAddCreditsNudgeEmailRequest { credit_type });
         self.exec_request_detailed(req, "POST", &url).await?;
@@ -329,7 +353,7 @@ impl Client {
             PathStyle::CodexApi => format!("{}/api/codex/tasks/list", self.base_url),
             PathStyle::ChatGptApi => format!("{}/wham/tasks/list", self.base_url),
         };
-        let req = self.http.get(&url).headers(self.headers());
+        let req = self.http.get(&url);
         let req = if let Some(lim) = limit {
             req.query(&[("limit", lim)])
         } else {
@@ -367,7 +391,7 @@ impl Client {
             PathStyle::CodexApi => format!("{}/api/codex/tasks/{}", self.base_url, task_id),
             PathStyle::ChatGptApi => format!("{}/wham/tasks/{}", self.base_url, task_id),
         };
-        let req = self.http.get(&url).headers(self.headers());
+        let req = self.http.get(&url);
         let (body, ct) = self.exec_request(req, "GET", &url).await?;
         let parsed: CodeTaskDetailsResponse = self.decode_json(&url, &ct, &body)?;
         Ok((parsed, body, ct))
@@ -388,7 +412,7 @@ impl Client {
                 self.base_url, task_id, turn_id
             ),
         };
-        let req = self.http.get(&url).headers(self.headers());
+        let req = self.http.get(&url);
         let (body, ct) = self.exec_request(req, "GET", &url).await?;
         self.decode_json::<TurnAttemptsSiblingTurnsResponse>(&url, &ct, &body)
     }
@@ -404,7 +428,7 @@ impl Client {
             PathStyle::CodexApi => format!("{}/api/codex/config/requirements", self.base_url),
             PathStyle::ChatGptApi => format!("{}/wham/config/requirements", self.base_url),
         };
-        let req = self.http.get(&url).headers(self.headers());
+        let req = self.http.get(&url);
         let (body, ct) = self.exec_request_detailed(req, "GET", &url).await?;
         self.decode_json::<ConfigFileResponse>(&url, &ct, &body)
             .map_err(RequestError::from)
@@ -421,7 +445,7 @@ impl Client {
             PathStyle::CodexApi => format!("{}/api/codex/config/bundle", self.base_url),
             PathStyle::ChatGptApi => format!("{}/wham/config/bundle", self.base_url),
         };
-        let req = self.http.get(&url).headers(self.headers());
+        let req = self.http.get(&url);
         let (body, ct) = self.exec_request_detailed(req, "GET", &url).await?;
         self.decode_json::<ConfigBundleResponse>(&url, &ct, &body)
             .map_err(RequestError::from)
@@ -437,7 +461,6 @@ impl Client {
         let req = self
             .http
             .post(&url)
-            .headers(self.headers())
             .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
             .json(&request_body);
         let (body, ct) = self.exec_request(req, "POST", &url).await?;
@@ -644,7 +667,52 @@ mod tests {
     use codex_backend_openapi_models::models::AdditionalRateLimitDetails;
     use codex_backend_openapi_models::models::RateLimitReachedKind;
     use codex_backend_openapi_models::models::RateLimitReachedType as BackendRateLimitReachedType;
+    use codex_client::INTEGRITY_STATE_HEADER_NAME;
+    use codex_client::INTEGRITY_STATE_UPDATE_HEADER_NAME;
+    use codex_http_state::HttpStateStore;
+    use codex_http_state::HttpStateSurface;
     use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
+
+    #[test]
+    fn backend_headers_and_response_observation_rotate_native_http_state() {
+        let codex_home = TempDir::new().expect("tempdir");
+        let surface = HttpStateSurface::CodexDesktop;
+        let store = HttpStateStore::new(codex_home.path().to_path_buf());
+        store
+            .set(surface, "ois1.initial.nonce.ciphertext".to_string())
+            .expect("state should store");
+        let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
+        let client = Client::from_auth_with_http_state(
+            "https://chatgpt.com/backend-api",
+            &auth,
+            HttpStateContext::new(codex_home.path().to_path_buf(), surface),
+        )
+        .expect("backend client");
+        let url = "https://chatgpt.com/backend-api/wham/usage";
+
+        let request_headers = client.headers(url);
+        assert_eq!(
+            request_headers
+                .get(INTEGRITY_STATE_HEADER_NAME)
+                .and_then(|value| value.to_str().ok()),
+            Some("ois1.initial.nonce.ciphertext")
+        );
+
+        let mut response_headers = HeaderMap::new();
+        response_headers.insert(
+            INTEGRITY_STATE_UPDATE_HEADER_NAME,
+            HeaderValue::from_static("ois1.rotated.nonce.ciphertext"),
+        );
+        client
+            .auth_provider
+            .observe_response_headers(url, &request_headers, &response_headers);
+
+        assert_eq!(
+            store.get(surface).expect("state should load").as_deref(),
+            Some("ois1.rotated.nonce.ciphertext")
+        );
+    }
 
     #[test]
     fn map_plan_type_supports_usage_based_business_variants() {


### PR DESCRIPTION
## Summary
- make `codex-backend-client` apply URL-aware auth and observe response headers centrally
- add an HTTP-state-aware constructor without changing existing ownerless callers
- attribute app-server `/usage` and credits-nudge requests to the initialized connection surface

## Stack
PR 10 of 15. Depends on #26080. Followed by #26088.

## Validation
- `CARGO_INCREMENTAL=0 just test -p codex-backend-client`
- targeted app-server `get_account_rate_limits_returns_snapshot` integration test
- `CARGO_INCREMENTAL=0 just fix -p codex-backend-client -p codex-app-server`
- `just fmt`
- `just bazel-lock-check`
- `git diff --check`