### PR TITLE
[codex] Add Rust-only formatter recipe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ In the codex-rs folder where the rust code lives:
     trivial; prefer new modules/files and keep `chatwidget.rs` focused on orchestration.
 - When running Rust commands (e.g. `just fix` or `just test`) be patient with the command and never try to kill them using the PID. Rust lock can make the execution slow, this is expected.
 
-Run `just fmt` (in the `codex-rs` directory) automatically after you have finished making code changes anywhere in this repository; do not ask for approval to run it. Additionally, run the tests:
+Run `just fmt-rust` automatically after you have finished making Rust-only code changes, or `just fmt` for all other changes anywhere in this repository; do not ask for approval to run it. Additionally, run the tests:
 
 1. Do not run `cargo test` directly. Use `just test` so test execution follows the repo defaults.
 2. Run the test for the specific project that was changed. For example, if changes were made in `codex-rs/tui`, run `just test -p codex-tui`.

--- a/justfile
+++ b/justfile
@@ -40,6 +40,10 @@ app-server-test-client *args:
 fmt:
     {{ python }} ../scripts/format.py
 
+# Format Rust code only.
+fmt-rust:
+    cargo fmt -- --config imports_granularity=Item
+
 # Check formatting without modifying files.
 fmt-check:
     {{ python }} ../scripts/format.py --check


### PR DESCRIPTION
## Why

Rust-only edits should not need to run the full repository formatter because `just fmt` also formats the justfile and Python trees. A narrower recipe gives agents and humans a clear command for routine Rust formatting while preserving `just fmt` for non-Rust or mixed changes.

## What changed

- Added `just fmt-rust`, wrapping the existing Cargo rustfmt invocation.
- Updated `AGENTS.md` to use `just fmt-rust` for Rust-only changes and `just fmt` for all other changes.

## Verification

- `just --dry-run fmt-rust`
- `just fmt-rust`
