### PR TITLE
feat: reuse low-risk Guardian approvals

### DIFF
--- a/codex-rs/core/src/guardian/review.rs
+++ b/codex-rs/core/src/guardian/review.rs
@@ -141,6 +141,17 @@ fn guardian_risk_level_str(level: GuardianRiskLevel) -> &'static str {
     }
 }
 
+fn guardian_assessment_allows_session_reuse(assessment: &GuardianAssessment) -> bool {
+    matches!(assessment.outcome, GuardianAssessmentOutcome::Allow)
+        && assessment.risk_level == GuardianRiskLevel::Low
+        && matches!(
+            assessment.user_authorization,
+            GuardianUserAuthorization::Low
+                | GuardianUserAuthorization::Medium
+                | GuardianUserAuthorization::High
+        )
+}
+
 /// Whether this turn should route allowed approval prompts through the guardian
 /// reviewer instead of surfacing them to the user. ARC may still block actions
 /// earlier in the flow.
@@ -561,7 +572,9 @@ async fn run_guardian_review(
         record_guardian_non_denial(&session, &assessment_turn_id).await;
     }
 
-    if approved {
+    if guardian_assessment_allows_session_reuse(&assessment) {
+        ReviewDecision::ApprovedForSession
+    } else if approved {
         ReviewDecision::Approved
     } else {
         ReviewDecision::Denied
@@ -824,5 +837,28 @@ mod review_tests {
             session_error.failure_reason(),
             GuardianReviewFailureReason::SessionError
         ));
+    }
+
+    #[test]
+    fn guardian_reuses_only_low_risk_authorized_allows() {
+        let low_authorized = GuardianAssessment {
+            risk_level: GuardianRiskLevel::Low,
+            user_authorization: GuardianUserAuthorization::High,
+            outcome: GuardianAssessmentOutcome::Allow,
+            rationale: "Routine local inspection.".to_string(),
+        };
+        assert!(guardian_assessment_allows_session_reuse(&low_authorized));
+
+        let low_unknown = GuardianAssessment {
+            user_authorization: GuardianUserAuthorization::Unknown,
+            ..low_authorized.clone()
+        };
+        assert!(!guardian_assessment_allows_session_reuse(&low_unknown));
+
+        let medium = GuardianAssessment {
+            risk_level: GuardianRiskLevel::Medium,
+            ..low_authorized
+        };
+        assert!(!guardian_assessment_allows_session_reuse(&medium));
     }
 }

--- a/codex-rs/core/src/guardian/tests.rs
+++ b/codex-rs/core/src/guardian/tests.rs
@@ -2168,7 +2168,7 @@ async fn guardian_parallel_reviews_fork_from_last_committed_trunk_history() -> a
                 /*retry_reason*/ None
             )
             .await,
-            ReviewDecision::Approved
+            ReviewDecision::ApprovedForSession
         );
         session
             .record_conversation_items(
@@ -2269,7 +2269,7 @@ async fn guardian_parallel_reviews_fork_from_last_committed_trunk_history() -> a
             Some("parallel follow-up".to_string()),
         )
         .await;
-        assert_eq!(third_decision, ReviewDecision::Approved);
+        assert_eq!(third_decision, ReviewDecision::ApprovedForSession);
         let requests = server.requests().await;
         assert_eq!(requests.len(), 3);
         let second_request_body = serde_json::from_slice::<serde_json::Value>(&requests[1])?;
@@ -2305,7 +2305,7 @@ async fn guardian_parallel_reviews_fork_from_last_committed_trunk_history() -> a
         gate_tx
             .send(())
             .expect("second guardian review gate should still be open");
-        assert_eq!(second_review.await?, ReviewDecision::Approved);
+        assert_eq!(second_review.await?, ReviewDecision::ApprovedForSession);
         server.shutdown().await;
 
         Ok(())

