### PR TITLE
Prioritize implicit Codex Apps MCP tools

### DIFF
--- a/codex-rs/codex-mcp/src/connection_manager_tests.rs
+++ b/codex-rs/codex-mcp/src/connection_manager_tests.rs
@@ -70,6 +70,21 @@ fn create_test_tool_with_connector(
     tool
 }
 
+fn create_codex_apps_test_tool(
+    callable_namespace: &str,
+    callable_name: &str,
+    connector_id: &str,
+) -> ToolInfo {
+    let mut tool = create_test_tool_with_connector(
+        CODEX_APPS_MCP_SERVER_NAME,
+        callable_name,
+        connector_id,
+        None,
+    );
+    tool.callable_namespace = callable_namespace.to_string();
+    tool
+}
+
 fn create_codex_apps_tools_cache_context(
     codex_home: PathBuf,
     account_id: Option<&str>,
@@ -337,6 +352,84 @@ fn test_normalize_tools_duplicated_names_skipped() {
     assert_eq!(
         model_tool_names(&model_tools),
         HashSet::from([ToolName::namespaced("mcp__server1", "duplicate_tool")])
+    );
+}
+
+#[test]
+fn test_normalize_tools_prioritizes_implicit_codex_apps_link_id() {
+    let explicit = create_codex_apps_test_tool(
+        "codex_apps__calendar",
+        "create_event",
+        "connector_aaa_calendar",
+    );
+    let mut implicit = create_codex_apps_test_tool(
+        "codex_apps__search_service",
+        "_web_run",
+        "connector_zzz_search_service",
+    );
+    implicit.tool.meta = Some(Meta(
+        serde_json::json!({
+            "link_id": "implicit_link::connector_openai_search_service",
+        })
+        .as_object()
+        .expect("object")
+        .clone(),
+    ));
+
+    let model_tools = normalize_tools_for_model_with_prefix(
+        vec![explicit, implicit],
+        /*prefix_mcp_tool_names*/ true,
+    );
+
+    assert_eq!(
+        model_tools
+            .iter()
+            .map(ToolInfo::canonical_tool_name)
+            .collect::<Vec<_>>(),
+        vec![
+            ToolName::namespaced("mcp__codex_apps__search_service", "_web_run"),
+            ToolName::namespaced("mcp__codex_apps__calendar", "create_event"),
+        ]
+    );
+}
+
+#[test]
+fn test_normalize_tools_prioritizes_implicit_codex_apps_resource_uri() {
+    let explicit = create_codex_apps_test_tool(
+        "codex_apps__calendar",
+        "create_event",
+        "connector_aaa_calendar",
+    );
+    let mut implicit = create_codex_apps_test_tool(
+        "codex_apps__search_service",
+        "_web_run",
+        "connector_zzz_search_service",
+    );
+    implicit.tool.meta = Some(Meta(
+        serde_json::json!({
+            "_codex_apps": {
+                "resource_uri": "connectors://connector_openai_search_service/implicit_link::connector_openai_search_service/web_run",
+            },
+        })
+        .as_object()
+        .expect("object")
+        .clone(),
+    ));
+
+    let model_tools = normalize_tools_for_model_with_prefix(
+        vec![explicit, implicit],
+        /*prefix_mcp_tool_names*/ true,
+    );
+
+    assert_eq!(
+        model_tools
+            .iter()
+            .map(ToolInfo::canonical_tool_name)
+            .collect::<Vec<_>>(),
+        vec![
+            ToolName::namespaced("mcp__codex_apps__search_service", "_web_run"),
+            ToolName::namespaced("mcp__codex_apps__calendar", "create_event"),
+        ]
     );
 }
 

--- a/codex-rs/codex-mcp/src/tools.rs
+++ b/codex-rs/codex-mcp/src/tools.rs
@@ -20,12 +20,17 @@ use sha1::Digest;
 use sha1::Sha1;
 use tracing::warn;
 
+use crate::mcp::CODEX_APPS_MCP_SERVER_NAME;
 use crate::mcp::sanitize_responses_api_tool_name;
 
 pub(crate) const MCP_TOOLS_CACHE_WRITE_DURATION_METRIC: &str =
     "codex.mcp.tools.cache_write.duration_ms";
 
 const LEGACY_MCP_TOOL_NAME_PREFIX: &str = "mcp__";
+const CODEX_APPS_META_KEY: &str = "_codex_apps";
+const CODEX_APPS_LINK_ID_KEY: &str = "link_id";
+const CODEX_APPS_RESOURCE_URI_KEY: &str = "resource_uri";
+const CODEX_APPS_IMPLICIT_LINK_ID_PREFIX: &str = "implicit_link::";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolInfo {
@@ -229,7 +234,15 @@ where
         }
     }
 
