### PR TITLE
Use Winget release environment secret

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -1946,6 +1946,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    environment:
+      name: mainline-release-winget
+      deployment: false
 
     steps:
       - name: Publish to WinGet


### PR DESCRIPTION
## Why
`WINGET_PUBLISH_PAT` now lives as a GitHub environment secret under `mainline-release-winget`. The WinGet release job needs to enter that environment so `secrets.WINGET_PUBLISH_PAT` resolves during stable/mainline Rust releases.

## What Changed
- Attach the `winget` job in `.github/workflows/rust-release.yml` to the `mainline-release-winget` environment.
- Set `deployment: false` so the job can read environment secrets without creating GitHub deployment records.

## Operational Note
The `mainline-release-winget` environment must allow `rust-v*.*.*` tag refs before this can run on release tags. The live environment currently has a custom policy named `rust-v*.*.*` with type `branch`; add the corresponding `tag` policy before relying on this path for a release.

## Validation
- `git diff --check origin/main...HEAD -- .github/workflows/rust-release.yml`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "yaml ok: #{f}" }' .github/workflows/rust-release.yml`