### PR TITLE
exec-server: Noise remote opt-in

### DIFF
--- a/codex-rs/exec-server/src/lib.rs
+++ b/codex-rs/exec-server/src/lib.rs
@@ -115,6 +115,7 @@ pub use protocol::WriteParams;
 pub use protocol::WriteResponse;
 pub use protocol::WriteStatus;
 pub use remote::RemoteEnvironmentConfig;
+pub use remote::RemoteRelayProtocol;
 pub use remote::run_remote_environment;
 pub use runtime_paths::ExecServerRuntimePaths;
 pub use server::DEFAULT_LISTEN_URL;

--- a/codex-rs/exec-server/src/noise_relay/mod.rs
+++ b/codex-rs/exec-server/src/noise_relay/mod.rs
@@ -1,17 +1,4 @@
-// These two modules intentionally land one stack layer before the remote
-// registration path starts the relay. Bazel compiles this PR as a library and
-// therefore sees their production-only entry points as dead, while the next
-// PR makes the same code reachable. Keep the allowances at the module boundary
-// so unrelated dead code elsewhere in exec-server remains an error.
-#[allow(
-    dead_code,
-    reason = "used by the remote Noise opt-in in the next stacked change"
-)]
 pub(crate) mod environment;
-#[allow(
-    dead_code,
-    reason = "used by the remote Noise opt-in in the next stacked change"
-)]
 mod executor_stream;
 mod harness;
 mod message_framing;
@@ -25,10 +12,6 @@ pub(crate) use harness::noise_harness_connection_from_websocket;
 
 // This value is already part of the relay wire contract. Keep it stable even
 // though the source module now uses the more precise Noise terminology.
-#[allow(
-    dead_code,
-    reason = "used by the remote Noise opt-in in the next stacked change"
-)]
 const NOISE_RELAY_RESET_REASON: &str = "secure_relay_protocol_error";
 
 // This bounds allocation in tungstenite before protobuf and Noise record

--- a/codex-rs/exec-server/src/remote.rs
+++ b/codex-rs/exec-server/src/remote.rs
@@ -14,6 +14,8 @@ use crate::ExecServerRuntimePaths;
 use crate::relay::run_multiplexed_environment;
 use crate::server::ConnectionProcessor;
 
+mod noise;
+
 const ERROR_BODY_PREVIEW_BYTES: usize = 4096;
 
 #[derive(Clone)]
@@ -44,6 +46,11 @@ impl EnvironmentRegistryClient {
         })
     }
 
+    /// Register using the original body-less registry contract.
+    ///
+    /// This method intentionally preserves the legacy request shape and timeout
+    /// behavior. Noise support is opt-in and must not silently alter existing
+    /// remote exec-server registrations.
     async fn register_environment(
         &self,
         environment_id: &str,
@@ -87,12 +94,27 @@ struct EnvironmentRegistryRegistrationResponse {
     url: String,
 }
 
+/// Protocol used for an exec-server's registered remote relay.
+///
+/// Legacy is intentionally the default during rollout. Noise must be selected
+/// explicitly so mixed-version deployments keep the original registry and relay
+/// contract until both endpoints are ready for Noise.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum RemoteRelayProtocol {
+    /// Original cleartext JSON-RPC relay protocol.
+    #[default]
+    Legacy,
+    /// Authenticated, end-to-end encrypted Noise relay protocol.
+    Noise,
+}
+
 /// Configuration for registering an exec-server for remote use.
 #[derive(Clone)]
 pub struct RemoteEnvironmentConfig {
     pub base_url: String,
     pub environment_id: String,
     pub name: String,
+    pub relay_protocol: RemoteRelayProtocol,
     auth_provider: SharedAuthProvider,
 }
 
@@ -102,6 +124,7 @@ impl std::fmt::Debug for RemoteEnvironmentConfig {
             .field("base_url", &self.base_url)
             .field("environment_id", &self.environment_id)
             .field("name", &self.name)
+            .field("relay_protocol", &self.relay_protocol)
             .field("auth_provider", &"<redacted>")
             .finish()
     }
