### PR TITLE
fix(tui): hide shell wrapper noise in command displays [2 of 3]

### DIFF
--- a/codex-rs/shell-command/src/bash.rs
+++ b/codex-rs/shell-command/src/bash.rs
@@ -98,20 +98,59 @@ pub fn extract_bash_command(command: &[String]) -> Option<(&str, &str)> {
     let [shell, flag, script] = command else {
         return None;
     };
-    if !matches!(flag.as_str(), "-lc" | "-c")
-        || !matches!(
-            detect_shell_type(PathBuf::from(shell)),
-            Some(ShellType::Zsh) | Some(ShellType::Bash) | Some(ShellType::Sh)
-        )
-    {
+    if !is_recognised_bash_lc_invocation(shell, flag) {
         return None;
     }
     Some((shell, script))
 }
 
+/// Single source of truth for "is `<shell> <flag>` a recognised bash-lc
+/// invocation we want to strip the wrapper from?".
+///
+/// Shared by `extract_bash_command` and `extract_bash_command_joined` so the
+/// acceptance rules (which flags, which shells) live in exactly one place.
+fn is_recognised_bash_lc_invocation(shell: &str, flag: &str) -> bool {
+    matches!(flag, "-lc" | "-c")
+        && matches!(
+            detect_shell_type(&PathBuf::from(shell)),
+            Some(ShellType::Zsh) | Some(ShellType::Bash) | Some(ShellType::Sh)
+        )
+}
+
+/// Like `extract_bash_command`, but also recognises argv where the inner
+/// script was flattened past `[shell, flag, script]` (e.g. the protocol
+/// payload re-split an unquoted form into `[shell, flag, word, word, ...]`).
+/// Returns an owned script, shlex-joined across the tail.
+///
+/// Caveat: this assumes every token after the flag is script text, so it is
+/// deliberately wrong for POSIX `sh -c <script> <arg0> <arg1>` where the tail
+/// is `$0`/`$1`/… — `["bash","-c","echo $0","foo"]` yields `"echo $0 foo"`.
+/// That mis-rendering is fine for display-only consumers (exec history,
+/// unified-exec, tab status detail). Canonical-identity/approval matching in
+/// `core/src/command_canonicalization.rs` stays strict; do not reuse here.
+pub fn extract_bash_command_joined(command: &[String]) -> Option<(String, String)> {
+    if let Some((shell, script)) = extract_bash_command(command) {
+        return Some((shell.to_string(), script.to_string()));
+    }
+    let [shell, flag, rest @ ..] = command else {
+        return None;
+    };
+    // `rest.len() < 2` rejects both the 3-element case (handled above) and
+    // the impossible <3-element case at once.
+    if rest.len() < 2 || !is_recognised_bash_lc_invocation(shell, flag) {
+        return None;
+    }
+    Some((shell.clone(), crate::parse_command::shlex_join(rest)))
+}
+
 /// Returns the sequence of plain commands within a `bash -lc "..."` or
 /// `zsh -lc "..."` invocation when the script only contains word-only commands
 /// joined by safe operators.
+///
+/// Uses the strict `extract_bash_command`, so flattened argv returns None
+/// rather than being rich-parsed: disambiguating "tail is script" from "tail
+/// is POSIX `$0`/`$1`" isn't safe here. Such argv instead lands in
+/// `single_unknown_for_command`'s joined fallback as `Unknown { cmd }`.
 pub fn parse_shell_lc_plain_commands(command: &[String]) -> Option<Vec<Vec<String>>> {
     let (_, script) = extract_bash_command(command)?;
 
@@ -324,6 +363,121 @@ mod tests {
     fn parse_seq(src: &str) -> Option<Vec<Vec<String>>> {
         let tree = try_parse_shell(src)?;
         try_parse_word_only_commands_sequence(&tree, src)
+    }
+
+    #[test]
+    fn extract_bash_command_joined_accepts_flattened_argv() {
+        // Unquoted `zsh -lc touch /tmp/foo` shlex-splits to 4 tokens, which
+        // strict extract_bash_command rejects; the joined variant stitches it.
+        let (shell, script) = extract_bash_command_joined(&[
+            "zsh".to_string(),
+            "-lc".to_string(),
+            "touch".to_string(),
+            "/tmp/foo".to_string(),
+        ])
+        .expect("known shell + -lc + tail should match");
+        assert_eq!(shell, "zsh");
+        assert_eq!(script, "touch /tmp/foo");
+    }
+
+    #[test]
+    fn extract_bash_command_joined_accepts_absolute_shell_path() {
+        let (shell, script) = extract_bash_command_joined(&[
+            "/opt/homebrew/bin/zsh".to_string(),
+            "-lc".to_string(),
+            "touch".to_string(),
+            "/tmp/foo".to_string(),
+        ])
+        .expect("absolute path resolving to zsh should match");
+        assert_eq!(shell, "/opt/homebrew/bin/zsh");
+        assert_eq!(script, "touch /tmp/foo");
+    }
+
+    #[test]
+    fn extract_bash_command_joined_handles_three_element_canonical_shape() {
+        let (_, script) = extract_bash_command_joined(&[
+            "bash".to_string(),
+            "-c".to_string(),
+            "echo hello".to_string(),
+        ])
+        .expect("canonical 3-element form should also match");
+        // Single tail element comes back as-is (no re-shlex-join).
+        assert_eq!(script, "echo hello");
+    }
+
+    #[test]
+    fn extract_bash_command_joined_rejects_non_shell_first_arg() {
+        assert!(
+            extract_bash_command_joined(&[
+                "python3".to_string(),
+                "-c".to_string(),
+                "print('hi')".to_string(),
+            ])
+            .is_none(),
+            "python3 -c is not a recognised shell wrapper"
+        );
+    }
+
+    #[test]
+    fn extract_bash_command_joined_rejects_unknown_flag() {
+        assert!(
+            extract_bash_command_joined(&[
+                "bash".to_string(),
+                "-x".to_string(),
+                "echo hi".to_string(),
+            ])
+            .is_none(),
+            "only -lc and -c are recognised"
+        );
+    }
+
+    #[test]
+    fn extract_bash_command_joined_rejects_empty_tail() {
+        assert!(
+            extract_bash_command_joined(&["bash".to_string(), "-lc".to_string()]).is_none(),
+            "no script tail means nothing to extract"
+        );
+    }
+
+    #[test]
+    fn extract_bash_command_joined_acceptance_tracks_strict_matcher() {
+        // The 3-element and 4+-element arms now share
+        // `is_recognised_bash_lc_invocation`; assert they agree across a
+        // matrix of (shell, flag) pairs so the two can't silently diverge.
+        let cases: &[(&str, &str)] = &[
+            // Accepted.
+            ("bash", "-lc"),
+            ("bash", "-c"),
+            ("zsh", "-lc"),
+            ("zsh", "-c"),
+            ("sh", "-lc"),
+            ("/bin/bash", "-lc"),
+            ("/opt/homebrew/bin/zsh", "-lc"),
+            // Rejected.
+            ("bash", "-x"),
+            ("bash", "-ic"),
+            ("bash", "-l"),
+            ("python3", "-c"),
+            ("fish", "-lc"),
+            ("pwsh", "-c"),
+        ];
+        for &(shell, flag) in cases {
+            let three: Vec<String> = vec![shell.into(), flag.into(), "echo hi".into()];
+            let four: Vec<String> = vec![shell.into(), flag.into(), "echo".into(), "hi".into()];
+
+            let strict_three = extract_bash_command(&three).is_some();
+            let joined_three = extract_bash_command_joined(&three).is_some();
+            let joined_four = extract_bash_command_joined(&four).is_some();
+
+            assert_eq!(
+                strict_three, joined_three,
+                "3-element delegation must agree with strict for ({shell:?}, {flag:?})",
+            );
+            assert_eq!(
+                strict_three, joined_four,
+                "4+-element relaxation must accept iff strict accepts for ({shell:?}, {flag:?})",
+            );
+        }
     }
 
     #[test]

--- a/codex-rs/shell-command/src/bash.rs
+++ b/codex-rs/shell-command/src/bash.rs
@@ -112,7 +112,7 @@ pub fn extract_bash_command(command: &[String]) -> Option<(&str, &str)> {
 fn is_recognised_bash_lc_invocation(shell: &str, flag: &str) -> bool {
     matches!(flag, "-lc" | "-c")
         && matches!(
-            detect_shell_type(&PathBuf::from(shell)),
+            detect_shell_type(PathBuf::from(shell)),
             Some(ShellType::Zsh) | Some(ShellType::Bash) | Some(ShellType::Sh)
         )
 }

--- a/codex-rs/shell-command/src/bash.rs
+++ b/codex-rs/shell-command/src/bash.rs
@@ -120,7 +120,8 @@ fn is_recognised_bash_lc_invocation(shell: &str, flag: &str) -> bool {
 /// Like `extract_bash_command`, but also recognises argv where the inner
 /// script was flattened past `[shell, flag, script]` (e.g. the protocol
 /// payload re-split an unquoted form into `[shell, flag, word, word, ...]`).
-/// Returns an owned script, shlex-joined across the tail.
+/// Returns an owned script reconstructed across the tail. Ordinary arguments
+/// are shell-quoted, while standalone shell operator tokens remain operators.
 ///
 /// Caveat: this assumes every token after the flag is script text, so it is
 /// deliberately wrong for POSIX `sh -c <script> <arg0> <arg1>` where the tail
@@ -140,7 +141,32 @@ pub fn extract_bash_command_joined(command: &[String]) -> Option<(String, String
     if rest.len() < 2 || !is_recognised_bash_lc_invocation(shell, flag) {
         return None;
     }
-    Some((shell.clone(), crate::parse_command::shlex_join(rest)))
+    Some((shell.clone(), join_flattened_shell_script(rest)))
+}
+
+fn join_flattened_shell_script(tokens: &[String]) -> String {
+    let mut script = String::new();
+    for token in tokens {
+        if !script.is_empty() {
+            script.push(' ');
+        }
+        if is_shell_operator_token(token) {
+            script.push_str(token);
+        } else {
+            let Ok(quoted) = shlex::try_quote(token) else {
+                return "<command included NUL byte>".to_string();
+            };
+            script.push_str(&quoted);
+        }
+    }
+    script
+}
+
+fn is_shell_operator_token(token: &str) -> bool {
+    token.chars().any(|ch| "<>|&;()".contains(ch))
+        && token
+            .chars()
+            .all(|ch| ch.is_ascii_digit() || "<>|&;()".contains(ch))
 }
 
 /// Returns the sequence of plain commands within a `bash -lc "..."` or
@@ -378,6 +404,26 @@ mod tests {
         .expect("known shell + -lc + tail should match");
         assert_eq!(shell, "zsh");
         assert_eq!(script, "touch /tmp/foo");
+    }
+
+    #[test]
+    fn extract_bash_command_joined_preserves_shell_operators() {
+        let (_, script) = extract_bash_command_joined(&[
+            "zsh".to_string(),
+            "-lc".to_string(),
+            "rg".to_string(),
+            "foo bar".to_string(),
+            "|".to_string(),
+            "head".to_string(),
+            ">".to_string(),
+            "/tmp/out".to_string(),
+            "2>&1".to_string(),
+            ";".to_string(),
+            "echo".to_string(),
+            "done".to_string(),
+        ])
+        .expect("known shell + -lc + tail should match");
+        assert_eq!(script, "rg 'foo bar' | head > /tmp/out 2>&1 ; echo done");
     }
 
     #[test]

--- a/codex-rs/shell-command/src/bash.rs
+++ b/codex-rs/shell-command/src/bash.rs
@@ -141,32 +141,35 @@ pub fn extract_bash_command_joined(command: &[String]) -> Option<(String, String
     if rest.len() < 2 || !is_recognised_bash_lc_invocation(shell, flag) {
         return None;
     }
-    Some((shell.clone(), join_flattened_shell_script(rest)))
-}
-
-fn join_flattened_shell_script(tokens: &[String]) -> String {
     let mut script = String::new();
-    for token in tokens {
+    for token in rest {
         if !script.is_empty() {
             script.push(' ');
         }
-        if is_shell_operator_token(token) {
+        let without_fd = token.trim_start_matches(|ch: char| ch.is_ascii_digit());
+        let is_operator = token.chars().any(|ch| "<>|&;()".contains(ch))
+            && token
+                .chars()
+                .all(|ch| ch.is_ascii_digit() || "<>|&;()".contains(ch));
+        let is_attached_redirection = [
+            "&>>", "<<<", ">>", "<<", "<>", ">|", ">&", "<&", "&>", ">", "<",
+        ]
+        .iter()
+        .any(|operator| {
+            without_fd
+                .strip_prefix(operator)
+                .is_some_and(|target| !target.is_empty())
+        });
+        if is_operator || is_attached_redirection {
             script.push_str(token);
         } else {
             let Ok(quoted) = shlex::try_quote(token) else {
-                return "<command included NUL byte>".to_string();
+                return Some((shell.clone(), "<command included NUL byte>".to_string()));
             };
             script.push_str(&quoted);
         }
     }
-    script
-}
-
-fn is_shell_operator_token(token: &str) -> bool {
-    token.chars().any(|ch| "<>|&;()".contains(ch))
-        && token
-            .chars()
-            .all(|ch| ch.is_ascii_digit() || "<>|&;()".contains(ch))
+    Some((shell.clone(), script))
 }
 
 /// Returns the sequence of plain commands within a `bash -lc "..."` or
@@ -176,7 +179,7 @@ fn is_shell_operator_token(token: &str) -> bool {
 /// Uses the strict `extract_bash_command`, so flattened argv returns None
 /// rather than being rich-parsed: disambiguating "tail is script" from "tail
 /// is POSIX `$0`/`$1`" isn't safe here. Such argv instead lands in
-/// `single_unknown_for_command`'s joined fallback as `Unknown { cmd }`.
+/// `single_unknown_for_command` as `Unknown { cmd }` with the wrapper intact.
 pub fn parse_shell_lc_plain_commands(command: &[String]) -> Option<Vec<Vec<String>>> {
     let (_, script) = extract_bash_command(command)?;
 
@@ -424,6 +427,21 @@ mod tests {
         ])
         .expect("known shell + -lc + tail should match");
         assert_eq!(script, "rg 'foo bar' | head > /tmp/out 2>&1 ; echo done");
+    }
+
+    #[test]
+    fn extract_bash_command_joined_preserves_attached_redirections() {
+        let (_, script) = extract_bash_command_joined(&[
+            "zsh".to_string(),
+            "-lc".to_string(),
+            "command".to_string(),
+            "2>/tmp/stderr".to_string(),
+            ">output".to_string(),
+            ">>log".to_string(),
+            "&>/tmp/all".to_string(),
+        ])
+        .expect("known shell + -lc + tail should match");
+        assert_eq!(script, "command 2>/tmp/stderr >output >>log &>/tmp/all");
     }
 
     #[test]

--- a/codex-rs/shell-command/src/parse_command.rs
+++ b/codex-rs/shell-command/src/parse_command.rs
@@ -53,11 +53,6 @@ fn single_unknown_for_command(command: &[String]) -> ParsedCommand {
             cmd: shell_command.to_string(),
         };
     }
-    // Fall back for argv flattened past `[shell, flag, script]` before
-    // leaking the wrapper into shlex_join below.
-    if let Some((_, script)) = crate::bash::extract_bash_command_joined(command) {
-        return ParsedCommand::Unknown { cmd: script };
-    }
     ParsedCommand::Unknown {
         cmd: shlex_join(command),
     }
@@ -81,14 +76,18 @@ mod tests {
     }
 
     #[test]
-    fn flattened_shell_wrapper_strips_to_script_only() {
-        // Flattened argv used to fall through to shlex_join, leaking the
-        // wrapper into Unknown.cmd; the joined fallback now stitches the tail.
-        let parsed = parse_command(&vec_str(&["zsh", "-lc", "touch", "/tmp/foo"]));
+    fn shell_wrapper_with_positional_args_remains_intact() {
+        let parsed = parse_command(&vec_str(&[
+            "bash",
+            "-c",
+            "echo \"$0\" \"$1\"",
+            "tool",
+            "arg",
+        ]));
         assert_eq!(
             parsed,
             vec![ParsedCommand::Unknown {
-                cmd: "touch /tmp/foo".to_string(),
+                cmd: "bash -c 'echo \"$0\" \"$1\"' tool arg".to_string(),
             }]
         );
     }
@@ -129,22 +128,6 @@ mod tests {
         let argv = vec_str(&["bash", "-x", "echo hi"]);
         assert!(crate::bash::extract_bash_command(&argv).is_none());
         assert!(crate::bash::extract_bash_command_joined(&argv).is_none());
-    }
-
-    #[test]
-    fn flattened_shell_wrapper_handles_absolute_shell_path() {
-        let parsed = parse_command(&vec_str(&[
-            "/opt/homebrew/bin/zsh",
-            "-lc",
-            "touch",
-            "/tmp/foo",
-        ]));
-        assert_eq!(
-            parsed,
-            vec![ParsedCommand::Unknown {
-                cmd: "touch /tmp/foo".to_string(),
-            }]
-        );
     }
 
     fn assert_parsed(args: &[String], expected: Vec<ParsedCommand>) {

--- a/codex-rs/shell-command/src/parse_command.rs
+++ b/codex-rs/shell-command/src/parse_command.rs
@@ -49,13 +49,17 @@ pub fn parse_command(command: &[String]) -> Vec<ParsedCommand> {
 
 fn single_unknown_for_command(command: &[String]) -> ParsedCommand {
     if let Some((_, shell_command)) = extract_shell_command(command) {
-        ParsedCommand::Unknown {
+        return ParsedCommand::Unknown {
             cmd: shell_command.to_string(),
-        }
-    } else {
-        ParsedCommand::Unknown {
-            cmd: shlex_join(command),
-        }
+        };
+    }
+    // Fall back for argv flattened past `[shell, flag, script]` before
+    // leaking the wrapper into shlex_join below.
+    if let Some((_, script)) = crate::bash::extract_bash_command_joined(command) {
+        return ParsedCommand::Unknown { cmd: script };
+    }
+    ParsedCommand::Unknown {
+        cmd: shlex_join(command),
     }
 }
 
@@ -74,6 +78,73 @@ mod tests {
 
     fn vec_str(args: &[&str]) -> Vec<String> {
         args.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn flattened_shell_wrapper_strips_to_script_only() {
+        // Flattened argv used to fall through to shlex_join, leaking the
+        // wrapper into Unknown.cmd; the joined fallback now stitches the tail.
+        let parsed = parse_command(&vec_str(&["zsh", "-lc", "touch", "/tmp/foo"]));
+        assert_eq!(
+            parsed,
+            vec![ParsedCommand::Unknown {
+                cmd: "touch /tmp/foo".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn three_element_shapes_match_strict_extract_bash_command() {
+        // For every input the strict matcher accepts, both helpers must
+        // produce the same (shell, script), so single_unknown_for_command
+        // doesn't change behaviour for 3-element argv.
+        let cases: &[&[&str]] = &[
+            &["bash", "-c", "echo hi"],
+            &["bash", "-lc", "echo hi"],
+            &["zsh", "-c", "echo hi"],
+            &["zsh", "-lc", "echo hi"],
+            &["sh", "-c", "echo hi"],
+            &["/bin/bash", "-lc", "cat foo"],
+            &["/opt/homebrew/bin/zsh", "-lc", "touch /tmp/foo"],
+        ];
+        for &argv_strs in cases {
+            let argv: Vec<String> = argv_strs.iter().map(|s| (*s).to_string()).collect();
+            let strict = crate::bash::extract_bash_command(&argv);
+            let joined = crate::bash::extract_bash_command_joined(&argv);
+            match (strict, joined) {
+                (Some((s_shell, s_script)), Some((j_shell, j_script))) => {
+                    assert_eq!(s_shell, j_shell.as_str(), "shell mismatch for {argv:?}");
+                    assert_eq!(s_script, j_script.as_str(), "script mismatch for {argv:?}");
+                }
+                (None, None) => {}
+                (s, j) => panic!("acceptance mismatch for {argv:?}: strict={s:?}, joined={j:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn three_element_shape_with_disallowed_flag_remains_unrecognised() {
+        // Negative side of the invariant: a flag strict rejects (`-x`) must
+        // also be rejected by the joined helper.
+        let argv = vec_str(&["bash", "-x", "echo hi"]);
+        assert!(crate::bash::extract_bash_command(&argv).is_none());
+        assert!(crate::bash::extract_bash_command_joined(&argv).is_none());
+    }
+
+    #[test]
+    fn flattened_shell_wrapper_handles_absolute_shell_path() {
+        let parsed = parse_command(&vec_str(&[
+            "/opt/homebrew/bin/zsh",
+            "-lc",
+            "touch",
+            "/tmp/foo",
+        ]));
+        assert_eq!(
+            parsed,
+            vec![ParsedCommand::Unknown {
+                cmd: "touch /tmp/foo".to_string(),
+            }]
+        );
     }
 
     fn assert_parsed(args: &[String], expected: Vec<ParsedCommand>) {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -298,7 +298,7 @@ use crate::exec_cell::CommandOutput;
 use crate::exec_cell::ExecCell;
 use crate::exec_cell::new_active_exec_command;
 use crate::exec_command::split_command_string;
-use crate::exec_command::strip_bash_lc_and_escape;
+use crate::exec_command::strip_shell_wrapper_for_display;
 use crate::get_git_diff::get_git_diff;
 use crate::history_cell;
 use crate::history_cell::HistoryCell;

--- a/codex-rs/tui/src/chatwidget/command_lifecycle.rs
+++ b/codex-rs/tui/src/chatwidget/command_lifecycle.rs
@@ -170,7 +170,7 @@ impl ChatWidget {
     ) {
         let key = process_id.unwrap_or(call_id).to_string();
         let command = split_command_string(command);
-        let command_display = strip_bash_lc_and_escape(&command);
+        let command_display = strip_shell_wrapper_for_display(&command);
         if let Some(existing) = self
             .unified_exec_processes
             .iter_mut()

--- a/codex-rs/tui/src/exec_cell/render.rs
+++ b/codex-rs/tui/src/exec_cell/render.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use super::model::CommandOutput;
 use super::model::ExecCall;
 use super::model::ExecCell;
-use crate::exec_command::strip_bash_lc_and_escape;
+use crate::exec_command::strip_shell_wrapper_for_display;
 use crate::history_cell::HistoryCell;
 use crate::history_cell::plain_lines;
 use crate::motion::MotionMode;
@@ -18,7 +18,6 @@ use crate::wrapping::adaptive_wrap_lines;
 use codex_ansi_escape::ansi_escape_line;
 use codex_app_server_protocol::CommandExecutionSource as ExecCommandSource;
 use codex_protocol::parse_command::ParsedCommand;
-use codex_shell_command::bash::extract_bash_command;
 use codex_utils_elapsed::format_duration;
 use itertools::Itertools;
 use ratatui::prelude::*;
@@ -65,17 +64,7 @@ pub(crate) fn new_active_exec_command(
 }
 
 fn format_unified_exec_interaction(command: &[String], input: Option<&str>) -> String {
-    // Strip the shell wrapper (canonical 3-element shape, or flattened argv)
-    // so the "Waited for `…`" line shows the inner script, not `zsh -lc …`.
-    let command_display = if let Some((_, script)) = extract_bash_command(command) {
-        script.to_string()
-    } else if let Some((_, script)) =
-        codex_shell_command::bash::extract_bash_command_joined(command)
-    {
-        script
-    } else {
-        command.join(" ")
-    };
+    let command_display = strip_shell_wrapper_for_display(command);
     match input {
         Some(data) if !data.is_empty() => {
             let preview = summarize_interaction_input(data);
@@ -213,7 +202,7 @@ impl HistoryCell for ExecCell {
             if i > 0 {
                 lines.push("".into());
             }
-            let script = strip_bash_lc_and_escape(&call.command);
+            let script = strip_shell_wrapper_for_display(&call.command);
             let highlighted_script = highlight_bash_to_lines(&script);
             let cmd_display = adaptive_wrap_lines(
                 &highlighted_script,
@@ -400,7 +389,7 @@ impl ExecCell {
         let cmd_display = if call.is_unified_exec_interaction() {
             format_unified_exec_interaction(&call.command, call.interaction_input.as_deref())
         } else {
-            strip_bash_lc_and_escape(&call.command)
+            strip_shell_wrapper_for_display(&call.command)
         };
         let highlighted_lines = highlight_bash_to_lines(&cmd_display);
 
@@ -741,6 +730,23 @@ mod tests {
         insta::assert_snapshot!(
             format_unified_exec_interaction(&command, /*input*/ None),
             @"Waited for `touch /tmp/foo`"
+        );
+    }
+
+    #[test]
+    fn flattened_shell_wrapper_preserves_operators_snapshot() {
+        let command = [
+            "/bin/zsh".to_string(),
+            "-lc".to_string(),
+            "rg".to_string(),
+            "foo".to_string(),
+            "|".to_string(),
+            "head".to_string(),
+        ];
+
+        insta::assert_snapshot!(
+            format_unified_exec_interaction(&command, /*input*/ None),
+            @"Waited for `rg foo | head`"
         );
     }
 

--- a/codex-rs/tui/src/exec_cell/render.rs
+++ b/codex-rs/tui/src/exec_cell/render.rs
@@ -65,8 +65,14 @@ pub(crate) fn new_active_exec_command(
 }
 
 fn format_unified_exec_interaction(command: &[String], input: Option<&str>) -> String {
+    // Strip the shell wrapper (canonical 3-element shape, or flattened argv)
+    // so the "Waited for `…`" line shows the inner script, not `zsh -lc …`.
     let command_display = if let Some((_, script)) = extract_bash_command(command) {
         script.to_string()
+    } else if let Some((_, script)) =
+        codex_shell_command::bash::extract_bash_command_joined(command)
+    {
+        script
     } else {
         command.join(" ")
     };
@@ -721,6 +727,21 @@ mod tests {
             .iter()
             .map(|span| span.content.as_ref())
             .collect::<String>()
+    }
+
+    #[test]
+    fn flattened_shell_wrapper_unified_exec_display_snapshot() {
+        let command = [
+            "/bin/zsh".to_string(),
+            "-lc".to_string(),
+            "touch".to_string(),
+            "/tmp/foo".to_string(),
+        ];
+
+        insta::assert_snapshot!(
+            format_unified_exec_interaction(&command, /*input*/ None),
+            @"Waited for `touch /tmp/foo`"
+        );
     }
 
     #[test]

--- a/codex-rs/tui/src/exec_command.rs
+++ b/codex-rs/tui/src/exec_command.rs
@@ -13,8 +13,13 @@ pub(crate) fn strip_bash_lc_and_escape(command: &[String]) -> String {
     if let Some((_, script)) = extract_shell_command(command) {
         return script.to_string();
     }
-    // Relaxed fallback for flattened argv, so every display-only wrapper-strip
-    // path agrees. Approval matching in command_canonicalization stays strict.
+    escape_command(command)
+}
+
+pub(crate) fn strip_shell_wrapper_for_display(command: &[String]) -> String {
+    if let Some((_, script)) = extract_shell_command(command) {
+        return script.to_string();
+    }
     if let Some((_, script)) = codex_shell_command::bash::extract_bash_command_joined(command) {
         return script;
     }
@@ -88,14 +93,28 @@ mod tests {
         let cmdline = strip_bash_lc_and_escape(&args);
         assert_eq!(cmdline, "echo hello");
 
-        // Test a wrapper whose inner command was flattened across argv.
+        // Approval displays must preserve positional arguments after the
+        // script rather than treating them as more script text.
+        let args = vec![
+            "bash".into(),
+            "-c".into(),
+            "rm -rf \"$1\"".into(),
+            "sh".into(),
+            "/tmp/target".into(),
+        ];
+        let cmdline = strip_bash_lc_and_escape(&args);
+        assert_eq!(cmdline, "bash -c 'rm -rf \"$1\"' sh /tmp/target");
+    }
+
+    #[test]
+    fn strip_shell_wrapper_for_display_handles_flattened_argv() {
         let args = vec![
             "/bin/zsh".into(),
             "-lc".into(),
             "python3".into(),
             "build.py".into(),
         ];
-        let cmdline = strip_bash_lc_and_escape(&args);
+        let cmdline = strip_shell_wrapper_for_display(&args);
         assert_eq!(cmdline, "python3 build.py");
     }
 

--- a/codex-rs/tui/src/exec_command.rs
+++ b/codex-rs/tui/src/exec_command.rs
@@ -13,6 +13,11 @@ pub(crate) fn strip_bash_lc_and_escape(command: &[String]) -> String {
     if let Some((_, script)) = extract_shell_command(command) {
         return script.to_string();
     }
+    // Relaxed fallback for flattened argv, so every display-only wrapper-strip
+    // path agrees. Approval matching in command_canonicalization stays strict.
+    if let Some((_, script)) = codex_shell_command::bash::extract_bash_command_joined(command) {
+        return script;
+    }
     escape_command(command)
 }
 
@@ -82,6 +87,16 @@ mod tests {
         let args = vec!["/bin/bash".into(), "-lc".into(), "echo hello".into()];
         let cmdline = strip_bash_lc_and_escape(&args);
         assert_eq!(cmdline, "echo hello");
+
+        // Test a wrapper whose inner command was flattened across argv.
+        let args = vec![
+            "/bin/zsh".into(),
+            "-lc".into(),
+            "python3".into(),
+            "build.py".into(),
+        ];
+        let cmdline = strip_bash_lc_and_escape(&args);
+        assert_eq!(cmdline, "python3 build.py");
     }
 
     #[test]


### PR DESCRIPTION
## Why

Some shell-wrapped commands arrive as flattened argv. Display-only paths then expose `/bin/zsh -lc` instead of the command the user recognizes, which also makes the later tab-status detail noisy.

## What Changed

- add a display-only helper that joins flattened `bash`, `zsh`, and `sh` wrapper tails
- use the helper for parsed unknown commands, unified exec history, and command display
- keep command canonicalization and approval identity matching strict

## How to Test

1. Run a command represented as `/bin/zsh -lc touch /tmp/foo` with the inner command split across argv.
2. Confirm exec history displays `touch /tmp/foo` without the shell wrapper.
3. Confirm canonical three-element shell wrappers still render unchanged.

Targeted tests:

- `just test -p codex-shell-command`
- `just test -p codex-tui flattened_shell_wrapper`

## Stack

1. [#26474](https://github.com/openai/codex/pull/26474) base OSC 21337 tab status
2. #26475 flattened shell command display (this PR)
3. [#26476](https://github.com/openai/codex/pull/26476) detailed and throttled tab activity

Part of #25879.
