### PR TITLE
Add OTEL resource attributes to Codex config

### DIFF
--- a/codex-rs/config/src/types.rs
+++ b/codex-rs/config/src/types.rs
@@ -526,6 +526,9 @@ pub struct OtelConfigToml {
     /// Optional metrics exporter
     pub metrics_exporter: Option<OtelExporterKind>,
 
+    /// Attributes to add to exported OTEL resources.
+    pub resource_attributes: Option<BTreeMap<String, String>>,
+
     /// Attributes to add to every exported trace span.
     pub span_attributes: Option<BTreeMap<String, String>>,
 
@@ -541,6 +544,7 @@ pub struct OtelConfig {
     pub exporter: OtelExporterKind,
     pub trace_exporter: OtelExporterKind,
     pub metrics_exporter: OtelExporterKind,
+    pub resource_attributes: BTreeMap<String, String>,
     pub span_attributes: BTreeMap<String, String>,
     pub tracestate: BTreeMap<String, BTreeMap<String, String>>,
 }
@@ -553,6 +557,7 @@ impl Default for OtelConfig {
             exporter: OtelExporterKind::None,
             trace_exporter: OtelExporterKind::None,
             metrics_exporter: OtelExporterKind::Statsig,
+            resource_attributes: BTreeMap::new(),
             span_attributes: BTreeMap::new(),
             tracestate: BTreeMap::new(),
         }

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -2001,6 +2001,13 @@
           ],
           "description": "Optional metrics exporter"
         },
