### PR TITLE
Pull plugin service less frequently

### DIFF
--- a/codex-rs/core-plugins/src/startup_sync.rs
+++ b/codex-rs/core-plugins/src/startup_sync.rs
@@ -1,9 +1,11 @@
+use std::fs::File;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 use std::process::Output;
 use std::process::Stdio;
 use std::time::Duration;
+use std::time::UNIX_EPOCH;
 
 use codex_otel::CURATED_PLUGINS_STARTUP_SYNC_FINAL_METRIC;
 use codex_otel::CURATED_PLUGINS_STARTUP_SYNC_METRIC;
@@ -22,12 +24,17 @@ const CURATED_PLUGINS_BACKUP_ARCHIVE_API_URL: &str =
     "https://chatgpt.com/backend-api/plugins/export/curated";
 const OPENAI_PLUGINS_OWNER: &str = "openai";
 const OPENAI_PLUGINS_REPO: &str = "plugins";
+const OPENAI_PLUGINS_GIT_URL: &str = "https://github.com/openai/plugins.git";
 const CURATED_PLUGINS_RELATIVE_DIR: &str = ".tmp/plugins";
 const CURATED_PLUGINS_SHA_FILE: &str = ".tmp/plugins.sha";
+const CURATED_PLUGINS_NEXT_CHECK_FILE: &str = ".tmp/plugins.next-check";
+const CURATED_PLUGINS_SYNC_LOCK_FILE: &str = ".tmp/plugins.sync.lock";
 const CURATED_PLUGINS_BACKUP_ARCHIVE_FALLBACK_VERSION: &str = "export-backup";
 const CURATED_PLUGINS_GIT_TIMEOUT: Duration = Duration::from_secs(30);
 const CURATED_PLUGINS_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 const CURATED_PLUGINS_BACKUP_ARCHIVE_TIMEOUT: Duration = Duration::from_secs(30);
+const CURATED_PLUGINS_MIN_CHECK_INTERVAL: Duration = Duration::from_secs(12 * 60 * 60);
+const CURATED_PLUGINS_MAX_CHECK_INTERVAL: Duration = Duration::from_secs(48 * 60 * 60);
 // Keep this comfortably above a normal sync attempt so we do not race another Codex process.
 const CURATED_PLUGINS_STALE_TEMP_DIR_MAX_AGE: Duration = Duration::from_secs(10 * 60);
 
@@ -78,7 +85,30 @@ fn sync_openai_plugins_repo_with_transport_overrides(
     api_base_url: &str,
     backup_archive_api_url: &str,
 ) -> Result<String, String> {
-    match sync_openai_plugins_repo_via_git(codex_home, git_binary) {
+    if let Some(local_sha) = local_curated_plugins_sha_before_next_check(codex_home) {
+        return Ok(local_sha);
+    }
+
+    let _file_guard = lock_curated_plugins_startup_sync(codex_home)?;
+
+    if let Some(local_sha) = local_curated_plugins_sha_before_next_check(codex_home) {
+        return Ok(local_sha);
+    }
+
+    let next_check_path = codex_home.join(CURATED_PLUGINS_NEXT_CHECK_FILE);
+    if !next_check_path.exists()
+        && let Some(local_sha) = local_curated_plugins_sha(codex_home)
+    {
+        if let Err(err) = write_curated_plugins_next_check(codex_home) {
+            warn!(
+                error = %err,
+                "failed to persist initial curated plugins sync deadline"
+            );
+        }
+        return Ok(local_sha);
+    }
+
+    let result = match sync_openai_plugins_repo_via_git(codex_home, git_binary) {
         Ok(remote_sha) => {
             emit_curated_plugins_startup_sync_metric("git", "success");
             emit_curated_plugins_startup_sync_final_metric("git", "success");
@@ -132,7 +162,66 @@ fn sync_openai_plugins_repo_with_transport_overrides(
                 }
             }
         }
+    };
+    if (result.is_ok() || has_local_curated_plugins_snapshot(codex_home))
+        && let Err(err) = write_curated_plugins_next_check(codex_home)
+    {
+        warn!(
+            error = %err,
+            "failed to persist curated plugins sync deadline"
+        );
     }
+    result
+}
+
+fn local_curated_plugins_sha_before_next_check(codex_home: &Path) -> Option<String> {
+    let local_sha = local_curated_plugins_sha(codex_home)?;
+    let now = UNIX_EPOCH.elapsed().ok()?.as_secs();
+    let next_check = read_sha_file(&codex_home.join(CURATED_PLUGINS_NEXT_CHECK_FILE))?
+        .parse::<u64>()
+        .ok()?;
+    let max_reasonable_next_check =
+        now.saturating_add(CURATED_PLUGINS_MAX_CHECK_INTERVAL.as_secs() + 5 * 60);
+    (next_check > now && next_check <= max_reasonable_next_check).then_some(local_sha)
+}
+
+fn local_curated_plugins_sha(codex_home: &Path) -> Option<String> {
+    has_local_curated_plugins_snapshot(codex_home).then(|| read_curated_plugins_sha(codex_home))?
+}
+
+fn lock_curated_plugins_startup_sync(codex_home: &Path) -> Result<File, String> {
+    let lock_path = codex_home.join(CURATED_PLUGINS_SYNC_LOCK_FILE);
+    std::fs::create_dir_all(codex_home.join(".tmp"))
+        .map_err(|err| format!("failed to create curated plugins sync directory: {err}"))?;
+    let lock_file = File::options()
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .map_err(|err| format!("failed to open curated plugins sync lock: {err}"))?;
+    lock_file
+        .lock()
+        .map_err(|err| format!("failed to lock curated plugins sync: {err}"))?;
+    Ok(lock_file)
+}
+
+fn write_curated_plugins_next_check(codex_home: &Path) -> Result<(), String> {
+    let now = UNIX_EPOCH
+        .elapsed()
+        .map_err(|err| format!("failed to calculate curated plugins sync deadline: {err}"))?;
+    let jitter_window =
+        (CURATED_PLUGINS_MAX_CHECK_INTERVAL - CURATED_PLUGINS_MIN_CHECK_INTERVAL).as_secs();
+    let next_check = now
+        .as_secs()
+        .saturating_add(CURATED_PLUGINS_MIN_CHECK_INTERVAL.as_secs())
+        .saturating_add(u64::from(now.subsec_nanos()) % (jitter_window + 1));
+    let next_check_path = codex_home.join(CURATED_PLUGINS_NEXT_CHECK_FILE);
+    std::fs::write(&next_check_path, format!("{next_check}\n")).map_err(|err| {
+        format!(
+            "failed to write curated plugins sync deadline {}: {err}",
+            next_check_path.display()
+        )
+    })
 }
 
 fn sync_openai_plugins_repo_via_git(codex_home: &Path, git_binary: &str) -> Result<String, String> {
@@ -146,13 +235,21 @@ fn sync_openai_plugins_repo_via_git(codex_home: &Path, git_binary: &str) -> Resu
     }
 
     let staged_repo_dir = prepare_curated_repo_parent_and_temp_dir(&repo_path)?;
