### PR TITLE
[codex] Extract shared Cargo CI setup action

### DIFF
--- a/.github/actions/finish-cargo-ci/action.yml
+++ b/.github/actions/finish-cargo-ci/action.yml
@@ -1,0 +1,109 @@
+name: finish-cargo-ci
+description: Save shared Cargo CI caches and report sccache statistics.
+inputs:
+  target:
+    description: Rust target triple used for cache namespacing.
+    required: true
+  profile:
+    description: Cargo profile used for cache namespacing.
+    required: true
+  cache-runner:
+    description: Runner name used for cache namespacing.
+    required: true
+  cargo-home-cache-hit:
+    description: Whether the exact Cargo home cache key was restored.
+    required: true
+  lockfile-hash:
+    description: SHA-256 hash of codex-rs/Cargo.lock.
+    required: true
+  toolchain-hash:
+    description: SHA-256 hash of codex-rs/rust-toolchain.toml.
+    required: true
+  summary-label:
+    description: Label shown beside the target in the sccache summary.
+    required: true
+  use-hermetic-cargo-home:
+    description: Save the workspace-local Cargo home used by musl builds.
+    required: false
+    default: "false"
+  use-sccache:
+    description: Save and report sccache state.
+    required: false
+    default: "true"
+  supplemental-cache-path:
+    description: Optional workload-specific cache path to save.
+    required: false
+    default: ""
+  supplemental-cache-key:
+    description: Cache key for the optional workload-specific cache.
+    required: false
+    default: ""
+  supplemental-cache-hit:
+    description: Whether the optional workload-specific cache was restored exactly.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Save cargo home cache
+      if: ${{ !cancelled() && inputs.cargo-home-cache-hit != 'true' && inputs.use-hermetic-cargo-home != 'true' }}
+      continue-on-error: true
+      uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: cargo-home-${{ inputs.cache-runner }}-${{ inputs.target }}-${{ inputs.profile }}-${{ inputs.lockfile-hash }}-${{ inputs.toolchain-hash }}
+
+    - name: Save cargo home cache
+      if: ${{ !cancelled() && inputs.cargo-home-cache-hit != 'true' && inputs.use-hermetic-cargo-home == 'true' }}
+      continue-on-error: true
+      uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          ${{ github.workspace }}/.cargo-home/bin/
+          ${{ github.workspace }}/.cargo-home/registry/index/
+          ${{ github.workspace }}/.cargo-home/registry/cache/
+          ${{ github.workspace }}/.cargo-home/git/db/
+        key: cargo-home-${{ inputs.cache-runner }}-${{ inputs.target }}-${{ inputs.profile }}-${{ inputs.lockfile-hash }}-${{ inputs.toolchain-hash }}
+
+    - name: Save sccache cache (fallback)
+      if: ${{ !cancelled() && inputs.use-sccache == 'true' && env.SCCACHE_GHA_ENABLED != 'true' }}
+      continue-on-error: true
+      uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-${{ inputs.cache-runner }}-${{ inputs.target }}-${{ inputs.profile }}-${{ inputs.lockfile-hash }}-${{ github.run_id }}
+
+    - name: sccache stats
+      if: ${{ inputs.use-sccache == 'true' }}
+      continue-on-error: true
+      shell: bash
+      run: sccache --show-stats || true
+
+    - name: sccache summary
+      if: ${{ inputs.use-sccache == 'true' }}
+      shell: bash
+      run: |
+        {
+          echo "### sccache stats — ${{ inputs.target }} (${{ inputs.summary-label }})";
+          echo;
+          echo '```';
+          sccache --show-stats || true;
+          echo '```';
+        } >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Save supplemental cache
+      if: ${{ !cancelled() && inputs.supplemental-cache-path != '' && inputs.supplemental-cache-hit != 'true' }}
+      continue-on-error: true
+      uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with:
+        path: ${{ inputs.supplemental-cache-path }}
+        key: ${{ inputs.supplemental-cache-key }}

--- a/.github/actions/finish-cargo-ci/action.yml
+++ b/.github/actions/finish-cargo-ci/action.yml
@@ -83,13 +83,13 @@ runs:
         key: sccache-${{ inputs.cache-runner }}-${{ inputs.target }}-${{ inputs.profile }}-${{ inputs.lockfile-hash }}-${{ github.run_id }}
 
     - name: sccache stats