--- a/codex-rs/core/src/session/tests/guardian_tests.rs
+++ b/codex-rs/core/src/session/tests/guardian_tests.rs
@@ -150,13 +150,13 @@ async fn request_permissions_routes_to_guardian_when_reviewer_is_enabled() {
         response,
         Some(RequestPermissionsResponse {
             permissions: requested_permissions.clone(),
-            scope: PermissionGrantScope::Turn,
+            scope: PermissionGrantScope::Session,
             strict_auto_review: false,
         })
     );
     assert_eq!(
         session
-            .granted_turn_permissions(codex_exec_server::LOCAL_ENVIRONMENT_ID)
+            .granted_session_permissions(codex_exec_server::LOCAL_ENVIRONMENT_ID)
             .await,
         Some(requested_permissions.into())
     );

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -147,19 +147,27 @@ impl Approvable<ShellRequest> for ShellRuntime {
         let guardian_review_id = ctx.guardian_review_id.clone();
         Box::pin(async move {
             if let Some(review_id) = guardian_review_id {
-                return review_approval_request(
-                    session,
-                    turn,
-                    review_id,
-                    GuardianApprovalRequest::Shell {
-                        id: call_id,
-                        command,
-                        cwd: cwd.clone(),
-                        sandbox_permissions: req.sandbox_permissions,
-                        additional_permissions: req.additional_permissions.clone(),
-                        justification: req.justification.clone(),
+                return with_cached_approval(
+                    &session.services,
+                    "shell",
+                    keys,
+                    move || async move {
+                        review_approval_request(
+                            session,
+                            turn,
+                            review_id,
+                            GuardianApprovalRequest::Shell {
+                                id: call_id,
+                                command,
+                                cwd: cwd.clone(),
+                                sandbox_permissions: req.sandbox_permissions,
+                                additional_permissions: req.additional_permissions.clone(),
+                                justification: req.justification.clone(),
+                            },
+                            retry_reason,
+                        )
+                        .await
                     },
-                    retry_reason,
                 )
                 .await;
             }

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -159,20 +159,28 @@ impl Approvable<UnifiedExecRequest> for UnifiedExecRuntime<'_> {
         let guardian_review_id = ctx.guardian_review_id.clone();
         Box::pin(async move {
             if let Some(review_id) = guardian_review_id {
-                return review_approval_request(
-                    session,
-                    turn,
-                    review_id,
-                    GuardianApprovalRequest::ExecCommand {
-                        id: call_id,
-                        command,
-                        cwd: cwd.clone(),
-                        sandbox_permissions: req.sandbox_permissions,
-                        additional_permissions: req.additional_permissions.clone(),
-                        justification: req.justification.clone(),
-                        tty: req.tty,
+                return with_cached_approval(
+                    &session.services,
+                    "unified_exec",
+                    keys,
+                    || async move {
+                        review_approval_request(
+                            session,
+                            turn,
+                            review_id,
+                            GuardianApprovalRequest::ExecCommand {
+                                id: call_id,
+                                command,
+                                cwd: cwd.clone(),
+                                sandbox_permissions: req.sandbox_permissions,
+                                additional_permissions: req.additional_permissions.clone(),
+                                justification: req.justification.clone(),
+                                tty: req.tty,
+                            },
+                            retry_reason,
+                        )
+                        .await
                     },
-                    retry_reason,
                 )
                 .await;
             }


### PR DESCRIPTION
## Why

Guardian currently asks again for repeated low-risk actions even when the reviewer has already confirmed explicit user authorization in the transcript. Reusing that narrow approval reduces repetitive prompts without broadening the permission boundary.

## What changed

- return a session-scoped approval only for low-risk `allow` assessments with explicit user authorization
- reuse the existing exact shell and unified-exec approval cache keys
- keep unknown authorization and medium-or-higher risk on the normal per-action approval path
- update permission-routing coverage for the session-scoped result

## Scope

This PR is independent and targets `main`. It does not add denial kinds, reviewer retries, or UI behavior.

Split from #26128. Related independent PRs: #26231, #26334, and #26232.

## Validation

- `just test -p codex-core guardian`
- focused permission-routing regression coverage for session-scoped Guardian approval