@@ -118,6 +141,7 @@ impl RemoteEnvironmentConfig {
             base_url,
             environment_id,
             name: "codex-exec-server".to_string(),
+            relay_protocol: RemoteRelayProtocol::Legacy,
             auth_provider,
         })
     }
@@ -133,6 +157,10 @@ pub async fn run_remote_environment(
     let client =
         EnvironmentRegistryClient::new(config.base_url.clone(), config.auth_provider.clone())?;
     let processor = ConnectionProcessor::new(runtime_paths);
+    if config.relay_protocol == RemoteRelayProtocol::Noise {
+        return noise::run_remote_environment(&config, &client, processor).await;
+    }
+
     let mut backoff = Duration::from_secs(1);
 
     loop {

--- a/codex-rs/exec-server/src/remote/noise.rs
+++ b/codex-rs/exec-server/src/remote/noise.rs
@@ -1,0 +1,271 @@
+//! Explicitly selected Noise registration and encrypted relay runtime.
+//!
+//! The legacy remote-exec path stays in the parent module. Keeping the Noise
+//! path here makes the opt-in boundary visible and keeps its stricter registry,
+//! identifier, timeout, and websocket requirements from changing legacy
+//! behavior accidentally. Once selected, failures remain on this path; there is
+//! no automatic fallback to the unauthenticated legacy relay.
+
+use std::time::Duration;
+
+use reqwest::StatusCode;
+use serde::Deserialize;
+use serde::Serialize;
+use tokio::time::sleep;
+use tokio::time::timeout;
+use tokio_tungstenite::connect_async_with_config;
+use tracing::info;
+use tracing::warn;
+
+use super::EnvironmentRegistryClient;
+use super::RemoteEnvironmentConfig;
+use super::endpoint_url;
+use crate::ExecServerError;
+use crate::NoiseChannelIdentity;
+use crate::NoiseChannelPublicKey;
+use crate::noise_relay::HarnessKeyValidator;
+use crate::noise_relay::noise_relay_websocket_config;
+use crate::noise_relay::run_noise_multiplexed_environment;
+use crate::server::ConnectionProcessor;
+
+const ENVIRONMENT_REGISTRY_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const MAX_EXECUTOR_REGISTRATION_ID_LEN: usize = 256;
+const MAX_REMOTE_ENVIRONMENT_ID_LEN: usize = 256;
+const NOISE_RELAY_SECURITY_PROFILE: &str = "noise_hybrid_ik_v1";
+const REMOTE_RENDEZVOUS_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+impl EnvironmentRegistryClient {
+    /// Register the exec-server's static Noise identity with a Noise-aware registry.
+    ///
+    /// Supplying this request body is the protocol-level opt in. Registries can
+    /// therefore distinguish Noise registrations from the legacy body-less
+    /// contract without guessing based on binary version or rollout state.
+    async fn register_noise_environment(
+        &self,
+        environment_id: &str,
+        executor_public_key: &NoiseChannelPublicKey,
+    ) -> Result<EnvironmentRegistryNoiseRegistrationResponse, ExecServerError> {
+        let response = self
+            .http
+            .post(endpoint_url(
+                &self.base_url,
+                &format!("/cloud/environment/{environment_id}/register"),
+            ))
+            .headers(self.auth_provider.to_auth_headers())
+            .timeout(ENVIRONMENT_REGISTRY_REQUEST_TIMEOUT)
+            .json(&EnvironmentRegistryRegistrationRequest {
+                security_profile: NOISE_RELAY_SECURITY_PROFILE,
+                executor_public_key,
+            })
+            .send()
+            .await?;
+        self.parse_json_response(response).await
+    }
+
+    /// Validate the authenticated harness key without exposing its authorization.
+    async fn validate_harness_key(
+        &self,
+        environment_id: &str,
+        executor_registration_id: &str,
+        harness_public_key: &NoiseChannelPublicKey,
+        harness_key_authorization: &str,
+    ) -> Result<(), ExecServerError> {
+        let response = self
+            .http
+            .post(endpoint_url(
+                &self.base_url,
+                &format!("/cloud/environment/{environment_id}/validate"),
+            ))
+            .headers(self.auth_provider.to_auth_headers())
+            .timeout(ENVIRONMENT_REGISTRY_REQUEST_TIMEOUT)
+            .json(&EnvironmentRegistryHarnessKeyValidationRequest {
+                executor_registration_id,
+                harness_public_key,
+                harness_key_authorization,
+            })
+            .send()
+            .await?;
+        let status = response.status();
+        if !status.is_success() {
+            // This request contains the short-lived harness authorization.
+            // Never propagate a response body that might echo it into logs or
+            // user-visible error chains.
+            if matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) {
+                return Err(ExecServerError::EnvironmentRegistryAuth(format!(
+                    "environment registry harness key validation authentication failed ({status})"
+                )));
+            }
+            return Err(ExecServerError::EnvironmentRegistryHttp {
+                status,
+                code: None,
+                message: "environment registry harness key validation failed".to_string(),
+            });
+        }
+        let response = response
+            .json::<EnvironmentRegistryHarnessKeyValidationResponse>()
+            .await?;
+        if !response.valid {
+            return Err(ExecServerError::Protocol(
+                "environment registry rejected Noise relay harness key".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Serialize)]
+struct EnvironmentRegistryRegistrationRequest<'a> {
+    security_profile: &'static str,
+    executor_public_key: &'a NoiseChannelPublicKey,
+}
+
+#[derive(Deserialize)]
+struct EnvironmentRegistryNoiseRegistrationResponse {
+    environment_id: String,
+    url: String,
+    security_profile: String,
+    executor_registration_id: String,
+}
+
+#[derive(Serialize)]
+struct EnvironmentRegistryHarnessKeyValidationRequest<'a> {
+    executor_registration_id: &'a str,
+    harness_public_key: &'a NoiseChannelPublicKey,
+    harness_key_authorization: &'a str,
+}
+
+#[derive(Deserialize)]
+struct EnvironmentRegistryHarnessKeyValidationResponse {
+    valid: bool,
+}
+
+#[derive(Clone)]
+struct RegistryHarnessKeyValidator {
+    client: EnvironmentRegistryClient,
+    environment_id: String,
+    executor_registration_id: String,
+}
+
+impl HarnessKeyValidator for RegistryHarnessKeyValidator {
+    async fn validate_harness_key(
+        &self,
+        harness_public_key: &NoiseChannelPublicKey,
+        authorization: &str,
+    ) -> Result<(), ExecServerError> {
+        self.client
+            .validate_harness_key(
+                &self.environment_id,
+                &self.executor_registration_id,
+                harness_public_key,
+                authorization,
+            )
+            .await
+    }
+}
+
+/// Run the Noise registration and encrypted relay loop.
+///
+/// A new executor identity is generated once per process invocation and reused
+/// across physical reconnects. The registry-returned registration ID is bound
+/// into every virtual stream's Noise prologue.
+pub(super) async fn run_remote_environment(
+    config: &RemoteEnvironmentConfig,
+    client: &EnvironmentRegistryClient,
+    processor: ConnectionProcessor,
+) -> Result<(), ExecServerError> {
+    validate_environment_id(&config.environment_id)?;
+    let identity = NoiseChannelIdentity::generate().map_err(|error| {
+        ExecServerError::Protocol(format!("failed to generate Noise relay identity: {error}"))
+    })?;
+    let mut backoff = Duration::from_secs(1);
+
+    loop {
+        let response = client
+            .register_noise_environment(&config.environment_id, &identity.public_key())
+            .await?;
+        if response.environment_id != config.environment_id {
+            return Err(ExecServerError::Protocol(
+                "environment registry returned a different environment id".to_string(),
+            ));
+        }
+        if response.security_profile != NOISE_RELAY_SECURITY_PROFILE {
+            return Err(ExecServerError::Protocol(format!(
+                "environment registry returned unsupported security profile `{}`",
+                response.security_profile
+            )));
+        }
+        validate_executor_registration_id(&response.executor_registration_id)?;
+        let environment_id = &response.environment_id;
+        info!(
+            "codex exec-server Noise environment registered with environment_id {environment_id}"
+        );
+
+        match timeout(
+            REMOTE_RENDEZVOUS_CONNECT_TIMEOUT,
+            connect_async_with_config(
+                response.url.as_str(),
+                Some(noise_relay_websocket_config()),
+                /*disable_nagle*/ false,
+            ),
+        )
+        .await
+        {
+            Ok(Ok((websocket, _))) => {
+                backoff = Duration::from_secs(1);
+                let executor_registration_id = response.executor_registration_id;
+                run_noise_multiplexed_environment(
+                    websocket,
+                    processor.clone(),
+                    response.environment_id,
+                    executor_registration_id.clone(),
+                    identity.clone(),
+                    RegistryHarnessKeyValidator {
+                        client: client.clone(),
+                        environment_id: config.environment_id.clone(),
+                        executor_registration_id,
+                    },
+                )
+                .await;
+            }
+            Ok(Err(err)) => warn!("failed to connect Noise remote exec-server websocket: {err}"),
+            Err(_) => warn!("timed out connecting Noise remote exec-server websocket"),
+        }
+
+        sleep(backoff).await;
+        backoff = (backoff * 2).min(Duration::from_secs(30));
+    }
+}
+
+fn validate_environment_id(environment_id: &str) -> Result<(), ExecServerError> {
+    if environment_id.len() > MAX_REMOTE_ENVIRONMENT_ID_LEN {
+        return Err(ExecServerError::EnvironmentRegistryConfig(format!(
+            "environment id cannot be longer than {MAX_REMOTE_ENVIRONMENT_ID_LEN} characters"
+        )));
+    }
+    // The ID is interpolated into authenticated registry request paths below.
+    // Keep it to one URL path component so a caller cannot use a delimiter to
+    // redirect the exec-server's registration credential to another endpoint.
+    if !environment_id
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+    {
+        return Err(ExecServerError::EnvironmentRegistryConfig(
+            "environment id must contain only ASCII letters, numbers, '-' or '_'".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_executor_registration_id(
+    executor_registration_id: &str,
+) -> Result<(), ExecServerError> {
+    if executor_registration_id.is_empty()
+        || executor_registration_id.trim() != executor_registration_id
+        || executor_registration_id.len() > MAX_EXECUTOR_REGISTRATION_ID_LEN
+    {
+        return Err(ExecServerError::Protocol(
+            "environment registry returned an invalid executor registration id".to_string(),
+        ));
+    }
+    Ok(())
+}

--- a/codex-rs/exec-server/src/remote/noise.rs
+++ b/codex-rs/exec-server/src/remote/noise.rs
@@ -23,9 +23,9 @@ use super::endpoint_url;
 use crate::ExecServerError;
 use crate::NoiseChannelIdentity;
 use crate::NoiseChannelPublicKey;
-use crate::noise_relay::HarnessKeyValidator;
+use crate::noise_relay::environment::HarnessKeyValidator;
+use crate::noise_relay::environment::run_noise_multiplexed_environment;
 use crate::noise_relay::noise_relay_websocket_config;
-use crate::noise_relay::run_noise_multiplexed_environment;
 use crate::server::ConnectionProcessor;
 
 const ENVIRONMENT_REGISTRY_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);


### PR DESCRIPTION
Stack (merge in order):

1. [#26239](https://github.com/openai/codex/pull/26239)
2. [#26241](https://github.com/openai/codex/pull/26241)
3. [#26242](https://github.com/openai/codex/pull/26242)
4. [#26243](https://github.com/openai/codex/pull/26243)
5. [#26240](https://github.com/openai/codex/pull/26240)
6. [#26247](https://github.com/openai/codex/pull/26247)
7. **[#26273](https://github.com/openai/codex/pull/26273)**
8. [#26246](https://github.com/openai/codex/pull/26246)
9. [#26244](https://github.com/openai/codex/pull/26244)
10. [#26245](https://github.com/openai/codex/pull/26245)