### PR TITLE
[rmcp-client] Adopt externally updated OAuth credentials

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -3579,6 +3579,7 @@ dependencies = [
  "codex-utils-pty",
  "futures",
  "keyring",
+ "libc",
  "memchr",
  "oauth2",
  "pretty_assertions",
@@ -3597,6 +3598,7 @@ dependencies = [
  "urlencoding",
  "webbrowser",
  "which 8.0.0",
+ "windows-sys 0.52.0",
  "wiremock",
 ]
 

--- a/codex-rs/rmcp-client/Cargo.toml
+++ b/codex-rs/rmcp-client/Cargo.toml
@@ -71,6 +71,8 @@ pretty_assertions = { workspace = true }
 serial_test = { workspace = true }
 tempfile = { workspace = true }
 wiremock = { workspace = true }
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 keyring = { workspace = true, features = ["linux-native-async-persistent"] }
 
@@ -79,6 +81,11 @@ keyring = { workspace = true, features = ["apple-native"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 keyring = { workspace = true, features = ["windows-native"] }
+windows-sys = { version = "0.52", features = [
+    "Win32_Foundation",
+    "Win32_System_Com",
+    "Win32_UI_Shell",
+] }
 
 [target.'cfg(any(target_os = "freebsd", target_os = "openbsd"))'.dependencies]
 keyring = { workspace = true, features = ["sync-secret-service"] }

--- a/codex-rs/rmcp-client/src/oauth.rs
+++ b/codex-rs/rmcp-client/src/oauth.rs
@@ -48,9 +48,8 @@ use tracing::warn;
 use codex_keyring_store::DefaultKeyringStore;
 use codex_keyring_store::KeyringStore;
 use rmcp::transport::auth::AuthorizationManager;
-use rmcp::transport::auth::CredentialStore;
 use rmcp::transport::auth::InMemoryCredentialStore;
-use rmcp::transport::auth::StoredCredentials;
+use rmcp::transport::auth::OAuthState;
 use tokio::sync::Mutex;
 use tokio::sync::OwnedMutexGuard;
 
@@ -140,8 +139,14 @@ fn load_oauth_tokens_from_keyring_with_fallback_to_file<K: KeyringStore>(
         Ok(None) => load_oauth_tokens_from_file(server_name, url),
         Err(error) => {
             warn!("failed to read OAuth tokens from keyring: {error}");
-            load_oauth_tokens_from_file(server_name, url)
-                .with_context(|| format!("failed to read OAuth tokens from keyring: {error}"))
+            match load_oauth_tokens_from_file(server_name, url) {
+                Ok(Some(tokens)) => Ok(Some(tokens)),
+                Ok(None) => Err(error).context(
+                    "failed to read OAuth tokens from keyring and no fallback credentials exist",
+                ),
+                Err(file_error) => Err(file_error)
+                    .with_context(|| format!("failed to read OAuth tokens from keyring: {error}")),
+            }
         }
     }
 }
@@ -297,6 +302,7 @@ struct OAuthPersistorInner {
     server_name: String,
     url: String,
     authorization_manager: Arc<Mutex<AuthorizationManager>>,
+    oauth_metadata_client: reqwest::Client,
     store_mode: OAuthCredentialsStoreMode,
     last_credentials: Mutex<Option<StoredOAuthTokens>>,
 }
@@ -307,11 +313,30 @@ enum CredentialReload {
     Removed,
 }
 
+pub(crate) async fn authorization_manager_from_tokens(
+    url: &str,
+    oauth_metadata_client: reqwest::Client,
+    tokens: &StoredOAuthTokens,
+) -> Result<AuthorizationManager> {
+    let mut oauth_state = OAuthState::new(url.to_string(), Some(oauth_metadata_client)).await?;
+    oauth_state
+        .set_credentials(&tokens.client_id, tokens.token_response.0.clone())
+        .await?;
+
+    match oauth_state {
+        OAuthState::Authorized(manager) | OAuthState::Unauthorized(manager) => Ok(manager),
+        _ => Err(anyhow::anyhow!(
+            "unexpected OAuth state while replacing credentials"
+        )),
+    }
+}
+
 impl OAuthPersistor {
     pub(crate) fn new(
         server_name: String,
         url: String,
         authorization_manager: Arc<Mutex<AuthorizationManager>>,
+        oauth_metadata_client: reqwest::Client,
         store_mode: OAuthCredentialsStoreMode,
         initial_credentials: Option<StoredOAuthTokens>,
     ) -> Self {
@@ -320,6 +345,7 @@ impl OAuthPersistor {
                 server_name,
                 url,
                 authorization_manager,
+                oauth_metadata_client,
                 store_mode,
                 last_credentials: Mutex::new(initial_credentials),
             }),
@@ -481,29 +507,15 @@ impl OAuthPersistor {
     }
 
     async fn replace_manager_credentials(&self, tokens: &StoredOAuthTokens) -> Result<()> {
-        let token_response = tokens.token_response.0.clone();
-        let store = InMemoryCredentialStore::new();
-        store
-            .save(StoredCredentials::new(
-                tokens.client_id.clone(),
-                Some(token_response.clone()),
-                token_response
-                    .scopes()
-                    .map(|scopes| scopes.iter().map(|scope| scope.to_string()).collect())
-                    .unwrap_or_default(),
-                Some(
-                    SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap_or_else(|_| Duration::from_secs(0))
-                        .as_secs(),
-                ),
-            ))
-            .await?;
-
+        let replacement = authorization_manager_from_tokens(
+            &self.inner.url,
+            self.inner.oauth_metadata_client.clone(),
+            tokens,
+        )
+        .await?;
         let manager = self.inner.authorization_manager.clone();
         let mut guard = manager.lock().await;
-        guard.configure_client_id(&tokens.client_id)?;
-        guard.set_credential_store(store);
+        *guard = replacement;
         Ok(())
     }
 
@@ -944,16 +956,27 @@ mod tests {
     use keyring::Error as KeyringError;
     use pretty_assertions::assert_eq;
     use std::ffi::OsString;
-    use std::sync::Barrier;
+    use std::process::Child;
+    use std::process::Command;
     use std::sync::Mutex;
     use std::sync::MutexGuard;
     use std::sync::OnceLock;
     use std::sync::PoisonError;
-    use std::sync::mpsc;
     use std::thread;
+    use std::time::Instant;
     use tempfile::tempdir;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::body_string_contains;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
 
     use codex_keyring_store::tests::MockKeyringStore;
+
+    const FALLBACK_WRITER_VARIANT_ENV: &str = "CODEX_TEST_FALLBACK_WRITER_VARIANT";
+    const FALLBACK_WRITER_ATTEMPT_ENV: &str = "CODEX_TEST_FALLBACK_WRITER_ATTEMPT";
+    const FALLBACK_WRITER_DONE_ENV: &str = "CODEX_TEST_FALLBACK_WRITER_DONE";
 
     struct TempCodexHome {
         _guard: MutexGuard<'static, ()>,
@@ -1068,6 +1091,99 @@ mod tests {
         )?
         .expect("tokens should load from fallback");
         assert_tokens_match_without_expiry(&loaded, &expected);
+        Ok(())
+    }
+
+    #[test]
+    fn load_oauth_tokens_preserves_keyring_error_without_fallback() -> Result<()> {
+        let _env = TempCodexHome::new();
+        let store = MockKeyringStore::default();
+        let tokens = sample_tokens();
+        let key = super::compute_store_key(&tokens.server_name, &tokens.url)?;
+        store.set_error(&key, KeyringError::Invalid("error".into(), "load".into()));
+
+        let error = super::load_oauth_tokens_from_keyring_with_fallback_to_file(
+            &store,
+            &tokens.server_name,
+            &tokens.url,
+        )
+        .expect_err("missing fallback must not turn a keyring failure into logout");
+
+        assert!(error.to_string().contains(
+            "failed to read OAuth tokens from keyring and no fallback credentials exist"
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[expect(
+        clippy::await_holding_invalid_type,
+        reason = "the test must inspect and refresh the same authorization manager instance"
+    )]
+    async fn replacement_updates_current_scopes_used_by_scope_less_refresh() -> Result<()> {
+        let server = MockServer::start().await;
+        let server_url = format!("{}/mcp", server.uri());
+        Mock::given(method("GET"))
+            .and(path("/.well-known/oauth-authorization-server/mcp"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "authorization_endpoint": format!("{}/oauth/authorize", server.uri()),
+                "token_endpoint": format!("{}/oauth/token", server.uri()),
+                "scopes_supported": ["external-scope"],
+            })))
+            .expect(2)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/oauth/token"))
+            .and(body_string_contains("refresh_token=refresh-token"))
+            .and(body_string_contains("scope=external-scope"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "refreshed-access-token",
+                "token_type": "Bearer",
+                "expires_in": 7200,
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let mut initial = sample_tokens();
+        initial.url = server_url.clone();
+        let oauth_metadata_client = reqwest::Client::new();
+        let manager = Arc::new(tokio::sync::Mutex::new(
+            super::authorization_manager_from_tokens(
+                &server_url,
+                oauth_metadata_client.clone(),
+                &initial,
+            )
+            .await?,
+        ));
+        let runtime = OAuthPersistor::new(
+            initial.server_name.clone(),
+            server_url,
+            Arc::clone(&manager),
+            oauth_metadata_client,
+            OAuthCredentialsStoreMode::File,
+            Some(initial.clone()),
+        );
+        let mut replacement = initial;
+        replacement
+            .token_response
+            .0
+            .set_scopes(Some(vec![Scope::new("external-scope".to_string())]));
+
+        runtime.replace_manager_credentials(&replacement).await?;
+        let guard = manager.lock().await;
+        assert_eq!(
+            guard.get_current_scopes().await,
+            vec!["external-scope".to_string()]
+        );
+        guard.refresh_token().await?;
+        assert_eq!(
+            guard.get_current_scopes().await,
+            vec!["external-scope".to_string()]
+        );
+        drop(guard);
+        server.verify().await;
         Ok(())
     }
 
@@ -1319,7 +1435,7 @@ mod tests {
     }
 
     #[test]
-    fn fallback_store_serializes_writes_for_different_servers() -> Result<()> {
+    fn fallback_store_serializes_cross_process_writes_for_different_servers() -> Result<()> {
         let _env = TempCodexHome::new();
         let first = sample_tokens();
         let mut second = sample_tokens();
@@ -1332,32 +1448,45 @@ mod tests {
         );
 
         let fallback_lock = super::acquire_fallback_store_lock()?;
-        let barrier = Arc::new(Barrier::new(3));
-        let (tx, rx) = mpsc::channel();
-        let handles = [first.clone(), second.clone()]
+        let codex_home = find_codex_home()?;
+        let markers = tempdir()?;
+        let mut writers = ["first", "second"]
             .into_iter()
-            .map(|tokens| {
-                let barrier = Arc::clone(&barrier);
-                let tx = tx.clone();
-                thread::spawn(move || {
-                    barrier.wait();
-                    tx.send(super::save_oauth_tokens_to_file(&tokens))
-                        .expect("send save result");
-                })
+            .map(|variant| {
+                let attempt = markers.path().join(format!("{variant}-attempt"));
+                let done = markers.path().join(format!("{variant}-done"));
+                let child = Command::new(std::env::current_exe()?)
+                    .args(["fallback_store_writer_child", "--ignored", "--nocapture"])
+                    .env("CODEX_HOME", codex_home.as_path())
+                    .env(FALLBACK_WRITER_VARIANT_ENV, variant)
+                    .env(FALLBACK_WRITER_ATTEMPT_ENV, &attempt)
+                    .env(FALLBACK_WRITER_DONE_ENV, &done)
+                    .spawn()?;
+                Ok((child, attempt, done))
             })
-            .collect::<Vec<_>>();
-        drop(tx);
-
-        barrier.wait();
-        thread::sleep(Duration::from_millis(50));
-        assert!(matches!(rx.try_recv(), Err(mpsc::TryRecvError::Empty)));
+            .collect::<Result<Vec<_>>>()?;
+        wait_for_paths(
+            &writers
+                .iter()
+                .map(|(_, attempt, _)| attempt.clone())
+                .collect::<Vec<_>>(),
+            Duration::from_secs(5),
+        )?;
+        thread::sleep(Duration::from_millis(100));
+        for (child, _, done) in &mut writers {
+            assert!(
+                child.try_wait()?.is_none(),
+                "fallback writer should block on the cross-process file lock"
+            );
+            assert!(
+                !done.exists(),
+                "fallback writer completed while another process held the file lock"
+            );
+        }
 
         drop(fallback_lock);
-        for _ in 0..2 {
-            rx.recv_timeout(Duration::from_secs(5))??;
-        }
-        for handle in handles {
-            handle.join().expect("fallback writer should not panic");
+        for (child, _, _) in &mut writers {
+            wait_for_child_success(child, Duration::from_secs(5))?;
         }
 
         let store = super::read_fallback_file()?.expect("fallback file should load");
@@ -1370,6 +1499,38 @@ mod tests {
                 .collect::<std::collections::BTreeSet<_>>(),
             [first_key, second_key].into_iter().collect()
         );
+        Ok(())
+    }
+
+    #[test]
+    #[ignore = "spawned by fallback_store_serializes_cross_process_writes_for_different_servers"]
+    fn fallback_store_writer_child() -> Result<()> {
+        let mut tokens = sample_tokens();
+        match std::env::var(FALLBACK_WRITER_VARIANT_ENV)?.as_str() {
+            "first" => {}
+            "second" => {
+                tokens.server_name = "other-server".to_string();
+                tokens.url = "https://other.example.test".to_string();
+                tokens.token_response.0 = OAuthTokenResponse::new(
+                    AccessToken::new("other-access-token".to_string()),
+                    BasicTokenType::Bearer,
+                    VendorExtraTokenFields::default(),
+                );
+            }
+            variant => anyhow::bail!("unexpected fallback writer variant: {variant}"),
+        }
+
+        let attempt = PathBuf::from(
+            std::env::var_os(FALLBACK_WRITER_ATTEMPT_ENV)
+                .context("fallback writer attempt path should be set")?,
+        );
+        let done = PathBuf::from(
+            std::env::var_os(FALLBACK_WRITER_DONE_ENV)
+                .context("fallback writer done path should be set")?,
+        );
+        fs::write(attempt, b"attempting")?;
+        super::save_oauth_tokens_to_file(&tokens)?;
+        fs::write(done, b"done")?;
         Ok(())
     }
 
@@ -1458,6 +1619,31 @@ mod tests {
             actual_response.expires_in().is_some(),
             expected_response.expires_in().is_some()
         );
+    }
+
+    fn wait_for_paths(paths: &[PathBuf], timeout: Duration) -> Result<()> {
+        let deadline = Instant::now() + timeout;
+        while !paths.iter().all(|path| path.exists()) {
+            if Instant::now() >= deadline {
+                anyhow::bail!("timed out waiting for fallback writer readiness");
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        Ok(())
+    }
+
+    fn wait_for_child_success(child: &mut Child, timeout: Duration) -> Result<()> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Some(status) = child.try_wait()? {
+                anyhow::ensure!(status.success(), "fallback writer failed: {status}");
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                anyhow::bail!("timed out waiting for fallback writer");
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
     }
 
     fn sample_tokens() -> StoredOAuthTokens {

--- a/codex-rs/rmcp-client/src/oauth.rs
+++ b/codex-rs/rmcp-client/src/oauth.rs
@@ -35,6 +35,7 @@ use sha2::Digest;
 use sha2::Sha256;
 use std::collections::BTreeMap;
 use std::fs;
+use std::fs::OpenOptions;
 use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -46,7 +47,11 @@ use tracing::warn;
 use codex_keyring_store::DefaultKeyringStore;
 use codex_keyring_store::KeyringStore;
 use rmcp::transport::auth::AuthorizationManager;
+use rmcp::transport::auth::CredentialStore;
+use rmcp::transport::auth::InMemoryCredentialStore;
+use rmcp::transport::auth::StoredCredentials;
 use tokio::sync::Mutex;
+use tokio::sync::Semaphore;
 
 use codex_utils_home_dir::find_codex_home;
 
@@ -163,6 +168,15 @@ pub fn save_oauth_tokens(
     tokens: &StoredOAuthTokens,
     store_mode: OAuthCredentialsStoreMode,
 ) -> Result<()> {
+    let _lock = acquire_oauth_server_lock(server_name, &tokens.url)?;
+    save_oauth_tokens_locked(server_name, tokens, store_mode)
+}
+
+fn save_oauth_tokens_locked(
+    server_name: &str,
+    tokens: &StoredOAuthTokens,
+    store_mode: OAuthCredentialsStoreMode,
+) -> Result<()> {
     let keyring_store = DefaultKeyringStore;
     match store_mode {
         OAuthCredentialsStoreMode::Auto => save_oauth_tokens_with_keyring_with_fallback_to_file(
@@ -266,6 +280,7 @@ struct OAuthPersistorInner {
     authorization_manager: Arc<Mutex<AuthorizationManager>>,
     store_mode: OAuthCredentialsStoreMode,
     last_credentials: Mutex<Option<StoredOAuthTokens>>,
+    update_lock: Semaphore,
 }
 
 impl OAuthPersistor {
@@ -283,17 +298,23 @@ impl OAuthPersistor {
                 authorization_manager,
                 store_mode,
                 last_credentials: Mutex::new(initial_credentials),
+                update_lock: Semaphore::new(1),
             }),
         }
     }
 
     /// Persists the latest stored credentials if they have changed.
     /// Deletes the credentials if they are no longer present.
+    pub(crate) async fn persist_if_needed(&self) -> Result<()> {
+        let _permit = self.inner.update_lock.acquire().await?;
+        self.persist_if_needed_locked().await
+    }
+
     #[expect(
         clippy::await_holding_invalid_type,
-        reason = "AuthorizationManager async access must be serialized through its mutex"
+        reason = "AuthorizationManager async access and persisted credential comparison must be serialized"
     )]
-    pub(crate) async fn persist_if_needed(&self) -> Result<()> {
+    async fn persist_if_needed_locked(&self) -> Result<()> {
         let (client_id, maybe_credentials) = {
             let manager = self.inner.authorization_manager.clone();
             let guard = manager.lock().await;
@@ -302,7 +323,7 @@ impl OAuthPersistor {
 
         match maybe_credentials {
             Some(credentials) => {
-                let mut last_credentials = self.inner.last_credentials.lock().await;
+                let last_credentials = self.inner.last_credentials.lock().await.clone();
                 let new_token_response = WrappedOAuthTokenResponse(credentials.clone());
                 let same_token = last_credentials
                     .as_ref()
@@ -320,10 +341,31 @@ impl OAuthPersistor {
                     token_response: new_token_response,
                     expires_at,
                 };
-                if last_credentials.as_ref() != Some(&stored) {
-                    save_oauth_tokens(&self.inner.server_name, &stored, self.inner.store_mode)?;
-                    *last_credentials = Some(stored);
+                if last_credentials
+                    .as_ref()
+                    .is_some_and(|previous| same_persisted_generation(previous, &stored))
+                {
+                    return Ok(());
                 }
+
+                let _server_lock =
+                    acquire_oauth_server_lock_async(&self.inner.server_name, &self.inner.url)
+                        .await?;
+                if let Some(persisted) = load_oauth_tokens(
+                    &self.inner.server_name,
+                    &self.inner.url,
+                    self.inner.store_mode,
+                )? && !last_credentials
+                    .as_ref()
+                    .is_some_and(|previous| same_persisted_generation(previous, &persisted))
+                {
+                    self.replace_manager_credentials(&persisted).await?;
+                    *self.inner.last_credentials.lock().await = Some(persisted);
+                    return Ok(());
+                }
+
+                save_oauth_tokens_locked(&self.inner.server_name, &stored, self.inner.store_mode)?;
+                *self.inner.last_credentials.lock().await = Some(stored);
             }
             None => {
                 let mut last_serialized = self.inner.last_credentials.lock().await;
@@ -347,9 +389,12 @@ impl OAuthPersistor {
 
     #[expect(
         clippy::await_holding_invalid_type,
-        reason = "AuthorizationManager async access must be serialized through its mutex"
+        reason = "AuthorizationManager async access and persisted credential adoption must be serialized"
     )]
     pub(crate) async fn refresh_if_needed(&self) -> Result<()> {
+        let _permit = self.inner.update_lock.acquire().await?;
+        self.adopt_persisted_credentials_if_changed().await?;
+
         let expires_at = {
             let guard = self.inner.last_credentials.lock().await;
             guard.as_ref().and_then(|tokens| tokens.expires_at)
@@ -370,7 +415,109 @@ impl OAuthPersistor {
             })?;
         }
 
-        self.persist_if_needed().await
+        self.persist_if_needed_locked().await
+    }
+
+    async fn adopt_persisted_credentials_if_changed(&self) -> Result<()> {
+        let _server_lock =
+            acquire_oauth_server_lock_async(&self.inner.server_name, &self.inner.url).await?;
+        let Some(persisted) = load_oauth_tokens(
+            &self.inner.server_name,
+            &self.inner.url,
+            self.inner.store_mode,
+        )?
+        else {
+            return Ok(());
+        };
+
+        let last_credentials = self.inner.last_credentials.lock().await.clone();
+        if last_credentials
+            .as_ref()
+            .is_some_and(|previous| same_persisted_generation(previous, &persisted))
+        {
+            return Ok(());
+        }
+
+        self.replace_manager_credentials(&persisted).await?;
+        *self.inner.last_credentials.lock().await = Some(persisted);
+        Ok(())
+    }
+
+    async fn replace_manager_credentials(&self, tokens: &StoredOAuthTokens) -> Result<()> {
+        let token_response = tokens.token_response.0.clone();
+        let store = InMemoryCredentialStore::new();
+        store
+            .save(StoredCredentials::new(
+                tokens.client_id.clone(),
+                Some(token_response.clone()),
+                token_response
+                    .scopes()
+                    .map(|scopes| scopes.iter().map(|scope| scope.to_string()).collect())
+                    .unwrap_or_default(),
+                Some(
+                    SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap_or_else(|_| Duration::from_secs(0))
+                        .as_secs(),
+                ),
+            ))
+            .await?;
+
+        let manager = self.inner.authorization_manager.clone();
+        let mut guard = manager.lock().await;
+        guard.configure_client_id(&tokens.client_id)?;
+        guard.set_credential_store(store);
+        Ok(())
+    }
+}
+
+struct OAuthServerLock {
+    _file: fs::File,
+}
+
+fn acquire_oauth_server_lock(server_name: &str, url: &str) -> Result<OAuthServerLock> {
+    let digest = sha_256_prefix(&Value::String(format!("{server_name}\n{url}")))?;
+    let path = find_codex_home()?.join(format!(".mcp-oauth-{digest}.lock"));
+    let file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)
+        .with_context(|| format!("failed to open OAuth credential lock at {}", path.display()))?;
+    file.lock()
+        .with_context(|| format!("failed to lock OAuth credentials at {}", path.display()))?;
+    Ok(OAuthServerLock { _file: file })
+}
+
+async fn acquire_oauth_server_lock_async(server_name: &str, url: &str) -> Result<OAuthServerLock> {
+    let server_name = server_name.to_string();
+    let url = url.to_string();
+    tokio::task::spawn_blocking(move || acquire_oauth_server_lock(&server_name, &url))
+        .await
+        .context("OAuth credential lock task failed")?
+}
+
+fn same_persisted_generation(left: &StoredOAuthTokens, right: &StoredOAuthTokens) -> bool {
+    if left.server_name != right.server_name
+        || left.url != right.url
+        || left.client_id != right.client_id
+        || left.expires_at != right.expires_at
+    {
+        return false;
+    }
+
+    let normalize = |response: &WrappedOAuthTokenResponse| {
+        let mut value = serde_json::to_value(response).ok()?;
+        value.as_object_mut()?.remove("expires_in");
+        Some(value)
+    };
+    match (
+        normalize(&left.token_response),
+        normalize(&right.token_response),
+    ) {
+        (Some(left), Some(right)) => left == right,
+        _ => false,
     }
 }
 

--- a/codex-rs/rmcp-client/src/oauth.rs
+++ b/codex-rs/rmcp-client/src/oauth.rs
@@ -593,6 +593,7 @@ fn acquire_fallback_store_lock() -> Result<FallbackStoreLock> {
 fn open_oauth_lock_file(path: &std::path::Path) -> Result<fs::File> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
+        secure_oauth_lock_dir(parent)?;
     }
     OpenOptions::new()
         .read(true)
@@ -601,6 +602,28 @@ fn open_oauth_lock_file(path: &std::path::Path) -> Result<fs::File> {
         .truncate(false)
         .open(path)
         .with_context(|| format!("failed to open OAuth credential lock at {}", path.display()))
+}
+
+#[cfg(unix)]
+fn secure_oauth_lock_dir(path: &std::path::Path) -> Result<()> {
+    use std::os::unix::fs::MetadataExt;
+    use std::os::unix::fs::PermissionsExt;
+
+    let metadata = fs::symlink_metadata(path)?;
+    let effective_uid = unsafe { libc::geteuid() };
+    if !metadata.file_type().is_dir() || metadata.uid() != effective_uid {
+        anyhow::bail!(
+            "OAuth credential lock directory {} is not owned by the current user",
+            path.display()
+        );
+    }
+    fs::set_permissions(path, fs::Permissions::from_mode(0o700))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn secure_oauth_lock_dir(_path: &std::path::Path) -> Result<()> {
+    Ok(())
 }
 
 fn oauth_server_lock_path(server_name: &str, url: &str) -> Result<PathBuf> {
@@ -616,15 +639,57 @@ fn fallback_store_lock_path() -> Result<PathBuf> {
     Ok(oauth_lock_root_path()?.join(format!("fallback-{store_digest}.lock")))
 }
 
+#[cfg(unix)]
 fn oauth_lock_root_path() -> Result<PathBuf> {
-    if let Some(user_profile) = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"))
-    {
-        return Ok(PathBuf::from(user_profile).join(".codex-mcp-oauth-locks"));
+    let effective_uid = unsafe { libc::geteuid() };
+    Ok(PathBuf::from("/tmp").join(format!("codex-mcp-oauth-{effective_uid}")))
+}
+
+#[cfg(windows)]
+fn oauth_lock_root_path() -> Result<PathBuf> {
+    Ok(windows_local_app_data_dir()?
+        .join("Temp")
+        .join("codex-mcp-oauth-locks"))
+}
+
+#[cfg(windows)]
+fn windows_local_app_data_dir() -> Result<PathBuf> {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt;
+    use windows_sys::Win32::System::Com::CoTaskMemFree;
+    use windows_sys::Win32::UI::Shell::FOLDERID_LocalAppData;
+    use windows_sys::Win32::UI::Shell::KF_FLAG_DEFAULT;
+    use windows_sys::Win32::UI::Shell::SHGetKnownFolderPath;
+
+    let mut path_ptr = std::ptr::null_mut::<u16>();
+    let known_folder_flags =
+        u32::try_from(KF_FLAG_DEFAULT).context("KF_FLAG_DEFAULT did not fit in u32")?;
+    let hr = unsafe {
+        SHGetKnownFolderPath(&FOLDERID_LocalAppData, known_folder_flags, 0, &mut path_ptr)
+    };
+    if hr != 0 {
+        anyhow::bail!("SHGetKnownFolderPath(FOLDERID_LocalAppData) failed with HRESULT {hr:#010x}");
+    }
+    if path_ptr.is_null() {
+        anyhow::bail!("SHGetKnownFolderPath(FOLDERID_LocalAppData) returned a null pointer");
     }
 
-    let codex_home = find_codex_home()?;
-    let parent = codex_home.parent().unwrap_or(codex_home);
-    Ok(parent.join(".codex-mcp-oauth-locks").to_path_buf())
+    let path = unsafe {
+        let mut len = 0usize;
+        while *path_ptr.add(len) != 0 {
+            len += 1;
+        }
+        let wide = std::slice::from_raw_parts(path_ptr, len);
+        let path = PathBuf::from(OsString::from_wide(wide));
+        CoTaskMemFree(path_ptr.cast());
+        path
+    };
+    Ok(path)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn oauth_lock_root_path() -> Result<PathBuf> {
+    anyhow::bail!("OAuth credential locks are unsupported on this platform")
 }
 
 fn same_persisted_generation(left: &StoredOAuthTokens, right: &StoredOAuthTokens) -> bool {
@@ -1221,22 +1286,35 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn load_file_credentials_from_read_only_codex_home() -> Result<()> {
+    fn read_only_home_and_codex_home_allow_reads_but_not_mutations() -> Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
         let _env = TempCodexHome::new();
         let tokens = sample_tokens();
         super::save_oauth_tokens_to_file(&tokens)?;
         let codex_home = find_codex_home()?;
-        let original_permissions = fs::metadata(&codex_home)?.permissions();
+        let user_home = PathBuf::from(std::env::var_os("HOME").expect("HOME should be set"));
+        let codex_home_permissions = fs::metadata(&codex_home)?.permissions();
+        let user_home_permissions = fs::metadata(&user_home)?.permissions();
         fs::set_permissions(&codex_home, fs::Permissions::from_mode(0o500))?;
+        fs::set_permissions(&user_home, fs::Permissions::from_mode(0o500))?;
 
         let loaded = super::load_oauth_tokens_from_file(&tokens.server_name, &tokens.url);
+        let key = super::compute_store_key(&tokens.server_name, &tokens.url)?;
+        let deletion = super::delete_oauth_tokens_from_file(&key);
 
-        fs::set_permissions(&codex_home, original_permissions)?;
-        let loaded = loaded?.expect("tokens should load from read-only CODEX_HOME");
+        fs::set_permissions(&codex_home, codex_home_permissions)?;
+        fs::set_permissions(&user_home, user_home_permissions)?;
+        let loaded = loaded?.expect("tokens should load from read-only homes");
         assert_tokens_match_without_expiry(&loaded, &tokens);
-        assert!(!codex_home.join(".mcp-oauth-locks").exists());
+        let error = deletion.expect_err("credential deletion should require a writable store");
+        assert_eq!(
+            error
+                .root_cause()
+                .downcast_ref::<std::io::Error>()
+                .map(std::io::Error::kind),
+            Some(ErrorKind::PermissionDenied)
+        );
         Ok(())
     }
 
@@ -1296,20 +1374,37 @@ mod tests {
     }
 
     #[test]
-    fn server_generation_lock_is_stable_across_codex_homes_and_tmpdirs() -> Result<()> {
+    fn server_generation_lock_is_stable_across_read_only_homes_and_tmpdirs() -> Result<()> {
+        #[cfg(unix)]
+        use std::os::unix::fs::PermissionsExt;
+
         let _env = TempCodexHome::new();
+        let first_home = PathBuf::from(std::env::var_os("HOME").expect("HOME should be set"));
         let first_tmpdir = tempdir()?;
         unsafe {
             std::env::set_var("TMPDIR", first_tmpdir.path());
         }
         let first = super::oauth_server_lock_path("server", "https://example.test")?;
         let other_codex_home = tempdir()?;
+        let other_home = tempdir()?;
         let second_tmpdir = tempdir()?;
+        #[cfg(unix)]
+        {
+            fs::set_permissions(&first_home, fs::Permissions::from_mode(0o500))?;
+            fs::set_permissions(other_home.path(), fs::Permissions::from_mode(0o500))?;
+        }
         unsafe {
             std::env::set_var("CODEX_HOME", other_codex_home.path());
+            std::env::set_var("HOME", other_home.path());
             std::env::set_var("TMPDIR", second_tmpdir.path());
+            std::env::set_var("USERPROFILE", other_home.path());
         }
         let second = super::oauth_server_lock_path("server", "https://example.test")?;
+        #[cfg(unix)]
+        {
+            fs::set_permissions(&first_home, fs::Permissions::from_mode(0o700))?;
+            fs::set_permissions(other_home.path(), fs::Permissions::from_mode(0o700))?;
+        }
 
         assert_eq!(first, second);
         Ok(())

--- a/codex-rs/rmcp-client/src/oauth.rs
+++ b/codex-rs/rmcp-client/src/oauth.rs
@@ -670,12 +670,12 @@ fn windows_local_app_data_dir() -> Result<PathBuf> {
     use std::os::windows::ffi::OsStringExt;
     use windows_sys::Win32::System::Com::CoTaskMemFree;
     use windows_sys::Win32::UI::Shell::FOLDERID_LocalAppData;
-    use windows_sys::Win32::UI::Shell::KF_FLAG_DEFAULT;
+    use windows_sys::Win32::UI::Shell::KF_FLAG_DONT_VERIFY;
     use windows_sys::Win32::UI::Shell::SHGetKnownFolderPath;
 
     let mut path_ptr = std::ptr::null_mut::<u16>();
     let known_folder_flags =
-        u32::try_from(KF_FLAG_DEFAULT).context("KF_FLAG_DEFAULT did not fit in u32")?;
+        u32::try_from(KF_FLAG_DONT_VERIFY).context("KF_FLAG_DONT_VERIFY did not fit in u32")?;
     let hr = unsafe {
         SHGetKnownFolderPath(&FOLDERID_LocalAppData, known_folder_flags, 0, &mut path_ptr)
     };
@@ -1541,6 +1541,7 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
 
         let _env = TempCodexHome::new();
+        #[cfg(unix)]
         let first_home = PathBuf::from(std::env::var_os("HOME").expect("HOME should be set"));
         let first_tmpdir = tempdir()?;
         unsafe {

--- a/codex-rs/rmcp-client/src/oauth.rs
+++ b/codex-rs/rmcp-client/src/oauth.rs
@@ -576,7 +576,7 @@ fn acquire_fallback_store_lock() -> Result<FallbackStoreLock> {
     let in_process_guard = FALLBACK_STORE_LOCK
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let path = find_codex_home()?.join(".mcp-oauth-locks/fallback-store.lock");
+    let path = fallback_store_lock_path()?;
     let file = open_oauth_lock_file(&path)?;
     file.lock().with_context(|| {
         format!(
@@ -605,13 +605,26 @@ fn open_oauth_lock_file(path: &std::path::Path) -> Result<fs::File> {
 
 fn oauth_server_lock_path(server_name: &str, url: &str) -> Result<PathBuf> {
     let server_digest = sha_256_prefix(&Value::String(format!("{server_name}\n{url}")))?;
-    let user_identity = std::env::var_os("HOME")
-        .or_else(|| std::env::var_os("USERPROFILE"))
-        .unwrap_or_else(|| std::env::temp_dir().into_os_string());
-    let user_digest = sha_256_prefix(&Value::String(user_identity.to_string_lossy().into_owned()))?;
-    Ok(std::env::temp_dir()
-        .join(format!("codex-mcp-oauth-{user_digest}"))
-        .join(format!("server-{server_digest}.lock")))
+    Ok(oauth_lock_root_path()?.join(format!("server-{server_digest}.lock")))
+}
+
+fn fallback_store_lock_path() -> Result<PathBuf> {
+    let credentials_path = fallback_file_path()?;
+    let store_digest = sha_256_prefix(&Value::String(
+        credentials_path.to_string_lossy().into_owned(),
+    ))?;
+    Ok(oauth_lock_root_path()?.join(format!("fallback-{store_digest}.lock")))
+}
+
+fn oauth_lock_root_path() -> Result<PathBuf> {
+    if let Some(user_profile) = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE"))
+    {
+        return Ok(PathBuf::from(user_profile).join(".codex-mcp-oauth-locks"));
+    }
+
+    let codex_home = find_codex_home()?;
+    let parent = codex_home.parent().unwrap_or(codex_home);
+    Ok(parent.join(".codex-mcp-oauth-locks").to_path_buf())
 }
 
 fn same_persisted_generation(left: &StoredOAuthTokens, right: &StoredOAuthTokens) -> bool {
@@ -623,17 +636,14 @@ fn same_persisted_generation(left: &StoredOAuthTokens, right: &StoredOAuthTokens
         return false;
     }
 
-    let mut left_response = left.token_response.0.clone();
-    let mut right_response = right.token_response.0.clone();
-    left_response.set_expires_in(None);
-    right_response.set_expires_in(None);
-    match (
-        serde_json::to_string(&left_response),
-        serde_json::to_string(&right_response),
-    ) {
-        (Ok(left), Ok(right)) => left == right,
-        _ => false,
-    }
+    let left_response = &left.token_response.0;
+    let right_response = &right.token_response.0;
+    left_response.access_token().secret() == right_response.access_token().secret()
+        && left_response.token_type() == right_response.token_type()
+        && left_response.refresh_token().map(RefreshToken::secret)
+            == right_response.refresh_token().map(RefreshToken::secret)
+        && left_response.scopes() == right_response.scopes()
+        && left_response.extra_fields().0 == right_response.extra_fields().0
 }
 
 const FALLBACK_FILENAME: &str = ".credentials.json";
@@ -868,6 +878,7 @@ mod tests {
     use anyhow::Result;
     use keyring::Error as KeyringError;
     use pretty_assertions::assert_eq;
+    use std::ffi::OsString;
     use std::sync::Barrier;
     use std::sync::Mutex;
     use std::sync::MutexGuard;
@@ -882,6 +893,10 @@ mod tests {
     struct TempCodexHome {
         _guard: MutexGuard<'static, ()>,
         _dir: tempfile::TempDir,
+        original_codex_home: Option<OsString>,
+        original_home: Option<OsString>,
+        original_tmpdir: Option<OsString>,
+        original_userprofile: Option<OsString>,
     }
 
     impl TempCodexHome {
@@ -892,12 +907,26 @@ mod tests {
                 .lock()
                 .unwrap_or_else(PoisonError::into_inner);
             let dir = tempdir().expect("create CODEX_HOME temp dir");
+            let codex_home = dir.path().join("codex-home");
+            let user_home = dir.path().join("user-home");
+            fs::create_dir_all(&codex_home).expect("create CODEX_HOME");
+            fs::create_dir_all(&user_home).expect("create user home");
+            let original_codex_home = std::env::var_os("CODEX_HOME");
+            let original_home = std::env::var_os("HOME");
+            let original_tmpdir = std::env::var_os("TMPDIR");
+            let original_userprofile = std::env::var_os("USERPROFILE");
             unsafe {
-                std::env::set_var("CODEX_HOME", dir.path());
+                std::env::set_var("CODEX_HOME", codex_home);
+                std::env::set_var("HOME", &user_home);
+                std::env::set_var("USERPROFILE", user_home);
             }
             Self {
                 _guard: guard,
                 _dir: dir,
+                original_codex_home,
+                original_home,
+                original_tmpdir,
+                original_userprofile,
             }
         }
     }
@@ -905,8 +934,18 @@ mod tests {
     impl Drop for TempCodexHome {
         fn drop(&mut self) {
             unsafe {
-                std::env::remove_var("CODEX_HOME");
+                restore_env_var("CODEX_HOME", self.original_codex_home.as_ref());
+                restore_env_var("HOME", self.original_home.as_ref());
+                restore_env_var("TMPDIR", self.original_tmpdir.as_ref());
+                restore_env_var("USERPROFILE", self.original_userprofile.as_ref());
             }
+        }
+    }
+
+    unsafe fn restore_env_var(name: &str, value: Option<&OsString>) {
+        match value {
+            Some(value) => unsafe { std::env::set_var(name, value) },
+            None => unsafe { std::env::remove_var(name) },
         }
     }
 
@@ -1143,6 +1182,65 @@ mod tests {
     }
 
     #[test]
+    fn persisted_generation_compares_vendor_fields_without_hashmap_order() {
+        let mut left = sample_tokens();
+        let mut right = left.clone();
+        let mut left_extra_fields = VendorExtraTokenFields::default();
+        left_extra_fields
+            .0
+            .insert("first".to_string(), serde_json::json!({"nested": true}));
+        left_extra_fields
+            .0
+            .insert("second".to_string(), serde_json::json!(["value"]));
+        let mut right_extra_fields = VendorExtraTokenFields::default();
+        right_extra_fields
+            .0
+            .insert("second".to_string(), serde_json::json!(["value"]));
+        right_extra_fields
+            .0
+            .insert("first".to_string(), serde_json::json!({"nested": true}));
+        left.token_response.0.set_extra_fields(left_extra_fields);
+        right.token_response.0.set_extra_fields(right_extra_fields);
+        right
+            .token_response
+            .0
+            .set_expires_in(Some(&Duration::from_secs(1)));
+
+        assert!(super::same_persisted_generation(&left, &right));
+
+        let mut changed_extra_fields = right.token_response.0.extra_fields().clone();
+        changed_extra_fields
+            .0
+            .insert("first".to_string(), serde_json::json!({"nested": false}));
+        right
+            .token_response
+            .0
+            .set_extra_fields(changed_extra_fields);
+        assert!(!super::same_persisted_generation(&left, &right));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_file_credentials_from_read_only_codex_home() -> Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let _env = TempCodexHome::new();
+        let tokens = sample_tokens();
+        super::save_oauth_tokens_to_file(&tokens)?;
+        let codex_home = find_codex_home()?;
+        let original_permissions = fs::metadata(&codex_home)?.permissions();
+        fs::set_permissions(&codex_home, fs::Permissions::from_mode(0o500))?;
+
+        let loaded = super::load_oauth_tokens_from_file(&tokens.server_name, &tokens.url);
+
+        fs::set_permissions(&codex_home, original_permissions)?;
+        let loaded = loaded?.expect("tokens should load from read-only CODEX_HOME");
+        assert_tokens_match_without_expiry(&loaded, &tokens);
+        assert!(!codex_home.join(".mcp-oauth-locks").exists());
+        Ok(())
+    }
+
+    #[test]
     fn fallback_store_serializes_writes_for_different_servers() -> Result<()> {
         let _env = TempCodexHome::new();
         let first = sample_tokens();
@@ -1198,12 +1296,18 @@ mod tests {
     }
 
     #[test]
-    fn server_generation_lock_is_shared_across_codex_homes() -> Result<()> {
+    fn server_generation_lock_is_stable_across_codex_homes_and_tmpdirs() -> Result<()> {
         let _env = TempCodexHome::new();
+        let first_tmpdir = tempdir()?;
+        unsafe {
+            std::env::set_var("TMPDIR", first_tmpdir.path());
+        }
         let first = super::oauth_server_lock_path("server", "https://example.test")?;
         let other_codex_home = tempdir()?;
+        let second_tmpdir = tempdir()?;
         unsafe {
             std::env::set_var("CODEX_HOME", other_codex_home.path());
+            std::env::set_var("TMPDIR", second_tmpdir.path());
         }
         let second = super::oauth_server_lock_path("server", "https://example.test")?;
 

--- a/codex-rs/rmcp-client/src/oauth.rs
+++ b/codex-rs/rmcp-client/src/oauth.rs
@@ -1373,6 +1373,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(any(unix, windows))]
     #[test]
     fn server_generation_lock_is_stable_across_read_only_homes_and_tmpdirs() -> Result<()> {
         #[cfg(unix)]
@@ -1385,6 +1386,14 @@ mod tests {
             std::env::set_var("TMPDIR", first_tmpdir.path());
         }
         let first = super::oauth_server_lock_path("server", "https://example.test")?;
+        #[cfg(unix)]
+        let expected_root =
+            PathBuf::from("/tmp").join(format!("codex-mcp-oauth-{}", unsafe { libc::geteuid() }));
+        #[cfg(windows)]
+        let expected_root = super::windows_local_app_data_dir()?
+            .join("Temp")
+            .join("codex-mcp-oauth-locks");
+        assert_eq!(first.parent(), Some(expected_root.as_path()));
         let other_codex_home = tempdir()?;
         let other_home = tempdir()?;
         let second_tmpdir = tempdir()?;

--- a/codex-rs/rmcp-client/src/oauth.rs
+++ b/codex-rs/rmcp-client/src/oauth.rs
@@ -977,6 +977,8 @@ mod tests {
     const FALLBACK_WRITER_VARIANT_ENV: &str = "CODEX_TEST_FALLBACK_WRITER_VARIANT";
     const FALLBACK_WRITER_ATTEMPT_ENV: &str = "CODEX_TEST_FALLBACK_WRITER_ATTEMPT";
     const FALLBACK_WRITER_DONE_ENV: &str = "CODEX_TEST_FALLBACK_WRITER_DONE";
+    const FALLBACK_HOLDER_READY_ENV: &str = "CODEX_TEST_FALLBACK_HOLDER_READY";
+    const FALLBACK_HOLDER_RELEASE_ENV: &str = "CODEX_TEST_FALLBACK_HOLDER_RELEASE";
 
     struct TempCodexHome {
         _guard: MutexGuard<'static, ()>,
@@ -1447,9 +1449,22 @@ mod tests {
             VendorExtraTokenFields::default(),
         );
 
-        let fallback_lock = super::acquire_fallback_store_lock()?;
         let codex_home = find_codex_home()?;
         let markers = tempdir()?;
+        let holder_ready = markers.path().join("holder-ready");
+        let holder_release = markers.path().join("holder-release");
+        let mut holder = Command::new(std::env::current_exe()?)
+            .args([
+                "fallback_store_lock_holder_child",
+                "--ignored",
+                "--nocapture",
+            ])
+            .env("CODEX_HOME", codex_home.as_path())
+            .env(FALLBACK_HOLDER_READY_ENV, &holder_ready)
+            .env(FALLBACK_HOLDER_RELEASE_ENV, &holder_release)
+            .spawn()?;
+        wait_for_paths(std::slice::from_ref(&holder_ready), Duration::from_secs(5))?;
+
         let mut writers = ["first", "second"]
             .into_iter()
             .map(|variant| {
@@ -1484,7 +1499,8 @@ mod tests {
             );
         }
 
-        drop(fallback_lock);
+        fs::write(holder_release, b"release")?;
+        wait_for_child_success(&mut holder, Duration::from_secs(5))?;
         for (child, _, _) in &mut writers {
             wait_for_child_success(child, Duration::from_secs(5))?;
         }
@@ -1499,6 +1515,24 @@ mod tests {
                 .collect::<std::collections::BTreeSet<_>>(),
             [first_key, second_key].into_iter().collect()
         );
+        Ok(())
+    }
+
+    #[test]
+    #[ignore = "spawned by fallback_store_serializes_cross_process_writes_for_different_servers"]
+    fn fallback_store_lock_holder_child() -> Result<()> {
+        let ready = PathBuf::from(
+            std::env::var_os(FALLBACK_HOLDER_READY_ENV)
+                .context("fallback holder ready path should be set")?,
+        );
+        let release = PathBuf::from(
+            std::env::var_os(FALLBACK_HOLDER_RELEASE_ENV)
+                .context("fallback holder release path should be set")?,
+        );
+        let fallback_lock = super::acquire_fallback_store_lock()?;
+        fs::write(ready, b"ready")?;
+        wait_for_paths(std::slice::from_ref(&release), Duration::from_secs(5))?;
+        drop(fallback_lock);
         Ok(())
     }
 

--- a/codex-rs/rmcp-client/src/oauth.rs
+++ b/codex-rs/rmcp-client/src/oauth.rs
@@ -39,6 +39,7 @@ use std::fs::OpenOptions;
 use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::time::Duration;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
@@ -51,7 +52,7 @@ use rmcp::transport::auth::CredentialStore;
 use rmcp::transport::auth::InMemoryCredentialStore;
 use rmcp::transport::auth::StoredCredentials;
 use tokio::sync::Mutex;
-use tokio::sync::Semaphore;
+use tokio::sync::OwnedMutexGuard;
 
 use codex_utils_home_dir::find_codex_home;
 
@@ -172,6 +173,15 @@ pub fn save_oauth_tokens(
     save_oauth_tokens_locked(server_name, tokens, store_mode)
 }
 
+pub(crate) async fn save_oauth_tokens_async(
+    server_name: &str,
+    tokens: &StoredOAuthTokens,
+    store_mode: OAuthCredentialsStoreMode,
+) -> Result<()> {
+    let _lock = acquire_oauth_server_lock_async(server_name, &tokens.url).await?;
+    save_oauth_tokens_locked(server_name, tokens, store_mode)
+}
+
 fn save_oauth_tokens_locked(
     server_name: &str,
     tokens: &StoredOAuthTokens,
@@ -238,6 +248,15 @@ pub fn delete_oauth_tokens(
     url: &str,
     store_mode: OAuthCredentialsStoreMode,
 ) -> Result<bool> {
+    let _lock = acquire_oauth_server_lock(server_name, url)?;
+    delete_oauth_tokens_locked(server_name, url, store_mode)
+}
+
+fn delete_oauth_tokens_locked(
+    server_name: &str,
+    url: &str,
+    store_mode: OAuthCredentialsStoreMode,
+) -> Result<bool> {
     let keyring_store = DefaultKeyringStore;
     delete_oauth_tokens_from_keyring_and_file(&keyring_store, store_mode, server_name, url)
 }
@@ -280,7 +299,12 @@ struct OAuthPersistorInner {
     authorization_manager: Arc<Mutex<AuthorizationManager>>,
     store_mode: OAuthCredentialsStoreMode,
     last_credentials: Mutex<Option<StoredOAuthTokens>>,
-    update_lock: Semaphore,
+}
+
+enum CredentialReload {
+    Unchanged,
+    Replaced,
+    Removed,
 }
 
 impl OAuthPersistor {
@@ -298,7 +322,6 @@ impl OAuthPersistor {
                 authorization_manager,
                 store_mode,
                 last_credentials: Mutex::new(initial_credentials),
-                update_lock: Semaphore::new(1),
             }),
         }
     }
@@ -306,7 +329,14 @@ impl OAuthPersistor {
     /// Persists the latest stored credentials if they have changed.
     /// Deletes the credentials if they are no longer present.
     pub(crate) async fn persist_if_needed(&self) -> Result<()> {
-        let _permit = self.inner.update_lock.acquire().await?;
+        let _server_lock =
+            acquire_oauth_server_lock_async(&self.inner.server_name, &self.inner.url).await?;
+        if !matches!(
+            self.reload_persisted_credentials_locked().await?,
+            CredentialReload::Unchanged
+        ) {
+            return Ok(());
+        }
         self.persist_if_needed_locked().await
     }
 
@@ -341,36 +371,22 @@ impl OAuthPersistor {
                     token_response: new_token_response,
                     expires_at,
                 };
-                if last_credentials
+                if !last_credentials
                     .as_ref()
                     .is_some_and(|previous| same_persisted_generation(previous, &stored))
                 {
-                    return Ok(());
+                    save_oauth_tokens_locked(
+                        &self.inner.server_name,
+                        &stored,
+                        self.inner.store_mode,
+                    )?;
+                    *self.inner.last_credentials.lock().await = Some(stored);
                 }
-
-                let _server_lock =
-                    acquire_oauth_server_lock_async(&self.inner.server_name, &self.inner.url)
-                        .await?;
-                if let Some(persisted) = load_oauth_tokens(
-                    &self.inner.server_name,
-                    &self.inner.url,
-                    self.inner.store_mode,
-                )? && !last_credentials
-                    .as_ref()
-                    .is_some_and(|previous| same_persisted_generation(previous, &persisted))
-                {
-                    self.replace_manager_credentials(&persisted).await?;
-                    *self.inner.last_credentials.lock().await = Some(persisted);
-                    return Ok(());
-                }
-
-                save_oauth_tokens_locked(&self.inner.server_name, &stored, self.inner.store_mode)?;
-                *self.inner.last_credentials.lock().await = Some(stored);
             }
             None => {
                 let mut last_serialized = self.inner.last_credentials.lock().await;
                 if last_serialized.take().is_some()
-                    && let Err(error) = delete_oauth_tokens(
+                    && let Err(error) = delete_oauth_tokens_locked(
                         &self.inner.server_name,
                         &self.inner.url,
                         self.inner.store_mode,
@@ -389,11 +405,20 @@ impl OAuthPersistor {
 
     #[expect(
         clippy::await_holding_invalid_type,
-        reason = "AuthorizationManager async access and persisted credential adoption must be serialized"
+        reason = "the server credential lock must span reload, refresh, and persistence"
     )]
     pub(crate) async fn refresh_if_needed(&self) -> Result<()> {
-        let _permit = self.inner.update_lock.acquire().await?;
-        self.adopt_persisted_credentials_if_changed().await?;
+        let _server_lock =
+            acquire_oauth_server_lock_async(&self.inner.server_name, &self.inner.url).await?;
+        if matches!(
+            self.reload_persisted_credentials_locked().await?,
+            CredentialReload::Removed
+        ) {
+            return Err(anyhow::anyhow!(
+                "OAuth credentials were removed for server {}",
+                self.inner.server_name
+            ));
+        }
 
         let expires_at = {
             let guard = self.inner.last_credentials.lock().await;
@@ -418,29 +443,41 @@ impl OAuthPersistor {
         self.persist_if_needed_locked().await
     }
 
-    async fn adopt_persisted_credentials_if_changed(&self) -> Result<()> {
-        let _server_lock =
-            acquire_oauth_server_lock_async(&self.inner.server_name, &self.inner.url).await?;
-        let Some(persisted) = load_oauth_tokens(
+    async fn reload_persisted_credentials_locked(&self) -> Result<CredentialReload> {
+        let loaded = load_oauth_tokens(
             &self.inner.server_name,
             &self.inner.url,
             self.inner.store_mode,
-        )?
-        else {
-            return Ok(());
-        };
+        )
+        .with_context(|| {
+            format!(
+                "failed to reload OAuth tokens for server {}",
+                self.inner.server_name
+            )
+        })?;
 
         let last_credentials = self.inner.last_credentials.lock().await.clone();
-        if last_credentials
-            .as_ref()
-            .is_some_and(|previous| same_persisted_generation(previous, &persisted))
-        {
-            return Ok(());
+        let unchanged = match (&loaded, &last_credentials) {
+            (Some(loaded), Some(previous)) => same_persisted_generation(loaded, previous),
+            (None, None) => true,
+            _ => false,
+        };
+        if unchanged {
+            return Ok(CredentialReload::Unchanged);
         }
 
-        self.replace_manager_credentials(&persisted).await?;
-        *self.inner.last_credentials.lock().await = Some(persisted);
-        Ok(())
+        match loaded {
+            Some(tokens) => {
+                self.replace_manager_credentials(&tokens).await?;
+                *self.inner.last_credentials.lock().await = Some(tokens);
+                Ok(CredentialReload::Replaced)
+            }
+            None => {
+                self.clear_manager_credentials().await;
+                *self.inner.last_credentials.lock().await = None;
+                Ok(CredentialReload::Removed)
+            }
+        }
     }
 
     async fn replace_manager_credentials(&self, tokens: &StoredOAuthTokens) -> Result<()> {
@@ -469,33 +506,112 @@ impl OAuthPersistor {
         guard.set_credential_store(store);
         Ok(())
     }
+
+    async fn clear_manager_credentials(&self) {
+        let manager = self.inner.authorization_manager.clone();
+        let mut guard = manager.lock().await;
+        guard.set_credential_store(InMemoryCredentialStore::new());
+    }
+}
+
+fn oauth_server_lock_for(server_name: &str, url: &str) -> Arc<Mutex<()>> {
+    static OAUTH_SERVER_LOCKS: OnceLock<std::sync::Mutex<BTreeMap<String, Arc<Mutex<()>>>>> =
+        OnceLock::new();
+
+    let mut locks = OAUTH_SERVER_LOCKS
+        .get_or_init(std::sync::Mutex::default)
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    locks
+        .entry(format!("{server_name}\n{url}"))
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone()
 }
 
 struct OAuthServerLock {
     _file: fs::File,
+    _in_process_guard: Option<OwnedMutexGuard<()>>,
 }
 
 fn acquire_oauth_server_lock(server_name: &str, url: &str) -> Result<OAuthServerLock> {
-    let digest = sha_256_prefix(&Value::String(format!("{server_name}\n{url}")))?;
-    let path = find_codex_home()?.join(format!(".mcp-oauth-{digest}.lock"));
-    let file = OpenOptions::new()
+    let path = oauth_server_lock_path(server_name, url)?;
+    let file = open_oauth_lock_file(&path)?;
+    file.lock()
+        .with_context(|| format!("failed to lock OAuth credentials at {}", path.display()))?;
+    Ok(OAuthServerLock {
+        _file: file,
+        _in_process_guard: None,
+    })
+}
+
+async fn acquire_oauth_server_lock_async(server_name: &str, url: &str) -> Result<OAuthServerLock> {
+    let in_process_guard = oauth_server_lock_for(server_name, url).lock_owned().await;
+    let path = oauth_server_lock_path(server_name, url)?;
+    let file = tokio::task::spawn_blocking({
+        let path = path.clone();
+        move || {
+            let file = open_oauth_lock_file(&path)?;
+            file.lock().with_context(|| {
+                format!("failed to lock OAuth credentials at {}", path.display())
+            })?;
+            Ok::<_, anyhow::Error>(file)
+        }
+    })
+    .await
+    .context("OAuth credential lock task failed")??;
+    Ok(OAuthServerLock {
+        _file: file,
+        _in_process_guard: Some(in_process_guard),
+    })
+}
+
+struct FallbackStoreLock {
+    _in_process_guard: std::sync::MutexGuard<'static, ()>,
+    _file: fs::File,
+}
+
+fn acquire_fallback_store_lock() -> Result<FallbackStoreLock> {
+    static FALLBACK_STORE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    let in_process_guard = FALLBACK_STORE_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let path = find_codex_home()?.join(".mcp-oauth-locks/fallback-store.lock");
+    let file = open_oauth_lock_file(&path)?;
+    file.lock().with_context(|| {
+        format!(
+            "failed to lock fallback OAuth credentials at {}",
+            path.display()
+        )
+    })?;
+    Ok(FallbackStoreLock {
+        _in_process_guard: in_process_guard,
+        _file: file,
+    })
+}
+
+fn open_oauth_lock_file(path: &std::path::Path) -> Result<fs::File> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    OpenOptions::new()
         .read(true)
         .write(true)
         .create(true)
         .truncate(false)
-        .open(&path)
-        .with_context(|| format!("failed to open OAuth credential lock at {}", path.display()))?;
-    file.lock()
-        .with_context(|| format!("failed to lock OAuth credentials at {}", path.display()))?;
-    Ok(OAuthServerLock { _file: file })
+        .open(path)
+        .with_context(|| format!("failed to open OAuth credential lock at {}", path.display()))
 }
 
-async fn acquire_oauth_server_lock_async(server_name: &str, url: &str) -> Result<OAuthServerLock> {
-    let server_name = server_name.to_string();
-    let url = url.to_string();
-    tokio::task::spawn_blocking(move || acquire_oauth_server_lock(&server_name, &url))
-        .await
-        .context("OAuth credential lock task failed")?
+fn oauth_server_lock_path(server_name: &str, url: &str) -> Result<PathBuf> {
+    let server_digest = sha_256_prefix(&Value::String(format!("{server_name}\n{url}")))?;
+    let user_identity = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .unwrap_or_else(|| std::env::temp_dir().into_os_string());
+    let user_digest = sha_256_prefix(&Value::String(user_identity.to_string_lossy().into_owned()))?;
+    Ok(std::env::temp_dir()
+        .join(format!("codex-mcp-oauth-{user_digest}"))
+        .join(format!("server-{server_digest}.lock")))
 }
 
 fn same_persisted_generation(left: &StoredOAuthTokens, right: &StoredOAuthTokens) -> bool {
@@ -507,16 +623,15 @@ fn same_persisted_generation(left: &StoredOAuthTokens, right: &StoredOAuthTokens
         return false;
     }
 
-    let normalize = |response: &WrappedOAuthTokenResponse| {
-        let mut value = serde_json::to_value(response).ok()?;
-        value.as_object_mut()?.remove("expires_in");
-        Some(value)
-    };
+    let mut left_response = left.token_response.0.clone();
+    let mut right_response = right.token_response.0.clone();
+    left_response.set_expires_in(None);
+    right_response.set_expires_in(None);
     match (
-        normalize(&left.token_response),
-        normalize(&right.token_response),
+        serde_json::to_string(&left_response),
+        serde_json::to_string(&right_response),
     ) {
-        (Some(left), Some(right)) => left == right,
+        (Ok(left), Ok(right)) => left == right,
         _ => false,
     }
 }
@@ -541,6 +656,7 @@ struct FallbackTokenEntry {
 }
 
 fn load_oauth_tokens_from_file(server_name: &str, url: &str) -> Result<Option<StoredOAuthTokens>> {
+    let _lock = acquire_fallback_store_lock()?;
     let Some(store) = read_fallback_file()? else {
         return Ok(None);
     };
@@ -584,6 +700,7 @@ fn load_oauth_tokens_from_file(server_name: &str, url: &str) -> Result<Option<St
 }
 
 fn save_oauth_tokens_to_file(tokens: &StoredOAuthTokens) -> Result<()> {
+    let _lock = acquire_fallback_store_lock()?;
     let key = compute_store_key(&tokens.server_name, &tokens.url)?;
     let mut store = read_fallback_file()?.unwrap_or_default();
 
@@ -613,6 +730,7 @@ fn save_oauth_tokens_to_file(tokens: &StoredOAuthTokens) -> Result<()> {
 }
 
 fn delete_oauth_tokens_from_file(key: &str) -> Result<bool> {
+    let _lock = acquire_fallback_store_lock()?;
     let mut store = match read_fallback_file()? {
         Some(store) => store,
         None => return Ok(false),
@@ -750,10 +868,13 @@ mod tests {
     use anyhow::Result;
     use keyring::Error as KeyringError;
     use pretty_assertions::assert_eq;
+    use std::sync::Barrier;
     use std::sync::Mutex;
     use std::sync::MutexGuard;
     use std::sync::OnceLock;
     use std::sync::PoisonError;
+    use std::sync::mpsc;
+    use std::thread;
     use tempfile::tempdir;
 
     use codex_keyring_store::tests::MockKeyringStore;
@@ -997,6 +1118,97 @@ mod tests {
         super::refresh_expires_in_from_timestamp(&mut tokens);
 
         assert_eq!(tokens.token_response.0.expires_in(), Some(Duration::ZERO));
+    }
+
+    #[test]
+    fn persisted_generation_ignores_reload_expires_in_drift() -> Result<()> {
+        let _env = TempCodexHome::new();
+        let mut tokens = sample_tokens();
+        tokens
+            .token_response
+            .0
+            .set_expires_in(Some(&Duration::from_secs(7200)));
+
+        super::save_oauth_tokens_to_file(&tokens)?;
+        let loaded = super::load_oauth_tokens_from_file(&tokens.server_name, &tokens.url)?
+            .expect("saved tokens should reload");
+
+        assert_ne!(
+            loaded.token_response.0.expires_in(),
+            tokens.token_response.0.expires_in()
+        );
+        assert_ne!(loaded, tokens);
+        assert!(super::same_persisted_generation(&loaded, &tokens));
+        Ok(())
+    }
+
+    #[test]
+    fn fallback_store_serializes_writes_for_different_servers() -> Result<()> {
+        let _env = TempCodexHome::new();
+        let first = sample_tokens();
+        let mut second = sample_tokens();
+        second.server_name = "other-server".to_string();
+        second.url = "https://other.example.test".to_string();
+        second.token_response.0 = OAuthTokenResponse::new(
+            AccessToken::new("other-access-token".to_string()),
+            BasicTokenType::Bearer,
+            VendorExtraTokenFields::default(),
+        );
+
+        let fallback_lock = super::acquire_fallback_store_lock()?;
+        let barrier = Arc::new(Barrier::new(3));
+        let (tx, rx) = mpsc::channel();
+        let handles = [first.clone(), second.clone()]
+            .into_iter()
+            .map(|tokens| {
+                let barrier = Arc::clone(&barrier);
+                let tx = tx.clone();
+                thread::spawn(move || {
+                    barrier.wait();
+                    tx.send(super::save_oauth_tokens_to_file(&tokens))
+                        .expect("send save result");
+                })
+            })
+            .collect::<Vec<_>>();
+        drop(tx);
+
+        barrier.wait();
+        thread::sleep(Duration::from_millis(50));
+        assert!(matches!(rx.try_recv(), Err(mpsc::TryRecvError::Empty)));
+
+        drop(fallback_lock);
+        for _ in 0..2 {
+            rx.recv_timeout(Duration::from_secs(5))??;
+        }
+        for handle in handles {
+            handle.join().expect("fallback writer should not panic");
+        }
+
+        let store = super::read_fallback_file()?.expect("fallback file should load");
+        let first_key = super::compute_store_key(&first.server_name, &first.url)?;
+        let second_key = super::compute_store_key(&second.server_name, &second.url)?;
+        assert_eq!(
+            store
+                .keys()
+                .cloned()
+                .collect::<std::collections::BTreeSet<_>>(),
+            [first_key, second_key].into_iter().collect()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn server_generation_lock_is_shared_across_codex_homes() -> Result<()> {
+        let _env = TempCodexHome::new();
+        let first = super::oauth_server_lock_path("server", "https://example.test")?;
+        let other_codex_home = tempdir()?;
+        unsafe {
+            std::env::set_var("CODEX_HOME", other_codex_home.path());
+        }
+        let second = super::oauth_server_lock_path("server", "https://example.test")?;
+
+        assert_eq!(first, second);
+        Ok(())
     }
 
     fn assert_tokens_match_without_expiry(

--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs
@@ -26,7 +26,7 @@ use urlencoding::decode;
 use crate::StoredOAuthTokens;
 use crate::WrappedOAuthTokenResponse;
 use crate::oauth::compute_expires_at_millis;
-use crate::save_oauth_tokens;
+use crate::oauth::save_oauth_tokens_async;
 use crate::utils::apply_default_headers;
 use crate::utils::build_default_headers;
 use codex_config::types::OAuthCredentialsStoreMode;
@@ -571,7 +571,7 @@ impl OauthLoginFlow {
                 token_response: WrappedOAuthTokenResponse(credentials),
                 expires_at,
             };
-            save_oauth_tokens(&self.server_name, &stored, self.store_mode)?;
+            save_oauth_tokens_async(&self.server_name, &stored, self.store_mode).await?;
 
             Ok(())
         }

--- a/codex-rs/rmcp-client/src/rmcp_client.rs
+++ b/codex-rs/rmcp-client/src/rmcp_client.rs
@@ -445,7 +445,6 @@ impl RmcpClient {
                 async move { service.list_tools(params).await }.boxed()
             })
             .await?;
-        self.persist_oauth_tokens().await;
         Ok(result)
     }
 
@@ -478,7 +477,6 @@ impl RmcpClient {
                 })
             })
             .collect::<Result<Vec<_>>>()?;
-        self.persist_oauth_tokens().await;
         Ok(ListToolsWithConnectorIdResult {
             next_cursor: result.next_cursor,
             tools,
@@ -504,7 +502,6 @@ impl RmcpClient {
                 async move { service.list_resources(params).await }.boxed()
             })
             .await?;
-        self.persist_oauth_tokens().await;
         Ok(result)
     }
 
@@ -519,7 +516,6 @@ impl RmcpClient {
                 async move { service.list_resource_templates(params).await }.boxed()
             })
             .await?;
-        self.persist_oauth_tokens().await;
         Ok(result)
     }
 
@@ -534,7 +530,6 @@ impl RmcpClient {
                 async move { service.read_resource(params).await }.boxed()
             })
             .await?;
-        self.persist_oauth_tokens().await;
         Ok(result)
     }
 
@@ -591,7 +586,6 @@ impl RmcpClient {
                 .boxed()
             })
             .await?;
-        self.persist_oauth_tokens().await;
         Ok(result)
     }
 
@@ -620,7 +614,6 @@ impl RmcpClient {
             },
         )
         .await?;
-        self.persist_oauth_tokens().await;
         Ok(())
     }
 
@@ -642,7 +635,6 @@ impl RmcpClient {
                 .boxed()
             })
             .await?;
-        self.persist_oauth_tokens().await;
         Ok(response)
     }
 
@@ -903,7 +895,9 @@ impl RmcpClient {
     {
         let operation = async {
             self.refresh_oauth_if_needed().await;
-            operation(service).await
+            let result = operation(service).await?;
+            self.persist_oauth_tokens().await;
+            Ok::<T, rmcp::service::ServiceError>(result)
         };
         match timeout {
             Some(duration) => active_time_timeout(duration, pause_state.subscribe(), operation)

--- a/codex-rs/rmcp-client/src/rmcp_client.rs
+++ b/codex-rs/rmcp-client/src/rmcp_client.rs
@@ -47,7 +47,6 @@ use rmcp::service::{self};
 use rmcp::transport::StreamableHttpClientTransport;
 use rmcp::transport::auth::AuthClient;
 use rmcp::transport::auth::AuthError;
-use rmcp::transport::auth::OAuthState;
 use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
 use rmcp::transport::streamable_http_client::StreamableHttpError;
 use serde::Deserialize;
@@ -66,6 +65,7 @@ use crate::in_process_transport::InProcessTransportFactory;
 use crate::load_oauth_tokens;
 use crate::oauth::OAuthPersistor;
 use crate::oauth::StoredOAuthTokens;
+use crate::oauth::authorization_manager_from_tokens;
 use crate::stdio_server_launcher::StdioServerCommand;
 use crate::stdio_server_launcher::StdioServerLauncher;
 use crate::stdio_server_launcher::StdioServerProcessHandle;
@@ -439,7 +439,6 @@ impl RmcpClient {
         params: Option<PaginatedRequestParams>,
         timeout: Option<Duration>,
     ) -> Result<ListToolsResult> {
-        self.refresh_oauth_if_needed().await;
         let result = self
             .run_service_operation("tools/list", timeout, move |service| {
                 let params = params.clone();
@@ -455,7 +454,6 @@ impl RmcpClient {
         params: Option<PaginatedRequestParams>,
         timeout: Option<Duration>,
     ) -> Result<ListToolsWithConnectorIdResult> {
-        self.refresh_oauth_if_needed().await;
         let result = self
             .run_service_operation("tools/list", timeout, move |service| {
                 let params = params.clone();
@@ -500,7 +498,6 @@ impl RmcpClient {
         params: Option<PaginatedRequestParams>,
         timeout: Option<Duration>,
     ) -> Result<ListResourcesResult> {
-        self.refresh_oauth_if_needed().await;
         let result = self
             .run_service_operation("resources/list", timeout, move |service| {
                 let params = params.clone();
@@ -516,7 +513,6 @@ impl RmcpClient {
         params: Option<PaginatedRequestParams>,
         timeout: Option<Duration>,
     ) -> Result<ListResourceTemplatesResult> {
-        self.refresh_oauth_if_needed().await;
         let result = self
             .run_service_operation("resources/templates/list", timeout, move |service| {
                 let params = params.clone();
@@ -532,7 +528,6 @@ impl RmcpClient {
         params: ReadResourceRequestParams,
         timeout: Option<Duration>,
     ) -> Result<ReadResourceResult> {
-        self.refresh_oauth_if_needed().await;
         let result = self
             .run_service_operation("resources/read", timeout, move |service| {
                 let params = params.clone();
@@ -550,7 +545,6 @@ impl RmcpClient {
         meta: Option<serde_json::Value>,
         timeout: Option<Duration>,
     ) -> Result<CallToolResult> {
-        self.refresh_oauth_if_needed().await;
         let arguments = match arguments {
             Some(Value::Object(map)) => Some(map),
             Some(other) => {
@@ -606,7 +600,6 @@ impl RmcpClient {
         method: &str,
         params: Option<serde_json::Value>,
     ) -> Result<()> {
-        self.refresh_oauth_if_needed().await;
         self.run_service_operation(
             "notifications/custom",
             /*timeout*/ None,
@@ -636,7 +629,6 @@ impl RmcpClient {
         method: &str,
         params: Option<serde_json::Value>,
     ) -> Result<ServerResult> {
-        self.refresh_oauth_if_needed().await;
         let response = self
             .run_service_operation("requests/custom", /*timeout*/ None, move |service| {
                 let params = params.clone();
@@ -869,20 +861,21 @@ impl RmcpClient {
         Fut: std::future::Future<Output = std::result::Result<T, rmcp::service::ServiceError>>,
     {
         let service = self.service().await?;
-        match Self::run_service_operation_once(
-            Arc::clone(&service),
-            label,
-            timeout,
-            self.elicitation_pause_state.clone(),
-            &operation,
-        )
-        .await
+        match self
+            .run_service_operation_once(
+                Arc::clone(&service),
+                label,
+                timeout,
+                self.elicitation_pause_state.clone(),
+                &operation,
+            )
+            .await
         {
             Ok(result) => Ok(result),
             Err(error) if Self::is_session_expired_404(&error) => {
                 self.reinitialize_after_session_expiry(&service).await?;
                 let recovered_service = self.service().await?;
-                Self::run_service_operation_once(
+                self.run_service_operation_once(
                     recovered_service,
                     label,
                     timeout,
@@ -897,6 +890,7 @@ impl RmcpClient {
     }
 
     async fn run_service_operation_once<T, F, Fut>(
+        &self,
         service: Arc<RunningService<RoleClient, ElicitationClientService>>,
         label: &str,
         timeout: Option<Duration>,
@@ -907,17 +901,19 @@ impl RmcpClient {
         F: Fn(Arc<RunningService<RoleClient, ElicitationClientService>>) -> Fut,
         Fut: std::future::Future<Output = std::result::Result<T, rmcp::service::ServiceError>>,
     {
+        let operation = async {
+            self.refresh_oauth_if_needed().await;
+            operation(service).await
+        };
         match timeout {
-            Some(duration) => {
-                active_time_timeout(duration, pause_state.subscribe(), operation(service))
-                    .await
-                    .map_err(|_| ClientOperationError::Timeout {
-                        label: label.to_string(),
-                        duration,
-                    })?
-                    .map_err(ClientOperationError::from)
-            }
-            None => operation(service).await.map_err(ClientOperationError::from),
+            Some(duration) => active_time_timeout(duration, pause_state.subscribe(), operation)
+                .await
+                .map_err(|_| ClientOperationError::Timeout {
+                    label: label.to_string(),
+                    duration,
+                })?
+                .map_err(ClientOperationError::from),
+            None => operation.await.map_err(ClientOperationError::from),
         }
     }
 
@@ -1021,23 +1017,9 @@ async fn create_oauth_transport_and_runtime(
     // TODO(aibrahim): teach OAuth bootstrap and refresh to use the same
     // shared HTTP client abstraction instead of always creating the local
     // reqwest metadata client here.
-    let mut oauth_state =
-        OAuthState::new(url.to_string(), Some(oauth_metadata_client.clone())).await?;
-
-    oauth_state
-        .set_credentials(
-            &initial_tokens.client_id,
-            initial_tokens.token_response.0.clone(),
-        )
-        .await?;
-
-    let manager = match oauth_state {
-        OAuthState::Authorized(manager) => manager,
-        OAuthState::Unauthorized(manager) => manager,
-        _ => {
-            return Err(anyhow!("unexpected OAuth state during client setup"));
-        }
-    };
+    let manager =
+        authorization_manager_from_tokens(url, oauth_metadata_client.clone(), &initial_tokens)
+            .await?;
 
     let auth_client = AuthClient::new(
         StreamableHttpClientAdapter::new(http_client, default_headers, /*auth_provider*/ None),
@@ -1054,6 +1036,7 @@ async fn create_oauth_transport_and_runtime(
         server_name.to_string(),
         url.to_string(),
         auth_manager,
+        oauth_metadata_client,
         credentials_store,
         Some(initial_tokens),
     );

--- a/codex-rs/rmcp-client/tests/streamable_http_oauth_startup.rs
+++ b/codex-rs/rmcp-client/tests/streamable_http_oauth_startup.rs
@@ -1,8 +1,5 @@
 mod streamable_http_test_support;
 
-use std::sync::Arc;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
@@ -16,7 +13,6 @@ use codex_rmcp_client::save_oauth_tokens;
 use oauth2::AccessToken;
 use oauth2::RefreshToken;
 use oauth2::basic::BasicTokenType;
-use pretty_assertions::assert_eq;
 use rmcp::transport::auth::OAuthTokenResponse;
 use rmcp::transport::auth::VendorExtraTokenFields;
 use serde_json::Value;
@@ -46,7 +42,6 @@ const EXTERNAL_ACCESS_TOKEN: &str = "external-access-token";
 const EXTERNAL_REFRESH_TOKEN: &str = "external-refresh-token";
 const STALE_REFRESHED_ACCESS_TOKEN: &str = "stale-refreshed-access-token";
 const STALE_ROTATED_REFRESH_TOKEN: &str = "stale-rotated-refresh-token";
-const REFRESH_SKEW: Duration = Duration::from_secs(30);
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn refreshes_expired_persisted_token_before_initialize() -> anyhow::Result<()> {
@@ -169,7 +164,7 @@ async fn oauth_startup_child() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn running_client_keeps_and_can_persist_over_external_oauth_update() -> anyhow::Result<()> {
+async fn running_client_adopts_external_oauth_update_before_next_operation() -> anyhow::Result<()> {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/.well-known/oauth-authorization-server/mcp"))
@@ -181,77 +176,56 @@ async fn running_client_keeps_and_can_persist_over_external_oauth_update() -> an
         .expect(1)
         .mount(&server)
         .await;
-    Mock::given(method("POST"))
-        .and(path("/oauth/token"))
-        .and(body_string_contains("grant_type=refresh_token"))
-        .and(body_string_contains(format!(
-            "refresh_token={OLD_REFRESH_TOKEN}"
-        )))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "access_token": STALE_REFRESHED_ACCESS_TOKEN,
-            "token_type": "Bearer",
-            "expires_in": 7200,
-            "refresh_token": STALE_ROTATED_REFRESH_TOKEN,
-        })))
-        .expect(1)
-        .mount(&server)
-        .await;
 
-    let tool_call_count = Arc::new(AtomicUsize::new(0));
     Mock::given(method("POST"))
         .and(path("/mcp"))
-        .respond_with({
-            let tool_call_count = Arc::clone(&tool_call_count);
-            move |request: &Request| {
-                let body: Value = request.body_json().expect("valid JSON-RPC request");
-                let method = body.get("method").and_then(Value::as_str);
-                let authorization = request
-                    .headers
-                    .get("authorization")
-                    .and_then(|value| value.to_str().ok());
-                let expected_access_token = match method {
-                    Some("tools/call") if tool_call_count.fetch_add(1, Ordering::SeqCst) == 1 => {
-                        STALE_REFRESHED_ACCESS_TOKEN
-                    }
-                    _ => OLD_ACCESS_TOKEN,
-                };
-                if authorization != Some(format!("Bearer {expected_access_token}").as_str()) {
-                    return ResponseTemplate::new(401);
-                }
+        .respond_with(|request: &Request| {
+            let body: Value = request.body_json().expect("valid JSON-RPC request");
+            let request_method = body.get("method").and_then(Value::as_str);
+            let expected_access_token = match request_method {
+                Some("tools/call") => EXTERNAL_ACCESS_TOKEN,
+                _ => OLD_ACCESS_TOKEN,
+            };
+            let authorization = request
+                .headers
+                .get("authorization")
+                .and_then(|value| value.to_str().ok());
+            if authorization != Some(format!("Bearer {expected_access_token}").as_str()) {
+                return ResponseTemplate::new(401);
+            }
 
-                match method {
-                    Some("initialize") => ResponseTemplate::new(200).set_body_json(json!({
-                        "jsonrpc": "2.0",
-                        "id": body.get("id").cloned().unwrap_or(Value::Null),
-                        "result": {
-                            "protocolVersion": body
-                                .pointer("/params/protocolVersion")
-                                .cloned()
-                                .unwrap_or_else(|| json!("2025-06-18")),
-                            "capabilities": {
-                                "tools": {},
-                            },
-                            "serverInfo": {
-                                "name": "oauth-external-update-test",
-                                "version": "0.0.0-test",
-                            },
+            match request_method {
+                Some("initialize") => ResponseTemplate::new(200).set_body_json(json!({
+                    "jsonrpc": "2.0",
+                    "id": body.get("id").cloned().unwrap_or(Value::Null),
+                    "result": {
+                        "protocolVersion": body
+                            .pointer("/params/protocolVersion")
+                            .cloned()
+                            .unwrap_or_else(|| json!("2025-06-18")),
+                        "capabilities": {
+                            "tools": {},
                         },
-                    })),
-                    Some("notifications/initialized") => ResponseTemplate::new(202),
-                    Some("tools/call") => ResponseTemplate::new(200).set_body_json(json!({
-                        "jsonrpc": "2.0",
-                        "id": body.get("id").cloned().unwrap_or(Value::Null),
-                        "result": {
-                            "content": [],
-                            "isError": false,
+                        "serverInfo": {
+                            "name": "oauth-external-update-test",
+                            "version": "0.0.0-test",
                         },
-                    })),
-                    method => ResponseTemplate::new(400)
-                        .set_body_string(format!("unexpected JSON-RPC method: {method:?}")),
-                }
+                    },
+                })),
+                Some("notifications/initialized") => ResponseTemplate::new(202),
+                Some("tools/call") => ResponseTemplate::new(200).set_body_json(json!({
+                    "jsonrpc": "2.0",
+                    "id": body.get("id").cloned().unwrap_or(Value::Null),
+                    "result": {
+                        "content": [],
+                        "isError": false,
+                    },
+                })),
+                method => ResponseTemplate::new(400)
+                    .set_body_string(format!("unexpected JSON-RPC method: {method:?}")),
             }
         })
-        .expect(4)
+        .expect(3)
         .mount(&server)
         .await;
 
@@ -272,25 +246,19 @@ async fn running_client_keeps_and_can_persist_over_external_oauth_update() -> an
         status.success(),
         "OAuth external update child failed: {status}"
     );
-    assert_eq!(tool_call_count.load(Ordering::SeqCst), 2);
     server.verify().await;
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-#[ignore = "spawned by running_client_keeps_and_can_persist_over_external_oauth_update"]
+#[ignore = "spawned by running_client_adopts_external_oauth_update_before_next_operation"]
 async fn oauth_external_update_child() -> anyhow::Result<()> {
     let server_url = std::env::var(EXTERNAL_UPDATE_CHILD_SERVER_URL_ENV)?;
-    let old_expires_at = SystemTime::now()
-        .duration_since(UNIX_EPOCH)?
-        .checked_add(REFRESH_SKEW + Duration::from_secs(5))
-        .expect("test expiry should fit")
-        .as_millis() as u64;
     save_test_tokens(
         &server_url,
         OLD_ACCESS_TOKEN,
         OLD_REFRESH_TOKEN,
-        old_expires_at,
+        future_expiry()?,
     )?;
 
     let client = RmcpClient::new_streamable_http_client(
@@ -306,51 +274,182 @@ async fn oauth_external_update_child() -> anyhow::Result<()> {
     .await?;
     initialize_client(&client).await?;
 
-    let external_expires_at = SystemTime::now()
-        .duration_since(UNIX_EPOCH)?
-        .checked_add(Duration::from_secs(7200))
-        .expect("test expiry should fit")
-        .as_millis() as u64;
     save_test_tokens(
         &server_url,
         EXTERNAL_ACCESS_TOKEN,
         EXTERNAL_REFRESH_TOKEN,
-        external_expires_at,
+        future_expiry()?,
     )?;
 
     client
         .call_tool(
-            "first-call-after-external-update".to_string(),
+            "call-after-external-update".to_string(),
             /*arguments*/ None,
             /*meta*/ None,
             Some(Duration::from_secs(5)),
         )
         .await?;
 
-    let refresh_at = UNIX_EPOCH
-        + Duration::from_millis(old_expires_at)
-            .saturating_sub(REFRESH_SKEW)
-            .saturating_add(Duration::from_millis(250));
-    if let Ok(wait) = refresh_at.duration_since(SystemTime::now()) {
-        tokio::time::sleep(wait).await;
-    }
+    assert_persisted_tokens(EXTERNAL_ACCESS_TOKEN, EXTERNAL_REFRESH_TOKEN)?;
+    Ok(())
+}
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn refresh_does_not_overwrite_external_oauth_update() -> anyhow::Result<()> {
+    let codex_home = TempDir::new()?;
+    let status = Command::new(std::env::current_exe()?)
+        .args([
+            "oauth_external_update_during_refresh_child",
+            "--exact",
+            "--ignored",
+            "--nocapture",
+        ])
+        .env("CODEX_HOME", codex_home.path())
+        .status()
+        .await?;
+    assert!(
+        status.success(),
+        "OAuth external update during refresh child failed: {status}"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[ignore = "spawned by refresh_does_not_overwrite_external_oauth_update"]
+async fn oauth_external_update_during_refresh_child() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+    let server_url = format!("{}/mcp", server.uri());
+    Mock::given(method("GET"))
+        .and(path("/.well-known/oauth-authorization-server/mcp"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "authorization_endpoint": format!("{}/oauth/authorize", server.uri()),
+            "token_endpoint": format!("{}/oauth/token", server.uri()),
+            "scopes_supported": [""],
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .and(body_string_contains("grant_type=refresh_token"))
+        .and(body_string_contains(format!(
+            "refresh_token={OLD_REFRESH_TOKEN}"
+        )))
+        .respond_with({
+            let server_url = server_url.clone();
+            move |_request: &Request| {
+                save_test_tokens(
+                    &server_url,
+                    EXTERNAL_ACCESS_TOKEN,
+                    EXTERNAL_REFRESH_TOKEN,
+                    future_expiry().expect("future expiry"),
+                )
+                .expect("save externally updated credentials");
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "access_token": STALE_REFRESHED_ACCESS_TOKEN,
+                    "token_type": "Bearer",
+                    "expires_in": 7200,
+                    "refresh_token": STALE_ROTATED_REFRESH_TOKEN,
+                }))
+            }
+        })
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/mcp"))
+        .respond_with(|request: &Request| {
+            let body: Value = request.body_json().expect("valid JSON-RPC request");
+            let request_method = body.get("method").and_then(Value::as_str);
+            let expected_access_token = match request_method {
+                Some("tools/call") => EXTERNAL_ACCESS_TOKEN,
+                _ => STALE_REFRESHED_ACCESS_TOKEN,
+            };
+            let authorization = request
+                .headers
+                .get("authorization")
+                .and_then(|value| value.to_str().ok());
+            if authorization != Some(format!("Bearer {expected_access_token}").as_str()) {
+                return ResponseTemplate::new(401);
+            }
+
+            match request_method {
+                Some("initialize") => ResponseTemplate::new(200).set_body_json(json!({
+                    "jsonrpc": "2.0",
+                    "id": body.get("id").cloned().unwrap_or(Value::Null),
+                    "result": {
+                        "protocolVersion": body
+                            .pointer("/params/protocolVersion")
+                            .cloned()
+                            .unwrap_or_else(|| json!("2025-06-18")),
+                        "capabilities": {
+                            "tools": {},
+                        },
+                        "serverInfo": {
+                            "name": "oauth-external-refresh-test",
+                            "version": "0.0.0-test",
+                        },
+                    },
+                })),
+                Some("notifications/initialized") => ResponseTemplate::new(202),
+                Some("tools/call") => ResponseTemplate::new(200).set_body_json(json!({
+                    "jsonrpc": "2.0",
+                    "id": body.get("id").cloned().unwrap_or(Value::Null),
+                    "result": {
+                        "content": [],
+                        "isError": false,
+                    },
+                })),
+                method => ResponseTemplate::new(400)
+                    .set_body_string(format!("unexpected JSON-RPC method: {method:?}")),
+            }
+        })
+        .expect(3)
+        .mount(&server)
+        .await;
+
+    save_test_tokens(&server_url, OLD_ACCESS_TOKEN, OLD_REFRESH_TOKEN, 0)?;
+    let client = RmcpClient::new_streamable_http_client(
+        SERVER_NAME,
+        &server_url,
+        /*bearer_token*/ None,
+        /*http_headers*/ None,
+        /*env_http_headers*/ None,
+        OAuthCredentialsStoreMode::File,
+        Environment::default_for_tests().get_http_client(),
+        /*auth_provider*/ None,
+    )
+    .await?;
+    initialize_client(&client).await?;
     client
         .call_tool(
-            "second-call-after-stale-refresh".to_string(),
+            "call-after-refresh-race".to_string(),
             /*arguments*/ None,
             /*meta*/ None,
             Some(Duration::from_secs(5)),
         )
         .await?;
 
+    assert_persisted_tokens(EXTERNAL_ACCESS_TOKEN, EXTERNAL_REFRESH_TOKEN)?;
+    server.verify().await;
+    Ok(())
+}
+
+fn future_expiry() -> anyhow::Result<u64> {
+    Ok(SystemTime::now()
+        .duration_since(UNIX_EPOCH)?
+        .saturating_add(Duration::from_secs(7200))
+        .as_millis() as u64)
+}
+
+fn assert_persisted_tokens(access_token: &str, refresh_token: &str) -> anyhow::Result<()> {
     let credentials = std::fs::read_to_string(
         std::path::Path::new(&std::env::var("CODEX_HOME")?).join(".credentials.json"),
     )?;
-    assert!(credentials.contains(STALE_REFRESHED_ACCESS_TOKEN));
-    assert!(credentials.contains(STALE_ROTATED_REFRESH_TOKEN));
-    assert!(!credentials.contains(EXTERNAL_ACCESS_TOKEN));
-    assert!(!credentials.contains(EXTERNAL_REFRESH_TOKEN));
+    assert!(credentials.contains(access_token));
+    assert!(credentials.contains(refresh_token));
+    assert!(!credentials.contains(STALE_REFRESHED_ACCESS_TOKEN));
+    assert!(!credentials.contains(STALE_ROTATED_REFRESH_TOKEN));
     Ok(())
 }
 

--- a/codex-rs/rmcp-client/tests/streamable_http_oauth_startup.rs
+++ b/codex-rs/rmcp-client/tests/streamable_http_oauth_startup.rs
@@ -1,6 +1,7 @@
 mod streamable_http_test_support;
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::Duration;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
@@ -28,28 +29,218 @@ use wiremock::MockServer;
 use wiremock::Request;
 use wiremock::ResponseTemplate;
 use wiremock::matchers::body_string_contains;
+use wiremock::matchers::header;
 use wiremock::matchers::method;
 use wiremock::matchers::path;
 
 use streamable_http_test_support::initialize_client;
 
 const SERVER_NAME: &str = "test-streamable-http-oauth-startup";
+const STARTUP_REFRESH_CHILD_SERVER_URL_ENV: &str = "MCP_TEST_OAUTH_STARTUP_REFRESH_SERVER_URL";
 const EXTERNAL_UPDATE_CHILD_SERVER_URL_ENV: &str = "MCP_TEST_OAUTH_EXTERNAL_UPDATE_SERVER_URL";
+const OPERATION_TIMEOUT_CHILD_SERVER_URL_ENV: &str = "MCP_TEST_OAUTH_TIMEOUT_SERVER_URL";
+const OPERATION_TIMEOUT_REFRESH_STARTED_ENV: &str = "MCP_TEST_OAUTH_TIMEOUT_REFRESH_STARTED";
 const REFRESH_CONTENTION_SERVER_URL_ENV: &str = "MCP_TEST_OAUTH_REFRESH_CONTENTION_SERVER_URL";
 const REFRESH_CONTENTION_ATTEMPT_ENV: &str = "MCP_TEST_OAUTH_REFRESH_CONTENTION_ATTEMPT";
 const REFRESH_CONTENTION_DONE_ENV: &str = "MCP_TEST_OAUTH_REFRESH_CONTENTION_DONE";
+const EXPIRED_ACCESS_TOKEN: &str = "expired-access-token";
+const VALID_REFRESH_TOKEN: &str = "valid-refresh-token";
+const REFRESHED_ACCESS_TOKEN: &str = "refreshed-access-token";
 const OLD_ACCESS_TOKEN: &str = "old-access-token";
 const OLD_REFRESH_TOKEN: &str = "old-refresh-token";
 const EXTERNAL_ACCESS_TOKEN: &str = "external-access-token";
 const EXTERNAL_REFRESH_TOKEN: &str = "external-refresh-token";
 const EXTERNAL_EXPIRES_AT: u64 = u64::MAX;
+const TIMEOUT_REFRESHED_ACCESS_TOKEN: &str = "timeout-refreshed-access-token";
 const STALE_REFRESHED_ACCESS_TOKEN: &str = "stale-refreshed-access-token";
 const STALE_ROTATED_REFRESH_TOKEN: &str = "stale-rotated-refresh-token";
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn refreshes_expired_persisted_token_before_initialize() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+    mount_oauth_metadata(&server, /*expected_calls*/ 1).await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .and(body_string_contains("grant_type=refresh_token"))
+        .and(body_string_contains(format!(
+            "refresh_token={VALID_REFRESH_TOKEN}"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": REFRESHED_ACCESS_TOKEN,
+            "token_type": "Bearer",
+            "expires_in": 7200,
+            "refresh_token": VALID_REFRESH_TOKEN,
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/mcp"))
+        .and(header(
+            "authorization",
+            format!("Bearer {REFRESHED_ACCESS_TOKEN}"),
+        ))
+        .respond_with(|request: &Request| oauth_mcp_response(request, REFRESHED_ACCESS_TOKEN))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let codex_home = TempDir::new()?;
+    let server_url = format!("{}/mcp", server.uri());
+    let status = Command::new(std::env::current_exe()?)
+        .args([
+            "oauth_startup_refresh_child",
+            "--exact",
+            "--ignored",
+            "--nocapture",
+        ])
+        .env("CODEX_HOME", codex_home.path())
+        .env(STARTUP_REFRESH_CHILD_SERVER_URL_ENV, server_url)
+        .status()
+        .await?;
+    assert!(status.success(), "OAuth startup child failed: {status}");
+    server.verify().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[ignore = "spawned by refreshes_expired_persisted_token_before_initialize"]
+async fn oauth_startup_refresh_child() -> anyhow::Result<()> {
+    let server_url = std::env::var(STARTUP_REFRESH_CHILD_SERVER_URL_ENV)?;
+    save_test_tokens(
+        &server_url,
+        EXPIRED_ACCESS_TOKEN,
+        VALID_REFRESH_TOKEN,
+        /*expires_at*/ 0,
+    )?;
+    initialized_oauth_client(&server_url).await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn operation_timeout_includes_oauth_generation_lock_wait() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+    mount_oauth_metadata(&server, /*expected_calls*/ 3).await;
+    let codex_home = TempDir::new()?;
+    let refresh_started = codex_home.path().join("refresh-started");
+    let refresh_started_for_mock = refresh_started.clone();
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .and(body_string_contains("grant_type=refresh_token"))
+        .and(body_string_contains(format!(
+            "refresh_token={EXTERNAL_REFRESH_TOKEN}"
+        )))
+        .respond_with(move |_request: &Request| {
+            std::fs::write(&refresh_started_for_mock, b"started").expect("write refresh marker");
+            ResponseTemplate::new(200)
+                .set_delay(Duration::from_secs(1))
+                .set_body_json(json!({
+                    "access_token": TIMEOUT_REFRESHED_ACCESS_TOKEN,
+                    "token_type": "Bearer",
+                    "expires_in": 7200,
+                    "refresh_token": EXTERNAL_REFRESH_TOKEN,
+                }))
+        })
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/mcp"))
+        .respond_with(|request: &Request| {
+            let Ok(body) = request.body_json::<Value>() else {
+                return ResponseTemplate::new(400);
+            };
+            let expected_access_token = match (
+                body.get("method").and_then(Value::as_str),
+                body.pointer("/params/name").and_then(Value::as_str),
+            ) {
+                (Some("tools/call"), Some("hold-generation-lock")) => {
+                    TIMEOUT_REFRESHED_ACCESS_TOKEN
+                }
+                _ => OLD_ACCESS_TOKEN,
+            };
+            oauth_mcp_response(request, expected_access_token)
+        })
+        .expect(5)
+        .mount(&server)
+        .await;
+
+    let server_url = format!("{}/mcp", server.uri());
+    let status = Command::new(std::env::current_exe()?)
+        .args([
+            "oauth_operation_timeout_child",
+            "--exact",
+            "--ignored",
+            "--nocapture",
+        ])
+        .env("CODEX_HOME", codex_home.path())
+        .env(OPERATION_TIMEOUT_CHILD_SERVER_URL_ENV, server_url)
+        .env(OPERATION_TIMEOUT_REFRESH_STARTED_ENV, refresh_started)
+        .status()
+        .await?;
+    assert!(
+        status.success(),
+        "OAuth operation timeout child failed: {status}"
+    );
+    server.verify().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[ignore = "spawned by operation_timeout_includes_oauth_generation_lock_wait"]
+async fn oauth_operation_timeout_child() -> anyhow::Result<()> {
+    let server_url = std::env::var(OPERATION_TIMEOUT_CHILD_SERVER_URL_ENV)?;
+    let refresh_started =
+        std::path::PathBuf::from(std::env::var(OPERATION_TIMEOUT_REFRESH_STARTED_ENV)?);
+    save_test_tokens(
+        &server_url,
+        OLD_ACCESS_TOKEN,
+        OLD_REFRESH_TOKEN,
+        future_expiry()?,
+    )?;
+    let lock_holder = Arc::new(initialized_oauth_client(&server_url).await?);
+    let timed_client = initialized_oauth_client(&server_url).await?;
+    save_test_tokens(
+        &server_url,
+        EXTERNAL_ACCESS_TOKEN,
+        EXTERNAL_REFRESH_TOKEN,
+        /*expires_at*/ 0,
+    )?;
+
+    let lock_holder_call = tokio::spawn(async move {
+        lock_holder
+            .call_tool(
+                "hold-generation-lock".to_string(),
+                /*arguments*/ None,
+                /*meta*/ None,
+                Some(Duration::from_secs(5)),
+            )
+            .await
+    });
+    wait_for_path(&refresh_started).await?;
+    let error = timed_client
+        .call_tool(
+            "must-time-out-on-generation-lock".to_string(),
+            /*arguments*/ None,
+            /*meta*/ None,
+            Some(Duration::from_millis(100)),
+        )
+        .await
+        .expect_err("generation lock wait must consume the operation timeout");
+    assert!(
+        error
+            .to_string()
+            .contains("timed out awaiting tools/call after 100ms"),
+        "unexpected timeout error: {error}"
+    );
+    lock_holder_call.await??;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn running_client_adopts_external_oauth_update_and_deletion() -> anyhow::Result<()> {
     let server = MockServer::start().await;
-    mount_oauth_metadata(&server).await;
+    mount_oauth_metadata(&server, /*expected_calls*/ 2).await;
 
     Mock::given(method("POST"))
         .and(path("/mcp"))
@@ -168,7 +359,7 @@ async fn oauth_external_delete_writer_child() -> anyhow::Result<()> {
 async fn refresh_holds_generation_lock_against_external_oauth_update() -> anyhow::Result<()> {
     let server = MockServer::start().await;
     let server_url = format!("{}/mcp", server.uri());
-    mount_oauth_metadata(&server).await;
+    mount_oauth_metadata(&server, /*expected_calls*/ 3).await;
     Mock::given(method("POST"))
         .and(path("/oauth/token"))
         .and(body_string_contains("grant_type=refresh_token"))
@@ -322,7 +513,7 @@ async fn oauth_external_update_writer_child() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn mount_oauth_metadata(server: &MockServer) {
+async fn mount_oauth_metadata(server: &MockServer, expected_calls: u64) {
     Mock::given(method("GET"))
         .and(path("/.well-known/oauth-authorization-server/mcp"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -330,7 +521,7 @@ async fn mount_oauth_metadata(server: &MockServer) {
             "token_endpoint": format!("{}/oauth/token", server.uri()),
             "scopes_supported": [""],
         })))
-        .expect(1)
+        .expect(expected_calls)
         .mount(server)
         .await;
 }

--- a/codex-rs/rmcp-client/tests/streamable_http_oauth_startup.rs
+++ b/codex-rs/rmcp-client/tests/streamable_http_oauth_startup.rs
@@ -9,6 +9,7 @@ use codex_exec_server::Environment;
 use codex_rmcp_client::RmcpClient;
 use codex_rmcp_client::StoredOAuthTokens;
 use codex_rmcp_client::WrappedOAuthTokenResponse;
+use codex_rmcp_client::delete_oauth_tokens;
 use codex_rmcp_client::save_oauth_tokens;
 use oauth2::AccessToken;
 use oauth2::RefreshToken;
@@ -24,18 +25,16 @@ use wiremock::MockServer;
 use wiremock::Request;
 use wiremock::ResponseTemplate;
 use wiremock::matchers::body_string_contains;
-use wiremock::matchers::header;
 use wiremock::matchers::method;
 use wiremock::matchers::path;
 
 use streamable_http_test_support::initialize_client;
 
 const SERVER_NAME: &str = "test-streamable-http-oauth-startup";
-const EXPIRED_ACCESS_TOKEN: &str = "expired-access-token";
-const REFRESH_TOKEN: &str = "valid-refresh-token";
-const REFRESHED_ACCESS_TOKEN: &str = "refreshed-access-token";
-const CHILD_SERVER_URL_ENV: &str = "MCP_TEST_OAUTH_STARTUP_SERVER_URL";
 const EXTERNAL_UPDATE_CHILD_SERVER_URL_ENV: &str = "MCP_TEST_OAUTH_EXTERNAL_UPDATE_SERVER_URL";
+const REFRESH_CONTENTION_SERVER_URL_ENV: &str = "MCP_TEST_OAUTH_REFRESH_CONTENTION_SERVER_URL";
+const REFRESH_CONTENTION_ATTEMPT_ENV: &str = "MCP_TEST_OAUTH_REFRESH_CONTENTION_ATTEMPT";
+const REFRESH_CONTENTION_DONE_ENV: &str = "MCP_TEST_OAUTH_REFRESH_CONTENTION_DONE";
 const OLD_ACCESS_TOKEN: &str = "old-access-token";
 const OLD_REFRESH_TOKEN: &str = "old-refresh-token";
 const EXTERNAL_ACCESS_TOKEN: &str = "external-access-token";
@@ -44,186 +43,22 @@ const STALE_REFRESHED_ACCESS_TOKEN: &str = "stale-refreshed-access-token";
 const STALE_ROTATED_REFRESH_TOKEN: &str = "stale-rotated-refresh-token";
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn refreshes_expired_persisted_token_before_initialize() -> anyhow::Result<()> {
+async fn running_client_adopts_external_oauth_update_and_deletion() -> anyhow::Result<()> {
     let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/.well-known/oauth-authorization-server/mcp"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "authorization_endpoint": format!("{}/oauth/authorize", server.uri()),
-            "token_endpoint": format!("{}/oauth/token", server.uri()),
-            "scopes_supported": [""],
-        })))
-        .expect(1)
-        .mount(&server)
-        .await;
-    Mock::given(method("POST"))
-        .and(path("/oauth/token"))
-        .and(body_string_contains("grant_type=refresh_token"))
-        .and(body_string_contains(format!(
-            "refresh_token={REFRESH_TOKEN}"
-        )))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "access_token": REFRESHED_ACCESS_TOKEN,
-            "token_type": "Bearer",
-            "expires_in": 7200,
-            "refresh_token": REFRESH_TOKEN,
-        })))
-        .expect(1)
-        .mount(&server)
-        .await;
-    Mock::given(method("POST"))
-        .and(path("/mcp"))
-        .and(header(
-            "authorization",
-            format!("Bearer {REFRESHED_ACCESS_TOKEN}"),
-        ))
-        .respond_with(|request: &Request| {
-            let body: Value = request.body_json().expect("valid JSON-RPC request");
-            match body.get("method").and_then(Value::as_str) {
-                Some("initialize") => ResponseTemplate::new(200).set_body_json(json!({
-                    "jsonrpc": "2.0",
-                    "id": body.get("id").cloned().unwrap_or(Value::Null),
-                    "result": {
-                        "protocolVersion": body
-                            .pointer("/params/protocolVersion")
-                            .cloned()
-                            .unwrap_or_else(|| json!("2025-06-18")),
-                        "capabilities": {},
-                        "serverInfo": {
-                            "name": "oauth-startup-test",
-                            "version": "0.0.0-test",
-                        },
-                    },
-                })),
-                Some("notifications/initialized") => ResponseTemplate::new(202),
-                method => ResponseTemplate::new(400)
-                    .set_body_string(format!("unexpected JSON-RPC method: {method:?}")),
-            }
-        })
-        .expect(2)
-        .mount(&server)
-        .await;
-
-    let codex_home = TempDir::new()?;
-    let server_url = format!("{}/mcp", server.uri());
-
-    // Credential storage resolves CODEX_HOME from the process environment.
-    // Run the client half of the test in an ignored helper test so it can use
-    // an isolated home without mutating the parent test runner's environment.
-    let status = Command::new(std::env::current_exe()?)
-        .args(["oauth_startup_child", "--exact", "--ignored", "--nocapture"])
-        .env("CODEX_HOME", codex_home.path())
-        .env(CHILD_SERVER_URL_ENV, server_url)
-        .status()
-        .await?;
-    assert!(status.success(), "OAuth startup child failed: {status}");
-    server.verify().await;
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-#[ignore = "spawned by refreshes_expired_persisted_token_before_initialize"]
-async fn oauth_startup_child() -> anyhow::Result<()> {
-    let server_url = std::env::var(CHILD_SERVER_URL_ENV)?;
-
-    // Save an expired access token with a valid refresh token so startup must
-    // refresh before sending the initialize request.
-    let mut response = OAuthTokenResponse::new(
-        AccessToken::new(EXPIRED_ACCESS_TOKEN.to_string()),
-        BasicTokenType::Bearer,
-        VendorExtraTokenFields::default(),
-    );
-    response.set_refresh_token(Some(RefreshToken::new(REFRESH_TOKEN.to_string())));
-    response.set_expires_in(Some(&Duration::from_secs(7200)));
-    let tokens = StoredOAuthTokens {
-        server_name: SERVER_NAME.to_string(),
-        url: server_url.clone(),
-        client_id: "test-client-id".to_string(),
-        token_response: WrappedOAuthTokenResponse(response),
-        expires_at: Some(0),
-    };
-    save_oauth_tokens(SERVER_NAME, &tokens, OAuthCredentialsStoreMode::File)?;
-
-    // This mirrors create_client's transport and initialization setup, except
-    // it omits the direct bearer token. Supplying that token would bypass the
-    // persisted OAuth credentials and the startup refresh under test.
-    let client = RmcpClient::new_streamable_http_client(
-        SERVER_NAME,
-        &server_url,
-        /*bearer_token*/ None,
-        /*http_headers*/ None,
-        /*env_http_headers*/ None,
-        OAuthCredentialsStoreMode::File,
-        Environment::default_for_tests().get_http_client(),
-        /*auth_provider*/ None,
-    )
-    .await?;
-
-    initialize_client(&client).await?;
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn running_client_adopts_external_oauth_update_before_next_operation() -> anyhow::Result<()> {
-    let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/.well-known/oauth-authorization-server/mcp"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "authorization_endpoint": format!("{}/oauth/authorize", server.uri()),
-            "token_endpoint": format!("{}/oauth/token", server.uri()),
-            "scopes_supported": [""],
-        })))
-        .expect(1)
-        .mount(&server)
-        .await;
+    mount_oauth_metadata(&server).await;
 
     Mock::given(method("POST"))
         .and(path("/mcp"))
         .respond_with(|request: &Request| {
-            let body: Value = request.body_json().expect("valid JSON-RPC request");
+            let Ok(body) = request.body_json::<Value>() else {
+                return ResponseTemplate::new(400);
+            };
             let request_method = body.get("method").and_then(Value::as_str);
             let expected_access_token = match request_method {
                 Some("tools/call") => EXTERNAL_ACCESS_TOKEN,
                 _ => OLD_ACCESS_TOKEN,
             };
-            let authorization = request
-                .headers
-                .get("authorization")
-                .and_then(|value| value.to_str().ok());
-            if authorization != Some(format!("Bearer {expected_access_token}").as_str()) {
-                return ResponseTemplate::new(401);
-            }
-
-            match request_method {
-                Some("initialize") => ResponseTemplate::new(200).set_body_json(json!({
-                    "jsonrpc": "2.0",
-                    "id": body.get("id").cloned().unwrap_or(Value::Null),
-                    "result": {
-                        "protocolVersion": body
-                            .pointer("/params/protocolVersion")
-                            .cloned()
-                            .unwrap_or_else(|| json!("2025-06-18")),
-                        "capabilities": {
-                            "tools": {},
-                        },
-                        "serverInfo": {
-                            "name": "oauth-external-update-test",
-                            "version": "0.0.0-test",
-                        },
-                    },
-                })),
-                Some("notifications/initialized") => ResponseTemplate::new(202),
-                Some("tools/call") => ResponseTemplate::new(200).set_body_json(json!({
-                    "jsonrpc": "2.0",
-                    "id": body.get("id").cloned().unwrap_or(Value::Null),
-                    "result": {
-                        "content": [],
-                        "isError": false,
-                    },
-                })),
-                method => ResponseTemplate::new(400)
-                    .set_body_string(format!("unexpected JSON-RPC method: {method:?}")),
-            }
+            oauth_mcp_response(request, expected_access_token)
         })
         .expect(3)
         .mount(&server)
@@ -251,7 +86,7 @@ async fn running_client_adopts_external_oauth_update_before_next_operation() -> 
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-#[ignore = "spawned by running_client_adopts_external_oauth_update_before_next_operation"]
+#[ignore = "spawned by running_client_adopts_external_oauth_update_and_deletion"]
 async fn oauth_external_update_child() -> anyhow::Result<()> {
     let server_url = std::env::var(EXTERNAL_UPDATE_CHILD_SERVER_URL_ENV)?;
     save_test_tokens(
@@ -261,18 +96,7 @@ async fn oauth_external_update_child() -> anyhow::Result<()> {
         future_expiry()?,
     )?;
 
-    let client = RmcpClient::new_streamable_http_client(
-        SERVER_NAME,
-        &server_url,
-        /*bearer_token*/ None,
-        /*http_headers*/ None,
-        /*env_http_headers*/ None,
-        OAuthCredentialsStoreMode::File,
-        Environment::default_for_tests().get_http_client(),
-        /*auth_provider*/ None,
-    )
-    .await?;
-    initialize_client(&client).await?;
+    let client = initialized_oauth_client(&server_url).await?;
 
     save_test_tokens(
         &server_url,
@@ -291,13 +115,105 @@ async fn oauth_external_update_child() -> anyhow::Result<()> {
         .await?;
 
     assert_persisted_tokens(EXTERNAL_ACCESS_TOKEN, EXTERNAL_REFRESH_TOKEN)?;
+    let status = Command::new(std::env::current_exe()?)
+        .args([
+            "oauth_external_delete_writer_child",
+            "--exact",
+            "--ignored",
+            "--nocapture",
+        ])
+        .env("CODEX_HOME", std::env::var("CODEX_HOME")?)
+        .env(EXTERNAL_UPDATE_CHILD_SERVER_URL_ENV, &server_url)
+        .status()
+        .await?;
+    assert!(
+        status.success(),
+        "OAuth external delete writer failed: {status}"
+    );
+
+    client
+        .call_tool(
+            "call-after-external-delete".to_string(),
+            /*arguments*/ None,
+            /*meta*/ None,
+            Some(Duration::from_secs(5)),
+        )
+        .await
+        .expect_err("externally deleted credentials must not be reused");
+    assert!(
+        !std::path::Path::new(&std::env::var("CODEX_HOME")?)
+            .join(".credentials.json")
+            .exists()
+    );
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn refresh_does_not_overwrite_external_oauth_update() -> anyhow::Result<()> {
+#[ignore = "spawned by oauth_external_update_child"]
+async fn oauth_external_delete_writer_child() -> anyhow::Result<()> {
+    let server_url = std::env::var(EXTERNAL_UPDATE_CHILD_SERVER_URL_ENV)?;
+    assert!(delete_oauth_tokens(
+        SERVER_NAME,
+        &server_url,
+        OAuthCredentialsStoreMode::File,
+    )?);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn refresh_holds_generation_lock_against_external_oauth_update() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+    let server_url = format!("{}/mcp", server.uri());
+    mount_oauth_metadata(&server).await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .and(body_string_contains("grant_type=refresh_token"))
+        .and(body_string_contains(format!(
+            "refresh_token={OLD_REFRESH_TOKEN}"
+        )))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_delay(Duration::from_millis(1500))
+                .set_body_json(json!({
+                    "access_token": STALE_REFRESHED_ACCESS_TOKEN,
+                    "token_type": "Bearer",
+                    "expires_in": 7200,
+                    "refresh_token": STALE_ROTATED_REFRESH_TOKEN,
+                })),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/mcp"))
+        .respond_with(|request: &Request| {
+            let Ok(body) = request.body_json::<Value>() else {
+                return ResponseTemplate::new(400);
+            };
+            let request_method = body.get("method").and_then(Value::as_str);
+            let expected_access_token = match (
+                request_method,
+                body.pointer("/params/name").and_then(Value::as_str),
+            ) {
+                (Some("initialize" | "notifications/initialized"), _) => OLD_ACCESS_TOKEN,
+                (Some("tools/call"), Some("trigger-refresh-contention")) => {
+                    STALE_REFRESHED_ACCESS_TOKEN
+                }
+                (Some("tools/call"), Some("call-after-refresh-contention")) => {
+                    EXTERNAL_ACCESS_TOKEN
+                }
+                _ => OLD_ACCESS_TOKEN,
+            };
+            oauth_mcp_response(request, expected_access_token)
+        })
+        .expect(4)
+        .mount(&server)
+        .await;
+
     let codex_home = TempDir::new()?;
-    let status = Command::new(std::env::current_exe()?)
+    let attempt_path = codex_home.path().join("external-update-attempt");
+    let done_path = codex_home.path().join("external-update-done");
+    let mut live_client = Command::new(std::env::current_exe()?)
         .args([
             "oauth_external_update_during_refresh_child",
             "--exact",
@@ -305,20 +221,104 @@ async fn refresh_does_not_overwrite_external_oauth_update() -> anyhow::Result<()
             "--nocapture",
         ])
         .env("CODEX_HOME", codex_home.path())
-        .status()
-        .await?;
+        .env(REFRESH_CONTENTION_SERVER_URL_ENV, &server_url)
+        .env(REFRESH_CONTENTION_DONE_ENV, &done_path)
+        .spawn()?;
+
+    wait_for_request_path(&server, "/oauth/token").await?;
+    let mut external_writer = Command::new(std::env::current_exe()?)
+        .args([
+            "oauth_external_update_writer_child",
+            "--exact",
+            "--ignored",
+            "--nocapture",
+        ])
+        .env("CODEX_HOME", codex_home.path())
+        .env(REFRESH_CONTENTION_SERVER_URL_ENV, &server_url)
+        .env(REFRESH_CONTENTION_ATTEMPT_ENV, &attempt_path)
+        .env(REFRESH_CONTENTION_DONE_ENV, &done_path)
+        .spawn()?;
+
+    wait_for_path(&attempt_path).await?;
+    tokio::time::sleep(Duration::from_millis(100)).await;
     assert!(
-        status.success(),
-        "OAuth external update during refresh child failed: {status}"
+        !done_path.exists(),
+        "external writer should block while refresh owns the generation lock"
     );
+    assert!(
+        external_writer.try_wait()?.is_none(),
+        "external writer exited before the refresh released its generation lock"
+    );
+
+    let writer_status = external_writer.wait().await?;
+    assert!(
+        writer_status.success(),
+        "OAuth external update writer failed: {writer_status}"
+    );
+    let live_status = live_client.wait().await?;
+    assert!(
+        live_status.success(),
+        "OAuth refresh contention child failed: {live_status}"
+    );
+
+    server.verify().await;
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-#[ignore = "spawned by refresh_does_not_overwrite_external_oauth_update"]
+#[ignore = "spawned by refresh_holds_generation_lock_against_external_oauth_update"]
 async fn oauth_external_update_during_refresh_child() -> anyhow::Result<()> {
-    let server = MockServer::start().await;
-    let server_url = format!("{}/mcp", server.uri());
+    let server_url = std::env::var(REFRESH_CONTENTION_SERVER_URL_ENV)?;
+    let done_path = std::path::PathBuf::from(std::env::var(REFRESH_CONTENTION_DONE_ENV)?);
+    save_test_tokens(
+        &server_url,
+        OLD_ACCESS_TOKEN,
+        OLD_REFRESH_TOKEN,
+        future_expiry()?,
+    )?;
+
+    let client = initialized_oauth_client(&server_url).await?;
+    save_test_tokens(&server_url, OLD_ACCESS_TOKEN, OLD_REFRESH_TOKEN, 0)?;
+    client
+        .call_tool(
+            "trigger-refresh-contention".to_string(),
+            /*arguments*/ None,
+            /*meta*/ None,
+            Some(Duration::from_secs(5)),
+        )
+        .await?;
+    wait_for_path(&done_path).await?;
+    client
+        .call_tool(
+            "call-after-refresh-contention".to_string(),
+            /*arguments*/ None,
+            /*meta*/ None,
+            Some(Duration::from_secs(5)),
+        )
+        .await?;
+
+    assert_persisted_tokens(EXTERNAL_ACCESS_TOKEN, EXTERNAL_REFRESH_TOKEN)?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[ignore = "spawned by refresh_holds_generation_lock_against_external_oauth_update"]
+async fn oauth_external_update_writer_child() -> anyhow::Result<()> {
+    let server_url = std::env::var(REFRESH_CONTENTION_SERVER_URL_ENV)?;
+    let attempt_path = std::env::var(REFRESH_CONTENTION_ATTEMPT_ENV)?;
+    let done_path = std::env::var(REFRESH_CONTENTION_DONE_ENV)?;
+    std::fs::write(attempt_path, b"attempting")?;
+    save_test_tokens(
+        &server_url,
+        EXTERNAL_ACCESS_TOKEN,
+        EXTERNAL_REFRESH_TOKEN,
+        future_expiry()?,
+    )?;
+    std::fs::write(done_path, b"done")?;
+    Ok(())
+}
+
+async fn mount_oauth_metadata(server: &MockServer) {
     Mock::given(method("GET"))
         .and(path("/.well-known/oauth-authorization-server/mcp"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
@@ -327,91 +327,14 @@ async fn oauth_external_update_during_refresh_child() -> anyhow::Result<()> {
             "scopes_supported": [""],
         })))
         .expect(1)
-        .mount(&server)
+        .mount(server)
         .await;
-    Mock::given(method("POST"))
-        .and(path("/oauth/token"))
-        .and(body_string_contains("grant_type=refresh_token"))
-        .and(body_string_contains(format!(
-            "refresh_token={OLD_REFRESH_TOKEN}"
-        )))
-        .respond_with({
-            let server_url = server_url.clone();
-            move |_request: &Request| {
-                save_test_tokens(
-                    &server_url,
-                    EXTERNAL_ACCESS_TOKEN,
-                    EXTERNAL_REFRESH_TOKEN,
-                    future_expiry().expect("future expiry"),
-                )
-                .expect("save externally updated credentials");
-                ResponseTemplate::new(200).set_body_json(json!({
-                    "access_token": STALE_REFRESHED_ACCESS_TOKEN,
-                    "token_type": "Bearer",
-                    "expires_in": 7200,
-                    "refresh_token": STALE_ROTATED_REFRESH_TOKEN,
-                }))
-            }
-        })
-        .expect(1)
-        .mount(&server)
-        .await;
-    Mock::given(method("POST"))
-        .and(path("/mcp"))
-        .respond_with(|request: &Request| {
-            let body: Value = request.body_json().expect("valid JSON-RPC request");
-            let request_method = body.get("method").and_then(Value::as_str);
-            let expected_access_token = match request_method {
-                Some("tools/call") => EXTERNAL_ACCESS_TOKEN,
-                _ => STALE_REFRESHED_ACCESS_TOKEN,
-            };
-            let authorization = request
-                .headers
-                .get("authorization")
-                .and_then(|value| value.to_str().ok());
-            if authorization != Some(format!("Bearer {expected_access_token}").as_str()) {
-                return ResponseTemplate::new(401);
-            }
+}
 
-            match request_method {
-                Some("initialize") => ResponseTemplate::new(200).set_body_json(json!({
-                    "jsonrpc": "2.0",
-                    "id": body.get("id").cloned().unwrap_or(Value::Null),
-                    "result": {
-                        "protocolVersion": body
-                            .pointer("/params/protocolVersion")
-                            .cloned()
-                            .unwrap_or_else(|| json!("2025-06-18")),
-                        "capabilities": {
-                            "tools": {},
-                        },
-                        "serverInfo": {
-                            "name": "oauth-external-refresh-test",
-                            "version": "0.0.0-test",
-                        },
-                    },
-                })),
-                Some("notifications/initialized") => ResponseTemplate::new(202),
-                Some("tools/call") => ResponseTemplate::new(200).set_body_json(json!({
-                    "jsonrpc": "2.0",
-                    "id": body.get("id").cloned().unwrap_or(Value::Null),
-                    "result": {
-                        "content": [],
-                        "isError": false,
-                    },
-                })),
-                method => ResponseTemplate::new(400)
-                    .set_body_string(format!("unexpected JSON-RPC method: {method:?}")),
-            }
-        })
-        .expect(3)
-        .mount(&server)
-        .await;
-
-    save_test_tokens(&server_url, OLD_ACCESS_TOKEN, OLD_REFRESH_TOKEN, 0)?;
+async fn initialized_oauth_client(server_url: &str) -> anyhow::Result<RmcpClient> {
     let client = RmcpClient::new_streamable_http_client(
         SERVER_NAME,
-        &server_url,
+        server_url,
         /*bearer_token*/ None,
         /*http_headers*/ None,
         /*env_http_headers*/ None,
@@ -421,17 +344,79 @@ async fn oauth_external_update_during_refresh_child() -> anyhow::Result<()> {
     )
     .await?;
     initialize_client(&client).await?;
-    client
-        .call_tool(
-            "call-after-refresh-race".to_string(),
-            /*arguments*/ None,
-            /*meta*/ None,
-            Some(Duration::from_secs(5)),
-        )
-        .await?;
+    Ok(client)
+}
 
-    assert_persisted_tokens(EXTERNAL_ACCESS_TOKEN, EXTERNAL_REFRESH_TOKEN)?;
-    server.verify().await;
+fn oauth_mcp_response(request: &Request, expected_access_token: &str) -> ResponseTemplate {
+    let authorization = request
+        .headers
+        .get("authorization")
+        .and_then(|value| value.to_str().ok());
+    if authorization != Some(format!("Bearer {expected_access_token}").as_str()) {
+        return ResponseTemplate::new(401);
+    }
+
+    let Ok(body) = request.body_json::<Value>() else {
+        return ResponseTemplate::new(400);
+    };
+    match body.get("method").and_then(Value::as_str) {
+        Some("initialize") => ResponseTemplate::new(200).set_body_json(json!({
+            "jsonrpc": "2.0",
+            "id": body.get("id").cloned().unwrap_or(Value::Null),
+            "result": {
+                "protocolVersion": body
+                    .pointer("/params/protocolVersion")
+                    .cloned()
+                    .unwrap_or_else(|| json!("2025-06-18")),
+                "capabilities": {
+                    "tools": {},
+                },
+                "serverInfo": {
+                    "name": "oauth-external-credential-test",
+                    "version": "0.0.0-test",
+                },
+            },
+        })),
+        Some("notifications/initialized") => ResponseTemplate::new(202),
+        Some("tools/call") => ResponseTemplate::new(200).set_body_json(json!({
+            "jsonrpc": "2.0",
+            "id": body.get("id").cloned().unwrap_or(Value::Null),
+            "result": {
+                "content": [],
+                "isError": false,
+            },
+        })),
+        method => ResponseTemplate::new(400)
+            .set_body_string(format!("unexpected JSON-RPC method: {method:?}")),
+    }
+}
+
+async fn wait_for_request_path(server: &MockServer, expected_path: &str) -> anyhow::Result<()> {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .iter()
+                .any(|request| request.url.path() == expected_path)
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await?;
+    Ok(())
+}
+
+async fn wait_for_path(path: &std::path::Path) -> anyhow::Result<()> {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while !path.exists() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await?;
     Ok(())
 }
 

--- a/codex-rs/rmcp-client/tests/streamable_http_oauth_startup.rs
+++ b/codex-rs/rmcp-client/tests/streamable_http_oauth_startup.rs
@@ -40,6 +40,10 @@ const STARTUP_REFRESH_CHILD_SERVER_URL_ENV: &str = "MCP_TEST_OAUTH_STARTUP_REFRE
 const EXTERNAL_UPDATE_CHILD_SERVER_URL_ENV: &str = "MCP_TEST_OAUTH_EXTERNAL_UPDATE_SERVER_URL";
 const OPERATION_TIMEOUT_CHILD_SERVER_URL_ENV: &str = "MCP_TEST_OAUTH_TIMEOUT_SERVER_URL";
 const OPERATION_TIMEOUT_REFRESH_STARTED_ENV: &str = "MCP_TEST_OAUTH_TIMEOUT_REFRESH_STARTED";
+const PERSIST_TIMEOUT_CHILD_SERVER_URL_ENV: &str = "MCP_TEST_OAUTH_PERSIST_TIMEOUT_SERVER_URL";
+const PERSIST_TIMEOUT_OPERATION_STARTED_ENV: &str =
+    "MCP_TEST_OAUTH_PERSIST_TIMEOUT_OPERATION_STARTED";
+const PERSIST_TIMEOUT_REFRESH_STARTED_ENV: &str = "MCP_TEST_OAUTH_PERSIST_TIMEOUT_REFRESH_STARTED";
 const REFRESH_CONTENTION_SERVER_URL_ENV: &str = "MCP_TEST_OAUTH_REFRESH_CONTENTION_SERVER_URL";
 const REFRESH_CONTENTION_ATTEMPT_ENV: &str = "MCP_TEST_OAUTH_REFRESH_CONTENTION_ATTEMPT";
 const REFRESH_CONTENTION_DONE_ENV: &str = "MCP_TEST_OAUTH_REFRESH_CONTENTION_DONE";
@@ -231,6 +235,138 @@ async fn oauth_operation_timeout_child() -> anyhow::Result<()> {
         error
             .to_string()
             .contains("timed out awaiting tools/call after 100ms"),
+        "unexpected timeout error: {error}"
+    );
+    lock_holder_call.await??;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn operation_timeout_includes_post_operation_persistence_lock_wait() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+    mount_oauth_metadata(&server, /*expected_calls*/ 3).await;
+    let codex_home = TempDir::new()?;
+    let operation_started = codex_home.path().join("operation-started");
+    let refresh_started = codex_home.path().join("refresh-started");
+    let refresh_started_for_mock = refresh_started.clone();
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .and(body_string_contains("grant_type=refresh_token"))
+        .and(body_string_contains(format!(
+            "refresh_token={EXTERNAL_REFRESH_TOKEN}"
+        )))
+        .respond_with(move |_request: &Request| {
+            std::fs::write(&refresh_started_for_mock, b"started").expect("write refresh marker");
+            ResponseTemplate::new(200)
+                .set_delay(Duration::from_secs(2))
+                .set_body_json(json!({
+                    "access_token": TIMEOUT_REFRESHED_ACCESS_TOKEN,
+                    "token_type": "Bearer",
+                    "expires_in": 7200,
+                    "refresh_token": EXTERNAL_REFRESH_TOKEN,
+                }))
+        })
+        .expect(1)
+        .mount(&server)
+        .await;
+    let operation_started_for_mock = operation_started.clone();
+    Mock::given(method("POST"))
+        .and(path("/mcp"))
+        .respond_with(move |request: &Request| {
+            let Ok(body) = request.body_json::<Value>() else {
+                return ResponseTemplate::new(400);
+            };
+            let request_name = body.pointer("/params/name").and_then(Value::as_str);
+            let expected_access_token = match request_name {
+                Some("hold-generation-lock-during-persistence") => TIMEOUT_REFRESHED_ACCESS_TOKEN,
+                _ => OLD_ACCESS_TOKEN,
+            };
+            let response = oauth_mcp_response(request, expected_access_token);
+            if request_name == Some("successful-call-before-persist-contention") {
+                std::fs::write(&operation_started_for_mock, b"started")
+                    .expect("write operation marker");
+                response.set_delay(Duration::from_secs(1))
+            } else {
+                response
+            }
+        })
+        .expect(6)
+        .mount(&server)
+        .await;
+
+    let server_url = format!("{}/mcp", server.uri());
+    let status = Command::new(std::env::current_exe()?)
+        .args([
+            "oauth_persist_timeout_child",
+            "--exact",
+            "--ignored",
+            "--nocapture",
+        ])
+        .env("CODEX_HOME", codex_home.path())
+        .env(PERSIST_TIMEOUT_CHILD_SERVER_URL_ENV, server_url)
+        .env(PERSIST_TIMEOUT_OPERATION_STARTED_ENV, operation_started)
+        .env(PERSIST_TIMEOUT_REFRESH_STARTED_ENV, refresh_started)
+        .status()
+        .await?;
+    assert!(
+        status.success(),
+        "OAuth persistence timeout child failed: {status}"
+    );
+    server.verify().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[ignore = "spawned by operation_timeout_includes_post_operation_persistence_lock_wait"]
+async fn oauth_persist_timeout_child() -> anyhow::Result<()> {
+    let server_url = std::env::var(PERSIST_TIMEOUT_CHILD_SERVER_URL_ENV)?;
+    let operation_started =
+        std::path::PathBuf::from(std::env::var(PERSIST_TIMEOUT_OPERATION_STARTED_ENV)?);
+    let refresh_started =
+        std::path::PathBuf::from(std::env::var(PERSIST_TIMEOUT_REFRESH_STARTED_ENV)?);
+    save_test_tokens(
+        &server_url,
+        OLD_ACCESS_TOKEN,
+        OLD_REFRESH_TOKEN,
+        future_expiry()?,
+    )?;
+    let timed_client = Arc::new(initialized_oauth_client(&server_url).await?);
+    let lock_holder = Arc::new(initialized_oauth_client(&server_url).await?);
+
+    let timed_call = tokio::spawn(async move {
+        timed_client
+            .call_tool(
+                "successful-call-before-persist-contention".to_string(),
+                /*arguments*/ None,
+                /*meta*/ None,
+                Some(Duration::from_millis(1500)),
+            )
+            .await
+    });
+    wait_for_path(&operation_started).await?;
+    save_test_tokens(
+        &server_url,
+        EXTERNAL_ACCESS_TOKEN,
+        EXTERNAL_REFRESH_TOKEN,
+        /*expires_at*/ 0,
+    )?;
+    let lock_holder_call = tokio::spawn(async move {
+        lock_holder
+            .call_tool(
+                "hold-generation-lock-during-persistence".to_string(),
+                /*arguments*/ None,
+                /*meta*/ None,
+                Some(Duration::from_secs(5)),
+            )
+            .await
+    });
+    wait_for_path(&refresh_started).await?;
+
+    let error = timed_call
+        .await?
+        .expect_err("persistence lock wait must consume the operation timeout");
+    assert!(
+        error.to_string().contains("timed out awaiting tools/call"),
         "unexpected timeout error: {error}"
     );
     lock_holder_call.await??;

--- a/codex-rs/rmcp-client/tests/streamable_http_oauth_startup.rs
+++ b/codex-rs/rmcp-client/tests/streamable_http_oauth_startup.rs
@@ -609,7 +609,12 @@ async fn oauth_external_update_during_refresh_child() -> anyhow::Result<()> {
     )?;
 
     let client = initialized_oauth_client(&server_url).await?;
-    save_test_tokens(&server_url, OLD_ACCESS_TOKEN, OLD_REFRESH_TOKEN, 0)?;
+    save_test_tokens(
+        &server_url,
+        OLD_ACCESS_TOKEN,
+        OLD_REFRESH_TOKEN,
+        /*expires_at*/ 0,
+    )?;
     client
         .call_tool(
             "trigger-refresh-contention".to_string(),

--- a/codex-rs/rmcp-client/tests/streamable_http_oauth_startup.rs
+++ b/codex-rs/rmcp-client/tests/streamable_http_oauth_startup.rs
@@ -1,6 +1,11 @@
 mod streamable_http_test_support;
 
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 use codex_config::types::OAuthCredentialsStoreMode;
 use codex_exec_server::Environment;
@@ -11,6 +16,7 @@ use codex_rmcp_client::save_oauth_tokens;
 use oauth2::AccessToken;
 use oauth2::RefreshToken;
 use oauth2::basic::BasicTokenType;
+use pretty_assertions::assert_eq;
 use rmcp::transport::auth::OAuthTokenResponse;
 use rmcp::transport::auth::VendorExtraTokenFields;
 use serde_json::Value;
@@ -33,6 +39,14 @@ const EXPIRED_ACCESS_TOKEN: &str = "expired-access-token";
 const REFRESH_TOKEN: &str = "valid-refresh-token";
 const REFRESHED_ACCESS_TOKEN: &str = "refreshed-access-token";
 const CHILD_SERVER_URL_ENV: &str = "MCP_TEST_OAUTH_STARTUP_SERVER_URL";
+const EXTERNAL_UPDATE_CHILD_SERVER_URL_ENV: &str = "MCP_TEST_OAUTH_EXTERNAL_UPDATE_SERVER_URL";
+const OLD_ACCESS_TOKEN: &str = "old-access-token";
+const OLD_REFRESH_TOKEN: &str = "old-refresh-token";
+const EXTERNAL_ACCESS_TOKEN: &str = "external-access-token";
+const EXTERNAL_REFRESH_TOKEN: &str = "external-refresh-token";
+const STALE_REFRESHED_ACCESS_TOKEN: &str = "stale-refreshed-access-token";
+const STALE_ROTATED_REFRESH_TOKEN: &str = "stale-rotated-refresh-token";
+const REFRESH_SKEW: Duration = Duration::from_secs(30);
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn refreshes_expired_persisted_token_before_initialize() -> anyhow::Result<()> {
@@ -152,4 +166,216 @@ async fn oauth_startup_child() -> anyhow::Result<()> {
 
     initialize_client(&client).await?;
     Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn running_client_keeps_and_can_persist_over_external_oauth_update() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/.well-known/oauth-authorization-server/mcp"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "authorization_endpoint": format!("{}/oauth/authorize", server.uri()),
+            "token_endpoint": format!("{}/oauth/token", server.uri()),
+            "scopes_supported": [""],
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .and(body_string_contains("grant_type=refresh_token"))
+        .and(body_string_contains(format!(
+            "refresh_token={OLD_REFRESH_TOKEN}"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": STALE_REFRESHED_ACCESS_TOKEN,
+            "token_type": "Bearer",
+            "expires_in": 7200,
+            "refresh_token": STALE_ROTATED_REFRESH_TOKEN,
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let tool_call_count = Arc::new(AtomicUsize::new(0));
+    Mock::given(method("POST"))
+        .and(path("/mcp"))
+        .respond_with({
+            let tool_call_count = Arc::clone(&tool_call_count);
+            move |request: &Request| {
+                let body: Value = request.body_json().expect("valid JSON-RPC request");
+                let method = body.get("method").and_then(Value::as_str);
+                let authorization = request
+                    .headers
+                    .get("authorization")
+                    .and_then(|value| value.to_str().ok());
+                let expected_access_token = match method {
+                    Some("tools/call") if tool_call_count.fetch_add(1, Ordering::SeqCst) == 1 => {
+                        STALE_REFRESHED_ACCESS_TOKEN
+                    }
+                    _ => OLD_ACCESS_TOKEN,
+                };
+                if authorization != Some(format!("Bearer {expected_access_token}").as_str()) {
+                    return ResponseTemplate::new(401);
+                }
+
+                match method {
+                    Some("initialize") => ResponseTemplate::new(200).set_body_json(json!({
+                        "jsonrpc": "2.0",
+                        "id": body.get("id").cloned().unwrap_or(Value::Null),
+                        "result": {
+                            "protocolVersion": body
+                                .pointer("/params/protocolVersion")
+                                .cloned()
+                                .unwrap_or_else(|| json!("2025-06-18")),
+                            "capabilities": {
+                                "tools": {},
+                            },
+                            "serverInfo": {
+                                "name": "oauth-external-update-test",
+                                "version": "0.0.0-test",
+                            },
+                        },
+                    })),
+                    Some("notifications/initialized") => ResponseTemplate::new(202),
+                    Some("tools/call") => ResponseTemplate::new(200).set_body_json(json!({
+                        "jsonrpc": "2.0",
+                        "id": body.get("id").cloned().unwrap_or(Value::Null),
+                        "result": {
+                            "content": [],
+                            "isError": false,
+                        },
+                    })),
+                    method => ResponseTemplate::new(400)
+                        .set_body_string(format!("unexpected JSON-RPC method: {method:?}")),
+                }
+            }
+        })
+        .expect(4)
+        .mount(&server)
+        .await;
+
+    let codex_home = TempDir::new()?;
+    let server_url = format!("{}/mcp", server.uri());
+    let status = Command::new(std::env::current_exe()?)
+        .args([
+            "oauth_external_update_child",
+            "--exact",
+            "--ignored",
+            "--nocapture",
+        ])
+        .env("CODEX_HOME", codex_home.path())
+        .env(EXTERNAL_UPDATE_CHILD_SERVER_URL_ENV, server_url)
+        .status()
+        .await?;
+    assert!(
+        status.success(),
+        "OAuth external update child failed: {status}"
+    );
+    assert_eq!(tool_call_count.load(Ordering::SeqCst), 2);
+    server.verify().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[ignore = "spawned by running_client_keeps_and_can_persist_over_external_oauth_update"]
+async fn oauth_external_update_child() -> anyhow::Result<()> {
+    let server_url = std::env::var(EXTERNAL_UPDATE_CHILD_SERVER_URL_ENV)?;
+    let old_expires_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)?
+        .checked_add(REFRESH_SKEW + Duration::from_secs(5))
+        .expect("test expiry should fit")
+        .as_millis() as u64;
+    save_test_tokens(
+        &server_url,
+        OLD_ACCESS_TOKEN,
+        OLD_REFRESH_TOKEN,
+        old_expires_at,
+    )?;
+
+    let client = RmcpClient::new_streamable_http_client(
+        SERVER_NAME,
+        &server_url,
+        /*bearer_token*/ None,
+        /*http_headers*/ None,
+        /*env_http_headers*/ None,
+        OAuthCredentialsStoreMode::File,
+        Environment::default_for_tests().get_http_client(),
+        /*auth_provider*/ None,
+    )
+    .await?;
+    initialize_client(&client).await?;
+
+    let external_expires_at = SystemTime::now()
+        .duration_since(UNIX_EPOCH)?
+        .checked_add(Duration::from_secs(7200))
+        .expect("test expiry should fit")
+        .as_millis() as u64;
+    save_test_tokens(
+        &server_url,
+        EXTERNAL_ACCESS_TOKEN,
+        EXTERNAL_REFRESH_TOKEN,
+        external_expires_at,
+    )?;
+
+    client
+        .call_tool(
+            "first-call-after-external-update".to_string(),
+            /*arguments*/ None,
+            /*meta*/ None,
+            Some(Duration::from_secs(5)),
+        )
+        .await?;
+
+    let refresh_at = UNIX_EPOCH
+        + Duration::from_millis(old_expires_at)
+            .saturating_sub(REFRESH_SKEW)
+            .saturating_add(Duration::from_millis(250));
+    if let Ok(wait) = refresh_at.duration_since(SystemTime::now()) {
+        tokio::time::sleep(wait).await;
+    }
+
+    client
+        .call_tool(
+            "second-call-after-stale-refresh".to_string(),
+            /*arguments*/ None,
+            /*meta*/ None,
+            Some(Duration::from_secs(5)),
+        )
+        .await?;
+
+    let credentials = std::fs::read_to_string(
+        std::path::Path::new(&std::env::var("CODEX_HOME")?).join(".credentials.json"),
+    )?;
+    assert!(credentials.contains(STALE_REFRESHED_ACCESS_TOKEN));
+    assert!(credentials.contains(STALE_ROTATED_REFRESH_TOKEN));
+    assert!(!credentials.contains(EXTERNAL_ACCESS_TOKEN));
+    assert!(!credentials.contains(EXTERNAL_REFRESH_TOKEN));
+    Ok(())
+}
+
+fn save_test_tokens(
+    server_url: &str,
+    access_token: &str,
+    refresh_token: &str,
+    expires_at: u64,
+) -> anyhow::Result<()> {
+    let mut response = OAuthTokenResponse::new(
+        AccessToken::new(access_token.to_string()),
+        BasicTokenType::Bearer,
+        VendorExtraTokenFields::default(),
+    );
+    response.set_refresh_token(Some(RefreshToken::new(refresh_token.to_string())));
+    response.set_expires_in(Some(&Duration::from_secs(7200)));
+    save_oauth_tokens(
+        SERVER_NAME,
+        &StoredOAuthTokens {
+            server_name: SERVER_NAME.to_string(),
+            url: server_url.to_string(),
+            client_id: "test-client-id".to_string(),
+            token_response: WrappedOAuthTokenResponse(response),
+            expires_at: Some(expires_at),
+        },
+        OAuthCredentialsStoreMode::File,
+    )
 }

--- a/codex-rs/rmcp-client/tests/streamable_http_oauth_startup.rs
+++ b/codex-rs/rmcp-client/tests/streamable_http_oauth_startup.rs
@@ -1,9 +1,11 @@
 mod streamable_http_test_support;
 
+use std::collections::BTreeMap;
 use std::time::Duration;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
+use anyhow::Context;
 use codex_config::types::OAuthCredentialsStoreMode;
 use codex_exec_server::Environment;
 use codex_rmcp_client::RmcpClient;
@@ -16,6 +18,7 @@ use oauth2::RefreshToken;
 use oauth2::basic::BasicTokenType;
 use rmcp::transport::auth::OAuthTokenResponse;
 use rmcp::transport::auth::VendorExtraTokenFields;
+use serde::Deserialize;
 use serde_json::Value;
 use serde_json::json;
 use tempfile::TempDir;
@@ -39,6 +42,7 @@ const OLD_ACCESS_TOKEN: &str = "old-access-token";
 const OLD_REFRESH_TOKEN: &str = "old-refresh-token";
 const EXTERNAL_ACCESS_TOKEN: &str = "external-access-token";
 const EXTERNAL_REFRESH_TOKEN: &str = "external-refresh-token";
+const EXTERNAL_EXPIRES_AT: u64 = u64::MAX;
 const STALE_REFRESHED_ACCESS_TOKEN: &str = "stale-refreshed-access-token";
 const STALE_ROTATED_REFRESH_TOKEN: &str = "stale-rotated-refresh-token";
 
@@ -102,7 +106,7 @@ async fn oauth_external_update_child() -> anyhow::Result<()> {
         &server_url,
         EXTERNAL_ACCESS_TOKEN,
         EXTERNAL_REFRESH_TOKEN,
-        future_expiry()?,
+        EXTERNAL_EXPIRES_AT,
     )?;
 
     client
@@ -114,7 +118,7 @@ async fn oauth_external_update_child() -> anyhow::Result<()> {
         )
         .await?;
 
-    assert_persisted_tokens(EXTERNAL_ACCESS_TOKEN, EXTERNAL_REFRESH_TOKEN)?;
+    assert_persisted_tokens(&server_url, EXTERNAL_ACCESS_TOKEN, EXTERNAL_REFRESH_TOKEN)?;
     let status = Command::new(std::env::current_exe()?)
         .args([
             "oauth_external_delete_writer_child",
@@ -297,7 +301,7 @@ async fn oauth_external_update_during_refresh_child() -> anyhow::Result<()> {
         )
         .await?;
 
-    assert_persisted_tokens(EXTERNAL_ACCESS_TOKEN, EXTERNAL_REFRESH_TOKEN)?;
+    assert_persisted_tokens(&server_url, EXTERNAL_ACCESS_TOKEN, EXTERNAL_REFRESH_TOKEN)?;
     Ok(())
 }
 
@@ -312,7 +316,7 @@ async fn oauth_external_update_writer_child() -> anyhow::Result<()> {
         &server_url,
         EXTERNAL_ACCESS_TOKEN,
         EXTERNAL_REFRESH_TOKEN,
-        future_expiry()?,
+        EXTERNAL_EXPIRES_AT,
     )?;
     std::fs::write(done_path, b"done")?;
     Ok(())
@@ -427,14 +431,42 @@ fn future_expiry() -> anyhow::Result<u64> {
         .as_millis() as u64)
 }
 
-fn assert_persisted_tokens(access_token: &str, refresh_token: &str) -> anyhow::Result<()> {
+#[derive(Debug, Deserialize, PartialEq)]
+struct PersistedCredentialEntry {
+    server_name: String,
+    server_url: String,
+    client_id: String,
+    access_token: String,
+    expires_at: Option<u64>,
+    refresh_token: Option<String>,
+    scopes: Vec<String>,
+}
+
+fn assert_persisted_tokens(
+    server_url: &str,
+    access_token: &str,
+    refresh_token: &str,
+) -> anyhow::Result<()> {
     let credentials = std::fs::read_to_string(
         std::path::Path::new(&std::env::var("CODEX_HOME")?).join(".credentials.json"),
     )?;
-    assert!(credentials.contains(access_token));
-    assert!(credentials.contains(refresh_token));
-    assert!(!credentials.contains(STALE_REFRESHED_ACCESS_TOKEN));
-    assert!(!credentials.contains(STALE_ROTATED_REFRESH_TOKEN));
+    let store = serde_json::from_str::<BTreeMap<String, PersistedCredentialEntry>>(&credentials)?;
+    let actual = store
+        .values()
+        .find(|entry| entry.server_name == SERVER_NAME && entry.server_url == server_url)
+        .context("target persisted OAuth credential entry should exist")?;
+    assert_eq!(
+        actual,
+        &PersistedCredentialEntry {
+            server_name: SERVER_NAME.to_string(),
+            server_url: server_url.to_string(),
+            client_id: "test-client-id".to_string(),
+            access_token: access_token.to_string(),
+            expires_at: Some(EXTERNAL_EXPIRES_AT),
+            refresh_token: Some(refresh_token.to_string()),
+            scopes: Vec::new(),
+        }
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Intent
Make running MCP OAuth clients adopt externally written login or logout generations without allowing refresh or persistence races, stale overwrites, or unbounded operation waits.

## User-visible behavior

### Before this change
When a user signed in, signed out, or updated MCP OAuth credentials in another Codex process using the same credential store, an already-running MCP client could retain its stale credentials. That could cause unexpected authentication failures or require signing in again. A concurrent refresh or save from the long-running client could also overwrite the newer persisted credential state.

### After this change
Before an MCP operation, the running client adopts an authoritative newer persisted credential generation, including external logout. Refresh and persistence are coordinated so stale generations do not overwrite newer state. Credential coordination, refresh, the operation itself, and post-operation persistence remain within the existing operation timeout behavior.

## Concrete implementation
- Hold stable per-user, per-server generation locks across persisted reload, refresh, and persistence, and serialize fallback-map mutations across processes.
- Keep fallback reads usable from read-only homes and use stable lock identities independent of `HOME`, `CODEX_HOME`, and `TMPDIR`.
- Resolve the Windows Local AppData lock namespace without requiring the directory to already exist.
- Adopt newer persisted credentials and authoritative logout while preserving live credentials on transient Auto/keyring read errors.
- Replace RMCP credentials through the credential-setting path so scopes stay synchronized.
- Include generation-lock acquisition, refresh, MCP operation, and post-operation persistence in the operation timeout.
- Compare persisted generations structurally while ignoring only `expires_in` drift.
- Cover startup refresh, external replacement/logout, stale-write prevention, dedicated holder-and-sibling-writer cross-process fallback contention, read-only homes, differing `TMPDIR`, scope replacement, and pre/post-operation lock timeout contention.

## Deferred scope
Mixed Auto keyring-versus-fallback precedence and module extraction remain deferred.

## Validation not covered by CI
None.