### PR TITLE
[codex] cover attributable model and backend requests

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2190,6 +2190,7 @@ dependencies = [
  "codex-api",
  "codex-backend-openapi-models",
  "codex-client",
+ "codex-http-state",
  "codex-login",
  "codex-model-provider",
  "codex-protocol",
@@ -2197,6 +2198,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -3365,6 +3367,7 @@ dependencies = [
  "chrono",
  "codex-app-server-protocol",
  "codex-collaboration-mode-templates",
+ "codex-http-state",
  "codex-login",
  "codex-otel",
  "codex-protocol",

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -895,7 +895,11 @@ impl MessageProcessor {
                 .map(|response| Some(response.into())),
             ClientRequest::ExternalAgentConfigImport { params, .. } => self
                 .external_agent_config_processor
-                .import(request_id.clone(), params)
+                .import(
+                    request_id.clone(),
+                    params,
+                    app_server_client_name.as_deref(),
+                )
                 .await
                 .map(|()| None),
             ClientRequest::ConfigValueWrite { params, .. } => {
@@ -1198,7 +1202,9 @@ impl MessageProcessor {
                 self.plugin_processor.plugin_uninstall(params).await
             }
             ClientRequest::ModelList { params, .. } => {
-                self.catalog_processor.model_list(params).await
+                self.catalog_processor
+                    .model_list(params, app_server_client_name.as_deref())
+                    .await
             }
             ClientRequest::ExperimentalFeatureList { params, .. } => {
                 self.catalog_processor
@@ -1261,7 +1267,9 @@ impl MessageProcessor {
                 self.turn_processor.thread_realtime_list_voices().await
             }
             ClientRequest::ReviewStart { params, .. } => {
-                self.turn_processor.review_start(&request_id, params).await
+                self.turn_processor
+                    .review_start(&request_id, params, app_server_client_name.as_deref())
+                    .await
             }
             ClientRequest::McpServerOauthLogin { params, .. } => {
                 self.mcp_processor.mcp_server_oauth_login(params).await
@@ -1317,11 +1325,13 @@ impl MessageProcessor {
                     .await
             }
             ClientRequest::GetAccountRateLimits { .. } => {
-                self.account_processor.get_account_rate_limits().await
+                self.account_processor
+                    .get_account_rate_limits(app_server_client_name.as_deref())
+                    .await
             }
             ClientRequest::SendAddCreditsNudgeEmail { params, .. } => {
                 self.account_processor
-                    .send_add_credits_nudge_email(params)
+                    .send_add_credits_nudge_email(params, app_server_client_name.as_deref())
                     .await
             }
             ClientRequest::GitDiffToRemote { params, .. } => {

--- a/codex-rs/app-server/src/models.rs
+++ b/codex-rs/app-server/src/models.rs
@@ -5,6 +5,7 @@ use codex_app_server_protocol::ModelServiceTier;
 use codex_app_server_protocol::ModelUpgradeInfo;
 use codex_app_server_protocol::ReasoningEffortOption;
 use codex_core::ThreadManager;
+use codex_http_state::HttpStateSurface;
 use codex_models_manager::manager::RefreshStrategy;
 use codex_protocol::openai_models::ModelPreset;
 use codex_protocol::openai_models::ReasoningEffortPreset;
@@ -12,9 +13,10 @@ use codex_protocol::openai_models::ReasoningEffortPreset;
 pub async fn supported_models(
     thread_manager: Arc<ThreadManager>,
     include_hidden: bool,
+    http_state_surface: HttpStateSurface,
 ) -> Vec<Model> {
     thread_manager
-        .list_models(RefreshStrategy::OnlineIfUncached)
+        .list_models_for_surface(RefreshStrategy::OnlineIfUncached, http_state_surface)
         .await
         .into_iter()
         .filter(|preset| include_hidden || preset.show_in_picker)

--- a/codex-rs/app-server/src/request_processors/account_processor.rs
+++ b/codex-rs/app-server/src/request_processors/account_processor.rs
@@ -1,4 +1,5 @@
 use super::*;
+use codex_http_state::HttpStateContext;
 use codex_http_state::HttpStateSurface;
 
 // Duration before a browser ChatGPT login attempt is abandoned.
@@ -135,8 +136,9 @@ impl AccountRequestProcessor {
 
     pub(crate) async fn get_account_rate_limits(
         &self,
+        app_server_client_name: Option<&str>,
     ) -> Result<Option<ClientResponsePayload>, JSONRPCErrorError> {
-        self.get_account_rate_limits_response()
+        self.get_account_rate_limits_response(Self::http_state_surface(app_server_client_name))
             .await
             .map(|response| Some(response.into()))
     }
@@ -144,10 +146,14 @@ impl AccountRequestProcessor {
     pub(crate) async fn send_add_credits_nudge_email(
         &self,
         params: SendAddCreditsNudgeEmailParams,
+        app_server_client_name: Option<&str>,
     ) -> Result<Option<ClientResponsePayload>, JSONRPCErrorError> {
-        self.send_add_credits_nudge_email_response(params)
-            .await
-            .map(|response| Some(response.into()))
+        self.send_add_credits_nudge_email_response(
+            params,
+            Self::http_state_surface(app_server_client_name),
+        )
+        .await
+        .map(|response| Some(response.into()))
     }
 
     pub(crate) async fn cancel_active_login(&self) {
@@ -876,8 +882,9 @@ impl AccountRequestProcessor {
 
     async fn get_account_rate_limits_response(
         &self,
+        http_state_surface: HttpStateSurface,
     ) -> Result<GetAccountRateLimitsResponse, JSONRPCErrorError> {
-        self.fetch_account_rate_limits()
+        self.fetch_account_rate_limits(http_state_surface)
             .await
             .map(
                 |(rate_limits, rate_limits_by_limit_id)| GetAccountRateLimitsResponse {
@@ -895,8 +902,9 @@ impl AccountRequestProcessor {
     async fn send_add_credits_nudge_email_response(
         &self,
         params: SendAddCreditsNudgeEmailParams,
+        http_state_surface: HttpStateSurface,
     ) -> Result<SendAddCreditsNudgeEmailResponse, JSONRPCErrorError> {
-        self.send_add_credits_nudge_email_inner(params)
+        self.send_add_credits_nudge_email_inner(params, http_state_surface)
             .await
             .map(|status| SendAddCreditsNudgeEmailResponse { status })
     }
@@ -904,8 +912,9 @@ impl AccountRequestProcessor {
     async fn send_add_credits_nudge_email_inner(
         &self,
         params: SendAddCreditsNudgeEmailParams,
+        http_state_surface: HttpStateSurface,
     ) -> Result<AddCreditsNudgeEmailStatus, JSONRPCErrorError> {
-        let Some(auth) = self.auth_manager.auth().await else {
+        let Some(auth) = self.auth_manager.auth_for_surface(http_state_surface).await else {
             return Err(invalid_request(
                 "codex account authentication required to notify workspace owner",
             ));
@@ -917,8 +926,7 @@ impl AccountRequestProcessor {
             ));
         }
 
-        let client = BackendClient::from_auth(self.config.chatgpt_base_url.clone(), &auth)
-            .map_err(|err| internal_error(format!("failed to construct backend client: {err}")))?;
+        let client = self.backend_client(&auth, http_state_surface)?;
 
         match client
             .send_add_credits_nudge_email(Self::backend_credit_type(params.credit_type))
@@ -943,6 +951,7 @@ impl AccountRequestProcessor {
 
     async fn fetch_account_rate_limits(
         &self,
+        http_state_surface: HttpStateSurface,
     ) -> Result<
         (
             CoreRateLimitSnapshot,
@@ -950,7 +959,7 @@ impl AccountRequestProcessor {
         ),
         JSONRPCErrorError,
     > {
-        let Some(auth) = self.auth_manager.auth().await else {
+        let Some(auth) = self.auth_manager.auth_for_surface(http_state_surface).await else {
             return Err(invalid_request(
                 "codex account authentication required to read rate limits",
             ));
@@ -962,8 +971,7 @@ impl AccountRequestProcessor {
             ));
         }
 
-        let client = BackendClient::from_auth(self.config.chatgpt_base_url.clone(), &auth)
-            .map_err(|err| internal_error(format!("failed to construct backend client: {err}")))?;
+        let client = self.backend_client(&auth, http_state_surface)?;
 
         let snapshots = client
             .get_rate_limits_many()
@@ -994,5 +1002,18 @@ impl AccountRequestProcessor {
             .unwrap_or_else(|| snapshots[0].clone());
 
         Ok((primary, rate_limits_by_limit_id))
+    }
+
+    fn backend_client(
+        &self,
+        auth: &CodexAuth,
+        http_state_surface: HttpStateSurface,
+    ) -> Result<BackendClient, JSONRPCErrorError> {
+        BackendClient::from_auth_with_http_state(
+            self.config.chatgpt_base_url.clone(),
+            auth,
+            HttpStateContext::new(self.config.codex_home.to_path_buf(), http_state_surface),
+        )
+        .map_err(|err| internal_error(format!("failed to construct backend client: {err}")))
     }
 }

--- a/codex-rs/app-server/src/request_processors/catalog_processor.rs
+++ b/codex-rs/app-server/src/request_processors/catalog_processor.rs
@@ -1,5 +1,6 @@
 use super::*;
 use codex_config::config_toml::ConfigToml;
+use codex_http_state::HttpStateSurface;
 use futures::StreamExt;
 
 #[derive(Clone)]
@@ -156,8 +157,9 @@ impl CatalogRequestProcessor {
     pub(crate) async fn model_list(
         &self,
         params: ModelListParams,
+        app_server_client_name: Option<&str>,
     ) -> Result<Option<ClientResponsePayload>, JSONRPCErrorError> {
-        Self::list_models(self.thread_manager.clone(), params)
+        Self::list_models(self.thread_manager.clone(), params, app_server_client_name)
             .await
             .map(|response| Some(response.into()))
     }
@@ -248,13 +250,22 @@ impl CatalogRequestProcessor {
     async fn list_models(
         thread_manager: Arc<ThreadManager>,
         params: ModelListParams,
+        app_server_client_name: Option<&str>,
     ) -> Result<ModelListResponse, JSONRPCErrorError> {
         let ModelListParams {
             limit,
             cursor,
             include_hidden,
         } = params;
-        let models = supported_models(thread_manager, include_hidden.unwrap_or(false)).await;
+        let http_state_surface = HttpStateSurface::from_app_server_client_name(
+            app_server_client_name.unwrap_or_default(),
+        );
+        let models = supported_models(
+            thread_manager,
+            include_hidden.unwrap_or(false),
+            http_state_surface,
+        )
+        .await;
         let total = models.len();
 
         if total == 0 {

--- a/codex-rs/app-server/src/request_processors/external_agent_config_processor.rs
+++ b/codex-rs/app-server/src/request_processors/external_agent_config_processor.rs
@@ -34,6 +34,7 @@ use codex_external_agent_sessions::ImportedExternalAgentSession;
 use codex_external_agent_sessions::PendingSessionImport;
 use codex_external_agent_sessions::prepare_validated_session_imports;
 use codex_external_agent_sessions::record_imported_session;
+use codex_http_state::HttpStateSurface;
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::InitialHistory;
 use codex_thread_store::ThreadMetadataPatch;
@@ -174,7 +175,11 @@ impl ExternalAgentConfigRequestProcessor {
         &self,
         request_id: ConnectionRequestId,
         params: ExternalAgentConfigImportParams,
+        app_server_client_name: Option<&str>,
     ) -> Result<(), JSONRPCErrorError> {
+        let http_state_surface = HttpStateSurface::from_app_server_client_name(
+            app_server_client_name.unwrap_or_default(),
+        );
         let needs_runtime_refresh = migration_items_need_runtime_refresh(&params.migration_items);
         let has_migration_items = !params.migration_items.is_empty();
         let has_plugin_imports = params.migration_items.iter().any(|item| {
@@ -223,7 +228,10 @@ impl ExternalAgentConfigRequestProcessor {
                         .prepare_validated_session_imports(pending_session_imports);
                     for pending_session_import in pending_session_imports {
                         match session_processor
-                            .import_external_agent_session(pending_session_import.session)
+                            .import_external_agent_session(
+                                pending_session_import.session,
+                                http_state_surface,
+                            )
                             .await
                         {
                             Ok(imported_thread_id) => {
@@ -277,6 +285,7 @@ impl ExternalAgentConfigRequestProcessor {
     async fn import_external_agent_session(
         &self,
         session: ImportedExternalAgentSession,
+        http_state_surface: HttpStateSurface,
     ) -> Result<ThreadId, JSONRPCErrorError> {
         let ImportedExternalAgentSession {
             cwd,
@@ -312,6 +321,7 @@ impl ExternalAgentConfigRequestProcessor {
                 metrics_service_name: None,
                 parent_trace: None,
                 environments,
+                http_state_surface: Some(http_state_surface),
             })
             .await
             .map_err(|err| internal_error(format!("failed to import session: {err}")))?;

--- a/codex-rs/app-server/src/request_processors/thread_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::error_code::method_not_found;
+use codex_http_state::HttpStateSurface;
 use codex_protocol::models::BUILT_IN_PERMISSION_PROFILE_DANGER_FULL_ACCESS;
 use codex_protocol::models::BUILT_IN_PERMISSION_PROFILE_WORKSPACE;
 
@@ -1088,6 +1089,9 @@ impl ThreadRequestProcessor {
                 metrics_service_name: service_name,
                 parent_trace: request_trace,
                 environments,
+                http_state_surface: Some(HttpStateSurface::from_app_server_client_name(
+                    app_server_client_name.as_deref().unwrap_or_default(),
+                )),
             })
             .instrument(tracing::info_span!(
                 "app_server.thread_start.create_thread",
@@ -2529,11 +2533,14 @@ impl ThreadRequestProcessor {
 
         match self
             .thread_manager
-            .resume_thread_with_history(
+            .resume_thread_with_history_for_surface(
                 config.clone(),
                 thread_history,
                 self.auth_manager.clone(),
                 self.request_trace_context(&request_id).await,
+                Some(HttpStateSurface::from_app_server_client_name(
+                    app_server_client_name.as_deref().unwrap_or_default(),
+                )),
             )
             .await
         {
@@ -3238,7 +3245,7 @@ impl ThreadRequestProcessor {
             ..
         } = self
             .thread_manager
-            .fork_thread_from_history(
+            .fork_thread_from_history_for_surface(
                 ForkSnapshot::Interrupted,
                 config,
                 InitialHistory::Resumed(ResumedHistory {
@@ -3248,6 +3255,9 @@ impl ThreadRequestProcessor {
                 }),
                 thread_source.map(Into::into),
                 self.request_trace_context(&request_id).await,
+                Some(HttpStateSurface::from_app_server_client_name(
+                    app_server_client_name.as_deref().unwrap_or_default(),
+                )),
             )
             .await
             .map_err(|err| match err {

--- a/codex-rs/app-server/src/request_processors/turn_processor.rs
+++ b/codex-rs/app-server/src/request_processors/turn_processor.rs
@@ -1,4 +1,5 @@
 use super::*;
+use codex_http_state::HttpStateSurface;
 use codex_protocol::protocol::AdditionalContextEntry as CoreAdditionalContextEntry;
 use codex_protocol::protocol::AdditionalContextKind as CoreAdditionalContextKind;
 
@@ -214,8 +215,9 @@ impl TurnRequestProcessor {
         &self,
         request_id: &ConnectionRequestId,
         params: ReviewStartParams,
+        app_server_client_name: Option<&str>,
     ) -> Result<Option<ClientResponsePayload>, JSONRPCErrorError> {
-        self.review_start_inner(request_id, params)
+        self.review_start_inner(request_id, params, app_server_client_name)
             .await
             .map(|()| None)
     }
@@ -1060,6 +1062,7 @@ impl TurnRequestProcessor {
         parent_thread: Arc<CodexThread>,
         review_request: ReviewRequest,
         display_text: &str,
+        http_state_surface: HttpStateSurface,
     ) -> std::result::Result<(), JSONRPCErrorError> {
         parent_thread.ensure_rollout_materialized().await;
         parent_thread.flush_rollout().await.map_err(|err| {
@@ -1087,7 +1090,7 @@ impl TurnRequestProcessor {
             ..
         } = self
             .thread_manager
-            .fork_thread_from_history(
+            .fork_thread_from_history_for_surface(
                 ForkSnapshot::Interrupted,
                 config.clone(),
                 InitialHistory::Resumed(ResumedHistory {
@@ -1097,6 +1100,7 @@ impl TurnRequestProcessor {
                 }),
                 /*thread_source*/ None,
                 self.request_trace_context(request_id).await,
+                Some(http_state_surface),
             )
             .await
             .map_err(|err| {
@@ -1168,6 +1172,7 @@ impl TurnRequestProcessor {
         &self,
         request_id: &ConnectionRequestId,
         params: ReviewStartParams,
+        app_server_client_name: Option<&str>,
     ) -> Result<(), JSONRPCErrorError> {
         let ReviewStartParams {
             thread_id,
@@ -1195,6 +1200,9 @@ impl TurnRequestProcessor {
                     parent_thread,
                     review_request,
                     &display_text,
+                    HttpStateSurface::from_app_server_client_name(
+                        app_server_client_name.unwrap_or_default(),
+                    ),
                 )
                 .await?;
             }

--- a/codex-rs/backend-client/Cargo.toml
+++ b/codex-rs/backend-client/Cargo.toml
@@ -20,9 +20,11 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 codex-backend-openapi-models = { path = "../codex-backend-openapi-models" }
 codex-api = { workspace = true }
 codex-client = { workspace = true }
+codex-http-state = { workspace = true }
 codex-login = { workspace = true }
 codex-model-provider = { workspace = true }
 codex-protocol = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = "1"
+tempfile = { workspace = true }

--- a/codex-rs/backend-client/src/client.rs
+++ b/codex-rs/backend-client/src/client.rs
@@ -8,6 +8,7 @@ use anyhow::Result;
 use codex_api::SharedAuthProvider;
 use codex_client::build_reqwest_client_with_custom_ca;
 use codex_client::with_chatgpt_cloudflare_cookie_store;
+use codex_http_state::HttpStateContext;
 use codex_login::CodexAuth;
 use codex_login::default_client::get_codex_user_agent;
 use codex_protocol::account::PlanType as AccountPlanType;
@@ -176,6 +177,20 @@ impl Client {
             .with_auth_provider(codex_model_provider::auth_provider_from_auth(auth)))
     }
 
+    pub fn from_auth_with_http_state(
+        base_url: impl Into<String>,
+        auth: &CodexAuth,
+        http_state: HttpStateContext,
+    ) -> Result<Self> {
+        Ok(Self::new(base_url)?
+            .with_user_agent(get_codex_user_agent())
+            .with_auth_provider(codex_model_provider::with_native_integrity_state(
+                codex_model_provider::auth_provider_from_auth(auth),
+                Some(auth),
+                Some(http_state),
+            )))
+    }
+
     pub fn with_auth_provider(mut self, auth: SharedAuthProvider) -> Self {
         self.auth_provider = auth;
         self
@@ -203,14 +218,14 @@ impl Client {
         self
     }
 
-    fn headers(&self) -> HeaderMap {
+    fn headers(&self, url: &str) -> HeaderMap {
         let mut h = HeaderMap::new();
         if let Some(ua) = &self.user_agent {
             h.insert(USER_AGENT, ua.clone());
         } else {
             h.insert(USER_AGENT, HeaderValue::from_static("codex-cli"));
         }
-        self.auth_provider.add_auth_headers(&mut h);
+        self.auth_provider.add_auth_headers_for_url(url, &mut h);
         if let Some(acc) = &self.chatgpt_account_id
             && let Ok(name) = HeaderName::from_bytes(b"ChatGPT-Account-Id")
             && let Ok(hv) = HeaderValue::from_str(acc)
@@ -231,7 +246,10 @@ impl Client {
         method: &str,
         url: &str,
     ) -> Result<(String, String)> {
-        let res = req.send().await?;
+        let request_headers = self.headers(url);
+        let res = req.headers(request_headers.clone()).send().await?;
+        self.auth_provider
+            .observe_response_headers(url, &request_headers, res.headers());
         let status = res.status();
         let ct = res
             .headers()
@@ -252,7 +270,14 @@ impl Client {
         method: &str,
         url: &str,
     ) -> std::result::Result<(String, String), RequestError> {
-        let res = req.send().await.map_err(anyhow::Error::from)?;
+        let request_headers = self.headers(url);
+        let res = req
+            .headers(request_headers.clone())
+            .send()
+            .await
+            .map_err(anyhow::Error::from)?;
+        self.auth_provider
+            .observe_response_headers(url, &request_headers, res.headers());
         let status = res.status();
         let content_type = res
             .headers()
@@ -296,7 +321,7 @@ impl Client {
             PathStyle::CodexApi => format!("{}/api/codex/usage", self.base_url),
             PathStyle::ChatGptApi => format!("{}/wham/usage", self.base_url),
         };
-        let req = self.http.get(&url).headers(self.headers());
+        let req = self.http.get(&url);
         let (body, ct) = self.exec_request(req, "GET", &url).await?;
         let payload: RateLimitStatusPayload = self.decode_json(&url, &ct, &body)?;
         Ok(Self::rate_limit_snapshots_from_payload(payload))
@@ -310,7 +335,6 @@ impl Client {
         let req = self
             .http
             .post(&url)
-            .headers(self.headers())
             .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
             .json(&SendAddCreditsNudgeEmailRequest { credit_type });
         self.exec_request_detailed(req, "POST", &url).await?;
@@ -328,7 +352,7 @@ impl Client {
             PathStyle::CodexApi => format!("{}/api/codex/tasks/list", self.base_url),
             PathStyle::ChatGptApi => format!("{}/wham/tasks/list", self.base_url),
         };
-        let req = self.http.get(&url).headers(self.headers());
+        let req = self.http.get(&url);
         let req = if let Some(lim) = limit {
             req.query(&[("limit", lim)])
         } else {
@@ -366,7 +390,7 @@ impl Client {
             PathStyle::CodexApi => format!("{}/api/codex/tasks/{}", self.base_url, task_id),
             PathStyle::ChatGptApi => format!("{}/wham/tasks/{}", self.base_url, task_id),
         };
-        let req = self.http.get(&url).headers(self.headers());
+        let req = self.http.get(&url);
         let (body, ct) = self.exec_request(req, "GET", &url).await?;
         let parsed: CodeTaskDetailsResponse = self.decode_json(&url, &ct, &body)?;
         Ok((parsed, body, ct))
@@ -387,7 +411,7 @@ impl Client {
                 self.base_url, task_id, turn_id
             ),
         };
-        let req = self.http.get(&url).headers(self.headers());
+        let req = self.http.get(&url);
         let (body, ct) = self.exec_request(req, "GET", &url).await?;
         self.decode_json::<TurnAttemptsSiblingTurnsResponse>(&url, &ct, &body)
     }
@@ -403,7 +427,7 @@ impl Client {
             PathStyle::CodexApi => format!("{}/api/codex/config/bundle", self.base_url),
             PathStyle::ChatGptApi => format!("{}/wham/config/bundle", self.base_url),
         };
-        let req = self.http.get(&url).headers(self.headers());
+        let req = self.http.get(&url);
         let (body, ct) = self.exec_request_detailed(req, "GET", &url).await?;
         self.decode_json::<ConfigBundleResponse>(&url, &ct, &body)
             .map_err(RequestError::from)
@@ -419,7 +443,6 @@ impl Client {
         let req = self
             .http
             .post(&url)
-            .headers(self.headers())
             .header(CONTENT_TYPE, HeaderValue::from_static("application/json"))
             .json(&request_body);
         let (body, ct) = self.exec_request(req, "POST", &url).await?;
@@ -626,7 +649,52 @@ mod tests {
     use codex_backend_openapi_models::models::AdditionalRateLimitDetails;
     use codex_backend_openapi_models::models::RateLimitReachedKind;
     use codex_backend_openapi_models::models::RateLimitReachedType as BackendRateLimitReachedType;
+    use codex_client::INTEGRITY_STATE_HEADER_NAME;
+    use codex_client::INTEGRITY_STATE_UPDATE_HEADER_NAME;
+    use codex_http_state::HttpStateStore;
+    use codex_http_state::HttpStateSurface;
     use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
+
+    #[test]
+    fn backend_headers_and_response_observation_rotate_native_http_state() {
+        let codex_home = TempDir::new().expect("tempdir");
+        let surface = HttpStateSurface::CodexDesktop;
+        let store = HttpStateStore::new(codex_home.path().to_path_buf());
+        store
+            .set(surface, "ois1.initial.nonce.ciphertext".to_string())
+            .expect("state should store");
+        let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
+        let client = Client::from_auth_with_http_state(
+            "https://chatgpt.com/backend-api",
+            &auth,
+            HttpStateContext::new(codex_home.path().to_path_buf(), surface),
+        )
+        .expect("backend client");
+        let url = "https://chatgpt.com/backend-api/wham/usage";
+
+        let request_headers = client.headers(url);
+        assert_eq!(
+            request_headers
+                .get(INTEGRITY_STATE_HEADER_NAME)
+                .and_then(|value| value.to_str().ok()),
+            Some("ois1.initial.nonce.ciphertext")
+        );
+
+        let mut response_headers = HeaderMap::new();
+        response_headers.insert(
+            INTEGRITY_STATE_UPDATE_HEADER_NAME,
+            HeaderValue::from_static("ois1.rotated.nonce.ciphertext"),
+        );
+        client
+            .auth_provider
+            .observe_response_headers(url, &request_headers, &response_headers);
+
+        assert_eq!(
+            store.get(surface).expect("state should load").as_deref(),
+            Some("ois1.rotated.nonce.ciphertext")
+        );
+    }
 
     #[test]
     fn map_plan_type_supports_usage_based_business_variants() {

--- a/codex-rs/core/src/agent/control.rs
+++ b/codex-rs/core/src/agent/control.rs
@@ -307,21 +307,6 @@ impl AgentControl {
         {
             let client_metadata = match state.get_thread(*parent_thread_id).await {
                 Ok(parent_thread) => {
-                    if let Some(surface) = parent_thread
-                        .codex
-                        .session
-                        .services
-                        .model_client
-                        .http_state_surface()
-                    {
-                        new_thread
-                            .thread
-                            .codex
-                            .session
-                            .services
-                            .model_client
-                            .set_http_state_surface(surface);
-                    }
                     parent_thread
                         .codex
                         .session

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -1798,6 +1798,15 @@ fn subagent_header_value(session_source: &SessionSource) -> Option<String> {
     }
 }
 
+pub(crate) fn http_state_surface_for_session(
+    session_source: &SessionSource,
+    app_server_client_name: Option<&str>,
+) -> HttpStateSurface {
+    app_server_client_name
+        .map(HttpStateSurface::from_app_server_client_name)
+        .unwrap_or_else(|| http_state_surface_for_session_source(session_source))
+}
+
 fn http_state_surface_for_session_source(session_source: &SessionSource) -> HttpStateSurface {
     match session_source {
         SessionSource::Cli => HttpStateSurface::CodexTui,

--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -91,6 +91,7 @@ pub(crate) async fn run_codex_thread_interactive(
         extensions: Arc::clone(&parent_session.services.extensions),
         conversation_history,
         session_source: SessionSource::SubAgent(subagent_source.clone()),
+        http_state_surface: parent_session.services.model_client.http_state_surface(),
         forked_from_thread_id,
         parent_thread_id: Some(parent_session.conversation_id),
         thread_source: Some(ThreadSource::Subagent),
@@ -110,13 +111,6 @@ pub(crate) async fn run_codex_thread_interactive(
     }))
     .or_cancel(&cancel_token)
     .await??;
-    if let Some(surface) = parent_session.services.model_client.http_state_surface() {
-        codex
-            .session
-            .services
-            .model_client
-            .set_http_state_surface(surface);
-    }
     let thread_config = codex.thread_config_snapshot().await;
     let client_metadata = parent_session.app_server_client_metadata().await;
     emit_subagent_session_started(

--- a/codex-rs/core/src/codex_thread.rs
+++ b/codex-rs/core/src/codex_thread.rs
@@ -6,6 +6,7 @@ use crate::session::Codex;
 use crate::session::SessionSettingsUpdate;
 use crate::session::SteerInputError;
 use codex_features::Feature;
+use codex_http_state::HttpStateSurface;
 use codex_otel::SessionTelemetry;
 use codex_protocol::ThreadId;
 use codex_protocol::config_types::ApprovalsReviewer;
@@ -300,6 +301,14 @@ impl CodexThread {
                 mcp_elicitations_auto_deny,
             )
             .await
+    }
+
+    pub fn http_state_surface(&self) -> Option<HttpStateSurface> {
+        self.codex
+            .session
+            .services
+            .model_client
+            .http_state_surface()
     }
 
     /// Preview persistent thread settings overrides without committing them.

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -58,6 +58,7 @@ use codex_features::Feature;
 use codex_features::unstable_features_warning_event;
 use codex_hooks::Hooks;
 use codex_hooks::HooksConfig;
+use codex_http_state::HttpStateSurface;
 use codex_login::AuthManager;
 use codex_login::CodexAuth;
 use codex_login::auth_env_telemetry::collect_auth_env_telemetry;
@@ -172,6 +173,7 @@ use tracing::warn;
 use uuid::Uuid;
 
 use crate::client::ModelClient;
+use crate::client::http_state_surface_for_session;
 use crate::codex_thread::ThreadConfigSnapshot;
 use crate::compact::collect_user_messages;
 use crate::config::Config;
@@ -401,6 +403,7 @@ pub(crate) struct CodexSpawnArgs {
     pub(crate) extensions: Arc<codex_extension_api::ExtensionRegistry<crate::config::Config>>,
     pub(crate) conversation_history: InitialHistory,
     pub(crate) session_source: SessionSource,
+    pub(crate) http_state_surface: Option<HttpStateSurface>,
     pub(crate) forked_from_thread_id: Option<ThreadId>,
     pub(crate) parent_thread_id: Option<ThreadId>,
     pub(crate) thread_source: Option<ThreadSource>,
@@ -485,6 +488,7 @@ impl Codex {
             extensions,
             conversation_history,
             session_source,
+            http_state_surface,
             forked_from_thread_id,
             parent_thread_id,
             thread_source,
@@ -531,6 +535,9 @@ impl Codex {
         };
 
         let config = Arc::new(config);
+        let http_state_surface = http_state_surface.unwrap_or_else(|| {
+            http_state_surface_for_session(&session_source, /*app_server_client_name*/ None)
+        });
         let refresh_strategy = if session_source.is_non_root_agent() {
             codex_models_manager::manager::RefreshStrategy::Offline
         } else {
@@ -542,10 +549,12 @@ impl Codex {
                 codex_models_manager::manager::RefreshStrategy::Offline
             )
         {
-            let _ = models_manager.list_models(refresh_strategy).await;
+            let _ = models_manager
+                .list_models_for_surface(refresh_strategy, http_state_surface)
+                .await;
         }
         let model = models_manager
-            .get_default_model(&config.model, refresh_strategy)
+            .get_default_model_for_surface(&config.model, refresh_strategy, http_state_surface)
             .await;
 
         // Resolve base instructions for the session. Priority order:
@@ -648,6 +657,7 @@ impl Codex {
             parent_rollout_thread_trace,
             attestation_provider,
             multi_agent_version,
+            http_state_surface,
         ))
         .await
         .map_err(|e| {

--- a/codex-rs/core/src/session/review.rs
+++ b/codex-rs/core/src/session/review.rs
@@ -29,7 +29,10 @@ pub(super) async fn spawn_review_thread(
     let available_models = sess
         .services
         .models_manager
-        .list_models(RefreshStrategy::OnlineIfUncached)
+        .list_models_for_surface(
+            RefreshStrategy::OnlineIfUncached,
+            parent_turn_context.http_state_surface,
+        )
         .await;
     let unified_exec_shell_mode = UnifiedExecShellMode::for_session(
         codex_tools::unified_exec_feature_mode_for_features(review_features.get()),
@@ -124,6 +127,7 @@ pub(super) async fn spawn_review_thread(
         current_date: parent_turn_context.current_date.clone(),
         timezone: parent_turn_context.timezone.clone(),
         app_server_client_name: parent_turn_context.app_server_client_name.clone(),
+        http_state_surface: parent_turn_context.http_state_surface,
         developer_instructions: None,
         user_instructions: None,
         compact_prompt: parent_turn_context.compact_prompt.clone(),

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -507,6 +507,7 @@ impl Session {
         parent_rollout_thread_trace: ThreadTraceContext,
         attestation_provider: Option<Arc<dyn AttestationProvider>>,
         multi_agent_version: Option<MultiAgentVersion>,
+        http_state_surface: HttpStateSurface,
     ) -> anyhow::Result<Arc<Self>> {
         debug!(
             "Configuring session: model={}; provider={:?}",
@@ -629,7 +630,9 @@ impl Session {
         let config_for_mcp = Arc::clone(&config);
         let mcp_manager_for_mcp = Arc::clone(&mcp_manager);
         let auth_and_mcp_fut = async move {
-            let auth = auth_manager_clone.auth().await;
+            let auth = auth_manager_clone
+                .auth_for_surface(http_state_surface)
+                .await;
             let mcp_servers = mcp_manager_for_mcp
                 .effective_servers(&config_for_mcp, auth.as_ref())
                 .await;
@@ -1054,6 +1057,9 @@ impl Session {
                 code_mode_service: crate::tools::code_mode::CodeModeService::new(),
                 environment_manager,
             };
+            services
+                .model_client
+                .set_http_state_surface(http_state_surface);
             services
                 .model_client
                 .set_window_generation(window_generation);

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -3405,6 +3405,7 @@ async fn includes_timed_out_message() {
 async fn turn_context_with_model_updates_model_fields() {
     let (session, mut turn_context) = make_session_and_context().await;
     turn_context.reasoning_effort = Some(ReasoningEffortConfig::Minimal);
+    turn_context.http_state_surface = HttpStateSurface::CodexDesktop;
     let updated = turn_context
         .with_model("gpt-5.4".to_string(), &session.services.models_manager)
         .await;
@@ -3436,6 +3437,7 @@ async fn turn_context_with_model_updates_model_fields() {
         updated.truncation_policy,
         expected_model_info.truncation_policy.into()
     );
+    assert_eq!(updated.http_state_surface, HttpStateSurface::CodexDesktop);
 }
 
 #[test]
@@ -4606,6 +4608,7 @@ async fn session_new_fails_when_zsh_fork_enabled_without_packaged_zsh() {
         codex_rollout_trace::ThreadTraceContext::disabled(),
         /*attestation_provider*/ None,
         Some(config.multi_agent_version_from_features()),
+        HttpStateSurface::CodexExec,
     )
     .await;
 
@@ -4811,6 +4814,10 @@ pub(crate) async fn make_session_and_context() -> (Session, TurnContext) {
         per_turn_config,
         model_info,
         &models_manager,
+        services
+            .model_client
+            .http_state_surface()
+            .expect("model client should have HTTP state"),
         /*network*/ None,
         turn_environments,
         session_configuration.cwd.clone(),
@@ -4956,6 +4963,7 @@ async fn make_session_with_config_and_rx(
         codex_rollout_trace::ThreadTraceContext::disabled(),
         /*attestation_provider*/ None,
         Some(config.multi_agent_version_from_features()),
+        HttpStateSurface::CodexExec,
     )
     .await?;
 
@@ -5068,6 +5076,7 @@ async fn make_session_with_history_source_and_agent_control_and_rx(
         codex_rollout_trace::ThreadTraceContext::disabled(),
         /*attestation_provider*/ None,
         Some(config.multi_agent_version_from_features()),
+        HttpStateSurface::CodexExec,
     )
     .await?;
 
@@ -6901,6 +6910,10 @@ where
         per_turn_config,
         model_info,
         &models_manager,
+        services
+            .model_client
+            .http_state_surface()
+            .expect("model client should have HTTP state"),
         /*network*/ None,
         turn_environments,
         session_configuration.cwd.clone(),

--- a/codex-rs/core/src/session/tests/guardian_tests.rs
+++ b/codex-rs/core/src/session/tests/guardian_tests.rs
@@ -717,6 +717,7 @@ async fn guardian_subagent_does_not_inherit_parent_exec_policy_rules() {
         session_source: SessionSource::SubAgent(SubAgentSource::Other(
             GUARDIAN_REVIEWER_NAME.to_string(),
         )),
+        http_state_surface: None,
         forked_from_thread_id: None,
         parent_thread_id: None,
         thread_source: None,

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -2051,7 +2051,14 @@ async fn try_run_sampling_request(
             }
             ResponseEvent::ModelsEtag(etag) => {
                 // Update internal state with latest models etag
-                sess.services.models_manager.refresh_if_new_etag(etag).await;
+                if let Some(http_state_surface) = sess.services.model_client.http_state_surface() {
+                    sess.services
+                        .models_manager
+                        .refresh_if_new_etag_for_surface(etag, http_state_surface)
+                        .await;
+                } else {
+                    sess.services.models_manager.refresh_if_new_etag(etag).await;
+                }
             }
             ResponseEvent::Completed {
                 response_id,

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::SkillLoadOutcome;
+use crate::client::http_state_surface_for_session;
 use crate::config::GhostSnapshotConfig;
 use crate::environment_selection::ResolvedTurnEnvironments;
 use codex_model_provider::SharedModelProvider;
@@ -76,6 +77,7 @@ pub struct TurnContext {
     pub(crate) current_date: Option<String>,
     pub(crate) timezone: Option<String>,
     pub(crate) app_server_client_name: Option<String>,
+    pub(crate) http_state_surface: HttpStateSurface,
     pub(crate) developer_instructions: Option<String>,
     pub(crate) compact_prompt: Option<String>,
     pub(crate) user_instructions: Option<String>,
@@ -224,7 +226,7 @@ impl TurnContext {
         );
         let features = self.features.clone();
         let available_models = models_manager
-            .list_models(RefreshStrategy::OnlineIfUncached)
+            .list_models_for_surface(RefreshStrategy::OnlineIfUncached, self.http_state_surface)
             .await;
 
         Self {
@@ -251,6 +253,7 @@ impl TurnContext {
             current_date: self.current_date.clone(),
             timezone: self.timezone.clone(),
             app_server_client_name: self.app_server_client_name.clone(),
+            http_state_surface: self.http_state_surface,
             developer_instructions: self.developer_instructions.clone(),
             compact_prompt: self.compact_prompt.clone(),
             user_instructions: self.user_instructions.clone(),
@@ -472,6 +475,7 @@ impl Session {
         per_turn_config: Config,
         model_info: ModelInfo,
         models_manager: &SharedModelsManager,
+        http_state_surface: HttpStateSurface,
         network: Option<NetworkProxy>,
         environments: ResolvedTurnEnvironments,
         cwd: AbsolutePathBuf,
@@ -551,6 +555,7 @@ impl Session {
             current_date: Some(current_date),
             timezone: Some(timezone),
             app_server_client_name: session_configuration.app_server_client_name.clone(),
+            http_state_surface,
             developer_instructions: session_configuration.developer_instructions.clone(),
             compact_prompt: session_configuration.compact_prompt.clone(),
             user_instructions: session_configuration.user_instructions.clone(),
@@ -792,6 +797,15 @@ impl Session {
             per_turn_config,
             model_info,
             &self.services.models_manager,
+            self.services
+                .model_client
+                .http_state_surface()
+                .unwrap_or_else(|| {
+                    http_state_surface_for_session(
+                        &session_configuration.session_source,
+                        session_configuration.app_server_client_name.as_deref(),
+                    )
+                }),
             self.services
                 .network_proxy
                 .load_full()

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -24,6 +24,7 @@ use codex_exec_server::EnvironmentManager;
 use codex_extension_api::ExtensionRegistry;
 use codex_extension_api::empty_extension_registry;
 use codex_features::Feature;
+use codex_http_state::HttpStateSurface;
 use codex_login::AuthManager;
 use codex_login::CodexAuth;
 use codex_model_provider::create_model_provider;
@@ -182,6 +183,7 @@ pub struct StartThreadOptions {
     pub metrics_service_name: Option<String>,
     pub parent_trace: Option<W3cTraceContext>,
     pub environments: Vec<TurnEnvironmentSelection>,
+    pub http_state_surface: Option<HttpStateSurface>,
 }
 
 pub(crate) struct ResumeThreadWithHistoryOptions {
@@ -451,6 +453,17 @@ impl ThreadManager {
             .await
     }
 
+    pub async fn list_models_for_surface(
+        &self,
+        refresh_strategy: RefreshStrategy,
+        http_state_surface: HttpStateSurface,
+    ) -> Vec<ModelPreset> {
+        self.state
+            .models_manager
+            .list_models_for_surface(refresh_strategy, http_state_surface)
+            .await
+    }
+
     pub fn list_collaboration_modes(&self) -> Vec<CollaborationModeMask> {
         self.state.models_manager.list_collaboration_modes()
     }
@@ -576,6 +589,7 @@ impl ThreadManager {
             metrics_service_name: None,
             parent_trace: None,
             environments,
+            http_state_surface: None,
         }))
         .await
     }
@@ -605,6 +619,7 @@ impl ThreadManager {
             Arc::clone(&self.state.auth_manager),
             self.agent_control(),
             session_source,
+            options.http_state_surface,
             /*parent_thread_id*/ None,
             forked_from_thread_id,
             thread_source,
@@ -680,6 +695,24 @@ impl ThreadManager {
         auth_manager: Arc<AuthManager>,
         parent_trace: Option<W3cTraceContext>,
     ) -> CodexResult<NewThread> {
+        self.resume_thread_with_history_for_surface(
+            config,
+            initial_history,
+            auth_manager,
+            parent_trace,
+            /*http_state_surface*/ None,
+        )
+        .await
+    }
+
+    pub async fn resume_thread_with_history_for_surface(
+        &self,
+        config: Config,
+        initial_history: InitialHistory,
+        auth_manager: Arc<AuthManager>,
+        parent_trace: Option<W3cTraceContext>,
+        http_state_surface: Option<HttpStateSurface>,
+    ) -> CodexResult<NewThread> {
         let environments = default_thread_environment_selections(
             self.state.environment_manager.as_ref(),
             &config.cwd,
@@ -693,6 +726,7 @@ impl ThreadManager {
             auth_manager,
             self.agent_control(),
             session_source,
+            http_state_surface,
             /*parent_thread_id*/ None,
             /*forked_from_thread_id*/ None,
             thread_source,
@@ -721,6 +755,7 @@ impl ThreadManager {
             InitialHistory::New,
             Arc::clone(&self.state.auth_manager),
             self.agent_control(),
+            /*http_state_surface*/ None,
             /*parent_thread_id*/ None,
             /*forked_from_thread_id*/ None,
             /*thread_source*/ None,
@@ -754,6 +789,7 @@ impl ThreadManager {
             auth_manager,
             self.agent_control(),
             session_source,
+            /*http_state_surface*/ None,
             /*parent_thread_id*/ None,
             /*forked_from_thread_id*/ None,
             thread_source,
@@ -883,6 +919,30 @@ impl ThreadManager {
             history,
             thread_source,
             parent_trace,
+            /*http_state_surface*/ None,
+        )
+        .await
+    }
+
+    pub async fn fork_thread_from_history_for_surface<S>(
+        &self,
+        snapshot: S,
+        config: Config,
+        history: InitialHistory,
+        thread_source: Option<ThreadSource>,
+        parent_trace: Option<W3cTraceContext>,
+        http_state_surface: Option<HttpStateSurface>,
+    ) -> CodexResult<NewThread>
+    where
+        S: Into<ForkSnapshot>,
+    {
+        self.fork_thread_with_initial_history(
+            snapshot.into(),
+            config,
+            history,
+            thread_source,
+            parent_trace,
+            http_state_surface,
         )
         .await
     }
@@ -894,6 +954,7 @@ impl ThreadManager {
         history: InitialHistory,
         thread_source: Option<ThreadSource>,
         parent_trace: Option<W3cTraceContext>,
+        http_state_surface: Option<HttpStateSurface>,
     ) -> CodexResult<NewThread> {
         // `forked_from_id()` describes this history's existing lineage. When
         // forking a resumed thread, the child copies the resumed thread itself.
@@ -924,6 +985,7 @@ impl ThreadManager {
             history,
             Arc::clone(&self.state.auth_manager),
             self.agent_control(),
+            http_state_surface,
             /*parent_thread_id*/ None,
             forked_from_thread_id,
             thread_source,
@@ -1127,6 +1189,7 @@ impl ThreadManagerState {
             Arc::clone(&self.auth_manager),
             agent_control,
             session_source,
+            /*http_state_surface*/ None,
             parent_thread_id,
             forked_from_thread_id,
             thread_source,
@@ -1163,6 +1226,7 @@ impl ThreadManagerState {
             Arc::clone(&self.auth_manager),
             agent_control,
             session_source,
+            /*http_state_surface*/ None,
             parent_thread_id,
             /*forked_from_thread_id*/ None,
             thread_source,
@@ -1200,6 +1264,7 @@ impl ThreadManagerState {
             Arc::clone(&self.auth_manager),
             agent_control,
             session_source,
+            /*http_state_surface*/ None,
             parent_thread_id,
             forked_from_thread_id,
             thread_source,
@@ -1222,6 +1287,7 @@ impl ThreadManagerState {
         initial_history: InitialHistory,
         auth_manager: Arc<AuthManager>,
         agent_control: AgentControl,
+        http_state_surface: Option<HttpStateSurface>,
         parent_thread_id: Option<ThreadId>,
         forked_from_thread_id: Option<ThreadId>,
         thread_source: Option<ThreadSource>,
@@ -1237,6 +1303,7 @@ impl ThreadManagerState {
             auth_manager,
             agent_control,
             self.session_source.clone(),
+            http_state_surface,
             parent_thread_id,
             forked_from_thread_id,
             thread_source,
@@ -1259,6 +1326,7 @@ impl ThreadManagerState {
         auth_manager: Arc<AuthManager>,
         agent_control: AgentControl,
         session_source: SessionSource,
+        http_state_surface: Option<HttpStateSurface>,
         parent_thread_id: Option<ThreadId>,
         forked_from_thread_id: Option<ThreadId>,
         thread_source: Option<ThreadSource>,
@@ -1306,6 +1374,19 @@ impl ThreadManagerState {
                 forked_from_thread_id,
             )
             .await;
+        let http_state_surface = match http_state_surface {
+            Some(http_state_surface) => Some(http_state_surface),
+            None => match &session_source {
+                SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
+                    parent_thread_id, ..
+                }) => self
+                    .get_thread(*parent_thread_id)
+                    .await
+                    .ok()
+                    .and_then(|thread| thread.http_state_surface()),
+                _ => None,
+            },
+        };
         let CodexSpawnOk {
             codex, thread_id, ..
         } = Box::pin(Codex::spawn(CodexSpawnArgs {
@@ -1320,6 +1401,7 @@ impl ThreadManagerState {
             extensions: Arc::clone(&self.extensions),
             conversation_history: initial_history,
             session_source,
+            http_state_surface,
             forked_from_thread_id,
             parent_thread_id,
             thread_source,

--- a/codex-rs/core/src/thread_manager_tests.rs
+++ b/codex-rs/core/src/thread_manager_tests.rs
@@ -333,6 +333,7 @@ async fn start_thread_rejects_explicit_local_environment_when_default_provider_i
                 environment_id: "local".to_string(),
                 cwd: config.cwd.clone(),
             }],
+            http_state_surface: None,
         })
         .await;
     let err = match result {
@@ -463,6 +464,7 @@ async fn start_thread_keeps_internal_threads_hidden_from_normal_lookups() {
             metrics_service_name: None,
             parent_trace: None,
             environments: Vec::new(),
+            http_state_surface: None,
         })
         .await
         .expect("internal thread should start");
@@ -518,6 +520,7 @@ async fn resume_and_fork_do_not_restore_thread_environments_from_rollout() {
             metrics_service_name: None,
             parent_trace: None,
             environments: environments.clone(),
+            http_state_surface: None,
         })
         .await
         .expect("start source thread");
@@ -788,6 +791,7 @@ async fn resume_stopped_thread_from_rollout_preserves_thread_source() {
             metrics_service_name: None,
             parent_trace: None,
             environments: Vec::new(),
+            http_state_surface: None,
         })
         .await
         .expect("start source thread");

--- a/codex-rs/core/tests/suite/subagent_notifications.rs
+++ b/codex-rs/core/tests/suite/subagent_notifications.rs
@@ -755,6 +755,7 @@ async fn subagent_stop_replaces_stop_and_skips_internal_subagents() -> Result<()
             metrics_service_name: None,
             parent_trace: None,
             environments: Vec::new(),
+            http_state_surface: None,
         })
         .await?;
 

--- a/codex-rs/memories/write/src/runtime.rs
+++ b/codex-rs/memories/write/src/runtime.rs
@@ -251,6 +251,7 @@ impl MemoryStartupContext {
                 metrics_service_name: None,
                 parent_trace: None,
                 environments,
+                http_state_surface: None,
             })
             .await?;
 

--- a/codex-rs/model-provider/src/models_endpoint.rs
+++ b/codex-rs/model-provider/src/models_endpoint.rs
@@ -10,6 +10,8 @@ use codex_api::auth_header_telemetry;
 use codex_api::map_api_error;
 use codex_feedback::FeedbackRequestTags;
 use codex_feedback::emit_feedback_request_tags_with_auth_env;
+use codex_http_state::HttpStateContext;
+use codex_http_state::HttpStateSurface;
 use codex_login::AuthEnvTelemetry;
 use codex_login::AuthManager;
 use codex_login::CodexAuth;
@@ -27,6 +29,7 @@ use http::HeaderMap;
 use tokio::time::timeout;
 
 use crate::auth::resolve_provider_auth;
+use crate::auth::with_native_integrity_state;
 
 const MODELS_REFRESH_TIMEOUT: Duration = Duration::from_secs(5);
 const MODELS_ENDPOINT: &str = "/models";
@@ -49,10 +52,13 @@ impl OpenAiModelsEndpoint {
         }
     }
 
-    async fn auth(&self) -> Option<CodexAuth> {
-        match self.auth_manager.as_ref() {
-            Some(auth_manager) => auth_manager.auth().await,
-            None => None,
+    async fn auth(&self, http_state_surface: Option<HttpStateSurface>) -> Option<CodexAuth> {
+        match (self.auth_manager.as_ref(), http_state_surface) {
+            (Some(auth_manager), Some(http_state_surface)) => {
+                auth_manager.auth_for_surface(http_state_surface).await
+            }
+            (Some(auth_manager), None) => auth_manager.auth().await,
+            (None, _) => None,
         }
     }
 
@@ -71,8 +77,8 @@ impl ModelsEndpointClient for OpenAiModelsEndpoint {
         self.provider_info.has_command_auth()
     }
 
-    async fn uses_codex_backend(&self) -> bool {
-        self.auth()
+    async fn uses_codex_backend(&self, http_state_surface: Option<HttpStateSurface>) -> bool {
+        self.auth(http_state_surface)
             .await
             .as_ref()
             .is_some_and(CodexAuth::uses_codex_backend)
@@ -81,13 +87,22 @@ impl ModelsEndpointClient for OpenAiModelsEndpoint {
     async fn list_models(
         &self,
         client_version: &str,
+        http_state_surface: Option<HttpStateSurface>,
     ) -> CoreResult<(Vec<ModelInfo>, Option<String>)> {
         let _timer =
             codex_otel::start_global_timer("codex.remote_models.fetch_update.duration_ms", &[]);
-        let auth = self.auth().await;
+        let auth = self.auth(http_state_surface).await;
         let auth_mode = auth.as_ref().map(CodexAuth::auth_mode);
         let api_provider = self.provider_info.to_api_provider(auth_mode)?;
-        let api_auth = resolve_provider_auth(auth.as_ref(), &self.provider_info)?;
+        let api_auth = with_native_integrity_state(
+            resolve_provider_auth(auth.as_ref(), &self.provider_info)?,
+            auth.as_ref(),
+            http_state_surface.and_then(|surface| {
+                self.auth_manager.as_ref().map(|auth_manager| {
+                    HttpStateContext::new(auth_manager.codex_home().to_path_buf(), surface)
+                })
+            }),
+        );
         let transport = ReqwestTransport::new(build_reqwest_client());
         let auth_telemetry = auth_header_telemetry(api_auth.as_ref());
         let request_telemetry: Arc<dyn RequestTelemetry> = Arc::new(ModelsRequestTelemetry {

--- a/codex-rs/models-manager/Cargo.toml
+++ b/codex-rs/models-manager/Cargo.toml
@@ -17,6 +17,7 @@ async-trait = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 codex-app-server-protocol = { workspace = true }
 codex-collaboration-mode-templates = { workspace = true }
+codex-http-state = { workspace = true }
 codex-login = { workspace = true }
 codex-otel = { workspace = true }
 codex-protocol = { workspace = true }

--- a/codex-rs/models-manager/src/manager.rs
+++ b/codex-rs/models-manager/src/manager.rs
@@ -4,6 +4,7 @@ use crate::config::ModelsManagerConfig;
 use crate::model_info;
 use async_trait::async_trait;
 use codex_app_server_protocol::AuthMode;
+use codex_http_state::HttpStateSurface;
 use codex_login::AuthManager;
 use codex_protocol::config_types::CollaborationModeMask;
 use codex_protocol::error::Result as CoreResult;
@@ -35,12 +36,13 @@ pub trait ModelsEndpointClient: fmt::Debug + Send + Sync {
     fn has_command_auth(&self) -> bool;
 
     /// Returns whether the currently resolved auth can use Codex backend-only models.
-    async fn uses_codex_backend(&self) -> bool;
+    async fn uses_codex_backend(&self, http_state_surface: Option<HttpStateSurface>) -> bool;
 
     /// Fetches the latest remote model catalog and optional ETag.
     async fn list_models(
         &self,
         client_version: &str,
+        http_state_surface: Option<HttpStateSurface>,
     ) -> CoreResult<(Vec<ModelInfo>, Option<String>)>;
 }
 
@@ -91,8 +93,36 @@ pub trait ModelsManager: fmt::Debug + Send + Sync {
         .await
     }
 
+    /// List all available models, attributing any network refresh to `http_state_surface`.
+    async fn list_models_for_surface(
+        &self,
+        refresh_strategy: RefreshStrategy,
+        http_state_surface: HttpStateSurface,
+    ) -> Vec<ModelPreset> {
+        async move {
+            let catalog = self
+                .raw_model_catalog_for_surface(refresh_strategy, http_state_surface)
+                .await;
+            self.build_available_models(catalog.models)
+        }
+        .instrument(tracing::info_span!(
+            "list_models",
+            refresh_strategy = %refresh_strategy
+        ))
+        .await
+    }
+
     /// Return the active raw model catalog, refreshing according to the specified strategy.
     async fn raw_model_catalog(&self, refresh_strategy: RefreshStrategy) -> ModelsResponse;
+
+    /// Return the active raw model catalog, attributing any network refresh to `http_state_surface`.
+    async fn raw_model_catalog_for_surface(
+        &self,
+        refresh_strategy: RefreshStrategy,
+        _http_state_surface: HttpStateSurface,
+    ) -> ModelsResponse {
+        self.raw_model_catalog(refresh_strategy).await
+    }
 
     /// Return the current in-memory remote model catalog without refreshing or loading cache state.
     async fn get_remote_models(&self) -> Vec<ModelInfo>;
@@ -157,6 +187,30 @@ pub trait ModelsManager: fmt::Debug + Send + Sync {
         .await
     }
 
+    /// Get the model identifier to use, attributing any network refresh to `http_state_surface`.
+    async fn get_default_model_for_surface(
+        &self,
+        model: &Option<String>,
+        refresh_strategy: RefreshStrategy,
+        http_state_surface: HttpStateSurface,
+    ) -> String {
+        async move {
+            if let Some(model) = model.as_ref() {
+                return model.to_string();
+            }
+            default_model_from_available(
+                self.list_models_for_surface(refresh_strategy, http_state_surface)
+                    .await,
+            )
+        }
+        .instrument(tracing::info_span!(
+            "get_default_model",
+            model.provided = model.is_some(),
+            refresh_strategy = %refresh_strategy
+        ))
+        .await
+    }
+
     // todo(aibrahim): look if we can tighten it to pub(crate)
     /// Look up model metadata, applying remote overrides and config adjustments.
     async fn get_model_info(&self, model: &str, config: &ModelsManagerConfig) -> ModelInfo {
@@ -172,6 +226,15 @@ pub trait ModelsManager: fmt::Debug + Send + Sync {
     ///
     /// Uses `Online` strategy to fetch latest models when ETags differ.
     async fn refresh_if_new_etag(&self, etag: String);
+
+    /// Refresh models for a new ETag, attributing any network refresh to `http_state_surface`.
+    async fn refresh_if_new_etag_for_surface(
+        &self,
+        etag: String,
+        _http_state_surface: HttpStateSurface,
+    ) {
+        self.refresh_if_new_etag(etag).await;
+    }
 }
 
 /// Shared model manager handle used across runtime services.
@@ -235,6 +298,22 @@ impl ModelsManager for OpenAiModelsManager {
         }
     }
 
+    async fn raw_model_catalog_for_surface(
+        &self,
+        refresh_strategy: RefreshStrategy,
+        http_state_surface: HttpStateSurface,
+    ) -> ModelsResponse {
+        if let Err(err) = self
+            .refresh_available_models_for_surface(refresh_strategy, http_state_surface)
+            .await
+        {
+            error!("failed to refresh available models: {err}");
+        }
+        ModelsResponse {
+            models: self.get_remote_models().await,
+        }
+    }
+
     async fn get_remote_models(&self) -> Vec<ModelInfo> {
         self.remote_models.read().await.clone()
     }
@@ -252,6 +331,26 @@ impl ModelsManager for OpenAiModelsManager {
     }
 
     async fn refresh_if_new_etag(&self, etag: String) {
+        self.refresh_if_new_etag_inner(etag, /*http_state_surface*/ None)
+            .await;
+    }
+
+    async fn refresh_if_new_etag_for_surface(
+        &self,
+        etag: String,
+        http_state_surface: HttpStateSurface,
+    ) {
+        self.refresh_if_new_etag_inner(etag, Some(http_state_surface))
+            .await;
+    }
+}
+
+impl OpenAiModelsManager {
+    async fn refresh_if_new_etag_inner(
+        &self,
+        etag: String,
+        http_state_surface: Option<HttpStateSurface>,
+    ) {
         let current_etag = self.get_etag().await;
         if current_etag.clone().is_some() && current_etag.as_deref() == Some(etag.as_str()) {
             if let Err(err) = self.cache_manager.renew_cache_ttl().await {
@@ -259,16 +358,35 @@ impl ModelsManager for OpenAiModelsManager {
             }
             return;
         }
-        if let Err(err) = self.refresh_available_models(RefreshStrategy::Online).await {
+        if let Err(err) = self
+            .refresh_available_models_inner(RefreshStrategy::Online, http_state_surface)
+            .await
+        {
             error!("failed to refresh available models: {err}");
         }
     }
-}
 
-impl OpenAiModelsManager {
     /// Refresh available models according to the specified strategy.
     async fn refresh_available_models(&self, refresh_strategy: RefreshStrategy) -> CoreResult<()> {
-        if !self.should_refresh_models().await {
+        self.refresh_available_models_inner(refresh_strategy, /*http_state_surface*/ None)
+            .await
+    }
+
+    async fn refresh_available_models_for_surface(
+        &self,
+        refresh_strategy: RefreshStrategy,
+        http_state_surface: HttpStateSurface,
+    ) -> CoreResult<()> {
+        self.refresh_available_models_inner(refresh_strategy, Some(http_state_surface))
+            .await
+    }
+
+    async fn refresh_available_models_inner(
+        &self,
+        refresh_strategy: RefreshStrategy,
+        http_state_surface: Option<HttpStateSurface>,
+    ) -> CoreResult<()> {
+        if !self.should_refresh_models(http_state_surface).await {
             if matches!(
                 refresh_strategy,
                 RefreshStrategy::Offline | RefreshStrategy::OnlineIfUncached
@@ -291,18 +409,24 @@ impl OpenAiModelsManager {
                     return Ok(());
                 }
                 info!("models cache: cache miss, fetching remote models");
-                self.fetch_and_update_models().await
+                self.fetch_and_update_models(http_state_surface).await
             }
             RefreshStrategy::Online => {
                 // Always fetch from network
-                self.fetch_and_update_models().await
+                self.fetch_and_update_models(http_state_surface).await
             }
         }
     }
 
-    async fn fetch_and_update_models(&self) -> CoreResult<()> {
+    async fn fetch_and_update_models(
+        &self,
+        http_state_surface: Option<HttpStateSurface>,
+    ) -> CoreResult<()> {
         let client_version = crate::client_version_to_whole();
-        let (models, etag) = self.endpoint_client.list_models(&client_version).await?;
+        let (models, etag) = self
+            .endpoint_client
+            .list_models(&client_version, http_state_surface)
+            .await?;
         self.apply_remote_models(models.clone()).await;
         *self.etag.write().await = etag.clone();
         self.cache_manager
@@ -311,8 +435,11 @@ impl OpenAiModelsManager {
         Ok(())
     }
 
-    async fn should_refresh_models(&self) -> bool {
-        self.endpoint_client.uses_codex_backend().await || self.endpoint_client.has_command_auth()
+    async fn should_refresh_models(&self, http_state_surface: Option<HttpStateSurface>) -> bool {
+        self.endpoint_client
+            .uses_codex_backend(http_state_surface)
+            .await
+            || self.endpoint_client.has_command_auth()
     }
 
     async fn get_etag(&self) -> Option<String> {

--- a/codex-rs/models-manager/src/manager_tests.rs
+++ b/codex-rs/models-manager/src/manager_tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::ModelsManagerConfig;
 use chrono::Utc;
 use codex_app_server_protocol::AuthMode;
+use codex_http_state::HttpStateSurface;
 use codex_login::AuthCredentialsStoreMode;
 use codex_login::AuthManager;
 use codex_login::CodexAuth;
@@ -76,6 +77,7 @@ struct TestModelsEndpoint {
     uses_codex_backend: bool,
     responses: Mutex<VecDeque<Vec<ModelInfo>>>,
     fetch_count: AtomicUsize,
+    surfaces: Mutex<Vec<Option<HttpStateSurface>>>,
 }
 
 impl TestModelsEndpoint {
@@ -85,6 +87,7 @@ impl TestModelsEndpoint {
             uses_codex_backend: true,
             responses: Mutex::new(responses.into()),
             fetch_count: AtomicUsize::new(0),
+            surfaces: Mutex::new(Vec::new()),
         })
     }
 
@@ -94,11 +97,19 @@ impl TestModelsEndpoint {
             uses_codex_backend: false,
             responses: Mutex::new(responses.into()),
             fetch_count: AtomicUsize::new(0),
+            surfaces: Mutex::new(Vec::new()),
         })
     }
 
     fn fetch_count(&self) -> usize {
         self.fetch_count.load(Ordering::SeqCst)
+    }
+
+    fn surfaces(&self) -> Vec<Option<HttpStateSurface>> {
+        self.surfaces
+            .lock()
+            .expect("surfaces lock should not be poisoned")
+            .clone()
     }
 }
 
@@ -150,15 +161,20 @@ impl ModelsEndpointClient for TestModelsEndpoint {
         self.has_command_auth
     }
 
-    async fn uses_codex_backend(&self) -> bool {
+    async fn uses_codex_backend(&self, _http_state_surface: Option<HttpStateSurface>) -> bool {
         self.uses_codex_backend
     }
 
     async fn list_models(
         &self,
         _client_version: &str,
+        http_state_surface: Option<HttpStateSurface>,
     ) -> CoreResult<(Vec<ModelInfo>, Option<String>)> {
         self.fetch_count.fetch_add(1, Ordering::SeqCst);
+        self.surfaces
+            .lock()
+            .expect("surfaces lock should not be poisoned")
+            .push(http_state_surface);
         let models = self
             .responses
             .lock()
@@ -334,6 +350,22 @@ async fn get_model_info_rejects_multi_segment_namespace_suffix_matching() {
 }
 
 #[tokio::test]
+async fn list_models_for_surface_attributes_network_refresh() {
+    let codex_home = tempdir().expect("temp dir");
+    let endpoint = TestModelsEndpoint::new(Vec::new());
+    let manager = openai_manager_for_tests(codex_home.path().to_path_buf(), endpoint.clone());
+
+    manager
+        .list_models_for_surface(RefreshStrategy::Online, HttpStateSurface::CodexDesktop)
+        .await;
+
+    assert_eq!(
+        endpoint.surfaces(),
+        vec![Some(HttpStateSurface::CodexDesktop)]
+    );
+}
+
+#[tokio::test]
 async fn refresh_available_models_sorts_by_priority() {
     let remote_models = vec![
         remote_model("priority-low", "Low", /*priority*/ 1),
@@ -500,6 +532,7 @@ async fn refresh_available_models_keeps_merging_for_api_auth() {
         uses_codex_backend: false,
         responses: Mutex::new(vec![remote_models.clone()].into()),
         fetch_count: AtomicUsize::new(0),
+        surfaces: Mutex::new(Vec::new()),
     });
     let manager = openai_manager_for_tests_with_auth(
         codex_home.path().to_path_buf(),
@@ -719,7 +752,7 @@ impl ModelsEndpointClient for TestAuthAwareModelsEndpoint {
         false
     }
 
-    async fn uses_codex_backend(&self) -> bool {
+    async fn uses_codex_backend(&self, _http_state_surface: Option<HttpStateSurface>) -> bool {
         match self.auth_manager.as_ref() {
             Some(auth_manager) => auth_manager
                 .auth()
@@ -733,6 +766,7 @@ impl ModelsEndpointClient for TestAuthAwareModelsEndpoint {
     async fn list_models(
         &self,
         _client_version: &str,
+        _http_state_surface: Option<HttpStateSurface>,
     ) -> CoreResult<(Vec<ModelInfo>, Option<String>)> {
         self.fetch_count.fetch_add(1, Ordering::SeqCst);
         let models = self


### PR DESCRIPTION
## Why
Several high-signal requests run through shared model and backend clients before or outside the main Responses path. They need explicit surface ownership so `/models`, `/wham/usage`, and related attributable requests use the same jar as the initiating session.

## What changed
- Thread request-scoped surface ownership through shared model-catalog refreshes and model-refresh preflights.
- Add optional HTTP-state context to `codex-backend-client` so attributable backend routes attach and rotate state.
- Pass the initialized app-server surface into account, catalog, thread, turn, external-agent, and session creation paths, including `GET /wham/usage`.
- Preserve the initiating surface for child threads, subagents, and detached reviews.

## Review guide
- Ownership is optional by design. Process-global work without an initiating surface should remain unattributed instead of guessing a jar.
- Child work should inherit the initiating session's surface before any attributable preflight begins.
- This PR reuses the transport wrappers from [#26139](https://github.com/openai/codex/pull/26139); it should not duplicate header policy.

## Stack
This is **PR 5 of 7** in the native HTTP-state stack. It depends on [#26140](https://github.com/openai/codex/pull/26140).

1. [#26137: per-surface store](https://github.com/openai/codex/pull/26137)
2. [#26138: app-server bridge](https://github.com/openai/codex/pull/26138)
3. [#26139: HTTP and WebSocket transport](https://github.com/openai/codex/pull/26139)
4. [#26140: login, refresh, logout, and remote control](https://github.com/openai/codex/pull/26140)
5. **[#26141: shared model and backend clients](https://github.com/openai/codex/pull/26141)** (this PR)
6. [#26142: app-owned requests](https://github.com/openai/codex/pull/26142)
7. [#26143: standalone CLI requests](https://github.com/openai/codex/pull/26143)

## Validation
- `codex-models-manager`, `codex-model-provider`, and `codex-backend-client` suites
- Targeted app-server usage and inherited-surface tests
- Scoped Clippy, formatting, whitespace, and Bazel lock checks
