### PR TITLE
[rmcp-client] Report unusable OAuth credentials as not logged in

### DIFF
--- a/codex-rs/rmcp-client/src/auth_status.rs
+++ b/codex-rs/rmcp-client/src/auth_status.rs
@@ -1,9 +1,12 @@
 use std::collections::HashMap;
 use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 use anyhow::Error;
 use anyhow::Result;
 use codex_protocol::protocol::McpAuthStatus;
+use oauth2::TokenResponse;
 use reqwest::Client;
 use reqwest::StatusCode;
 use reqwest::Url;
@@ -12,7 +15,8 @@ use reqwest::header::HeaderMap;
 use serde::Deserialize;
 use tracing::debug;
 
-use crate::oauth::has_oauth_tokens;
+use crate::oauth::StoredOAuthTokens;
+use crate::oauth::load_oauth_tokens;
 use crate::utils::apply_default_headers;
 use crate::utils::build_default_headers;
 use codex_config::types::OAuthCredentialsStoreMode;
@@ -44,7 +48,10 @@ pub async fn determine_streamable_http_auth_status(
         return Ok(McpAuthStatus::BearerToken);
     }
 
-    if has_oauth_tokens(server_name, url, store_mode)? {
+    if load_oauth_tokens(server_name, url, store_mode)?
+        .as_ref()
+        .is_some_and(stored_oauth_tokens_are_locally_usable)
+    {
         return Ok(McpAuthStatus::OAuth);
     }
 
@@ -58,6 +65,36 @@ pub async fn determine_streamable_http_auth_status(
             Ok(McpAuthStatus::Unsupported)
         }
     }
+}
+
+fn stored_oauth_tokens_are_locally_usable(tokens: &StoredOAuthTokens) -> bool {
+    if tokens.client_id.trim().is_empty() {
+        return false;
+    }
+
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_else(|_| Duration::from_secs(0))
+        .as_millis() as u64;
+    let is_expired = tokens
+        .expires_at
+        .is_some_and(|expires_at| expires_at <= now_ms);
+
+    if is_expired {
+        return tokens
+            .token_response
+            .0
+            .refresh_token()
+            .is_some_and(|token| !token.secret().trim().is_empty());
+    }
+
+    !tokens
+        .token_response
+        .0
+        .access_token()
+        .secret()
+        .trim()
+        .is_empty()
 }
 
 /// Attempt to determine whether a streamable HTTP MCP server advertises OAuth login.

--- a/codex-rs/rmcp-client/src/auth_status.rs
+++ b/codex-rs/rmcp-client/src/auth_status.rs
@@ -48,11 +48,12 @@ pub async fn determine_streamable_http_auth_status(
         return Ok(McpAuthStatus::BearerToken);
     }
 
