### PR TITLE
Flush ad-hoc memory instruction seed

### DIFF
--- a/codex-rs/memories/write/src/extensions/ad_hoc.rs
+++ b/codex-rs/memories/write/src/extensions/ad_hoc.rs
@@ -16,7 +16,8 @@ pub(super) async fn seed_instructions(memory_root: &Path) -> std::io::Result<()>
         .await
     {
         Ok(mut file) => {
-            tokio::io::AsyncWriteExt::write_all(&mut file, INSTRUCTIONS.as_bytes()).await
+            tokio::io::AsyncWriteExt::write_all(&mut file, INSTRUCTIONS.as_bytes()).await?;
+            tokio::io::AsyncWriteExt::flush(&mut file).await
         }
         Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
         Err(err) => Err(err),


### PR DESCRIPTION
## Summary
- flush the ad-hoc memory instruction seed before returning
- ensure callers observe the seeded instructions on disk

## Validation
- `just test -p codex-memories-write`
- `just fix -p codex-memories-write`
- `just fmt`
