### PR TITLE
Release MCP manager lock before listing tools

### DIFF
--- a/codex-rs/codex-mcp/src/connection_manager.rs
+++ b/codex-rs/codex-mcp/src/connection_manager.rs
@@ -112,6 +112,57 @@ pub struct McpConnectionManager {
     startup_cancellation_token: CancellationToken,
 }
 
+/// An owned view of the MCP state needed to list tools.
+///
+/// Taking a snapshot allows callers to release synchronization around the
+/// connection manager before waiting for MCP clients to finish starting.
+pub struct McpToolListSnapshot {
+    clients: HashMap<String, AsyncManagedClient>,
+    server_metadata: HashMap<String, McpServerMetadata>,
+    prefix_mcp_tool_names: bool,
+}
+
+impl McpToolListSnapshot {
+    /// Returns all tools in this snapshot with model-visible names normalized.
+    #[instrument(level = "trace", skip_all, fields(mcp_server_count = self.clients.len()))]
+    pub async fn list_all_tools(self) -> Vec<ToolInfo> {
+        let mut tools = Vec::new();
+        for (server_name, managed_client) in self.clients {
+            let has_cached_tool_info_snapshot = managed_client.cached_tool_info_snapshot.is_some();
+            let startup_complete = managed_client
+                .startup_complete
+                .load(std::sync::atomic::Ordering::Acquire);
+            trace!(
+                server_name = %server_name,
+                has_cached_tool_info_snapshot,
+                startup_complete,
+                "waiting for MCP server tools while building tool list"
+            );
+            let Some(server_tools) = managed_client
+                .listed_tools()
+                .instrument(trace_span!(
+                    "list_tools_for_server",
+                    server_name = %server_name,
+                    has_cached_tool_info_snapshot,
+                    startup_complete
+                ))
+                .await
+            else {
+                continue;
+            };
+            trace!(
+                server_name = %server_name,
+                tool_count = server_tools.len(),
+                "listed MCP server tools while building tool list"
+            );
+            tools.extend(server_tools.into_iter().map(|tool| {
+                McpConnectionManager::with_server_metadata(&self.server_metadata, tool)
+            }));
+        }
+        normalize_tools_for_model_with_prefix(tools, self.prefix_mcp_tool_names)
+    }
+}
+
 impl McpConnectionManager {
     pub fn new_uninitialized(
         approval_policy: &Constrained<AskForApproval>,
@@ -411,45 +462,18 @@ impl McpConnectionManager {
         failures
     }
 
-    /// Returns all tools with model-visible names normalized.
-    #[instrument(level = "trace", skip_all, fields(mcp_server_count = self.clients.len()))]
-    pub async fn list_all_tools(&self) -> Vec<ToolInfo> {
-        let mut tools = Vec::new();
-        for (server_name, managed_client) in &self.clients {
-            let has_cached_tool_info_snapshot = managed_client.cached_tool_info_snapshot.is_some();
-            let startup_complete = managed_client
-                .startup_complete
-                .load(std::sync::atomic::Ordering::Acquire);
-            trace!(
-                server_name = %server_name,
-                has_cached_tool_info_snapshot,
-                startup_complete,
-                "waiting for MCP server tools while building tool list"
-            );
-            let Some(server_tools) = managed_client
-                .listed_tools()
-                .instrument(trace_span!(
-                    "list_tools_for_server",
-                    server_name = %server_name,
-                    has_cached_tool_info_snapshot,
-                    startup_complete
-                ))
-                .await
-            else {
-                continue;
-            };
-            trace!(
-                server_name = %server_name,
-                tool_count = server_tools.len(),
-                "listed MCP server tools while building tool list"
-            );
-            tools.extend(
-                server_tools
-                    .into_iter()
-                    .map(|tool| self.with_server_metadata(tool)),
-            );
+    /// Captures the state needed to list tools without retaining access to the manager.
+    pub fn tool_list_snapshot(&self) -> McpToolListSnapshot {
+        McpToolListSnapshot {
+            clients: self.clients.clone(),
+            server_metadata: self.server_metadata.clone(),
+            prefix_mcp_tool_names: self.prefix_mcp_tool_names,
         }
-        normalize_tools_for_model_with_prefix(tools, self.prefix_mcp_tool_names)
+    }
+
+    /// Returns all tools with model-visible names normalized.
+    pub async fn list_all_tools(&self) -> Vec<ToolInfo> {
+        self.tool_list_snapshot().list_all_tools().await
     }
 
     /// Returns presentation metadata without waiting for uncached clients still initializing.
@@ -524,7 +548,7 @@ impl McpConnectionManager {
             .into_iter()
             .map(|mut tool| {
                 tool.tool = tool_with_model_visible_input_schema(&tool.tool);
-                self.with_server_metadata(tool)
+                Self::with_server_metadata(&self.server_metadata, tool)
             });
         Ok(normalize_tools_for_model_with_prefix(
             tools,
@@ -532,8 +556,11 @@ impl McpConnectionManager {
         ))
     }
 
-    fn with_server_metadata(&self, mut tool: ToolInfo) -> ToolInfo {
-        let Some(metadata) = self.server_metadata.get(&tool.server_name) else {
+    fn with_server_metadata(
+        server_metadata: &HashMap<String, McpServerMetadata>,
+        mut tool: ToolInfo,
+    ) -> ToolInfo {
+        let Some(metadata) = server_metadata.get(&tool.server_name) else {
             tool.supports_parallel_tool_calls = false;
             tool.server_origin = None;
             return tool;

--- a/codex-rs/codex-mcp/src/connection_manager_tests.rs
+++ b/codex-rs/codex-mcp/src/connection_manager_tests.rs
@@ -981,6 +981,51 @@ async fn list_all_tools_blocks_while_client_is_pending_without_cached_tool_info_
 }
 
 #[tokio::test]
+async fn list_all_tools_does_not_retain_manager_read_lock() {
+    let pending_client = futures::future::pending::<Result<ManagedClient, StartupOutcomeError>>()
+        .boxed()
+        .shared();
+    let approval_policy = Constrained::allow_any(AskForApproval::OnFailure);
+    let permission_profile = Constrained::allow_any(PermissionProfile::default());
+    let mut manager = McpConnectionManager::new_uninitialized(
+        &approval_policy,
+        &permission_profile,
+        /*prefix_mcp_tool_names*/ true,
+    );
+    manager.clients.insert(
+        CODEX_APPS_MCP_SERVER_NAME.to_string(),
+        AsyncManagedClient {
+            client: pending_client,
+            cached_tool_info_snapshot: None,
+            cached_server_info: None,
+            startup_complete: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            tool_plugin_provenance: Arc::new(ToolPluginProvenance::default()),
+            cancel_token: CancellationToken::new(),
+        },
+    );
+    let manager = Arc::new(tokio::sync::RwLock::new(manager));
+    let list_task = {
+        let manager = manager.read().await;
+        tokio::spawn(manager.tool_list_snapshot().list_all_tools())
+    };
+
+    tokio::task::yield_now().await;
+    {
+        let _write_guard = tokio::time::timeout(Duration::from_millis(10), manager.write())
+            .await
+            .expect("tool listing should not retain the manager read lock");
+    }
+
+    list_task.abort();
+    assert!(
+        list_task
+            .await
+            .expect_err("pending tool listing should abort")
+            .is_cancelled()
+    );
+}
+
+#[tokio::test]
 async fn list_all_tools_does_not_block_when_cached_tool_info_snapshot_is_empty() {
     let pending_client = futures::future::pending::<Result<ManagedClient, StartupOutcomeError>>()
         .boxed()

--- a/codex-rs/codex-mcp/src/lib.rs
+++ b/codex-rs/codex-mcp/src/lib.rs
@@ -1,4 +1,5 @@
 pub use connection_manager::McpConnectionManager;
+pub use connection_manager::McpToolListSnapshot;
 pub use connection_manager::tool_is_model_visible;
 pub use elicitation::ElicitationReviewRequest;
 pub use elicitation::ElicitationReviewer;

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -1062,10 +1062,6 @@ async fn run_sampling_request(
     }
 }
 
-#[expect(
-    clippy::await_holding_invalid_type,
-    reason = "tool router construction reads through the session-owned manager guard"
-)]
 #[instrument(level = "trace",
     skip_all,
     fields(
@@ -1079,18 +1075,22 @@ pub(crate) async fn built_tools(
     turn_context: &TurnContext,
     cancellation_token: &CancellationToken,
 ) -> CodexResult<Arc<ToolRouter>> {
-    let mcp_connection_manager = sess
-        .services
-        .mcp_connection_manager
-        .read()
-        .instrument(trace_span!("read_mcp_connection_manager"))
-        .await;
-    let has_mcp_servers = mcp_connection_manager.has_servers();
-    let all_mcp_tools = mcp_connection_manager
+    let (has_mcp_servers, mcp_tool_list_snapshot) = {
+        let mcp_connection_manager = sess
+            .services
+            .mcp_connection_manager
+            .read()
+            .instrument(trace_span!("read_mcp_connection_manager"))
+            .await;
+        (
+            mcp_connection_manager.has_servers(),
+            mcp_connection_manager.tool_list_snapshot(),
+        )
+    };
+    let all_mcp_tools = mcp_tool_list_snapshot
         .list_all_tools()
         .or_cancel(cancellation_token)
         .await?;
-    drop(mcp_connection_manager);
     let loaded_plugins = sess
         .services
         .plugins_manager


### PR DESCRIPTION
## Summary

Startup prewarm builds the tool router while MCP servers may still be initializing. Previously, tool listing retained the MCP connection manager read lock while awaiting server startup. Session shutdown needs the manager write lock to begin MCP shutdown, so pending tool listing could delay process exit.

This change captures the MCP clients, server metadata, and tool-name configuration in an owned snapshot while holding the read lock, then releases the lock before awaiting tool listing. Existing normalization, cache, and metadata behavior remains unchanged.

A focused regression test keeps tool listing pending and verifies that the manager write lock remains immediately available.

## Benchmark

A 10-run synchronization benchmark started tool listing with an MCP startup future that completed after 250 ms, then measured how long shutdown-style write-lock acquisition took:

- `main`: median 252.122 ms, range 251.109-252.959 ms
- this branch: median 0.000 ms, range 0.000-0.001 ms

On `main`, shutdown waited for the full remaining startup delay. With the snapshot, the write lock was available immediately, so process exit no longer scales with pending tool-list prewarm.