-    if load_oauth_tokens(server_name, url, store_mode)?
-        .as_ref()
-        .is_some_and(stored_oauth_tokens_are_locally_usable)
-    {
-        return Ok(McpAuthStatus::OAuth);
+    if let Some(tokens) = load_oauth_tokens(server_name, url, store_mode)? {
+        return Ok(if stored_oauth_tokens_are_locally_usable(&tokens) {
+            McpAuthStatus::OAuth
+        } else {
+            McpAuthStatus::NotLoggedIn
+        });
     }
 
     match discover_streamable_http_oauth_with_headers(url, &default_headers).await {

--- a/codex-rs/rmcp-client/src/auth_status.rs
+++ b/codex-rs/rmcp-client/src/auth_status.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 use std::time::Duration;
-use std::time::SystemTime;
-use std::time::UNIX_EPOCH;
 
 use anyhow::Error;
 use anyhow::Result;
@@ -17,6 +15,7 @@ use tracing::debug;
 
 use crate::oauth::StoredOAuthTokens;
 use crate::oauth::load_oauth_tokens;
+use crate::oauth::token_needs_refresh;
 use crate::utils::apply_default_headers;
 use crate::utils::build_default_headers;
 use codex_config::types::OAuthCredentialsStoreMode;
@@ -73,15 +72,7 @@ fn stored_oauth_tokens_are_locally_usable(tokens: &StoredOAuthTokens) -> bool {
         return false;
     }
 
-    let now_ms = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_else(|_| Duration::from_secs(0))
-        .as_millis() as u64;
-    let is_expired = tokens
-        .expires_at
-        .is_some_and(|expires_at| expires_at <= now_ms);
-
-    if is_expired {
+    if token_needs_refresh(tokens.expires_at) {
         return tokens
             .token_response
             .0

--- a/codex-rs/rmcp-client/src/oauth.rs
+++ b/codex-rs/rmcp-client/src/oauth.rs
@@ -499,7 +499,7 @@ fn expires_in_from_timestamp(expires_at: u64) -> Option<u64> {
     }
 }
 
-fn token_needs_refresh(expires_at: Option<u64>) -> bool {
+pub(crate) fn token_needs_refresh(expires_at: Option<u64>) -> bool {
     let Some(expires_at) = expires_at else {
         return false;
     };

--- a/codex-rs/rmcp-client/src/oauth.rs
+++ b/codex-rs/rmcp-client/src/oauth.rs
@@ -94,14 +94,6 @@ pub(crate) fn load_oauth_tokens(
     }
 }
 
-pub(crate) fn has_oauth_tokens(
-    server_name: &str,
-    url: &str,
-    store_mode: OAuthCredentialsStoreMode,
-) -> Result<bool> {
-    Ok(load_oauth_tokens(server_name, url, store_mode)?.is_some())
-}
-
 fn refresh_expires_in_from_timestamp(tokens: &mut StoredOAuthTokens) {
     let Some(expires_at) = tokens.expires_at else {
         return;

--- a/codex-rs/rmcp-client/tests/oauth_auth_status.rs
+++ b/codex-rs/rmcp-client/tests/oauth_auth_status.rs
@@ -1,0 +1,237 @@
+mod streamable_http_test_support;
+
+use std::fs;
+use std::net::TcpListener;
+use std::time::Duration;
+
+use codex_config::types::OAuthCredentialsStoreMode;
+use codex_exec_server::Environment;
+use codex_protocol::protocol::McpAuthStatus;
+use codex_rmcp_client::RmcpClient;
+use codex_rmcp_client::StoredOAuthTokens;
+use codex_rmcp_client::WrappedOAuthTokenResponse;
+use codex_rmcp_client::determine_streamable_http_auth_status;
+use codex_rmcp_client::save_oauth_tokens;
+use oauth2::AccessToken;
+use oauth2::RefreshToken;
+use oauth2::basic::BasicTokenType;
+use rmcp::transport::auth::OAuthTokenResponse;
+use rmcp::transport::auth::VendorExtraTokenFields;
+use serde_json::json;
+use tempfile::TempDir;
+use tokio::process::Command;
+use wiremock::Mock;
+use wiremock::MockServer;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::header;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
+
+use streamable_http_test_support::initialize_client;
+
+const SERVER_NAME: &str = "test-oauth-auth-status";
+const CHILD_SCENARIO_ENV: &str = "MCP_TEST_AUTH_STATUS_SCENARIO";
+const CHILD_SERVER_URL_ENV: &str = "MCP_TEST_AUTH_STATUS_SERVER_URL";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn oauth_status_does_not_prove_stored_credentials_are_usable() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/.well-known/oauth-authorization-server/mcp"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "authorization_endpoint": format!("{}/oauth/authorize", server.uri()),
+            "token_endpoint": format!("{}/oauth/token", server.uri()),
+        })))
+        .expect(2)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/mcp"))
+        .and(header(
+            "authorization",
+            "Bearer server-rejected-access-token",
+        ))
+        .respond_with(ResponseTemplate::new(401))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let server_url = format!("{}/mcp", server.uri());
+    run_child("expired_without_refresh", &server_url).await?;
+    run_child("server_rejected", &server_url).await?;
+
+    server.verify().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn oauth_status_only_requires_a_loadable_matching_store_entry() -> anyhow::Result<()> {
+    run_child("empty_fields", "not-a-valid-url").await?;
+
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let unreachable_url = format!("http://{}/mcp", listener.local_addr()?);
+    drop(listener);
+    run_child("unreachable_server", &unreachable_url).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn malformed_oauth_store_returns_an_error_instead_of_oauth() -> anyhow::Result<()> {
+    run_child("malformed_store", "not-a-valid-url").await
+}
+
+async fn run_child(scenario: &str, server_url: &str) -> anyhow::Result<()> {
+    let codex_home = TempDir::new()?;
+    let status = Command::new(std::env::current_exe()?)
+        .args([
+            "oauth_auth_status_child",
+            "--exact",
+            "--ignored",
+            "--nocapture",
+        ])
+        .env("CODEX_HOME", codex_home.path())
+        .env(CHILD_SCENARIO_ENV, scenario)
+        .env(CHILD_SERVER_URL_ENV, server_url)
+        .status()
+        .await?;
+
+    assert!(status.success(), "auth status child failed: {status}");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[ignore = "spawned by OAuth auth status tests"]
+async fn oauth_auth_status_child() -> anyhow::Result<()> {
+    let scenario = std::env::var(CHILD_SCENARIO_ENV)?;
+    let server_url = std::env::var(CHILD_SERVER_URL_ENV)?;
+
+    if scenario == "malformed_store" {
+        let codex_home = std::env::var("CODEX_HOME")?;
+        fs::write(
+            std::path::Path::new(&codex_home).join(".credentials.json"),
+            "{not valid json",
+        )?;
+
+        let error = determine_auth_status(&server_url)
+            .await
+            .expect_err("malformed credentials should not report OAuth");
+        let message = format!("{error:#}");
+        assert!(
+            message.contains("failed to parse credentials file"),
+            "unexpected error: {message}"
+        );
+        return Ok(());
+    }
+
+    let (access_token, client_id, refresh_token, expires_at) = match scenario.as_str() {
+        "expired_without_refresh" => (
+            "expired-access-token",
+            "client-id",
+            /*refresh_token*/ None,
+            Some(0),
+        ),
+        "server_rejected" => (
+            "server-rejected-access-token",
+            "client-id",
+            /*refresh_token*/ None,
+            /*expires_at*/ None,
+        ),
+        "empty_fields" => ("", "", Some(""), /*expires_at*/ None),
+        "unreachable_server" => (
+            "access-token",
+            "client-id",
+            /*refresh_token*/ None,
+            /*expires_at*/ None,
+        ),
+        unexpected => panic!("unexpected child scenario: {unexpected}"),
+    };
+    save_tokens(
+        &server_url,
+        access_token,
+        client_id,
+        refresh_token,
+        expires_at,
+    )?;
+
+    assert_eq!(
+        determine_auth_status(&server_url).await?,
+        McpAuthStatus::OAuth
+    );
+
+    match scenario.as_str() {
+        "expired_without_refresh" | "server_rejected" => {
+            let client = new_client(&server_url).await?;
+            assert!(
+                initialize_client(&client).await.is_err(),
+                "{scenario} credentials unexpectedly initialized"
+            );
+        }
+        "unreachable_server" => {
+            if let Ok(client) = new_client(&server_url).await {
+                assert!(
+                    initialize_client(&client).await.is_err(),
+                    "unreachable server unexpectedly initialized"
+                );
+            }
+        }
+        "empty_fields" => {}
+        unexpected => panic!("unexpected child scenario: {unexpected}"),
+    }
+
+    Ok(())
+}
+
+fn save_tokens(
+    server_url: &str,
+    access_token: &str,
+    client_id: &str,
+    refresh_token: Option<&str>,
+    expires_at: Option<u64>,
+) -> anyhow::Result<()> {
+    let mut response = OAuthTokenResponse::new(
+        AccessToken::new(access_token.to_string()),
+        BasicTokenType::Bearer,
+        VendorExtraTokenFields::default(),
+    );
+    if let Some(refresh_token) = refresh_token {
+        response.set_refresh_token(Some(RefreshToken::new(refresh_token.to_string())));
+    }
+    response.set_expires_in(Some(&Duration::from_secs(7200)));
+
+    save_oauth_tokens(
+        SERVER_NAME,
+        &StoredOAuthTokens {
+            server_name: SERVER_NAME.to_string(),
+            url: server_url.to_string(),
+            client_id: client_id.to_string(),
+            token_response: WrappedOAuthTokenResponse(response),
+            expires_at,
+        },
+        OAuthCredentialsStoreMode::File,
+    )
+}
+
+async fn determine_auth_status(server_url: &str) -> anyhow::Result<McpAuthStatus> {
+    determine_streamable_http_auth_status(
+        SERVER_NAME,
+        server_url,
+        /*bearer_token_env_var*/ None,
+        /*http_headers*/ None,
+        /*env_http_headers*/ None,
+        OAuthCredentialsStoreMode::File,
+    )
+    .await
+}
+
+async fn new_client(server_url: &str) -> anyhow::Result<RmcpClient> {
+    RmcpClient::new_streamable_http_client(
+        SERVER_NAME,
+        server_url,
+        /*bearer_token*/ None,
+        /*http_headers*/ None,
+        /*env_http_headers*/ None,
+        OAuthCredentialsStoreMode::File,
+        Environment::default_for_tests().get_http_client(),
+        /*auth_provider*/ None,
+    )
+    .await
+}

--- a/codex-rs/rmcp-client/tests/oauth_auth_status.rs
+++ b/codex-rs/rmcp-client/tests/oauth_auth_status.rs
@@ -3,6 +3,8 @@ mod streamable_http_test_support;
 use std::fs;
 use std::net::TcpListener;
 use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
 
 use codex_config::types::OAuthCredentialsStoreMode;
 use codex_exec_server::Environment;
@@ -46,7 +48,8 @@ async fn blank_client_ids_are_not_logged_in_without_discovery() -> anyhow::Resul
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn blank_refresh_tokens_do_not_make_expired_credentials_usable() -> anyhow::Result<()> {
+async fn expired_credentials_require_nonblank_refresh_token() -> anyhow::Result<()> {
+    run_child("expired_without_refresh", "not-a-valid-url").await?;
     run_child("expired_with_empty_refresh", "not-a-valid-url").await?;
     run_child("expired_with_whitespace_refresh", "not-a-valid-url").await
 }
@@ -57,8 +60,19 @@ async fn refreshable_expired_credentials_report_oauth() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn refresh_window_boundary_matches_startup_refresh() -> anyhow::Result<()> {
+    run_child("inside_refresh_window", "not-a-valid-url").await?;
+    run_child("outside_refresh_window", "not-a-valid-url").await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn future_credentials_without_refresh_report_oauth_without_discovery() -> anyhow::Result<()> {
     run_child("future_without_refresh", "not-a-valid-url").await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn legacy_credentials_without_expiry_report_oauth_without_discovery() -> anyhow::Result<()> {
+    run_child("legacy_without_expiry", "not-a-valid-url").await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -147,6 +161,35 @@ async fn oauth_auth_status_child() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    if scenario == "legacy_without_expiry" {
+        let response = OAuthTokenResponse::new(
+            AccessToken::new("access-token".to_string()),
+            BasicTokenType::Bearer,
+            VendorExtraTokenFields::default(),
+        );
+        save_oauth_tokens(
+            SERVER_NAME,
+            &StoredOAuthTokens {
+                server_name: SERVER_NAME.to_string(),
+                url: server_url.clone(),
+                client_id: "client-id".to_string(),
+                token_response: WrappedOAuthTokenResponse(response),
+                expires_at: None,
+            },
+            OAuthCredentialsStoreMode::File,
+        )?;
+
+        assert_eq!(
+            determine_auth_status(&server_url).await?,
+            McpAuthStatus::OAuth
+        );
+        return Ok(());
+    }
+
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_else(|_| Duration::from_secs(0))
+        .as_millis() as u64;
     let (access_token, client_id, refresh_token, expires_at, expected_status) =
         match scenario.as_str() {
             "empty_access_token" => (
@@ -175,6 +218,13 @@ async fn oauth_auth_status_child() -> anyhow::Result<()> {
                 " \t ",
                 /*refresh_token*/ None,
                 /*expires_at*/ None,
+                McpAuthStatus::NotLoggedIn,
+            ),
+            "expired_without_refresh" => (
+                "expired-access-token",
+                "client-id",
+                /*refresh_token*/ None,
+                Some(0),
                 McpAuthStatus::NotLoggedIn,
             ),
             "expired_with_empty_refresh" => (
@@ -211,6 +261,20 @@ async fn oauth_auth_status_child() -> anyhow::Result<()> {
                 Some("refresh-token"),
                 Some(0),
                 McpAuthStatus::OAuth,
+            ),
+            "inside_refresh_window" => (
+                "",
+                "client-id",
+                Some("refresh-token"),
+                Some(now_ms.saturating_add(29_000)),
+                McpAuthStatus::OAuth,
+            ),
+            "outside_refresh_window" => (
+                "",
+                "client-id",
+                Some("refresh-token"),
+                Some(now_ms.saturating_add(31_000)),
+                McpAuthStatus::NotLoggedIn,
             ),
             "future_without_refresh" => (
                 "access-token",
@@ -251,9 +315,12 @@ async fn oauth_auth_status_child() -> anyhow::Result<()> {
         | "whitespace_access_token"
         | "empty_client_id"
         | "whitespace_client_id"
+        | "expired_without_refresh"
         | "expired_with_empty_refresh"
         | "expired_with_whitespace_refresh"
         | "expired_with_refresh"
+        | "inside_refresh_window"
+        | "outside_refresh_window"
         | "future_without_refresh" => {}
         unexpected => panic!("unexpected child scenario: {unexpected}"),
     }

--- a/codex-rs/rmcp-client/tests/oauth_auth_status.rs
+++ b/codex-rs/rmcp-client/tests/oauth_auth_status.rs
@@ -273,7 +273,7 @@ async fn oauth_auth_status_child() -> anyhow::Result<()> {
                 "",
                 "client-id",
                 Some("refresh-token"),
-                Some(now_ms.saturating_add(31_000)),
+                Some(now_ms.saturating_add(60_000)),
                 McpAuthStatus::NotLoggedIn,
             ),
             "future_without_refresh" => (

--- a/codex-rs/rmcp-client/tests/oauth_auth_status.rs
+++ b/codex-rs/rmcp-client/tests/oauth_auth_status.rs
@@ -34,29 +34,25 @@ const CHILD_SCENARIO_ENV: &str = "MCP_TEST_AUTH_STATUS_SCENARIO";
 const CHILD_SERVER_URL_ENV: &str = "MCP_TEST_AUTH_STATUS_SERVER_URL";
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn locally_unusable_credentials_are_not_logged_in() -> anyhow::Result<()> {
-    let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/.well-known/oauth-authorization-server/mcp"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "authorization_endpoint": format!("{}/oauth/authorize", server.uri()),
-            "token_endpoint": format!("{}/oauth/token", server.uri()),
-        })))
-        .expect(2)
-        .mount(&server)
-        .await;
+async fn blank_access_tokens_are_not_logged_in_without_discovery() -> anyhow::Result<()> {
+    run_child("empty_access_token", "not-a-valid-url").await?;
+    run_child("whitespace_access_token", "not-a-valid-url").await
+}
 
-    let server_url = format!("{}/mcp", server.uri());
-    run_child("expired_without_refresh", &server_url).await?;
-    run_child("empty_fields", &server_url).await?;
-
-    server.verify().await;
-    Ok(())
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn blank_refresh_tokens_do_not_make_expired_credentials_usable() -> anyhow::Result<()> {
+    run_child("expired_with_empty_refresh", "not-a-valid-url").await?;
+    run_child("expired_with_whitespace_refresh", "not-a-valid-url").await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn refreshable_expired_credentials_report_oauth() -> anyhow::Result<()> {
     run_child("expired_with_refresh", "not-a-valid-url").await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn future_credentials_without_refresh_report_oauth_without_discovery() -> anyhow::Result<()> {
+    run_child("future_without_refresh", "not-a-valid-url").await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -147,10 +143,31 @@ async fn oauth_auth_status_child() -> anyhow::Result<()> {
 
     let (access_token, client_id, refresh_token, expires_at, expected_status) =
         match scenario.as_str() {
-            "expired_without_refresh" => (
-                "expired-access-token",
+            "empty_access_token" => (
+                "",
                 "client-id",
                 /*refresh_token*/ None,
+                /*expires_at*/ None,
+                McpAuthStatus::NotLoggedIn,
+            ),
+            "whitespace_access_token" => (
+                " \t ",
+                "client-id",
+                /*refresh_token*/ None,
+                /*expires_at*/ None,
+                McpAuthStatus::NotLoggedIn,
+            ),
+            "expired_with_empty_refresh" => (
+                "expired-access-token",
+                "client-id",
+                Some(""),
+                Some(0),
+                McpAuthStatus::NotLoggedIn,
+            ),
+            "expired_with_whitespace_refresh" => (
+                "expired-access-token",
+                "client-id",
+                Some(" \t "),
                 Some(0),
                 McpAuthStatus::NotLoggedIn,
             ),
@@ -160,13 +177,6 @@ async fn oauth_auth_status_child() -> anyhow::Result<()> {
                 /*refresh_token*/ None,
                 /*expires_at*/ None,
                 McpAuthStatus::OAuth,
-            ),
-            "empty_fields" => (
-                "",
-                "",
-                Some(""),
-                /*expires_at*/ None,
-                McpAuthStatus::NotLoggedIn,
             ),
             "unreachable_server" => (
                 "access-token",
@@ -180,6 +190,13 @@ async fn oauth_auth_status_child() -> anyhow::Result<()> {
                 "client-id",
                 Some("refresh-token"),
                 Some(0),
+                McpAuthStatus::OAuth,
+            ),
+            "future_without_refresh" => (
+                "access-token",
+                "client-id",
+                /*refresh_token*/ None,
+                Some(u64::MAX),
                 McpAuthStatus::OAuth,
             ),
             unexpected => panic!("unexpected child scenario: {unexpected}"),
@@ -210,7 +227,12 @@ async fn oauth_auth_status_child() -> anyhow::Result<()> {
                 );
             }
         }
-        "expired_without_refresh" | "empty_fields" | "expired_with_refresh" => {}
+        "empty_access_token"
+        | "whitespace_access_token"
+        | "expired_with_empty_refresh"
+        | "expired_with_whitespace_refresh"
+        | "expired_with_refresh"
+        | "future_without_refresh" => {}
         unexpected => panic!("unexpected child scenario: {unexpected}"),
     }
 

--- a/codex-rs/rmcp-client/tests/oauth_auth_status.rs
+++ b/codex-rs/rmcp-client/tests/oauth_auth_status.rs
@@ -40,6 +40,12 @@ async fn blank_access_tokens_are_not_logged_in_without_discovery() -> anyhow::Re
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn blank_client_ids_are_not_logged_in_without_discovery() -> anyhow::Result<()> {
+    run_child("empty_client_id", "not-a-valid-url").await?;
+    run_child("whitespace_client_id", "not-a-valid-url").await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn blank_refresh_tokens_do_not_make_expired_credentials_usable() -> anyhow::Result<()> {
     run_child("expired_with_empty_refresh", "not-a-valid-url").await?;
     run_child("expired_with_whitespace_refresh", "not-a-valid-url").await
@@ -157,6 +163,20 @@ async fn oauth_auth_status_child() -> anyhow::Result<()> {
                 /*expires_at*/ None,
                 McpAuthStatus::NotLoggedIn,
             ),
+            "empty_client_id" => (
+                "access-token",
+                "",
+                /*refresh_token*/ None,
+                /*expires_at*/ None,
+                McpAuthStatus::NotLoggedIn,
+            ),
+            "whitespace_client_id" => (
+                "access-token",
+                " \t ",
+                /*refresh_token*/ None,
+                /*expires_at*/ None,
+                McpAuthStatus::NotLoggedIn,
+            ),
             "expired_with_empty_refresh" => (
                 "expired-access-token",
                 "client-id",
@@ -229,6 +249,8 @@ async fn oauth_auth_status_child() -> anyhow::Result<()> {
         }
         "empty_access_token"
         | "whitespace_access_token"
+        | "empty_client_id"
+        | "whitespace_client_id"
         | "expired_with_empty_refresh"
         | "expired_with_whitespace_refresh"
         | "expired_with_refresh"

--- a/codex-rs/rmcp-client/tests/oauth_auth_status.rs
+++ b/codex-rs/rmcp-client/tests/oauth_auth_status.rs
@@ -34,7 +34,7 @@ const CHILD_SCENARIO_ENV: &str = "MCP_TEST_AUTH_STATUS_SCENARIO";
 const CHILD_SERVER_URL_ENV: &str = "MCP_TEST_AUTH_STATUS_SERVER_URL";
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn oauth_status_does_not_prove_stored_credentials_are_usable() -> anyhow::Result<()> {
+async fn locally_unusable_credentials_are_not_logged_in() -> anyhow::Result<()> {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/.well-known/oauth-authorization-server/mcp"))
@@ -43,6 +43,32 @@ async fn oauth_status_does_not_prove_stored_credentials_are_usable() -> anyhow::
             "token_endpoint": format!("{}/oauth/token", server.uri()),
         })))
         .expect(2)
+        .mount(&server)
+        .await;
+
+    let server_url = format!("{}/mcp", server.uri());
+    run_child("expired_without_refresh", &server_url).await?;
+    run_child("empty_fields", &server_url).await?;
+
+    server.verify().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn refreshable_expired_credentials_report_oauth() -> anyhow::Result<()> {
+    run_child("expired_with_refresh", "not-a-valid-url").await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn server_rejected_credentials_still_report_oauth() -> anyhow::Result<()> {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/.well-known/oauth-authorization-server/mcp"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "authorization_endpoint": format!("{}/oauth/authorize", server.uri()),
+            "token_endpoint": format!("{}/oauth/token", server.uri()),
+        })))
+        .expect(1)
         .mount(&server)
         .await;
     Mock::given(method("POST"))
@@ -57,7 +83,6 @@ async fn oauth_status_does_not_prove_stored_credentials_are_usable() -> anyhow::
         .await;
 
     let server_url = format!("{}/mcp", server.uri());
-    run_child("expired_without_refresh", &server_url).await?;
     run_child("server_rejected", &server_url).await?;
 
     server.verify().await;
@@ -65,9 +90,7 @@ async fn oauth_status_does_not_prove_stored_credentials_are_usable() -> anyhow::
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn oauth_status_only_requires_a_loadable_matching_store_entry() -> anyhow::Result<()> {
-    run_child("empty_fields", "not-a-valid-url").await?;
-
+async fn unreachable_server_with_credentials_still_reports_oauth() -> anyhow::Result<()> {
     let listener = TcpListener::bind("127.0.0.1:0")?;
     let unreachable_url = format!("http://{}/mcp", listener.local_addr()?);
     drop(listener);
@@ -122,28 +145,45 @@ async fn oauth_auth_status_child() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    let (access_token, client_id, refresh_token, expires_at) = match scenario.as_str() {
-        "expired_without_refresh" => (
-            "expired-access-token",
-            "client-id",
-            /*refresh_token*/ None,
-            Some(0),
-        ),
-        "server_rejected" => (
-            "server-rejected-access-token",
-            "client-id",
-            /*refresh_token*/ None,
-            /*expires_at*/ None,
-        ),
-        "empty_fields" => ("", "", Some(""), /*expires_at*/ None),
-        "unreachable_server" => (
-            "access-token",
-            "client-id",
-            /*refresh_token*/ None,
-            /*expires_at*/ None,
-        ),
-        unexpected => panic!("unexpected child scenario: {unexpected}"),
-    };
+    let (access_token, client_id, refresh_token, expires_at, expected_status) =
+        match scenario.as_str() {
+            "expired_without_refresh" => (
+                "expired-access-token",
+                "client-id",
+                /*refresh_token*/ None,
+                Some(0),
+                McpAuthStatus::NotLoggedIn,
+            ),
+            "server_rejected" => (
+                "server-rejected-access-token",
+                "client-id",
+                /*refresh_token*/ None,
+                /*expires_at*/ None,
+                McpAuthStatus::OAuth,
+            ),
+            "empty_fields" => (
+                "",
+                "",
+                Some(""),
+                /*expires_at*/ None,
+                McpAuthStatus::NotLoggedIn,
+            ),
+            "unreachable_server" => (
+                "access-token",
+                "client-id",
+                /*refresh_token*/ None,
+                /*expires_at*/ None,
+                McpAuthStatus::OAuth,
+            ),
+            "expired_with_refresh" => (
+                "expired-access-token",
+                "client-id",
+                Some("refresh-token"),
+                Some(0),
+                McpAuthStatus::OAuth,
+            ),
+            unexpected => panic!("unexpected child scenario: {unexpected}"),
+        };
     save_tokens(
         &server_url,
         access_token,
@@ -152,13 +192,10 @@ async fn oauth_auth_status_child() -> anyhow::Result<()> {
         expires_at,
     )?;
 
-    assert_eq!(
-        determine_auth_status(&server_url).await?,
-        McpAuthStatus::OAuth
-    );
+    assert_eq!(determine_auth_status(&server_url).await?, expected_status);
 
     match scenario.as_str() {
-        "expired_without_refresh" | "server_rejected" => {
+        "server_rejected" => {
             let client = new_client(&server_url).await?;
             assert!(
                 initialize_client(&client).await.is_err(),
@@ -173,7 +210,7 @@ async fn oauth_auth_status_child() -> anyhow::Result<()> {
                 );
             }
         }
-        "empty_fields" => {}
+        "expired_without_refresh" | "empty_fields" | "expired_with_refresh" => {}
         unexpected => panic!("unexpected child scenario: {unexpected}"),
     }
 


### PR DESCRIPTION
## Intent

Correct MCP OAuth auth-status reporting using only locally stored credential state. Preserve the existing `McpAuthStatus` enum and wire variants, and do not add network credential validation.

## User-visible behavior

### Before

Locally unusable stored credentials could still be reported as `OAuth`. The UI and API clients could therefore present the MCP server as logged in even when required credential fields were blank or the token was expired and could not be refreshed. Users or clients would discover the problem only when connection or initialization later failed.

### After

Stored credentials that are locally known to be unusable report `NotLoggedIn`: blank access tokens, blank client IDs, and expired credentials without a non-empty refresh token. Refreshable credentials, valid unexpired credentials, and legacy credentials with unknown expiry remain `OAuth`.

OAuth discovery behavior is unchanged. Discovery runs only when there is no matching stored credential, and auth status does not contact the server to validate a stored token.

## Concrete implementation

When a matching stored credential exists, auth status returns a terminal local result: `OAuth` for locally usable credentials and `NotLoggedIn` for credentials known unusable. Classification uses the same 30-second refresh window as RMCP startup, so credentials with a usable refresh token remain authenticated when startup can refresh them.

The existing `McpAuthStatus` enum and wire representation are unchanged.

## Validation not covered by CI

The focused suite contains ten executable tests. Deterministic coverage independently exercises empty or whitespace access tokens and client IDs; missing, empty, or whitespace refresh tokens on expired credentials; the refresh-window boundary; refreshable expired credentials; future-dated credentials without refresh; and legacy credentials without expiry metadata.

Manually verified that the published branch tree matches the locally tested and formatted tree, and reviewed the diff to confirm there are no enum, protocol, network-validation, or storage-format changes.

## Deferred

Server-rejected credentials remain `OAuth` because rejection cannot be determined without network validation. Unreachable servers are not classified as logged out. Malformed credential-store errors and their `Unsupported` mapping remain a separate error-classification topic.
