### PR TITLE
[codex] Add remote plugin IDs to plugin analytics events

### DIFF
--- a/codex-rs/analytics/src/analytics_capture.rs
+++ b/codex-rs/analytics/src/analytics_capture.rs
@@ -1,0 +1,26 @@
+use crate::events::TrackEventsRequest;
+use std::fs::OpenOptions;
+use std::io;
+use std::io::Write;
+use std::path::Path;
+
+pub(crate) const ANALYTICS_EVENTS_CAPTURE_FILE_ENV_VAR: &str =
+    "CODEX_ANALYTICS_EVENTS_CAPTURE_FILE";
+
+pub(crate) fn append_payload(path: &Path, payload: &TrackEventsRequest) -> io::Result<()> {
+    let mut line = serde_json::to_vec(payload)
+        .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
+    line.push(b'\n');
+
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    let mut file = options.open(path)?;
+    file.write_all(&line)?;
+    file.flush()
+}

--- a/codex-rs/analytics/src/analytics_capture.rs
+++ b/codex-rs/analytics/src/analytics_capture.rs
@@ -1,4 +1,5 @@
 use crate::events::TrackEventsRequest;
+use std::fs::File;
 use std::fs::OpenOptions;
 use std::io;
 use std::io::Write;
@@ -7,11 +8,21 @@ use std::path::Path;
 pub(crate) const ANALYTICS_EVENTS_CAPTURE_FILE_ENV_VAR: &str =
     "CODEX_ANALYTICS_EVENTS_CAPTURE_FILE";
 
+pub(crate) fn initialize(path: &Path) -> io::Result<()> {
+    open_capture_file(path).map(drop)
+}
+
 pub(crate) fn append_payload(path: &Path, payload: &TrackEventsRequest) -> io::Result<()> {
     let mut line = serde_json::to_vec(payload)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidData, err))?;
     line.push(b'\n');
 
+    let mut file = open_capture_file(path)?;
+    file.write_all(&line)?;
+    file.flush()
+}
+
+fn open_capture_file(path: &Path) -> io::Result<File> {
     let mut options = OpenOptions::new();
     options.create(true).append(true);
     #[cfg(unix)]
@@ -19,8 +30,5 @@ pub(crate) fn append_payload(path: &Path, payload: &TrackEventsRequest) -> io::R
         use std::os::unix::fs::OpenOptionsExt;
         options.mode(0o600);
     }
-
-    let mut file = options.open(path)?;
-    file.write_all(&line)?;
-    file.flush()
+    options.open(path)
 }

