### PR TITLE
feat(tui): show Codex state in iTerm2 tabs [1 of 3]

### DIFF
--- a/codex-rs/config/src/types.rs
+++ b/codex-rs/config/src/types.rs
@@ -730,6 +730,15 @@ pub struct Tui {
     #[serde(default)]
     pub terminal_title: Option<Vec<String>>,
 
+    /// Emit OSC 21337 tab-status indicators (the colored dot iTerm2 paints on
+    /// the tab itself for Working / Waiting / Idle).
+    ///
+    /// Other terminals ignore OSC 21337 silently, so this only has an effect
+    /// in iTerm2. Defaults to `true`; set to `false` to suppress emission
+    /// (e.g. if another tool is already managing the tab status).
+    #[serde(default = "default_true")]
+    pub tab_status: bool,
+
     /// Syntax highlighting theme name (kebab-case).
     ///
     /// When set, overrides automatic light/dark theme detection.

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -3040,6 +3040,11 @@
           "description": "Color status line items with colors derived from the active syntax theme. Defaults to `true`.",
           "type": "boolean"
         },
+        "tab_status": {
+          "default": true,
+          "description": "Emit OSC 21337 tab-status indicators (the colored dot iTerm2 paints on the tab itself for Working / Waiting / Idle).\n\nOther terminals ignore OSC 21337 silently, so this only has an effect in iTerm2. Defaults to `true`; set to `false` to suppress emission (e.g. if another tool is already managing the tab status).",
+          "type": "boolean"
+        },
         "terminal_resize_reflow_max_rows": {
           "default": null,
           "description": "Trim terminal resize-reflow replay to the most recent rendered terminal rows when the transcript exceeds this cap. Omit to use Codex's terminal-specific default. Set to `0` to keep all rendered rows.",

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -618,6 +618,7 @@ fn config_toml_deserializes_model_availability_nux() {
             status_line: None,
             status_line_use_colors: true,
             terminal_title: None,
+            tab_status: true,
             theme: None,
             pet: None,
             pet_anchor: TuiPetAnchor::Composer,
@@ -663,6 +664,33 @@ status_line_use_colors = false
             .expect("tui config should deserialize")
             .status_line_use_colors
     );
+}
+
+#[test]
+fn config_toml_tab_status_defaults_to_enabled() {
+    let cfg: ConfigToml =
+        toml::from_str("[tui]").expect("TOML deserialization should succeed for TUI config");
+
+    assert!(cfg.tui.expect("tui config should deserialize").tab_status);
+}
+
+#[tokio::test]
+async fn runtime_config_resolves_tab_status_disabled() {
+    let cfg = Config::load_from_base_config_with_overrides(
+        toml::from_str(
+            r#"
+[tui]
+tab_status = false
+"#,
+        )
+        .expect("TOML deserialization should succeed for TUI config"),
+        ConfigOverrides::default(),
+        tempdir().expect("tempdir").abs(),
+    )
+    .await
+    .expect("load config");
+
+    assert!(!cfg.tui_tab_status);
 }
 
 #[test]
