### PR TITLE
[codex] Send Responses Lite transport header

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -143,6 +143,8 @@ pub const X_RESPONSESAPI_INCLUDE_TIMING_METRICS_HEADER: &str =
     "x-responsesapi-include-timing-metrics";
 const X_CODEX_WS_STREAM_REQUEST_START_MS_CLIENT_METADATA_KEY: &str =
     "x-codex-ws-stream-request-start-ms";
+const WS_REQUEST_HEADER_RESPONSES_LITE_CLIENT_METADATA_KEY: &str =
+    "ws_request_header_x_openai_internal_codex_responses_lite";
 const RESPONSES_WEBSOCKETS_V2_BETA_HEADER_VALUE: &str = "responses_websockets=2026-02-06";
 const X_OPENAI_INTERNAL_CODEX_RESPONSES_LITE_HEADER: &str =
     "x-openai-internal-codex-responses-lite";
@@ -261,17 +263,11 @@ struct LastResponse {
 
 #[derive(Debug, Default)]
 struct WebsocketSession {
-    connection: Option<CachedWebsocketConnection>,
+    connection: Option<ApiWebSocketConnection>,
     last_request: Option<ResponsesApiRequest>,
     last_response_rx: Option<oneshot::Receiver<LastResponse>>,
     last_response_from_untraced_warmup: bool,
     connection_reused: StdMutex<bool>,
-}
-
-#[derive(Debug)]
-struct CachedWebsocketConnection {
-    inner: ApiWebSocketConnection,
-    use_responses_lite: bool,
 }
 
 impl WebsocketSession {
@@ -664,6 +660,7 @@ impl ModelClient {
     fn build_ws_client_metadata(
         &self,
         turn_metadata_header: Option<&str>,
+        model_info: &ModelInfo,
     ) -> HashMap<String, String> {
         let mut client_metadata = HashMap::new();
         client_metadata.insert(
@@ -689,6 +686,12 @@ impl ModelClient {
             client_metadata.insert(
                 X_CODEX_TURN_METADATA_HEADER.to_string(),
                 turn_metadata.to_string(),
+            );
+        }
+        if model_info.use_responses_lite {
+            client_metadata.insert(
+                WS_REQUEST_HEADER_RESPONSES_LITE_CLIENT_METADATA_KEY.to_string(),
+                "true".to_string(),
             );
         }
         client_metadata
@@ -847,16 +850,11 @@ impl ModelClient {
         api_auth: SharedAuthProvider,
         turn_state: Option<Arc<OnceLock<String>>>,
         turn_metadata_header: Option<&str>,
-        use_responses_lite: bool,
         auth_context: AuthRequestTelemetryContext,
         request_route_telemetry: RequestRouteTelemetry,
     ) -> std::result::Result<ApiWebSocketConnection, ApiError> {
         let headers = self
-            .build_websocket_headers(
-                turn_state.as_ref(),
-                turn_metadata_header,
-                use_responses_lite,
-            )
+            .build_websocket_headers(turn_state.as_ref(), turn_metadata_header)
             .await;
         let websocket_telemetry = ModelClientSession::build_websocket_telemetry(
             session_telemetry,
@@ -938,7 +936,6 @@ impl ModelClient {
         &self,
         turn_state: Option<&Arc<OnceLock<String>>>,
         turn_metadata_header: Option<&str>,
-        use_responses_lite: bool,
     ) -> ApiHeaderMap {
         let turn_metadata_header = parse_turn_metadata_header(turn_metadata_header);
         let session_id = self.state.session_id.to_string();
@@ -966,7 +963,6 @@ impl ModelClient {
                 HeaderValue::from_static("true"),
             );
         }
-        add_responses_lite_header(&mut headers, use_responses_lite);
         headers
     }
 }
@@ -1113,21 +1109,14 @@ impl ModelClientSession {
     pub async fn preconnect_websocket(
         &mut self,
         session_telemetry: &SessionTelemetry,
-        model_info: &ModelInfo,
+        _model_info: &ModelInfo,
     ) -> std::result::Result<(), ApiError> {
         if !self.client.responses_websocket_enabled() {
             return Ok(());
         }
-        let use_responses_lite = model_info.use_responses_lite;
-        if self
-            .websocket_session
-            .connection
-            .as_ref()
-            .is_some_and(|connection| connection.use_responses_lite == use_responses_lite)
-        {
+        if self.websocket_session.connection.is_some() {
             return Ok(());
         }
-        self.reset_websocket_session();
 
         let client_setup = self.client.current_client_setup().await.map_err(|err| {
             ApiError::Stream(format!(
@@ -1147,15 +1136,11 @@ impl ModelClientSession {
                 client_setup.api_auth,
                 Some(Arc::clone(&self.turn_state)),
                 /*turn_metadata_header*/ None,
-                use_responses_lite,
                 auth_context,
                 RequestRouteTelemetry::for_endpoint(RESPONSES_ENDPOINT),
             )
             .await?;
-        self.websocket_session.connection = Some(CachedWebsocketConnection {
-            inner: connection,
-            use_responses_lite,
-        });
+        self.websocket_session.connection = Some(connection);
         self.websocket_session
             .set_connection_reused(/*connection_reused*/ false);
         Ok(())
@@ -1183,25 +1168,23 @@ impl ModelClientSession {
             api_auth,
             turn_metadata_header,
             options,
-            use_responses_lite,
             auth_context,
             request_route_telemetry,
         } = params;
         let needs_new = match self.websocket_session.connection.as_ref() {
-            Some(connection) => {
-                connection.inner.is_closed().await
-                    || connection.use_responses_lite != use_responses_lite
-            }
+            Some(conn) => conn.is_closed().await,
             None => true,
         };
 
         if needs_new {
-            self.reset_websocket_session();
+            self.websocket_session.last_request = None;
+            self.websocket_session.last_response_rx = None;
+            self.websocket_session.last_response_from_untraced_warmup = false;
             let turn_state = options
                 .turn_state
                 .clone()
                 .unwrap_or_else(|| Arc::clone(&self.turn_state));
-            let connection = self
+            let new_conn = match self
                 .client
                 .connect_websocket(
                     session_telemetry,
@@ -1209,15 +1192,20 @@ impl ModelClientSession {
                     api_auth,
                     Some(turn_state),
                     turn_metadata_header,
-                    use_responses_lite,
                     auth_context,
                     request_route_telemetry,
                 )
-                .await?;
-            self.websocket_session.connection = Some(CachedWebsocketConnection {
-                inner: connection,
-                use_responses_lite,
-            });
+                .await
+            {
+                Ok(new_conn) => new_conn,
+                Err(err) => {
+                    if matches!(err, ApiError::Transport(TransportError::Timeout)) {
+                        self.reset_websocket_session();
+                    }
+                    return Err(err);
+                }
+            };
+            self.websocket_session.connection = Some(new_conn);
             self.websocket_session
                 .set_connection_reused(/*connection_reused*/ false);
         } else {
@@ -1228,7 +1216,6 @@ impl ModelClientSession {
         self.websocket_session
             .connection
             .as_ref()
-            .map(|connection| &connection.inner)
             .ok_or(ApiError::Stream(
                 "websocket connection is unavailable".to_string(),
             ))
@@ -1424,7 +1411,10 @@ impl ModelClientSession {
             )?;
             let mut ws_payload = ResponseCreateWsRequest {
                 client_metadata: response_create_client_metadata(
-                    Some(self.client.build_ws_client_metadata(turn_metadata_header)),
+                    Some(
+                        self.client
+                            .build_ws_client_metadata(turn_metadata_header, model_info),
+                    ),
                     request_trace.as_ref(),
                 ),
                 ..ResponseCreateWsRequest::from(&request)
@@ -1440,7 +1430,6 @@ impl ModelClientSession {
                     api_auth: client_setup.api_auth,
                     turn_metadata_header,
                     options: &options,
-                    use_responses_lite: model_info.use_responses_lite,
                     auth_context: request_auth_context,
                     request_route_telemetry: RequestRouteTelemetry::for_endpoint(
                         RESPONSES_ENDPOINT,
@@ -1497,7 +1486,6 @@ impl ModelClientSession {
                     ))
                 })?;
             let stream_result = websocket_connection
-                .inner
                 .stream_request(ws_request, self.websocket_session.connection_reused())
                 .await
                 .map_err(|err| {
@@ -2015,7 +2003,6 @@ struct WebsocketConnectParams<'a> {
     api_auth: SharedAuthProvider,
     turn_metadata_header: Option<&'a str>,
     options: &'a ApiResponsesOptions,
-    use_responses_lite: bool,
     auth_context: AuthRequestTelemetryContext,
     request_route_telemetry: RequestRouteTelemetry,
 }

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -660,7 +660,7 @@ impl ModelClient {
     fn build_ws_client_metadata(
         &self,
         turn_metadata_header: Option<&str>,
-        model_info: &ModelInfo,
+        use_responses_lite: bool,
     ) -> HashMap<String, String> {
         let mut client_metadata = HashMap::new();
         client_metadata.insert(
@@ -688,7 +688,7 @@ impl ModelClient {
                 turn_metadata.to_string(),
             );
         }
-        if model_info.use_responses_lite {
+        if use_responses_lite {
             client_metadata.insert(
                 WS_REQUEST_HEADER_RESPONSES_LITE_CLIENT_METADATA_KEY.to_string(),
                 "true".to_string(),
@@ -1411,10 +1411,10 @@ impl ModelClientSession {
             )?;
             let mut ws_payload = ResponseCreateWsRequest {
                 client_metadata: response_create_client_metadata(
-                    Some(
-                        self.client
-                            .build_ws_client_metadata(turn_metadata_header, model_info),
-                    ),
+                    Some(self.client.build_ws_client_metadata(
+                        turn_metadata_header,
+                        model_info.use_responses_lite,
+                    )),
                     request_trace.as_ref(),
                 ),
                 ..ResponseCreateWsRequest::from(&request)

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -261,12 +261,17 @@ struct LastResponse {
 
 #[derive(Debug, Default)]
 struct WebsocketSession {
-    connection: Option<ApiWebSocketConnection>,
-    use_responses_lite: Option<bool>,
+    connection: Option<CachedWebsocketConnection>,
     last_request: Option<ResponsesApiRequest>,
     last_response_rx: Option<oneshot::Receiver<LastResponse>>,
     last_response_from_untraced_warmup: bool,
     connection_reused: StdMutex<bool>,
+}
+
+#[derive(Debug)]
+struct CachedWebsocketConnection {
+    inner: ApiWebSocketConnection,
+    use_responses_lite: bool,
 }
 
 impl WebsocketSession {
@@ -976,7 +981,6 @@ impl Drop for ModelClientSession {
 impl ModelClientSession {
     fn reset_websocket_session(&mut self) {
         self.websocket_session.connection = None;
-        self.websocket_session.use_responses_lite = None;
         self.websocket_session.last_request = None;
         self.websocket_session.last_response_rx = None;
         self.websocket_session.last_response_from_untraced_warmup = false;
@@ -1114,8 +1118,11 @@ impl ModelClientSession {
             return Ok(());
         }
         let use_responses_lite = model_info.use_responses_lite;
-        if self.websocket_session.connection.is_some()
-            && self.websocket_session.use_responses_lite == Some(use_responses_lite)
+        if self
+            .websocket_session
+            .connection
+            .as_ref()
+            .is_some_and(|connection| connection.use_responses_lite == use_responses_lite)
         {
             return Ok(());
         }
@@ -1144,8 +1151,10 @@ impl ModelClientSession {
                 RequestRouteTelemetry::for_endpoint(RESPONSES_ENDPOINT),
             )
             .await?;
-        self.websocket_session.connection = Some(connection);
-        self.websocket_session.use_responses_lite = Some(use_responses_lite);
+        self.websocket_session.connection = Some(CachedWebsocketConnection {
+            inner: connection,
+            use_responses_lite,
+        });
         self.websocket_session
             .set_connection_reused(/*connection_reused*/ false);
         Ok(())
@@ -1178,9 +1187,9 @@ impl ModelClientSession {
             request_route_telemetry,
         } = params;
         let needs_new = match self.websocket_session.connection.as_ref() {
-            Some(conn) => {
-                conn.is_closed().await
-                    || self.websocket_session.use_responses_lite != Some(use_responses_lite)
+            Some(connection) => {
+                connection.inner.is_closed().await
+                    || connection.use_responses_lite != use_responses_lite
             }
             None => true,
         };
@@ -1191,7 +1200,7 @@ impl ModelClientSession {
                 .turn_state
                 .clone()
                 .unwrap_or_else(|| Arc::clone(&self.turn_state));
-            let new_conn = match self
+            let connection = self
                 .client
                 .connect_websocket(
                     session_telemetry,
@@ -1203,18 +1212,11 @@ impl ModelClientSession {
                     auth_context,
                     request_route_telemetry,
                 )
-                .await
-            {
-                Ok(new_conn) => new_conn,
-                Err(err) => {
-                    if matches!(err, ApiError::Transport(TransportError::Timeout)) {
-                        self.reset_websocket_session();
-                    }
-                    return Err(err);
-                }
-            };
-            self.websocket_session.connection = Some(new_conn);
-            self.websocket_session.use_responses_lite = Some(use_responses_lite);
+                .await?;
+            self.websocket_session.connection = Some(CachedWebsocketConnection {
+                inner: connection,
+                use_responses_lite,
+            });
             self.websocket_session
                 .set_connection_reused(/*connection_reused*/ false);
         } else {
@@ -1225,6 +1227,7 @@ impl ModelClientSession {
         self.websocket_session
             .connection
             .as_ref()
+            .map(|connection| &connection.inner)
             .ok_or(ApiError::Stream(
                 "websocket connection is unavailable".to_string(),
             ))
@@ -1493,6 +1496,7 @@ impl ModelClientSession {
                     ))
                 })?;
             let stream_result = websocket_connection
+                .inner
                 .stream_request(ws_request, self.websocket_session.connection_reused())
                 .await
                 .map_err(|err| {

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -144,6 +144,8 @@ pub const X_RESPONSESAPI_INCLUDE_TIMING_METRICS_HEADER: &str =
 const X_CODEX_WS_STREAM_REQUEST_START_MS_CLIENT_METADATA_KEY: &str =
     "x-codex-ws-stream-request-start-ms";
 const RESPONSES_WEBSOCKETS_V2_BETA_HEADER_VALUE: &str = "responses_websockets=2026-02-06";
+const X_OPENAI_INTERNAL_CODEX_RESPONSES_LITE_HEADER: &str =
+    "x-openai-internal-codex-responses-lite";
 const RESPONSES_ENDPOINT: &str = "/responses";
 const RESPONSES_COMPACT_ENDPOINT: &str = "/responses/compact";
 // `/responses/compact` is unary, so the timeout covers the full response rather than one idle
@@ -260,6 +262,7 @@ struct LastResponse {
 #[derive(Debug, Default)]
 struct WebsocketSession {
     connection: Option<ApiWebSocketConnection>,
+    use_responses_lite: Option<bool>,
     last_request: Option<ResponsesApiRequest>,
     last_response_rx: Option<oneshot::Receiver<LastResponse>>,
     last_response_from_untraced_warmup: bool,
@@ -838,11 +841,16 @@ impl ModelClient {
         api_auth: SharedAuthProvider,
         turn_state: Option<Arc<OnceLock<String>>>,
         turn_metadata_header: Option<&str>,
+        use_responses_lite: bool,
         auth_context: AuthRequestTelemetryContext,
         request_route_telemetry: RequestRouteTelemetry,
     ) -> std::result::Result<ApiWebSocketConnection, ApiError> {
         let headers = self
-            .build_websocket_headers(turn_state.as_ref(), turn_metadata_header)
+            .build_websocket_headers(
+                turn_state.as_ref(),
+                turn_metadata_header,
+                use_responses_lite,
+            )
             .await;
         let websocket_telemetry = ModelClientSession::build_websocket_telemetry(
             session_telemetry,
@@ -924,6 +932,7 @@ impl ModelClient {
         &self,
         turn_state: Option<&Arc<OnceLock<String>>>,
         turn_metadata_header: Option<&str>,
+        use_responses_lite: bool,
     ) -> ApiHeaderMap {
         let turn_metadata_header = parse_turn_metadata_header(turn_metadata_header);
         let session_id = self.state.session_id.to_string();
@@ -951,6 +960,7 @@ impl ModelClient {
                 HeaderValue::from_static("true"),
             );
         }
+        add_responses_lite_header(&mut headers, use_responses_lite);
         headers
     }
 }
@@ -966,6 +976,7 @@ impl Drop for ModelClientSession {
 impl ModelClientSession {
     fn reset_websocket_session(&mut self) {
         self.websocket_session.connection = None;
+        self.websocket_session.use_responses_lite = None;
         self.websocket_session.last_request = None;
         self.websocket_session.last_response_rx = None;
         self.websocket_session.last_response_from_untraced_warmup = false;
@@ -982,6 +993,7 @@ impl ModelClientSession {
         &self,
         turn_metadata_header: Option<&str>,
         compression: Compression,
+        use_responses_lite: bool,
     ) -> ApiResponsesOptions {
         let turn_metadata_header = parse_turn_metadata_header(turn_metadata_header);
         let session_id = self.client.state.session_id.to_string();
@@ -1000,6 +1012,7 @@ impl ModelClientSession {
                 if let Some(header_value) = self.client.generate_attestation_header_for().await {
                     headers.insert(X_OAI_ATTESTATION_HEADER, header_value);
                 }
+                add_responses_lite_header(&mut headers, use_responses_lite);
                 headers
             },
             compression,
@@ -1095,14 +1108,18 @@ impl ModelClientSession {
     pub async fn preconnect_websocket(
         &mut self,
         session_telemetry: &SessionTelemetry,
-        _model_info: &ModelInfo,
+        model_info: &ModelInfo,
     ) -> std::result::Result<(), ApiError> {
         if !self.client.responses_websocket_enabled() {
             return Ok(());
         }
-        if self.websocket_session.connection.is_some() {
+        let use_responses_lite = model_info.use_responses_lite;
+        if self.websocket_session.connection.is_some()
+            && self.websocket_session.use_responses_lite == Some(use_responses_lite)
+        {
             return Ok(());
         }
+        self.reset_websocket_session();
 
         let client_setup = self.client.current_client_setup().await.map_err(|err| {
             ApiError::Stream(format!(
@@ -1122,11 +1139,13 @@ impl ModelClientSession {
                 client_setup.api_auth,
                 Some(Arc::clone(&self.turn_state)),
                 /*turn_metadata_header*/ None,
+                use_responses_lite,
                 auth_context,
                 RequestRouteTelemetry::for_endpoint(RESPONSES_ENDPOINT),
             )
             .await?;
         self.websocket_session.connection = Some(connection);
+        self.websocket_session.use_responses_lite = Some(use_responses_lite);
         self.websocket_session
             .set_connection_reused(/*connection_reused*/ false);
         Ok(())
@@ -1154,18 +1173,20 @@ impl ModelClientSession {
             api_auth,
             turn_metadata_header,
             options,
+            use_responses_lite,
             auth_context,
             request_route_telemetry,
         } = params;
         let needs_new = match self.websocket_session.connection.as_ref() {
-            Some(conn) => conn.is_closed().await,
+            Some(conn) => {
+                conn.is_closed().await
+                    || self.websocket_session.use_responses_lite != Some(use_responses_lite)
+            }
             None => true,
         };
 
         if needs_new {
-            self.websocket_session.last_request = None;
-            self.websocket_session.last_response_rx = None;
-            self.websocket_session.last_response_from_untraced_warmup = false;
+            self.reset_websocket_session();
             let turn_state = options
                 .turn_state
                 .clone()
@@ -1178,6 +1199,7 @@ impl ModelClientSession {
                     api_auth,
                     Some(turn_state),
                     turn_metadata_header,
+                    use_responses_lite,
                     auth_context,
                     request_route_telemetry,
                 )
@@ -1192,6 +1214,7 @@ impl ModelClientSession {
                 }
             };
             self.websocket_session.connection = Some(new_conn);
+            self.websocket_session.use_responses_lite = Some(use_responses_lite);
             self.websocket_session
                 .set_connection_reused(/*connection_reused*/ false);
         } else {
@@ -1267,7 +1290,11 @@ impl ModelClientSession {
             );
             let compression = self.responses_request_compression(client_setup.auth.as_ref());
             let mut options = self
-                .build_responses_options(turn_metadata_header, compression)
+                .build_responses_options(
+                    turn_metadata_header,
+                    compression,
+                    model_info.use_responses_lite,
+                )
                 .await;
 
             let request = self.client.build_responses_request(
@@ -1377,7 +1404,11 @@ impl ModelClientSession {
             let compression = self.responses_request_compression(client_setup.auth.as_ref());
 
             let options = self
-                .build_responses_options(turn_metadata_header, compression)
+                .build_responses_options(
+                    turn_metadata_header,
+                    compression,
+                    model_info.use_responses_lite,
+                )
                 .await;
             let request = self.client.build_responses_request(
                 &client_setup.api_provider,
@@ -1405,6 +1436,7 @@ impl ModelClientSession {
                     api_auth: client_setup.api_auth,
                     turn_metadata_header,
                     options: &options,
+                    use_responses_lite: model_info.use_responses_lite,
                     auth_context: request_auth_context,
                     request_route_telemetry: RequestRouteTelemetry::for_endpoint(
                         RESPONSES_ENDPOINT,
@@ -1707,6 +1739,15 @@ fn build_responses_headers(
     headers
 }
 
+fn add_responses_lite_header(headers: &mut ApiHeaderMap, use_responses_lite: bool) {
+    if use_responses_lite {
+        headers.insert(
+            X_OPENAI_INTERNAL_CODEX_RESPONSES_LITE_HEADER,
+            HeaderValue::from_static("true"),
+        );
+    }
+}
+
 fn subagent_header_value(session_source: &SessionSource) -> Option<String> {
     match session_source {
         SessionSource::SubAgent(subagent_source) => match subagent_source {
@@ -1969,6 +2010,7 @@ struct WebsocketConnectParams<'a> {
     api_auth: SharedAuthProvider,
     turn_metadata_header: Option<&'a str>,
     options: &'a ApiResponsesOptions,
+    use_responses_lite: bool,
     auth_context: AuthRequestTelemetryContext,
     request_route_telemetry: RequestRouteTelemetry,
 }

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -534,6 +534,7 @@ impl ModelClient {
         if let Some(header_value) = self.generate_attestation_header_for().await {
             extra_headers.insert(X_OAI_ATTESTATION_HEADER, header_value);
         }
+        add_responses_lite_header(&mut extra_headers, model_info.use_responses_lite);
         let compact_request_timeout = client_setup
             .api_provider
             .stream_idle_timeout

--- a/codex-rs/core/src/client_tests.rs
+++ b/codex-rs/core/src/client_tests.rs
@@ -549,7 +549,10 @@ async fn websocket_handshake_includes_attestation_for_chatgpt_codex_responses() 
         model_client_with_counting_attestation(/*include_attestation*/ true);
 
     let headers = model_client
-        .build_websocket_headers(/*turn_state*/ None, /*turn_metadata_header*/ None)
+        .build_websocket_headers(
+            /*turn_state*/ None, /*turn_metadata_header*/ None,
+            /*use_responses_lite*/ false,
+        )
         .await;
 
     assert_eq!(

--- a/codex-rs/core/src/client_tests.rs
+++ b/codex-rs/core/src/client_tests.rs
@@ -293,8 +293,10 @@ fn build_ws_client_metadata_includes_window_lineage_and_turn_metadata() {
 
     client.advance_window_generation();
 
-    let client_metadata =
-        client.build_ws_client_metadata(Some(r#"{"turn_id":"turn-123"}"#), &test_model_info());
+    let client_metadata = client.build_ws_client_metadata(
+        Some(r#"{"turn_id":"turn-123"}"#),
+        /*use_responses_lite*/ false,
+    );
     let thread_id = client.state.thread_id;
     assert_eq!(
         client_metadata,

--- a/codex-rs/core/src/client_tests.rs
+++ b/codex-rs/core/src/client_tests.rs
@@ -293,7 +293,8 @@ fn build_ws_client_metadata_includes_window_lineage_and_turn_metadata() {
 
     client.advance_window_generation();
 
-    let client_metadata = client.build_ws_client_metadata(Some(r#"{"turn_id":"turn-123"}"#));
+    let client_metadata =
+        client.build_ws_client_metadata(Some(r#"{"turn_id":"turn-123"}"#), &test_model_info());
     let thread_id = client.state.thread_id;
     assert_eq!(
         client_metadata,
@@ -549,10 +550,7 @@ async fn websocket_handshake_includes_attestation_for_chatgpt_codex_responses() 
         model_client_with_counting_attestation(/*include_attestation*/ true);
 
     let headers = model_client
-        .build_websocket_headers(
-            /*turn_state*/ None, /*turn_metadata_header*/ None,
-            /*use_responses_lite*/ false,
-        )
+        .build_websocket_headers(/*turn_state*/ None, /*turn_metadata_header*/ None)
         .await;
 
     assert_eq!(

--- a/codex-rs/core/tests/suite/client_websockets.rs
+++ b/codex-rs/core/tests/suite/client_websockets.rs
@@ -517,6 +517,8 @@ async fn responses_websocket_reuses_connection_after_session_drop() {
 async fn responses_websocket_reconnects_when_responses_lite_mode_changes() {
     skip_if_no_network!();
 
+    // Keep the first two sockets open so each reconnect must be caused by a Lite mode change,
+    // rather than by the test server closing a fully consumed connection.
     let server = start_websocket_server(vec![
         vec![
             vec![ev_response_created("lite-1"), ev_completed("lite-1")],

--- a/codex-rs/core/tests/suite/client_websockets.rs
+++ b/codex-rs/core/tests/suite/client_websockets.rs
@@ -62,6 +62,7 @@ const OPENAI_BETA_HEADER: &str = "OpenAI-Beta";
 const USER_AGENT_HEADER: &str = "user-agent";
 const WS_V2_BETA_HEADER_VALUE: &str = "responses_websockets=2026-02-06";
 const X_CLIENT_REQUEST_ID_HEADER: &str = "x-client-request-id";
+const RESPONSES_LITE_HEADER: &str = "x-openai-internal-codex-responses-lite";
 const TEST_INSTALLATION_ID: &str = "11111111-1111-4111-8111-111111111111";
 const X_CODEX_WS_STREAM_REQUEST_START_MS_CLIENT_METADATA_KEY: &str =
     "x-codex-ws-stream-request-start-ms";
@@ -508,6 +509,102 @@ async fn responses_websocket_reuses_connection_after_session_drop() {
 
     assert_eq!(server.handshakes().len(), 1);
     assert_eq!(server.single_connection().len(), 2);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn responses_websocket_reconnects_when_responses_lite_mode_changes() {
+    skip_if_no_network!();
+
+    let server = start_websocket_server(vec![
+        vec![
+            vec![ev_response_created("lite-1"), ev_completed("lite-1")],
+            vec![ev_response_created("lite-2"), ev_completed("lite-2")],
+            vec![ev_response_created("unused-1"), ev_completed("unused-1")],
+        ],
+        vec![
+            vec![ev_response_created("normal-1"), ev_completed("normal-1")],
+            vec![ev_response_created("unused-2"), ev_completed("unused-2")],
+        ],
+        vec![vec![ev_response_created("lite-3"), ev_completed("lite-3")]],
+    ])
+    .await;
+
+    let harness = websocket_harness(&server).await;
+    let mut lite_model_info = harness.model_info.clone();
+    lite_model_info.use_responses_lite = true;
+    let normal_model_info = harness.model_info.clone();
+
+    {
+        let mut session = harness.client.new_session();
+        session
+            .preconnect_websocket(&harness.session_telemetry, &lite_model_info)
+            .await
+            .expect("Responses Lite websocket preconnect failed");
+        stream_until_complete_with_model_info(
+            &mut session,
+            &harness,
+            &prompt_with_input(vec![message_item("lite one")]),
+            &lite_model_info,
+            "lite-1",
+        )
+        .await;
+    }
+    {
+        let mut session = harness.client.new_session();
+        stream_until_complete_with_model_info(
+            &mut session,
+            &harness,
+            &prompt_with_input(vec![message_item("lite two")]),
+            &lite_model_info,
+            "lite-2",
+        )
+        .await;
+    }
+    {
+        let mut session = harness.client.new_session();
+        stream_until_complete_with_model_info(
+            &mut session,
+            &harness,
+            &prompt_with_input(vec![message_item("normal one")]),
+            &normal_model_info,
+            "normal-1",
+        )
+        .await;
+    }
+    {
+        let mut session = harness.client.new_session();
+        session
+            .preconnect_websocket(&harness.session_telemetry, &lite_model_info)
+            .await
+            .expect("Responses Lite websocket reconnect failed");
+        stream_until_complete_with_model_info(
+            &mut session,
+            &harness,
+            &prompt_with_input(vec![message_item("lite three")]),
+            &lite_model_info,
+            "lite-3",
+        )
+        .await;
+    }
+
+    assert_eq!(
+        server
+            .handshakes()
+            .iter()
+            .map(|handshake| handshake.header(RESPONSES_LITE_HEADER))
+            .collect::<Vec<_>>(),
+        vec![Some("true".to_string()), None, Some("true".to_string())]
+    );
+    assert_eq!(
+        server
+            .connections()
+            .iter()
+            .map(Vec::len)
+            .collect::<Vec<_>>(),
+        vec![2, 1, 1]
+    );
 
     server.shutdown().await;
 }
@@ -2026,6 +2123,40 @@ async fn stream_until_complete(
         /*service_tier*/ None,
     )
     .await;
+}
+
+async fn stream_until_complete_with_model_info(
+    client_session: &mut ModelClientSession,
+    harness: &WebsocketTestHarness,
+    prompt: &Prompt,
+    model_info: &ModelInfo,
+    expected_response_id: &str,
+) {
+    let mut stream = client_session
+        .stream(
+            prompt,
+            model_info,
+            &harness.session_telemetry,
+            harness.effort.clone(),
+            harness.summary,
+            /*service_tier*/ None,
+            /*turn_metadata_header*/ None,
+            &codex_rollout_trace::InferenceTraceContext::disabled(),
+        )
+        .await
+        .expect("websocket stream failed");
+
+    while let Some(event) = stream.next().await {
+        match event {
+            Ok(ResponseEvent::Completed { response_id, .. }) => {
+                assert_eq!(response_id, expected_response_id);
+                return;
+            }
+            Ok(_) => {}
+            Err(err) => panic!("websocket stream failed: {err}"),
+        }
+    }
+    panic!("websocket stream ended before completion");
 }
 
 async fn stream_until_complete_with_service_tier(

--- a/codex-rs/core/tests/suite/client_websockets.rs
+++ b/codex-rs/core/tests/suite/client_websockets.rs
@@ -62,7 +62,8 @@ const OPENAI_BETA_HEADER: &str = "OpenAI-Beta";
 const USER_AGENT_HEADER: &str = "user-agent";
 const WS_V2_BETA_HEADER_VALUE: &str = "responses_websockets=2026-02-06";
 const X_CLIENT_REQUEST_ID_HEADER: &str = "x-client-request-id";
-const RESPONSES_LITE_HEADER: &str = "x-openai-internal-codex-responses-lite";
+const WS_REQUEST_HEADER_RESPONSES_LITE_CLIENT_METADATA_KEY: &str =
+    "ws_request_header_x_openai_internal_codex_responses_lite";
 const TEST_INSTALLATION_ID: &str = "11111111-1111-4111-8111-111111111111";
 const X_CODEX_WS_STREAM_REQUEST_START_MS_CLIENT_METADATA_KEY: &str =
     "x-codex-ws-stream-request-start-ms";
@@ -514,98 +515,79 @@ async fn responses_websocket_reuses_connection_after_session_drop() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn responses_websocket_reconnects_when_responses_lite_mode_changes() {
+async fn responses_websocket_sends_responses_lite_metadata_per_request() {
     skip_if_no_network!();
 
-    // Keep the first two sockets open so each reconnect must be caused by a Lite mode change,
-    // rather than by the test server closing a fully consumed connection.
-    let server = start_websocket_server(vec![
-        vec![
-            vec![ev_response_created("lite-1"), ev_completed("lite-1")],
-            vec![ev_response_created("lite-2"), ev_completed("lite-2")],
-            vec![ev_response_created("unused-1"), ev_completed("unused-1")],
-        ],
-        vec![
-            vec![ev_response_created("normal-1"), ev_completed("normal-1")],
-            vec![ev_response_created("unused-2"), ev_completed("unused-2")],
-        ],
-        vec![vec![ev_response_created("lite-3"), ev_completed("lite-3")]],
-    ])
+    let server = start_websocket_server(vec![vec![
+        vec![ev_response_created("normal-1"), ev_completed("normal-1")],
+        vec![ev_response_created("lite-1"), ev_completed("lite-1")],
+        vec![ev_response_created("normal-2"), ev_completed("normal-2")],
+    ]])
     .await;
 
     let harness = websocket_harness(&server).await;
-    let mut lite_model_info = harness.model_info.clone();
+    let mut normal_model_info = harness.model_info.clone();
+    normal_model_info.supports_reasoning_summaries = true;
+    let mut lite_model_info = normal_model_info.clone();
     lite_model_info.use_responses_lite = true;
-    let normal_model_info = harness.model_info.clone();
+    let mut session = harness.client.new_session();
 
-    {
-        let mut session = harness.client.new_session();
-        session
-            .preconnect_websocket(&harness.session_telemetry, &lite_model_info)
-            .await
-            .expect("Responses Lite websocket preconnect failed");
-        stream_until_complete_with_model_info(
-            &mut session,
-            &harness,
-            &prompt_with_input(vec![message_item("lite one")]),
-            &lite_model_info,
-            "lite-1",
-        )
-        .await;
-    }
-    {
-        let mut session = harness.client.new_session();
-        stream_until_complete_with_model_info(
-            &mut session,
-            &harness,
-            &prompt_with_input(vec![message_item("lite two")]),
-            &lite_model_info,
-            "lite-2",
-        )
-        .await;
-    }
-    {
-        let mut session = harness.client.new_session();
-        stream_until_complete_with_model_info(
-            &mut session,
-            &harness,
-            &prompt_with_input(vec![message_item("normal one")]),
-            &normal_model_info,
-            "normal-1",
-        )
-        .await;
-    }
-    {
-        let mut session = harness.client.new_session();
-        session
-            .preconnect_websocket(&harness.session_telemetry, &lite_model_info)
-            .await
-            .expect("Responses Lite websocket reconnect failed");
-        stream_until_complete_with_model_info(
-            &mut session,
-            &harness,
-            &prompt_with_input(vec![message_item("lite three")]),
-            &lite_model_info,
-            "lite-3",
-        )
-        .await;
-    }
+    stream_until_complete_with_model_info(
+        &mut session,
+        &harness,
+        &prompt_with_input(vec![message_item("normal one")]),
+        &normal_model_info,
+        "normal-1",
+    )
+    .await;
+    stream_until_complete_with_model_info(
+        &mut session,
+        &harness,
+        &prompt_with_input(vec![message_item("lite")]),
+        &lite_model_info,
+        "lite-1",
+    )
+    .await;
+    stream_until_complete_with_model_info(
+        &mut session,
+        &harness,
+        &prompt_with_input(vec![message_item("normal two")]),
+        &normal_model_info,
+        "normal-2",
+    )
+    .await;
 
+    let connection = server.single_connection();
     assert_eq!(
-        server
-            .handshakes()
+        connection
             .iter()
-            .map(|handshake| handshake.header(RESPONSES_LITE_HEADER))
+            .map(|request| {
+                let body = request.body_json();
+                json!({
+                    "responses_lite": body["client_metadata"]
+                        .get(WS_REQUEST_HEADER_RESPONSES_LITE_CLIENT_METADATA_KEY),
+                    "reasoning_context": body["reasoning"].get("context"),
+                    "parallel_tool_calls": body["parallel_tool_calls"],
+                })
+            })
             .collect::<Vec<_>>(),
-        vec![Some("true".to_string()), None, Some("true".to_string())]
-    );
-    assert_eq!(
-        server
-            .connections()
-            .iter()
-            .map(Vec::len)
-            .collect::<Vec<_>>(),
-        vec![2, 1, 1]
+        vec![
+            json!({
+                "responses_lite": null,
+                "reasoning_context": null,
+                "parallel_tool_calls": false,
+            }),
+            json!({
+                "responses_lite": "true",
+                "reasoning_context": "all_turns",
+                "parallel_tool_calls": false,
+            }),
+            json!({
+                "responses_lite": null,
+                "reasoning_context": null,
+                "parallel_tool_calls": false,
+            }),
+        ]
     );
 
     server.shutdown().await;

--- a/codex-rs/core/tests/suite/responses_lite.rs
+++ b/codex-rs/core/tests/suite/responses_lite.rs
@@ -10,10 +10,13 @@ use codex_image_generation_extension::install as install_image_generation_extens
 use codex_login::CodexAuth;
 use codex_protocol::config_types::WebSearchMode;
 use codex_protocol::openai_models::InputModality;
+use codex_protocol::protocol::EventMsg;
+use codex_protocol::protocol::Op;
 use codex_web_search_extension::install as install_web_search_extension;
 use core_test_support::responses;
 use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::test_codex;
+use core_test_support::wait_for_event;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 
@@ -96,6 +99,57 @@ async fn responses_lite_uses_standalone_web_search_and_image_generation() -> Res
         .context("Responses request tools should be an array")?;
     assert!(!has_hosted_tool(tools, "web_search"));
     assert!(!has_hosted_tool(tools, "image_generation"));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn responses_lite_compact_request_uses_lite_transport_contract() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = responses::start_mock_server().await;
+    let response_mock = responses::mount_sse_once(
+        &server,
+        responses::sse(vec![
+            responses::ev_response_created("resp-1"),
+            responses::ev_completed("resp-1"),
+        ]),
+    )
+    .await;
+    let compact_mock =
+        responses::mount_compact_json_once(&server, serde_json::json!({ "output": [] })).await;
+
+    let mut builder = test_codex().with_model_info_override("gpt-5.4", |model_info| {
+        model_info.use_responses_lite = true;
+        model_info.supports_parallel_tool_calls = true;
+    });
+    let test = builder.build(&server).await?;
+
+    test.submit_turn("Compact this conversation").await?;
+    test.codex.submit(Op::Compact).await?;
+    wait_for_event(&test.codex, |event| {
+        matches!(event, EventMsg::TurnComplete(_))
+    })
+    .await;
+
+    response_mock.single_request();
+    let compact_request = compact_mock.single_request();
+    assert_eq!(
+        compact_request.header(RESPONSES_LITE_HEADER).as_deref(),
+        Some("true")
+    );
+    let compact_body = compact_request.body_json();
+    assert_eq!(
+        compact_body
+            .get("reasoning")
+            .and_then(|reasoning| reasoning.get("context"))
+            .and_then(Value::as_str),
+        Some("all_turns")
+    );
+    assert_eq!(
+        compact_body.get("parallel_tool_calls"),
+        Some(&Value::Bool(false))
+    );
 
     Ok(())
 }

--- a/codex-rs/core/tests/suite/responses_lite.rs
+++ b/codex-rs/core/tests/suite/responses_lite.rs
@@ -14,7 +14,10 @@ use codex_web_search_extension::install as install_web_search_extension;
 use core_test_support::responses;
 use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::test_codex;
+use pretty_assertions::assert_eq;
 use serde_json::Value;
+
+const RESPONSES_LITE_HEADER: &str = "x-openai-internal-codex-responses-lite";
 
 fn responses_extensions(auth: &CodexAuth) -> Arc<ExtensionRegistry<Config>> {
     let auth_manager = codex_core::test_support::auth_manager_from_auth(auth.clone());
@@ -76,6 +79,10 @@ async fn responses_lite_uses_standalone_web_search_and_image_generation() -> Res
     test.submit_turn("Use standalone tools").await?;
 
     let request = response_mock.single_request();
+    assert_eq!(
+        request.header(RESPONSES_LITE_HEADER).as_deref(),
+        Some("true")
+    );
     request
         .tool_by_name("web", "run")
         .context("Responses Lite should expose standalone web search")?;
@@ -154,6 +161,7 @@ async fn non_lite_uses_hosted_tools_when_standalone_features_are_disabled() -> R
     test.submit_turn("Use hosted tools").await?;
 
     let request = response_mock.single_request();
+    assert_eq!(request.header(RESPONSES_LITE_HEADER), None);
     assert!(request.tool_by_name("web", "run").is_none());
     assert!(request.tool_by_name("image_gen", "imagegen").is_none());
     let body = request.body_json();


### PR DESCRIPTION
## Summary

- send `X-OpenAI-Internal-Codex-Responses-Lite: true` on HTTP Responses requests and WebSocket upgrade requests when model metadata enables Responses Lite
- use client metadata when sending it over the websocket

This PR is stacked on #26490.

## Why

The Responses Lite marker is request-scoped for HTTP but connection-scoped for Responses-over-WebSocket because it is carried on the upgrade request. Reusing a cached socket opened for the opposite mode would therefore send the wrong transport contract.

## Validation

- `just test -p codex-core responses_lite`
- `just test -p codex-core responses_websocket_reconnects_when_responses_lite_mode_changes`
- `just fix -p codex-core`
- `just fmt`