--- a/codex-rs/analytics/src/analytics_client_tests.rs
+++ b/codex-rs/analytics/src/analytics_client_tests.rs
@@ -2877,6 +2877,7 @@ fn plugin_used_event_serializes_expected_shape() {
             "event_type": "codex_plugin_used",
             "event_params": {
                 "plugin_id": "sample@test",
+                "remote_plugin_id": null,
                 "plugin_name": "sample",
                 "marketplace_name": "test",
                 "has_skills": true,
@@ -2907,6 +2908,7 @@ fn plugin_management_event_serializes_expected_shape() {
             "event_type": "codex_plugin_installed",
             "event_params": {
                 "plugin_id": "sample@test",
+                "remote_plugin_id": null,
                 "plugin_name": "sample",
                 "marketplace_name": "test",
                 "has_skills": true,
@@ -2919,7 +2921,7 @@ fn plugin_management_event_serializes_expected_shape() {
 }
 
 #[test]
-fn plugin_management_event_can_use_remote_plugin_id_override() {
+fn plugin_management_event_serializes_local_and_remote_plugin_ids() {
     let mut plugin = sample_plugin_metadata();
     plugin.remote_plugin_id = Some("plugins~Plugin_remote".to_string());
     let event = TrackEventRequest::PluginInstalled(CodexPluginEventRequest {
@@ -2929,8 +2931,9 @@ fn plugin_management_event_can_use_remote_plugin_id_override() {
 
     let payload = serde_json::to_value(&event).expect("serialize plugin installed event");
 
+    assert_eq!(payload["event_params"]["plugin_id"], "sample@test");
     assert_eq!(
-        payload["event_params"]["plugin_id"],
+        payload["event_params"]["remote_plugin_id"],
         "plugins~Plugin_remote"
     );
     assert_eq!(payload["event_params"]["plugin_name"], "sample");
@@ -3274,6 +3277,7 @@ async fn reducer_ingests_plugin_state_changed_fact() {
             "event_type": "codex_plugin_disabled",
             "event_params": {
                 "plugin_id": "sample@test",
+                "remote_plugin_id": null,
                 "plugin_name": "sample",
                 "marketplace_name": "test",
                 "has_skills": true,

--- a/codex-rs/analytics/src/client.rs
+++ b/codex-rs/analytics/src/client.rs
@@ -79,6 +79,12 @@ impl AnalyticsEventsDestination {
     fn from_base_url_and_capture_file(base_url: String, capture_file: Option<PathBuf>) -> Self {
         #[cfg(debug_assertions)]
         if let Some(path) = capture_file {
+            if let Err(err) = crate::analytics_capture::initialize(&path) {
+                tracing::error!(
+                    path = %path.display(),
+                    "failed to initialize analytics event capture; network delivery remains disabled: {err}"
+                );
+            }
             tracing::warn!(
                 path = %path.display(),
                 "analytics event capture enabled; network delivery is disabled"

--- a/codex-rs/analytics/src/client.rs
+++ b/codex-rs/analytics/src/client.rs
@@ -37,6 +37,7 @@ use codex_login::default_client::create_client;
 use codex_plugin::PluginTelemetryMetadata;
 use codex_protocol::request_permissions::RequestPermissionsResponse;
 use std::collections::HashSet;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
@@ -58,15 +59,64 @@ pub struct AnalyticsEventsClient {
     queue: Option<AnalyticsEventsQueue>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum AnalyticsEventsDestination {
+    Http {
+        url: String,
+    },
+    #[cfg(debug_assertions)]
+    CaptureFile {
+        path: PathBuf,
+    },
+}
+
+impl AnalyticsEventsDestination {
+    fn from_base_url(base_url: String) -> Self {
+        let capture_file = analytics_capture_file_from_env();
+        Self::from_base_url_and_capture_file(base_url, capture_file)
+    }
+
+    fn from_base_url_and_capture_file(base_url: String, capture_file: Option<PathBuf>) -> Self {
+        #[cfg(debug_assertions)]
+        if let Some(path) = capture_file {
+            tracing::warn!(
+                path = %path.display(),
+                "analytics event capture enabled; network delivery is disabled"
+            );
+            return Self::CaptureFile { path };
+        }
+
+        #[cfg(not(debug_assertions))]
+        let _ = capture_file;
+
+        let base_url = base_url.trim_end_matches('/');
+        Self::Http {
+            url: format!("{base_url}/codex/analytics-events/events"),
+        }
+    }
+}
+
+fn analytics_capture_file_from_env() -> Option<PathBuf> {
+    #[cfg(debug_assertions)]
+    {
+        std::env::var_os(crate::analytics_capture::ANALYTICS_EVENTS_CAPTURE_FILE_ENV_VAR)
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+    }
+
+    #[cfg(not(debug_assertions))]
+    None
+}
+
 impl AnalyticsEventsQueue {
-    pub(crate) fn new(auth_manager: Arc<AuthManager>, base_url: String) -> Self {
+    fn new(auth_manager: Arc<AuthManager>, destination: AnalyticsEventsDestination) -> Self {
         let (sender, mut receiver) = mpsc::channel(ANALYTICS_EVENTS_QUEUE_SIZE);
         tokio::spawn(async move {
             let mut reducer = AnalyticsReducer::default();
             while let Some(input) = receiver.recv().await {
                 let mut events = Vec::new();
                 reducer.ingest(input, &mut events).await;
-                send_track_events(&auth_manager, &base_url, events).await;
+                send_track_events(&auth_manager, &destination, events).await;
             }
         });
         Self {
@@ -123,9 +173,10 @@ impl AnalyticsEventsClient {
         base_url: String,
         analytics_enabled: Option<bool>,
     ) -> Self {
+        let destination = AnalyticsEventsDestination::from_base_url(base_url);
         Self {
             queue: (analytics_enabled != Some(false))
-                .then(|| AnalyticsEventsQueue::new(Arc::clone(&auth_manager), base_url)),
+                .then(|| AnalyticsEventsQueue::new(Arc::clone(&auth_manager), destination)),
         }
     }
 
@@ -403,7 +454,7 @@ impl AnalyticsEventsClient {
 
 async fn send_track_events(
     auth_manager: &AuthManager,
-    base_url: &str,
+    destination: &AnalyticsEventsDestination,
     events: Vec<TrackEventRequest>,
 ) {
     if events.is_empty() {
@@ -417,10 +468,8 @@ async fn send_track_events(
         return;
     }
 
-    let base_url = base_url.trim_end_matches('/');
-    let url = format!("{base_url}/codex/analytics-events/events");
     for events in track_event_request_batches(events) {
-        send_track_events_request(&auth, &url, events).await;
+        send_track_events_request(&auth, destination, events).await;
     }
 }
 
@@ -447,13 +496,27 @@ fn track_event_request_batches(events: Vec<TrackEventRequest>) -> Vec<Vec<TrackE
     batches
 }
 
-async fn send_track_events_request(auth: &CodexAuth, url: &str, events: Vec<TrackEventRequest>) {
+async fn send_track_events_request(
+    auth: &CodexAuth,
+    destination: &AnalyticsEventsDestination,
+    events: Vec<TrackEventRequest>,
+) {
     if events.is_empty() {
         return;
     }
 
     let payload = TrackEventsRequest { events };
 
+    #[cfg(debug_assertions)]
+    if capture_track_events_request(destination, &payload) {
+        return;
+    }
+
+    let url = match destination {
+        AnalyticsEventsDestination::Http { url } => url,
+        #[cfg(debug_assertions)]
+        AnalyticsEventsDestination::CaptureFile { .. } => return,
+    };
     let response = create_client()
         .post(url)
         .timeout(ANALYTICS_EVENTS_TIMEOUT)
@@ -474,6 +537,24 @@ async fn send_track_events_request(auth: &CodexAuth, url: &str, events: Vec<Trac
             tracing::warn!("failed to send events request: {err}");
         }
     }
+}
+
+#[cfg(debug_assertions)]
+fn capture_track_events_request(
+    destination: &AnalyticsEventsDestination,
+    payload: &TrackEventsRequest,
+) -> bool {
+    let AnalyticsEventsDestination::CaptureFile { path } = destination else {
+        return false;
+    };
+
+    if let Err(err) = crate::analytics_capture::append_payload(path, payload) {
+        tracing::error!(
+            path = %path.display(),
+            "failed to capture analytics events; network delivery remains disabled: {err}"
+        );
+    }
+    true
 }
 
 #[cfg(test)]

--- a/codex-rs/analytics/src/client_tests.rs
+++ b/codex-rs/analytics/src/client_tests.rs
@@ -111,8 +111,25 @@ fn analytics_destination_uses_explicit_capture_file() {
 
     assert_eq!(
         destination,
-        AnalyticsEventsDestination::CaptureFile { path: capture_path }
+        AnalyticsEventsDestination::CaptureFile {
+            path: capture_path.clone()
+        }
     );
+    assert_eq!(
+        fs::read_to_string(&capture_path).expect("read capture file"),
+        ""
+    );
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mode = fs::metadata(&capture_path)
+            .expect("read capture file metadata")
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600);
+    }
+    fs::remove_file(capture_path).expect("remove capture file");
 }
 
 #[test]

--- a/codex-rs/analytics/src/client_tests.rs
+++ b/codex-rs/analytics/src/client_tests.rs
@@ -1,7 +1,9 @@
 use super::AnalyticsEventsClient;
 use super::AnalyticsEventsDestination;
 use super::AnalyticsEventsQueue;
+#[cfg(debug_assertions)]
 use super::capture_track_events_request;
+#[cfg(debug_assertions)]
 use super::send_track_events_request;
 use super::track_event_request_batches;
 use crate::events::CodexAcceptedLineFingerprintsEventParams;
@@ -34,10 +36,13 @@ use codex_app_server_protocol::TurnSteerResponse;
 use codex_utils_absolute_path::test_support::PathBufExt;
 use codex_utils_absolute_path::test_support::test_path_buf;
 use std::collections::HashSet;
+#[cfg(debug_assertions)]
 use std::fs;
+#[cfg(debug_assertions)]
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
+#[cfg(debug_assertions)]
 use std::time::SystemTime;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TryRecvError;
@@ -80,6 +85,7 @@ fn sample_regular_track_event(thread_id: &str) -> TrackEventRequest {
     })
 }
 
+#[cfg(debug_assertions)]
 fn unique_capture_path(name: &str) -> PathBuf {
     let nonce = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
@@ -102,6 +108,7 @@ fn client_with_receiver() -> (AnalyticsEventsClient, mpsc::Receiver<AnalyticsFac
 }
 
 #[test]
+#[cfg(debug_assertions)]
 fn analytics_destination_uses_explicit_capture_file() {
     let capture_path = unique_capture_path("destination");
     let destination = AnalyticsEventsDestination::from_base_url_and_capture_file(
@@ -147,7 +154,24 @@ fn analytics_destination_uses_http_without_capture_file() {
     );
 }
 
+#[test]
+#[cfg(not(debug_assertions))]
+fn analytics_destination_ignores_capture_file_in_release() {
+    let destination = AnalyticsEventsDestination::from_base_url_and_capture_file(
+        "https://chatgpt.com/backend-api/".to_string(),
+        Some(std::path::PathBuf::from("ignored.jsonl")),
+    );
+
+    assert_eq!(
+        destination,
+        AnalyticsEventsDestination::Http {
+            url: "https://chatgpt.com/backend-api/codex/analytics-events/events".to_string()
+        }
+    );
+}
+
 #[tokio::test]
+#[cfg(debug_assertions)]
 async fn capture_file_writes_exact_serialized_request() {
     let capture_path = unique_capture_path("single");
     let destination = AnalyticsEventsDestination::CaptureFile {
@@ -170,6 +194,7 @@ async fn capture_file_writes_exact_serialized_request() {
 }
 
 #[tokio::test]
+#[cfg(debug_assertions)]
 async fn capture_file_writes_final_batches_as_separate_lines() {
     let capture_path = unique_capture_path("batches");
     let destination = AnalyticsEventsDestination::CaptureFile {
@@ -203,6 +228,7 @@ async fn capture_file_writes_final_batches_as_separate_lines() {
 }
 
 #[test]
+#[cfg(debug_assertions)]
 fn capture_write_failure_still_consumes_delivery() {
     let capture_path = unique_capture_path("missing-parent").join("events.jsonl");
     let destination = AnalyticsEventsDestination::CaptureFile { path: capture_path };

--- a/codex-rs/analytics/src/client_tests.rs
+++ b/codex-rs/analytics/src/client_tests.rs
@@ -143,7 +143,7 @@ fn analytics_destination_uses_explicit_capture_file() {
 fn analytics_destination_uses_http_without_capture_file() {
     let destination = AnalyticsEventsDestination::from_base_url_and_capture_file(
         "https://chatgpt.com/backend-api/".to_string(),
-        None,
+        /*capture_file*/ None,
     );
 
     assert_eq!(

--- a/codex-rs/analytics/src/client_tests.rs
+++ b/codex-rs/analytics/src/client_tests.rs
@@ -1,5 +1,8 @@
 use super::AnalyticsEventsClient;
+use super::AnalyticsEventsDestination;
 use super::AnalyticsEventsQueue;
+use super::capture_track_events_request;
+use super::send_track_events_request;
 use super::track_event_request_batches;
 use crate::events::CodexAcceptedLineFingerprintsEventParams;
 use crate::events::CodexAcceptedLineFingerprintsEventRequest;
@@ -31,8 +34,11 @@ use codex_app_server_protocol::TurnSteerResponse;
 use codex_utils_absolute_path::test_support::PathBufExt;
 use codex_utils_absolute_path::test_support::test_path_buf;
 use std::collections::HashSet;
+use std::fs;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::time::SystemTime;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TryRecvError;
 
@@ -74,6 +80,17 @@ fn sample_regular_track_event(thread_id: &str) -> TrackEventRequest {
     })
 }
 
+fn unique_capture_path(name: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("system clock should be after Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "codex-analytics-{name}-{}-{nonce}.jsonl",
+        std::process::id()
+    ))
+}
+
 fn client_with_receiver() -> (AnalyticsEventsClient, mpsc::Receiver<AnalyticsFact>) {
     let (sender, receiver) = mpsc::channel(8);
     let queue = AnalyticsEventsQueue {
@@ -82,6 +99,101 @@ fn client_with_receiver() -> (AnalyticsEventsClient, mpsc::Receiver<AnalyticsFac
         plugin_used_emitted_keys: Arc::new(Mutex::new(HashSet::new())),
     };
     (AnalyticsEventsClient { queue: Some(queue) }, receiver)
+}
+
+#[test]
+fn analytics_destination_uses_explicit_capture_file() {
+    let capture_path = unique_capture_path("destination");
+    let destination = AnalyticsEventsDestination::from_base_url_and_capture_file(
+        "https://chatgpt.com/backend-api/".to_string(),
+        Some(capture_path.clone()),
+    );
+
+    assert_eq!(
+        destination,
+        AnalyticsEventsDestination::CaptureFile { path: capture_path }
+    );
+}
+
+#[test]
+fn analytics_destination_uses_http_without_capture_file() {
+    let destination = AnalyticsEventsDestination::from_base_url_and_capture_file(
+        "https://chatgpt.com/backend-api/".to_string(),
+        None,
+    );
+
+    assert_eq!(
+        destination,
+        AnalyticsEventsDestination::Http {
+            url: "https://chatgpt.com/backend-api/codex/analytics-events/events".to_string()
+        }
+    );
+}
+
+#[tokio::test]
+async fn capture_file_writes_exact_serialized_request() {
+    let capture_path = unique_capture_path("single");
+    let destination = AnalyticsEventsDestination::CaptureFile {
+        path: capture_path.clone(),
+    };
+    let event = sample_regular_track_event("thread-1");
+    let expected_event = serde_json::to_value(&event).expect("serialize expected event");
+    let auth = codex_login::CodexAuth::create_dummy_chatgpt_auth_for_testing();
+
+    send_track_events_request(&auth, &destination, vec![event]).await;
+
+    let contents = fs::read_to_string(&capture_path).expect("read capture file");
+    let lines = contents.lines().collect::<Vec<_>>();
+    assert_eq!(lines.len(), 1);
+    let payload: serde_json::Value =
+        serde_json::from_str(lines[0]).expect("parse captured payload");
+    assert_eq!(payload, serde_json::json!({"events": [expected_event]}));
+
+    fs::remove_file(capture_path).expect("remove capture file");
+}
+
+#[tokio::test]
+async fn capture_file_writes_final_batches_as_separate_lines() {
+    let capture_path = unique_capture_path("batches");
+    let destination = AnalyticsEventsDestination::CaptureFile {
+        path: capture_path.clone(),
+    };
+    let auth = codex_login::CodexAuth::create_dummy_chatgpt_auth_for_testing();
+    let events = vec![
+        sample_regular_track_event("thread-1"),
+        sample_accepted_line_fingerprint_event("thread-2"),
+        sample_regular_track_event("thread-3"),
+    ];
+
+    for batch in track_event_request_batches(events) {
+        send_track_events_request(&auth, &destination, batch).await;
+    }
+
+    let contents = fs::read_to_string(&capture_path).expect("read capture file");
+    let payloads = contents
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("parse capture line"))
+        .collect::<Vec<_>>();
+    assert_eq!(payloads.len(), 3);
+    assert_eq!(payloads[0]["events"][0]["skill_id"], "skill-thread-1");
+    assert_eq!(
+        payloads[1]["events"][0]["event_type"],
+        "codex_accepted_line_fingerprints"
+    );
+    assert_eq!(payloads[2]["events"][0]["skill_id"], "skill-thread-3");
+
+    fs::remove_file(capture_path).expect("remove capture file");
+}
+
+#[test]
+fn capture_write_failure_still_consumes_delivery() {
+    let capture_path = unique_capture_path("missing-parent").join("events.jsonl");
+    let destination = AnalyticsEventsDestination::CaptureFile { path: capture_path };
+    let payload = crate::events::TrackEventsRequest {
+        events: vec![sample_regular_track_event("thread-1")],
+    };
+
+    assert!(capture_track_events_request(&destination, &payload));
 }
 
 fn sample_turn_start_request() -> ClientRequest {

--- a/codex-rs/analytics/src/events.rs
+++ b/codex-rs/analytics/src/events.rs
@@ -863,6 +863,7 @@ pub(crate) struct CodexTurnSteerEventRequest {
 #[derive(Serialize)]
 pub(crate) struct CodexPluginMetadata {
     pub(crate) plugin_id: Option<String>,
+    pub(crate) remote_plugin_id: Option<String>,
     pub(crate) plugin_name: Option<String>,
     pub(crate) marketplace_name: Option<String>,
     pub(crate) has_skills: Option<bool>,
@@ -923,9 +924,9 @@ pub(crate) fn codex_plugin_metadata(plugin: PluginTelemetryMetadata) -> CodexPlu
         remote_plugin_id,
         capability_summary,
     } = plugin;
-    let event_plugin_id = remote_plugin_id.unwrap_or_else(|| plugin_id.as_key());
     CodexPluginMetadata {
-        plugin_id: Some(event_plugin_id),
+        plugin_id: Some(plugin_id.as_key()),
+        remote_plugin_id,
         plugin_name: Some(plugin_id.plugin_name),
         marketplace_name: Some(plugin_id.marketplace_name),
         has_skills: capability_summary

--- a/codex-rs/analytics/src/lib.rs
+++ b/codex-rs/analytics/src/lib.rs
@@ -1,4 +1,6 @@
 mod accepted_lines;
+#[cfg(debug_assertions)]
+mod analytics_capture;
 mod client;
 mod events;
 mod facts;

--- a/codex-rs/app-server-test-client/Cargo.toml
+++ b/codex-rs/app-server-test-client/Cargo.toml
@@ -25,5 +25,4 @@ url = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
 [lib]
-test = false
 doctest = false

--- a/codex-rs/app-server-test-client/README.md
+++ b/codex-rs/app-server-test-client/README.md
@@ -18,6 +18,33 @@ cargo run -p codex-app-server-test-client -- \
 cargo run -p codex-app-server-test-client -- model-list
 ```
 
+## Testing Plugin Analytics
+
+The `plugin-analytics-smoke` command exercises `plugin/installed`, plugin
+enable/disable config writes, and a structured plugin mention through one
+app-server connection. Analytics are captured to a local JSONL file and are
+not sent to the analytics backend. The model turn uses a loopback Responses
+API server.
+
+The selected plugin must already be installed remotely, and the active Codex
+profile must be authenticated.
+
+```bash
+# Build a debug Codex binary; analytics capture is unavailable in release builds.
+cargo build -p codex-cli --bin codex
+
+cargo run -p codex-app-server-test-client -- \
+  --codex-bin ./target/debug/codex \
+  plugin-analytics-smoke \
+  --plugin-id linear@openai-curated-remote
+```
+
+Use `--capture-file /tmp/plugin-analytics.jsonl` to select the output path.
+The command validates one `codex_plugin_disabled`, `codex_plugin_enabled`, and
+`codex_plugin_used` event, prints them, and leaves the JSONL file in place for
+inspection. It does not install or uninstall plugins and does not modify the
+profile's persistent config.
+
 ## Watching Raw Inbound Traffic
 
 Initialize a connection, then print every inbound JSON-RPC message until you stop it with

--- a/codex-rs/app-server-test-client/README.md
+++ b/codex-rs/app-server-test-client/README.md
@@ -45,6 +45,53 @@ The command validates one `codex_plugin_disabled`, `codex_plugin_enabled`, and
 inspection. It does not install or uninstall plugins and does not modify the
 profile's persistent config.
 
+### Testing remote install and uninstall analytics
+
+`plugin-analytics-mutation-smoke` is a manually invoked live smoke test. It
+contacts the configured remote plugin API and temporarily changes the active
+account's installed-plugin state. It is not run by `cargo test`, `just test`,
+or CI.
+
+Choose a remote plugin that is available to the active account and is not
+currently installed. The command refuses to run when the plugin is already
+installed, installs it, validates `codex_plugin_installed`, uninstalls it,
+validates `codex_plugin_uninstalled`, and verifies that the original
+uninstalled state was restored.
+
+`--remote-plugin-id` takes the backend ID, such as `plugins~Plugin_...`, not the
+local `<plugin>@<marketplace>` ID.
+
+```bash
+cargo run -p codex-app-server-test-client -- \
+  --codex-bin ./target/debug/codex \
+  plugin-analytics-mutation-smoke \
+  --remote-plugin-id <REMOTE_PLUGIN_ID> \
+  --confirm-account-mutation \
+  --capture-file /tmp/plugin-mutation-analytics.jsonl
+```
+
+Analytics use the normal queue, reduction, batching, and serialization path,
+but the debug capture destination suppresses analytics network delivery. The
+command prints one of these final states:
+
+- `PASS`: both events validated and the plugin is uninstalled.
+- `FAIL-CLEAN`: validation failed, but the original uninstalled state was
+  restored.
+- `FAIL-LOCAL-CACHE`: the backend is uninstalled, but local cleanup reported
+  an error.
+- `FAIL-DIRTY`: cleanup failed and the plugin still appears installed.
+- `FAIL-UNKNOWN`: the command could not verify the final installed state.
+
+For a dirty or uncertain result, retry cleanup with:
+
+```bash
+cargo run -p codex-app-server-test-client -- \
+  --codex-bin ./target/debug/codex \
+  plugin-remote-uninstall \
+  --remote-plugin-id <REMOTE_PLUGIN_ID> \
+  --confirm-account-mutation
+```
+
 ## Watching Raw Inbound Traffic
 
 Initialize a connection, then print every inbound JSON-RPC message until you stop it with

--- a/codex-rs/app-server-test-client/src/lib.rs
+++ b/codex-rs/app-server-test-client/src/lib.rs
@@ -87,6 +87,8 @@ use url::Url;
 use uuid::Uuid;
 
 mod loopback_responses_server;
+mod plugin_analytics_capture;
+mod plugin_analytics_mutation_smoke;
 mod plugin_analytics_smoke;
 
 const NOTIFICATIONS_TO_OPT_OUT: &[&str] = &[
@@ -284,6 +286,32 @@ enum CliCommand {
         #[arg(long)]
         capture_file: Option<PathBuf>,
     },
+    /// Install and uninstall one remote plugin while validating analytics capture.
+    #[command(name = "plugin-analytics-mutation-smoke")]
+    PluginAnalyticsMutationSmoke {
+        /// Backend remote plugin id. The plugin must be initially uninstalled.
+        #[arg(long)]
+        remote_plugin_id: String,
+        /// Acknowledge that this command mutates the active account's plugin state.
+        #[arg(long)]
+        confirm_account_mutation: bool,
+        /// JSONL output path. Defaults to a PID-specific file under the system temp directory.
+        #[arg(long)]
+        capture_file: Option<PathBuf>,
+    },
+    /// Best-effort recovery command that uninstalls one remote plugin.
+    #[command(name = "plugin-remote-uninstall")]
+    PluginRemoteUninstall {
+        /// Backend remote plugin id to uninstall.
+        #[arg(long)]
+        remote_plugin_id: String,
+        /// Acknowledge that this command mutates the active account's plugin state.
+        #[arg(long)]
+        confirm_account_mutation: bool,
+        /// JSONL output path. Defaults to a PID-specific file under the system temp directory.
+        #[arg(long)]
+        capture_file: Option<PathBuf>,
+    },
 }
 
 pub async fn run() -> Result<()> {
@@ -445,6 +473,49 @@ pub async fn run() -> Result<()> {
             }
             let codex_bin = codex_bin.context("plugin-analytics-smoke requires --codex-bin")?;
             plugin_analytics_smoke::run(&codex_bin, &config_overrides, &plugin_id, capture_file)
+        }
+        CliCommand::PluginAnalyticsMutationSmoke {
+            remote_plugin_id,
+            confirm_account_mutation,
+            capture_file,
+        } => {
+            ensure_dynamic_tools_unused(&dynamic_tools, "plugin-analytics-mutation-smoke")?;
+            if url.is_some() {
+                bail!(
+                    "plugin-analytics-mutation-smoke requires --codex-bin and does not support --url"
+                );
+            }
+            let codex_bin =
+                codex_bin.context("plugin-analytics-mutation-smoke requires --codex-bin")?;
+            plugin_analytics_mutation_smoke::run(
+                &codex_bin,
+                &config_overrides,
+                &remote_plugin_id,
+                plugin_analytics_mutation_smoke::AccountMutationConfirmation::from_flag(
+                    confirm_account_mutation,
+                ),
+                capture_file,
+            )
+        }
+        CliCommand::PluginRemoteUninstall {
+            remote_plugin_id,
+            confirm_account_mutation,
+            capture_file,
+        } => {
+            ensure_dynamic_tools_unused(&dynamic_tools, "plugin-remote-uninstall")?;
+            if url.is_some() {
+                bail!("plugin-remote-uninstall requires --codex-bin and does not support --url");
+            }
+            let codex_bin = codex_bin.context("plugin-remote-uninstall requires --codex-bin")?;
+            plugin_analytics_mutation_smoke::run_cleanup(
+                &codex_bin,
+                &config_overrides,
+                &remote_plugin_id,
+                plugin_analytics_mutation_smoke::AccountMutationConfirmation::from_flag(
+                    confirm_account_mutation,
+                ),
+                capture_file,
+            )
         }
     }
 }

--- a/codex-rs/app-server-test-client/src/lib.rs
+++ b/codex-rs/app-server-test-client/src/lib.rs
@@ -86,6 +86,9 @@ use tungstenite::stream::MaybeTlsStream;
 use url::Url;
 use uuid::Uuid;
 
+mod loopback_responses_server;
+mod plugin_analytics_smoke;
+
 const NOTIFICATIONS_TO_OPT_OUT: &[&str] = &[
     // v2 item deltas.
     "command/exec/outputDelta",
@@ -271,6 +274,16 @@ enum CliCommand {
         #[arg(long, default_value_t = 15)]
         hold_seconds: u64,
     },
+    /// Exercise remote plugin analytics through production app-server RPC paths.
+    #[command(name = "plugin-analytics-smoke")]
+    PluginAnalyticsSmoke {
+        /// Installed local plugin id, such as `linear@openai-curated-remote`.
+        #[arg(long)]
+        plugin_id: String,
+        /// JSONL output path. Defaults to a PID-specific file under the system temp directory.
+        #[arg(long)]
+        capture_file: Option<PathBuf>,
+    },
 }
 
 pub async fn run() -> Result<()> {
@@ -421,6 +434,17 @@ pub async fn run() -> Result<()> {
                 script,
                 hold_seconds,
             )
+        }
+        CliCommand::PluginAnalyticsSmoke {
+            plugin_id,
+            capture_file,
+        } => {
+            ensure_dynamic_tools_unused(&dynamic_tools, "plugin-analytics-smoke")?;
+            if url.is_some() {
+                bail!("plugin-analytics-smoke requires --codex-bin and does not support --url");
+            }
+            let codex_bin = codex_bin.context("plugin-analytics-smoke requires --codex-bin")?;
+            plugin_analytics_smoke::run(&codex_bin, &config_overrides, &plugin_id, capture_file)
         }
     }
 }
@@ -1437,6 +1461,14 @@ impl CodexClient {
     }
 
     fn spawn_stdio(codex_bin: &Path, config_overrides: &[String]) -> Result<Self> {
+        Self::spawn_stdio_with_env(codex_bin, config_overrides, &[])
+    }
+
+    fn spawn_stdio_with_env(
+        codex_bin: &Path,
+        config_overrides: &[String],
+        environment: &[(OsString, OsString)],
+    ) -> Result<Self> {
         let codex_bin_display = codex_bin.display();
         let mut cmd = Command::new(codex_bin);
         if let Some(codex_bin_parent) = codex_bin.parent() {
@@ -1449,6 +1481,9 @@ impl CodexClient {
         }
         for override_kv in config_overrides {
             cmd.arg("--config").arg(override_kv);
+        }
+        for (name, value) in environment {
+            cmd.env(name, value);
         }
         let mut codex_app_server = cmd
             .arg("app-server")

--- a/codex-rs/app-server-test-client/src/loopback_responses_server.rs
+++ b/codex-rs/app-server-test-client/src/loopback_responses_server.rs
@@ -1,0 +1,145 @@
+use anyhow::Context;
+use anyhow::Result;
+use std::io;
+use std::io::Read;
+use std::io::Write;
+use std::net::TcpListener;
+use std::net::TcpStream;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::thread;
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+pub(super) struct LoopbackResponsesServer {
+    base_url: String,
+    shutdown: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl LoopbackResponsesServer {
+    pub(super) fn start() -> Result<Self> {
+        let listener =
+            TcpListener::bind("127.0.0.1:0").context("bind loopback Responses API server")?;
+        listener
+            .set_nonblocking(true)
+            .context("set loopback Responses API server nonblocking")?;
+        let address = listener.local_addr()?;
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let thread_shutdown = Arc::clone(&shutdown);
+        let thread = thread::spawn(move || {
+            while !thread_shutdown.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        if let Err(err) = handle_model_connection(stream) {
+                            eprintln!("loopback Responses API server error: {err}");
+                        }
+                    }
+                    Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(err) => {
+                        eprintln!("loopback Responses API accept error: {err}");
+                        break;
+                    }
+                }
+            }
+        });
+        Ok(Self {
+            base_url: format!("http://{address}"),
+            shutdown,
+            thread: Some(thread),
+        })
+    }
+
+    pub(super) fn base_url(&self) -> &str {
+        &self.base_url
+    }
+}
+
+impl Drop for LoopbackResponsesServer {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn handle_model_connection(mut stream: TcpStream) -> io::Result<()> {
+    stream.set_nonblocking(false)?;
+    stream.set_read_timeout(Some(Duration::from_secs(2)))?;
+    let request = read_http_request(&mut stream)?;
+    let request_line = request
+        .split(|byte| *byte == b'\n')
+        .next()
+        .and_then(|line| std::str::from_utf8(line).ok())
+        .unwrap_or_default();
+    if request_line.starts_with("POST ") && request_line.contains("/responses ") {
+        let body = concat!(
+            "event: response.created\n",
+            "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp-plugin-analytics\"}}\n\n",
+            "event: response.completed\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp-plugin-analytics\",\"usage\":{\"input_tokens\":0,\"input_tokens_details\":null,\"output_tokens\":0,\"output_tokens_details\":null,\"total_tokens\":0}}}\n\n"
+        );
+        write_http_response(&mut stream, "200 OK", "text/event-stream", body)
+    } else {
+        write_http_response(
+            &mut stream,
+            "404 Not Found",
+            "application/json",
+            r#"{"error":"not found"}"#,
+        )
+    }
+}
+
+fn read_http_request(stream: &mut TcpStream) -> io::Result<Vec<u8>> {
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 4096];
+    let header_end = loop {
+        let read = stream.read(&mut buffer)?;
+        if read == 0 {
+            return Ok(request);
+        }
+        request.extend_from_slice(&buffer[..read]);
+        if let Some(position) = request.windows(4).position(|window| window == b"\r\n\r\n") {
+            break position + 4;
+        }
+    };
+    let content_length = parse_content_length(&request[..header_end]);
+    while request.len() < header_end + content_length {
+        let read = stream.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        request.extend_from_slice(&buffer[..read]);
+    }
+    Ok(request)
+}
+
+fn parse_content_length(headers: &[u8]) -> usize {
+    String::from_utf8_lossy(headers)
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse().ok())
+                .flatten()
+        })
+        .unwrap_or(0)
+}
+
+fn write_http_response(
+    stream: &mut TcpStream,
+    status: &str,
+    content_type: &str,
+    body: &str,
+) -> io::Result<()> {
+    write!(
+        stream,
+        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    )?;
+    stream.flush()
+}

--- a/codex-rs/app-server-test-client/src/plugin_analytics_capture.rs
+++ b/codex-rs/app-server-test-client/src/plugin_analytics_capture.rs
@@ -1,0 +1,134 @@
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::bail;
+use serde_json::Value;
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::thread;
+use std::time::Duration;
+use std::time::Instant;
+
+const CAPTURE_READY_TIMEOUT: Duration = Duration::from_secs(5);
+const CAPTURE_READY_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+pub(super) fn wait_until_capture_is_ready(path: &Path) -> Result<()> {
+    let deadline = Instant::now() + CAPTURE_READY_TIMEOUT;
+    loop {
+        match fs::metadata(path) {
+            Ok(_) => return Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(err)
+                    .with_context(|| format!("inspect capture file {}", path.display()));
+            }
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "analytics capture did not become ready at {}; use an authenticated profile and a debug Codex binary",
+                path.display()
+            );
+        }
+        thread::sleep(CAPTURE_READY_POLL_INTERVAL);
+    }
+}
+
+pub(super) fn read_events_for_remote_plugin(
+    path: &Path,
+    remote_plugin_id: &str,
+) -> Result<Vec<Value>> {
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => {
+            return Err(err).with_context(|| format!("read capture file {}", path.display()));
+        }
+    };
+    let mut matching = Vec::new();
+    for (index, line) in contents.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let payload: Value = serde_json::from_str(line).with_context(|| {
+            format!(
+                "parse analytics capture line {} from {}",
+                index + 1,
+                path.display()
+            )
+        })?;
+        let events = payload["events"]
+            .as_array()
+            .context("analytics capture payload is missing events")?;
+        matching.extend(
+            events
+                .iter()
+                .filter(|event| event["event_params"]["remote_plugin_id"] == remote_plugin_id)
+                .cloned(),
+        );
+    }
+    Ok(matching)
+}
+
+pub(super) struct PluginEventIdentity<'a> {
+    pub(super) plugin_id: &'a str,
+    pub(super) remote_plugin_id: &'a str,
+    pub(super) plugin_name: &'a str,
+    pub(super) marketplace_name: &'a str,
+}
+
+pub(super) fn validate_mutation_events(
+    events: Vec<Value>,
+    expected: PluginEventIdentity<'_>,
+) -> Result<Vec<Value>> {
+    let mut validated = Vec::new();
+    for event_type in ["codex_plugin_installed", "codex_plugin_uninstalled"] {
+        let matching = events
+            .iter()
+            .filter(|event| event["event_type"] == event_type)
+            .collect::<Vec<_>>();
+        let [event] = matching.as_slice() else {
+            bail!(
+                "expected exactly one `{event_type}` event for `{}`, found {}",
+                expected.remote_plugin_id,
+                matching.len()
+            );
+        };
+        validate_event(event, &expected)?;
+        validated.push((*event).clone());
+    }
+    Ok(validated)
+}
+
+fn validate_event(event: &Value, expected: &PluginEventIdentity<'_>) -> Result<()> {
+    let params = &event["event_params"];
+    require_string(params, "plugin_id", expected.plugin_id)?;
+    require_string(params, "remote_plugin_id", expected.remote_plugin_id)?;
+    require_string(params, "plugin_name", expected.plugin_name)?;
+    require_string(params, "marketplace_name", expected.marketplace_name)?;
+    for field in [
+        "has_skills",
+        "mcp_server_count",
+        "connector_ids",
+        "product_client_id",
+    ] {
+        if params.get(field).is_none_or(Value::is_null) {
+            bail!(
+                "{} event has null or missing `{field}`",
+                event["event_type"]
+            );
+        }
+    }
+    Ok(())
+}
+
+fn require_string(params: &Value, field: &str, expected: &str) -> Result<()> {
+    let actual = params.get(field).and_then(Value::as_str);
+    if actual != Some(expected) {
+        bail!("expected `{field}` to be `{expected}`, got {actual:?}");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "plugin_analytics_capture_tests.rs"]
+mod tests;

--- a/codex-rs/app-server-test-client/src/plugin_analytics_capture_tests.rs
+++ b/codex-rs/app-server-test-client/src/plugin_analytics_capture_tests.rs
@@ -1,0 +1,107 @@
+use super::PluginEventIdentity;
+use super::read_events_for_remote_plugin;
+use super::validate_mutation_events;
+use serde_json::Value;
+use serde_json::json;
+use std::fs;
+use std::path::PathBuf;
+use std::process;
+use std::time::SystemTime;
+
+const REMOTE_PLUGIN_ID: &str = "plugins~Plugin_test";
+
+#[test]
+fn reads_and_validates_remote_plugin_mutation_events() {
+    let path = unique_capture_path("valid");
+    let installed = mutation_event("codex_plugin_installed");
+    let uninstalled = mutation_event("codex_plugin_uninstalled");
+    let unrelated = json!({
+        "event_type": "codex_plugin_installed",
+        "event_params": {
+            "remote_plugin_id": "plugins~Plugin_other"
+        }
+    });
+    let contents = [
+        json!({"events": [unrelated]}),
+        json!({"events": [installed]}),
+        json!({"events": [uninstalled]}),
+    ]
+    .into_iter()
+    .map(|payload| serde_json::to_string(&payload).expect("serialize capture payload"))
+    .collect::<Vec<_>>()
+    .join("\n");
+    fs::write(&path, contents).expect("write capture file");
+
+    let events = read_events_for_remote_plugin(&path, REMOTE_PLUGIN_ID)
+        .expect("read matching plugin events");
+    let validated =
+        validate_mutation_events(events, expected_identity()).expect("validate mutation events");
+
+    assert_eq!(validated, vec![installed, uninstalled]);
+    fs::remove_file(path).expect("remove capture file");
+}
+
+#[test]
+fn rejects_duplicate_mutation_events() {
+    let installed = mutation_event("codex_plugin_installed");
+    let error = validate_mutation_events(
+        vec![
+            installed.clone(),
+            installed,
+            mutation_event("codex_plugin_uninstalled"),
+        ],
+        expected_identity(),
+    )
+    .expect_err("duplicate install events should fail validation");
+
+    assert!(error.to_string().contains("found 2"));
+}
+
+#[test]
+fn rejects_missing_capability_metadata() {
+    let mut installed = mutation_event("codex_plugin_installed");
+    installed["event_params"]["has_skills"] = Value::Null;
+    let error = validate_mutation_events(
+        vec![installed, mutation_event("codex_plugin_uninstalled")],
+        expected_identity(),
+    )
+    .expect_err("missing capability metadata should fail validation");
+
+    assert!(error.to_string().contains("has_skills"));
+}
+
+fn mutation_event(event_type: &str) -> Value {
+    json!({
+        "event_type": event_type,
+        "event_params": {
+            "plugin_id": "sample@openai-curated-remote",
+            "remote_plugin_id": REMOTE_PLUGIN_ID,
+            "plugin_name": "sample",
+            "marketplace_name": "openai-curated-remote",
+            "has_skills": true,
+            "mcp_server_count": 0,
+            "connector_ids": [],
+            "product_client_id": "test-client"
+        }
+    })
+}
+
+fn expected_identity() -> PluginEventIdentity<'static> {
+    PluginEventIdentity {
+        plugin_id: "sample@openai-curated-remote",
+        remote_plugin_id: REMOTE_PLUGIN_ID,
+        plugin_name: "sample",
+        marketplace_name: "openai-curated-remote",
+    }
+}
+
+fn unique_capture_path(name: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("system clock should be after Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "codex-plugin-analytics-capture-{name}-{}-{nonce}.jsonl",
+        process::id()
+    ))
+}

--- a/codex-rs/app-server-test-client/src/plugin_analytics_mutation_smoke.rs
+++ b/codex-rs/app-server-test-client/src/plugin_analytics_mutation_smoke.rs
@@ -1,0 +1,497 @@
+use super::CodexClient;
+use super::plugin_analytics_capture::PluginEventIdentity;
+use super::plugin_analytics_capture::read_events_for_remote_plugin;
+use super::plugin_analytics_capture::validate_mutation_events;
+use super::plugin_analytics_capture::wait_until_capture_is_ready;
+use super::plugin_analytics_smoke::ANALYTICS_CAPTURE_ENV_VAR;
+use super::plugin_analytics_smoke::prepare_capture_file;
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use anyhow::bail;
+use codex_app_server_protocol::ClientRequest;
+use codex_app_server_protocol::PluginAvailability;
+use codex_app_server_protocol::PluginInstallParams;
+use codex_app_server_protocol::PluginInstallPolicy;
+use codex_app_server_protocol::PluginInstallResponse;
+use codex_app_server_protocol::PluginReadParams;
+use codex_app_server_protocol::PluginReadResponse;
+use codex_app_server_protocol::PluginUninstallParams;
+use codex_app_server_protocol::PluginUninstallResponse;
+use serde_json::Value;
+use std::ffi::OsString;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process;
+use std::thread;
+use std::time::Duration;
+use std::time::Instant;
+
+const REMOTE_MARKETPLACE_HINT: &str = "openai-curated-remote";
+const STATE_TIMEOUT: Duration = Duration::from_secs(15);
+const CAPTURE_TIMEOUT: Duration = Duration::from_secs(10);
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+pub(super) fn run(
+    codex_bin: &Path,
+    config_overrides: &[String],
+    remote_plugin_id: &str,
+    confirmation: AccountMutationConfirmation,
+    capture_file: Option<PathBuf>,
+) -> Result<()> {
+    require_confirmation(confirmation)?;
+    let capture_path = capture_file.unwrap_or_else(|| {
+        std::env::temp_dir().join(format!(
+            "codex-plugin-analytics-mutation-{}.jsonl",
+            process::id()
+        ))
+    });
+    prepare_capture_file(&capture_path)?;
+    let mut client = spawn_client(codex_bin, config_overrides, &capture_path)?;
+    wait_until_capture_is_ready(&capture_path)?;
+
+    let initial = read_remote_plugin(&mut client, remote_plugin_id)?;
+    validate_initial_plugin(&initial, remote_plugin_id)?;
+    println!(
+        "remote plugin mutation smoke: local_id={} remote_id={} marketplace={}",
+        initial.plugin_id, initial.remote_plugin_id, initial.marketplace_name
+    );
+
+    let MutationSequenceResult {
+        result: sequence_result,
+        uninstall_rpc_failed,
+    } = run_mutation_sequence(&mut client, &capture_path, &initial);
+    let restoration = restore_uninstalled_state(&mut client, remote_plugin_id);
+    println!("capture file: {}", capture_path.display());
+
+    match (sequence_result, restoration) {
+        (Ok(events), RestorationStatus::Clean) => {
+            println!(
+                "\n[plugin analytics mutation smoke validated]\n{}",
+                serde_json::to_string_pretty(&events)?
+            );
+            println!("PASS: analytics validated; original uninstalled state restored");
+            Ok(())
+        }
+        (Err(err), RestorationStatus::Clean) if uninstall_rpc_failed => {
+            eprintln!(
+                "FAIL-LOCAL-CACHE: backend state is uninstalled, but the uninstall RPC failed after the backend mutation: {err:#}"
+            );
+            Err(err)
+        }
+        (Err(err), RestorationStatus::Clean) => {
+            eprintln!("FAIL-CLEAN: {err:#}");
+            eprintln!("The original uninstalled account state was restored.");
+            Err(err)
+        }
+        (sequence_result, RestorationStatus::LocalCleanupFailure(cleanup_err)) => {
+            let sequence_err = sequence_result.err();
+            eprintln!(
+                "FAIL-LOCAL-CACHE: backend state is uninstalled, but local cleanup reported an error: {cleanup_err:#}"
+            );
+            Err(sequence_err.unwrap_or(cleanup_err))
+        }
+        (sequence_result, RestorationStatus::Dirty(cleanup_err)) => {
+            if let Err(err) = sequence_result {
+                eprintln!("mutation smoke failed before cleanup: {err:#}");
+            }
+            print_dirty_recovery(codex_bin, remote_plugin_id, &cleanup_err);
+            Err(cleanup_err)
+        }
+        (sequence_result, RestorationStatus::Unknown(cleanup_err)) => {
+            if let Err(err) = sequence_result {
+                eprintln!("mutation smoke failed before final state verification: {err:#}");
+            }
+            eprintln!(
+                "FAIL-UNKNOWN: could not verify whether `{remote_plugin_id}` is installed: {cleanup_err:#}"
+            );
+            print_recovery_command(codex_bin, remote_plugin_id);
+            Err(cleanup_err)
+        }
+    }
+}
+
+pub(super) fn run_cleanup(
+    codex_bin: &Path,
+    config_overrides: &[String],
+    remote_plugin_id: &str,
+    confirmation: AccountMutationConfirmation,
+    capture_file: Option<PathBuf>,
+) -> Result<()> {
+    require_confirmation(confirmation)?;
+    let capture_path = capture_file.unwrap_or_else(|| {
+        std::env::temp_dir().join(format!(
+            "codex-plugin-remote-uninstall-{}.jsonl",
+            process::id()
+        ))
+    });
+    prepare_capture_file(&capture_path)?;
+    let mut client = spawn_client(codex_bin, config_overrides, &capture_path)?;
+    println!("capture file: {}", capture_path.display());
+
+    match restore_uninstalled_state(&mut client, remote_plugin_id) {
+        RestorationStatus::Clean => {
+            println!("PASS: `{remote_plugin_id}` is uninstalled");
+            Ok(())
+        }
+        RestorationStatus::LocalCleanupFailure(err) => {
+            eprintln!(
+                "FAIL-LOCAL-CACHE: backend state is uninstalled, but local cleanup reported an error: {err:#}"
+            );
+            Err(err)
+        }
+        RestorationStatus::Dirty(err) => {
+            print_dirty_recovery(codex_bin, remote_plugin_id, &err);
+            Err(err)
+        }
+        RestorationStatus::Unknown(err) => {
+            eprintln!(
+                "FAIL-UNKNOWN: could not verify whether `{remote_plugin_id}` is installed: {err:#}"
+            );
+            Err(err)
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum AccountMutationConfirmation {
+    Confirmed,
+    Missing,
+}
+
+impl AccountMutationConfirmation {
+    pub(super) fn from_flag(confirm_account_mutation: bool) -> Self {
+        if confirm_account_mutation {
+            Self::Confirmed
+        } else {
+            Self::Missing
+        }
+    }
+}
+
+fn require_confirmation(confirmation: AccountMutationConfirmation) -> Result<()> {
+    if matches!(confirmation, AccountMutationConfirmation::Missing) {
+        bail!(
+            "this command installs and uninstalls a plugin on the active account; rerun with --confirm-account-mutation"
+        );
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ExpectedInstalledState {
+    Installed,
+    Uninstalled,
+}
+
+impl ExpectedInstalledState {
+    fn is_installed(self) -> bool {
+        matches!(self, Self::Installed)
+    }
+}
+
+fn spawn_client(
+    codex_bin: &Path,
+    config_overrides: &[String],
+    capture_path: &Path,
+) -> Result<CodexClient> {
+    let mut overrides = config_overrides.to_vec();
+    overrides.extend([
+        "analytics.enabled=true".to_string(),
+        "features.plugins=true".to_string(),
+        "features.remote_plugin=true".to_string(),
+    ]);
+    let environment = vec![(
+        OsString::from(ANALYTICS_CAPTURE_ENV_VAR),
+        capture_path.as_os_str().to_os_string(),
+    )];
+    let mut client = CodexClient::spawn_stdio_with_env(codex_bin, &overrides, &environment)?;
+    client.initialize()?;
+    Ok(client)
+}
+
+#[derive(Clone, Debug)]
+struct RemotePluginExpectation {
+    plugin_id: String,
+    remote_plugin_id: String,
+    plugin_name: String,
+    marketplace_name: String,
+    installed: bool,
+    install_policy: PluginInstallPolicy,
+    availability: PluginAvailability,
+}
+
+fn read_remote_plugin(
+    client: &mut CodexClient,
+    remote_plugin_id: &str,
+) -> Result<RemotePluginExpectation> {
+    let request_id = client.request_id();
+    let response: PluginReadResponse = client.send_request(
+        ClientRequest::PluginRead {
+            request_id: request_id.clone(),
+            params: PluginReadParams {
+                marketplace_path: None,
+                remote_marketplace_name: Some(REMOTE_MARKETPLACE_HINT.to_string()),
+                plugin_name: remote_plugin_id.to_string(),
+            },
+        },
+        request_id,
+        "plugin/read",
+    )?;
+    let summary = response.plugin.summary;
+    let actual_remote_plugin_id = summary
+        .remote_plugin_id
+        .with_context(|| format!("plugin/read returned no remote id for `{remote_plugin_id}`"))?;
+    if actual_remote_plugin_id != remote_plugin_id {
+        bail!(
+            "plugin/read returned remote id `{actual_remote_plugin_id}` for requested id `{remote_plugin_id}`"
+        );
+    }
+    Ok(RemotePluginExpectation {
+        plugin_id: summary.id,
+        remote_plugin_id: actual_remote_plugin_id,
+        plugin_name: summary.name,
+        marketplace_name: response.plugin.marketplace_name,
+        installed: summary.installed,
+        install_policy: summary.install_policy,
+        availability: summary.availability,
+    })
+}
+
+fn validate_initial_plugin(plugin: &RemotePluginExpectation, remote_plugin_id: &str) -> Result<()> {
+    if plugin.installed {
+        bail!(
+            "refusing to run: remote plugin `{remote_plugin_id}` is already installed; choose an initially uninstalled plugin"
+        );
+    }
+    if plugin.availability != PluginAvailability::Available {
+        bail!(
+            "remote plugin `{remote_plugin_id}` is not available: {:?}",
+            plugin.availability
+        );
+    }
+    if plugin.install_policy == PluginInstallPolicy::NotAvailable {
+        bail!("remote plugin `{remote_plugin_id}` is not available for install");
+    }
+    Ok(())
+}
+
+struct MutationSequenceResult {
+    result: Result<Vec<Value>>,
+    uninstall_rpc_failed: bool,
+}
+
+fn run_mutation_sequence(
+    client: &mut CodexClient,
+    capture_path: &Path,
+    expected: &RemotePluginExpectation,
+) -> MutationSequenceResult {
+    let mut uninstall_rpc_failed = false;
+    let result = (|| {
+        install_remote_plugin(client, expected)?;
+        wait_for_installed_state(
+            client,
+            &expected.remote_plugin_id,
+            ExpectedInstalledState::Installed,
+        )?;
+        wait_for_remote_plugin_event(
+            capture_path,
+            &expected.remote_plugin_id,
+            "codex_plugin_installed",
+        )?;
+
+        let uninstall_error = uninstall_remote_plugin(client, &expected.remote_plugin_id).err();
+        uninstall_rpc_failed = uninstall_error.is_some();
+        wait_for_installed_state(
+            client,
+            &expected.remote_plugin_id,
+            ExpectedInstalledState::Uninstalled,
+        )
+        .map_err(|state_err| {
+            if let Some(err) = uninstall_error.as_ref() {
+                anyhow!("plugin/uninstall failed: {err:#}; final state check failed: {state_err:#}")
+            } else {
+                state_err
+            }
+        })?;
+
+        let events = wait_for_remote_plugin_events(capture_path, &expected.remote_plugin_id)?;
+        let events = validate_mutation_events(
+            events,
+            PluginEventIdentity {
+                plugin_id: &expected.plugin_id,
+                remote_plugin_id: &expected.remote_plugin_id,
+                plugin_name: &expected.plugin_name,
+                marketplace_name: &expected.marketplace_name,
+            },
+        )?;
+        if let Some(err) = uninstall_error {
+            return Err(err.context(
+                "plugin/uninstall reported an error after the backend became uninstalled",
+            ));
+        }
+        Ok(events)
+    })();
+
+    MutationSequenceResult {
+        result,
+        uninstall_rpc_failed,
+    }
+}
+
+fn install_remote_plugin(client: &mut CodexClient, plugin: &RemotePluginExpectation) -> Result<()> {
+    let request_id = client.request_id();
+    let _: PluginInstallResponse = client.send_request(
+        ClientRequest::PluginInstall {
+            request_id: request_id.clone(),
+            params: PluginInstallParams {
+                marketplace_path: None,
+                remote_marketplace_name: Some(plugin.marketplace_name.clone()),
+                plugin_name: plugin.remote_plugin_id.clone(),
+            },
+        },
+        request_id,
+        "plugin/install",
+    )?;
+    Ok(())
+}
+
+fn uninstall_remote_plugin(client: &mut CodexClient, remote_plugin_id: &str) -> Result<()> {
+    let request_id = client.request_id();
+    let _: PluginUninstallResponse = client.send_request(
+        ClientRequest::PluginUninstall {
+            request_id: request_id.clone(),
+            params: PluginUninstallParams {
+                plugin_id: remote_plugin_id.to_string(),
+            },
+        },
+        request_id,
+        "plugin/uninstall",
+    )?;
+    Ok(())
+}
+
+fn wait_for_installed_state(
+    client: &mut CodexClient,
+    remote_plugin_id: &str,
+    expected_state: ExpectedInstalledState,
+) -> Result<RemotePluginExpectation> {
+    let deadline = Instant::now() + STATE_TIMEOUT;
+    loop {
+        match read_remote_plugin(client, remote_plugin_id) {
+            Ok(plugin) if plugin.installed == expected_state.is_installed() => return Ok(plugin),
+            Ok(_) => {}
+            Err(err) if Instant::now() >= deadline => return Err(err),
+            Err(_) => {}
+        }
+        if Instant::now() >= deadline {
+            bail!(
+                "timed out waiting for remote plugin `{remote_plugin_id}` to become {expected_state:?}"
+            );
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+enum RestorationStatus {
+    Clean,
+    LocalCleanupFailure(anyhow::Error),
+    Dirty(anyhow::Error),
+    Unknown(anyhow::Error),
+}
+
+fn restore_uninstalled_state(
+    client: &mut CodexClient,
+    remote_plugin_id: &str,
+) -> RestorationStatus {
+    let current = match read_remote_plugin(client, remote_plugin_id) {
+        Ok(current) => current,
+        Err(err) => return RestorationStatus::Unknown(err),
+    };
+    if !current.installed {
+        return RestorationStatus::Clean;
+    }
+
+    let uninstall_result = uninstall_remote_plugin(client, remote_plugin_id);
+    match wait_for_installed_state(
+        client,
+        remote_plugin_id,
+        ExpectedInstalledState::Uninstalled,
+    ) {
+        Ok(_) => match uninstall_result {
+            Ok(()) => RestorationStatus::Clean,
+            Err(err) => RestorationStatus::LocalCleanupFailure(err),
+        },
+        Err(state_err) => {
+            let error = match uninstall_result {
+                Ok(()) => state_err,
+                Err(uninstall_err) => anyhow!(
+                    "cleanup uninstall failed: {uninstall_err:#}; state verification failed: {state_err:#}"
+                ),
+            };
+            RestorationStatus::Dirty(error)
+        }
+    }
+}
+
+fn wait_for_remote_plugin_event(
+    path: &Path,
+    remote_plugin_id: &str,
+    event_type: &str,
+) -> Result<Value> {
+    let deadline = Instant::now() + CAPTURE_TIMEOUT;
+    loop {
+        let events = read_events_for_remote_plugin(path, remote_plugin_id)?;
+        if let Some(event) = events
+            .into_iter()
+            .find(|event| event["event_type"] == event_type)
+        {
+            return Ok(event);
+        }
+        if Instant::now() >= deadline {
+            bail!("timed out waiting for `{event_type}` for remote plugin `{remote_plugin_id}`");
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+fn wait_for_remote_plugin_events(path: &Path, remote_plugin_id: &str) -> Result<Vec<Value>> {
+    let deadline = Instant::now() + CAPTURE_TIMEOUT;
+    loop {
+        let events = read_events_for_remote_plugin(path, remote_plugin_id)?;
+        if ["codex_plugin_installed", "codex_plugin_uninstalled"]
+            .iter()
+            .all(|event_type| {
+                events
+                    .iter()
+                    .any(|event| event["event_type"] == *event_type)
+            })
+        {
+            return Ok(events);
+        }
+        if Instant::now() >= deadline {
+            bail!(
+                "timed out waiting for install/uninstall analytics for remote plugin `{remote_plugin_id}`"
+            );
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+fn print_dirty_recovery(codex_bin: &Path, remote_plugin_id: &str, err: &anyhow::Error) {
+    eprintln!(
+        "FAIL-DIRTY: remote plugin `{remote_plugin_id}` still appears installed after cleanup: {err:#}"
+    );
+    print_recovery_command(codex_bin, remote_plugin_id);
+}
+
+fn print_recovery_command(codex_bin: &Path, remote_plugin_id: &str) {
+    let test_client = std::env::current_exe()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|_| "codex-app-server-test-client".to_string());
+    eprintln!("Recovery command:");
+    eprintln!(
+        "  {test_client} --codex-bin {} plugin-remote-uninstall --remote-plugin-id {remote_plugin_id} --confirm-account-mutation",
+        codex_bin.display()
+    );
+}

--- a/codex-rs/app-server-test-client/src/plugin_analytics_smoke.rs
+++ b/codex-rs/app-server-test-client/src/plugin_analytics_smoke.rs
@@ -1,0 +1,406 @@
+use super::CodexClient;
+use super::loopback_responses_server::LoopbackResponsesServer;
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::bail;
+use codex_app_server_protocol::ClientRequest;
+use codex_app_server_protocol::ConfigValueWriteParams;
+use codex_app_server_protocol::ConfigWriteResponse;
+use codex_app_server_protocol::MergeStrategy;
+use codex_app_server_protocol::PluginAvailability;
+use codex_app_server_protocol::PluginInstalledParams;
+use codex_app_server_protocol::PluginInstalledResponse;
+use codex_app_server_protocol::ThreadStartParams;
+use codex_app_server_protocol::TurnStartParams;
+use codex_app_server_protocol::TurnStatus;
+use codex_app_server_protocol::UserInput;
+use serde_json::Value;
+use serde_json::json;
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process;
+use std::thread;
+use std::time::Duration;
+use std::time::Instant;
+
+const ANALYTICS_CAPTURE_ENV_VAR: &str = "CODEX_ANALYTICS_EVENTS_CAPTURE_FILE";
+const TEST_USER_CONFIG_ENV_VAR: &str = "CODEX_APP_SERVER_TEST_USER_CONFIG_FILE";
+const CAPTURE_TIMEOUT: Duration = Duration::from_secs(10);
+const CAPTURE_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const MOCK_MODEL_SLUG: &str = "plugin-analytics-smoke";
+const MOCK_PROVIDER_ID: &str = "plugin_analytics_smoke";
+
+pub(super) fn run(
+    codex_bin: &Path,
+    config_overrides: &[String],
+    plugin_id: &str,
+    capture_file: Option<PathBuf>,
+) -> Result<()> {
+    let capture_path = capture_file.unwrap_or_else(|| {
+        std::env::temp_dir().join(format!("codex-plugin-analytics-{}.jsonl", process::id()))
+    });
+    prepare_capture_file(&capture_path)?;
+
+    let temporary_config = TemporaryConfigFile::create()?;
+    let responses_server = LoopbackResponsesServer::start()?;
+    let mut overrides = config_overrides.to_vec();
+    overrides.extend(smoke_config_overrides(
+        responses_server.base_url(),
+        plugin_id,
+    )?);
+
+    let child_environment = vec![
+        (
+            OsString::from(ANALYTICS_CAPTURE_ENV_VAR),
+            capture_path.as_os_str().to_os_string(),
+        ),
+        (
+            OsString::from(TEST_USER_CONFIG_ENV_VAR),
+            temporary_config.path().as_os_str().to_os_string(),
+        ),
+    ];
+    let mut client = CodexClient::spawn_stdio_with_env(codex_bin, &overrides, &child_environment)?;
+    client.initialize()?;
+
+    let installed = plugin_installed(&mut client)?;
+    let expected = expected_plugin(&installed, plugin_id)?;
+    write_plugin_enabled(&mut client, temporary_config.path(), plugin_id, false)?;
+    write_plugin_enabled(&mut client, temporary_config.path(), plugin_id, true)?;
+
+    let plugin_config_key = format!("plugins.{plugin_id}.enabled");
+    let thread = client.thread_start(ThreadStartParams {
+        model: Some(MOCK_MODEL_SLUG.to_string()),
+        model_provider: Some(MOCK_PROVIDER_ID.to_string()),
+        config: Some(HashMap::from([(plugin_config_key, json!(true))])),
+        base_instructions: Some(String::new()),
+        developer_instructions: Some(String::new()),
+        ephemeral: Some(true),
+        ..Default::default()
+    })?;
+    let turn = client.turn_start(TurnStartParams {
+        thread_id: thread.thread.id.clone(),
+        client_user_message_id: None,
+        input: vec![UserInput::Mention {
+            name: expected.plugin_name.clone(),
+            path: format!("plugin://{plugin_id}"),
+        }],
+        ..Default::default()
+    })?;
+    client.stream_turn(&thread.thread.id, &turn.turn.id)?;
+    if client.last_turn_status != Some(TurnStatus::Completed) {
+        bail!(
+            "plugin analytics smoke turn did not complete: status={:?}, error={:?}",
+            client.last_turn_status,
+            client.last_turn_error_message
+        );
+    }
+
+    let events = wait_for_plugin_events(&capture_path, plugin_id)?;
+    let validated = validate_plugin_events(events, &expected)?;
+    println!(
+        "\n[plugin analytics smoke validated]\n{}",
+        serde_json::to_string_pretty(&validated)?
+    );
+    println!("capture file: {}", capture_path.display());
+    Ok(())
+}
+
+#[derive(Debug)]
+struct ExpectedPlugin {
+    plugin_id: String,
+    remote_plugin_id: String,
+    plugin_name: String,
+    marketplace_name: String,
+}
+
+fn plugin_installed(client: &mut CodexClient) -> Result<PluginInstalledResponse> {
+    let request_id = client.request_id();
+    client.send_request(
+        ClientRequest::PluginInstalled {
+            request_id: request_id.clone(),
+            params: PluginInstalledParams {
+                cwds: None,
+                install_suggestion_plugin_names: None,
+            },
+        },
+        request_id,
+        "plugin/installed",
+    )
+}
+
+fn expected_plugin(response: &PluginInstalledResponse, plugin_id: &str) -> Result<ExpectedPlugin> {
+    let matches = response
+        .marketplaces
+        .iter()
+        .flat_map(|marketplace| {
+            marketplace
+                .plugins
+                .iter()
+                .filter(move |plugin| plugin.id == plugin_id)
+                .map(move |plugin| (marketplace, plugin))
+        })
+        .collect::<Vec<_>>();
+    let [(marketplace, plugin)] = matches.as_slice() else {
+        bail!(
+            "expected exactly one installed plugin with local id `{plugin_id}`, found {}",
+            matches.len()
+        );
+    };
+    if !plugin.installed {
+        bail!("plugin `{plugin_id}` is not installed");
+    }
+    if plugin.availability != PluginAvailability::Available {
+        bail!(
+            "plugin `{plugin_id}` is not available: {:?}",
+            plugin.availability
+        );
+    }
+    let remote_plugin_id = plugin
+        .remote_plugin_id
+        .clone()
+        .with_context(|| format!("plugin `{plugin_id}` does not have a remote plugin id"))?;
+
+    Ok(ExpectedPlugin {
+        plugin_id: plugin.id.clone(),
+        remote_plugin_id,
+        plugin_name: plugin.name.clone(),
+        marketplace_name: marketplace.name.clone(),
+    })
+}
+
+fn write_plugin_enabled(
+    client: &mut CodexClient,
+    config_path: &Path,
+    plugin_id: &str,
+    enabled: bool,
+) -> Result<()> {
+    let request_id = client.request_id();
+    let response: ConfigWriteResponse = client.send_request(
+        ClientRequest::ConfigValueWrite {
+            request_id: request_id.clone(),
+            params: ConfigValueWriteParams {
+                key_path: format!("plugins.{plugin_id}.enabled"),
+                value: json!(enabled),
+                merge_strategy: MergeStrategy::Replace,
+                file_path: Some(config_path.display().to_string()),
+                expected_version: None,
+            },
+        },
+        request_id,
+        "config/value/write",
+    )?;
+    println!(
+        "< config/value/write plugin={plugin_id} enabled={enabled} status={:?}",
+        response.status
+    );
+    Ok(())
+}
+
+fn smoke_config_overrides(responses_base_url: &str, plugin_id: &str) -> Result<Vec<String>> {
+    let provider_base_url = serde_json::to_string(&format!("{responses_base_url}/v1"))
+        .context("serialize mock provider base URL")?;
+    Ok(vec![
+        "analytics.enabled=true".to_string(),
+        "features.plugins=true".to_string(),
+        "features.remote_plugin=true".to_string(),
+        format!("model={}", quoted(MOCK_MODEL_SLUG)?),
+        format!("model_provider={}", quoted(MOCK_PROVIDER_ID)?),
+        format!(
+            "model_providers.{MOCK_PROVIDER_ID}.name={}",
+            quoted("Plugin analytics smoke mock provider")?
+        ),
+        format!("model_providers.{MOCK_PROVIDER_ID}.base_url={provider_base_url}"),
+        format!(
+            "model_providers.{MOCK_PROVIDER_ID}.wire_api={}",
+            quoted("responses")?
+        ),
+        format!("model_providers.{MOCK_PROVIDER_ID}.requires_openai_auth=false"),
+        format!("model_providers.{MOCK_PROVIDER_ID}.request_max_retries=0"),
+        format!("model_providers.{MOCK_PROVIDER_ID}.stream_max_retries=0"),
+        format!("plugins.{plugin_id}.enabled=true"),
+    ])
+}
+
+fn quoted(value: &str) -> Result<String> {
+    serde_json::to_string(value).context("serialize config string")
+}
+
+fn prepare_capture_file(path: &Path) -> Result<()> {
+    let parent = path
+        .parent()
+        .context("capture file must have a parent directory")?;
+    if !parent.is_dir() {
+        bail!(
+            "capture file parent directory does not exist: {}",
+            parent.display()
+        );
+    }
+    match fs::remove_file(path) {
+        Ok(()) => {}
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("remove previous capture file {}", path.display()));
+        }
+    }
+    Ok(())
+}
+
+fn wait_for_plugin_events(path: &Path, plugin_id: &str) -> Result<Vec<Value>> {
+    let deadline = Instant::now() + CAPTURE_TIMEOUT;
+    loop {
+        let events = read_plugin_events(path, plugin_id)?;
+        if required_event_types()
+            .iter()
+            .all(|event_type| event_count(&events, event_type) >= 1)
+        {
+            return Ok(events);
+        }
+        if Instant::now() >= deadline {
+            bail!(
+                "timed out waiting for plugin analytics events in {}: found {:?}",
+                path.display(),
+                events
+                    .iter()
+                    .filter_map(|event| event["event_type"].as_str())
+                    .collect::<Vec<_>>()
+            );
+        }
+        thread::sleep(CAPTURE_POLL_INTERVAL);
+    }
+}
+
+fn read_plugin_events(path: &Path, plugin_id: &str) -> Result<Vec<Value>> {
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => {
+            return Err(err).with_context(|| format!("read capture file {}", path.display()));
+        }
+    };
+    let mut matching = Vec::new();
+    for (index, line) in contents.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let payload: Value = serde_json::from_str(line).with_context(|| {
+            format!(
+                "parse analytics capture line {} from {}",
+                index + 1,
+                path.display()
+            )
+        })?;
+        let events = payload["events"]
+            .as_array()
+            .context("analytics capture payload is missing events")?;
+        matching.extend(
+            events
+                .iter()
+                .filter(|event| event["event_params"]["plugin_id"] == plugin_id)
+                .cloned(),
+        );
+    }
+    Ok(matching)
+}
+
+fn validate_plugin_events(events: Vec<Value>, expected: &ExpectedPlugin) -> Result<Vec<Value>> {
+    let mut validated = Vec::new();
+    for event_type in required_event_types() {
+        let matching = events
+            .iter()
+            .filter(|event| event["event_type"] == event_type)
+            .collect::<Vec<_>>();
+        let [event] = matching.as_slice() else {
+            bail!(
+                "expected exactly one `{event_type}` event for `{}`, found {}",
+                expected.plugin_id,
+                matching.len()
+            );
+        };
+        validate_identity(event, expected)?;
+        if event_type == "codex_plugin_used" {
+            validate_used_metadata(event)?;
+        }
+        validated.push((*event).clone());
+    }
+    Ok(validated)
+}
+
+fn required_event_types() -> [&'static str; 3] {
+    [
+        "codex_plugin_disabled",
+        "codex_plugin_enabled",
+        "codex_plugin_used",
+    ]
+}
+
+fn event_count(events: &[Value], event_type: &str) -> usize {
+    events
+        .iter()
+        .filter(|event| event["event_type"] == event_type)
+        .count()
+}
+
+fn validate_identity(event: &Value, expected: &ExpectedPlugin) -> Result<()> {
+    let params = &event["event_params"];
+    require_string(params, "plugin_id", &expected.plugin_id)?;
+    require_string(params, "remote_plugin_id", &expected.remote_plugin_id)?;
+    require_string(params, "plugin_name", &expected.plugin_name)?;
+    require_string(params, "marketplace_name", &expected.marketplace_name)
+}
+
+fn validate_used_metadata(event: &Value) -> Result<()> {
+    let params = &event["event_params"];
+    for field in [
+        "has_skills",
+        "mcp_server_count",
+        "connector_ids",
+        "mcp_server_names",
+        "thread_id",
+        "turn_id",
+        "model_slug",
+    ] {
+        if params.get(field).is_none_or(Value::is_null) {
+            bail!("codex_plugin_used event has null or missing `{field}`");
+        }
+    }
+    require_string(params, "model_slug", MOCK_MODEL_SLUG)
+}
+
+fn require_string(params: &Value, field: &str, expected: &str) -> Result<()> {
+    let actual = params.get(field).and_then(Value::as_str);
+    if actual != Some(expected) {
+        bail!("expected `{field}` to be `{expected}`, got {actual:?}");
+    }
+    Ok(())
+}
+
+struct TemporaryConfigFile {
+    path: PathBuf,
+}
+
+impl TemporaryConfigFile {
+    fn create() -> Result<Self> {
+        let path = std::env::temp_dir().join(format!(
+            "codex-plugin-analytics-config-{}.toml",
+            process::id()
+        ));
+        fs::write(&path, "")
+            .with_context(|| format!("create temporary config file {}", path.display()))?;
+        Ok(Self { path })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TemporaryConfigFile {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}

--- a/codex-rs/app-server-test-client/src/plugin_analytics_smoke.rs
+++ b/codex-rs/app-server-test-client/src/plugin_analytics_smoke.rs
@@ -27,7 +27,7 @@ use std::thread;
 use std::time::Duration;
 use std::time::Instant;
 
-const ANALYTICS_CAPTURE_ENV_VAR: &str = "CODEX_ANALYTICS_EVENTS_CAPTURE_FILE";
+pub(super) const ANALYTICS_CAPTURE_ENV_VAR: &str = "CODEX_ANALYTICS_EVENTS_CAPTURE_FILE";
 const TEST_USER_CONFIG_ENV_VAR: &str = "CODEX_APP_SERVER_TEST_USER_CONFIG_FILE";
 const CAPTURE_TIMEOUT: Duration = Duration::from_secs(10);
 const CAPTURE_POLL_INTERVAL: Duration = Duration::from_millis(50);
@@ -229,7 +229,7 @@ fn quoted(value: &str) -> Result<String> {
     serde_json::to_string(value).context("serialize config string")
 }
 
-fn prepare_capture_file(path: &Path) -> Result<()> {
+pub(super) fn prepare_capture_file(path: &Path) -> Result<()> {
     let parent = path
         .parent()
         .context("capture file must have a parent directory")?;

--- a/codex-rs/app-server-test-client/src/plugin_analytics_smoke.rs
+++ b/codex-rs/app-server-test-client/src/plugin_analytics_smoke.rs
@@ -68,8 +68,18 @@ pub(super) fn run(
 
     let installed = plugin_installed(&mut client)?;
     let expected = expected_plugin(&installed, plugin_id)?;
-    write_plugin_enabled(&mut client, temporary_config.path(), plugin_id, false)?;
-    write_plugin_enabled(&mut client, temporary_config.path(), plugin_id, true)?;
+    write_plugin_enabled(
+        &mut client,
+        temporary_config.path(),
+        plugin_id,
+        /*enabled*/ false,
+    )?;
+    write_plugin_enabled(
+        &mut client,
+        temporary_config.path(),
+        plugin_id,
+        /*enabled*/ true,
+    )?;
 
     let plugin_config_key = format!("plugins.{plugin_id}.enabled");
     let thread = client.thread_start(ThreadStartParams {

--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -9,6 +9,8 @@ use codex_config::ThreadConfigLoader;
 use codex_core::config::Config;
 use codex_core::resolve_installation_id;
 use codex_login::AuthManager;
+#[cfg(debug_assertions)]
+use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_cli::CliConfigOverrides;
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -113,6 +115,8 @@ pub use crate::transport::auth::WebsocketAuthCliMode;
 
 const LOG_FORMAT_ENV_VAR: &str = "LOG_FORMAT";
 const OTEL_SERVICE_NAME: &str = "codex-app-server";
+#[cfg(debug_assertions)]
+const TEST_USER_CONFIG_FILE_ENV_VAR: &str = "CODEX_APP_SERVER_TEST_USER_CONFIG_FILE";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum LogFormat {
@@ -430,6 +434,10 @@ pub async fn run_main_with_transport_options(
     auth: AppServerWebsocketAuthSettings,
     runtime_options: AppServerRuntimeOptions,
 ) -> IoResult<()> {
+    let loader_overrides = loader_overrides_with_test_user_config_file(
+        loader_overrides,
+        test_user_config_file_from_env(),
+    )?;
     let (transport_event_tx, mut transport_event_rx) =
         mpsc::channel::<TransportEvent>(CHANNEL_CAPACITY);
     let (outgoing_tx, mut outgoing_rx) = mpsc::channel::<OutgoingEnvelope>(CHANNEL_CAPACITY);
@@ -1099,6 +1107,43 @@ pub async fn run_main_with_transport_options(
     Ok(())
 }
 
+fn test_user_config_file_from_env() -> Option<std::path::PathBuf> {
+    #[cfg(debug_assertions)]
+    {
+        std::env::var_os(TEST_USER_CONFIG_FILE_ENV_VAR)
+            .filter(|value| !value.is_empty())
+            .map(std::path::PathBuf::from)
+    }
+
+    #[cfg(not(debug_assertions))]
+    None
+}
+
+fn loader_overrides_with_test_user_config_file(
+    mut loader_overrides: LoaderOverrides,
+    test_user_config_file: Option<std::path::PathBuf>,
+) -> IoResult<LoaderOverrides> {
+    #[cfg(debug_assertions)]
+    if let Some(path) = test_user_config_file {
+        let path = AbsolutePathBuf::from_absolute_path(path).map_err(|err| {
+            std::io::Error::new(
+                ErrorKind::InvalidInput,
+                format!("invalid test user config path: {err}"),
+            )
+        })?;
+        warn!(
+            path = %path.as_path().display(),
+            "using debug-only app-server test user config file"
+        );
+        loader_overrides.user_config_path = Some(path);
+    }
+
+    #[cfg(not(debug_assertions))]
+    let _ = test_user_config_file;
+
+    Ok(loader_overrides)
+}
+
 fn analytics_rpc_transport(transport: &AppServerTransport) -> AppServerRpcTransport {
     match transport {
         AppServerTransport::Stdio => AppServerRpcTransport::Stdio,
@@ -1111,6 +1156,9 @@ fn analytics_rpc_transport(transport: &AppServerTransport) -> AppServerRpcTransp
 #[cfg(test)]
 mod tests {
     use super::LogFormat;
+    use super::loader_overrides_with_test_user_config_file;
+    use codex_config::LoaderOverrides;
+    use codex_utils_absolute_path::AbsolutePathBuf;
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -1129,5 +1177,20 @@ mod tests {
         assert_eq!(LogFormat::from_env_value(Some("")), LogFormat::Default);
         assert_eq!(LogFormat::from_env_value(Some("text")), LogFormat::Default);
         assert_eq!(LogFormat::from_env_value(Some("jsonl")), LogFormat::Default);
+    }
+
+    #[test]
+    fn debug_test_user_config_file_overrides_loader_path() {
+        let path = std::env::temp_dir().join("codex-app-server-test-config.toml");
+        let loader_overrides = loader_overrides_with_test_user_config_file(
+            LoaderOverrides::default(),
+            Some(path.clone()),
+        )
+        .expect("test config path should be valid");
+
+        assert_eq!(
+            loader_overrides.user_config_path,
+            Some(AbsolutePathBuf::from_absolute_path(path).expect("absolute test path"))
+        );
     }
 }

--- a/codex-rs/app-server/src/request_processors.rs
+++ b/codex-rs/app-server/src/request_processors.rs
@@ -311,7 +311,6 @@ use codex_core_plugins::PluginReadRequest;
 use codex_core_plugins::PluginUninstallError as CorePluginUninstallError;
 use codex_core_plugins::loader::load_plugin_apps;
 use codex_core_plugins::loader::load_plugin_mcp_servers;
-use codex_core_plugins::loader::plugin_telemetry_metadata_from_root;
 use codex_core_plugins::manifest::PluginManifestInterface;
 use codex_core_plugins::marketplace::MarketplaceError;
 use codex_core_plugins::marketplace::MarketplacePluginSource;

--- a/codex-rs/app-server/src/request_processors/config_processor.rs
+++ b/codex-rs/app-server/src/request_processors/config_processor.rs
@@ -295,15 +295,14 @@ impl ConfigRequestProcessor {
         &self,
         pending_changes: std::collections::BTreeMap<String, bool>,
     ) {
+        let plugins_manager = self.thread_manager.plugins_manager();
         for (plugin_id, enabled) in pending_changes {
             let Ok(plugin_id) = PluginId::parse(&plugin_id) else {
                 continue;
             };
-            let metadata = codex_core_plugins::loader::installed_plugin_telemetry_metadata(
-                self.config_manager.codex_home(),
-                &plugin_id,
-            )
-            .await;
+            let metadata = plugins_manager
+                .telemetry_metadata_for_installed_plugin(&plugin_id)
+                .await;
             if enabled {
                 self.analytics_events_client.track_plugin_enabled(metadata);
             } else {

--- a/codex-rs/app-server/src/request_processors/plugins.rs
+++ b/codex-rs/app-server/src/request_processors/plugins.rs
@@ -1523,9 +1523,14 @@ impl PluginRequestProcessor {
                 Some(self.effective_plugins_changed_callback()),
             );
 
-        let mut plugin_metadata =
-            plugin_telemetry_metadata_from_root(&result.plugin_id, &result.installed_path).await;
-        plugin_metadata.remote_plugin_id = Some(remote_plugin_id);
+        let plugin_metadata = self
+            .thread_manager
+            .plugins_manager()
+            .telemetry_metadata_for_installed_plugin_with_remote_id(
+                &result.plugin_id,
+                &remote_plugin_id,
+            )
+            .await;
         self.analytics_events_client
             .track_plugin_installed(plugin_metadata);
 
@@ -1801,11 +1806,27 @@ impl PluginRequestProcessor {
         let remote_plugin_service_config = RemotePluginServiceConfig {
             chatgpt_base_url: config.chatgpt_base_url.clone(),
         };
+        let uninstall_target = codex_core_plugins::remote::resolve_remote_plugin_uninstall_target(
+            &remote_plugin_service_config,
+            auth.as_ref(),
+            &plugin_id,
+        )
+        .await
+        .map_err(|err| {
+            remote_plugin_catalog_error_to_jsonrpc(err, "resolve remote plugin before uninstall")
+        })?;
+        let plugins_manager = self.thread_manager.plugins_manager();
+        let plugin_telemetry = plugins_manager
+            .telemetry_metadata_for_installed_plugin_with_remote_id(
+                &uninstall_target.plugin_id,
+                &uninstall_target.remote_plugin_id,
+            )
+            .await;
         let uninstall_result = codex_core_plugins::remote::uninstall_remote_plugin(
             &remote_plugin_service_config,
             auth.as_ref(),
             config.codex_home.to_path_buf(),
-            &plugin_id,
+            uninstall_target,
         )
         .await;
 
@@ -1813,7 +1834,8 @@ impl PluginRequestProcessor {
             &uninstall_result,
             Ok(()) | Err(RemotePluginCatalogError::CacheRemove(_))
         ) {
-            let plugins_manager = self.thread_manager.plugins_manager();
+            self.analytics_events_client
+                .track_plugin_uninstalled(plugin_telemetry);
             if plugins_manager.clear_remote_installed_plugins_cache() {
                 self.on_effective_plugins_changed();
             }

--- a/codex-rs/app-server/tests/suite/v2/plugin_install.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_install.rs
@@ -739,6 +739,7 @@ async fn plugin_install_tracks_analytics_event() -> Result<()> {
                 "event_type": "codex_plugin_installed",
                 "event_params": {
                     "plugin_id": "sample-plugin@debug",
+                    "remote_plugin_id": null,
                     "plugin_name": "sample-plugin",
                     "marketplace_name": "debug",
                     "has_skills": false,
@@ -791,7 +792,8 @@ async fn plugin_install_tracks_remote_plugin_analytics_event() -> Result<()> {
             "events": [{
                 "event_type": "codex_plugin_installed",
                 "event_params": {
-                    "plugin_id": REMOTE_PLUGIN_ID,
+                    "plugin_id": "linear@openai-curated-remote",
+                    "remote_plugin_id": REMOTE_PLUGIN_ID,
                     "plugin_name": "linear",
                     "marketplace_name": "openai-curated-remote",
                     "has_skills": true,

--- a/codex-rs/app-server/tests/suite/v2/plugin_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_list.rs
@@ -3,10 +3,14 @@ use std::time::Duration;
 use anyhow::Result;
 use anyhow::bail;
 use app_test_support::ChatGptAuthFixture;
+use app_test_support::DEFAULT_CLIENT_NAME;
 use app_test_support::TestAppServer;
 use app_test_support::to_response;
 use app_test_support::write_chatgpt_auth;
+use codex_app_server_protocol::ConfigValueWriteParams;
+use codex_app_server_protocol::ConfigWriteResponse;
 use codex_app_server_protocol::JSONRPCResponse;
+use codex_app_server_protocol::MergeStrategy;
 use codex_app_server_protocol::PluginAuthPolicy;
 use codex_app_server_protocol::PluginInstallPolicy;
 use codex_app_server_protocol::PluginInstalledParams;
@@ -19,6 +23,7 @@ use codex_app_server_protocol::PluginShareDiscoverability;
 use codex_app_server_protocol::PluginSource;
 use codex_app_server_protocol::PluginSummary;
 use codex_app_server_protocol::RequestId;
+use codex_app_server_protocol::WriteStatus;
 use codex_config::types::AuthCredentialsStoreMode;
 use codex_core::config::set_project_trust_level;
 use codex_protocol::config_types::TrustLevel;
@@ -277,6 +282,103 @@ enabled = true
         ]
     );
     assert_eq!(response.marketplace_load_errors, Vec::new());
+    Ok(())
+}
+
+#[tokio::test]
+async fn plugin_toggle_analytics_resolves_remote_plugin_id_from_installed_snapshot() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    let server = MockServer::start().await;
+    write_remote_plugin_catalog_config(
+        codex_home.path(),
+        &format!("{}/backend-api/", server.uri()),
+    )?;
+    write_chatgpt_auth(
+        codex_home.path(),
+        ChatGptAuthFixture::new("chatgpt-token")
+            .account_id("account-123")
+            .chatgpt_user_id("user-123")
+            .chatgpt_account_id("account-123"),
+        AuthCredentialsStoreMode::File,
+    )?;
+    write_installed_plugin_with_version(&codex_home, "openai-curated-remote", "linear", "1.2.3")?;
+    let global_installed_body = remote_installed_plugin_body("", "1.2.3", /*enabled*/ true);
+    mount_remote_installed_plugins(&server, "GLOBAL", &global_installed_body).await;
+    mount_remote_installed_plugins(&server, "WORKSPACE", empty_remote_installed_plugins_body())
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/analytics-events/events"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"status":"ok"}"#))
+        .mount(&server)
+        .await;
+
+    let mut app_server = TestAppServer::new(codex_home.path()).await?;
+    timeout(DEFAULT_TIMEOUT, app_server.initialize()).await??;
+
+    let installed_request_id = app_server
+        .send_plugin_installed_request(PluginInstalledParams {
+            cwds: None,
+            install_suggestion_plugin_names: None,
+        })
+        .await?;
+    let installed_response: JSONRPCResponse = timeout(
+        DEFAULT_TIMEOUT,
+        app_server.read_stream_until_response_message(RequestId::Integer(installed_request_id)),
+    )
+    .await??;
+    let _: PluginInstalledResponse = to_response(installed_response)?;
+
+    for enabled in [false, true] {
+        let request_id = app_server
+            .send_config_value_write_request(ConfigValueWriteParams {
+                file_path: None,
+                key_path: "plugins.linear@openai-curated-remote.enabled".to_string(),
+                value: serde_json::json!(enabled),
+                merge_strategy: MergeStrategy::Replace,
+                expected_version: None,
+            })
+            .await?;
+        let response: JSONRPCResponse = timeout(
+            DEFAULT_TIMEOUT,
+            app_server.read_stream_until_response_message(RequestId::Integer(request_id)),
+        )
+        .await??;
+        let response: ConfigWriteResponse = to_response(response)?;
+        assert_eq!(response.status, WriteStatus::Ok);
+    }
+
+    let events = wait_for_plugin_analytics_events(&server, /*expected_count*/ 2).await?;
+    assert_eq!(
+        events,
+        vec![
+            serde_json::json!({
+                "event_type": "codex_plugin_disabled",
+                "event_params": {
+                    "plugin_id": "linear@openai-curated-remote",
+                    "remote_plugin_id": "plugins~Plugin_00000000000000000000000000000000",
+                    "plugin_name": "linear",
+                    "marketplace_name": "openai-curated-remote",
+                    "has_skills": false,
+                    "mcp_server_count": 0,
+                    "connector_ids": [],
+                    "product_client_id": DEFAULT_CLIENT_NAME,
+                }
+            }),
+            serde_json::json!({
+                "event_type": "codex_plugin_enabled",
+                "event_params": {
+                    "plugin_id": "linear@openai-curated-remote",
+                    "remote_plugin_id": "plugins~Plugin_00000000000000000000000000000000",
+                    "plugin_name": "linear",
+                    "marketplace_name": "openai-curated-remote",
+                    "has_skills": false,
+                    "mcp_server_count": 0,
+                    "connector_ids": [],
+                    "product_client_id": DEFAULT_CLIENT_NAME,
+                }
+            }),
+        ]
+    );
     Ok(())
 }
 
@@ -3414,4 +3516,39 @@ fn write_plugin_share_local_path_mapping(
         codex_home.join(".tmp/plugin-share-local-paths-v1.json"),
         format!("{contents}\n"),
     )
+}
+
+async fn wait_for_plugin_analytics_events(
+    server: &MockServer,
+    expected_count: usize,
+) -> Result<Vec<serde_json::Value>> {
+    timeout(DEFAULT_TIMEOUT, async {
+        loop {
+            let requests = server.received_requests().await.unwrap_or_default();
+            let events = requests
+                .iter()
+                .filter(|request| {
+                    request.method == "POST"
+                        && request
+                            .url
+                            .path()
+                            .ends_with("/codex/analytics-events/events")
+                })
+                .filter_map(|request| {
+                    serde_json::from_slice::<serde_json::Value>(&request.body).ok()
+                })
+                .flat_map(|payload| payload["events"].as_array().cloned().unwrap_or_default())
+                .filter(|event| {
+                    event["event_type"]
+                        .as_str()
+                        .is_some_and(|event_type| event_type.starts_with("codex_plugin_"))
+                })
+                .collect::<Vec<_>>();
+            if events.len() >= expected_count {
+                return Ok::<_, anyhow::Error>(events);
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await?
 }

--- a/codex-rs/app-server/tests/suite/v2/plugin_uninstall.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_uninstall.rs
@@ -139,6 +139,7 @@ async fn plugin_uninstall_tracks_analytics_event() -> Result<()> {
                 "event_type": "codex_plugin_uninstalled",
                 "event_params": {
                     "plugin_id": "sample-plugin@debug",
+                    "remote_plugin_id": null,
                     "plugin_name": "sample-plugin",
                     "marketplace_name": "debug",
                     "has_skills": false,
@@ -216,6 +217,11 @@ async fn plugin_uninstall_writes_remote_plugin_to_cloud_when_remote_plugin_enabl
         )
         .mount(&server)
         .await;
+    Mock::given(method("POST"))
+        .and(path("/backend-api/codex/analytics-events/events"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"status":"ok"}"#))
+        .mount(&server)
+        .await;
 
     let remote_plugin_cache_root = codex_home
         .path()
@@ -224,6 +230,11 @@ async fn plugin_uninstall_writes_remote_plugin_to_cloud_when_remote_plugin_enabl
     std::fs::write(
         remote_plugin_cache_root.join("1.0.0/.codex-plugin/plugin.json"),
         r#"{"name":"linear","version":"1.0.0"}"#,
+    )?;
+    std::fs::create_dir_all(remote_plugin_cache_root.join("1.0.0/skills/plan-work"))?;
+    std::fs::write(
+        remote_plugin_cache_root.join("1.0.0/skills/plan-work/SKILL.md"),
+        "---\nname: plan-work\ndescription: Plan work\n---\n",
     )?;
     let legacy_remote_plugin_cache_root = codex_home.path().join(format!(
         "plugins/cache/openai-curated-remote/{REMOTE_PLUGIN_ID}"
@@ -255,11 +266,31 @@ async fn plugin_uninstall_writes_remote_plugin_to_cloud_when_remote_plugin_enabl
     .await?;
     assert!(!remote_plugin_cache_root.exists());
     assert!(!legacy_remote_plugin_cache_root.exists());
+    let payload = wait_for_plugin_analytics_payload(&server).await?;
+    assert_eq!(
+        payload,
+        json!({
+            "events": [{
+                "event_type": "codex_plugin_uninstalled",
+                "event_params": {
+                    "plugin_id": "linear@openai-curated-remote",
+                    "remote_plugin_id": REMOTE_PLUGIN_ID,
+                    "plugin_name": "linear",
+                    "marketplace_name": "openai-curated-remote",
+                    "has_skills": true,
+                    "mcp_server_count": 0,
+                    "connector_ids": [],
+                    "product_client_id": DEFAULT_CLIENT_NAME,
+                }
+            }]
+        })
+    );
     Ok(())
 }
 
 #[tokio::test]
-async fn plugin_uninstall_uses_detail_scope_for_cache_namespace() -> Result<()> {
+async fn plugin_uninstall_uses_detail_identity_and_scope_for_uninstall_target() -> Result<()> {
+    const REQUEST_REMOTE_PLUGIN_ID: &str = "plugins~Plugin_linear_alias";
     let codex_home = TempDir::new()?;
     let server = MockServer::start().await;
     write_remote_plugin_catalog_config(
@@ -274,7 +305,15 @@ async fn plugin_uninstall_uses_detail_scope_for_cache_namespace() -> Result<()> 
             .chatgpt_account_id("account-123"),
         AuthCredentialsStoreMode::File,
     )?;
-    mount_remote_plugin_detail(&server, REMOTE_PLUGIN_ID, "1.0.0", "WORKSPACE").await;
+    mount_remote_plugin_detail_response_with_name(
+        &server,
+        REQUEST_REMOTE_PLUGIN_ID,
+        REMOTE_PLUGIN_ID,
+        "linear",
+        "1.0.0",
+        "WORKSPACE",
+    )
+    .await;
 
     Mock::given(method("POST"))
         .and(path(format!(
@@ -307,7 +346,7 @@ async fn plugin_uninstall_uses_detail_scope_for_cache_namespace() -> Result<()> 
 
     let request_id = mcp
         .send_plugin_uninstall_request(PluginUninstallParams {
-            plugin_id: REMOTE_PLUGIN_ID.to_string(),
+            plugin_id: REQUEST_REMOTE_PLUGIN_ID.to_string(),
         })
         .await?;
     let response: JSONRPCResponse = timeout(
@@ -617,6 +656,25 @@ async fn mount_remote_plugin_detail_with_name(
     release_version: &str,
     scope: &str,
 ) {
+    mount_remote_plugin_detail_response_with_name(
+        server,
+        remote_plugin_id,
+        remote_plugin_id,
+        plugin_name,
+        release_version,
+        scope,
+    )
+    .await;
+}
+
+async fn mount_remote_plugin_detail_response_with_name(
+    server: &MockServer,
+    request_remote_plugin_id: &str,
+    response_remote_plugin_id: &str,
+    plugin_name: &str,
+    release_version: &str,
+    scope: &str,
+) {
     let discoverability = if scope == "WORKSPACE" {
         r#"
   "discoverability": "LISTED","#
@@ -625,7 +683,7 @@ async fn mount_remote_plugin_detail_with_name(
     };
     let detail_body = format!(
         r#"{{
-  "id": "{remote_plugin_id}",
+  "id": "{response_remote_plugin_id}",
   "name": "{plugin_name}",
   "scope": "{scope}",{discoverability}
   "installation_policy": "AVAILABLE",
@@ -644,7 +702,9 @@ async fn mount_remote_plugin_detail_with_name(
     );
 
     Mock::given(method("GET"))
-        .and(path(format!("/backend-api/ps/plugins/{remote_plugin_id}")))
+        .and(path(format!(
+            "/backend-api/ps/plugins/{request_remote_plugin_id}"
+        )))
         .and(header("authorization", "Bearer chatgpt-token"))
         .and(header("chatgpt-account-id", "account-123"))
         .respond_with(ResponseTemplate::new(200).set_body_string(detail_body))
@@ -685,4 +745,27 @@ async fn wait_for_remote_plugin_request_count(
     })
     .await??;
     Ok(())
+}
+
+async fn wait_for_plugin_analytics_payload(server: &MockServer) -> Result<serde_json::Value> {
+    timeout(DEFAULT_TIMEOUT, async {
+        loop {
+            let Some(requests) = server.received_requests().await else {
+                tokio::time::sleep(Duration::from_millis(25)).await;
+                continue;
+            };
+            if let Some(request) = requests.iter().find(|request| {
+                request.method == "POST"
+                    && request
+                        .url
+                        .path()
+                        .ends_with("/codex/analytics-events/events")
+            }) {
+                return serde_json::from_slice(&request.body)
+                    .map_err(|err| anyhow::anyhow!("invalid analytics payload: {err}"));
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await?
 }

--- a/codex-rs/core-plugins/src/loader.rs
+++ b/codex-rs/core-plugins/src/loader.rs
@@ -28,7 +28,6 @@ use codex_plugin::PluginHookSource;
 use codex_plugin::PluginId;
 use codex_plugin::PluginIdError;
 use codex_plugin::PluginLoadOutcome;
-use codex_plugin::PluginTelemetryMetadata;
 use codex_protocol::protocol::Product;
 use codex_protocol::protocol::SkillScope;
 use codex_utils_absolute_path::AbsolutePathBuf;
@@ -1019,13 +1018,11 @@ async fn load_apps_from_paths(
     connector_ids
 }
 
-pub async fn plugin_telemetry_metadata_from_root(
+pub async fn plugin_capability_summary_from_root(
     plugin_id: &PluginId,
     plugin_root: &AbsolutePathBuf,
-) -> PluginTelemetryMetadata {
-    let Some(manifest) = load_plugin_manifest(plugin_root.as_path()) else {
-        return PluginTelemetryMetadata::from_plugin_id(plugin_id);
-    };
+) -> Option<PluginCapabilitySummary> {
+    let manifest = load_plugin_manifest(plugin_root.as_path())?;
 
     let manifest_paths = &manifest.paths;
     let has_skills = !plugin_skill_roots(plugin_root, manifest_paths).is_empty();
@@ -1041,22 +1038,18 @@ pub async fn plugin_telemetry_metadata_from_root(
     mcp_server_names.sort_unstable();
     mcp_server_names.dedup();
 
-    PluginTelemetryMetadata {
-        plugin_id: plugin_id.clone(),
-        remote_plugin_id: None,
-        capability_summary: Some(PluginCapabilitySummary {
-            config_name: plugin_id.as_key(),
-            display_name: plugin_id.plugin_name.clone(),
-            description: None,
-            has_skills,
-            mcp_server_names,
-            app_connector_ids: load_apps_from_paths(
-                plugin_root.as_path(),
-                plugin_app_config_paths(plugin_root.as_path(), manifest_paths),
-            )
-            .await,
-        }),
-    }
+    Some(PluginCapabilitySummary {
+        config_name: plugin_id.as_key(),
+        display_name: plugin_id.plugin_name.clone(),
+        description: None,
+        has_skills,
+        mcp_server_names,
+        app_connector_ids: load_apps_from_paths(
+            plugin_root.as_path(),
+            plugin_app_config_paths(plugin_root.as_path(), manifest_paths),
+        )
+        .await,
+    })
 }
 
 pub async fn load_plugin_mcp_servers(plugin_root: &Path) -> HashMap<String, McpServerConfig> {
@@ -1073,24 +1066,6 @@ pub async fn load_plugin_mcp_servers(plugin_root: &Path) -> HashMap<String, McpS
     }
 
     mcp_servers
-}
-
-pub async fn installed_plugin_telemetry_metadata(
-    codex_home: &Path,
-    plugin_id: &PluginId,
-) -> PluginTelemetryMetadata {
-    let store = match PluginStore::try_new(codex_home.to_path_buf()) {
-        Ok(store) => store,
-        Err(err) => {
-            warn!("failed to resolve plugin cache root: {err}");
-            return PluginTelemetryMetadata::from_plugin_id(plugin_id);
-        }
-    };
-    let Some(plugin_root) = store.active_plugin_root(plugin_id) else {
-        return PluginTelemetryMetadata::from_plugin_id(plugin_id);
-    };
-
-    plugin_telemetry_metadata_from_root(plugin_id, &plugin_root).await
 }
 
 async fn load_mcp_servers_from_file(

--- a/codex-rs/core-plugins/src/manager.rs
+++ b/codex-rs/core-plugins/src/manager.rs
@@ -4,7 +4,6 @@ use crate::installed_marketplaces::installed_marketplace_roots_from_layer_stack;
 use crate::loader::PluginHookLoadOutcome;
 use crate::loader::configured_curated_plugin_ids_from_codex_home;
 use crate::loader::curated_plugin_cache_version;
-use crate::loader::installed_plugin_telemetry_metadata;
 use crate::loader::load_plugin_apps;
 use crate::loader::load_plugin_hooks;
 use crate::loader::load_plugin_hooks_from_layer_stack;
@@ -13,7 +12,7 @@ use crate::loader::load_plugin_skills;
 use crate::loader::load_plugins_from_layer_stack;
 use crate::loader::log_plugin_load_errors;
 use crate::loader::materialize_marketplace_plugin_source;
-use crate::loader::plugin_telemetry_metadata_from_root;
+use crate::loader::plugin_capability_summary_from_root;
 use crate::loader::refresh_curated_plugin_cache;
 use crate::loader::refresh_non_curated_plugin_cache;
 use crate::loader::refresh_non_curated_plugin_cache_force_reinstall;
@@ -63,6 +62,7 @@ use codex_plugin::AppConnectorId;
 use codex_plugin::PluginCapabilitySummary;
 use codex_plugin::PluginId;
 use codex_plugin::PluginIdError;
+use codex_plugin::PluginTelemetryMetadata;
 use codex_plugin::prompt_safe_plugin_description;
 use codex_protocol::protocol::HookEventName;
 use codex_protocol::protocol::Product;
@@ -538,6 +538,61 @@ impl PluginsManager {
         remote_installed_plugins_to_config(plugins, &self.store)
     }
 
+    fn remote_plugin_id_for(&self, plugin_id: &PluginId) -> Option<String> {
+        let cache = match self.remote_installed_plugins_cache.read() {
+            Ok(cache) => cache,
+            Err(err) => err.into_inner(),
+        };
+        cache.as_ref()?.iter().find_map(|plugin| {
+            (plugin.name == plugin_id.plugin_name
+                && plugin.marketplace_name == plugin_id.marketplace_name)
+                .then(|| plugin.id.clone())
+        })
+    }
+
+    pub async fn telemetry_metadata_for_installed_plugin(
+        &self,
+        plugin_id: &PluginId,
+    ) -> PluginTelemetryMetadata {
+        let capability_summary = match self.store.active_plugin_root(plugin_id) {
+            Some(plugin_root) => plugin_capability_summary_from_root(plugin_id, &plugin_root).await,
+            None => None,
+        };
+        PluginTelemetryMetadata {
+            plugin_id: plugin_id.clone(),
+            remote_plugin_id: self.remote_plugin_id_for(plugin_id),
+            capability_summary,
+        }
+    }
+
+    pub async fn telemetry_metadata_for_installed_plugin_with_remote_id(
+        &self,
+        plugin_id: &PluginId,
+        remote_plugin_id: &str,
+    ) -> PluginTelemetryMetadata {
+        let capability_summary = match self.store.active_plugin_root(plugin_id) {
+            Some(plugin_root) => plugin_capability_summary_from_root(plugin_id, &plugin_root).await,
+            None => None,
+        };
+        PluginTelemetryMetadata {
+            plugin_id: plugin_id.clone(),
+            remote_plugin_id: Some(remote_plugin_id.to_string()),
+            capability_summary,
+        }
+    }
+
+    pub fn telemetry_metadata_for_capability_summary(
+        &self,
+        summary: &PluginCapabilitySummary,
+    ) -> Option<PluginTelemetryMetadata> {
+        let plugin_id = PluginId::parse(&summary.config_name).ok()?;
+        Some(PluginTelemetryMetadata {
+            remote_plugin_id: self.remote_plugin_id_for(&plugin_id),
+            plugin_id,
+            capability_summary: Some(summary.clone()),
+        })
+    }
+
     pub fn build_remote_installed_plugin_marketplaces_from_cache(
         &self,
         visible_scopes: &[RemotePluginScope],
@@ -875,7 +930,7 @@ impl PluginsManager {
         };
         if let Some(analytics_events_client) = analytics_events_client {
             analytics_events_client.track_plugin_installed(
-                plugin_telemetry_metadata_from_root(&result.plugin_id, &result.installed_path)
+                self.telemetry_metadata_for_installed_plugin(&result.plugin_id)
                     .await,
             );
         }
@@ -916,7 +971,10 @@ impl PluginsManager {
 
     async fn uninstall_plugin_id(&self, plugin_id: PluginId) -> Result<(), PluginUninstallError> {
         let plugin_telemetry = if self.store.active_plugin_root(&plugin_id).is_some() {
-            Some(installed_plugin_telemetry_metadata(self.codex_home.as_path(), &plugin_id).await)
+            Some(
+                self.telemetry_metadata_for_installed_plugin(&plugin_id)
+                    .await,
+            )
         } else {
             None
         };

--- a/codex-rs/core-plugins/src/manager_tests.rs
+++ b/codex-rs/core-plugins/src/manager_tests.rs
@@ -369,6 +369,112 @@ remote_plugin = true
 }
 
 #[tokio::test]
+async fn installed_plugin_telemetry_metadata_uses_local_identity_without_remote_snapshot() {
+    let codex_home = TempDir::new().unwrap();
+    write_cached_plugin(codex_home.path(), "test", "sample");
+    let manager = PluginsManager::new(codex_home.path().to_path_buf());
+    let plugin_id = PluginId::parse("sample@test").expect("plugin id should parse");
+
+    let metadata = manager
+        .telemetry_metadata_for_installed_plugin(&plugin_id)
+        .await;
+
+    assert_eq!(
+        metadata,
+        PluginTelemetryMetadata {
+            plugin_id,
+            remote_plugin_id: None,
+            capability_summary: Some(PluginCapabilitySummary {
+                config_name: "sample@test".to_string(),
+                display_name: "sample".to_string(),
+                description: None,
+                has_skills: true,
+                mcp_server_names: Vec::new(),
+                app_connector_ids: Vec::new(),
+            }),
+        }
+    );
+}
+
+#[tokio::test]
+async fn installed_plugin_telemetry_metadata_resolves_remote_snapshot_identity() {
+    let codex_home = TempDir::new().unwrap();
+    write_cached_plugin(codex_home.path(), "openai-curated-remote", "linear");
+    let manager = PluginsManager::new(codex_home.path().to_path_buf());
+    manager.write_remote_installed_plugins_cache(vec![remote_installed_linear_plugin()]);
+    let plugin_id =
+        PluginId::parse("linear@openai-curated-remote").expect("plugin id should parse");
+
+    let metadata = manager
+        .telemetry_metadata_for_installed_plugin(&plugin_id)
+        .await;
+
+    assert_eq!(
+        metadata,
+        PluginTelemetryMetadata {
+            plugin_id,
+            remote_plugin_id: Some("plugins~Plugin_linear".to_string()),
+            capability_summary: Some(PluginCapabilitySummary {
+                config_name: "linear@openai-curated-remote".to_string(),
+                display_name: "linear".to_string(),
+                description: None,
+                has_skills: true,
+                mcp_server_names: Vec::new(),
+                app_connector_ids: Vec::new(),
+            }),
+        }
+    );
+}
+
+#[tokio::test]
+async fn installed_plugin_telemetry_metadata_accepts_authoritative_remote_identity() {
+    let codex_home = TempDir::new().unwrap();
+    let manager = PluginsManager::new(codex_home.path().to_path_buf());
+    let plugin_id =
+        PluginId::parse("linear@openai-curated-remote").expect("plugin id should parse");
+
+    let metadata = manager
+        .telemetry_metadata_for_installed_plugin_with_remote_id(&plugin_id, "plugins~Plugin_linear")
+        .await;
+
+    assert_eq!(
+        metadata,
+        PluginTelemetryMetadata {
+            plugin_id,
+            remote_plugin_id: Some("plugins~Plugin_linear".to_string()),
+            capability_summary: None,
+        }
+    );
+}
+
+#[test]
+fn capability_summary_telemetry_metadata_resolves_remote_snapshot_identity() {
+    let codex_home = TempDir::new().unwrap();
+    let manager = PluginsManager::new(codex_home.path().to_path_buf());
+    manager.write_remote_installed_plugins_cache(vec![remote_installed_linear_plugin()]);
+    let summary = PluginCapabilitySummary {
+        config_name: "linear@openai-curated-remote".to_string(),
+        display_name: "Linear".to_string(),
+        description: Some("Track work".to_string()),
+        has_skills: true,
+        mcp_server_names: vec!["linear".to_string()],
+        app_connector_ids: vec![AppConnectorId("linear-app".to_string())],
+    };
+
+    let metadata = manager.telemetry_metadata_for_capability_summary(&summary);
+
+    assert_eq!(
+        metadata,
+        Some(PluginTelemetryMetadata {
+            plugin_id: PluginId::parse("linear@openai-curated-remote")
+                .expect("plugin id should parse"),
+            remote_plugin_id: Some("plugins~Plugin_linear".to_string()),
+            capability_summary: Some(summary),
+        })
+    );
+}
+
+#[tokio::test]
 async fn remote_installed_cache_prefers_local_curated_conflicts_when_remote_plugin_disabled() {
     let codex_home = TempDir::new().unwrap();
     write_file(
@@ -638,14 +744,14 @@ async fn plugin_telemetry_metadata_uses_default_mcp_config_path() {
 }"#,
     );
 
-    let metadata = plugin_telemetry_metadata_from_root(
+    let summary = plugin_capability_summary_from_root(
         &PluginId::parse("sample@test").expect("plugin id should parse"),
         &plugin_root.abs(),
     )
     .await;
 
     assert_eq!(
-        metadata.capability_summary,
+        summary,
         Some(PluginCapabilitySummary {
             config_name: "sample@test".to_string(),
             display_name: "sample".to_string(),

--- a/codex-rs/core-plugins/src/remote.rs
+++ b/codex-rs/core-plugins/src/remote.rs
@@ -99,6 +99,12 @@ pub struct RemotePluginServiceConfig {
     pub chatgpt_base_url: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemotePluginUninstallTarget {
+    pub plugin_id: PluginId,
+    pub remote_plugin_id: String,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct RemoteMarketplace {
     pub name: String,
@@ -1068,42 +1074,64 @@ pub async fn install_remote_plugin(
     Ok(())
 }
 
+pub async fn resolve_remote_plugin_uninstall_target(
+    config: &RemotePluginServiceConfig,
+    auth: Option<&CodexAuth>,
+    remote_plugin_id: &str,
+) -> Result<RemotePluginUninstallTarget, RemotePluginCatalogError> {
+    let auth = ensure_chatgpt_auth(auth)?;
+    let plugin = fetch_plugin_detail(
+        config,
+        auth,
+        remote_plugin_id,
+        /*include_download_urls*/ false,
+    )
+    .await?;
+    let marketplace_name = remote_plugin_canonical_marketplace_name(&plugin)?.to_string();
+    let remote_plugin_id = plugin.id;
+    let plugin_id = PluginId::new(plugin.name, marketplace_name).map_err(|err| {
+        RemotePluginCatalogError::UnexpectedResponse(format!(
+            "invalid local plugin id for remote plugin `{remote_plugin_id}`: {err}"
+        ))
+    })?;
+    Ok(RemotePluginUninstallTarget {
+        plugin_id,
+        remote_plugin_id,
+    })
+}
+
 pub async fn uninstall_remote_plugin(
     config: &RemotePluginServiceConfig,
     auth: Option<&CodexAuth>,
     codex_home: PathBuf,
-    plugin_id: &str,
+    target: RemotePluginUninstallTarget,
 ) -> Result<(), RemotePluginCatalogError> {
     let auth = ensure_chatgpt_auth(auth)?;
-    let plugin = fetch_plugin_detail(
-        config, auth, plugin_id, /*include_download_urls*/ false,
-    )
-    .await?;
-    let marketplace_name = remote_plugin_canonical_marketplace_name(&plugin)?.to_string();
-    let plugin_name = plugin.name;
-
+    let RemotePluginUninstallTarget {
+        plugin_id,
+        remote_plugin_id,
+    } = target;
     let base_url = config.chatgpt_base_url.trim_end_matches('/');
-    let url = format!("{base_url}/plugins/{plugin_id}/uninstall");
+    let url = format!("{base_url}/plugins/{remote_plugin_id}/uninstall");
     let client = build_reqwest_client();
     let request = authenticated_request(client.post(&url), auth)?;
     let response: RemotePluginMutationResponse = send_and_decode(request, &url).await?;
-    if response.id != plugin_id {
+    if response.id != remote_plugin_id {
         return Err(RemotePluginCatalogError::UnexpectedPluginId {
-            expected: plugin_id.to_string(),
+            expected: remote_plugin_id,
             actual: response.id,
         });
     }
     if response.enabled {
         return Err(RemotePluginCatalogError::UnexpectedEnabledState {
-            plugin_id: plugin_id.to_string(),
+            plugin_id: response.id,
             expected_enabled: false,
             actual_enabled: response.enabled,
         });
     }
 
-    let legacy_plugin_id = plugin_id.to_string();
     tokio::task::spawn_blocking(move || {
-        remove_remote_plugin_cache(codex_home, marketplace_name, plugin_name, legacy_plugin_id)
+        remove_remote_plugin_cache(codex_home, plugin_id, response.id)
     })
     .await
     .map_err(|err| {
@@ -1118,18 +1146,11 @@ pub async fn uninstall_remote_plugin(
 
 fn remove_remote_plugin_cache(
     codex_home: PathBuf,
-    marketplace_name: String,
-    plugin_name: String,
+    plugin_id: PluginId,
     legacy_plugin_id: String,
 ) -> Result<(), String> {
     let store = PluginStore::try_new(codex_home.clone())
         .map_err(|err| format!("failed to resolve remote plugin cache root: {err}"))?;
-    let plugin_id =
-        PluginId::new(plugin_name.clone(), marketplace_name.clone()).map_err(|err| {
-            format!(
-                "invalid remote plugin cache id for `{plugin_name}` in `{marketplace_name}`: {err}"
-            )
-        })?;
     let plugin_cache_root = store.plugin_base_root(&plugin_id);
     store.uninstall(&plugin_id).map_err(|err| {
         format!(
@@ -1140,7 +1161,7 @@ fn remove_remote_plugin_cache(
 
     let legacy_remote_plugin_cache_root = codex_home
         .join(PLUGINS_CACHE_DIR)
-        .join(marketplace_name)
+        .join(plugin_id.marketplace_name)
         .join(legacy_plugin_id);
     if legacy_remote_plugin_cache_root != plugin_cache_root.as_path()
         && legacy_remote_plugin_cache_root.exists()

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -561,13 +561,16 @@ async fn build_skills_and_plugins(
     sess.services
         .analytics_events_client
         .track_app_mentioned(tracking.clone(), mentioned_app_invocations);
-    for plugin in mentioned_plugins
-        .iter()
-        .filter_map(crate::plugins::PluginCapabilitySummary::telemetry_metadata)
-    {
-        sess.services
-            .analytics_events_client
-            .track_plugin_used(tracking.clone(), plugin);
+    for summary in &mentioned_plugins {
+        if let Some(plugin) = sess
+            .services
+            .plugins_manager
+            .telemetry_metadata_for_capability_summary(summary)
+        {
+            sess.services
+                .analytics_events_client
+                .track_plugin_used(tracking.clone(), plugin);
+        }
     }
 
     let mut injection_items: Vec<ResponseItem> = match injected_host_skill_prompts {

--- a/codex-rs/core/tests/suite/plugins.rs
+++ b/codex-rs/core/tests/suite/plugins.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 use anyhow::Result;
+use codex_core_plugins::remote::RemotePluginScope;
 use codex_features::Feature;
 use codex_login::CodexAuth;
 use codex_protocol::protocol::EventMsg;
@@ -23,11 +24,18 @@ use core_test_support::test_codex::test_codex;
 use core_test_support::wait_for_event;
 use core_test_support::wait_for_mcp_server;
 use tempfile::TempDir;
+use wiremock::Mock;
 use wiremock::MockServer;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
+use wiremock::matchers::query_param;
 
 const SAMPLE_PLUGIN_CONFIG_NAME: &str = "sample@test";
 const SAMPLE_PLUGIN_DISPLAY_NAME: &str = "sample";
 const SAMPLE_PLUGIN_DESCRIPTION: &str = "inspect sample data";
+const REMOTE_SAMPLE_PLUGIN_CONFIG_NAME: &str = "sample@openai-curated-remote";
+const REMOTE_SAMPLE_PLUGIN_ID: &str = "plugins~Plugin_sample";
 
 fn sample_plugin_root(home: &TempDir) -> std::path::PathBuf {
     home.path().join("plugins/cache/test/sample/local")
@@ -63,6 +71,33 @@ fn write_plugin_skill_plugin(home: &TempDir) -> std::path::PathBuf {
     )
     .expect("write plugin skill");
     skill_dir.join("SKILL.md")
+}
+
+fn write_remote_plugin_skill_plugin(home: &TempDir) {
+    let plugin_root = home
+        .path()
+        .join("plugins/cache/openai-curated-remote/sample/local");
+    std::fs::create_dir_all(plugin_root.join(".codex-plugin"))
+        .expect("create remote plugin manifest dir");
+    std::fs::write(
+        plugin_root.join(".codex-plugin/plugin.json"),
+        r#"{"name":"sample","description":"inspect sample data"}"#,
+    )
+    .expect("write remote plugin manifest");
+    let skill_dir = plugin_root.join("skills/sample-search");
+    std::fs::create_dir_all(&skill_dir).expect("create remote plugin skill dir");
+    std::fs::write(
+        skill_dir.join("SKILL.md"),
+        "---\ndescription: inspect sample data\n---\n\n# body\n",
+    )
+    .expect("write remote plugin skill");
+    std::fs::write(
+        home.path().join("config.toml"),
+        format!(
+            "[features]\nplugins = true\nremote_plugin = true\n\n[plugins.\"{REMOTE_SAMPLE_PLUGIN_CONFIG_NAME}\"]\nenabled = true\n"
+        ),
+    )
+    .expect("write remote plugin config");
 }
 
 fn write_plugin_mcp_plugin(home: &TempDir, command: &str) {
@@ -358,32 +393,12 @@ async fn explicit_plugin_mentions_track_plugin_used_analytics() -> Result<()> {
         .await?;
     wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
 
-    let deadline = Instant::now() + Duration::from_secs(10);
-    let plugin_event = loop {
-        let requests = server.received_requests().await.unwrap_or_default();
-        if let Some(event) = requests
-            .into_iter()
-            .filter(|request| request.url.path() == "/codex/analytics-events/events")
-            .find_map(|request| {
-                let payload: serde_json::Value = serde_json::from_slice(&request.body).ok()?;
-                payload["events"].as_array().and_then(|events| {
-                    events
-                        .iter()
-                        .find(|event| event["event_type"] == "codex_plugin_used")
-                        .cloned()
-                })
-            })
-        {
-            break event;
-        }
-        if Instant::now() >= deadline {
-            panic!("timed out waiting for plugin analytics request");
-        }
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    };
-
-    let event = plugin_event;
+    let event = wait_for_plugin_used_analytics_event(&server).await;
     assert_eq!(event["event_params"]["plugin_id"], "sample@test");
+    assert_eq!(
+        event["event_params"]["remote_plugin_id"],
+        serde_json::Value::Null
+    );
     assert_eq!(event["event_params"]["plugin_name"], "sample");
     assert_eq!(event["event_params"]["marketplace_name"], "test");
     assert_eq!(event["event_params"]["has_skills"], true);
@@ -405,4 +420,123 @@ async fn explicit_plugin_mentions_track_plugin_used_analytics() -> Result<()> {
     assert!(event["event_params"]["turn_id"].as_str().is_some());
 
     Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicit_remote_plugin_mentions_track_remote_plugin_id() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+    let server = start_mock_server().await;
+    let _resp_mock = mount_sse_once(
+        &server,
+        sse(vec![ev_response_created("resp-1"), ev_completed("resp-1")]),
+    )
+    .await;
+    let global_installed_body = format!(
+        r#"{{
+  "plugins": [{{
+    "id": "{REMOTE_SAMPLE_PLUGIN_ID}",
+    "name": "sample",
+    "scope": "GLOBAL",
+    "installation_policy": "AVAILABLE",
+    "authentication_policy": "ON_USE",
+    "release": {{
+      "version": "1.0.0",
+      "display_name": "Sample",
+      "description": "Inspect sample data",
+      "app_ids": [],
+      "interface": {{}},
+      "skills": []
+    }},
+    "enabled": true,
+    "disabled_skill_names": []
+  }}],
+  "pagination": {{"limit": 50, "next_page_token": null}}
+}}"#
+    );
+    Mock::given(method("GET"))
+        .and(path("/ps/plugins/installed"))
+        .and(query_param("scope", "GLOBAL"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(global_installed_body))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/ps/plugins/installed"))
+        .and(query_param("scope", "WORKSPACE"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string(
+                r#"{"plugins":[],"pagination":{"limit":50,"next_page_token":null}}"#,
+            ),
+        )
+        .mount(&server)
+        .await;
+
+    let codex_home = Arc::new(TempDir::new()?);
+    write_remote_plugin_skill_plugin(codex_home.as_ref());
+    let test_codex = build_analytics_plugin_test_codex(&server, codex_home).await?;
+    let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
+    test_codex
+        .thread_manager
+        .plugins_manager()
+        .build_and_cache_remote_installed_plugin_marketplaces(
+            &test_codex.config.plugins_config_input(),
+            Some(&auth),
+            &[RemotePluginScope::Global],
+            /*on_effective_plugins_changed*/ None,
+        )
+        .await?;
+    let codex = Arc::clone(&test_codex.codex);
+
+    codex
+        .submit(Op::UserInput {
+            environments: None,
+            items: vec![codex_protocol::user_input::UserInput::Mention {
+                name: "sample".into(),
+                path: format!("plugin://{REMOTE_SAMPLE_PLUGIN_CONFIG_NAME}"),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: Default::default(),
+        })
+        .await?;
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    let event = wait_for_plugin_used_analytics_event(&server).await;
+    assert_eq!(
+        event["event_params"]["plugin_id"],
+        REMOTE_SAMPLE_PLUGIN_CONFIG_NAME
+    );
+    assert_eq!(
+        event["event_params"]["remote_plugin_id"],
+        REMOTE_SAMPLE_PLUGIN_ID
+    );
+    assert_eq!(event["event_params"]["has_skills"], true);
+
+    Ok(())
+}
+
+async fn wait_for_plugin_used_analytics_event(server: &MockServer) -> serde_json::Value {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let requests = server.received_requests().await.unwrap_or_default();
+        if let Some(event) = requests
+            .into_iter()
+            .filter(|request| request.url.path() == "/codex/analytics-events/events")
+            .find_map(|request| {
+                let payload: serde_json::Value = serde_json::from_slice(&request.body).ok()?;
+                payload["events"].as_array().and_then(|events| {
+                    events
+                        .iter()
+                        .find(|event| event["event_type"] == "codex_plugin_used")
+                        .cloned()
+                })
+            })
+        {
+            return event;
+        }
+        if Instant::now() >= deadline {
+            panic!("timed out waiting for plugin analytics request");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
 }

--- a/codex-rs/plugin/src/lib.rs
+++ b/codex-rs/plugin/src/lib.rs
@@ -41,31 +41,9 @@ pub struct PluginHookSource {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PluginTelemetryMetadata {
+    /// Local plugin identifier used by Codex configuration and the plugin cache.
     pub plugin_id: PluginId,
-    /// Optional backend identifier for remote plugins, used when analytics
-    /// should report the remote id instead of the local plugin cache id.
+    /// Optional backend identifier for remote plugins.
     pub remote_plugin_id: Option<String>,
     pub capability_summary: Option<PluginCapabilitySummary>,
-}
-
-impl PluginTelemetryMetadata {
-    pub fn from_plugin_id(plugin_id: &PluginId) -> Self {
-        Self {
-            plugin_id: plugin_id.clone(),
-            remote_plugin_id: None,
-            capability_summary: None,
-        }
-    }
-}
-
-impl PluginCapabilitySummary {
-    pub fn telemetry_metadata(&self) -> Option<PluginTelemetryMetadata> {
-        PluginId::parse(&self.config_name)
-            .ok()
-            .map(|plugin_id| PluginTelemetryMetadata {
-                plugin_id,
-                remote_plugin_id: None,
-                capability_summary: Some(self.clone()),
-            })
-    }
 }


### PR DESCRIPTION
## Summary
- Emit both local `plugin_id` and nullable `remote_plugin_id` for plugin analytics events
- Move telemetry construction into `PluginsManager` so emitters receive complete immutable metadata
- Split remote uninstall into resolution and execution so analytics can capture the authoritative remote ID before cache removal
- Update plugin used, enable/disable, install, and uninstall coverage to assert the new identity handling

## Testing
- `just test -p codex-analytics`
- `just test -p codex-core-plugins`
- `just test -p codex-plugin`
- Focused `codex-app-server` and `codex-core` plugin analytics integration tests
- `just fix -p codex-plugin`, `just fix -p codex-analytics`, `just fix -p codex-core-plugins`, `just fix -p codex-app-server`, `just fix -p codex-core`
- `just fmt`


## Manual validation

Added two plugin analytics smoke workflows to the existing `codex-app-server-test-client` developer harness. Both use the production app-server RPC and analytics processing paths while redirecting analytics to a local JSONL file instead of sending them remotely.

### Enable, disable, and use

`plugin-analytics-smoke` takes an installed plugin’s local Codex ID, calls `plugin/installed` to obtain its authoritative `remotePluginId`, and exercises:

- Plugin disable
- Plugin enable
- Plugin use through a structured plugin mention

It validates that exactly one `codex_plugin_disabled`, `codex_plugin_enabled`, and `codex_plugin_used` event contains both the expected local `plugin_id` and resolved `remote_plugin_id`.

Validated with:

```bash
cargo build -p codex-cli --bin codex

cargo run -p codex-app-server-test-client -- \
  --codex-bin ./target/debug/codex \
  plugin-analytics-smoke \
  --plugin-id github@openai-curated-remote \
  --capture-file /tmp/plugin-analytics.jsonl
```

### Remote install and uninstall

`plugin-analytics-mutation-smoke` takes an authoritative backend plugin ID and exercises the production `plugin/read`, `plugin/install`, and `plugin/uninstall` paths.

The selected plugin must initially be uninstalled. The command:

- Resolves the plugin’s local Codex ID from `plugin/read`
- Installs the plugin
- Validates `codex_plugin_installed`
- Uninstalls the plugin
- Validates `codex_plugin_uninstalled`
- Verifies that the original uninstalled account state was restored
- Attempts cleanup and prints a recovery command if the sequence fails

Because this changes the active account’s plugin state, it requires the explicit `--confirm-account-mutation` flag.

Validated with:

```bash
cargo run -p codex-app-server-test-client -- \
  --codex-bin ./target/debug/codex \
  plugin-analytics-mutation-smoke \
  --remote-plugin-id plugins~Plugin_b12006c2cc04819192cb1c1227ac52f7 \
  --confirm-account-mutation \
  --capture-file /tmp/plugin-mutation-analytics.jsonl
```

The supplied remote ID resolved to `game-studio@openai-curated-remote`. The smoke test validated that both install and uninstall events contained:

- `plugin_id: game-studio@openai-curated-remote`
- `remote_plugin_id: plugins~Plugin_b12006c2cc04819192cb1c1227ac52f7`