### PR TITLE
core: stop goal continuation after terminal turn errors

### DIFF
--- a/codex-rs/core/src/goals.rs
+++ b/codex-rs/core/src/goals.rs
@@ -30,7 +30,9 @@ use codex_prompts::continuation_prompt;
 use codex_prompts::objective_updated_prompt;
 use codex_protocol::ThreadId;
 use codex_protocol::config_types::ModeKind;
+use codex_protocol::error::CodexErr;
 use codex_protocol::models::ResponseItem;
+use codex_protocol::protocol::CodexErrorInfo;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::ThreadGoal;
 use codex_protocol::protocol::ThreadGoalStatus;
@@ -129,12 +131,13 @@ pub(crate) enum GoalRuntimeEvent<'a> {
         turn_context: &'a TurnContext,
         turn_completed: bool,
     },
+    TurnErrored {
+        turn_context: &'a TurnContext,
+        error: &'a CodexErr,
+    },
     MaybeContinueIfIdle,
     TaskAborted {
         turn_context: Option<&'a TurnContext>,
-    },
-    UsageLimitReached {
-        turn_context: &'a TurnContext,
     },
     ExternalMutationStarting,
     ExternalSet {
@@ -142,6 +145,12 @@ pub(crate) enum GoalRuntimeEvent<'a> {
     },
     ExternalClear,
     ThreadResumed,
+}
+
+#[derive(Clone, Copy)]
+enum TerminalGoalErrorStatus {
+    Paused,
+    UsageLimited,
 }
 
 pub(crate) struct GoalRuntimeState {
@@ -359,17 +368,20 @@ impl Session {
                     .await;
                 Ok(())
             }),