-      if: ${{ inputs.use-sccache == 'true' }}
+      if: ${{ !cancelled() && inputs.use-sccache == 'true' }}
       continue-on-error: true
       shell: bash
       run: sccache --show-stats || true
 
     - name: sccache summary
-      if: ${{ inputs.use-sccache == 'true' }}
+      if: ${{ !cancelled() && inputs.use-sccache == 'true' }}
       shell: bash
       run: |
         {

--- a/.github/actions/setup-cargo-ci/action.yml
+++ b/.github/actions/setup-cargo-ci/action.yml
@@ -1,0 +1,126 @@
+name: setup-cargo-ci
+description: Prepare a Cargo CI job with its Rust toolchain and shared caches.
+inputs:
+  target:
+    description: Rust target triple to install and use for cache namespacing.
+    required: true
+  profile:
+    description: Cargo profile used for cache namespacing.
+    required: true
+  cache-runner:
+    description: Runner name used for cache namespacing.
+    required: true
+  components:
+    description: Optional comma-separated Rust toolchain components.
+    required: false
+    default: ""
+  use-hermetic-cargo-home:
+    description: Configure a workspace-local Cargo home for musl builds.
+    required: false
+    default: "false"
+  use-sccache:
+    description: Install and configure sccache.
+    required: false
+    default: "true"
+outputs:
+  cargo-home-cache-hit:
+    description: Whether the exact Cargo home cache key was restored.
+    value: ${{ steps.cache_cargo_home_restore.outputs.cache-hit }}
+  lockfile-hash:
+    description: SHA-256 hash of codex-rs/Cargo.lock.
+    value: ${{ steps.lockhash.outputs.hash }}
+  toolchain-hash:
+    description: SHA-256 hash of codex-rs/rust-toolchain.toml.
+    value: ${{ steps.lockhash.outputs.toolchain_hash }}
+
+runs:
+  using: composite
+  steps:
+    - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+      with:
+        targets: ${{ inputs.target }}
+        components: ${{ inputs.components }}
+
+    - name: Use hermetic Cargo home
+      if: ${{ inputs.use-hermetic-cargo-home == 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        cargo_home="${GITHUB_WORKSPACE}/.cargo-home"
+        mkdir -p "${cargo_home}/bin"
+        echo "CARGO_HOME=${cargo_home}" >> "$GITHUB_ENV"
+        echo "${cargo_home}/bin" >> "$GITHUB_PATH"
+        : > "${cargo_home}/config.toml"
+
+    - name: Compute lockfile hash
+      id: lockhash
+      working-directory: codex-rs
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "hash=$(sha256sum Cargo.lock | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+        echo "toolchain_hash=$(sha256sum rust-toolchain.toml | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+    - name: Restore cargo home cache
+      id: cache_cargo_home_restore
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          ${{ github.workspace }}/.cargo-home/bin/
+          ${{ github.workspace }}/.cargo-home/registry/index/
+          ${{ github.workspace }}/.cargo-home/registry/cache/
+          ${{ github.workspace }}/.cargo-home/git/db/
+        key: cargo-home-${{ inputs.cache-runner }}-${{ inputs.target }}-${{ inputs.profile }}-${{ steps.lockhash.outputs.hash }}-${{ steps.lockhash.outputs.toolchain_hash }}
+        restore-keys: |
+          cargo-home-${{ inputs.cache-runner }}-${{ inputs.target }}-${{ inputs.profile }}-
+
+    - name: Install sccache
+      if: ${{ inputs.use-sccache == 'true' }}
+      uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
+      with:
+        tool: sccache
+        version: 0.7.5
+
+    - name: Configure sccache backend
+      if: ${{ inputs.use-sccache == 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ -n "${ACTIONS_CACHE_URL:-}" && -n "${ACTIONS_RUNTIME_TOKEN:-}" ]]; then
+          echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
+          echo "Using sccache GitHub backend"
+        else
+          echo "SCCACHE_GHA_ENABLED=false" >> "$GITHUB_ENV"
+          if [[ -n "${DEV_DRIVE:-}" ]]; then
+            echo "SCCACHE_DIR=${DEV_DRIVE}\\.sccache" >> "$GITHUB_ENV"
+          else
+            echo "SCCACHE_DIR=${GITHUB_WORKSPACE}/.sccache" >> "$GITHUB_ENV"
+          fi
+          echo "Using sccache local disk + actions/cache fallback"
+        fi
+
+    - name: Enable sccache wrapper
+      if: ${{ inputs.use-sccache == 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        wrapper="$(command -v sccache)"
+        if [[ "${RUNNER_OS}" == "Windows" ]] && command -v cygpath >/dev/null 2>&1; then
+          wrapper="$(cygpath -w "${wrapper}")"
+        fi
+        echo "RUSTC_WRAPPER=${wrapper}" >> "$GITHUB_ENV"
+        echo "CARGO_BUILD_RUSTC_WRAPPER=${wrapper}" >> "$GITHUB_ENV"
+
+    - name: Restore sccache cache (fallback)
+      if: ${{ inputs.use-sccache == 'true' && env.SCCACHE_GHA_ENABLED != 'true' }}
+      uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with:
+        path: ${{ env.SCCACHE_DIR }}
+        key: sccache-${{ inputs.cache-runner }}-${{ inputs.target }}-${{ inputs.profile }}-${{ steps.lockhash.outputs.hash }}-${{ github.run_id }}
+        restore-keys: |
+          sccache-${{ inputs.cache-runner }}-${{ inputs.target }}-${{ inputs.profile }}-${{ steps.lockhash.outputs.hash }}-
+          sccache-${{ inputs.cache-runner }}-${{ inputs.target }}-${{ inputs.profile }}-

--- a/.github/workflows/rust-ci-full-nextest-platform.yml
+++ b/.github/workflows/rust-ci-full-nextest-platform.yml
@@ -94,84 +94,20 @@ jobs:
       - name: Install DotSlash
         uses: facebook/install-dotslash@1e4e7b3e07eaca387acb98f1d4720e0bee8dbb6a # v2
 
-      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
-        with:
-          targets: ${{ inputs.target }}
-
       - name: Expose MSVC SDK environment (Windows)
         if: ${{ runner.os == 'Windows' && inputs.target == 'aarch64-pc-windows-msvc' }}
         uses: ./.github/actions/setup-msvc-env
         with:
           target: ${{ inputs.target }}
 
-      - name: Compute lockfile hash
-        id: lockhash
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "hash=$(sha256sum Cargo.lock | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-          echo "toolchain_hash=$(sha256sum rust-toolchain.toml | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-
-      - name: Restore cargo home cache
-        id: cache_cargo_home_restore
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      - name: Set up Cargo CI
+        id: cargo_setup
+        uses: ./.github/actions/setup-cargo-ci
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: cargo-home-${{ env.ARCHIVE_CACHE_RUNNER }}-${{ inputs.target }}-${{ inputs.profile }}-${{ steps.lockhash.outputs.hash }}-${{ steps.lockhash.outputs.toolchain_hash }}
-          restore-keys: |
-            cargo-home-${{ env.ARCHIVE_CACHE_RUNNER }}-${{ inputs.target }}-${{ inputs.profile }}-
-
-      - name: Install sccache
-        if: ${{ env.USE_SCCACHE == 'true' }}
-        uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
-        with:
-          tool: sccache
-          version: 0.7.5
-
-      - name: Configure sccache backend
-        if: ${{ env.USE_SCCACHE == 'true' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -n "${ACTIONS_CACHE_URL:-}" && -n "${ACTIONS_RUNTIME_TOKEN:-}" ]]; then
-            echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
-            echo "Using sccache GitHub backend"
-          else
-            echo "SCCACHE_GHA_ENABLED=false" >> "$GITHUB_ENV"
-            if [[ -n "${DEV_DRIVE:-}" ]]; then
-              echo "SCCACHE_DIR=${DEV_DRIVE}\\.sccache" >> "$GITHUB_ENV"
-            else
-              echo "SCCACHE_DIR=${{ github.workspace }}/.sccache" >> "$GITHUB_ENV"
-            fi
-            echo "Using sccache local disk + actions/cache fallback"
-          fi
-
-      - name: Enable sccache wrapper
-        if: ${{ env.USE_SCCACHE == 'true' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          wrapper="$(command -v sccache)"
-          if [[ "${RUNNER_OS}" == "Windows" ]] && command -v cygpath >/dev/null 2>&1; then
-            wrapper="$(cygpath -w "${wrapper}")"
-          fi
-          echo "RUSTC_WRAPPER=${wrapper}" >> "$GITHUB_ENV"
-          echo "CARGO_BUILD_RUSTC_WRAPPER=${wrapper}" >> "$GITHUB_ENV"
-
-      - name: Restore sccache cache (fallback)
-        if: ${{ env.USE_SCCACHE == 'true' && env.SCCACHE_GHA_ENABLED != 'true' }}
-        id: cache_sccache_restore
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: ${{ env.SCCACHE_DIR }}
-          key: sccache-${{ env.ARCHIVE_CACHE_RUNNER }}-${{ inputs.target }}-${{ inputs.profile }}-${{ steps.lockhash.outputs.hash }}-${{ github.run_id }}
-          restore-keys: |
-            sccache-${{ env.ARCHIVE_CACHE_RUNNER }}-${{ inputs.target }}-${{ inputs.profile }}-${{ steps.lockhash.outputs.hash }}-
-            sccache-${{ env.ARCHIVE_CACHE_RUNNER }}-${{ inputs.target }}-${{ inputs.profile }}-
+          target: ${{ inputs.target }}
+          profile: ${{ inputs.profile }}
+          cache-runner: ${{ env.ARCHIVE_CACHE_RUNNER }}
+          use-sccache: ${{ env.USE_SCCACHE }}
 
       - uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
         with:
@@ -250,7 +186,7 @@ jobs:
           retention-days: 1
 
       - name: Save cargo home cache
-        if: always() && !cancelled() && steps.cache_cargo_home_restore.outputs.cache-hit != 'true'
+        if: always() && !cancelled() && steps.cargo_setup.outputs.cargo-home-cache-hit != 'true'
         continue-on-error: true
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
@@ -259,7 +195,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: cargo-home-${{ env.ARCHIVE_CACHE_RUNNER }}-${{ inputs.target }}-${{ inputs.profile }}-${{ steps.lockhash.outputs.hash }}-${{ steps.lockhash.outputs.toolchain_hash }}
+          key: cargo-home-${{ env.ARCHIVE_CACHE_RUNNER }}-${{ inputs.target }}-${{ inputs.profile }}-${{ steps.cargo_setup.outputs.lockfile-hash }}-${{ steps.cargo_setup.outputs.toolchain-hash }}
 
       - name: Save sccache cache (fallback)
         if: always() && !cancelled() && env.USE_SCCACHE == 'true' && env.SCCACHE_GHA_ENABLED != 'true'
@@ -267,7 +203,7 @@ jobs:
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ env.SCCACHE_DIR }}
-          key: sccache-${{ env.ARCHIVE_CACHE_RUNNER }}-${{ inputs.target }}-${{ inputs.profile }}-${{ steps.lockhash.outputs.hash }}-${{ github.run_id }}
+          key: sccache-${{ env.ARCHIVE_CACHE_RUNNER }}-${{ inputs.target }}-${{ inputs.profile }}-${{ steps.cargo_setup.outputs.lockfile-hash }}-${{ github.run_id }}
 
       - name: sccache stats
         if: always() && env.USE_SCCACHE == 'true'

--- a/.github/workflows/rust-ci-full-nextest-platform.yml
+++ b/.github/workflows/rust-ci-full-nextest-platform.yml
@@ -185,42 +185,18 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-      - name: Save cargo home cache
-        if: always() && !cancelled() && steps.cargo_setup.outputs.cargo-home-cache-hit != 'true'
-        continue-on-error: true
-        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      - name: Finish Cargo CI
+        if: always()
+        uses: ./.github/actions/finish-cargo-ci
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: cargo-home-${{ env.ARCHIVE_CACHE_RUNNER }}-${{ inputs.target }}-${{ inputs.profile }}-${{ steps.cargo_setup.outputs.lockfile-hash }}-${{ steps.cargo_setup.outputs.toolchain-hash }}
-
-      - name: Save sccache cache (fallback)
-        if: always() && !cancelled() && env.USE_SCCACHE == 'true' && env.SCCACHE_GHA_ENABLED != 'true'
-        continue-on-error: true
-        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: ${{ env.SCCACHE_DIR }}
-          key: sccache-${{ env.ARCHIVE_CACHE_RUNNER }}-${{ inputs.target }}-${{ inputs.profile }}-${{ steps.cargo_setup.outputs.lockfile-hash }}-${{ github.run_id }}
-
-      - name: sccache stats
-        if: always() && env.USE_SCCACHE == 'true'
-        continue-on-error: true
-        run: sccache --show-stats || true
-
-      - name: sccache summary
-        if: always() && env.USE_SCCACHE == 'true'
-        shell: bash
-        run: |
-          {
-            echo "### sccache stats — ${{ inputs.target }} (tests)";
-            echo;
-            echo '```';
-            sccache --show-stats || true;
-            echo '```';
-          } >> "$GITHUB_STEP_SUMMARY"
+          target: ${{ inputs.target }}
+          profile: ${{ inputs.profile }}
+          cache-runner: ${{ env.ARCHIVE_CACHE_RUNNER }}
+          cargo-home-cache-hit: ${{ steps.cargo_setup.outputs.cargo-home-cache-hit }}
+          lockfile-hash: ${{ steps.cargo_setup.outputs.lockfile-hash }}
+          toolchain-hash: ${{ steps.cargo_setup.outputs.toolchain-hash }}
+          summary-label: tests
+          use-sccache: ${{ env.USE_SCCACHE }}
 
   shard:
     name: Tests shard ${{ matrix.shard }}/4

--- a/.github/workflows/rust-ci-full-nextest-platform.yml
+++ b/.github/workflows/rust-ci-full-nextest-platform.yml
@@ -94,12 +94,6 @@ jobs:
       - name: Install DotSlash
         uses: facebook/install-dotslash@1e4e7b3e07eaca387acb98f1d4720e0bee8dbb6a # v2
 
-      - name: Expose MSVC SDK environment (Windows)
-        if: ${{ runner.os == 'Windows' && inputs.target == 'aarch64-pc-windows-msvc' }}
-        uses: ./.github/actions/setup-msvc-env
-        with:
-          target: ${{ inputs.target }}
-
       - name: Set up Cargo CI
         id: cargo_setup
         uses: ./.github/actions/setup-cargo-ci
@@ -108,6 +102,12 @@ jobs:
           profile: ${{ inputs.profile }}
           cache-runner: ${{ env.ARCHIVE_CACHE_RUNNER }}
           use-sccache: ${{ env.USE_SCCACHE }}
+
+      - name: Expose MSVC SDK environment (Windows)
+        if: ${{ runner.os == 'Windows' && inputs.target == 'aarch64-pc-windows-msvc' }}
+        uses: ./.github/actions/setup-msvc-env
+        with:
+          target: ${{ inputs.target }}
 
       - uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
         with:

--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -260,87 +260,16 @@ jobs:
             sudo apt-get update -y
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends pkg-config libcap-dev
           fi
-      - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+      - name: Set up Cargo CI
+        id: cargo_setup
+        uses: ./.github/actions/setup-cargo-ci
         with:
-          targets: ${{ matrix.target }}
+          target: ${{ matrix.target }}
+          profile: ${{ matrix.profile }}
+          cache-runner: ${{ matrix.runner }}
           components: clippy
-
-      - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-musl'}}
-        name: Use hermetic Cargo home (musl)
-        shell: bash
-        run: |
-          set -euo pipefail
-          cargo_home="${GITHUB_WORKSPACE}/.cargo-home"
-          mkdir -p "${cargo_home}/bin"
-          echo "CARGO_HOME=${cargo_home}" >> "$GITHUB_ENV"
-          echo "${cargo_home}/bin" >> "$GITHUB_PATH"
-          : > "${cargo_home}/config.toml"
-
-      - name: Compute lockfile hash
-        id: lockhash
-        working-directory: codex-rs
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "hash=$(sha256sum Cargo.lock | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-          echo "toolchain_hash=$(sha256sum rust-toolchain.toml | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-
-      # Explicit cache restore: split cargo home vs target, so we can
-      # avoid caching the large target dir on the gnu-dev job.
-      - name: Restore cargo home cache
-        id: cache_cargo_home_restore
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ${{ github.workspace }}/.cargo-home/bin/
-            ${{ github.workspace }}/.cargo-home/registry/index/
-            ${{ github.workspace }}/.cargo-home/registry/cache/
-            ${{ github.workspace }}/.cargo-home/git/db/
-          key: cargo-home-${{ matrix.runner }}-${{ matrix.target }}-${{ matrix.profile }}-${{ steps.lockhash.outputs.hash }}-${{ steps.lockhash.outputs.toolchain_hash }}
-          restore-keys: |
-            cargo-home-${{ matrix.runner }}-${{ matrix.target }}-${{ matrix.profile }}-
-
-      # Install and restore sccache cache
-      - name: Install sccache
-        if: ${{ env.USE_SCCACHE == 'true' }}
-        uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
-        with:
-          tool: sccache
-          version: 0.7.5
-
-      - name: Configure sccache backend
-        if: ${{ env.USE_SCCACHE == 'true' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -n "${ACTIONS_CACHE_URL:-}" && -n "${ACTIONS_RUNTIME_TOKEN:-}" ]]; then
-            echo "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
-            echo "Using sccache GitHub backend"
-          else
-            echo "SCCACHE_GHA_ENABLED=false" >> "$GITHUB_ENV"
-            echo "SCCACHE_DIR=${{ github.workspace }}/.sccache" >> "$GITHUB_ENV"
-            echo "Using sccache local disk + actions/cache fallback"
-          fi
-
-      - name: Enable sccache wrapper
-        if: ${{ env.USE_SCCACHE == 'true' }}
-        shell: bash
-        run: echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
-
-      - name: Restore sccache cache (fallback)
-        if: ${{ env.USE_SCCACHE == 'true' && env.SCCACHE_GHA_ENABLED != 'true' }}
-        id: cache_sccache_restore
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: ${{ github.workspace }}/.sccache/
-          key: sccache-${{ matrix.runner }}-${{ matrix.target }}-${{ matrix.profile }}-${{ steps.lockhash.outputs.hash }}-${{ github.run_id }}
-          restore-keys: |
-            sccache-${{ matrix.runner }}-${{ matrix.target }}-${{ matrix.profile }}-${{ steps.lockhash.outputs.hash }}-
-            sccache-${{ matrix.runner }}-${{ matrix.target }}-${{ matrix.profile }}-
+          use-hermetic-cargo-home: ${{ contains(matrix.target, 'musl') && 'true' || 'false' }}
+          use-sccache: ${{ env.USE_SCCACHE }}
 
       - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-musl'}}
         name: Prepare APT cache directories (musl)
@@ -411,7 +340,7 @@ jobs:
       # Save caches explicitly; make non-fatal so cache packaging
       # never fails the overall job. Only save when key wasn't hit.
       - name: Save cargo home cache
-        if: always() && !cancelled() && steps.cache_cargo_home_restore.outputs.cache-hit != 'true'
+        if: always() && !cancelled() && steps.cargo_setup.outputs.cargo-home-cache-hit != 'true'
         continue-on-error: true
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
@@ -424,15 +353,15 @@ jobs:
             ${{ github.workspace }}/.cargo-home/registry/index/
             ${{ github.workspace }}/.cargo-home/registry/cache/
             ${{ github.workspace }}/.cargo-home/git/db/
-          key: cargo-home-${{ matrix.runner }}-${{ matrix.target }}-${{ matrix.profile }}-${{ steps.lockhash.outputs.hash }}-${{ steps.lockhash.outputs.toolchain_hash }}
+          key: cargo-home-${{ matrix.runner }}-${{ matrix.target }}-${{ matrix.profile }}-${{ steps.cargo_setup.outputs.lockfile-hash }}-${{ steps.cargo_setup.outputs.toolchain-hash }}
 
       - name: Save sccache cache (fallback)
         if: always() && !cancelled() && env.USE_SCCACHE == 'true' && env.SCCACHE_GHA_ENABLED != 'true'
         continue-on-error: true
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
-          path: ${{ github.workspace }}/.sccache/
-          key: sccache-${{ matrix.runner }}-${{ matrix.target }}-${{ matrix.profile }}-${{ steps.lockhash.outputs.hash }}-${{ github.run_id }}
+          path: ${{ env.SCCACHE_DIR }}
+          key: sccache-${{ matrix.runner }}-${{ matrix.target }}-${{ matrix.profile }}-${{ steps.cargo_setup.outputs.lockfile-hash }}-${{ github.run_id }}
 
       - name: sccache stats
         if: always() && env.USE_SCCACHE == 'true'

--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -337,57 +337,22 @@ jobs:
           path: codex-rs/target/**/cargo-timings/cargo-timing.html
           if-no-files-found: warn
 
-      # Save caches explicitly; make non-fatal so cache packaging
-      # never fails the overall job. Only save when key wasn't hit.
-      - name: Save cargo home cache
-        if: always() && !cancelled() && steps.cargo_setup.outputs.cargo-home-cache-hit != 'true'
-        continue-on-error: true
-        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      - name: Finish Cargo CI
+        if: always()
+        uses: ./.github/actions/finish-cargo-ci
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ${{ github.workspace }}/.cargo-home/bin/
-            ${{ github.workspace }}/.cargo-home/registry/index/
-            ${{ github.workspace }}/.cargo-home/registry/cache/
-            ${{ github.workspace }}/.cargo-home/git/db/
-          key: cargo-home-${{ matrix.runner }}-${{ matrix.target }}-${{ matrix.profile }}-${{ steps.cargo_setup.outputs.lockfile-hash }}-${{ steps.cargo_setup.outputs.toolchain-hash }}
-
-      - name: Save sccache cache (fallback)
-        if: always() && !cancelled() && env.USE_SCCACHE == 'true' && env.SCCACHE_GHA_ENABLED != 'true'
-        continue-on-error: true
-        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: ${{ env.SCCACHE_DIR }}
-          key: sccache-${{ matrix.runner }}-${{ matrix.target }}-${{ matrix.profile }}-${{ steps.cargo_setup.outputs.lockfile-hash }}-${{ github.run_id }}
-
-      - name: sccache stats
-        if: always() && env.USE_SCCACHE == 'true'
-        continue-on-error: true
-        run: sccache --show-stats || true
-
-      - name: sccache summary
-        if: always() && env.USE_SCCACHE == 'true'
-        shell: bash
-        run: |
-          {
-            echo "### sccache stats — ${{ matrix.target }} (${{ matrix.profile }})";
-            echo;
-            echo '```';
-            sccache --show-stats || true;
-            echo '```';
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Save APT cache (musl)
-        if: always() && !cancelled() && (matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-musl') && steps.cache_apt_restore.outputs.cache-hit != 'true'
-        continue-on-error: true
-        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: |
-            /var/cache/apt
-          key: apt-${{ matrix.runner }}-${{ matrix.target }}-v1
+          target: ${{ matrix.target }}
+          profile: ${{ matrix.profile }}
+          cache-runner: ${{ matrix.runner }}
+          cargo-home-cache-hit: ${{ steps.cargo_setup.outputs.cargo-home-cache-hit }}
+          lockfile-hash: ${{ steps.cargo_setup.outputs.lockfile-hash }}
+          toolchain-hash: ${{ steps.cargo_setup.outputs.toolchain-hash }}
+          summary-label: ${{ matrix.profile }}
+          use-hermetic-cargo-home: ${{ contains(matrix.target, 'musl') && 'true' || 'false' }}
+          use-sccache: ${{ env.USE_SCCACHE }}
+          supplemental-cache-path: ${{ contains(matrix.target, 'musl') && '/var/cache/apt' || '' }}
+          supplemental-cache-key: apt-${{ matrix.runner }}-${{ matrix.target }}-v1
+          supplemental-cache-hit: ${{ steps.cache_apt_restore.outputs.cache-hit }}
 
   tests_macos_aarch64:
     name: Tests — macos-15-xlarge - aarch64-apple-darwin


### PR DESCRIPTION
## Why

The full Cargo clippy matrix and nextest archive workflow independently maintain the same Rust toolchain, Cargo-home cache, and sccache lifecycle. Keeping those copies aligned makes follow-up CI changes larger and easier to drift.

This is a behavior-preserving prefactor for subsequent Cargo CI work. It does not add jobs, targets, or new clippy coverage.

## What changed

- Add `.github/actions/setup-cargo-ci`, a composite action that installs the requested Rust target and components, configures an optional hermetic Cargo home, restores Cargo caches, and sets up sccache.
- Add `.github/actions/finish-cargo-ci`, a composite action that saves Cargo and fallback sccache caches and reports sccache statistics.
- Let callers optionally pass a workload-specific supplemental cache to the finish action; the musl jobs use this for their APT cache while retaining their existing restore and preparation logic.
- Use the actions from the existing `rust-ci-full` clippy matrix and reusable nextest archive workflow, preserving the existing target, profile, runner, cache-key, Windows Dev Drive, and musl behavior.

## Validation

- Parsed the new actions and both updated workflows with `yq`.
- Verified cache keys continue to use the same runner, target, profile, lockfile, and toolchain values.
- Confirmed `rust-ci.yml` is unchanged and the diff introduces no additional CI coverage.
- Dispatched `rust-ci-full` manually and confirmed the setup and finish actions execute across the exercised platforms; the run's remaining failures were unrelated test failures plus one ARM64 runner shutdown.