### PR TITLE
Prewarm skills during thread resume

### DIFF
--- a/codex-rs/app-server/src/request_processors/catalog_processor.rs
+++ b/codex-rs/app-server/src/request_processors/catalog_processor.rs
@@ -647,9 +647,11 @@ impl CatalogRequestProcessor {
                 config.features.enabled(Feature::Plugins) && workspace_codex_plugins_enabled;
             let plugin_hooks = if plugins_enabled {
                 let plugins_input = config.plugins_config_input();
-                plugins_manager
-                    .plugin_hooks_for_layer_stack(&config.config_layer_stack, &plugins_input)
-                    .await
+                let plugin_outcome = plugins_manager.plugins_for_config(&plugins_input).await;
+                codex_core_plugins::PluginHookLoadOutcome {
+                    hook_sources: plugin_outcome.effective_plugin_hook_sources(),
+                    hook_load_warnings: plugin_outcome.effective_plugin_hook_warnings(),
+                }
             } else {
                 codex_core_plugins::PluginHookLoadOutcome::default()
             };

--- a/codex-rs/app-server/src/request_processors/thread_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor.rs
@@ -2450,6 +2450,14 @@ impl ThreadRequestProcessor {
             }
         }
 
+        let thread_manager_for_prewarm = Arc::clone(&self.thread_manager);
+        let config_for_prewarm = Arc::clone(&self.config);
+        tokio::spawn(async move {
+            thread_manager_for_prewarm
+                .prewarm_plugins_and_skills(config_for_prewarm)
+                .await;
+        });
+
         let ThreadResumeParams {
             thread_id,
             history,

--- a/codex-rs/app-server/tests/suite/v2/hooks_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/hooks_list.rs
@@ -265,6 +265,84 @@ async fn hooks_list_shows_discovered_plugin_hook() -> Result<()> {
 }
 
 #[tokio::test]
+async fn hooks_list_warms_plugin_capabilities_for_thread_start() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    let cwd = TempDir::new()?;
+    write_plugin_hook_config(
+        codex_home.path(),
+        r#"{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo plugin hook"
+          }
+        ]
+      }
+    ]
+  }
+}"#,
+    )?;
+    let plugin_mcp_path = codex_home
+        .path()
+        .join("plugins/cache/test/demo/local/.mcp.json");
+    std::fs::write(
+        &plugin_mcp_path,
+        r#"{
+  "mcpServers": {
+    "plugin-server": {
+      "url": "http://127.0.0.1:1/mcp"
+    }
+  }
+}"#,
+    )?;
+
+    let mut mcp = TestAppServer::new(codex_home.path()).await?;
+    timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;
+
+    let hooks_list_id = mcp
+        .send_hooks_list_request(HooksListParams {
+            cwds: vec![cwd.path().to_path_buf()],
+        })
+        .await?;
+    timeout(
+        DEFAULT_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(hooks_list_id)),
+    )
+    .await??;
+
+    std::fs::remove_file(plugin_mcp_path)?;
+
+    let thread_start_id = mcp
+        .send_thread_start_request(ThreadStartParams::default())
+        .await?;
+    let _: ThreadStartResponse = to_response(
+        timeout(
+            DEFAULT_TIMEOUT,
+            mcp.read_stream_until_response_message(RequestId::Integer(thread_start_id)),
+        )
+        .await??,
+    )?;
+    timeout(
+        DEFAULT_TIMEOUT,
+        mcp.read_stream_until_matching_notification("plugin MCP server starting", |notification| {
+            notification.method == "mcpServer/startupStatus/updated"
+                && notification
+                    .params
+                    .as_ref()
+                    .and_then(|params| params.get("name"))
+                    .and_then(serde_json::Value::as_str)
+                    == Some("plugin-server")
+        }),
+    )
+    .await??;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn hooks_list_shows_plugin_hook_load_warnings() -> Result<()> {
     let codex_home = TempDir::new()?;
     let cwd = TempDir::new()?;

--- a/codex-rs/core-plugins/src/manager.rs
+++ b/codex-rs/core-plugins/src/manager.rs
@@ -78,7 +78,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::sync::atomic::AtomicBool;
-use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::time::Instant;
 use tokio::sync::Semaphore;
@@ -405,9 +404,8 @@ pub struct PluginsManager {
     featured_plugin_ids_cache: RwLock<Option<CachedFeaturedPluginIds>>,
     configured_marketplace_upgrade_state: RwLock<ConfiguredMarketplaceUpgradeState>,
     non_curated_cache_refresh_state: RwLock<NonCuratedCacheRefreshState>,
-    cached_enabled_outcome: RwLock<Option<CachedPluginLoadOutcome>>,
+    enabled_outcome_cache: RwLock<EnabledOutcomeCache>,
     enabled_outcome_load_semaphore: Semaphore,
-    enabled_outcome_cache_generation: AtomicU64,
     remote_installed_plugins_cache: RwLock<Option<Vec<RemoteInstalledPlugin>>>,
     remote_installed_plugins_cache_refresh_state: RwLock<RemoteInstalledPluginsCacheRefreshState>,
     remote_sync_lock: Semaphore,
@@ -419,6 +417,12 @@ pub struct PluginsManager {
 struct CachedPluginLoadOutcome {
     key: PluginLoadCacheKey,
     outcome: PluginLoadOutcome,
+}
+
+#[derive(Default)]
+struct EnabledOutcomeCache {
+    generation: u64,
+    outcome: Option<CachedPluginLoadOutcome>,
 }
 
 #[derive(Clone, PartialEq, Eq)]
@@ -452,9 +456,8 @@ impl PluginsManager {
                 ConfiguredMarketplaceUpgradeState::default(),
             ),
             non_curated_cache_refresh_state: RwLock::new(NonCuratedCacheRefreshState::default()),
-            cached_enabled_outcome: RwLock::new(None),
+            enabled_outcome_cache: RwLock::new(EnabledOutcomeCache::default()),
             enabled_outcome_load_semaphore: Semaphore::new(/*permits*/ 1),
-            enabled_outcome_cache_generation: AtomicU64::new(0),
             remote_installed_plugins_cache: RwLock::new(None),
             remote_installed_plugins_cache_refresh_state: RwLock::new(
                 RemoteInstalledPluginsCacheRefreshState::default(),
@@ -513,9 +516,7 @@ impl PluginsManager {
         if !force_reload && let Some(outcome) = self.cached_enabled_outcome(&cache_key) {
             return outcome;
         }
-        let cache_generation = self
-            .enabled_outcome_cache_generation
-            .load(Ordering::Acquire);
+        let cache_generation = self.enabled_outcome_cache_generation();
         let outcome = load_plugins_from_layer_stack(
             &config.config_layer_stack,
             self.remote_installed_plugin_configs(),
@@ -525,20 +526,7 @@ impl PluginsManager {
         )
         .await;
         log_plugin_load_errors(&outcome);
-        if self
-            .enabled_outcome_cache_generation
-            .load(Ordering::Acquire)
-            == cache_generation
-        {
-            let mut cache = match self.cached_enabled_outcome.write() {
-                Ok(cache) => cache,
-                Err(err) => err.into_inner(),
-            };
-            *cache = Some(CachedPluginLoadOutcome {
-                key: cache_key,
-                outcome: outcome.clone(),
-            });
-        }
+        self.cache_enabled_outcome_if_current(cache_generation, cache_key, outcome.clone());
         outcome
     }
 
@@ -552,13 +540,12 @@ impl PluginsManager {
     }
 
     fn clear_enabled_outcome_cache(&self) {
-        self.enabled_outcome_cache_generation
-            .fetch_add(1, Ordering::AcqRel);
-        let mut cached_enabled_outcome = match self.cached_enabled_outcome.write() {
+        let mut cache = match self.enabled_outcome_cache.write() {
             Ok(cache) => cache,
             Err(err) => err.into_inner(),
         };
-        *cached_enabled_outcome = None;
+        cache.generation = cache.generation.wrapping_add(1);
+        cache.outcome = None;
     }
 
     /// Load plugins for a config layer stack without touching the plugins cache.
@@ -610,16 +597,40 @@ impl PluginsManager {
     }
 
     fn cached_enabled_outcome(&self, key: &PluginLoadCacheKey) -> Option<PluginLoadOutcome> {
-        match self.cached_enabled_outcome.read() {
+        match self.enabled_outcome_cache.read() {
             Ok(cache) => cache
+                .outcome
                 .as_ref()
                 .filter(|cached| cached.key == *key)
                 .map(|cached| cached.outcome.clone()),
             Err(err) => err
                 .into_inner()
+                .outcome
                 .as_ref()
                 .filter(|cached| cached.key == *key)
                 .map(|cached| cached.outcome.clone()),
+        }
+    }
+
+    fn enabled_outcome_cache_generation(&self) -> u64 {
+        match self.enabled_outcome_cache.read() {
+            Ok(cache) => cache.generation,
+            Err(err) => err.into_inner().generation,
+        }
+    }
+
+    fn cache_enabled_outcome_if_current(
+        &self,
+        generation: u64,
+        key: PluginLoadCacheKey,
+        outcome: PluginLoadOutcome,
+    ) {
+        let mut cache = match self.enabled_outcome_cache.write() {
+            Ok(cache) => cache,
+            Err(err) => err.into_inner(),
+        };
+        if cache.generation == generation {
+            cache.outcome = Some(CachedPluginLoadOutcome { key, outcome });
         }
     }
 

--- a/codex-rs/core-plugins/src/manager.rs
+++ b/codex-rs/core-plugins/src/manager.rs
@@ -57,8 +57,9 @@ use codex_config::apply_user_plugin_config_edits;
 use codex_config::clear_user_plugin;
 use codex_config::set_user_plugin_enabled;
 use codex_config::types::PluginConfig;
-use codex_config::version_for_toml;
 use codex_core_skills::SkillMetadata;
+use codex_core_skills::config_rules::SkillConfigRules;
+use codex_core_skills::config_rules::skill_config_rules_from_stack;
 use codex_hooks::plugin_hook_declarations;
 use codex_login::AuthManager;
 use codex_login::CodexAuth;
@@ -77,6 +78,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::time::Instant;
 use tokio::sync::Semaphore;
@@ -404,6 +406,8 @@ pub struct PluginsManager {
     configured_marketplace_upgrade_state: RwLock<ConfiguredMarketplaceUpgradeState>,
     non_curated_cache_refresh_state: RwLock<NonCuratedCacheRefreshState>,
     cached_enabled_outcome: RwLock<Option<CachedPluginLoadOutcome>>,
+    enabled_outcome_load_semaphore: Semaphore,
+    enabled_outcome_cache_generation: AtomicU64,
     remote_installed_plugins_cache: RwLock<Option<Vec<RemoteInstalledPlugin>>>,
     remote_installed_plugins_cache_refresh_state: RwLock<RemoteInstalledPluginsCacheRefreshState>,
     remote_sync_lock: Semaphore,
@@ -413,8 +417,15 @@ pub struct PluginsManager {
 
 #[derive(Clone)]
 struct CachedPluginLoadOutcome {
-    config_version: String,
+    key: PluginLoadCacheKey,
     outcome: PluginLoadOutcome,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct PluginLoadCacheKey {
+    configured_plugins: HashMap<String, PluginConfig>,
+    skill_config_rules: SkillConfigRules,
+    remote_plugin_enabled: bool,
 }
 
 impl PluginsManager {
@@ -442,6 +453,8 @@ impl PluginsManager {
             ),
             non_curated_cache_refresh_state: RwLock::new(NonCuratedCacheRefreshState::default()),
             cached_enabled_outcome: RwLock::new(None),
+            enabled_outcome_load_semaphore: Semaphore::new(/*permits*/ 1),
+            enabled_outcome_cache_generation: AtomicU64::new(0),
             remote_installed_plugins_cache: RwLock::new(None),
             remote_installed_plugins_cache_refresh_state: RwLock::new(
                 RemoteInstalledPluginsCacheRefreshState::default(),
@@ -484,11 +497,25 @@ impl PluginsManager {
             return PluginLoadOutcome::default();
         }
 
-        let config_version = version_for_toml(&config.config_layer_stack.effective_config());
-        if !force_reload && let Some(outcome) = self.cached_enabled_outcome(&config_version) {
+        let cache_key = PluginLoadCacheKey {
+            configured_plugins: configured_plugins_from_stack(&config.config_layer_stack),
+            skill_config_rules: skill_config_rules_from_stack(&config.config_layer_stack),
+            remote_plugin_enabled: config.remote_plugin_enabled,
+        };
+        if !force_reload && let Some(outcome) = self.cached_enabled_outcome(&cache_key) {
             return outcome;
         }
 
+        let Ok(_load_permit) = self.enabled_outcome_load_semaphore.acquire().await else {
+            warn!("plugin load semaphore closed");
+            return PluginLoadOutcome::default();
+        };
+        if !force_reload && let Some(outcome) = self.cached_enabled_outcome(&cache_key) {
+            return outcome;
+        }
+        let cache_generation = self
+            .enabled_outcome_cache_generation
+            .load(Ordering::Acquire);
         let outcome = load_plugins_from_layer_stack(
             &config.config_layer_stack,
             self.remote_installed_plugin_configs(),
@@ -498,14 +525,20 @@ impl PluginsManager {
         )
         .await;
         log_plugin_load_errors(&outcome);
-        let mut cache = match self.cached_enabled_outcome.write() {
-            Ok(cache) => cache,
-            Err(err) => err.into_inner(),
-        };
-        *cache = Some(CachedPluginLoadOutcome {
-            config_version,
-            outcome: outcome.clone(),
-        });
+        if self
+            .enabled_outcome_cache_generation
+            .load(Ordering::Acquire)
+            == cache_generation
+        {
+            let mut cache = match self.cached_enabled_outcome.write() {
+                Ok(cache) => cache,
+                Err(err) => err.into_inner(),
+            };
+            *cache = Some(CachedPluginLoadOutcome {
+                key: cache_key,
+                outcome: outcome.clone(),
+            });
+        }
         outcome
     }
 
@@ -519,6 +552,8 @@ impl PluginsManager {
     }
 
     fn clear_enabled_outcome_cache(&self) {
+        self.enabled_outcome_cache_generation
+            .fetch_add(1, Ordering::AcqRel);
         let mut cached_enabled_outcome = match self.cached_enabled_outcome.write() {
             Ok(cache) => cache,
             Err(err) => err.into_inner(),
@@ -574,16 +609,16 @@ impl PluginsManager {
             .effective_plugin_skill_roots()
     }
 
-    fn cached_enabled_outcome(&self, config_version: &str) -> Option<PluginLoadOutcome> {
+    fn cached_enabled_outcome(&self, key: &PluginLoadCacheKey) -> Option<PluginLoadOutcome> {
         match self.cached_enabled_outcome.read() {
             Ok(cache) => cache
                 .as_ref()
-                .filter(|cached| cached.config_version == config_version)
+                .filter(|cached| cached.key == *key)
                 .map(|cached| cached.outcome.clone()),
             Err(err) => err
                 .into_inner()
                 .as_ref()
-                .filter(|cached| cached.config_version == config_version)
+                .filter(|cached| cached.key == *key)
                 .map(|cached| cached.outcome.clone()),
         }
     }

--- a/codex-rs/core-plugins/src/manager_tests.rs
+++ b/codex-rs/core-plugins/src/manager_tests.rs
@@ -1370,6 +1370,27 @@ async fn plugin_cache_ignores_unrelated_session_overrides() {
     assert_eq!(second.plugins()[0].mcp_servers.len(), 1);
 }
 
+#[test]
+fn plugin_cache_invalidation_rejects_stale_load_completion() {
+    let codex_home = TempDir::new().unwrap();
+    let manager = PluginsManager::new(codex_home.path().to_path_buf());
+    let cache_key = PluginLoadCacheKey {
+        configured_plugins: HashMap::new(),
+        skill_config_rules: SkillConfigRules::default(),
+        remote_plugin_enabled: false,
+    };
+    let stale_generation = manager.enabled_outcome_cache_generation();
+
+    manager.clear_enabled_outcome_cache();
+    manager.cache_enabled_outcome_if_current(
+        stale_generation,
+        cache_key.clone(),
+        PluginLoadOutcome::default(),
+    );
+
+    assert_eq!(manager.cached_enabled_outcome(&cache_key), None);
+}
+
 #[tokio::test]
 async fn load_plugins_rejects_invalid_plugin_keys() {
     let codex_home = TempDir::new().unwrap();

--- a/codex-rs/core-plugins/src/manager_tests.rs
+++ b/codex-rs/core-plugins/src/manager_tests.rs
@@ -1301,6 +1301,76 @@ async fn load_plugins_returns_empty_when_feature_disabled() {
 }
 
 #[tokio::test]
+async fn plugin_cache_ignores_unrelated_session_overrides() {
+    let codex_home = TempDir::new().unwrap();
+    let plugin_root = codex_home
+        .path()
+        .join("plugins/cache")
+        .join("test/sample/local");
+    write_plugin(
+        codex_home.path().join("plugins/cache/test").as_path(),
+        "sample/local",
+        "sample",
+    );
+    write_file(
+        &plugin_root.join(".mcp.json"),
+        r#"{
+  "mcpServers": {
+    "sample": {
+      "url": "https://sample.example/mcp"
+    }
+  }
+}"#,
+    );
+
+    let user_file = codex_home.path().join(CONFIG_TOML_FILE).abs();
+    let user_config: toml::Value = toml::from_str(&plugin_config_toml(
+        /*enabled*/ true, /*plugins_feature_enabled*/ true,
+    ))
+    .expect("user config should parse");
+    let stack = |session_config: &str| {
+        ConfigLayerStack::new(
+            vec![
+                ConfigLayerEntry::new(
+                    ConfigLayerSource::User {
+                        file: user_file.clone(),
+                        profile: None,
+                    },
+                    user_config.clone(),
+                ),
+                ConfigLayerEntry::new(
+                    ConfigLayerSource::SessionFlags,
+                    toml::from_str(session_config).expect("session config should parse"),
+                ),
+            ],
+            ConfigRequirements::default(),
+            ConfigRequirementsToml::default(),
+        )
+        .expect("config layer stack should build")
+    };
+    let config = |session_config| {
+        PluginsConfigInput::new(
+            stack(session_config),
+            /*plugins_enabled*/ true,
+            /*remote_plugin_enabled*/ false,
+            "https://chatgpt.com".to_string(),
+        )
+    };
+    let manager = PluginsManager::new(codex_home.path().to_path_buf());
+
+    let first = manager
+        .plugins_for_config(&config(r#"model = "first""#))
+        .await;
+    std::fs::remove_file(plugin_root.join(".mcp.json")).unwrap();
+    let second = manager
+        .plugins_for_config(&config(r#"model = "second""#))
+        .await;
+
+    assert_eq!(second, first);
+    assert_eq!(second.plugins()[0].mcp_servers.len(), 1);
+}
+
+#[tokio::test]
 async fn load_plugins_rejects_invalid_plugin_keys() {
     let codex_home = TempDir::new().unwrap();
     let plugin_root = codex_home

--- a/codex-rs/core-skills/src/manager.rs
+++ b/codex-rs/core-skills/src/manager.rs
@@ -9,6 +9,7 @@ use codex_protocol::protocol::Product;
 use codex_protocol::protocol::SkillScope;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_plugins::PluginSkillRoot;
+use tokio::sync::OnceCell;
 use tracing::info;
 use tracing::warn;
 
@@ -53,7 +54,7 @@ pub struct SkillsManager {
     restriction_product: Option<Product>,
     extra_roots: RwLock<Vec<AbsolutePathBuf>>,
     cache_by_cwd: RwLock<HashMap<AbsolutePathBuf, SkillLoadOutcome>>,
-    cache_by_config: RwLock<HashMap<ConfigSkillsCacheKey, SkillLoadOutcome>>,
+    cache_by_config: RwLock<HashMap<ConfigSkillsCacheKey, Arc<OnceCell<SkillLoadOutcome>>>>,
 }
 
 impl SkillsManager {
@@ -108,17 +109,17 @@ impl SkillsManager {
         let roots = self.skill_roots_for_config(input, fs).await;
         let skill_config_rules = skill_config_rules_from_stack(&input.config_layer_stack);
         let cache_key = config_skills_cache_key(&roots, &skill_config_rules);
-        if let Some(outcome) = self.cached_outcome_for_config(&cache_key) {
-            return outcome;
-        }
-
-        let outcome = self.build_skill_outcome(roots, &skill_config_rules).await;
-        let mut cache = self
-            .cache_by_config
-            .write()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        cache.insert(cache_key, outcome.clone());
-        outcome
+        let cache_entry = {
+            let mut cache = self
+                .cache_by_config
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            Arc::clone(cache.entry(cache_key).or_default())
+        };
+        cache_entry
+            .get_or_init(|| self.build_skill_outcome(roots, &skill_config_rules))
+            .await
+            .clone()
     }
 
     pub async fn skill_roots_for_config(
@@ -154,8 +155,21 @@ impl SkillsManager {
             return outcome;
         }
 
+        if use_cwd_cache {
+            if force_reload {
+                self.clear_config_cache();
+            }
+            let outcome = self.skills_for_config(input, fs).await;
+            let mut cache = self
+                .cache_by_cwd
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            cache.insert(input.cwd.clone(), outcome.clone());
+            return outcome;
+        }
+
         let mut roots = skill_roots(
-            fs.clone(),
+            fs,
             &input.config_layer_stack,
             &input.cwd,
             input.effective_skill_roots.clone(),
@@ -166,15 +180,7 @@ impl SkillsManager {
             roots.retain(|root| root.scope != SkillScope::System);
         }
         let skill_config_rules = skill_config_rules_from_stack(&input.config_layer_stack);
-        let outcome = self.build_skill_outcome(roots, &skill_config_rules).await;
-        if use_cwd_cache {
-            let mut cache = self
-                .cache_by_cwd
-                .write()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            cache.insert(input.cwd.clone(), outcome.clone());
-        }
-        outcome
+        self.build_skill_outcome(roots, &skill_config_rules).await
     }
 
     async fn build_skill_outcome(
@@ -200,15 +206,7 @@ impl SkillsManager {
             cache.clear();
             cleared
         };
-        let cleared_config = {
-            let mut cache = self
-                .cache_by_config
-                .write()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let cleared = cache.len();
-            cache.clear();
-            cleared
-        };
+        let cleared_config = self.clear_config_cache();
         let cleared = cleared_cwd + cleared_config;
         info!("skills cache cleared ({cleared} entries)");
     }
@@ -220,14 +218,14 @@ impl SkillsManager {
         }
     }
 
-    fn cached_outcome_for_config(
-        &self,
-        cache_key: &ConfigSkillsCacheKey,
-    ) -> Option<SkillLoadOutcome> {
-        match self.cache_by_config.read() {
-            Ok(cache) => cache.get(cache_key).cloned(),
-            Err(err) => err.into_inner().get(cache_key).cloned(),
-        }
+    fn clear_config_cache(&self) -> usize {
+        let mut cache = self
+            .cache_by_config
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let cleared = cache.len();
+        cache.clear();
+        cleared
     }
 
     fn extra_roots(&self) -> Vec<AbsolutePathBuf> {

--- a/codex-rs/core-skills/src/manager_tests.rs
+++ b/codex-rs/core-skills/src/manager_tests.rs
@@ -222,6 +222,59 @@ async fn skills_for_config_reuses_cache_for_same_effective_config() {
 }
 
 #[tokio::test]
+async fn skills_for_config_reuses_in_progress_load() {
+    let codex_home = tempfile::tempdir().expect("tempdir");
+    let cwd = tempfile::tempdir().expect("tempdir");
+    let config_layer_stack = config_stack(&codex_home, "");
+    let skills_manager = Arc::new(SkillsManager::new(
+        codex_home.path().abs(),
+        /*bundled_skills_enabled*/ true,
+    ));
+    let skills_input = SkillsLoadInput::new(
+        cwd.path().abs(),
+        Vec::new(),
+        config_layer_stack.clone(),
+        bundled_skills_enabled_from_stack(&config_layer_stack),
+    );
+    let roots = skills_manager
+        .skill_roots_for_config(&skills_input, Some(Arc::clone(&LOCAL_FS)))
+        .await;
+    let cache_key =
+        config_skills_cache_key(&roots, &skill_config_rules_from_stack(&config_layer_stack));
+    let in_progress = Arc::new(OnceCell::new());
+    skills_manager
+        .cache_by_config
+        .write()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(cache_key, Arc::clone(&in_progress));
+
+    let lookup = {
+        let skills_manager = Arc::clone(&skills_manager);
+        tokio::spawn(async move {
+            skills_manager
+                .skills_for_config(&skills_input, Some(Arc::clone(&LOCAL_FS)))
+                .await
+        })
+    };
+    tokio::task::yield_now().await;
+    assert!(!lookup.is_finished());
+
+    let expected = SkillLoadOutcome {
+        errors: vec![crate::SkillError {
+            path: cwd.path().abs(),
+            message: "loaded once".to_string(),
+        }],
+        ..Default::default()
+    };
+    in_progress
+        .set(expected.clone())
+        .expect("in-progress load should not be initialized");
+
+    let outcome = lookup.await.expect("skill lookup should finish");
+    assert_eq!(outcome.errors, expected.errors);
+}
+
+#[tokio::test]
 async fn set_extra_roots_replaces_runtime_roots_and_clears_cache() {
     let codex_home = tempfile::tempdir().expect("tempdir");
     let cwd = tempfile::tempdir().expect("tempdir");

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -439,7 +439,7 @@ pub(crate) struct AppServerClientMetadata {
     pub(crate) client_version: Option<String>,
 }
 
-async fn warm_plugins_and_skills_for_session_init(
+pub(crate) async fn warm_plugins_and_skills_for_session_init(
     config: Arc<Config>,
     environment_manager: Arc<EnvironmentManager>,
     plugins_manager: Arc<PluginsManager>,

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -13,6 +13,7 @@ use crate::session::CodexSpawnArgs;
 use crate::session::CodexSpawnOk;
 use crate::session::INITIAL_SUBMIT_ID;
 use crate::session::resolve_multi_agent_version;
+use crate::session::session::warm_plugins_and_skills_for_session_init;
 use crate::shell_snapshot::ShellSnapshot;
 use crate::tasks::InterruptedTurnHistoryMarker;
 use crate::tasks::interrupted_turn_history_marker;
@@ -423,6 +424,22 @@ impl ThreadManager {
 
     pub fn environment_manager(&self) -> Arc<EnvironmentManager> {
         self.state.environment_manager.clone()
+    }
+
+    /// Populate the plugin and skill caches for a likely upcoming thread.
+    pub async fn prewarm_plugins_and_skills(&self, config: Arc<Config>) {
+        let environments = default_thread_environment_selections(
+            self.state.environment_manager.as_ref(),
+            &config.cwd,
+        );
+        let _ = warm_plugins_and_skills_for_session_init(
+            config,
+            Arc::clone(&self.state.environment_manager),
+            Arc::clone(&self.state.plugins_manager),
+            Arc::clone(&self.state.skills_manager),
+            environments,
+        )
+        .await;
     }
 
     pub fn default_environment_selections(

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -16,6 +16,7 @@ use crate::app_event::RealtimeAudioDeviceKind;
 #[cfg(target_os = "windows")]
 use crate::app_event::WindowsSandboxEnableMode;
 use crate::app_event_sender::AppEventSender;
+use crate::app_server_session::AppServerBootstrap;
 use crate::app_server_session::AppServerSession;
 use crate::app_server_session::AppServerStartedThread;
 use crate::app_server_session::TurnPermissionsOverride;
@@ -727,6 +728,8 @@ impl App {
         app_server_target: AppServerTarget,
         state_db: Option<StateDbHandle>,
         environment_manager: Arc<EnvironmentManager>,
+        startup_elapsed_before_app: Duration,
+        startup_bootstrap: Option<AppServerBootstrap>,
         startup_hooks_browser: Option<HooksListEntry>,
     ) -> Result<AppExitInfo> {
         use tokio_stream::StreamExt;
@@ -774,9 +777,11 @@ impl App {
                 });
             }
         };
-        let bootstrap_started_at = Instant::now();
-        let bootstrap = app_server.bootstrap(&config).await?;
-        let bootstrap_ms = bootstrap_started_at.elapsed().as_millis();
+        let bootstrap = match startup_bootstrap {
+            Some(bootstrap) => bootstrap,
+            None => app_server.bootstrap(&config).await?,
+        };
+        let bootstrap_ms = bootstrap.duration.as_millis();
         let mut model = bootstrap.default_model;
         let available_models = bootstrap.available_models;
         let remote_connection = crate::status::remote_connection::remote_connection_status_value(
@@ -1085,7 +1090,7 @@ See the Codex keymap documentation for supported actions and examples."
 
         tui.frame_requester().schedule_frame();
         tracing::info!(
-            duration_ms = %startup_started_at.elapsed().as_millis(),
+            duration_ms = %(startup_elapsed_before_app + startup_started_at.elapsed()).as_millis(),
             bootstrap_ms = %bootstrap_ms,
             runtime_model_provider_ms = %runtime_model_provider_ms,
             thread_and_widget_ms = %thread_and_widget_ms,

--- a/codex-rs/tui/src/app_server_session.rs
+++ b/codex-rs/tui/src/app_server_session.rs
@@ -127,6 +127,8 @@ use color_eyre::eyre::Result;
 use color_eyre::eyre::WrapErr;
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::time::Duration;
+use std::time::Instant;
 use uuid::Uuid;
 
 const JSONRPC_INVALID_REQUEST: i64 = -32600;
@@ -150,6 +152,7 @@ fn is_thread_settings_update_unsupported(source: &JSONRPCErrorError) -> bool {
 /// fetched asynchronously after bootstrap returns so that the TUI can render
 /// its first frame without waiting for the rate-limit round-trip.
 pub(crate) struct AppServerBootstrap {
+    pub(crate) duration: Duration,
     pub(crate) account_email: Option<String>,
     pub(crate) auth_mode: Option<TelemetryAuthMode>,
     pub(crate) status_account_display: Option<StatusAccountDisplay>,
@@ -239,6 +242,7 @@ impl AppServerSession {
     }
 
     pub(crate) async fn bootstrap(&mut self, config: &Config) -> Result<AppServerBootstrap> {
+        let started_at = Instant::now();
         let account = self.read_account().await?;
         let model_request_id = self.next_request_id();
         let models: ModelListResponse = self
@@ -314,6 +318,7 @@ impl AppServerSession {
             None => (None, None, None, None, FeedbackAudience::External, false),
         };
         Ok(AppServerBootstrap {
+            duration: started_at.elapsed(),
             account_email,
             auth_mode,
             status_account_display,

--- a/codex-rs/tui/src/external_agent_config_migration_startup.rs
+++ b/codex-rs/tui/src/external_agent_config_migration_startup.rs
@@ -25,7 +25,7 @@ pub(crate) enum ExternalAgentConfigMigrationStartupOutcome {
     ExitRequested,
 }
 
-fn should_show_external_agent_config_migration_prompt(
+pub(crate) fn should_show_external_agent_config_migration_prompt(
     config: &Config,
     entered_trust_nux: bool,
 ) -> bool {

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -71,6 +71,7 @@ use std::fs::OpenOptions;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Instant;
 pub use token_usage::TokenUsage;
 use tracing::Level;
 use tracing::error;
@@ -276,6 +277,7 @@ pub(crate) mod test_support;
 use crate::onboarding::onboarding_screen::OnboardingScreenArgs;
 use crate::onboarding::onboarding_screen::run_onboarding_app;
 use crate::startup_hooks_review::StartupHooksReviewOutcome;
+use crate::startup_hooks_review::load_startup_hooks_review_entry;
 use crate::startup_hooks_review::maybe_run_startup_hooks_review;
 use crate::tui::Tui;
 pub use cli::Cli;
@@ -1781,11 +1783,33 @@ async fn run_ratatui_app(
             resume_picker::SessionSelection::Resume(_)
         );
     let bypass_hook_trust_for_startup_review = config.bypass_hook_trust && !is_persistent_resume;
+    let hooks_request_handle = app_server.request_handle();
+    let hooks_cwd = config.cwd.to_path_buf();
+    let startup_prefetch_started_at = Instant::now();
+    let should_defer_bootstrap =
+        external_agent_config_migration_startup::should_show_external_agent_config_migration_prompt(
+            &config,
+            should_show_trust_screen_flag,
+        );
+    let (startup_bootstrap, startup_hooks_entry) = if should_defer_bootstrap {
+        (
+            None,
+            load_startup_hooks_review_entry(hooks_request_handle, hooks_cwd).await,
+        )
+    } else {
+        let (bootstrap, entry) = tokio::join!(
+            app_server.bootstrap(&config),
+            load_startup_hooks_review_entry(hooks_request_handle, hooks_cwd),
+        );
+        (Some(bootstrap?), entry)
+    };
+    let startup_elapsed_before_app = startup_prefetch_started_at.elapsed();
     let startup_hooks_browser = match maybe_run_startup_hooks_review(
         &mut app_server,
         &mut tui,
         &config,
         bypass_hook_trust_for_startup_review,
+        startup_hooks_entry,
     )
     .await?
     {
@@ -1810,6 +1834,8 @@ async fn run_ratatui_app(
         app_server_target,
         state_db,
         environment_manager,
+        startup_elapsed_before_app,
+        startup_bootstrap,
         startup_hooks_browser,
     )
     .await;

--- a/codex-rs/tui/src/startup_hooks_review.rs
+++ b/codex-rs/tui/src/startup_hooks_review.rs
@@ -28,7 +28,9 @@ use crate::render::renderable::ColumnRenderable;
 use crate::render::renderable::Renderable;
 use crate::tui::Tui;
 use crate::tui::TuiEvent;
+use codex_app_server_client::AppServerRequestHandle;
 use codex_app_server_protocol::HooksListEntry;
+use std::path::PathBuf;
 
 pub(crate) enum StartupHooksReviewOutcome {
     Continue,
@@ -42,21 +44,32 @@ enum StartupHooksReviewSelection {
     ContinueWithoutTrusting,
 }
 
+pub(crate) async fn load_startup_hooks_review_entry(
+    request_handle: AppServerRequestHandle,
+    cwd: PathBuf,
+) -> HooksListEntry {
+    let response = match fetch_hooks_list(request_handle, cwd.clone()).await {
+        Ok(response) => response,
+        Err(err) => {
+            tracing::warn!("failed to load startup hook review state: {err:#}");
+            return HooksListEntry {
+                cwd,
+                hooks: Vec::new(),
+                warnings: Vec::new(),
+                errors: Vec::new(),
+            };
+        }
+    };
+    hooks_list_entry_for_cwd(response, &cwd)
+}
+
 pub(crate) async fn maybe_run_startup_hooks_review(
     app_server: &mut AppServerSession,
     tui: &mut Tui,
     config: &Config,
     bypass_hook_trust: bool,
+    entry: HooksListEntry,
 ) -> Result<StartupHooksReviewOutcome> {
-    let cwd = config.cwd.to_path_buf();
-    let response = match fetch_hooks_list(app_server.request_handle(), cwd.clone()).await {
-        Ok(response) => response,
-        Err(err) => {
-            tracing::warn!("failed to load startup hook review state: {err:#}");
-            return Ok(StartupHooksReviewOutcome::Continue);
-        }
-    };
-    let entry = hooks_list_entry_for_cwd(response, &cwd);
     if !review_is_needed(bypass_hook_trust, &entry) {
         return Ok(StartupHooksReviewOutcome::Continue);
     }


### PR DESCRIPTION
Stacked on #26469.

## Summary

Resuming a thread starts session initialization only after the app server has loaded the thread. Session initialization then resolves plugin skill roots and discovers skills before the resumed thread is ready, leaving that work serialized on the startup path.

This change starts the same plugin and skill warmup when `thread/resume` begins, allowing it to overlap with loading the thread. Config-scoped skill loads now use a shared in-progress result, so session initialization reuses either the active prewarm or its completed outcome instead of repeating discovery. Existing force-reload and cache invalidation paths continue to clear the config cache.

In 30 alternating release-build pairs resuming the same Ruff session, the median `thread_and_widget` startup phase decreased from 267ms on #26469 to 248ms on this branch. The branch was faster in 27 of 30 pairs, with a paired median improvement of 21ms. Median time to the first editable composer decreased from 1.043s to 1.026s; that end-to-end measurement is noisier because account/model bootstrap and network latency are outside this change.