### PR TITLE
Redact access tokens from Guardian transcript evidence

### DIFF
--- a/codex-rs/core/src/guardian/prompt.rs
+++ b/codex-rs/core/src/guardian/prompt.rs
@@ -26,6 +26,8 @@ use super::GuardianAssessment;
 use super::TRUNCATION_TAG;
 use super::approval_request::format_guardian_action_pretty;
 
+const REDACTED_GUARDIAN_TRANSCRIPT_VALUE: &str = "<redacted>";
+
 /// Transcript entry retained for guardian review after filtering.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) struct GuardianTranscriptEntry {
@@ -425,8 +427,11 @@ pub(crate) fn collect_guardian_transcript_entries(
     };
     let content_entry =
         |kind, content| content_items_to_text(content).and_then(|text| non_empty_entry(kind, text));
-    let serialized_entry =
-        |kind, serialized: Option<String>| serialized.and_then(|text| non_empty_entry(kind, text));
+    let serialized_entry = |kind, serialized: Option<String>| {
+        serialized
+            .map(redact_guardian_tool_evidence)
+            .and_then(|text| non_empty_entry(kind, text))
+    };
 
     for item in items {
         let entry = match item {
@@ -463,10 +468,10 @@ pub(crate) fn collect_guardian_transcript_entries(
                 ..
             } => {
                 tool_names_by_call_id.insert(call_id.clone(), name.clone());
-                (!arguments.trim().is_empty()).then(|| GuardianTranscriptEntry {
-                    kind: GuardianTranscriptEntryKind::Tool(format!("tool {name} call")),
-                    text: arguments.clone(),
-                })
+                non_empty_entry(
+                    GuardianTranscriptEntryKind::Tool(format!("tool {name} call")),
+                    redact_guardian_tool_evidence(arguments.clone()),
+                )
             }
             ResponseItem::CustomToolCall {
                 call_id,
@@ -475,10 +480,10 @@ pub(crate) fn collect_guardian_transcript_entries(
                 ..
             } => {
                 tool_names_by_call_id.insert(call_id.clone(), name.clone());
-                (!input.trim().is_empty()).then(|| GuardianTranscriptEntry {
-                    kind: GuardianTranscriptEntryKind::Tool(format!("tool {name} call")),
-                    text: input.clone(),
-                })
+                non_empty_entry(
+                    GuardianTranscriptEntryKind::Tool(format!("tool {name} call")),
+                    redact_guardian_tool_evidence(input.clone()),
+                )
             }
             ResponseItem::WebSearchCall { action, .. } => action.as_ref().and_then(|action| {
                 serialized_entry(
@@ -499,7 +504,7 @@ pub(crate) fn collect_guardian_transcript_entries(
                             |name| format!("tool {name} result"),
                         ),
                     ),
-                    text,
+                    redact_guardian_tool_evidence(text),
                 )
             }),
             _ => None,
@@ -511,6 +516,49 @@ pub(crate) fn collect_guardian_transcript_entries(
     }
 
     entries
+}
+
+fn redact_guardian_tool_evidence(text: String) -> String {
+    let Ok(mut value) = serde_json::from_str::<Value>(&text) else {
+        return text;
+    };
+    if !redact_access_token_fields(&mut value) {
+        return text;
+    }
+    serde_json::to_string(&value).unwrap_or(text)
+}
+
+fn redact_access_token_fields(value: &mut Value) -> bool {
+    match value {
+        Value::Array(values) => {
+            let mut redacted_any = false;
+            for value in values {
+                redacted_any |= redact_access_token_fields(value);
+            }
+            redacted_any
+        }
+        Value::Object(fields) => {
+            let mut redacted_any = false;
+            for (field_name, value) in fields {
+                if is_access_token_field_name(field_name) {
+                    *value = Value::String(REDACTED_GUARDIAN_TRANSCRIPT_VALUE.to_string());
+                    redacted_any = true;
+                } else {
+                    redacted_any |= redact_access_token_fields(value);
+                }
+            }
+            redacted_any
+        }
+        _ => false,
+    }
+}
+
+fn is_access_token_field_name(field_name: &str) -> bool {
+    field_name
+        .chars()
+        .filter(char::is_ascii_alphanumeric)
+        .map(|ch| ch.to_ascii_lowercase())
+        .eq("accesstoken".chars())
 }
 
 pub(crate) fn guardian_truncate_text(content: &str, token_cap: usize) -> (String, bool) {

--- a/codex-rs/core/src/guardian/tests.rs
+++ b/codex-rs/core/src/guardian/tests.rs
@@ -755,6 +755,41 @@ fn collect_guardian_transcript_entries_includes_recent_tool_calls_and_output() {
 }
 
 #[test]
+fn collect_guardian_transcript_entries_redacts_access_token_fields_in_tool_output() {
+    let items = vec![
+        ResponseItem::FunctionCall {
+            id: None,
+            name: "salesforce_org_list".to_string(),
+            namespace: None,
+            arguments: "{}".to_string(),
+            call_id: "call-1".to_string(),
+        },
+        ResponseItem::FunctionCallOutput {
+            call_id: "call-1".to_string(),
+            output: codex_protocol::models::FunctionCallOutputPayload::from_text(
+                r#"{"result":[{"accessToken":"secret-value","alias":"dev","instanceUrl":"https://example.my.salesforce.com"},{"access_token":"another-secret-value","alias":"staging"}],"status":0}"#
+                    .to_string(),
+            ),
+        },
+    ];
+
+    let entries = collect_guardian_transcript_entries(&items);
+    let output: serde_json::Value =
+        serde_json::from_str(&entries[1].text).expect("redacted tool output should remain JSON");
+
+    assert_eq!(output["result"][0]["accessToken"], "<redacted>");
+    assert_eq!(output["result"][0]["alias"], "dev");
+    assert_eq!(output["result"][1]["access_token"], "<redacted>");
+    assert_eq!(output["result"][1]["alias"], "staging");
+    assert_eq!(
+        output["result"][0]["instanceUrl"],
+        "https://example.my.salesforce.com"
+    );
+    assert!(!entries[1].text.contains("secret-value"));
+    assert!(!entries[1].text.contains("another-secret-value"));
+}
+
+#[test]
 fn guardian_truncate_text_keeps_prefix_suffix_and_xml_marker() {
     let content = "prefix ".repeat(200) + &" suffix".repeat(200);
 


### PR DESCRIPTION
## Summary
- redact JSON fields named `accessToken` / `access_token` before tool evidence is retained for Guardian review
- recurse through arrays and objects so multi-result responses are fully scrubbed
- preserve ordinary JSON metadata and non-JSON transcript evidence unchanged

## Why
Some CLI JSON responses include reusable access tokens alongside metadata. Guardian needs enough tool evidence to review an approval, but it does not need the token value itself.

This intentionally targets access-token fields only. It avoids broad transcript rewriting while closing the observed credential-retention path.

Related report (second failure shape found while investigating the Salesforce incident):
- Slack: [Salesforce auto-review latency report](https://openai.slack.com/archives/C0AMFAQBZ2N/p1780423390084299)
- Sentry feedback: [`019e897e-c9b0-7370-bf3d-ec57dbf28edd`](https://openai.sentry.io/issues/?project=4510195390611458&query=thread_id%3A019e897e-c9b0-7370-bf3d-ec57dbf28edd)

## Validation
- `just fmt`
- `just fix -p codex-core`
- `cargo test -p codex-core collect_guardian_transcript_entries`
- `git diff --check`