+        "resource_attributes": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Attributes to add to exported OTEL resources.",
+          "type": "object"
+        },
         "span_attributes": {
           "additionalProperties": {
             "type": "string"

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -8037,6 +8037,10 @@ async fn load_config_applies_otel_trace_metadata() -> std::io::Result<()> {
     let mut fixture = create_test_fixture()?;
     fixture.cfg = toml::from_str(
         r#"
+[otel.resource_attributes]
+"openai_cluster_kind" = "applied-devbox"
+"openai_cluster_name" = "devbox-1"
+
 [otel.span_attributes]
 "example.trace_attr" = "enabled"
 
@@ -8057,6 +8061,16 @@ beta = "two"
     )
     .await?;
 
+    assert_eq!(
+        config.otel.resource_attributes,
+        BTreeMap::from([
+            (
+                "openai_cluster_kind".to_string(),
+                "applied-devbox".to_string(),
+            ),
+            ("openai_cluster_name".to_string(), "devbox-1".to_string()),
+        ])
+    );
     assert_eq!(
         config.otel.span_attributes,
         BTreeMap::from([("example.trace_attr".to_string(), "enabled".to_string())])
@@ -8086,6 +8100,10 @@ environment = "test"
 "" = "missing-key"
 "example.trace_attr" = "enabled"
 
+[otel.resource_attributes]
+"" = "missing-key"
+"openai_cluster_name" = "devbox-1"
+
 [otel.tracestate.example]
 alpha = "one"
 beta = "two\ntoo"
@@ -8108,6 +8126,10 @@ alpha = "one\ntwo"
 
     assert_eq!(config.otel.environment, "test");
     assert_eq!(
+        config.otel.resource_attributes,
+        BTreeMap::from([("openai_cluster_name".to_string(), "devbox-1".to_string())])
+    );
+    assert_eq!(
         config.otel.span_attributes,
         BTreeMap::from([("example.trace_attr".to_string(), "enabled".to_string())])
     );
@@ -8117,6 +8139,14 @@ alpha = "one\ntwo"
             "example".to_string(),
             BTreeMap::from([("alpha".to_string(), "one".to_string())]),
         )])
+    );
+    assert!(
+        config.startup_warnings.iter().any(|warning| {
+            warning.contains("Ignoring invalid `otel.resource_attributes` config")
+                && warning.contains("configured resource attribute key must not be empty")
+        }),
+        "{:?}",
+        config.startup_warnings
     );
     assert!(
         config.startup_warnings.iter().any(|warning| {

--- a/codex-rs/core/src/config/otel.rs
+++ b/codex-rs/core/src/config/otel.rs
@@ -22,6 +22,8 @@ pub(crate) fn resolve_config(
     // Provider initialization installs process-global OTEL state. Sanitize
     // user-editable trace metadata here so malformed config is reported as a
     // startup warning instead of making startup fail.
+    let resource_attributes =
+        resolve_resource_attributes(config.resource_attributes, startup_warnings);
     let span_attributes = resolve_span_attributes(config.span_attributes, startup_warnings);
     let tracestate = resolve_tracestate(config.tracestate, startup_warnings);
 
@@ -31,9 +33,31 @@ pub(crate) fn resolve_config(
         exporter,
         trace_exporter,
         metrics_exporter,
+        resource_attributes,
         span_attributes,
         tracestate,
     }
+}
+
+fn resolve_resource_attributes(
+    resource_attributes: Option<BTreeMap<String, String>>,
+    startup_warnings: &mut Vec<String>,
+) -> BTreeMap<String, String> {
+    let Some(resource_attributes) = resource_attributes else {
+        return BTreeMap::new();
+    };
+
+    let mut valid_attributes = BTreeMap::new();
+    for (key, value) in resource_attributes {
+        let attribute = BTreeMap::from([(key.clone(), value.clone())]);
+        if let Err(err) = codex_otel::validate_resource_attributes(&attribute) {
+            push_invalid_config_warning("otel.resource_attributes", err, startup_warnings);
+            continue;
+        }
+        valid_attributes.insert(key, value);
+    }
+
+    valid_attributes
 }
 
 fn resolve_span_attributes(

--- a/codex-rs/core/src/otel_init.rs
+++ b/codex-rs/core/src/otel_init.rs
@@ -89,6 +89,7 @@ pub fn build_provider(
         trace_exporter,
         metrics_exporter,
         runtime_metrics,
+        resource_attributes: config.otel.resource_attributes.clone(),
         span_attributes: config.otel.span_attributes.clone(),
         tracestate: config.otel.tracestate.clone(),
     })

--- a/codex-rs/otel/README.md
+++ b/codex-rs/otel/README.md
@@ -39,6 +39,7 @@ let settings = OtelSettings {
         tls: None,
     },
     metrics_exporter: OtelExporter::None,
+    resource_attributes: std::collections::BTreeMap::new(),
     span_attributes: std::collections::BTreeMap::new(),
     tracestate: std::collections::BTreeMap::new(),
 };
@@ -51,10 +52,14 @@ if let Some(provider) = OtelProvider::from(&settings)? {
 }
 ```
 
-Configured span attributes and W3C tracestate member fields are applied to
-exported trace spans and propagated trace context:
+Configured resource attributes are applied to exported OTEL resources. Configured
+span attributes and W3C tracestate member fields are applied to exported trace
+spans and propagated trace context:
 
 ```toml
+[otel.resource_attributes]
+"example.resource_attr" = "enabled"
+
 [otel.span_attributes]
 "example.trace_attr" = "enabled"
 

--- a/codex-rs/otel/src/config.rs
+++ b/codex-rs/otel/src/config.rs
@@ -35,16 +35,28 @@ pub(crate) fn resolve_exporter(exporter: &OtelExporter) -> OtelExporter {
     }
 }
 
-/// Validates configured span attributes before they are attached to exported spans.
-pub fn validate_span_attributes(attributes: &BTreeMap<String, String>) -> std::io::Result<()> {
+fn validate_attribute_keys(
+    attributes: &BTreeMap<String, String>,
+    kind: &str,
+) -> std::io::Result<()> {
     if attributes.keys().any(String::is_empty) {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
-            "configured span attribute key must not be empty",
+            format!("configured {kind} attribute key must not be empty"),
         ));
     }
 
     Ok(())
+}
+
+/// Validates configured resource attributes before they are attached to exported resources.
+pub fn validate_resource_attributes(attributes: &BTreeMap<String, String>) -> std::io::Result<()> {
+    validate_attribute_keys(attributes, "resource")
+}
+
+/// Validates configured span attributes before they are attached to exported spans.
+pub fn validate_span_attributes(attributes: &BTreeMap<String, String>) -> std::io::Result<()> {
+    validate_attribute_keys(attributes, "span")
 }
 
 #[derive(Clone, Debug)]
