### PR TITLE
[codex] Add /usr/bin/bash shell fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ In the codex-rs folder where the rust code lives:
   - Implementations may still use `async fn foo(&self, ...) -> T` when they satisfy that contract.
   - Do not use `#[allow(async_fn_in_trait)]` as a shortcut around spelling the future contract explicitly.
 - When writing tests, prefer comparing the equality of entire objects over fields one by one.
+- Do not add tests for values that are statically defined.
+- Do not add negative tests for logic that was removed.
 - Do not add general product or user-facing documentation to the `docs/` folder. The official Codex documentation lives elsewhere. The exception is app-server API documentation, which is covered by the app-server guidance below.
 - Prefer private modules and explicitly exported public crate API.
 - If you change `ConfigToml` or nested config types, run `just write-config-schema` to update `codex-rs/core/config.schema.json`.

--- a/codex-rs/shell-command/src/shell_detect.rs
+++ b/codex-rs/shell-command/src/shell_detect.rs
@@ -174,7 +174,7 @@ fn get_zsh_shell(path: Option<&PathBuf>) -> Option<DetectedShell> {
     })
 }
 
-const BASH_FALLBACK_PATHS: &[&str] = &["/bin/bash"];
+const BASH_FALLBACK_PATHS: &[&str] = &["/bin/bash", "/usr/bin/bash"];
 
 fn get_bash_shell(path: Option<&PathBuf>) -> Option<DetectedShell> {
     let shell_path = get_shell_path(ShellType::Bash, path, "bash", BASH_FALLBACK_PATHS);
@@ -325,6 +325,10 @@ mod tests {
         );
         assert_eq!(
             detect_shell_type(PathBuf::from("/bin/bash")),
+            Some(ShellType::Bash)
+        );
+        assert_eq!(
+            detect_shell_type(PathBuf::from("/usr/bin/bash")),
             Some(ShellType::Bash)
         );
         assert_eq!(


### PR DESCRIPTION
## Why

Some Linux environments expose `bash` at `/usr/bin/bash` instead of `/bin/bash`. The shell detection fallback list should cover both standard locations once PATH/user-shell probing fails.

Stacked on #26480.

## What changed

- Add `/usr/bin/bash` to the bash fallback path list in `codex-shell-command`.
- Extend shell type detection coverage for `/usr/bin/bash`.
- Add AGENTS.md testing guidance to avoid tests for statically defined values and negative tests for removed logic.

## Verification

- `just test -p codex-shell-command`