+            GoalRuntimeEvent::TurnErrored {
+                turn_context,
+                error,
+            } => Box::pin(async move {
+                self.handle_thread_goal_turn_error(turn_context, error)
+                    .await?;
+                Ok(())
+            }),
             GoalRuntimeEvent::MaybeContinueIfIdle => Box::pin(async move {
                 self.maybe_continue_goal_if_idle_runtime().await;
                 Ok(())
             }),
             GoalRuntimeEvent::TaskAborted { turn_context } => Box::pin(async move {
                 self.handle_thread_goal_task_abort(turn_context).await;
-                Ok(())
-            }),
-            GoalRuntimeEvent::UsageLimitReached { turn_context } => Box::pin(async move {
-                self.usage_limit_active_thread_goal_for_turn(turn_context)
-                    .await?;
                 Ok(())
             }),
             GoalRuntimeEvent::ExternalMutationStarting => Box::pin(async move {
@@ -1138,14 +1150,41 @@ impl Session {
         }
     }
 
-    async fn usage_limit_active_thread_goal_for_turn(
+    async fn handle_thread_goal_turn_error(
         &self,
         turn_context: &TurnContext,
+        error: &CodexErr,
+    ) -> anyhow::Result<()> {
+        if error.to_codex_protocol_error() == CodexErrorInfo::UsageLimitExceeded {
+            return self
+                .finish_active_thread_goal_after_terminal_error(
+                    turn_context,
+                    TerminalGoalErrorStatus::UsageLimited,
+                )
+                .await;
+        }
+
+        if matches!(error, CodexErr::TurnAborted | CodexErr::Interrupted) {
+            return Ok(());
+        }
+
+        // This is a terminal turn error. Leave request-local retry decisions to
+        // the turn; pause the goal so idle continuation does not replay it.
+        self.finish_active_thread_goal_after_terminal_error(
+            turn_context,
+            TerminalGoalErrorStatus::Paused,
+        )
+        .await
+    }
+
+    async fn finish_active_thread_goal_after_terminal_error(
+        &self,
+        turn_context: &TurnContext,
+        status: TerminalGoalErrorStatus,
     ) -> anyhow::Result<()> {
         if should_ignore_goal_for_mode(turn_context.collaboration_mode.mode) {
             return Ok(());
         }
-
         if !self.enabled(Feature::Goals) {
             return Ok(());
         }
@@ -1159,6 +1198,7 @@ impl Session {
         let Some(state_db) = self.state_db_for_thread_goals().await? else {
             return Ok(());
         };
+
         self.account_thread_goal_progress(
             turn_context,
             BudgetLimitSteering::Suppressed,
@@ -1168,11 +1208,21 @@ impl Session {
         let previous_status = self
             .current_goal_status_for_metrics(&state_db, /*expected_goal_id*/ None)
             .await?;
-        let Some(goal) = state_db
-            .thread_goals()
-            .usage_limit_active_thread_goal(self.thread_id)
-            .await?
-        else {
+        let goal = match status {
+            TerminalGoalErrorStatus::UsageLimited => {
+                state_db
+                    .thread_goals()
+                    .usage_limit_active_thread_goal(self.thread_id)
+                    .await?
+            }
+            TerminalGoalErrorStatus::Paused => {
+                state_db
+                    .thread_goals()
+                    .pause_active_thread_goal(self.thread_id)
+                    .await?
+            }
+        };
+        let Some(goal) = goal else {
             return Ok(());
         };
         self.emit_goal_terminal_metrics_if_status_changed(previous_status, &goal);

--- a/codex-rs/core/src/goals.rs
+++ b/codex-rs/core/src/goals.rs
@@ -43,6 +43,8 @@ use codex_rollout::state_db::reconcile_rollout;
 use codex_thread_store::LocalThreadStore;
 use futures::future::BoxFuture;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 use std::time::Instant;
 use tokio::sync::Mutex;
@@ -116,6 +118,7 @@ pub struct ExternalGoalSet {
 /// Callers report the session event they observed; this module owns the policy
 /// for how that event changes goal runtime state.
 pub(crate) enum GoalRuntimeEvent<'a> {
+    TurnAttemptStarted,
     TurnStarted {
         turn_context: &'a TurnContext,
         token_usage: TokenUsage,
@@ -147,15 +150,10 @@ pub(crate) enum GoalRuntimeEvent<'a> {
     ThreadResumed,
 }
 
-#[derive(Clone, Copy)]
-enum TerminalGoalErrorStatus {
-    Paused,
-    UsageLimited,
-}
-
 pub(crate) struct GoalRuntimeState {
     pub(crate) state_db: Mutex<Option<StateDbHandle>>,
     pub(crate) budget_limit_reported_goal_id: Mutex<Option<String>>,
+    suppress_next_idle_continuation: AtomicBool,
     accounting_lock: Semaphore,
     accounting: Mutex<GoalAccountingSnapshot>,
     pub(crate) continuation_lock: Semaphore,
@@ -171,6 +169,7 @@ impl GoalRuntimeState {
         Self {
             state_db: Mutex::new(None),
             budget_limit_reported_goal_id: Mutex::new(None),
+            suppress_next_idle_continuation: AtomicBool::new(false),
             accounting_lock: Semaphore::new(/*permits*/ 1),
             accounting: Mutex::new(GoalAccountingSnapshot::new()),
             continuation_lock: Semaphore::new(/*permits*/ 1),
@@ -329,6 +328,12 @@ impl Session {
         event: GoalRuntimeEvent<'a>,
     ) -> BoxFuture<'a, anyhow::Result<()>> {
         match event {
+            GoalRuntimeEvent::TurnAttemptStarted => Box::pin(async move {
+                self.goal_runtime
+                    .suppress_next_idle_continuation
+                    .store(false, Ordering::Release);
+                Ok(())
+            }),
             GoalRuntimeEvent::TurnStarted {
                 turn_context,
                 token_usage,
@@ -377,6 +382,13 @@ impl Session {
                 Ok(())
             }),
             GoalRuntimeEvent::MaybeContinueIfIdle => Box::pin(async move {
+                if self
+                    .goal_runtime
+                    .suppress_next_idle_continuation
+                    .swap(false, Ordering::AcqRel)
+                {
+                    return Ok(());
+                }
                 self.maybe_continue_goal_if_idle_runtime().await;
                 Ok(())
             }),
@@ -1157,30 +1169,30 @@ impl Session {
     ) -> anyhow::Result<()> {
         if error.to_codex_protocol_error() == CodexErrorInfo::UsageLimitExceeded {
             return self
-                .finish_active_thread_goal_after_terminal_error(
-                    turn_context,
-                    TerminalGoalErrorStatus::UsageLimited,
-                )
+                .usage_limit_active_thread_goal_for_turn(turn_context)
                 .await;
         }
 
-        if matches!(error, CodexErr::TurnAborted | CodexErr::Interrupted) {
+        if matches!(
+            error,
+            CodexErr::ContextWindowExceeded | CodexErr::Interrupted
+        ) {
             return Ok(());
         }
 
-        // This is a terminal turn error. Leave request-local retry decisions to
-        // the turn; pause the goal so idle continuation does not replay it.
-        self.finish_active_thread_goal_after_terminal_error(
-            turn_context,
-            TerminalGoalErrorStatus::Paused,
-        )
-        .await
+        if self.enabled(Feature::Goals)
+            && !should_ignore_goal_for_mode(turn_context.collaboration_mode.mode)
+        {
+            self.goal_runtime
+                .suppress_next_idle_continuation
+                .store(true, Ordering::Release);
+        }
+        Ok(())
     }
 
-    async fn finish_active_thread_goal_after_terminal_error(
+    async fn usage_limit_active_thread_goal_for_turn(
         &self,
         turn_context: &TurnContext,
-        status: TerminalGoalErrorStatus,
     ) -> anyhow::Result<()> {
         if should_ignore_goal_for_mode(turn_context.collaboration_mode.mode) {
             return Ok(());
@@ -1198,7 +1210,6 @@ impl Session {
         let Some(state_db) = self.state_db_for_thread_goals().await? else {
             return Ok(());
         };
-
         self.account_thread_goal_progress(
             turn_context,
             BudgetLimitSteering::Suppressed,
@@ -1208,21 +1219,11 @@ impl Session {
         let previous_status = self
             .current_goal_status_for_metrics(&state_db, /*expected_goal_id*/ None)
             .await?;
-        let goal = match status {
-            TerminalGoalErrorStatus::UsageLimited => {
-                state_db
-                    .thread_goals()
-                    .usage_limit_active_thread_goal(self.thread_id)
-                    .await?
-            }
-            TerminalGoalErrorStatus::Paused => {
-                state_db
-                    .thread_goals()
-                    .pause_active_thread_goal(self.thread_id)
-                    .await?
-            }
-        };
-        let Some(goal) = goal else {
+        let Some(goal) = state_db
+            .thread_goals()
+            .usage_limit_active_thread_goal(self.thread_id)
+            .await?
+        else {
             return Ok(());
         };
         self.emit_goal_terminal_metrics_if_status_changed(previous_status, &goal);

--- a/codex-rs/core/src/goals.rs
+++ b/codex-rs/core/src/goals.rs
@@ -1187,9 +1187,7 @@ impl Session {
                 .await
                 .turn
                 .as_ref()
-                .is_some_and(|turn| {
-                    turn.turn_id == turn_context.sub_id && turn.active_this_turn()
-                });
+                .is_some_and(|turn| turn.turn_id == turn_context.sub_id && turn.active_this_turn());
         if had_active_goal_this_turn {
             self.goal_runtime
                 .suppress_next_idle_continuation

--- a/codex-rs/core/src/goals.rs
+++ b/codex-rs/core/src/goals.rs
@@ -382,6 +382,7 @@ impl Session {
                 Ok(())
             }),
             GoalRuntimeEvent::MaybeContinueIfIdle => Box::pin(async move {
+                self.maybe_start_turn_for_pending_work().await;
                 if self
                     .goal_runtime
                     .suppress_next_idle_continuation
@@ -389,7 +390,7 @@ impl Session {
                 {
                     return Ok(());
                 }
-                self.maybe_continue_goal_if_idle_runtime().await;
+                self.maybe_start_goal_continuation_turn().await;
                 Ok(())
             }),
             GoalRuntimeEvent::TaskAborted { turn_context } => Box::pin(async move {
@@ -1173,16 +1174,23 @@ impl Session {
                 .await;
         }
 
-        if matches!(
-            error,
-            CodexErr::ContextWindowExceeded | CodexErr::Interrupted
-        ) {
+        if matches!(error, CodexErr::TurnAborted | CodexErr::Interrupted) {
             return Ok(());
         }
 
-        if self.enabled(Feature::Goals)
+        let had_active_goal_this_turn = self.enabled(Feature::Goals)
             && !should_ignore_goal_for_mode(turn_context.collaboration_mode.mode)
-        {
+            && self
+                .goal_runtime
+                .accounting
+                .lock()
+                .await
+                .turn
+                .as_ref()
+                .is_some_and(|turn| {
+                    turn.turn_id == turn_context.sub_id && turn.active_this_turn()
+                });
+        if had_active_goal_this_turn {
             self.goal_runtime
                 .suppress_next_idle_continuation
                 .store(true, Ordering::Release);

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -9628,8 +9628,10 @@ async fn usage_limit_runtime_stops_active_goal_and_prevents_idle_continuation() 
     .await;
     set_total_token_usage(&sess, post_goal_token_usage()).await;
 
-    sess.goal_runtime_apply(GoalRuntimeEvent::UsageLimitReached {
+    let error = CodexErr::QuotaExceeded;
+    sess.goal_runtime_apply(GoalRuntimeEvent::TurnErrored {
         turn_context: tc.as_ref(),
+        error: &error,
     })
     .await?;
 
@@ -9640,6 +9642,58 @@ async fn usage_limit_runtime_stops_active_goal_and_prevents_idle_continuation() 
         .await?
         .expect("goal should remain persisted after usage limiting");
     assert_eq!(codex_state::ThreadGoalStatus::UsageLimited, goal.status);
+    assert_eq!(70, goal.tokens_used);
+
+    sess.abort_all_tasks(TurnAbortReason::Replaced).await;
+    sess.goal_runtime_apply(GoalRuntimeEvent::MaybeContinueIfIdle)
+        .await?;
+    assert!(sess.active_turn.lock().await.is_none());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_error_pauses_active_goal_and_prevents_idle_continuation() -> anyhow::Result<()> {
+    let (sess, tc, _rx, _codex_home) = make_goal_session_and_context_with_rx().await;
+    sess.set_thread_goal(
+        tc.as_ref(),
+        SetGoalRequest {
+            objective: Some("Keep improving the benchmark".to_string()),
+            status: None,
+            token_budget: Some(Some(500)),
+        },
+    )
+    .await?;
+    sess.goal_runtime_apply(GoalRuntimeEvent::TurnStarted {
+        turn_context: tc.as_ref(),
+        token_usage: TokenUsage::default(),
+    })
+    .await?;
+    sess.spawn_task(
+        Arc::clone(&tc),
+        Vec::new(),
+        NeverEndingTask {
+            kind: TaskKind::Regular,
+            listen_to_cancellation_token: false,
+        },
+    )
+    .await;
+    set_total_token_usage(&sess, post_goal_token_usage()).await;
+
+    let error = CodexErr::InvalidRequest("bad compaction request".to_string());
+    sess.goal_runtime_apply(GoalRuntimeEvent::TurnErrored {
+        turn_context: tc.as_ref(),
+        error: &error,
+    })
+    .await?;
+
+    let state_db = goal_test_state_db(sess.as_ref()).await?;
+    let goal = state_db
+        .thread_goals()
+        .get_thread_goal(sess.thread_id)
+        .await?
+        .expect("goal should remain persisted after turn error");
+    assert_eq!(codex_state::ThreadGoalStatus::Paused, goal.status);
     assert_eq!(70, goal.tokens_used);
 
     sess.abort_all_tasks(TurnAbortReason::Replaced).await;

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -9680,7 +9680,7 @@ async fn turn_error_suppresses_next_idle_goal_continuation() -> anyhow::Result<(
     .await;
     set_total_token_usage(&sess, post_goal_token_usage()).await;
 
-    let error = CodexErr::InvalidRequest("bad compaction request".to_string());
+    let error = CodexErr::ContextWindowExceeded;
     sess.goal_runtime_apply(GoalRuntimeEvent::TurnErrored {
         turn_context: tc.as_ref(),
         error: &error,
@@ -9699,6 +9699,61 @@ async fn turn_error_suppresses_next_idle_goal_continuation() -> anyhow::Result<(
     sess.goal_runtime_apply(GoalRuntimeEvent::MaybeContinueIfIdle)
         .await?;
     assert!(sess.active_turn.lock().await.is_none());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_error_suppression_still_starts_pending_trigger_turn() -> anyhow::Result<()> {
+    let (sess, tc, _rx, _codex_home) = make_goal_session_and_context_with_rx().await;
+    sess.set_thread_goal(
+        tc.as_ref(),
+        SetGoalRequest {
+            objective: Some("Keep improving the benchmark".to_string()),
+            status: None,
+            token_budget: Some(Some(500)),
+        },
+    )
+    .await?;
+    sess.goal_runtime_apply(GoalRuntimeEvent::TurnStarted {
+        turn_context: tc.as_ref(),
+        token_usage: TokenUsage::default(),
+    })
+    .await?;
+    sess.spawn_task(
+        Arc::clone(&tc),
+        Vec::new(),
+        NeverEndingTask {
+            kind: TaskKind::Regular,
+            listen_to_cancellation_token: false,
+        },
+    )
+    .await;
+
+    let error = CodexErr::InvalidRequest("bad compaction request".to_string());
+    sess.goal_runtime_apply(GoalRuntimeEvent::TurnErrored {
+        turn_context: tc.as_ref(),
+        error: &error,
+    })
+    .await?;
+    sess.input_queue
+        .enqueue_mailbox_communication(InterAgentCommunication::new(
+            AgentPath::try_from("/root/worker").expect("worker path should parse"),
+            AgentPath::root(),
+            Vec::new(),
+            "pending trigger".to_string(),
+            /*trigger_turn*/ true,
+        ))
+        .await;
+
+    sess.abort_all_tasks(TurnAbortReason::Replaced).await;
+    assert!(sess.input_queue.has_trigger_turn_mailbox_items().await);
+
+    sess.goal_runtime_apply(GoalRuntimeEvent::MaybeContinueIfIdle)
+        .await?;
+    assert!(!sess.input_queue.has_trigger_turn_mailbox_items().await);
+
+    sess.abort_all_tasks(TurnAbortReason::Replaced).await;
 
     Ok(())
 }

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -9653,7 +9653,7 @@ async fn usage_limit_runtime_stops_active_goal_and_prevents_idle_continuation() 
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn turn_error_pauses_active_goal_and_prevents_idle_continuation() -> anyhow::Result<()> {
+async fn turn_error_suppresses_next_idle_goal_continuation() -> anyhow::Result<()> {
     let (sess, tc, _rx, _codex_home) = make_goal_session_and_context_with_rx().await;
     sess.set_thread_goal(
         tc.as_ref(),
@@ -9693,8 +9693,7 @@ async fn turn_error_pauses_active_goal_and_prevents_idle_continuation() -> anyho
         .get_thread_goal(sess.thread_id)
         .await?
         .expect("goal should remain persisted after turn error");
-    assert_eq!(codex_state::ThreadGoalStatus::Paused, goal.status);
-    assert_eq!(70, goal.tokens_used);
+    assert_eq!(codex_state::ThreadGoalStatus::Active, goal.status);
 
     sess.abort_all_tasks(TurnAbortReason::Replaced).await;
     sess.goal_runtime_apply(GoalRuntimeEvent::MaybeContinueIfIdle)

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -148,18 +148,7 @@ pub(crate) async fn run_turn(
     // diffs/full reinjection + user input) and trigger compaction preemptively
     // when they would push the thread over the compaction threshold.
     if let Err(err) = run_pre_sampling_compact(&sess, &turn_context, &mut client_session).await {
-        let error = err.to_codex_protocol_error();
-        sess.emit_turn_error_lifecycle(turn_context.as_ref(), error.clone())
-            .await;
-        if error == CodexErrorInfo::UsageLimitExceeded
-            && let Err(err) = sess
-                .goal_runtime_apply(GoalRuntimeEvent::UsageLimitReached {
-                    turn_context: turn_context.as_ref(),
-                })
-                .await
-        {
-            warn!("failed to usage-limit active goal after usage-limit error: {err}");
-        }
+        emit_turn_error_and_apply_goal_runtime(&sess, &turn_context, &err).await;
         error!("Failed to run pre-sampling compact");
         return None;
     }
@@ -301,20 +290,7 @@ pub(crate) async fn run_turn(
                     )
                     .await
                     {
-                        let error = err.to_codex_protocol_error();
-                        sess.emit_turn_error_lifecycle(turn_context.as_ref(), error.clone())
-                            .await;
-                        if error == CodexErrorInfo::UsageLimitExceeded
-                            && let Err(err) = sess
-                                .goal_runtime_apply(GoalRuntimeEvent::UsageLimitReached {
-                                    turn_context: turn_context.as_ref(),
-                                })
-                                .await
-                        {
-                            warn!(
-                                "failed to usage-limit active goal after usage-limit error: {err}"
-                            );
-                        }
+                        emit_turn_error_and_apply_goal_runtime(&sess, &turn_context, &err).await;
                         return None;
                     }
                     can_drain_pending_input = !model_needs_follow_up;
@@ -387,6 +363,7 @@ pub(crate) async fn run_turn(
                 let error = CodexErrorInfo::BadRequest;
                 sess.emit_turn_error_lifecycle(turn_context.as_ref(), error.clone())
                     .await;
+                apply_goal_runtime_turn_error(&sess, &turn_context, &codex_error).await;
                 let event = EventMsg::Error(ErrorEvent {
                     message: "Invalid image in your last message. Please remove it and try again."
                         .to_string(),
@@ -397,18 +374,7 @@ pub(crate) async fn run_turn(
             }
             Err(e) => {
                 info!("Turn error: {e:#}");
-                let error = e.to_codex_protocol_error();
-                sess.emit_turn_error_lifecycle(turn_context.as_ref(), error.clone())
-                    .await;
-                if error == CodexErrorInfo::UsageLimitExceeded
-                    && let Err(err) = sess
-                        .goal_runtime_apply(GoalRuntimeEvent::UsageLimitReached {
-                            turn_context: turn_context.as_ref(),
-                        })
-                        .await
-                {
-                    warn!("failed to usage-limit active goal after usage-limit error: {err}");
-                }
+                emit_turn_error_and_apply_goal_runtime(&sess, &turn_context, &e).await;
                 sess.track_turn_codex_error(turn_context.as_ref(), &e);
                 let event = EventMsg::Error(e.to_error_event(/*message_prefix*/ None));
                 sess.send_event(&turn_context, event).await;
@@ -419,6 +385,32 @@ pub(crate) async fn run_turn(
     }
 
     last_agent_message
+}
+
+async fn emit_turn_error_and_apply_goal_runtime(
+    sess: &Arc<Session>,
+    turn_context: &Arc<TurnContext>,
+    error: &CodexErr,
+) {
+    sess.emit_turn_error_lifecycle(turn_context.as_ref(), error.to_codex_protocol_error())
+        .await;
+    apply_goal_runtime_turn_error(sess, turn_context, error).await;
+}
+
+async fn apply_goal_runtime_turn_error(
+    sess: &Arc<Session>,
+    turn_context: &Arc<TurnContext>,
+    error: &CodexErr,
+) {
+    if let Err(err) = sess
+        .goal_runtime_apply(GoalRuntimeEvent::TurnErrored {
+            turn_context: turn_context.as_ref(),
+            error,
+        })
+        .await
+    {
+        warn!("failed to apply goal runtime turn-error event: {err}");
+    }
 }
 
 async fn run_hooks_and_record_inputs(

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -141,6 +141,13 @@ pub(crate) async fn run_turn(
     prewarmed_client_session: Option<ModelClientSession>,
     cancellation_token: CancellationToken,
 ) -> Option<String> {
+    if let Err(err) = sess
+        .goal_runtime_apply(GoalRuntimeEvent::TurnAttemptStarted)
+        .await
+    {
+        warn!("failed to apply goal runtime turn-attempt-started event: {err}");
+    }
+
     let mut client_session =
         prewarmed_client_session.unwrap_or_else(|| sess.services.model_client.new_session());
     // TODO(ccunningham): Pre-turn compaction runs before context updates and the


### PR DESCRIPTION
## Why

Active goals automatically continue when a thread becomes idle. If a turn ended with a terminal error, the goal could remain active and immediately retry the same failing work, causing an infinite continuation loop.

## What changed

- Route turn failures through a shared `GoalRuntimeEvent::TurnErrored` path.
- Pause active goals after terminal errors so idle continuation cannot restart them.
- Preserve the existing usage-limit transition, and leave goals unchanged for explicit turn aborts or interruptions.
- Apply the goal transition consistently across compaction, sampling, invalid-image, and general turn-error paths.

## Test plan

- Added coverage that a terminal turn error pauses the active goal and prevents idle continuation.
- Updated the usage-limit regression test to exercise the shared turn-error path.
