### PR TITLE
Promote auth elicitation by default

### DIFF
--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -5502,17 +5502,17 @@ async fn to_mcp_config_preserves_auth_elicitation_feature_from_config() -> std::
     let mcp_config = config.to_mcp_config(&plugins_manager).await;
     assert_eq!(
         mcp_config.client_elicitation_capability,
-        ElicitationCapability::default()
-    );
-
-    let _ = config.features.enable(Feature::AuthElicitation);
-    let mcp_config = config.to_mcp_config(&plugins_manager).await;
-    assert_eq!(
-        mcp_config.client_elicitation_capability,
         ElicitationCapability {
             form: Some(FormElicitationCapability::default()),
             url: Some(UrlElicitationCapability::default()),
         }
+    );
+
+    let _ = config.features.disable(Feature::AuthElicitation);
+    let mcp_config = config.to_mcp_config(&plugins_manager).await;
+    assert_eq!(
+        mcp_config.client_elicitation_capability,
+        ElicitationCapability::default()
     );
 
     Ok(())

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -1283,7 +1283,12 @@ async fn install_host_owned_codex_apps_manager(session: &Session, turn_context: 
 
 #[tokio::test]
 async fn codex_apps_auth_elicitation_feature_disabled_returns_original_result() {
-    let (session, turn_context, rx_event) = make_session_and_context_with_rx().await;
+    let (session, mut turn_context, rx_event) = make_session_and_context_with_rx().await;
+    let mut features = Features::with_defaults();
+    features.disable(Feature::AuthElicitation);
+    Arc::get_mut(&mut turn_context)
+        .expect("single turn context ref")
+        .features = ManagedFeatures::from(features);
     install_host_owned_codex_apps_manager(&session, &turn_context).await;
     let result = codex_apps_auth_failure_result();
     let metadata = codex_apps_auth_failure_metadata();

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -1138,8 +1138,8 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::AuthElicitation,
         key: "auth_elicitation",
-        stage: Stage::UnderDevelopment,
-        default_enabled: false,
+        stage: Stage::Stable,
+        default_enabled: true,
     },
     FeatureSpec {
         id: Feature::Personality,

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -302,9 +302,9 @@ fn tool_call_mcp_elicitation_is_stable_and_enabled_by_default() {
 }
 
 #[test]
-fn auth_elicitation_is_under_development() {
-    assert_eq!(Feature::AuthElicitation.stage(), Stage::UnderDevelopment);
-    assert_eq!(Feature::AuthElicitation.default_enabled(), false);
+fn auth_elicitation_is_stable_and_enabled_by_default() {
+    assert_eq!(Feature::AuthElicitation.stage(), Stage::Stable);
+    assert_eq!(Feature::AuthElicitation.default_enabled(), true);
     assert_eq!(
         feature_for_key("auth_elicitation"),
         Some(Feature::AuthElicitation)


### PR DESCRIPTION
## Summary
- Promote `auth_elicitation` to `Stable` and enable it by default.
- Update feature and core tests to cover the new default behavior and explicit disable path.

## Testing
- `just test -p codex-features`
- `just test -p codex-core auth_elicitation`