### PR TITLE
[3 of 3] Pump trigger-turn work before idle lifecycle

### DIFF
--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -445,6 +445,15 @@ impl Session {
             .await;
     }
 
+    // Keep this detached work in a synchronous helper so the task runner future remains Send.
+    fn spawn_post_task_idle_work(self: &Arc<Self>) {
+        let session = Arc::clone(self);
+        tokio::spawn(async move {
+            session.maybe_start_turn_for_pending_work().await;
+            session.emit_thread_idle_lifecycle_if_idle().await;
+        });
+    }
+
     /// Starts a regular turn with the provided sub-id when pending work should wake an idle
     /// session.
     ///
@@ -755,7 +764,7 @@ impl Session {
         if !cleared_active_turn {
             return;
         }
-        self.emit_thread_idle_lifecycle_if_idle().await;
+        self.spawn_post_task_idle_work();
     }
 
     async fn take_active_turn(&self) -> Option<ActiveTurn> {


### PR DESCRIPTION
## Stack

1. [#26547](https://github.com/openai/codex/pull/26547) - [1 of 3] Align goal extension with core behavior
2. [#26548](https://github.com/openai/codex/pull/26548) - [2 of 3] Move goal runtime to extension
3. [#26549](https://github.com/openai/codex/pull/26549) - [3 of 3] Pump trigger-turn work before idle lifecycle

## Why

The old core goal `MaybeContinueIfIdle` path also woke pending `trigger_turn` mailbox work. Once goal continuation moves to the extension lifecycle, that broader mailbox scheduling behavior needs to live outside the goal runtime or pending inter-agent work can remain queued until some later event wakes the thread.

## What Changed

- Starts pending `trigger_turn` mailbox work after a task clears the active turn and before thread-idle lifecycle contributors run.
- Keeps the post-task idle work in a small synchronous helper because awaiting this path inline makes the spawned task runner future fail `Send` analysis.
