### PR TITLE
codex-pr-body: avoid confidential references

### DIFF
--- a/.codex/skills/codex-pr-body/SKILL.md
+++ b/.codex/skills/codex-pr-body/SKILL.md
@@ -19,6 +19,8 @@ Limit discussion to the _net change_ of the commit. It is generally frowned upon
 
 Avoid references to absolute paths on my local disk. When talking about a path that is within the repository, simply use the repo-relative path.
 
+Avoid references to confidential information including but not limited to codenames or OpenAI-internal URLs.
+
 It is generally helpful to discuss how the change was verified. That said, it is unnecessary to mention things that CI checks automatically, e.g., do not include "ran `just fmt`" as part of the test plan. Though identifying the new tests that were purposely introduced to verify the new behavior introduced by the pull request is often appropriate.
 
 Make use of Markdown to format the pull request professionally. Ensure "code things" appear in single backticks when referenced inline. Fenced code blocks are useful when referencing code or showing a shell transcript. Also, make use of GitHub permalinks when citing existing pieces of code that are relevant to the change.


### PR DESCRIPTION
## Why

PR descriptions can be visible outside the context used to generate them. In #23710, a generated description referenced an internal document, showing that the skill needs an explicit guardrail against exposing confidential context.

## What changed

- Updated the `codex-pr-body` guidance to prohibit confidential references, including codenames and OpenAI-internal URLs.