@@ -3366,6 +3394,7 @@ fn tui_config_missing_notifications_field_defaults_to_enabled() {
             status_line: None,
             status_line_use_colors: true,
             terminal_title: None,
+            tab_status: true,
             theme: None,
             pet: None,
             pet_anchor: TuiPetAnchor::Composer,

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -749,6 +749,12 @@ pub struct Config {
     /// message when blocked on the user.
     pub tui_terminal_title: Option<Vec<String>>,
 
+    /// Whether to emit OSC 21337 tab-status indicators (iTerm2's per-tab dot).
+    ///
+    /// Defaults to `true`. Other terminals ignore the OSC silently, so this
+    /// is effectively iTerm2-only. Set to `false` to suppress emission.
+    pub tui_tab_status: bool,
+
     /// Syntax highlighting theme override (kebab-case name).
     pub tui_theme: Option<String>,
 
@@ -3659,6 +3665,11 @@ impl Config {
                 .map(|t| t.status_line_use_colors)
                 .unwrap_or(true),
             tui_terminal_title: cfg.tui.as_ref().and_then(|t| t.terminal_title.clone()),
+            tui_tab_status: cfg
+                .tui
+                .as_ref()
+                .map(|t| t.tab_status)
+                .unwrap_or(/*default*/ true),
             tui_theme: cfg.tui.as_ref().and_then(|t| t.theme.clone()),
             tui_pet: cfg.tui.as_ref().and_then(|t| t.pet.clone()),
             tui_pet_anchor: cfg

--- a/codex-rs/thread-manager-sample/src/main.rs
+++ b/codex-rs/thread-manager-sample/src/main.rs
@@ -207,6 +207,7 @@ fn new_config(model: Option<String>, arg0_paths: Arg0DispatchPaths) -> anyhow::R
         tui_status_line: None,
         tui_status_line_use_colors: true,
         tui_terminal_title: None,
+        tui_tab_status: true,
         tui_theme: None,
         tui_raw_output_mode: false,
         tui_pet: None,

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -311,7 +311,7 @@ impl BottomPane {
 
     /// Compute the desired tab-status state from current task + modal state.
     ///
-    /// Waiting pre-empts Working: a user-blocking modal is the more important
+    /// Waiting preempts Working: a user-blocking modal is the more important
     /// signal to surface. Waiting reads the same `terminal_title_requires_action`
     /// signal as the title indicator, so the two can never disagree.
     fn desired_tab_status(&self) -> TabStatus {

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -317,7 +317,7 @@ impl BottomPane {
     fn desired_tab_status(&self) -> TabStatus {
         if self.terminal_title_requires_action() {
             TabStatus::Waiting
-        } else if self.is_task_running {
+        } else if self.is_task_running || !self.unified_exec_footer.is_empty() {
             TabStatus::Working
         } else {
             TabStatus::Idle
@@ -1254,6 +1254,7 @@ impl BottomPane {
     pub(crate) fn set_unified_exec_processes(&mut self, processes: Vec<String>) {
         if self.unified_exec_footer.set_processes(processes) {
             self.sync_status_inline_message();
+            self.refresh_tab_status();
             self.request_redraw();
         }
     }
@@ -2029,6 +2030,55 @@ mod tests {
 
         pane.set_task_running(/*running*/ false);
         assert_eq!(pane.last_tab_status_for_test(), Some(TabStatus::Idle));
+    }
+
+    #[test]
+    fn tab_status_tracks_background_terminal_lifecycle() {
+        let features = Features::with_defaults();
+        let mut pane = fresh_pane();
+        let mut states = Vec::new();
+
+        pane.refresh_tab_status();
+        states.push(pane.last_tab_status_for_test());
+
+        pane.set_unified_exec_processes(vec!["sleep 30".to_string()]);
+        states.push(pane.last_tab_status_for_test());
+
+        pane.set_task_running(/*running*/ true);
+        pane.set_task_running(/*running*/ false);
+        states.push(pane.last_tab_status_for_test());
+
+        pane.push_approval_request(exec_request(), &features);
+        states.push(pane.last_tab_status_for_test());
+
+        let _ = pane.on_ctrl_c();
+        states.push(pane.last_tab_status_for_test());
+
+        pane.set_unified_exec_processes(Vec::new());
+        states.push(pane.last_tab_status_for_test());
+
+        assert_snapshot!(format!("{states:#?}"), @r###"
+        [
+            Some(
+                Idle,
+            ),
+            Some(
+                Working,
+            ),
+            Some(
+                Working,
+            ),
+            Some(
+                Waiting,
+            ),
+            Some(
+                Working,
+            ),
+            Some(
+                Idle,
+            ),
+        ]
+        "###);
     }
 
     #[test]

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -59,6 +59,7 @@ mod request_user_input;
 mod status_line_setup;
 mod status_line_style;
 mod status_surface_preview;
+mod tab_status_state;
 mod title_setup;
 pub(crate) use action_required_title::ACTION_REQUIRED_PREVIEW_PREFIX;
 pub(crate) use action_required_title::build_action_required_title_text;
@@ -188,10 +189,12 @@ pub(crate) use chat_composer_history::HistoryEntry;
 
 use crate::status_indicator_widget::StatusDetailsCapitalization;
 use crate::status_indicator_widget::StatusIndicatorWidget;
+use crate::tab_status::TabStatus;
 pub(crate) use experimental_features_view::ExperimentalFeatureItem;
 pub(crate) use experimental_features_view::ExperimentalFeaturesView;
 pub(crate) use list_selection_view::SelectionAction;
 pub(crate) use list_selection_view::SelectionItem;
+use tab_status_state::TabStatusState;
 
 struct DelayedApprovalRequest {
     request: ApprovalRequest,
@@ -238,6 +241,7 @@ pub(crate) struct BottomPane {
     context_window_percent: Option<i64>,
     context_window_used_tokens: Option<i64>,
     keymap: RuntimeKeymap,
+    tab_status: TabStatusState,
 }
 
 pub(crate) struct BottomPaneParams {
@@ -295,7 +299,36 @@ impl BottomPane {
             context_window_percent: None,
             context_window_used_tokens: None,
             keymap,
+            tab_status: TabStatusState::new(),
         }
+    }
+
+    /// Toggle OSC 21337 tab-status emission. Set post-construction by
+    /// `ChatWidget` so tests don't need to thread it through BottomPaneParams.
+    pub(crate) fn set_tab_status_enabled(&mut self, enabled: bool) {
+        self.tab_status.set_enabled(enabled);
+    }
+
+    /// Compute the desired tab-status state from current task + modal state.
+    ///
+    /// Waiting pre-empts Working: a user-blocking modal is the more important
+    /// signal to surface. Waiting reads the same `terminal_title_requires_action`
+    /// signal as the title indicator, so the two can never disagree.
+    fn desired_tab_status(&self) -> TabStatus {
+        if self.terminal_title_requires_action() {
+            TabStatus::Waiting
+        } else if self.is_task_running {
+            TabStatus::Working
+        } else {
+            TabStatus::Idle
+        }
+    }
+
+    /// Emit an OSC 21337 update if the desired state differs from what we
+    /// last wrote. Invoked at state-class transitions only.
+    fn refresh_tab_status(&mut self) {
+        let desired = self.desired_tab_status();
+        self.tab_status.refresh(desired);
     }
 
     pub fn set_skills(&mut self, skills: Option<Vec<SkillMetadata>>) {
@@ -494,6 +527,9 @@ impl BottomPane {
     fn push_view(&mut self, view: Box<dyn BottomPaneView>) {
         self.view_stack.push(view);
         self.schedule_active_view_frame();
+        // The new top-of-stack may be a user-blocking modal, so re-evaluate
+        // (the tab moves to Waiting when the view declares it).
+        self.refresh_tab_status();
         self.request_redraw();
     }
 
@@ -740,6 +776,10 @@ impl BottomPane {
         self.composer.sync_popups();
         self.maybe_show_delayed_approval_requests_at(now);
         self.schedule_active_view_frame();
+        // Poll every frame: the imperative refresh at push/task-state sites
+        // misses transitions where a pop into a non-empty stack changes the
+        // active view, or where a dismissal bypasses on_active_view_complete.
+        self.refresh_tab_status();
     }
 
     fn schedule_active_view_frame(&self) {
@@ -964,6 +1004,12 @@ impl BottomPane {
         self.status.is_some()
     }
 
+    /// Test-only view of the last OSC 21337 tab status we wrote.
+    #[cfg(test)]
+    pub(crate) fn last_tab_status_for_test(&self) -> Option<TabStatus> {
+        self.tab_status.last_status()
+    }
+
     #[cfg(test)]
     pub(crate) fn status_line_text(&self) -> Option<String> {
         self.composer.status_line_text()
@@ -1010,6 +1056,7 @@ impl BottomPane {
             // Hide the status indicator when a task completes, but keep other modal views.
             self.hide_status_indicator();
         }
+        self.refresh_tab_status();
     }
 
     pub(crate) fn set_queue_submissions(&mut self, queue_submissions: bool) {
@@ -1474,6 +1521,10 @@ impl BottomPane {
     fn on_active_view_complete(&mut self) {
         self.resume_status_timer_after_modal();
         self.set_composer_input_enabled(/*enabled*/ true, /*placeholder*/ None);
+        // Re-evaluate so completion paths that bypass
+        // pop_active_view_with_completion (paste-completes-modal, shutdown
+        // view_stack.clear) still drop out of Waiting.
+        self.refresh_tab_status();
     }
 
     fn pause_status_timer_for_modal(&mut self) {
@@ -1929,6 +1980,106 @@ mod tests {
         fn view_id(&self) -> Option<&'static str> {
             self.id
         }
+    }
+
+    fn fresh_pane() -> BottomPane {
+        let (tx_raw, _rx) = unbounded_channel::<AppEvent>();
+        let tx = AppEventSender::new(tx_raw);
+        BottomPane::new(BottomPaneParams {
+            app_event_tx: tx,
+            frame_requester: FrameRequester::test_dummy(),
+            has_input_focus: true,
+            enhanced_keys_supported: false,
+            placeholder_text: "Ask Codex to do anything".to_string(),
+            disable_paste_burst: true,
+            animations_enabled: true,
+            skills: Some(Vec::new()),
+        })
+    }
+
+    #[test]
+    fn tab_status_disabled_suppresses_emission() {
+        // Refresh must honor the `tui.tab_status = false` opt-out: nothing
+        // recorded across the Working/Idle arc.
+        let mut pane = fresh_pane();
+        pane.set_tab_status_enabled(/*enabled*/ false);
+
+        pane.set_task_running(/*running*/ true);
+        assert_eq!(pane.last_tab_status_for_test(), None);
+
+        pane.set_task_running(/*running*/ false);
+        assert_eq!(pane.last_tab_status_for_test(), None);
+    }
+
+    #[test]
+    fn tab_status_transitions_through_a_typical_turn() {
+        let features = Features::with_defaults();
+        let mut pane = fresh_pane();
+        pane.refresh_tab_status();
+        assert_eq!(pane.last_tab_status_for_test(), Some(TabStatus::Idle));
+
+        pane.set_task_running(/*running*/ true);
+        assert_eq!(pane.last_tab_status_for_test(), Some(TabStatus::Working));
+
+        pane.push_approval_request(exec_request(), &features);
+        assert_eq!(pane.last_tab_status_for_test(), Some(TabStatus::Waiting));
+
+        let _ = pane.on_ctrl_c();
+        assert_eq!(pane.last_tab_status_for_test(), Some(TabStatus::Working));
+
+        pane.set_task_running(/*running*/ false);
+        assert_eq!(pane.last_tab_status_for_test(), Some(TabStatus::Idle));
+    }
+
+    #[test]
+    fn tab_status_clears_via_on_active_view_complete_bypass() {
+        // Some completion paths bypass pop_active_view_with_completion
+        // (handle_paste's view-complete branch, show_shutdown_in_progress).
+        // Driving state off on_active_view_complete must drop out of Waiting
+        // for those too.
+        let features = Features::with_defaults();
+        let mut pane = fresh_pane();
+        pane.set_task_running(/*running*/ true);
+        pane.push_approval_request(exec_request(), &features);
+        assert_eq!(pane.last_tab_status_for_test(), Some(TabStatus::Waiting));
+
+        // Simulate handle_paste's view-complete branch: clear then complete.
+        pane.view_stack.clear();
+        pane.on_active_view_complete();
+        assert_eq!(pane.last_tab_status_for_test(), Some(TabStatus::Working));
+    }
+
+    #[test]
+    fn tab_status_drops_waiting_when_pop_leaves_non_empty_stack() {
+        // pop_active_view_with_completion only calls on_active_view_complete
+        // when the stack empties. Popping an action modal while a non-action
+        // view remains underneath fires no imperative refresh, so only the
+        // per-frame poll can drop the tab out of Waiting.
+        let features = Features::with_defaults();
+        let mut pane = fresh_pane();
+
+        // Underlay: a non-action view that stays on the stack.
+        pane.show_view(Box::new(DismissibleView::default()));
+        pane.set_task_running(/*running*/ true);
+        assert_eq!(
+            pane.last_tab_status_for_test(),
+            Some(TabStatus::Working),
+            "non-action underlay shouldn't move us off Working",
+        );
+
+        pane.push_approval_request(exec_request(), &features);
+        assert_eq!(pane.last_tab_status_for_test(), Some(TabStatus::Waiting));
+
+        // Cancel: DismissibleView remains underneath, so on_active_view_complete
+        // does not fire and only the per-frame poll catches the transition.
+        let _ = pane.on_ctrl_c();
+        pane.pre_draw_tick();
+        assert_eq!(
+            pane.last_tab_status_for_test(),
+            Some(TabStatus::Working),
+            "pre_draw_tick must drop the tab out of Waiting once the \
+             top of the stack is no longer action-required",
+        );
     }
 
     #[test]

--- a/codex-rs/tui/src/bottom_pane/tab_status_state.rs
+++ b/codex-rs/tui/src/bottom_pane/tab_status_state.rs
@@ -1,0 +1,37 @@
+use crate::tab_status::TabStatus;
+use crate::tab_status::set_tab_status;
+
+/// Tracks the OSC 21337 state emitted by the bottom pane.
+pub(super) struct TabStatusState {
+    enabled: bool,
+    last_status: Option<TabStatus>,
+}
+
+impl TabStatusState {
+    pub(super) fn new() -> Self {
+        Self {
+            enabled: true,
+            last_status: None,
+        }
+    }
+
+    pub(super) fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+    }
+
+    pub(super) fn refresh(&mut self, desired: TabStatus) {
+        if !self.enabled || self.last_status == Some(desired) {
+            return;
+        }
+        if let Err(err) = set_tab_status(desired) {
+            tracing::debug!(error = %err, "failed to set tab status");
+            return;
+        }
+        self.last_status = Some(desired);
+    }
+
+    #[cfg(test)]
+    pub(super) fn last_status(&self) -> Option<TabStatus> {
+        self.last_status
+    }
+}

--- a/codex-rs/tui/src/chatwidget/constructor.rs
+++ b/codex-rs/tui/src/chatwidget/constructor.rs
@@ -229,6 +229,9 @@ impl ChatWidget {
         }
         widget
             .bottom_pane
+            .set_tab_status_enabled(widget.config.tui_tab_status);
+        widget
+            .bottom_pane
             .set_vim_enabled(widget.config.tui_vim_mode_default);
         widget
             .bottom_pane

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -186,6 +186,7 @@ mod status;
 mod status_indicator_widget;
 mod streaming;
 mod style;
+mod tab_status;
 mod terminal_hyperlinks;
 mod terminal_palette;
 mod terminal_probe;

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -164,6 +164,7 @@ mod notifications;
 #[cfg(any(not(debug_assertions), test))]
 mod npm_registry;
 pub(crate) mod onboarding;
+mod osc_text;
 mod oss_selection;
 mod pager_overlay;
 mod permission_compat;

--- a/codex-rs/tui/src/osc_text.rs
+++ b/codex-rs/tui/src/osc_text.rs
@@ -1,0 +1,28 @@
+//! Sanitization for untrusted terminal-title and tab-status OSC text.
+
+/// Whether a control or invisible formatting character is unsafe in OSC text.
+pub(crate) fn is_disallowed_osc_text_char(ch: char) -> bool {
+    if ch.is_control() {
+        return true;
+    }
+
+    matches!(
+        ch,
+        '\u{00AD}'
+            | '\u{034F}'
+            | '\u{061C}'
+            | '\u{180E}'
+            | '\u{200B}'..='\u{200F}'
+            | '\u{202A}'..='\u{202E}'
+            | '\u{2060}'..='\u{206F}'
+            | '\u{FE00}'..='\u{FE0F}'
+            | '\u{FEFF}'
+            | '\u{FFF9}'..='\u{FFFB}'
+            | '\u{1BCA0}'..='\u{1BCA3}'
+            | '\u{E0100}'..='\u{E01EF}'
+    )
+}
+
+#[cfg(test)]
+#[path = "osc_text_tests.rs"]
+mod tests;

--- a/codex-rs/tui/src/osc_text_tests.rs
+++ b/codex-rs/tui/src/osc_text_tests.rs
@@ -1,0 +1,24 @@
+use super::is_disallowed_osc_text_char;
+
+#[test]
+fn rejects_controls_bidi_and_invisible_format_chars() {
+    for ch in [
+        '\x07', '\x1b', '\u{009b}', '\n', '\u{202E}', '\u{2066}', '\u{200F}', '\u{061C}',
+        '\u{200B}', '\u{FEFF}',
+    ] {
+        assert!(
+            is_disallowed_osc_text_char(ch),
+            "expected {ch:?} to be disallowed"
+        );
+    }
+}
+
+#[test]
+fn allows_ordinary_text() {
+    for ch in ['a', 'Z', '0', ' ', '/', '.', '\u{2026}', '\u{00E9}'] {
+        assert!(
+            !is_disallowed_osc_text_char(ch),
+            "expected {ch:?} to be allowed"
+        );
+    }
+}

--- a/codex-rs/tui/src/tab_status.rs
+++ b/codex-rs/tui/src/tab_status.rs
@@ -1,0 +1,134 @@
+//! OSC 21337 tab-status output helpers for the TUI.
+//!
+//! This module owns the low-level write path: callers decide *when* the tab
+//! status changes, this only knows how to write the sequence. The
+//! `IsTerminal` gate matches the terminal-title module so non-TTY stdout
+//! (e.g. piped `codex exec`) doesn't get escape sequences in captured output.
+//!
+//! OSC 21337 is an iTerm2 extension; other terminals ignore it. The payload
+//! is a semicolon-separated list of `key=value` pairs. We emit `status`
+//! (label), `indicator` (dot color), and `status-color` (text color).
+
+use std::fmt;
+use std::io;
+use std::io::IsTerminal;
+use std::io::stdout;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+
+use crossterm::Command;
+use ratatui::crossterm::execute;
+
+/// Whether this process has ever written an OSC 21337 sequence. Gates the
+/// shutdown-time `clear_tab_status` so that, when we never emitted, we don't
+/// clobber a status set by another tool sharing the tab.
+static EMITTED: AtomicBool = AtomicBool::new(/*v*/ false);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TabStatus {
+    Working,
+    Waiting,
+    Idle,
+}
+
+impl TabStatus {
+    fn label(self) -> &'static str {
+        match self {
+            TabStatus::Working => "Working",
+            TabStatus::Waiting => "Waiting",
+            TabStatus::Idle => "Idle",
+        }
+    }
+
+    /// Dot color. Matches the palette other agent CLIs emit so multiple
+    /// tools read consistently in the tab bar.
+    fn indicator(self) -> &'static str {
+        match self {
+            TabStatus::Working => "#ff9500",
+            TabStatus::Waiting => "#5f87ff",
+            TabStatus::Idle => "#00d75f",
+        }
+    }
+
+    /// Status-text color. Working/Waiting match the dot; Idle dims so the
+    /// colored dot stays the active affordance once codex is done.
+    fn text_color(self) -> &'static str {
+        match self {
+            TabStatus::Working => "#ff9500",
+            TabStatus::Waiting => "#5f87ff",
+            TabStatus::Idle => "#888888",
+        }
+    }
+}
+
+pub(crate) fn set_tab_status(status: TabStatus) -> io::Result<()> {
+    if !stdout().is_terminal() {
+        return Ok(());
+    }
+    execute!(stdout(), SetTabStatus(status))?;
+    EMITTED.store(/*val*/ true, Ordering::Relaxed);
+    Ok(())
+}
+
+pub(crate) fn clear_tab_status() -> io::Result<()> {
+    if !stdout().is_terminal() || !EMITTED.load(Ordering::Relaxed) {
+        return Ok(());
+    }
+    execute!(stdout(), ClearTabStatus)?;
+    EMITTED.store(/*val*/ false, Ordering::Relaxed);
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SetTabStatus(TabStatus);
+
+impl Command for SetTabStatus {
+    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        write!(
+            f,
+            "\x1b]21337;status={};indicator={};status-color={}\x07",
+            self.0.label(),
+            self.0.indicator(),
+            self.0.text_color()
+        )
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> io::Result<()> {
+        Err(std::io::Error::other(
+            "tried to execute SetTabStatus using WinAPI; use ANSI instead",
+        ))
+    }
+
+    #[cfg(windows)]
+    fn is_ansi_code_supported(&self) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ClearTabStatus;
+
+impl Command for ClearTabStatus {
+    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        // Explicit empty values for every managed field so iTerm clears
+        // them rather than leaving stale content visible.
+        write!(f, "\x1b]21337;status=;indicator=;status-color=\x07")
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> io::Result<()> {
+        Err(std::io::Error::other(
+            "tried to execute ClearTabStatus using WinAPI; use ANSI instead",
+        ))
+    }
+
+    #[cfg(windows)]
+    fn is_ansi_code_supported(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+#[path = "tab_status_tests.rs"]
+mod tests;

--- a/codex-rs/tui/src/tab_status_tests.rs
+++ b/codex-rs/tui/src/tab_status_tests.rs
@@ -1,0 +1,49 @@
+use crossterm::Command;
+use pretty_assertions::assert_eq;
+
+use super::ClearTabStatus;
+use super::SetTabStatus;
+use super::TabStatus;
+
+#[test]
+fn working_emits_orange_with_matching_text_color() {
+    let mut out = String::new();
+    SetTabStatus(TabStatus::Working)
+        .write_ansi(&mut out)
+        .expect("encode tab status");
+    assert_eq!(
+        out,
+        "\x1b]21337;status=Working;indicator=#ff9500;status-color=#ff9500\x07"
+    );
+}
+
+#[test]
+fn waiting_emits_blue_with_matching_text_color() {
+    let mut out = String::new();
+    SetTabStatus(TabStatus::Waiting)
+        .write_ansi(&mut out)
+        .expect("encode tab status");
+    assert_eq!(
+        out,
+        "\x1b]21337;status=Waiting;indicator=#5f87ff;status-color=#5f87ff\x07"
+    );
+}
+
+#[test]
+fn idle_uses_dim_text_color() {
+    let mut out = String::new();
+    SetTabStatus(TabStatus::Idle)
+        .write_ansi(&mut out)
+        .expect("encode tab status");
+    assert_eq!(
+        out,
+        "\x1b]21337;status=Idle;indicator=#00d75f;status-color=#888888\x07"
+    );
+}
+
+#[test]
+fn clear_emits_empty_fields() {
+    let mut out = String::new();
+    ClearTabStatus.write_ansi(&mut out).expect("encode clear");
+    assert_eq!(out, "\x1b]21337;status=;indicator=;status-color=\x07");
+}

--- a/codex-rs/tui/src/terminal_title.rs
+++ b/codex-rs/tui/src/terminal_title.rs
@@ -121,7 +121,7 @@ fn sanitize_terminal_title(title: &str) -> String {
             continue;
         }
 
-        if is_disallowed_terminal_title_char(ch) {
+        if crate::osc_text::is_disallowed_osc_text_char(ch) {
             continue;
         }
 
@@ -143,37 +143,6 @@ fn sanitize_terminal_title(title: &str) -> String {
     }
 
     sanitized
-}
-
-/// Returns whether `ch` should be dropped from terminal-title output.
-///
-/// This includes both plain control characters and a curated set of invisible
-/// formatting codepoints. The bidi entries here cover the Trojan-Source-style
-/// text-reordering controls that can make a title render misleadingly relative
-/// to its underlying byte sequence.
-fn is_disallowed_terminal_title_char(ch: char) -> bool {
-    if ch.is_control() {
-        return true;
-    }
-
-    // Strip Trojan-Source-related bidi controls plus common non-rendering
-    // formatting characters so title text cannot smuggle terminal control
-    // semantics or visually misleading content.
-    matches!(
-        ch,
-        '\u{00AD}'
-            | '\u{034F}'
-            | '\u{061C}'
-            | '\u{180E}'
-            | '\u{200B}'..='\u{200F}'
-            | '\u{202A}'..='\u{202E}'
-            | '\u{2060}'..='\u{206F}'
-            | '\u{FE00}'..='\u{FE0F}'
-            | '\u{FEFF}'
-            | '\u{FFF9}'..='\u{FFFB}'
-            | '\u{1BCA0}'..='\u{1BCA3}'
-            | '\u{E0100}'..='\u{E01EF}'
-    )
 }
 
 #[cfg(test)]

--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -291,6 +291,10 @@ pub fn restore_after_exit() -> Result<()> {
     if let Err(err) = terminal_stderr::finish() {
         first_error.get_or_insert(err);
     }
+    // Clear any tab-status indicator Codex was managing so the tab returns
+    // to a neutral state after exit. Best-effort: ignore failures, they
+    // don't block restoring the terminal.
+    let _ = crate::tab_status::clear_tab_status();
 
     match first_error {
         Some(err) => Err(err),


### PR DESCRIPTION
## Why

iTerm2's OSC 21337 status channel can show whether Codex is working, idle, or waiting for user input without replacing the terminal title. This is the base layer of the stack proposed by iTerm2 author George Nachman in #25879.

A Codex-owned background terminal can outlive the foreground turn. Treating that state as Idle makes OSC 21337 unsafe as an orchestration signal, so live background work must keep the tab Working.

## What Changed

- add a default-on `tui.tab_status` configuration switch
- emit OSC 21337 Working, Waiting, and Idle states from the TUI
- keep the tab Working while either a foreground turn or a tracked unified-exec process is active
- refresh status immediately when background processes start or exit, while preserving Waiting precedence
- clear only status fields Codex previously emitted when the TUI exits
- keep emission state isolated in a small bottom-pane state module
- add snapshot coverage for the foreground, background, Waiting, and Idle lifecycle

A panic or `SIGKILL` can leave the last tab status visible until another process overwrites it, matching the existing terminal-title limitation.

## How to Test

1. Run Codex in iTerm2 and start a turn.
2. Confirm the tab status changes from Working to Waiting for an approval prompt.
3. Start a background terminal command and let the foreground turn complete; confirm the tab remains Working.
4. Stop the final background process and confirm the tab becomes Idle.
5. Set `tui.tab_status = false` and confirm Codex emits no tab-status updates.

Targeted tests:

- `just test -p codex-config`
- `just test -p codex-tui tab_status`

## Stack

1. #26474 base OSC 21337 tab status (this PR)
2. [#26475](https://github.com/openai/codex/pull/26475) flattened shell command display
3. [#26476](https://github.com/openai/codex/pull/26476) detailed and throttled tab activity

Closes #25879.
