### PR TITLE
[codex] Fix Windows sandbox build script lint

### DIFF
--- a/codex-rs/windows-sandbox-rs/build.rs
+++ b/codex-rs/windows-sandbox-rs/build.rs
@@ -4,18 +4,16 @@ use std::path::PathBuf;
 const SETUP_BIN: &str = "codex-windows-sandbox-setup";
 const SETUP_MANIFEST: &str = "codex-windows-sandbox-setup.manifest";
 
-fn main() {
+fn main() -> Result<(), String> {
     println!("cargo:rerun-if-changed={SETUP_MANIFEST}");
 
     if env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
-        return;
+        return Ok(());
     }
 
-    let manifest_path = PathBuf::from(
-        env::var_os("CARGO_MANIFEST_DIR")
-            .expect("CARGO_MANIFEST_DIR should be set for build scripts"),
-    )
-    .join(SETUP_MANIFEST);
+    let manifest_dir = env::var_os("CARGO_MANIFEST_DIR")
+        .ok_or_else(|| "CARGO_MANIFEST_DIR should be set for build scripts".to_string())?;
+    let manifest_path = PathBuf::from(manifest_dir).join(SETUP_MANIFEST);
     let manifest_path = manifest_path.display();
 
     // Keep this scoped to the setup helper so Codex binaries that link the
@@ -36,4 +34,6 @@ fn main() {
         }
         _ => {}
     }
+
+    Ok(())
 }


### PR DESCRIPTION
## Why

The Windows ARM64 Cargo clippy job on `main` is failing because workspace lints deny `clippy::expect_used`, and the `codex-windows-sandbox` build script used `expect()` while reading `CARGO_MANIFEST_DIR`.

## What changed

`codex-rs/windows-sandbox-rs/build.rs` now returns `Result<(), String>` from `main()` and converts a missing `CARGO_MANIFEST_DIR` into an explicit build-script error. The non-Windows early return and Windows linker argument behavior are unchanged.

## Verification

- `just clippy -p codex-windows-sandbox -- -D warnings`
- `just test -p codex-windows-sandbox`
