### PR TITLE
Mark connector-used turns at MCP send time

### DIFF
--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -102,6 +102,7 @@ const MCP_RESULT_TELEMETRY_SERVER_USER_FLOW_SPAN_ATTR: &str =
     "codex.mcp.server_user_flow.triggered";
 const MCP_RESULT_TELEMETRY_TARGET_ID_MAX_CHARS: usize = 256;
 const MCP_TOOL_CALL_EVENT_RESULT_MAX_BYTES: usize = DEFAULT_OUTPUT_BYTES_CAP;
+const CONNECTOR_USED_THIS_TURN_METADATA_KEY: &str = "connector_used_this_turn";
 
 /// Handles the specified tool call and dispatches the appropriate MCP tool-call
 /// item lifecycle events to the `Session`.
@@ -340,8 +341,14 @@ async fn handle_approved_mcp_tool_call(
     };
     let result = async {
         let rewritten_arguments = rewrite?;
-        let request_meta =
-            build_mcp_tool_call_request_meta(turn_context, &server, call_id, metadata);
+        let connector_used_this_turn = same_turn_connector_used(sess).await;
+        let request_meta = build_mcp_tool_call_request_meta(
+            turn_context,
+            &server,
+            call_id,
+            metadata,
+            connector_used_this_turn,
+        );
         let result = execute_mcp_tool_call(
             sess,
             turn_context,
@@ -1033,21 +1040,35 @@ async fn custom_mcp_tool_approval_mode(
         .unwrap_or_default()
 }
 
+async fn same_turn_connector_used(sess: &Session) -> bool {
+    sess.get_connector_selection()
+        .await
+        .iter()
+        .any(|connector_id| !connector_id.is_empty())
+}
+
 fn build_mcp_tool_call_request_meta(
     turn_context: &TurnContext,
     server: &str,
     call_id: &str,
     metadata: Option<&McpToolApprovalMetadata>,
+    connector_used_this_turn: bool,
 ) -> Option<serde_json::Value> {
     let mut request_meta = serde_json::Map::new();
 
-    if let Some(turn_metadata) = turn_context
+    if let Some(mut turn_metadata) = turn_context
         .turn_metadata_state
         .current_meta_value_for_mcp_request(McpTurnMetadataContext {
             model: turn_context.model_info.slug.as_str(),
             reasoning_effort: turn_context.effective_reasoning_effort(),
         })
     {
+        if connector_used_this_turn && let Some(turn_metadata) = turn_metadata.as_object_mut() {
+            turn_metadata.insert(
+                CONNECTOR_USED_THIS_TURN_METADATA_KEY.to_string(),
+                serde_json::Value::String("true".to_string()),
+            );
+        }
         request_meta.insert(
             crate::X_CODEX_TURN_METADATA_HEADER.to_string(),
             turn_metadata,

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -41,6 +41,7 @@ use core_test_support::responses::start_mock_server;
 use pretty_assertions::assert_eq;
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
@@ -1034,6 +1035,7 @@ async fn mcp_tool_call_request_meta_includes_turn_metadata_for_custom_server() {
         "custom_server",
         "call-custom",
         /*metadata*/ None,
+        /*connector_used_this_turn*/ false,
     )
     .expect("custom servers should receive turn metadata");
     let turn_metadata = meta
@@ -1076,6 +1078,7 @@ async fn mcp_tool_call_request_meta_includes_turn_started_at_unix_ms() {
         "custom_server",
         "call-custom",
         /*metadata*/ None,
+        /*connector_used_this_turn*/ false,
     )
     .expect("custom servers should receive turn metadata");
     let turn_metadata = meta
@@ -1105,7 +1108,13 @@ async fn plugin_mcp_tool_call_request_meta_includes_plugin_id() {
     metadata.plugin_id = Some("sample@test".to_string());
 
     assert_eq!(
-        build_mcp_tool_call_request_meta(&turn_context, "sample", "call-plugin", Some(&metadata),),
+        build_mcp_tool_call_request_meta(
+            &turn_context,
+            "sample",
+            "call-plugin",
+            Some(&metadata),
+            /*connector_used_this_turn*/ false,
+        ),
         Some(serde_json::json!({
             crate::X_CODEX_TURN_METADATA_HEADER: expected_turn_metadata,
             MCP_TOOL_PLUGIN_ID_META_KEY: "sample@test",
@@ -1150,10 +1159,17 @@ async fn mcp_tool_call_item_includes_plugin_id() {
 #[tokio::test]
 async fn codex_apps_tool_call_request_meta_includes_turn_metadata_and_codex_apps_meta() {
     let (_, turn_context) = make_session_and_context().await;
-    let expected_turn_metadata = turn_context
+    let mut expected_turn_metadata = turn_context
         .turn_metadata_state
         .current_meta_value_for_mcp_request(mcp_turn_metadata_context(&turn_context))
         .expect("turn metadata");
+    expected_turn_metadata
+        .as_object_mut()
+        .expect("turn metadata should be an object")
+        .insert(
+            CONNECTOR_USED_THIS_TURN_METADATA_KEY.to_string(),
+            serde_json::Value::String("true".to_string()),
+        );
     let metadata = McpToolApprovalMetadata {
         annotations: None,
         connector_id: Some("calendar".to_string()),
@@ -1182,6 +1198,7 @@ async fn codex_apps_tool_call_request_meta_includes_turn_metadata_and_codex_apps
             CODEX_APPS_MCP_SERVER_NAME,
             "call_abc123xyz789",
             Some(&metadata),
+            /*connector_used_this_turn*/ true,
         ),
         Some(serde_json::json!({
             crate::X_CODEX_TURN_METADATA_HEADER: expected_turn_metadata,
@@ -1209,6 +1226,7 @@ async fn codex_apps_tool_call_request_meta_includes_call_id_without_existing_cod
             CODEX_APPS_MCP_SERVER_NAME,
             "call_abc123xyz789",
             /*metadata*/ None,
+            /*connector_used_this_turn*/ false,
         ),
         Some(serde_json::json!({
             crate::X_CODEX_TURN_METADATA_HEADER: expected_turn_metadata,
@@ -1216,6 +1234,70 @@ async fn codex_apps_tool_call_request_meta_includes_call_id_without_existing_cod
                 "call_id": "call_abc123xyz789",
             },
         }))
+    );
+}
+
+#[tokio::test]
+async fn mcp_tool_call_request_meta_marks_same_turn_connector_usage() {
+    let (session, turn_context) = make_session_and_context().await;
+    session
+        .merge_connector_selection(HashSet::from(["connector_example".to_string()]))
+        .await;
+
+    let connector_used_this_turn = same_turn_connector_used(&session).await;
+    assert!(connector_used_this_turn);
+
+    let meta = build_mcp_tool_call_request_meta(
+        &turn_context,
+        CODEX_APPS_MCP_SERVER_NAME,
+        "call-tool",
+        /*metadata*/ None,
+        connector_used_this_turn,
+    )
+    .expect("search service should receive turn metadata");
+    let turn_metadata = meta
+        .get(crate::X_CODEX_TURN_METADATA_HEADER)
+        .expect("turn metadata should be present");
+
+    assert_eq!(
+        turn_metadata
+            .get(CONNECTOR_USED_THIS_TURN_METADATA_KEY)
+            .and_then(serde_json::Value::as_str),
+        Some("true")
+    );
+}
+
+#[tokio::test]
+async fn same_turn_connector_usage_ignores_current_tool_metadata() {
+    let (session, turn_context) = make_session_and_context().await;
+    let metadata = approval_metadata(
+        Some("connector_current_tool"),
+        Some("Current Tool Connector"),
+        /*connector_description*/ None,
+        /*tool_title*/ None,
+        /*tool_description*/ None,
+    );
+
+    let connector_used_this_turn = same_turn_connector_used(&session).await;
+    assert!(!connector_used_this_turn);
+
+    let meta = build_mcp_tool_call_request_meta(
+        &turn_context,
+        CODEX_APPS_MCP_SERVER_NAME,
+        "call-tool",
+        Some(&metadata),
+        connector_used_this_turn,
+    )
+    .expect("codex apps tool should receive turn metadata");
+    let turn_metadata = meta
+        .get(crate::X_CODEX_TURN_METADATA_HEADER)
+        .expect("turn metadata should be present");
+
+    assert!(
+        turn_metadata
+            .get(CONNECTOR_USED_THIS_TURN_METADATA_KEY)
+            .is_none(),
+        "current tool metadata alone should not mark connector usage"
     );
 }
 


### PR DESCRIPTION
## Summary

Set `connector_used_this_turn=true` in `x-codex-turn-metadata` while building MCP tool request metadata when the active turn has connector selection.

This checks turn state immediately before sending the MCP request, so a turn that starts without connectors but later selects one still carries the signal on downstream MCP requests.

The flag intentionally does not use the current MCP tool's connector metadata by itself. That avoids a request self-marking as prior connector usage just because the target tool is represented through connector-backed metadata.

Codex does not encode connector policy or internal connector allowlists. It emits turn-scoped connector state, and downstream services can apply their own policy.

## Validation

- `cargo fmt` in `codex-rs` (completed; stable rustfmt warned that `imports_granularity = Item` is nightly-only)
- `cargo test -p codex-core mcp_tool_call_request_meta` (4 passed)
- `cargo test -p codex-core same_turn_connector_usage_ignores_current_tool_metadata` (1 passed)

`just` is not installed in this environment, so I could not run the repo-preferred `just fmt` / `just test` wrappers locally.