@@ -57,6 +69,7 @@ pub struct OtelSettings {
     pub trace_exporter: OtelExporter,
     pub metrics_exporter: OtelExporter,
     pub runtime_metrics: bool,
+    pub resource_attributes: BTreeMap<String, String>,
     pub span_attributes: BTreeMap<String, String>,
     pub tracestate: BTreeMap<String, BTreeMap<String, String>>,
 }

--- a/codex-rs/otel/src/lib.rs
+++ b/codex-rs/otel/src/lib.rs
@@ -16,6 +16,7 @@ pub use crate::config::OtelHttpProtocol;
 pub use crate::config::OtelSettings;
 pub use crate::config::OtelTlsConfig;
 pub use crate::config::StatsigMetricsSettings;
+pub use crate::config::validate_resource_attributes;
 pub use crate::config::validate_span_attributes;
 pub use crate::events::session_telemetry::AuthEnvTelemetryMetadata;
 pub use crate::events::session_telemetry::SessionTelemetry;

--- a/codex-rs/otel/src/provider.rs
+++ b/codex-rs/otel/src/provider.rs
@@ -89,9 +89,9 @@ impl OtelProvider {
         }
 
         // Provider setup installs process-global OTEL state that cannot be
-        // rolled back. Validate trace metadata before any setup path can
-        // mutate those globals, and keep span attribute checks aligned with
-        // config loading when traces are exported.
+        // rolled back. Validate configured metadata before any setup path can
+        // mutate those globals, and keep checks aligned with config loading.
+        crate::config::validate_resource_attributes(&settings.resource_attributes)?;
         if trace_enabled {
             crate::config::validate_span_attributes(&settings.span_attributes)?;
         }
@@ -232,6 +232,12 @@ fn resource_attributes(
         ),
         KeyValue::new(ENV_ATTRIBUTE, settings.environment.clone()),
     ];