+    let mut clone_command = Command::new(git_binary);
+    clone_command
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .arg("clone")
+        .arg("--depth")
+        .arg("1");
+    if repo_path.join(".git").is_dir() {
+        clone_command
+            .arg("--reference-if-able")
+            .arg(&repo_path)
+            .arg("--dissociate");
+    }
     let clone_output = run_git_command_with_timeout(
-        Command::new(git_binary)
-            .env("GIT_OPTIONAL_LOCKS", "0")
-            .arg("clone")
-            .arg("--depth")
-            .arg("1")
-            .arg("https://github.com/openai/plugins.git")
+        clone_command
+            .arg(OPENAI_PLUGINS_GIT_URL)
             .arg(staged_repo_dir.path()),
         "git clone curated plugins repo",
         CURATED_PLUGINS_GIT_TIMEOUT,

--- a/codex-rs/core-plugins/src/startup_sync.rs
+++ b/codex-rs/core-plugins/src/startup_sync.rs
@@ -5,7 +5,6 @@ use std::process::Command;
 use std::process::Output;
 use std::process::Stdio;
 use std::time::Duration;
-use std::time::UNIX_EPOCH;
 
 use codex_otel::CURATED_PLUGINS_STARTUP_SYNC_FINAL_METRIC;
 use codex_otel::CURATED_PLUGINS_STARTUP_SYNC_METRIC;
@@ -27,14 +26,11 @@ const OPENAI_PLUGINS_REPO: &str = "plugins";
 const OPENAI_PLUGINS_GIT_URL: &str = "https://github.com/openai/plugins.git";
 const CURATED_PLUGINS_RELATIVE_DIR: &str = ".tmp/plugins";
 const CURATED_PLUGINS_SHA_FILE: &str = ".tmp/plugins.sha";
-const CURATED_PLUGINS_NEXT_CHECK_FILE: &str = ".tmp/plugins.next-check";
 const CURATED_PLUGINS_SYNC_LOCK_FILE: &str = ".tmp/plugins.sync.lock";
 const CURATED_PLUGINS_BACKUP_ARCHIVE_FALLBACK_VERSION: &str = "export-backup";
 const CURATED_PLUGINS_GIT_TIMEOUT: Duration = Duration::from_secs(30);
 const CURATED_PLUGINS_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 const CURATED_PLUGINS_BACKUP_ARCHIVE_TIMEOUT: Duration = Duration::from_secs(30);
-const CURATED_PLUGINS_MIN_CHECK_INTERVAL: Duration = Duration::from_secs(12 * 60 * 60);
-const CURATED_PLUGINS_MAX_CHECK_INTERVAL: Duration = Duration::from_secs(48 * 60 * 60);
 // Keep this comfortably above a normal sync attempt so we do not race another Codex process.
 const CURATED_PLUGINS_STALE_TEMP_DIR_MAX_AGE: Duration = Duration::from_secs(10 * 60);
 
@@ -85,30 +81,9 @@ fn sync_openai_plugins_repo_with_transport_overrides(
     api_base_url: &str,
     backup_archive_api_url: &str,
 ) -> Result<String, String> {
-    if let Some(local_sha) = local_curated_plugins_sha_before_next_check(codex_home) {
-        return Ok(local_sha);
-    }
-
     let _file_guard = lock_curated_plugins_startup_sync(codex_home)?;
 
-    if let Some(local_sha) = local_curated_plugins_sha_before_next_check(codex_home) {
-        return Ok(local_sha);
-    }
-
-    let next_check_path = codex_home.join(CURATED_PLUGINS_NEXT_CHECK_FILE);
-    if !next_check_path.exists()
-        && let Some(local_sha) = local_curated_plugins_sha(codex_home)
-    {
-        if let Err(err) = write_curated_plugins_next_check(codex_home) {
-            warn!(
-                error = %err,
-                "failed to persist initial curated plugins sync deadline"
-            );
-        }
-        return Ok(local_sha);
-    }
-
-    let result = match sync_openai_plugins_repo_via_git(codex_home, git_binary) {
+    match sync_openai_plugins_repo_via_git(codex_home, git_binary) {
         Ok(remote_sha) => {
             emit_curated_plugins_startup_sync_metric("git", "success");
             emit_curated_plugins_startup_sync_final_metric("git", "success");
@@ -162,31 +137,7 @@ fn sync_openai_plugins_repo_with_transport_overrides(
                 }
             }
         }
-    };
-    if (result.is_ok() || has_local_curated_plugins_snapshot(codex_home))
-        && let Err(err) = write_curated_plugins_next_check(codex_home)
-    {
-        warn!(
-            error = %err,
-            "failed to persist curated plugins sync deadline"
-        );
     }
-    result
-}
-
-fn local_curated_plugins_sha_before_next_check(codex_home: &Path) -> Option<String> {
-    let local_sha = local_curated_plugins_sha(codex_home)?;
-    let now = UNIX_EPOCH.elapsed().ok()?.as_secs();
-    let next_check = read_sha_file(&codex_home.join(CURATED_PLUGINS_NEXT_CHECK_FILE))?
-        .parse::<u64>()
-        .ok()?;
-    let max_reasonable_next_check =
-        now.saturating_add(CURATED_PLUGINS_MAX_CHECK_INTERVAL.as_secs() + 5 * 60);
-    (next_check > now && next_check <= max_reasonable_next_check).then_some(local_sha)
-}
-
-fn local_curated_plugins_sha(codex_home: &Path) -> Option<String> {
-    has_local_curated_plugins_snapshot(codex_home).then(|| read_curated_plugins_sha(codex_home))?
 }
 
 fn lock_curated_plugins_startup_sync(codex_home: &Path) -> Result<File, String> {
@@ -205,25 +156,6 @@ fn lock_curated_plugins_startup_sync(codex_home: &Path) -> Result<File, String> 
     Ok(lock_file)
 }
 
-fn write_curated_plugins_next_check(codex_home: &Path) -> Result<(), String> {
-    let now = UNIX_EPOCH
-        .elapsed()
-        .map_err(|err| format!("failed to calculate curated plugins sync deadline: {err}"))?;
-    let jitter_window =
-        (CURATED_PLUGINS_MAX_CHECK_INTERVAL - CURATED_PLUGINS_MIN_CHECK_INTERVAL).as_secs();
-    let next_check = now
-        .as_secs()
-        .saturating_add(CURATED_PLUGINS_MIN_CHECK_INTERVAL.as_secs())
-        .saturating_add(u64::from(now.subsec_nanos()) % (jitter_window + 1));
-    let next_check_path = codex_home.join(CURATED_PLUGINS_NEXT_CHECK_FILE);
-    std::fs::write(&next_check_path, format!("{next_check}\n")).map_err(|err| {
-        format!(
-            "failed to write curated plugins sync deadline {}: {err}",
-            next_check_path.display()
-        )
-    })
-}
-
 fn sync_openai_plugins_repo_via_git(codex_home: &Path, git_binary: &str) -> Result<String, String> {
     let repo_path = curated_plugins_repo_path(codex_home);
     let sha_path = codex_home.join(CURATED_PLUGINS_SHA_FILE);
@@ -234,39 +166,86 @@ fn sync_openai_plugins_repo_via_git(codex_home: &Path, git_binary: &str) -> Resu
         return Ok(remote_sha);
     }
 
-    let staged_repo_dir = prepare_curated_repo_parent_and_temp_dir(&repo_path)?;
-    let mut clone_command = Command::new(git_binary);
-    clone_command
-        .env("GIT_OPTIONAL_LOCKS", "0")
-        .arg("clone")
-        .arg("--depth")
-        .arg("1");
     if repo_path.join(".git").is_dir() {
-        clone_command
-            .arg("--reference-if-able")
-            .arg(&repo_path)
-            .arg("--dissociate");
+        fetch_curated_plugins_commit(&repo_path, &remote_sha, git_binary)?;
+        reset_curated_plugins_checkout(&repo_path, git_binary)?;
+        ensure_marketplace_manifest_exists(&repo_path)?;
+    } else {
+        let staged_repo_dir = prepare_curated_repo_parent_and_temp_dir(&repo_path)?;
+        run_git_in_repo(
+            staged_repo_dir.path(),
+            git_binary,
+            &["init"],
+            "git init curated plugins repo",
+        )?;
+        fetch_curated_plugins_commit(staged_repo_dir.path(), &remote_sha, git_binary)?;
+        reset_curated_plugins_checkout(staged_repo_dir.path(), git_binary)?;
+        ensure_marketplace_manifest_exists(staged_repo_dir.path())?;
+        activate_curated_repo(&repo_path, staged_repo_dir)?;
     }
-    let clone_output = run_git_command_with_timeout(
-        clone_command
-            .arg(OPENAI_PLUGINS_GIT_URL)
-            .arg(staged_repo_dir.path()),
-        "git clone curated plugins repo",
-        CURATED_PLUGINS_GIT_TIMEOUT,
-    )?;
-    ensure_git_success(&clone_output, "git clone curated plugins repo")?;
 
-    let cloned_sha = git_head_sha(staged_repo_dir.path(), git_binary)?;
-    if cloned_sha != remote_sha {
+    let fetched_sha = git_head_sha(&repo_path, git_binary)?;
+    if fetched_sha != remote_sha {
         return Err(format!(
-            "curated plugins clone HEAD mismatch: expected {remote_sha}, got {cloned_sha}"
+            "curated plugins fetch HEAD mismatch: expected {remote_sha}, got {fetched_sha}"
         ));
     }
 
-    ensure_marketplace_manifest_exists(staged_repo_dir.path())?;
-    activate_curated_repo(&repo_path, staged_repo_dir)?;
     write_curated_plugins_sha(&sha_path, &remote_sha)?;
     Ok(remote_sha)
+}
+
+fn fetch_curated_plugins_commit(
+    repo_path: &Path,
+    remote_sha: &str,
+    git_binary: &str,
+) -> Result<(), String> {
+    run_git_in_repo(
+        repo_path,
+        git_binary,
+        &[
+            "fetch",
+            "--depth",
+            "1",
+            "--no-tags",
+            OPENAI_PLUGINS_GIT_URL,
+            remote_sha,
+        ],
+        "git fetch curated plugins repo",
+    )
+}
+
+fn reset_curated_plugins_checkout(repo_path: &Path, git_binary: &str) -> Result<(), String> {
+    run_git_in_repo(
+        repo_path,
+        git_binary,
+        &["reset", "--hard", "FETCH_HEAD"],
+        "git reset curated plugins repo",
+    )?;
+    run_git_in_repo(
+        repo_path,
+        git_binary,
+        &["clean", "-fdx"],
+        "git clean curated plugins repo",
+    )
+}
+
+fn run_git_in_repo(
+    repo_path: &Path,
+    git_binary: &str,
+    args: &[&str],
+    context: &str,
+) -> Result<(), String> {
+    let output = run_git_command_with_timeout(
+        Command::new(git_binary)
+            .env("GIT_OPTIONAL_LOCKS", "0")
+            .arg("-C")
+            .arg(repo_path)
+            .args(args),
+        context,
+        CURATED_PLUGINS_GIT_TIMEOUT,
+    )?;
+    ensure_git_success(&output, context)
 }
 
 fn sync_openai_plugins_repo_via_http(

--- a/codex-rs/core-plugins/src/startup_sync.rs
+++ b/codex-rs/core-plugins/src/startup_sync.rs
@@ -24,6 +24,7 @@ const CURATED_PLUGINS_BACKUP_ARCHIVE_API_URL: &str =
 const OPENAI_PLUGINS_OWNER: &str = "openai";
 const OPENAI_PLUGINS_REPO: &str = "plugins";
 const OPENAI_PLUGINS_GIT_URL: &str = "https://github.com/openai/plugins.git";
+const CURATED_PLUGINS_FETCH_REF: &str = "refs/codex/curated-sync";
 const CURATED_PLUGINS_RELATIVE_DIR: &str = ".tmp/plugins";
 const CURATED_PLUGINS_SHA_FILE: &str = ".tmp/plugins.sha";
 const CURATED_PLUGINS_SYNC_LOCK_FILE: &str = ".tmp/plugins.sync.lock";
@@ -166,31 +167,36 @@ fn sync_openai_plugins_repo_via_git(codex_home: &Path, git_binary: &str) -> Resu
         return Ok(remote_sha);
     }
 
+    let staged_repo_dir = prepare_curated_repo_parent_and_temp_dir(&repo_path)?;
+    run_git_in_repo(
+        staged_repo_dir.path(),
+        git_binary,
+        &["init"],
+        "git init curated plugins repo",
+    )?;
+
     if repo_path.join(".git").is_dir() {
         fetch_curated_plugins_commit(&repo_path, &remote_sha, git_binary)?;
-        reset_curated_plugins_checkout(&repo_path, git_binary)?;
-        ensure_marketplace_manifest_exists(&repo_path)?;
-    } else {
-        let staged_repo_dir = prepare_curated_repo_parent_and_temp_dir(&repo_path)?;
-        run_git_in_repo(
+        fetch_curated_plugins_commit_from_source(
             staged_repo_dir.path(),
+            &repo_path,
+            CURATED_PLUGINS_FETCH_REF,
             git_binary,
-            &["init"],
-            "git init curated plugins repo",
         )?;
+    } else {
         fetch_curated_plugins_commit(staged_repo_dir.path(), &remote_sha, git_binary)?;
-        reset_curated_plugins_checkout(staged_repo_dir.path(), git_binary)?;
-        ensure_marketplace_manifest_exists(staged_repo_dir.path())?;
-        activate_curated_repo(&repo_path, staged_repo_dir)?;
     }
 
-    let fetched_sha = git_head_sha(&repo_path, git_binary)?;
+    reset_curated_plugins_checkout(staged_repo_dir.path(), git_binary)?;
+    let fetched_sha = git_head_sha(staged_repo_dir.path(), git_binary)?;
     if fetched_sha != remote_sha {
         return Err(format!(
             "curated plugins fetch HEAD mismatch: expected {remote_sha}, got {fetched_sha}"
         ));
     }
 
+    ensure_marketplace_manifest_exists(staged_repo_dir.path())?;
+    activate_curated_repo(&repo_path, staged_repo_dir)?;
     write_curated_plugins_sha(&sha_path, &remote_sha)?;
     Ok(remote_sha)
 }
@@ -200,26 +206,57 @@ fn fetch_curated_plugins_commit(
     remote_sha: &str,
     git_binary: &str,
 ) -> Result<(), String> {
-    run_git_in_repo(
+    fetch_curated_plugins_commit_from(
         repo_path,
+        OPENAI_PLUGINS_GIT_URL.as_ref(),
+        remote_sha,
         git_binary,
-        &[
-            "fetch",
-            "--depth",
-            "1",
-            "--no-tags",
-            OPENAI_PLUGINS_GIT_URL,
-            remote_sha,
-        ],
         "git fetch curated plugins repo",
     )
+}
+
+fn fetch_curated_plugins_commit_from_source(
+    repo_path: &Path,
+    source_repo_path: &Path,
+    remote_sha: &str,
+    git_binary: &str,
+) -> Result<(), String> {
+    fetch_curated_plugins_commit_from(
+        repo_path,
+        source_repo_path,
+        remote_sha,
+        git_binary,
+        "git copy fetched curated plugins commit",
+    )
+}
+
+fn fetch_curated_plugins_commit_from(
+    repo_path: &Path,
+    source: &Path,
+    source_revision: &str,
+    git_binary: &str,
+    context: &str,
+) -> Result<(), String> {
+    let fetch_refspec = format!("+{source_revision}:{CURATED_PLUGINS_FETCH_REF}");
+    let output = run_git_command_with_timeout(
+        Command::new(git_binary)
+            .env("GIT_OPTIONAL_LOCKS", "0")
+            .arg("-C")
+            .arg(repo_path)
+            .args(["fetch", "--depth", "1", "--no-tags"])
+            .arg(source)
+            .arg(fetch_refspec),
+        context,
+        CURATED_PLUGINS_GIT_TIMEOUT,
+    )?;
+    ensure_git_success(&output, context)
 }
 
 fn reset_curated_plugins_checkout(repo_path: &Path, git_binary: &str) -> Result<(), String> {
     run_git_in_repo(
         repo_path,
         git_binary,
-        &["reset", "--hard", "FETCH_HEAD"],
+        &["reset", "--hard", CURATED_PLUGINS_FETCH_REF],
         "git reset curated plugins repo",
     )?;
     run_git_in_repo(

--- a/codex-rs/core-plugins/src/startup_sync_tests.rs
+++ b/codex-rs/core-plugins/src/startup_sync_tests.rs
@@ -525,17 +525,22 @@ fn sync_openai_plugins_repo_via_git_succeeds_with_local_rewritten_remote() {
         .lines()
         .skip(first_sync_invocation_count)
         .collect::<Vec<_>>();
+    let curated_repo_path = curated_plugins_repo_path(tmp.path());
     assert!(incremental_sync_invocations.iter().any(|invocation| {
-        invocation.contains(" fetch --depth 1 --no-tags https://github.com/openai/plugins.git ")
-            && invocation.ends_with(updated_sha.as_str())
+        invocation.starts_with(&format!("-C {} fetch ", curated_repo_path.display()))
+            && invocation.contains(" https://github.com/openai/plugins.git ")
+            && invocation.contains(updated_sha.as_str())
+            && invocation.ends_with(CURATED_PLUGINS_FETCH_REF)
+    }));
+    assert!(incremental_sync_invocations.iter().any(|invocation| {
+        invocation.contains(" fetch --depth 1 --no-tags ")
+            && invocation.contains(&format!(" {} ", curated_repo_path.display()))
+            && invocation.ends_with(&format!(
+                "{CURATED_PLUGINS_FETCH_REF}:{CURATED_PLUGINS_FETCH_REF}"
+            ))
     }));
     assert!(
         incremental_sync_invocations
-            .iter()
-            .any(|invocation| invocation.ends_with(" reset --hard FETCH_HEAD"))
-    );
-    assert!(
-        !incremental_sync_invocations
             .iter()
             .any(|invocation| invocation.ends_with(" init"))
     );
@@ -544,6 +549,10 @@ fn sync_openai_plugins_repo_via_git_succeeds_with_local_rewritten_remote() {
             .iter()
             .any(|invocation| invocation.split_whitespace().any(|arg| arg == "clone"))
     );
+    assert!(!incremental_sync_invocations.iter().any(|invocation| {
+        invocation.starts_with(&format!("-C {} reset ", curated_repo_path.display()))
+            || invocation.starts_with(&format!("-C {} clean ", curated_repo_path.display()))
+    }));
     assert!(!has_plugins_clone_dirs(tmp.path()));
 
     let unchanged_sync_invocation_count = invocation_log_contents.lines().count();
@@ -668,6 +677,77 @@ exit 1
         .expect_err("git sync should fail");
 
     assert!(err.contains("fatal: early EOF"));
+    assert!(!has_plugins_clone_dirs(tmp.path()));
+}
+
+#[cfg(unix)]
+#[test]
+fn sync_openai_plugins_repo_via_git_preserves_existing_snapshot_on_validation_failure() {
+    let tmp = tempdir().expect("tempdir");
+    let repo_path = curated_plugins_repo_path(tmp.path());
+    write_openai_curated_marketplace(&repo_path, &["gmail"]);
+    std::fs::create_dir_all(repo_path.join(".git")).expect("create git dir");
+    write_curated_plugin_sha(tmp.path());
+
+    let bin_dir = tempfile::Builder::new()
+        .prefix("fake-git-invalid-update-")
+        .tempdir()
+        .expect("tempdir");
+    let git_path = bin_dir.path().join("git");
+    let remote_sha = "fedcba9876543210fedcba9876543210fedcba98";
+
+    write_executable_script(
+        &git_path,
+        &format!(
+            r#"#!/bin/sh
+if [ "$1" = "ls-remote" ]; then
+  printf '%s\tHEAD\n' "{remote_sha}"
+  exit 0
+fi
+if [ "$1" = "-C" ] && [ "$2" = "{}" ] && [ "$3" = "rev-parse" ]; then
+  printf '%s\n' "{TEST_CURATED_PLUGIN_SHA}"
+  exit 0
+fi
+if [ "$1" = "-C" ] && [ "$2" = "{}" ] && [ "$3" = "fetch" ]; then
+  exit 0
+fi
+if [ "$1" = "-C" ] && [ "$3" = "init" ]; then
+  mkdir -p "$2/.git"
+  exit 0
+fi
+if [ "$1" = "-C" ] && [ "$3" = "fetch" ]; then
+  exit 0
+fi
+if [ "$1" = "-C" ] && [ "$3" = "reset" ]; then
+  mkdir -p "$2/plugins/linear/.codex-plugin"
+  printf '%s\n' '{{"name":"linear"}}' > "$2/plugins/linear/.codex-plugin/plugin.json"
+  exit 0
+fi
+if [ "$1" = "-C" ] && [ "$3" = "clean" ]; then
+  exit 0
+fi
+if [ "$1" = "-C" ] && [ "$3" = "rev-parse" ]; then
+  printf '%s\n' "{remote_sha}"
+  exit 0
+fi
+echo "unexpected git invocation: $@" >&2
+exit 1
+"#,
+            repo_path.display(),
+            repo_path.display(),
+        ),
+    );
+
+    let err = sync_openai_plugins_repo_via_git(tmp.path(), git_path.to_str().expect("utf8 path"))
+        .expect_err("invalid staged checkout should fail");
+
+    assert!(err.contains("curated plugins archive missing marketplace manifest"));
+    assert_curated_gmail_repo(&repo_path);
+    assert!(!repo_path.join("plugins/linear").exists());
+    assert_eq!(
+        read_curated_plugins_sha(tmp.path()).as_deref(),
+        Some(TEST_CURATED_PLUGIN_SHA)
+    );
     assert!(!has_plugins_clone_dirs(tmp.path()));
 }
 

--- a/codex-rs/core-plugins/src/startup_sync_tests.rs
+++ b/codex-rs/core-plugins/src/startup_sync_tests.rs
@@ -3,6 +3,10 @@ use pretty_assertions::assert_eq;
 use std::io::Write;
 use std::path::Path;
 use std::path::PathBuf;
+#[cfg(unix)]
+use std::sync::Barrier;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 use tempfile::tempdir;
 use wiremock::Mock;
 use wiremock::MockServer;
@@ -66,6 +70,25 @@ fn write_curated_plugin_sha(codex_home: &Path) {
     );
 }
 
+fn assert_next_check_in_window(codex_home: &Path, sync_started_at: u64) {
+    let next_check_at = std::fs::read_to_string(codex_home.join(".tmp/plugins.next-check"))
+        .expect("read next check")
+        .trim()
+        .parse::<u64>()
+        .expect("parse next check");
+    assert!(next_check_at >= sync_started_at + CURATED_PLUGINS_MIN_CHECK_INTERVAL.as_secs());
+    assert!(next_check_at <= sync_started_at + CURATED_PLUGINS_MAX_CHECK_INTERVAL.as_secs() + 1);
+}
+
+fn sync_with_unavailable_transports(codex_home: &Path) -> Result<String, String> {
+    sync_openai_plugins_repo_with_transport_overrides(
+        codex_home,
+        "missing-git-for-test",
+        "http://127.0.0.1:9",
+        "http://127.0.0.1:9/backend-api/plugins/export/curated",
+    )
+}
+
 fn has_plugins_clone_dirs(codex_home: &Path) -> bool {
     let Ok(entries) = std::fs::read_dir(codex_home.join(".tmp")) else {
         return false;
@@ -93,6 +116,22 @@ fn write_executable_script(path: &Path, contents: &str) {
         permissions.set_mode(0o755);
         std::fs::set_permissions(path, permissions).expect("chmod");
     }
+}
+
+#[cfg(unix)]
+fn run_git(repo: &Path, args: &[&str]) -> std::process::Output {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .expect("run git");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
 }
 
 async fn mount_github_repo_and_ref(server: &MockServer, sha: &str) {
@@ -208,6 +247,27 @@ fn read_curated_plugins_sha_reads_trimmed_sha_file() {
     );
 }
 
+#[test]
+fn sync_openai_plugins_repo_staggers_existing_snapshot_and_reuses_deadline() {
+    let tmp = tempdir().expect("tempdir");
+    write_openai_curated_marketplace(&curated_plugins_repo_path(tmp.path()), &["gmail"]);
+    write_curated_plugin_sha(tmp.path());
+    let sync_started_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("current time after epoch")
+        .as_secs();
+
+    assert_eq!(
+        sync_with_unavailable_transports(tmp.path()),
+        Ok(TEST_CURATED_PLUGIN_SHA.to_string())
+    );
+    assert_next_check_in_window(tmp.path(), sync_started_at);
+    assert_eq!(
+        sync_with_unavailable_transports(tmp.path()),
+        Ok(TEST_CURATED_PLUGIN_SHA.to_string())
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn remove_stale_curated_repo_temp_dirs_removes_only_matching_directories() {
@@ -253,20 +313,23 @@ fn remove_stale_curated_repo_temp_dirs_removes_only_matching_directories() {
 
 #[cfg(unix)]
 #[test]
-fn sync_openai_plugins_repo_prefers_git_when_available() {
+fn concurrent_syncs_share_one_git_remote_check() {
     let tmp = tempdir().expect("tempdir");
     let bin_dir = tempfile::Builder::new()
         .prefix("fake-git-")
         .tempdir()
         .expect("tempdir");
     let git_path = bin_dir.path().join("git");
+    let invocation_log = bin_dir.path().join("invocations.log");
     let sha = "0123456789abcdef0123456789abcdef01234567";
 
     write_executable_script(
         &git_path,
         &format!(
             r#"#!/bin/sh
+printf '%s\n' "$1" >> '{}'
 if [ "$1" = "ls-remote" ]; then
+  sleep 1
   printf '%s\tHEAD\n' "{sha}"
   exit 0
 fi
@@ -285,23 +348,50 @@ if [ "$1" = "-C" ] && [ "$3" = "rev-parse" ] && [ "$4" = "HEAD" ]; then
 fi
 echo "unexpected git invocation: $@" >&2
 exit 1
-"#
+"#,
+            invocation_log.display()
         ),
     );
 
-    let synced_sha = sync_openai_plugins_repo_with_transport_overrides(
-        tmp.path(),
-        git_path.to_str().expect("utf8 path"),
-        "http://127.0.0.1:9",
-        "http://127.0.0.1:9/backend-api/plugins/export/curated",
-    )
-    .expect("git sync should succeed");
+    let barrier = Barrier::new(2);
+    let results = std::thread::scope(|scope| {
+        let run_sync = || {
+            barrier.wait();
+            sync_openai_plugins_repo_with_transport_overrides(
+                tmp.path(),
+                git_path.to_str().expect("utf8 path"),
+                "http://127.0.0.1:9",
+                "http://127.0.0.1:9/backend-api/plugins/export/curated",
+            )
+        };
+        let first = scope.spawn(run_sync);
+        let second = scope.spawn(run_sync);
+        [
+            first.join().expect("first sync thread"),
+            second.join().expect("second sync thread"),
+        ]
+    });
 
-    assert_eq!(synced_sha, sha);
+    assert_eq!(results, [Ok(sha.to_string()), Ok(sha.to_string())]);
     let repo_path = curated_plugins_repo_path(tmp.path());
     assert!(repo_path.join(".git").is_dir());
     assert_curated_gmail_repo(&repo_path);
     assert_eq!(read_curated_plugins_sha(tmp.path()).as_deref(), Some(sha));
+    let invocations = std::fs::read_to_string(invocation_log).expect("read invocation log");
+    assert_eq!(
+        invocations
+            .lines()
+            .filter(|invocation| *invocation == "ls-remote")
+            .count(),
+        1
+    );
+    assert_eq!(
+        invocations
+            .lines()
+            .filter(|invocation| *invocation == "clone")
+            .count(),
+        1
+    );
 }
 
 #[cfg(unix)]
@@ -328,36 +418,20 @@ fn sync_openai_plugins_repo_via_git_succeeds_with_local_rewritten_remote() {
     )
     .expect("write plugin manifest");
 
-    let init_status = Command::new("git")
-        .arg("-C")
-        .arg(&work_repo)
-        .arg("init")
-        .status()
-        .expect("run git init");
-    assert!(init_status.success());
-
-    let add_status = Command::new("git")
-        .arg("-C")
-        .arg(&work_repo)
-        .arg("add")
-        .arg(".")
-        .status()
-        .expect("run git add");
-    assert!(add_status.success());
-
-    let commit_status = Command::new("git")
-        .arg("-C")
-        .arg(&work_repo)
-        .arg("-c")
-        .arg("user.name=Codex Test")
-        .arg("-c")
-        .arg("user.email=codex@example.com")
-        .arg("commit")
-        .arg("-m")
-        .arg("init")
-        .status()
-        .expect("run git commit");
-    assert!(commit_status.success());
+    run_git(&work_repo, &["init"]);
+    run_git(&work_repo, &["add", "."]);
+    run_git(
+        &work_repo,
+        &[
+            "-c",
+            "user.name=Codex Test",
+            "-c",
+            "user.email=codex@example.com",
+            "commit",
+            "-m",
+            "init",
+        ],
+    );
 
     std::fs::create_dir_all(remote_repo.parent().expect("remote parent"))
         .expect("create remote parent");
@@ -370,14 +444,7 @@ fn sync_openai_plugins_repo_via_git_succeeds_with_local_rewritten_remote() {
         .expect("run git clone --bare");
     assert!(clone_status.success());
 
-    let sha_output = Command::new("git")
-        .arg("-C")
-        .arg(&work_repo)
-        .arg("rev-parse")
-        .arg("HEAD")
-        .output()
-        .expect("run git rev-parse");
-    assert!(sha_output.status.success());
+    let sha_output = run_git(&work_repo, &["rev-parse", "HEAD"]);
     let sha = String::from_utf8_lossy(&sha_output.stdout)
         .trim()
         .to_string();
@@ -397,10 +464,12 @@ fn sync_openai_plugins_repo_via_git_succeeds_with_local_rewritten_remote() {
         .tempdir()
         .expect("tempdir");
     let git_wrapper = bin_dir.path().join("git");
+    let invocation_log = bin_dir.path().join("invocations.log");
     write_executable_script(
         &git_wrapper,
         &format!(
-            "#!/bin/sh\nGIT_CONFIG_GLOBAL='{}' exec git \"$@\"\n",
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\nGIT_CONFIG_GLOBAL='{}' exec git \"$@\"\n",
+            invocation_log.display(),
             git_config_path.display()
         ),
     );
@@ -415,6 +484,69 @@ fn sync_openai_plugins_repo_via_git_succeeds_with_local_rewritten_remote() {
         read_curated_plugins_sha(tmp.path()).as_deref(),
         Some(sha.as_str())
     );
+    assert!(!has_plugins_clone_dirs(tmp.path()));
+
+    let first_sync_invocation_count = std::fs::read_to_string(&invocation_log)
+        .expect("read first sync invocations")
+        .lines()
+        .count();
+    write_openai_curated_marketplace(&work_repo, &["gmail", "linear"]);
+    run_git(&work_repo, &["add", "."]);
+    run_git(
+        &work_repo,
+        &[
+            "-c",
+            "user.name=Codex Test",
+            "-c",
+            "user.email=codex@example.com",
+            "commit",
+            "-m",
+            "update",
+        ],
+    );
+    let branch_output = run_git(&work_repo, &["symbolic-ref", "--short", "HEAD"]);
+    let branch = String::from_utf8_lossy(&branch_output.stdout)
+        .trim()
+        .to_string();
+    let remote_repo = remote_repo.to_str().expect("utf8 remote repo");
+    let push_ref = format!("HEAD:refs/heads/{branch}");
+    run_git(&work_repo, &["push", remote_repo, &push_ref]);
+    let updated_sha_output = run_git(&work_repo, &["rev-parse", "HEAD"]);
+    let updated_sha = String::from_utf8_lossy(&updated_sha_output.stdout)
+        .trim()
+        .to_string();
+
+    let synced_sha =
+        sync_openai_plugins_repo_via_git(tmp.path(), git_wrapper.to_str().expect("utf8 path"))
+            .expect("incremental git sync should succeed");
+
+    assert_eq!(synced_sha, updated_sha);
+    assert!(
+        curated_plugins_repo_path(tmp.path())
+            .join("plugins/linear/.codex-plugin/plugin.json")
+            .is_file()
+    );
+    assert_eq!(
+        read_curated_plugins_sha(tmp.path()).as_deref(),
+        Some(updated_sha.as_str())
+    );
+    assert!(
+        !curated_plugins_repo_path(tmp.path())
+            .join(".git/objects/info/alternates")
+            .exists()
+    );
+    let invocation_log = std::fs::read_to_string(&invocation_log).expect("read sync invocations");
+    let incremental_sync_invocations = invocation_log
+        .lines()
+        .skip(first_sync_invocation_count)
+        .collect::<Vec<_>>();
+    assert!(incremental_sync_invocations.iter().any(|invocation| {
+        invocation.starts_with("clone --depth 1 --reference-if-able ")
+            && invocation.contains(" --dissociate https://github.com/openai/plugins.git ")
+    }));
+    assert!(!incremental_sync_invocations.iter().any(|invocation| {
+        invocation.starts_with("clone --depth 1 https://github.com/openai/plugins.git")
+    }));
     assert!(!has_plugins_clone_dirs(tmp.path()));
 }
 
@@ -603,6 +735,7 @@ async fn sync_openai_plugins_repo_skips_export_archive_when_snapshot_exists() {
     let curated_root = curated_plugins_repo_path(tmp.path());
     write_openai_curated_marketplace(&curated_root, &["linear"]);
     write_curated_plugin_sha(tmp.path());
+    write_file(&tmp.path().join(".tmp/plugins.next-check"), "0\n");
 
     let plugin_manifest_path = curated_root.join("plugins/linear/.codex-plugin/plugin.json");
     let original_manifest =
@@ -638,6 +771,12 @@ async fn sync_openai_plugins_repo_skips_export_archive_when_snapshot_exists() {
     assert_eq!(
         read_curated_plugins_sha(tmp.path()).as_deref(),
         Some(TEST_CURATED_PLUGIN_SHA)
+    );
+    assert_ne!(
+        std::fs::read_to_string(tmp.path().join(".tmp/plugins.next-check"))
+            .expect("read next check")
+            .trim(),
+        "0"
     );
 }
 

--- a/codex-rs/core-plugins/src/startup_sync_tests.rs
+++ b/codex-rs/core-plugins/src/startup_sync_tests.rs
@@ -5,8 +5,6 @@ use std::path::Path;
 use std::path::PathBuf;
 #[cfg(unix)]
 use std::sync::Barrier;
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
 use tempfile::tempdir;
 use wiremock::Mock;
 use wiremock::MockServer;
@@ -68,25 +66,6 @@ fn write_curated_plugin_sha(codex_home: &Path) {
         &codex_home.join(".tmp/plugins.sha"),
         &format!("{TEST_CURATED_PLUGIN_SHA}\n"),
     );
-}
-
-fn assert_next_check_in_window(codex_home: &Path, sync_started_at: u64) {
-    let next_check_at = std::fs::read_to_string(codex_home.join(".tmp/plugins.next-check"))
-        .expect("read next check")
-        .trim()
-        .parse::<u64>()
-        .expect("parse next check");
-    assert!(next_check_at >= sync_started_at + CURATED_PLUGINS_MIN_CHECK_INTERVAL.as_secs());
-    assert!(next_check_at <= sync_started_at + CURATED_PLUGINS_MAX_CHECK_INTERVAL.as_secs() + 1);
-}
-
-fn sync_with_unavailable_transports(codex_home: &Path) -> Result<String, String> {
-    sync_openai_plugins_repo_with_transport_overrides(
-        codex_home,
-        "missing-git-for-test",
-        "http://127.0.0.1:9",
-        "http://127.0.0.1:9/backend-api/plugins/export/curated",
-    )
 }
 
 fn has_plugins_clone_dirs(codex_home: &Path) -> bool {
@@ -247,27 +226,6 @@ fn read_curated_plugins_sha_reads_trimmed_sha_file() {
     );
 }
 
-#[test]
-fn sync_openai_plugins_repo_staggers_existing_snapshot_and_reuses_deadline() {
-    let tmp = tempdir().expect("tempdir");
-    write_openai_curated_marketplace(&curated_plugins_repo_path(tmp.path()), &["gmail"]);
-    write_curated_plugin_sha(tmp.path());
-    let sync_started_at = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("current time after epoch")
-        .as_secs();
-
-    assert_eq!(
-        sync_with_unavailable_transports(tmp.path()),
-        Ok(TEST_CURATED_PLUGIN_SHA.to_string())
-    );
-    assert_next_check_in_window(tmp.path(), sync_started_at);
-    assert_eq!(
-        sync_with_unavailable_transports(tmp.path()),
-        Ok(TEST_CURATED_PLUGIN_SHA.to_string())
-    );
-}
-
 #[cfg(unix)]
 #[test]
 fn remove_stale_curated_repo_temp_dirs_removes_only_matching_directories() {
@@ -313,7 +271,7 @@ fn remove_stale_curated_repo_temp_dirs_removes_only_matching_directories() {
 
 #[cfg(unix)]
 #[test]
-fn concurrent_syncs_share_one_git_remote_check() {
+fn concurrent_syncs_serialize_fetches_without_skipping_remote_checks() {
     let tmp = tempdir().expect("tempdir");
     let bin_dir = tempfile::Builder::new()
         .prefix("fake-git-")
@@ -327,19 +285,28 @@ fn concurrent_syncs_share_one_git_remote_check() {
         &git_path,
         &format!(
             r#"#!/bin/sh
-printf '%s\n' "$1" >> '{}'
+printf '%s\n' "$*" >> '{}'
 if [ "$1" = "ls-remote" ]; then
   sleep 1
   printf '%s\tHEAD\n' "{sha}"
   exit 0
 fi
-if [ "$1" = "clone" ]; then
-  dest="$5"
-  mkdir -p "$dest/.git" "$dest/.agents/plugins" "$dest/plugins/gmail/.codex-plugin"
-  cat > "$dest/.agents/plugins/marketplace.json" <<'EOF'
+if [ "$1" = "-C" ] && [ "$3" = "init" ]; then
+  mkdir -p "$2/.git"
+  exit 0
+fi
+if [ "$1" = "-C" ] && [ "$3" = "fetch" ]; then
+  exit 0
+fi
+if [ "$1" = "-C" ] && [ "$3" = "reset" ]; then
+  mkdir -p "$2/.agents/plugins" "$2/plugins/gmail/.codex-plugin"
+  cat > "$2/.agents/plugins/marketplace.json" <<'EOF'
 {{"name":"openai-curated","plugins":[{{"name":"gmail","source":{{"source":"local","path":"./plugins/gmail"}}}}]}}
 EOF
-  printf '%s\n' '{{"name":"gmail"}}' > "$dest/plugins/gmail/.codex-plugin/plugin.json"
+  printf '%s\n' '{{"name":"gmail"}}' > "$2/plugins/gmail/.codex-plugin/plugin.json"
+  exit 0
+fi
+if [ "$1" = "-C" ] && [ "$3" = "clean" ]; then
   exit 0
 fi
 if [ "$1" = "-C" ] && [ "$3" = "rev-parse" ] && [ "$4" = "HEAD" ]; then
@@ -381,16 +348,21 @@ exit 1
     assert_eq!(
         invocations
             .lines()
-            .filter(|invocation| *invocation == "ls-remote")
+            .filter(|invocation| invocation.starts_with("ls-remote "))
             .count(),
-        1
+        2
     );
     assert_eq!(
         invocations
             .lines()
-            .filter(|invocation| *invocation == "clone")
+            .filter(|invocation| invocation.contains(" fetch --depth 1 --no-tags "))
             .count(),
         1
+    );
+    assert!(
+        !invocations
+            .lines()
+            .any(|invocation| invocation.split_whitespace().any(|arg| arg == "clone"))
     );
 }
 
@@ -490,6 +462,18 @@ fn sync_openai_plugins_repo_via_git_succeeds_with_local_rewritten_remote() {
         .expect("read first sync invocations")
         .lines()
         .count();
+    let first_sync_invocations =
+        std::fs::read_to_string(&invocation_log).expect("read first sync invocations");
+    assert!(
+        first_sync_invocations
+            .lines()
+            .any(|invocation| invocation.contains(" fetch --depth 1 --no-tags "))
+    );
+    assert!(
+        !first_sync_invocations
+            .lines()
+            .any(|invocation| invocation.split_whitespace().any(|arg| arg == "clone"))
+    );
     write_openai_curated_marketplace(&work_repo, &["gmail", "linear"]);
     run_git(&work_repo, &["add", "."]);
     run_git(
@@ -535,19 +519,54 @@ fn sync_openai_plugins_repo_via_git_succeeds_with_local_rewritten_remote() {
             .join(".git/objects/info/alternates")
             .exists()
     );
-    let invocation_log = std::fs::read_to_string(&invocation_log).expect("read sync invocations");
-    let incremental_sync_invocations = invocation_log
+    let invocation_log_contents =
+        std::fs::read_to_string(&invocation_log).expect("read sync invocations");
+    let incremental_sync_invocations = invocation_log_contents
         .lines()
         .skip(first_sync_invocation_count)
         .collect::<Vec<_>>();
     assert!(incremental_sync_invocations.iter().any(|invocation| {
-        invocation.starts_with("clone --depth 1 --reference-if-able ")
-            && invocation.contains(" --dissociate https://github.com/openai/plugins.git ")
+        invocation.contains(" fetch --depth 1 --no-tags https://github.com/openai/plugins.git ")
+            && invocation.ends_with(updated_sha.as_str())
     }));
-    assert!(!incremental_sync_invocations.iter().any(|invocation| {
-        invocation.starts_with("clone --depth 1 https://github.com/openai/plugins.git")
-    }));
+    assert!(
+        incremental_sync_invocations
+            .iter()
+            .any(|invocation| invocation.ends_with(" reset --hard FETCH_HEAD"))
+    );
+    assert!(
+        !incremental_sync_invocations
+            .iter()
+            .any(|invocation| invocation.ends_with(" init"))
+    );
+    assert!(
+        !incremental_sync_invocations
+            .iter()
+            .any(|invocation| invocation.split_whitespace().any(|arg| arg == "clone"))
+    );
     assert!(!has_plugins_clone_dirs(tmp.path()));
+
+    let unchanged_sync_invocation_count = invocation_log_contents.lines().count();
+    let synced_sha =
+        sync_openai_plugins_repo_via_git(tmp.path(), git_wrapper.to_str().expect("utf8 path"))
+            .expect("unchanged git sync should succeed");
+
+    assert_eq!(synced_sha, updated_sha);
+    let invocation_log = std::fs::read_to_string(&invocation_log).expect("read sync invocations");
+    let unchanged_sync_invocations = invocation_log
+        .lines()
+        .skip(unchanged_sync_invocation_count)
+        .collect::<Vec<_>>();
+    assert!(
+        unchanged_sync_invocations
+            .iter()
+            .any(|invocation| invocation.starts_with("ls-remote "))
+    );
+    assert!(
+        !unchanged_sync_invocations
+            .iter()
+            .any(|invocation| invocation.contains(" fetch "))
+    );
 }
 
 #[tokio::test]
@@ -614,7 +633,7 @@ exit 1
 
 #[cfg(unix)]
 #[test]
-fn sync_openai_plugins_repo_via_git_cleans_up_staged_dir_on_clone_failure() {
+fn sync_openai_plugins_repo_via_git_cleans_up_staged_dir_on_fetch_failure() {
     let tmp = tempdir().expect("tempdir");
     let bin_dir = tempfile::Builder::new()
         .prefix("fake-git-partial-fail-")
@@ -631,9 +650,11 @@ if [ "$1" = "ls-remote" ]; then
   printf '%s\tHEAD\n' "{sha}"
   exit 0
 fi
-if [ "$1" = "clone" ]; then
-  dest="$5"
-  mkdir -p "$dest/.git"
+if [ "$1" = "-C" ] && [ "$3" = "init" ]; then
+  mkdir -p "$2/.git"
+  exit 0
+fi
+if [ "$1" = "-C" ] && [ "$3" = "fetch" ]; then
   echo "fatal: early EOF" >&2
   exit 128
 fi
@@ -735,7 +756,6 @@ async fn sync_openai_plugins_repo_skips_export_archive_when_snapshot_exists() {
     let curated_root = curated_plugins_repo_path(tmp.path());
     write_openai_curated_marketplace(&curated_root, &["linear"]);
     write_curated_plugin_sha(tmp.path());
-    write_file(&tmp.path().join(".tmp/plugins.next-check"), "0\n");
 
     let plugin_manifest_path = curated_root.join("plugins/linear/.codex-plugin/plugin.json");
     let original_manifest =
@@ -771,12 +791,6 @@ async fn sync_openai_plugins_repo_skips_export_archive_when_snapshot_exists() {
     assert_eq!(
         read_curated_plugins_sha(tmp.path()).as_deref(),
         Some(TEST_CURATED_PLUGIN_SHA)
-    );
-    assert_ne!(
-        std::fs::read_to_string(tmp.path().join(".tmp/plugins.next-check"))
-            .expect("read next check")
-            .trim(),
-        "0"
     );
 }
 


### PR DESCRIPTION
# Summary
Reduce download traffic to `github.com/openai/plugins` while continuing to check for updates on every Codex startup.

# Root cause
The startup sync replaced the local repository with a fresh shallow clone whenever the remote revision changed. At Codex's global scale, repeatedly downloading the repository created excessive GitHub traffic.

# Changes
- Run `git ls-remote` on each startup to read the remote HEAD SHA.
- Skip all repository downloads when the local and remote SHAs match.
- Update existing checkouts with an exact-SHA shallow `git fetch`, followed by reset and clean.
- Bootstrap new installations with `git init` plus the same shallow fetch, rather than cloning.
- Keep the existing file lock so concurrent Codex processes serialize updates and do not duplicate fetches.
- Preserve the existing GitHub HTTP and export archive fallback behavior.

# Impact
Each startup makes one lightweight remote HEAD check. Repository objects are downloaded only when the revision changes, and existing Git objects are reused during updates.

# Validation
- `just test -p codex-core-plugins startup_sync` (15 tests passed)
- `just test -p codex-core-plugins` (201 tests passed)
- `just clippy -p codex-core-plugins` (passes with one pre-existing `large_enum_variant` warning)
- Production app-server smoke test against GitHub:
  - Fresh home: `ls-remote`, `git init`, one exact-SHA shallow fetch
  - Unchanged restart: `ls-remote` and local `rev-parse` only; no fetch or clone
- Bench smoke passed