-    candidates.sort_by(|left, right| left.raw_tool_identity.cmp(&right.raw_tool_identity));
+    candidates.sort_by(|left, right| {
+        left.tool
+            .server_name
+            .cmp(&right.tool.server_name)
+            .then_with(|| {
+                codex_apps_tool_priority(&left.tool).cmp(&codex_apps_tool_priority(&right.tool))
+            })
+            .then_with(|| left.raw_tool_identity.cmp(&right.raw_tool_identity))
+    });
 
     let mut used_names = HashSet::new();
     let mut model_tools = Vec::new();
@@ -255,6 +268,38 @@ struct CallableToolCandidate {
     raw_tool_identity: String,
     callable_namespace: String,
     callable_name: String,
+}
+
+fn codex_apps_tool_priority(tool: &ToolInfo) -> u8 {
+    if tool.server_name == CODEX_APPS_MCP_SERVER_NAME && is_implicit_codex_apps_tool(tool) {
+        0
+    } else {
+        1
+    }
+}
+
+fn is_implicit_codex_apps_tool(tool: &ToolInfo) -> bool {
+    let Some(meta) = tool.tool.meta.as_deref() else {
+        return false;
+    };
+
+    meta.get(CODEX_APPS_LINK_ID_KEY)
+        .and_then(JsonValue::as_str)
+        .is_some_and(is_implicit_link_id)
+        || meta
+            .get(CODEX_APPS_META_KEY)
+            .and_then(JsonValue::as_object)
+            .and_then(|codex_apps| codex_apps.get(CODEX_APPS_RESOURCE_URI_KEY))
+            .and_then(JsonValue::as_str)
+            .is_some_and(resource_uri_has_implicit_link_segment)
+}
+
+fn is_implicit_link_id(link_id: &str) -> bool {
+    link_id.starts_with(CODEX_APPS_IMPLICIT_LINK_ID_PREFIX)
+}
+
+fn resource_uri_has_implicit_link_segment(resource_uri: &str) -> bool {
+    resource_uri.split('/').any(is_implicit_link_id)
 }
 
 const MCP_TOOL_NAME_DELIMITER: &str = "__";


### PR DESCRIPTION
## Summary

- Prioritize implicit Codex Apps tools during MCP tool normalization while preserving existing server-level ordering.
- Detect implicit links from either top-level `link_id` or nested `_codex_apps.resource_uri`, matching the backend behavior from openai/openai@102457d4e8ff9dab1528fb9d6aa9ae8882ffc235.
- Add coverage for both metadata paths so implicit Search Service ordering beats explicit Codex Apps tools even when the raw identity sort would put it later.

## Validation

- `cargo fmt -- --config imports_granularity=Item`
- `env PATH=/private/tmp/codex-tools/bin:$PATH /private/tmp/codex-tools/bin/just test -p codex-mcp`
- `env PATH=/private/tmp/codex-tools/bin:$PATH /private/tmp/codex-tools/bin/just fix -p codex-mcp`
- `git diff --check`