+    attributes.extend(
+        settings
+            .resource_attributes
+            .iter()
+            .map(|(key, value)| KeyValue::new(key.clone(), value.clone())),
+    );
     if kind == ResourceKind::Logs
         && let Some(host_name) = host_name.and_then(normalize_host_name)
     {
@@ -510,6 +516,34 @@ mod tests {
     }
 
     #[test]
+    fn resource_attributes_include_configured_attributes_for_logs_and_traces() {
+        let mut settings = test_otel_settings();
+        settings.resource_attributes = BTreeMap::from([
+            (
+                "openai_cluster_kind".to_string(),
+                "applied-devbox".to_string(),
+            ),
+            ("openai_cluster_name".to_string(), "devbox-1".to_string()),
+        ]);
+
+        for kind in [ResourceKind::Logs, ResourceKind::Traces] {
+            let attrs = resource_attributes(&settings, Some("opentelemetry-test"), kind)
+                .into_iter()
+                .map(|kv| (kv.key.as_str().to_string(), kv.value.as_str().to_string()))
+                .collect::<BTreeMap<_, _>>();
+
+            assert_eq!(
+                attrs.get("openai_cluster_kind").map(String::as_str),
+                Some("applied-devbox")
+            );
+            assert_eq!(
+                attrs.get("openai_cluster_name").map(String::as_str),
+                Some("devbox-1")
+            );
+        }
+    }
+
+    #[test]
     fn log_export_target_excludes_trace_safe_events() {
         assert!(is_log_export_target("codex_otel.log_only"));
         assert!(is_log_export_target("codex_otel.network_proxy"));
@@ -535,6 +569,7 @@ mod tests {
             trace_exporter: OtelExporter::None,
             metrics_exporter: OtelExporter::None,
             runtime_metrics: false,
+            resource_attributes: BTreeMap::new(),
             span_attributes: BTreeMap::new(),
             tracestate: BTreeMap::new(),
         }

--- a/codex-rs/otel/tests/suite/otlp_http_loopback.rs
+++ b/codex-rs/otel/tests/suite/otlp_http_loopback.rs
@@ -240,6 +240,7 @@ fn otel_provider_rejects_header_unsafe_configured_tracestate() {
         },
         metrics_exporter: OtelExporter::None,
         runtime_metrics: false,
+        resource_attributes: BTreeMap::new(),
         span_attributes: BTreeMap::new(),
         tracestate: BTreeMap::from([(
             "example".to_string(),
@@ -305,6 +306,7 @@ fn otlp_http_exporter_sends_traces_to_collector()
         },
         metrics_exporter: OtelExporter::None,
         runtime_metrics: false,
+        resource_attributes: BTreeMap::new(),
         span_attributes: BTreeMap::from([(
             "test.configured_attribute".to_string(),
             "configured-value".to_string(),
@@ -449,6 +451,7 @@ async fn otlp_http_exporter_sends_traces_to_collector_in_tokio_runtime()
         },
         metrics_exporter: OtelExporter::None,
         runtime_metrics: false,
+        resource_attributes: BTreeMap::new(),
         span_attributes: BTreeMap::new(),
         tracestate: BTreeMap::new(),
     })?
@@ -570,6 +573,7 @@ fn otlp_http_exporter_sends_traces_to_collector_in_current_thread_tokio_runtime(
                 },
                 metrics_exporter: OtelExporter::None,
                 runtime_metrics: false,
+                resource_attributes: BTreeMap::new(),
                 span_attributes: BTreeMap::new(),
                 tracestate: BTreeMap::new(),
             })

--- a/codex-rs/windows-sandbox-rs/src/wfp_setup.rs
+++ b/codex-rs/windows-sandbox-rs/src/wfp_setup.rs
@@ -55,6 +55,7 @@ fn build_wfp_metrics_provider(
         trace_exporter: OtelExporter::None,
         metrics_exporter: OtelExporter::Statsig,
         runtime_metrics: false,
+        resource_attributes: BTreeMap::new(),
         span_attributes: BTreeMap::new(),
         tracestate: BTreeMap::new(),
     })


### PR DESCRIPTION
## Summary
- Add `[otel.resource_attributes]` config support and attach configured values to exported OTEL resources.
- Preserve existing trace-only `[otel.span_attributes]` behavior.
- Regenerate `config.schema.json` and add focused config/provider coverage.

## Compatibility / impact
- Default behavior is unchanged: if `[otel.resource_attributes]` is absent, Codex exports the same resource attributes as before.
- This only affects deployments that explicitly configure `[otel.resource_attributes]`.
- Existing `[otel.span_attributes]` behavior remains trace-only and unchanged.
- Non-devbox / non-monitoring environments should see no telemetry shape change unless they opt into the new config key.

## Validation
- `cargo fmt --manifest-path codex-rs/core/Cargo.toml --check`
- `cargo fmt --manifest-path codex-rs/otel/Cargo.toml --check`
- `cargo test --manifest-path codex-rs/otel/Cargo.toml resource_attributes_include_configured_attributes_for_logs_and_traces -- --nocapture`
- `cargo test --manifest-path codex-rs/core/Cargo.toml load_config_applies_otel_trace_metadata -- --nocapture`
- `cargo test --manifest-path codex-rs/core/Cargo.toml load_config_drops_invalid_otel_trace_metadata_entries -- --nocapture`
- `cargo test --manifest-path codex-rs/core/Cargo.toml config_schema_matches_fixture -- --nocapture`

## Rollout note
The devbox config PR should replace the cluster identity entries under `[otel.span_attributes]` with `[otel.resource_attributes]` in the same change. That PR should merge only after a Codex release includes this support, because currently deployed Codex binaries reject unknown config fields.