### PR TITLE
[rmcp-client] Refresh expired OAuth tokens before startup

### DIFF
--- a/codex-rs/rmcp-client/tests/streamable_http_oauth_startup.rs
+++ b/codex-rs/rmcp-client/tests/streamable_http_oauth_startup.rs
@@ -11,6 +11,7 @@ use codex_rmcp_client::save_oauth_tokens;
 use oauth2::AccessToken;
 use oauth2::RefreshToken;
 use oauth2::basic::BasicTokenType;
+use pretty_assertions::assert_eq;
 use rmcp::transport::auth::OAuthTokenResponse;
 use rmcp::transport::auth::VendorExtraTokenFields;
 use serde_json::Value;
@@ -107,6 +108,24 @@ async fn refreshes_expired_persisted_token_before_initialize() -> anyhow::Result
         .env(CHILD_SERVER_URL_ENV, server_url)
         .status()
         .await?;
+    let stale_authorization = format!("Bearer {EXPIRED_ACCESS_TOKEN}");
+    let requests = server.received_requests().await.unwrap_or_default();
+    let stale_token_request_count = requests
+        .iter()
+        .filter(|request| {
+            request.method == "POST"
+                && request.url.path() == "/mcp"
+                && request
+                    .headers
+                    .get("authorization")
+                    .and_then(|value| value.to_str().ok())
+                    == Some(stale_authorization.as_str())
+        })
+        .count();
+    assert_eq!(
+        stale_token_request_count, 0,
+        "expired access token was sent during startup"
+    );
     assert!(status.success(), "OAuth startup child failed: {status}");
     server.verify().await;
     Ok(())


### PR DESCRIPTION
## Intent

Ensure that Codex startup never initializes an MCP server with an expired persisted OAuth access token. The refresh-before-initialize implementation landed in #26482; this PR preserves that user-visible contract by independently detecting any stale token sent during startup.

## User-visible behavior

### Before this change

On the pre-fix path, Codex can send the expired persisted access token in the MCP `initialize` request. The MCP server rejects the stale credential, so the user sees MCP startup fail or an unnecessary reauthentication flow even when a refresh token is available.

### After this change

Codex refreshes a known-expired persisted access token before MCP `initialize`. The startup handshake uses the refreshed token and completes without a stale-token authentication interruption.

## Implementation

The production behavior is supplied by #26482, which represents a known-expired persisted token as `expires_in = 0` so RMCP refreshes it before initialization. This PR adds no production logic. Its net change inspects recorded `POST /mcp` requests in the focused startup scenario and asserts that none used the expired bearer token before evaluating child-process success.

## Validation

- `just test -p codex-rmcp-client refreshes_expired_persisted_token_before_initialize` passed, including the benchmark smoke run.
- With pre-fix-equivalent `expires_in = None` behavior, the same scenario failed at the stale-token assertion with one expired-token request, before the child-success assertion.