### PR TITLE
core: dedupe runtime PATH prepends after snapshots

### DIFF
--- a/codex-rs/core/src/tools/runtimes/mod.rs
+++ b/codex-rs/core/src/tools/runtimes/mod.rs
@@ -33,6 +33,31 @@ pub(crate) mod apply_patch;
 pub(crate) mod shell;
 pub(crate) mod unified_exec;
 
+const PREPEND_PATH_ENTRY_AFTER_SNAPSHOT: &str = r#"__codex_prepend_path_entry() {
+  __codex_path_entry="$1"
+  if [ -z "$__codex_path_entry" ]; then
+    return
+  fi
+  __codex_old_path="${PATH:-}"
+  PATH="$__codex_path_entry"
+  while [ -n "$__codex_old_path" ]; do
+    case "$__codex_old_path" in
+      *:*)
+        __codex_path_part="${__codex_old_path%%:*}"
+        __codex_old_path="${__codex_old_path#*:}"
+        ;;
+      *)
+        __codex_path_part="$__codex_old_path"
+        __codex_old_path=
+        ;;
+    esac
+    if [ -n "$__codex_path_part" ] && [ "$__codex_path_part" != "$__codex_path_entry" ]; then
+      PATH="$PATH:$__codex_path_part"
+    fi
+  done
+  export PATH
+}"#;
+
 /// Shared helper to construct sandbox transform inputs from a tokenized command line.
 /// Validates that at least a program is present.
 pub(crate) fn build_sandbox_command(
@@ -141,17 +166,21 @@ impl RuntimePathPrepends {
             return String::new();
         }
 
-        self.entries
+        let exports = self
+            .entries
             .iter()
             .filter(|entry| !entry.is_empty())
             .map(|entry| {
                 let entry = shell_single_quote(entry);
-                format!(
-                    "if [ -n \"${{PATH:-}}\" ]; then export PATH='{entry}':\"$PATH\"; else export PATH='{entry}'; fi"
-                )
+                format!("__codex_prepend_path_entry '{entry}'")
             })
             .collect::<Vec<_>>()
-            .join("\n")
+            .join("\n");
+        if exports.is_empty() {
+            String::new()
+        } else {
+            format!("{PREPEND_PATH_ENTRY_AFTER_SNAPSHOT}\n{exports}")
+        }
     }
 }
 

--- a/codex-rs/core/src/tools/runtimes/mod_tests.rs
+++ b/codex-rs/core/src/tools/runtimes/mod_tests.rs
@@ -992,8 +992,10 @@ fn maybe_wrap_shell_lc_with_snapshot_applies_explicit_path_override() {
 #[cfg(unix)]
 #[test]
 fn maybe_wrap_shell_lc_with_snapshot_preserves_package_path_prepend() -> anyhow::Result<()> {
-    let (stdout, package_path_dir) =
-        run_snapshot_path_probe_with_runtime_path_prepend(HashMap::new())?;
+    let (stdout, package_path_dir) = run_snapshot_path_probe_with_runtime_path_prepend(
+        HashMap::new(),
+        SnapshotPathFixture::SnapshotBinOnly,
+    )?;
 
     assert_eq!(
         stdout,
@@ -1009,6 +1011,7 @@ fn maybe_wrap_shell_lc_with_snapshot_applies_runtime_path_prepend_after_explicit
 -> anyhow::Result<()> {
     let (stdout, package_path_dir) = run_snapshot_path_probe_with_runtime_path_prepend(
         HashMap::from([("PATH".to_string(), "/worktree/bin".to_string())]),
+        SnapshotPathFixture::SnapshotBinOnly,
     )?;
 
     assert_eq!(
@@ -1020,14 +1023,46 @@ fn maybe_wrap_shell_lc_with_snapshot_applies_runtime_path_prepend_after_explicit
 }
 
 #[cfg(unix)]
+#[test]
+fn maybe_wrap_shell_lc_with_snapshot_deduplicates_runtime_path_prepend_from_snapshot_path()
+-> anyhow::Result<()> {
+    let (stdout, package_path_dir) = run_snapshot_path_probe_with_runtime_path_prepend(
+        HashMap::new(),
+        SnapshotPathFixture::AlreadyContainsPackagePath,
+    )?;
+
+    assert_eq!(
+        stdout,
+        format!("{}:/snapshot/bin", package_path_dir.display()),
+        "runtime PATH prepend should not duplicate an entry restored by the snapshot"
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+enum SnapshotPathFixture {
+    SnapshotBinOnly,
+    AlreadyContainsPackagePath,
+}
+
+#[cfg(unix)]
 fn run_snapshot_path_probe_with_runtime_path_prepend(
     explicit_env_overrides: HashMap<String, String>,
+    snapshot_path_fixture: SnapshotPathFixture,
 ) -> anyhow::Result<(String, PathBuf)> {
     let dir = tempdir()?;
+    let package_path_dir = dir.path().join("codex-path");
+    let snapshot_path_value = match snapshot_path_fixture {
+        SnapshotPathFixture::SnapshotBinOnly => "/snapshot/bin".to_string(),
+        SnapshotPathFixture::AlreadyContainsPackagePath => {
+            format!("{}:/snapshot/bin", package_path_dir.display())
+        }
+    };
     let snapshot_path = dir.path().join("snapshot.sh");
+    let snapshot_path_value = shell_single_quote(&snapshot_path_value);
     std::fs::write(
         &snapshot_path,
-        "# Snapshot file\nexport PATH='/snapshot/bin'\n",
+        format!("# Snapshot file\nexport PATH='{snapshot_path_value}'\n"),
     )?;
     let session_shell = shell_with_snapshot(
         ShellType::Bash,
@@ -1040,7 +1075,6 @@ fn run_snapshot_path_probe_with_runtime_path_prepend(
         "-lc".to_string(),
         "printf '%s' \"$PATH\"".to_string(),
     ];
-    let package_path_dir = dir.path().join("codex-path");
     let mut env = HashMap::from([("PATH".to_string(), "/worktree/bin".to_string())]);
     let mut runtime_path_prepends = RuntimePathPrepends::default();
     runtime_path_prepends.prepend(&mut env, package_path_dir.as_path());


### PR DESCRIPTION
## Why

https://github.com/openai/codex/pull/26189 moved package `codex-path` prepending into the Rust runtime and replays runtime-owned `PATH` prepends after restoring shell snapshots. A release repro showed that local shell commands could end up with the package `codex-path` entry twice when the sourced snapshot already contained that same path and runtime replay prepended it again. That made commands such as `which -a rg` report the packaged `rg` twice.

## What

- Make `RuntimePathPrepends::shell_exports_after_snapshot` use a shell-side prepend helper that removes empty `PATH` entries and existing copies of the runtime-owned entry before prepending it.
- Keep the replay behavior aligned with the Rust-side `prepend_path_entry` de-dupe semantics.
- Add a regression test where the shell snapshot already contains the package path, verifying replay does not duplicate it.

## Verification

- `just test -p codex-core tools::runtimes::tests`
- `just fix -p codex-core`

## Documentation

No developer documentation changes needed.
