### PR TITLE
fix(tui): avoid duplicated streamed markdown lines

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1830,6 +1830,8 @@ impl ChatWidget {
             if let Some(controller) = self.plan_stream_controller.as_mut() {
                 controller.clear_queue();
             }
+            self.stream_controller = None;
+            self.plan_stream_controller = None;
             self.clear_active_stream_tail();
             self.request_redraw();
         }

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1624,11 +1624,18 @@ impl ChatWidget {
         self.raw_output_mode = enabled;
         self.config.tui_raw_output_mode = enabled;
         let render_mode = self.history_render_mode();
+        let mut stream_state_changed = false;
         if let Some(controller) = self.stream_controller.as_mut() {
-            controller.set_render_mode(render_mode);
+            stream_state_changed |= controller.set_render_mode(render_mode);
         }
         if let Some(controller) = self.plan_stream_controller.as_mut() {
-            controller.set_render_mode(render_mode);
+            stream_state_changed |= controller.set_render_mode(render_mode);
+        }
+        if stream_state_changed {
+            if !self.stream_controllers_idle() {
+                self.app_event_tx.send(AppEvent::StartCommitAnimation);
+            }
+            self.sync_active_stream_tail();
         }
         self.refresh_status_surfaces();
     }

--- a/codex-rs/tui/src/chatwidget/streaming.rs
+++ b/codex-rs/tui/src/chatwidget/streaming.rs
@@ -19,7 +19,7 @@ impl ChatWidget {
     pub(super) fn flush_answer_stream_with_separator(&mut self) {
         let had_stream_controller = self.stream_controller.is_some();
         if let Some(mut controller) = self.stream_controller.take() {
-            let scrollback_reflow = if controller.has_live_tail() {
+            let scrollback_reflow = if controller.requires_final_scrollback_reflow() {
                 crate::app_event::ConsolidationScrollbackReflow::Required
             } else {
                 crate::app_event::ConsolidationScrollbackReflow::IfResizeReflowRan
@@ -158,10 +158,10 @@ impl ChatWidget {
         self.transcript.saw_plan_item_this_turn = true;
         let (finalized_streamed_cell, consolidated_plan_source) =
             if let Some(mut controller) = self.plan_stream_controller.take() {
-                let had_live_tail = controller.has_live_tail();
+                let requires_scrollback_reflow = controller.requires_final_scrollback_reflow();
                 self.clear_active_stream_tail();
                 let (cell, source) = controller.finalize();
-                if had_live_tail {
+                if requires_scrollback_reflow {
                     (None, source)
                 } else {
                     (cell, source)

--- a/codex-rs/tui/src/chatwidget/tests/snapshots/codex_tui__chatwidget__tests__status_and_layout__raw_output_toggle_refreshes_active_stream_tail.snap
+++ b/codex-rs/tui/src/chatwidget/tests/snapshots/codex_tui__chatwidget__tests__status_and_layout__raw_output_toggle_refreshes_active_stream_tail.snap
@@ -1,0 +1,5 @@
+---
+source: tui/src/chatwidget/tests/status_and_layout.rs
+expression: raw_tail
+---
+  **tail remains visible**

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -1447,6 +1447,43 @@ async fn finalize_turn_persists_held_stream_tail() {
 }
 
 #[tokio::test]
+async fn finalize_turn_persists_held_plan_stream_tail() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    let cwd = chat.config.cwd.to_path_buf();
+
+    let mut controller = crate::streaming::controller::PlanStreamController::new(
+        Some(/*width*/ 80),
+        cwd.as_path(),
+        HistoryRenderMode::Rich,
+    );
+    controller.push("1. prefix already emitted\n");
+    controller.push("tail remains visible\n");
+    let (_cell, idle) = controller.on_commit_tick_batch(/*max_lines*/ usize::MAX);
+    assert!(idle, "stable plan prefix should drain before termination");
+    assert!(
+        controller.has_live_tail(),
+        "expected plan tail to remain mutable before termination",
+    );
+    chat.plan_stream_controller = Some(controller);
+
+    while rx.try_recv().is_ok() {}
+
+    chat.finalize_turn();
+
+    let mut consolidated_plan = String::new();
+    while let Ok(event) = rx.try_recv() {
+        if let AppEvent::ConsolidateProposedPlan(source) = event {
+            consolidated_plan = source;
+        }
+    }
+    assert!(
+        consolidated_plan.contains("tail remains visible"),
+        "expected held plan tail to be persisted on termination, got {consolidated_plan:?}",
+    );
+    assert!(chat.plan_stream_controller.is_none());
+}
+
+#[tokio::test]
 async fn raw_output_toggle_refreshes_active_stream_tail() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
 

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -1484,6 +1484,42 @@ async fn finalize_turn_persists_held_plan_stream_tail() {
 }
 
 #[tokio::test]
+async fn finalize_turn_persists_structural_plan_tail_as_history_cell() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    let cwd = chat.config.cwd.to_path_buf();
+
+    let mut controller = crate::streaming::controller::PlanStreamController::new(
+        Some(/*width*/ 80),
+        cwd.as_path(),
+        HistoryRenderMode::Rich,
+    );
+    controller.push("| Step | Owner |\n");
+    controller.push("| --- | --- |\n");
+    controller.push("| Preserve held table tail | Agent |\n");
+    assert!(
+        controller.requires_final_scrollback_reflow(),
+        "expected table plan tail to require consolidation reflow",
+    );
+    chat.plan_stream_controller = Some(controller);
+
+    while rx.try_recv().is_ok() {}
+
+    chat.finalize_turn();
+
+    let inserted = drain_insert_history(&mut rx);
+    let rendered = inserted
+        .iter()
+        .map(|cell| lines_to_single_string(cell))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        rendered.contains("Preserve held table tail"),
+        "expected structural plan tail to be persisted directly, got {rendered:?}",
+    );
+    assert!(chat.plan_stream_controller.is_none());
+}
+
+#[tokio::test]
 async fn raw_output_toggle_refreshes_active_stream_tail() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
 
@@ -1519,6 +1555,7 @@ async fn raw_output_toggle_refreshes_active_stream_tail() {
         raw_tail.contains("**tail remains visible**"),
         "expected active tail to refresh after raw toggle, got {raw_tail:?}",
     );
+    insta::assert_snapshot!(raw_tail);
 }
 
 #[tokio::test]

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -1410,6 +1410,81 @@ async fn streaming_final_answer_keeps_task_running_state() {
 }
 
 #[tokio::test]
+async fn finalize_turn_persists_held_stream_tail() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+
+    chat.on_task_started();
+    chat.on_agent_message_delta("prefix already emitted\n".to_string());
+    chat.on_agent_message_delta("tail remains visible\n".to_string());
+    chat.on_commit_tick();
+    drain_insert_history(&mut rx);
+
+    let active_before = chat
+        .transcript
+        .active_cell
+        .as_ref()
+        .map(|cell| lines_to_single_string(&cell.display_lines(/*width*/ 80)))
+        .unwrap_or_default();
+    assert!(
+        active_before.contains("tail remains visible"),
+        "expected held tail before termination, got {active_before:?}",
+    );
+
+    chat.finalize_turn();
+
+    let inserted = drain_insert_history(&mut rx);
+    let rendered = inserted
+        .iter()
+        .map(|cell| lines_to_single_string(cell))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        rendered.contains("tail remains visible"),
+        "expected held tail to be persisted on termination, got {rendered:?}",
+    );
+    assert!(chat.transcript.active_cell.is_none());
+    assert!(chat.stream_controller.is_none());
+}
+
+#[tokio::test]
+async fn raw_output_toggle_refreshes_active_stream_tail() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+
+    chat.on_task_started();
+    chat.on_agent_message_delta("prefix already emitted\n".to_string());
+    chat.on_agent_message_delta("**tail remains visible**\n".to_string());
+    chat.on_commit_tick();
+
+    let rich_tail = chat
+        .transcript
+        .active_cell
+        .as_ref()
+        .map(|cell| lines_to_single_string(&cell.display_lines(/*width*/ 80)))
+        .unwrap_or_default();
+    assert!(
+        rich_tail.contains("tail remains visible"),
+        "expected rich tail before toggle, got {rich_tail:?}",
+    );
+    assert!(
+        !rich_tail.contains("**tail remains visible**"),
+        "expected rich tail to render markdown before toggle, got {rich_tail:?}",
+    );
+
+    chat.set_raw_output_mode(/*enabled*/ true);
+
+    let raw_tail = chat
+        .transcript
+        .active_cell
+        .as_ref()
+        .map(|cell| lines_to_single_string(&cell.display_lines(/*width*/ 80)))
+        .unwrap_or_default();
+    assert!(
+        raw_tail.contains("**tail remains visible**"),
+        "expected active tail to refresh after raw toggle, got {raw_tail:?}",
+    );
+}
+
+#[tokio::test]
 async fn ctrl_c_interrupt_pauses_active_goal_turn() {
     let (mut chat, mut rx, mut op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
     let thread_id = ThreadId::new();

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -259,7 +259,10 @@ async fn flush_answer_stream_keeps_default_reflow_for_plain_text_tail() {
         cwd.as_path(),
         HistoryRenderMode::Rich,
     );
-    assert!(controller.push("plain response line\n"));
+    assert!(
+        !controller.push("plain response line\n"),
+        "short prose should stay in the ordinary mutable tail until finalization",
+    );
     chat.stream_controller = Some(controller);
 
     while rx.try_recv().is_ok() {}

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -1520,6 +1520,48 @@ async fn finalize_turn_persists_structural_plan_tail_as_history_cell() {
 }
 
 #[tokio::test]
+async fn interrupted_stream_tail_is_not_persisted_on_finalize_turn() {
+    let (mut chat, mut rx, mut op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+
+    chat.on_task_started();
+    chat.on_agent_message_delta("prefix already emitted\n".to_string());
+    chat.on_agent_message_delta("preview tail should be dropped\n".to_string());
+    chat.on_commit_tick();
+    drain_insert_history(&mut rx);
+
+    let active_before = chat
+        .transcript
+        .active_cell
+        .as_ref()
+        .map(|cell| lines_to_single_string(&cell.display_lines(/*width*/ 80)))
+        .unwrap_or_default();
+    assert!(
+        active_before.contains("preview tail should be dropped"),
+        "expected preview tail before interrupt, got {active_before:?}",
+    );
+
+    chat.handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
+    match op_rx.try_recv() {
+        Ok(Op::Interrupt { .. }) => {}
+        other => panic!("expected Op::Interrupt, got {other:?}"),
+    }
+
+    chat.finalize_turn();
+
+    let inserted = drain_insert_history(&mut rx);
+    let rendered = inserted
+        .iter()
+        .map(|cell| lines_to_single_string(cell))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        !rendered.contains("preview tail should be dropped"),
+        "interrupted preview tail should not be persisted, got {rendered:?}",
+    );
+    assert!(chat.stream_controller.is_none());
+}
+
+#[tokio::test]
 async fn raw_output_toggle_refreshes_active_stream_tail() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
 

--- a/codex-rs/tui/src/chatwidget/turn_runtime.rs
+++ b/codex-rs/tui/src/chatwidget/turn_runtime.rs
@@ -117,10 +117,10 @@ impl ChatWidget {
         // If a stream is currently active, finalize it.
         self.flush_answer_stream_with_separator();
         if let Some(mut controller) = self.plan_stream_controller.take() {
-            let had_live_tail = controller.has_live_tail();
+            let requires_scrollback_reflow = controller.requires_final_scrollback_reflow();
             self.clear_active_stream_tail();
             let (cell, source) = controller.finalize();
-            if !had_live_tail && let Some(cell) = cell {
+            if !requires_scrollback_reflow && let Some(cell) = cell {
                 self.add_boxed_history(cell);
             }
             if let Some(source) = source {

--- a/codex-rs/tui/src/chatwidget/turn_runtime.rs
+++ b/codex-rs/tui/src/chatwidget/turn_runtime.rs
@@ -117,10 +117,9 @@ impl ChatWidget {
         // If a stream is currently active, finalize it.
         self.flush_answer_stream_with_separator();
         if let Some(mut controller) = self.plan_stream_controller.take() {
-            let requires_scrollback_reflow = controller.requires_final_scrollback_reflow();
             self.clear_active_stream_tail();
             let (cell, source) = controller.finalize();
-            if !requires_scrollback_reflow && let Some(cell) = cell {
+            if let Some(cell) = cell {
                 self.add_boxed_history(cell);
             }
             if let Some(source) = source {
@@ -296,10 +295,9 @@ impl ChatWidget {
     pub(super) fn finalize_turn(&mut self) {
         self.flush_answer_stream_with_separator();
         if let Some(mut controller) = self.plan_stream_controller.take() {
-            let requires_scrollback_reflow = controller.requires_final_scrollback_reflow();
             self.clear_active_stream_tail();
             let (cell, source) = controller.finalize();
-            if !requires_scrollback_reflow && let Some(cell) = cell {
+            if let Some(cell) = cell {
                 self.add_boxed_history(cell);
             }
             if let Some(source) = source {

--- a/codex-rs/tui/src/chatwidget/turn_runtime.rs
+++ b/codex-rs/tui/src/chatwidget/turn_runtime.rs
@@ -294,9 +294,19 @@ impl ChatWidget {
     /// This does not clear MCP startup tracking, because MCP startup can overlap with turn cleanup
     /// and should continue to drive the bottom-pane running indicator while it is in progress.
     pub(super) fn finalize_turn(&mut self) {
-        // Drop preview-only stream tail content on any termination path before
-        // failed-cell finalization, so transient tail cells are never persisted.
-        self.clear_active_stream_tail();
+        self.flush_answer_stream_with_separator();
+        if let Some(mut controller) = self.plan_stream_controller.take() {
+            let requires_scrollback_reflow = controller.requires_final_scrollback_reflow();
+            self.clear_active_stream_tail();
+            let (cell, source) = controller.finalize();
+            if !requires_scrollback_reflow && let Some(cell) = cell {
+                self.add_boxed_history(cell);
+            }
+            if let Some(source) = source {
+                self.app_event_tx
+                    .send(AppEvent::ConsolidateProposedPlan(source));
+            }
+        }
         // Ensure any spinner is replaced by a red ✗ and flushed into history.
         self.finalize_active_cell_as_failed();
         // Turn-scoped hook rows are transient live state; once the turn is over,
@@ -314,8 +324,6 @@ impl ChatWidget {
         self.last_unified_wait = None;
         self.unified_exec_wait_streak = None;
         self.adaptive_chunking.reset();
-        self.stream_controller = None;
-        self.plan_stream_controller = None;
         self.status_state.pending_status_indicator_restore = false;
         self.clear_cancel_edit();
         self.request_status_line_branch_refresh();

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -667,12 +667,13 @@ impl StreamCore {
             boundaries.push(self.raw_source.len());
         }
 
-        for boundary in boundaries {
-            if self.render_source(&self.raw_source[..boundary]).len() >= rendered_len {
-                return boundary;
-            }
-        }
-        self.raw_source.len()
+        let idx = boundaries.partition_point(|boundary| {
+            self.render_source(&self.raw_source[..*boundary]).len() < rendered_len
+        });
+        boundaries
+            .get(idx)
+            .copied()
+            .unwrap_or(self.raw_source.len())
     }
 
     fn partial_source_line_after_rendered_len(
@@ -838,7 +839,7 @@ fn visible_text_source_boundary(source: &str, visible_prefix: &str) -> Option<us
             continue;
         }
 
-        if matches!(ch, '*' | '_' | '`') {
+        if matches!(ch, '*' | '_' | '`') && visible_chars.peek().copied() != Some(ch) {
             continue;
         }
 
@@ -3005,6 +3006,36 @@ mod tests {
         assert!(
             joined.contains("delta") && joined.contains("tail line"),
             "raw suffix should preserve un-emitted heading text; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+        );
+    }
+
+    #[test]
+    fn controller_set_render_mode_raw_suffix_preserves_escaped_marker_prefix() {
+        let mut ctrl = stream_controller(Some(/*width*/ 12));
+        ctrl.push("\\* alpha beta gamma delta epsilon zeta eta theta\n");
+        ctrl.push("tail line\n");
+
+        let (first_emit, idle) = ctrl.on_commit_tick();
+        let first_emit = first_emit
+            .expect("expected first rich wrapped escaped-marker emission")
+            .transcript_lines(u16::MAX);
+        assert!(!idle, "expected remaining rich content after one tick");
+
+        ctrl.set_render_mode(HistoryRenderMode::Raw);
+
+        let (cell, _source) = ctrl.finalize();
+        let remaining = cell
+            .map(|c| lines_to_plain_strings(&c.transcript_lines(u16::MAX)))
+            .unwrap_or_default();
+        let first_emit = lines_to_plain_strings(&first_emit).join("\n");
+        let joined = remaining.join("\n");
+        assert!(
+            !joined.contains("\\* alpha beta"),
+            "raw suffix must not replay the already-visible escaped marker prefix; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+        );
+        assert!(
+            joined.contains("delta") && joined.contains("tail line"),
+            "raw suffix should preserve un-emitted escaped-marker text; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
         );
     }
 

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -89,6 +89,13 @@ struct StreamCore {
     stable_prefix_len_cache: Option<StablePrefixLenCache>,
     /// Incremental holdback scanner state for append-only source updates.
     holdback_scanner: TableHoldbackScanner,
+    /// Number of source lines to keep mutable even when no structural holdback is active.
+    ///
+    /// CommonMark can reinterpret the newest block after the next line arrives. For example, a
+    /// paragraph after a fenced code block inside a list can shift when the following blank/list
+    /// marker is parsed. Holding a small source suffix keeps that boundary out of scrollback until
+    /// it is stable.
+    default_tail_lines: usize,
 }
 
 struct StablePrefixLenCache {
@@ -104,7 +111,12 @@ struct StablePrefixLenCache {
 }
 
 impl StreamCore {
-    fn new(width: Option<usize>, cwd: &Path, render_mode: HistoryRenderMode) -> Self {
+    fn new(
+        width: Option<usize>,
+        cwd: &Path,
+        render_mode: HistoryRenderMode,
+        default_tail_lines: usize,
+    ) -> Self {
         Self {
             state: StreamState::new(width, cwd),
             width,
@@ -116,6 +128,7 @@ impl StreamCore {
             render_mode,
             stable_prefix_len_cache: None,
             holdback_scanner: TableHoldbackScanner::new(),
+            default_tail_lines,
         }
     }
 
@@ -216,6 +229,7 @@ impl StreamCore {
         self.rendered_lines[start..].to_vec()
     }
 
+    #[cfg(test)]
     #[inline]
     fn has_tail(&self) -> bool {
         self.enqueued_stable_len < self.rendered_lines.len()
@@ -235,7 +249,7 @@ impl StreamCore {
             return;
         }
         let had_pending_queue = self.state.queued_len() > 0;
-        let had_live_tail = self.has_tail();
+        let had_structural_tail = self.requires_final_scrollback_reflow();
         self.width = width;
         self.state.collector.set_width(width);
         if self.raw_source.is_empty() {
@@ -244,21 +258,25 @@ impl StreamCore {
 
         self.recompute_streaming_render();
         self.emitted_stable_len = self.emitted_stable_len.min(self.rendered_lines.len());
+        let target_stable_len = self.compute_target_stable_len();
         if had_pending_queue
-            && self.emitted_stable_len == self.rendered_lines.len()
-            && self.emitted_stable_len > 0
+            && self.emitted_stable_len >= target_stable_len
+            && target_stable_len > 0
         {
             // If wrapped remainder compresses into fewer lines at the new width,
             // keep at least one line un-emitted so pre-resize pending content is
             // not skipped permanently.
-            self.emitted_stable_len -= 1;
+            self.emitted_stable_len = target_stable_len - 1;
         }
         self.state.clear_queue();
-        if self.emitted_stable_len > 0 && !had_pending_queue && !had_live_tail {
+        if self.emitted_stable_len > 0 && !had_pending_queue && !had_structural_tail {
             // Avoid replaying already-emitted content after resize when no
             // stable lines were waiting in the queue and there was no mutable
-            // tail to preserve.
-            self.enqueued_stable_len = self.rendered_lines.len();
+            // structural tail to preserve. Ordinary source-line tails are
+            // remapped to the new render suffix and stay mutable.
+            let target_stable_len = self.compute_target_stable_len();
+            self.emitted_stable_len = target_stable_len;
+            self.enqueued_stable_len = target_stable_len;
             return;
         }
         self.rebuild_stable_queue_from_render();
@@ -296,7 +314,7 @@ impl StreamCore {
         }
 
         let had_pending_queue = self.state.queued_len() > 0;
-        let had_live_tail = self.has_tail();
+        let had_structural_tail = self.requires_final_scrollback_reflow();
         self.render_mode = render_mode;
         if self.raw_source.is_empty() {
             return;
@@ -304,15 +322,18 @@ impl StreamCore {
 
         self.recompute_streaming_render();
         self.emitted_stable_len = self.emitted_stable_len.min(self.rendered_lines.len());
+        let target_stable_len = self.compute_target_stable_len();
         if had_pending_queue
-            && self.emitted_stable_len == self.rendered_lines.len()
-            && self.emitted_stable_len > 0
+            && self.emitted_stable_len >= target_stable_len
+            && target_stable_len > 0
         {
-            self.emitted_stable_len -= 1;
+            self.emitted_stable_len = target_stable_len - 1;
         }
         self.state.clear_queue();
-        if self.emitted_stable_len > 0 && !had_pending_queue && !had_live_tail {
-            self.enqueued_stable_len = self.rendered_lines.len();
+        if self.emitted_stable_len > 0 && !had_pending_queue && !had_structural_tail {
+            let target_stable_len = self.compute_target_stable_len();
+            self.emitted_stable_len = target_stable_len;
+            self.enqueued_stable_len = target_stable_len;
             return;
         }
         self.rebuild_stable_queue_from_render();
@@ -389,7 +410,7 @@ impl StreamCore {
             | TableHoldbackState::PendingHeader {
                 header_start: start,
             } => self.tail_budget_from_source_start(start),
-            TableHoldbackState::None => 0,
+            TableHoldbackState::None => self.default_tail_budget_lines(),
         };
         tracing::trace!(
             state = ?holdback_state,
@@ -454,6 +475,44 @@ impl StreamCore {
         });
         stable_prefix_len
     }
+
+    fn default_tail_budget_lines(&mut self) -> usize {
+        if self.default_tail_lines == 0 || self.rendered_lines.is_empty() {
+            return 0;
+        }
+        let Some(source_start) = tail_source_start(&self.raw_source, self.default_tail_lines)
+        else {
+            return 0;
+        };
+        self.tail_budget_from_source_start(source_start)
+    }
+
+    fn requires_final_scrollback_reflow(&self) -> bool {
+        self.render_mode != HistoryRenderMode::Raw
+            && !matches!(self.holdback_scanner.state(), TableHoldbackState::None)
+    }
+}
+
+fn tail_source_start(source: &str, tail_lines: usize) -> Option<usize> {
+    if source.is_empty() || tail_lines == 0 {
+        return None;
+    }
+
+    let mut end = source.len();
+    if source.as_bytes().last() == Some(&b'\n') {
+        end = end.saturating_sub(1);
+    }
+    let content_end = end;
+
+    let mut start = 0;
+    for _ in 0..tail_lines {
+        start = source[..end].rfind('\n').map(|idx| idx + 1).unwrap_or(0);
+        end = start.saturating_sub(1);
+    }
+    if start == content_end && start > 0 {
+        start = source[..end].rfind('\n').map(|idx| idx + 1).unwrap_or(0);
+    }
+    Some(start)
 }
 
 /// Controller for streaming agent message content with table-aware holdback.
@@ -472,7 +531,7 @@ impl StreamController {
     /// the old viewport until app-level reflow repairs the finalized transcript.
     pub(crate) fn new(width: Option<usize>, cwd: &Path, render_mode: HistoryRenderMode) -> Self {
         Self {
-            core: StreamCore::new(width, cwd, render_mode),
+            core: StreamCore::new(width, cwd, render_mode, /*default_tail_lines*/ 1),
             header_emitted: false,
         }
     }
@@ -532,9 +591,14 @@ impl StreamController {
         !self.header_emitted && self.core.enqueued_stable_len == 0
     }
 
+    #[cfg(test)]
     #[inline]
     pub(crate) fn has_live_tail(&self) -> bool {
         self.core.has_tail()
+    }
+
+    pub(crate) fn requires_final_scrollback_reflow(&self) -> bool {
+        self.core.requires_final_scrollback_reflow()
     }
 
     pub(crate) fn clear_queue(&mut self) {
@@ -585,7 +649,7 @@ impl PlanStreamController {
     /// callers must update it when the terminal width changes.
     pub(crate) fn new(width: Option<usize>, cwd: &Path, render_mode: HistoryRenderMode) -> Self {
         Self {
-            core: StreamCore::new(width, cwd, render_mode),
+            core: StreamCore::new(width, cwd, render_mode, /*default_tail_lines*/ 0),
             header_emitted: false,
             top_padding_emitted: false,
         }
@@ -635,9 +699,14 @@ impl PlanStreamController {
         self.core.queued_lines()
     }
 
+    #[cfg(test)]
     #[inline]
     pub(crate) fn has_live_tail(&self) -> bool {
         self.core.has_tail()
+    }
+
+    pub(crate) fn requires_final_scrollback_reflow(&self) -> bool {
+        self.core.requires_final_scrollback_reflow()
     }
 
     #[inline]
@@ -808,7 +877,8 @@ mod tests {
     fn controller_set_width_rebuilds_queued_lines() {
         let mut ctrl = stream_controller(Some(120));
         let delta = "This is a long line that should wrap into multiple rows when resized.\n";
-        assert!(ctrl.push(delta));
+        assert!(!ctrl.push(delta));
+        assert!(ctrl.push("tail line\n"));
         assert_eq!(ctrl.queued_lines(), 1);
 
         ctrl.set_width(Some(24));
@@ -832,6 +902,7 @@ mod tests {
         let line =
             "This is a long line that definitely wraps when the terminal shrinks to 24 columns.\n";
         ctrl.push(line);
+        ctrl.push("tail line\n");
         let (cell, _) = ctrl.on_commit_tick_batch(usize::MAX);
         assert!(cell.is_some(), "expected emitted cell");
         assert_eq!(ctrl.queued_lines(), 0);
@@ -848,7 +919,8 @@ mod tests {
     #[test]
     fn controller_tick_batch_zero_is_noop() {
         let mut ctrl = stream_controller(Some(80));
-        assert!(ctrl.push("line one\n"));
+        assert!(!ctrl.push("line one\n"));
+        assert!(ctrl.push("line two\n"));
         assert_eq!(ctrl.queued_lines(), 1);
 
         let (cell, idle) = ctrl.on_commit_tick_batch(/*max_lines*/ 0);
@@ -911,6 +983,33 @@ mod tests {
             "expected no live tail outside table holdback state",
         );
         assert!(!ctrl.has_live_tail());
+    }
+
+    #[test]
+    fn controller_does_not_duplicate_list_continuation_after_fenced_code() {
+        let lines = collect_streamed_lines(
+            &[
+                "**Happy Path**\n",
+                "\n",
+                "1. In the second terminal, make the smoke home non-writable:\n",
+                "   ```fish\n",
+                "   chmod a-w $CODEX_SMOKE_HOME\n",
+                "   ```\n",
+                "   Expected: the running TUI stays open.\n",
+                "\n",
+                "2. In the TUI, type `/model` and press Enter.\n",
+            ],
+            Some(/*width*/ 80),
+        );
+
+        let expected_count = lines
+            .iter()
+            .filter(|line| line.trim() == "Expected: the running TUI stays open.")
+            .count();
+        assert_eq!(
+            expected_count, 1,
+            "expected list continuation to render once, got {lines:?}",
+        );
     }
 
     #[test]
@@ -997,8 +1096,17 @@ mod tests {
         }
 
         assert!(
-            drained.iter().any(|l| l.contains("second line")),
-            "pending lines should continue draining after resize; got {drained:?}",
+            drained.iter().any(|l| l.contains("IIII JJJJ")),
+            "pending wrapped lines should continue draining after resize; got {drained:?}",
+        );
+
+        let (cell, _source) = ctrl.finalize();
+        let final_lines = cell
+            .map(|cell| lines_to_plain_strings(&cell.transcript_lines(u16::MAX)))
+            .unwrap_or_default();
+        assert!(
+            final_lines.iter().any(|line| line.contains("second line")),
+            "ordinary mutable tail should flush on finalize; got {final_lines:?}",
         );
     }
 
@@ -1028,6 +1136,8 @@ mod tests {
         assert_eq!(ctrl.queued_lines(), 0, "expected empty queue before table");
 
         ctrl.push("| A | B |\n");
+        let (_cell, idle) = ctrl.on_commit_tick();
+        assert!(idle, "pre-table intro should drain before resize");
         assert_eq!(
             ctrl.queued_lines(),
             0,
@@ -1247,7 +1357,7 @@ mod tests {
         let mut ctrl = stream_controller(Some(80));
 
         ctrl.push("Intro line before table.\n");
-        assert_eq!(ctrl.queued_lines(), 1);
+        assert_eq!(ctrl.queued_lines(), 0);
 
         ctrl.push("| Key | Value |\n");
         ctrl.push("| --- | --- |\n");
@@ -1898,6 +2008,7 @@ mod tests {
     fn controller_set_width_partial_wrapped_emit_keeps_wrapped_remainder() {
         let mut ctrl = stream_controller(Some(18));
         ctrl.push("alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu\n");
+        ctrl.push("tail line\n");
 
         let (first_emit, idle) = ctrl.on_commit_tick();
         assert!(first_emit.is_some(), "expected first wrapped line emission");

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -272,9 +272,10 @@ impl StreamCore {
         if self.emitted_stable_len > 0 && !had_pending_queue && !had_structural_tail {
             // Avoid replaying already-emitted content after resize when no
             // stable lines were waiting in the queue and there was no mutable
-            // structural tail to preserve. Ordinary source-line tails are
-            // remapped to the new render suffix and stay mutable.
-            let target_stable_len = self.compute_target_stable_len();
+            // structural tail to preserve. Use the unfloored stable boundary so
+            // ordinary source-line tails are remapped to the new render suffix
+            // and stay mutable even if the stable prefix compressed.
+            let target_stable_len = self.stable_len_before_emitted_floor();
             self.emitted_stable_len = target_stable_len;
             self.enqueued_stable_len = target_stable_len;
             return;
@@ -315,7 +316,13 @@ impl StreamCore {
 
         let had_pending_queue = self.state.queued_len() > 0;
         let had_structural_tail = self.requires_final_scrollback_reflow();
+        let live_default_tail_source_start = if !had_pending_queue && !had_structural_tail {
+            self.live_default_tail_source_start()
+        } else {
+            None
+        };
         self.render_mode = render_mode;
+        self.stable_prefix_len_cache = None;
         if self.raw_source.is_empty() {
             return;
         }
@@ -331,7 +338,11 @@ impl StreamCore {
         }
         self.state.clear_queue();
         if self.emitted_stable_len > 0 && !had_pending_queue && !had_structural_tail {
-            let target_stable_len = self.compute_target_stable_len();
+            let target_stable_len = if let Some(source_start) = live_default_tail_source_start {
+                self.stable_prefix_len_for_source_start(source_start)
+            } else {
+                self.compute_target_stable_len()
+            };
             self.emitted_stable_len = target_stable_len;
             self.enqueued_stable_len = target_stable_len;
             return;
@@ -341,11 +352,13 @@ impl StreamCore {
 
     /// Compute how many rendered lines should be in the stable region.
     fn compute_target_stable_len(&mut self) -> usize {
-        let tail_budget = self.active_tail_budget_lines();
-        self.rendered_lines
-            .len()
-            .saturating_sub(tail_budget)
+        self.stable_len_before_emitted_floor()
             .max(self.emitted_stable_len)
+    }
+
+    fn stable_len_before_emitted_floor(&mut self) -> usize {
+        let tail_budget = self.active_tail_budget_lines();
+        self.rendered_lines.len().saturating_sub(tail_budget)
     }
 
     /// Advance `enqueued_stable_len` toward the target stable boundary and enqueue any
@@ -397,8 +410,9 @@ impl StreamCore {
     /// table region is held as tail because adding a row can reshape table
     /// column widths. For `PendingHeader`, only content from the speculative
     /// header line onward is kept mutable so earlier prose can continue
-    /// streaming. When no table is detected, everything flows directly to
-    /// stable. This is the core decision point for the holdback mechanism.
+    /// streaming. When no table is detected, the configured default source
+    /// suffix remains mutable. This is the core decision point for the holdback
+    /// mechanism.
     fn active_tail_budget_lines(&mut self) -> usize {
         if self.render_mode == HistoryRenderMode::Raw {
             return 0;
@@ -455,11 +469,8 @@ impl StreamCore {
         }
 
         let render_start = Instant::now();
-        let stable_prefix_render = render_markdown_agent_with_links_and_cwd(
-            &self.raw_source[..source_start.min(self.raw_source.len())],
-            self.width,
-            Some(self.cwd.as_path()),
-        );
+        let stable_prefix_render =
+            self.render_source(&self.raw_source[..source_start.min(self.raw_source.len())]);
         let stable_prefix_len = stable_prefix_render.len();
         tracing::trace!(
             source_start,
@@ -480,11 +491,21 @@ impl StreamCore {
         if self.default_tail_lines == 0 || self.rendered_lines.is_empty() {
             return 0;
         }
-        let Some(source_start) = tail_source_start(&self.raw_source, self.default_tail_lines)
-        else {
+        let Some(source_start) = self.default_tail_source_start() else {
             return 0;
         };
         self.tail_budget_from_source_start(source_start)
+    }
+
+    fn live_default_tail_source_start(&self) -> Option<usize> {
+        if self.default_tail_lines == 0 || self.enqueued_stable_len >= self.rendered_lines.len() {
+            return None;
+        }
+        self.default_tail_source_start()
+    }
+
+    fn default_tail_source_start(&self) -> Option<usize> {
+        tail_source_start(&self.raw_source, self.default_tail_lines)
     }
 
     fn requires_final_scrollback_reflow(&self) -> bool {
@@ -1124,6 +1145,102 @@ mod tests {
         );
 
         assert_eq!(rendered, vec!["• tail without newline".to_string()]);
+    }
+
+    #[test]
+    fn controller_set_width_preserves_default_tail_after_stable_prefix_compresses() {
+        let mut ctrl = stream_controller(Some(/*width*/ 24));
+        ctrl.push("AAAA BBBB CCCC DDDD EEEE FFFF GGGG HHHH IIII JJJJ\n");
+        ctrl.push("tail stays visible\n");
+
+        let (_cell, idle) = ctrl.on_commit_tick_batch(usize::MAX);
+        assert!(idle, "stable prefix should fully drain");
+        assert_eq!(ctrl.queued_lines(), 0, "expected empty queue before resize");
+        assert!(
+            ctrl.has_live_tail(),
+            "expected short second line to be held as the default tail",
+        );
+
+        ctrl.set_width(Some(/*width*/ 120));
+
+        let tail_after_resize = hyperlink_lines_to_plain_strings(&ctrl.current_tail_lines());
+        assert_eq!(
+            tail_after_resize,
+            vec!["tail stays visible".to_string()],
+            "wider resize must not mark the default tail as already emitted",
+        );
+
+        let (cell, _source) = ctrl.finalize();
+        let finalized = cell
+            .map(|cell| lines_to_plain_strings(&cell.transcript_lines(u16::MAX)))
+            .unwrap_or_default();
+        assert_eq!(
+            finalized,
+            vec!["  tail stays visible".to_string()],
+            "finalize should still flush the preserved default tail",
+        );
+    }
+
+    #[test]
+    fn controller_set_render_mode_does_not_replay_drained_raw_output() {
+        let mut ctrl =
+            StreamController::new(Some(/*width*/ 120), &test_cwd(), HistoryRenderMode::Raw);
+        ctrl.push("AAAA BBBB CCCC DDDD EEEE FFFF GGGG HHHH IIII JJJJ\n");
+        ctrl.push("tail already emitted\n");
+
+        let (_cell, idle) = ctrl.on_commit_tick_batch(usize::MAX);
+        assert!(idle, "raw stable output should fully drain");
+        assert_eq!(ctrl.queued_lines(), 0, "expected empty queue before toggle");
+
+        ctrl.set_render_mode(HistoryRenderMode::Rich);
+
+        let (cell, _source) = ctrl.finalize();
+        assert!(
+            cell.is_none(),
+            "already-drained raw output must not be replayed after switching to rich mode",
+        );
+    }
+
+    #[test]
+    fn controller_set_render_mode_preserves_held_default_tail_when_switching_to_raw() {
+        let mut ctrl = stream_controller(Some(/*width*/ 120));
+        ctrl.push("prefix already emitted\n");
+        ctrl.push("tail stays visible\n");
+
+        let (_cell, idle) = ctrl.on_commit_tick_batch(usize::MAX);
+        assert!(idle, "stable prefix should fully drain");
+        assert_eq!(ctrl.queued_lines(), 0, "expected empty queue before toggle");
+        assert!(
+            ctrl.has_live_tail(),
+            "expected second line to be held as the default tail",
+        );
+
+        ctrl.set_render_mode(HistoryRenderMode::Raw);
+
+        let tail_after_toggle = hyperlink_lines_to_plain_strings(&ctrl.current_tail_lines());
+        assert_eq!(
+            tail_after_toggle,
+            vec!["tail stays visible".to_string()],
+            "raw toggle must not mark the held default tail as already emitted",
+        );
+
+        assert!(
+            ctrl.push("new raw line\n"),
+            "next raw line should make the preserved tail stable",
+        );
+        let (cell, idle) = ctrl.on_commit_tick_batch(usize::MAX);
+        assert!(idle, "raw stable output should fully drain");
+        let emitted = cell
+            .map(|cell| lines_to_plain_strings(&cell.transcript_lines(u16::MAX)))
+            .unwrap_or_default();
+        assert_eq!(
+            emitted,
+            vec![
+                "  tail stays visible".to_string(),
+                "  new raw line".to_string(),
+            ],
+            "held tail should drain before newer raw output",
+        );
     }
 
     #[test]

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -744,31 +744,7 @@ impl StreamCore {
             return source_start + boundary;
         }
 
-        let mut boundaries = Vec::new();
-        boundaries.push(source_start);
-        boundaries.extend(
-            self.raw_source[source_start..source_end]
-                .char_indices()
-                .map(|(idx, ch)| source_start + idx + ch.len_utf8()),
-        );
-
-        for boundary in boundaries {
-            let rendered = self.render_source(&self.raw_source[..boundary]);
-            if rendered.len() < emitted_prefix.len() {
-                continue;
-            }
-            let rendered_text = rendered[..emitted_prefix.len()]
-                .iter()
-                .map(hyperlink_line_text)
-                .collect::<Vec<_>>();
-            if rendered_text == emitted_text {
-                return boundary;
-            }
-        }
-
-        self.source_boundary_after_rendered_len(emitted_prefix.len())
-            .min(source_end)
-            .max(source_start)
+        source_start
     }
 
     fn default_tail_budget_lines(&mut self) -> usize {
@@ -805,20 +781,34 @@ fn visible_text_source_boundary(source: &str, visible_prefix: &str) -> Option<us
 
     let mut visible_chars = visible_prefix.chars().peekable();
     let mut iter = source.char_indices().peekable();
+    let mut at_line_start = true;
     while let Some((idx, ch)) = iter.next() {
         if visible_chars.peek().is_none() {
             return Some(idx);
         }
 
+        if at_line_start && skip_line_marker(ch, &mut iter, visible_chars.peek().copied()) {
+            continue;
+        }
+
         if ch == '[' {
             let mut label_end = None;
             let mut label_chars = Vec::new();
+            let mut depth = 1usize;
             for (label_idx, label_ch) in iter.by_ref() {
                 if label_ch == ']' {
-                    label_end = Some(label_idx + label_ch.len_utf8());
-                    break;
+                    depth = depth.saturating_sub(1);
+                    if depth == 0 {
+                        label_end = Some(label_idx + label_ch.len_utf8());
+                        break;
+                    }
+                    label_chars.push((label_idx, label_ch));
+                } else {
+                    if label_ch == '[' {
+                        depth += 1;
+                    }
+                    label_chars.push((label_idx, label_ch));
                 }
-                label_chars.push((label_idx, label_ch));
             }
             let label_end = label_end?;
             for (label_idx, label_ch) in label_chars {
@@ -844,6 +834,7 @@ fn visible_text_source_boundary(source: &str, visible_prefix: &str) -> Option<us
                     }
                 }
             }
+            at_line_start = false;
             continue;
         }
 
@@ -854,10 +845,12 @@ fn visible_text_source_boundary(source: &str, visible_prefix: &str) -> Option<us
         match visible_chars.peek().copied() {
             Some(expected) if expected == ch => {
                 visible_chars.next();
+                at_line_start = ch == '\n';
                 if visible_chars.peek().is_none() {
                     return Some(idx + ch.len_utf8());
                 }
             }
+            Some(_) if ch.is_ascii_punctuation() => continue,
             _ => return None,
         }
     }
@@ -865,14 +858,70 @@ fn visible_text_source_boundary(source: &str, visible_prefix: &str) -> Option<us
     visible_chars.peek().is_none().then_some(source.len())
 }
 
+fn skip_line_marker(
+    ch: char,
+    iter: &mut std::iter::Peekable<std::str::CharIndices<'_>>,
+    expected: Option<char>,
+) -> bool {
+    if expected == Some(ch) {
+        return false;
+    }
+
+    if matches!(ch, '#' | '>' | '-' | '+' | '*') {
+        while let Some((_, next_ch)) = iter.peek().copied() {
+            if next_ch.is_whitespace() {
+                iter.next();
+            } else {
+                break;
+            }
+        }
+        return true;
+    }
+
+    if ch.is_ascii_digit() {
+        let mut clone = iter.clone();
+        while let Some((_, next_ch)) = clone.peek().copied() {
+            if next_ch.is_ascii_digit() {
+                clone.next();
+            } else {
+                break;
+            }
+        }
+        if let Some((_, '.' | ')')) = clone.next() {
+            while let Some((_, next_ch)) = clone.peek().copied() {
+                if next_ch.is_whitespace() {
+                    clone.next();
+                } else {
+                    break;
+                }
+            }
+            *iter = clone;
+            return true;
+        }
+    }
+
+    false
+}
+
 fn skip_link_destination(source: &str, label_end: usize) -> Option<usize> {
     let after_label = source.get(label_end..)?;
     if !after_label.starts_with('(') {
         return None;
     }
-    after_label
-        .find(')')
-        .map(|destination_end| label_end + destination_end + ')'.len_utf8())
+    let mut depth = 0usize;
+    for (idx, ch) in after_label.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return Some(label_end + idx + ch.len_utf8());
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 fn trim_rendered_prefix(
@@ -2864,6 +2913,98 @@ mod tests {
         assert!(
             joined.contains("gamma") && joined.contains("tail line"),
             "raw suffix should preserve un-emitted source after the rendered link label; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+        );
+    }
+
+    #[test]
+    fn controller_set_render_mode_raw_suffix_skips_balanced_link_destination() {
+        let mut ctrl = stream_controller(Some(/*width*/ 10));
+        ctrl.push(
+            "[alpha beta](https://example.com/a(foo)/bar) gamma delta epsilon zeta eta theta\n",
+        );
+        ctrl.push("tail line\n");
+
+        let (first_emit, idle) = ctrl.on_commit_tick();
+        let first_emit = first_emit
+            .expect("expected first rich wrapped line emission")
+            .transcript_lines(u16::MAX);
+        assert!(!idle, "expected remaining rich content after one tick");
+
+        ctrl.set_render_mode(HistoryRenderMode::Raw);
+
+        let (cell, _source) = ctrl.finalize();
+        let remaining = cell
+            .map(|c| lines_to_plain_strings(&c.transcript_lines(u16::MAX)))
+            .unwrap_or_default();
+        let first_emit = lines_to_plain_strings(&first_emit).join("\n");
+        let joined = remaining.join("\n");
+        assert!(
+            !joined.contains("foo") && !joined.contains("/bar"),
+            "raw suffix must skip the full hidden destination with balanced parens; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+        );
+        assert!(
+            joined.contains("gamma") && joined.contains("tail line"),
+            "raw suffix should resume after the link destination; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+        );
+    }
+
+    #[test]
+    fn controller_set_render_mode_raw_suffix_handles_nested_link_label() {
+        let mut ctrl = stream_controller(Some(/*width*/ 14));
+        ctrl.push("[alpha [beta] rest](https://example.com) gamma delta epsilon zeta\n");
+        ctrl.push("tail line\n");
+
+        let (first_emit, idle) = ctrl.on_commit_tick();
+        let first_emit = first_emit
+            .expect("expected first rich wrapped line emission")
+            .transcript_lines(u16::MAX);
+        assert!(!idle, "expected remaining rich content after one tick");
+
+        ctrl.set_render_mode(HistoryRenderMode::Raw);
+
+        let (cell, _source) = ctrl.finalize();
+        let remaining = cell
+            .map(|c| lines_to_plain_strings(&c.transcript_lines(u16::MAX)))
+            .unwrap_or_default();
+        let first_emit = lines_to_plain_strings(&first_emit).join("\n");
+        let joined = remaining.join("\n");
+        assert!(
+            !joined.contains("](https://example.com)") && !joined.contains("https://example.com"),
+            "raw suffix must not resume inside nested link markup; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+        );
+        assert!(
+            joined.contains("gamma") && joined.contains("tail line"),
+            "raw suffix should preserve text after the nested link label; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+        );
+    }
+
+    #[test]
+    fn controller_set_render_mode_raw_suffix_offsets_heading_marker() {
+        let mut ctrl = stream_controller(Some(/*width*/ 12));
+        ctrl.push("## alpha beta gamma delta epsilon zeta eta theta\n");
+        ctrl.push("tail line\n");
+
+        let (first_emit, idle) = ctrl.on_commit_tick();
+        let first_emit = first_emit
+            .expect("expected first rich wrapped heading emission")
+            .transcript_lines(u16::MAX);
+        assert!(!idle, "expected remaining rich content after one tick");
+
+        ctrl.set_render_mode(HistoryRenderMode::Raw);
+
+        let (cell, _source) = ctrl.finalize();
+        let remaining = cell
+            .map(|c| lines_to_plain_strings(&c.transcript_lines(u16::MAX)))
+            .unwrap_or_default();
+        let first_emit = lines_to_plain_strings(&first_emit).join("\n");
+        let joined = remaining.join("\n");
+        assert!(
+            !joined.contains("## alpha beta"),
+            "raw suffix must not replay the already-visible heading prefix; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+        );
+        assert!(
+            joined.contains("delta") && joined.contains("tail line"),
+            "raw suffix should preserve un-emitted heading text; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
         );
     }
 

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -792,6 +792,29 @@ fn visible_text_source_boundary(source: &str, visible_prefix: &str) -> Option<us
             continue;
         }
 
+        if ch == '&'
+            && let Some((entity_char, entity_end)) = markdown_entity_at(source, idx)
+        {
+            match visible_chars.peek().copied() {
+                Some(expected) if expected == entity_char => {
+                    visible_chars.next();
+                    if visible_chars.peek().is_none() {
+                        return Some(entity_end);
+                    }
+                    while let Some((next_idx, _)) = iter.peek().copied() {
+                        if next_idx < entity_end {
+                            iter.next();
+                        } else {
+                            break;
+                        }
+                    }
+                    at_line_start = false;
+                    continue;
+                }
+                _ => return None,
+            }
+        }
+
         if ch == '[' {
             let mut label_end = None;
             let mut label_chars = Vec::new();
@@ -902,6 +925,21 @@ fn skip_line_marker(
     }
 
     false
+}
+
+fn markdown_entity_at(source: &str, start: usize) -> Option<(char, usize)> {
+    for (entity, ch) in [
+        ("&amp;", '&'),
+        ("&lt;", '<'),
+        ("&gt;", '>'),
+        ("&quot;", '"'),
+        ("&#39;", '\''),
+    ] {
+        if source[start..].starts_with(entity) {
+            return Some((ch, start + entity.len()));
+        }
+    }
+    None
 }
 
 fn skip_link_destination(source: &str, label_end: usize) -> Option<usize> {
@@ -3036,6 +3074,36 @@ mod tests {
         assert!(
             joined.contains("delta") && joined.contains("tail line"),
             "raw suffix should preserve un-emitted escaped-marker text; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+        );
+    }
+
+    #[test]
+    fn controller_set_render_mode_raw_suffix_skips_markdown_entity() {
+        let mut ctrl = stream_controller(Some(/*width*/ 9));
+        ctrl.push("alpha &amp; beta gamma delta epsilon zeta eta theta\n");
+        ctrl.push("tail line\n");
+
+        let (first_emit, idle) = ctrl.on_commit_tick();
+        let first_emit = first_emit
+            .expect("expected first rich wrapped entity emission")
+            .transcript_lines(u16::MAX);
+        assert!(!idle, "expected remaining rich content after one tick");
+
+        ctrl.set_render_mode(HistoryRenderMode::Raw);
+
+        let (cell, _source) = ctrl.finalize();
+        let remaining = cell
+            .map(|c| lines_to_plain_strings(&c.transcript_lines(u16::MAX)))
+            .unwrap_or_default();
+        let first_emit = lines_to_plain_strings(&first_emit).join("\n");
+        let joined = remaining.join("\n");
+        assert!(
+            !joined.contains("amp;") && !joined.contains("alpha &amp;"),
+            "raw suffix must not resume inside an already-visible markdown entity; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+        );
+        assert!(
+            joined.contains("beta") && joined.contains("tail line"),
+            "raw suffix should preserve text after the markdown entity; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
         );
     }
 

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -123,7 +123,6 @@ struct StablePrefixLenCache {
 struct PartialSourceLine {
     source_start: usize,
     source_end: usize,
-    emitted_source_end: usize,
     emitted_prefix: Vec<HyperlinkLine>,
 }
 
@@ -169,8 +168,11 @@ impl StreamCore {
         if delta.contains('\n')
             && let Some(committed_source) = self.state.collector.commit_complete_source()
         {
+            let previous_source_len = self.raw_source.len();
+            let previous_rendered_len = self.rendered_lines.len();
             self.raw_source.push_str(&committed_source);
             self.holdback_scanner.push_source_chunk(&committed_source);
+            self.cache_default_tail_prefix_after_append(previous_source_len, previous_rendered_len);
             self.recompute_streaming_render();
             enqueued = self.sync_stable_queue();
         }
@@ -291,6 +293,9 @@ impl StreamCore {
         } else {
             None
         };
+        let partial_queue_len = partial_line
+            .as_ref()
+            .map(|partial_line| self.partial_source_line_queue_len(partial_line));
         let emitted_source_boundary =
             self.source_boundary_after_rendered_len(self.emitted_stable_len);
         self.width = width;
@@ -300,8 +305,8 @@ impl StreamCore {
         }
 
         self.recompute_streaming_render();
-        if let Some(partial_line) = partial_line {
-            self.rebuild_stable_queue_preserving_partial_source_line(partial_line);
+        if let Some((partial_line, partial_queue_len)) = partial_line.zip(partial_queue_len) {
+            self.preserve_partial_source_line_queue(partial_line, partial_queue_len);
             return;
         }
         self.emitted_stable_len = self.rendered_len_for_source_boundary(emitted_source_boundary);
@@ -368,6 +373,9 @@ impl StreamCore {
         } else {
             None
         };
+        let partial_queue_len = partial_line
+            .as_ref()
+            .map(|partial_line| self.partial_source_line_queue_len(partial_line));
         let live_default_tail_source_start = if !had_pending_queue && !had_structural_tail {
             self.live_default_tail_source_start()
         } else {
@@ -382,8 +390,8 @@ impl StreamCore {
         }
 
         self.recompute_streaming_render();
-        if let Some(partial_line) = partial_line {
-            self.rebuild_stable_queue_preserving_partial_source_line(partial_line);
+        if let Some((partial_line, partial_queue_len)) = partial_line.zip(partial_queue_len) {
+            self.preserve_partial_source_line_queue(partial_line, partial_queue_len);
             return true;
         }
         self.emitted_stable_len = self.rendered_len_for_source_boundary(emitted_source_boundary);
@@ -463,40 +471,40 @@ impl StreamCore {
         self.enqueued_stable_len = target_stable_len;
     }
 
-    fn rebuild_stable_queue_preserving_partial_source_line(
+    fn partial_source_line_queue_len(&mut self, partial_line: &PartialSourceLine) -> usize {
+        if self.synthetic_queue_remaining > 0 {
+            return self.synthetic_queue_remaining.min(self.state.queued_len());
+        }
+
+        let source_line_end_len = self.rendered_len_for_source_boundary(partial_line.source_end);
+        source_line_end_len
+            .saturating_sub(self.emitted_stable_len)
+            .min(self.state.queued_len())
+    }
+
+    fn preserve_partial_source_line_queue(
         &mut self,
         partial_line: PartialSourceLine,
+        partial_queue_len: usize,
     ) {
         let source_line_start_len =
             self.rendered_len_for_source_boundary(partial_line.source_start);
         let source_line_end_len = self.rendered_len_for_source_boundary(partial_line.source_end);
         let target_stable_len = self.compute_target_stable_len();
 
-        self.clear_stable_queue();
+        // Keep the queued suffix built before the remap until this partially
+        // emitted source line drains. Rebuilding that suffix after resize or
+        // `/raw` requires parsing rendered rich markdown back into source
+        // bytes, which is fragile for inline Markdown and expensive on the UI
+        // thread.
         self.emitted_stable_len = source_line_start_len;
-
-        let mut queued = if self.render_mode == HistoryRenderMode::Raw {
-            plain_hyperlink_lines(raw_lines_from_source(
-                &self.raw_source[partial_line.emitted_source_end..partial_line.source_end],
-            ))
-        } else {
-            trim_rendered_prefix(
-                self.rendered_lines[source_line_start_len..source_line_end_len].to_vec(),
-                &partial_line.emitted_prefix,
-            )
-        };
-        let synthetic_len = queued.len();
-        if source_line_end_len < target_stable_len {
-            queued.extend(self.rendered_lines[source_line_end_len..target_stable_len].to_vec());
-        }
-        if !queued.is_empty() {
-            self.state.enqueue(queued);
-        }
         self.enqueued_stable_len = source_line_end_len.max(target_stable_len);
-        if synthetic_len > 0 {
-            self.synthetic_queue_remaining = synthetic_len;
+        if partial_queue_len > 0 {
+            self.synthetic_queue_remaining = partial_queue_len;
             self.synthetic_queue_target_emitted_len = Some(source_line_end_len);
             self.synthetic_queue_partial = Some(partial_line);
+        } else {
+            self.clear_synthetic_queue_accounting();
         }
     }
 
@@ -524,26 +532,10 @@ impl StreamCore {
         let mut ordinary_lines = step.len();
         if self.synthetic_queue_remaining > 0 {
             let synthetic_lines = ordinary_lines.min(self.synthetic_queue_remaining);
-            let mut emitted_prefix = None;
             if let Some(partial_line) = &mut self.synthetic_queue_partial {
                 partial_line
                     .emitted_prefix
                     .extend(step[..synthetic_lines].to_vec());
-                emitted_prefix = Some((
-                    partial_line.source_start,
-                    partial_line.source_end,
-                    partial_line.emitted_prefix.clone(),
-                ));
-            }
-            if let Some((source_start, source_end, emitted_prefix)) = emitted_prefix {
-                let emitted_source_end = self.source_boundary_after_rendered_prefix(
-                    source_start,
-                    source_end,
-                    &emitted_prefix,
-                );
-                if let Some(partial_line) = &mut self.synthetic_queue_partial {
-                    partial_line.emitted_source_end = emitted_source_end;
-                }
             }
             ordinary_lines -= synthetic_lines;
             self.synthetic_queue_remaining -= synthetic_lines;
@@ -694,15 +686,9 @@ impl StreamCore {
                 }
                 let emitted_prefix =
                     self.rendered_lines[source_start_rendered_len..rendered_len].to_vec();
-                let emitted_source_end = self.source_boundary_after_rendered_prefix(
-                    source_start,
-                    source_end,
-                    &emitted_prefix,
-                );
                 return Some(PartialSourceLine {
                     source_start,
                     source_end,
-                    emitted_source_end,
                     emitted_prefix,
                 });
             }
@@ -722,30 +708,6 @@ impl StreamCore {
             boundaries.push(self.raw_source.len());
         }
         boundaries
-    }
-
-    fn source_boundary_after_rendered_prefix(
-        &self,
-        source_start: usize,
-        source_end: usize,
-        emitted_prefix: &[HyperlinkLine],
-    ) -> usize {
-        if emitted_prefix.is_empty() {
-            return source_start;
-        }
-        let emitted_text = emitted_prefix
-            .iter()
-            .map(hyperlink_line_text)
-            .collect::<Vec<_>>();
-        let emitted_visible_text = emitted_text.join(" ");
-        if let Some(boundary) = visible_text_source_boundary(
-            &self.raw_source[source_start..source_end],
-            &emitted_visible_text,
-        ) {
-            return source_start + boundary;
-        }
-
-        source_start
     }
 
     fn default_tail_budget_lines(&mut self) -> usize {
@@ -769,198 +731,28 @@ impl StreamCore {
         tail_source_start(&self.raw_source, self.default_tail_lines)
     }
 
+    fn cache_default_tail_prefix_after_append(
+        &mut self,
+        previous_source_len: usize,
+        previous_rendered_len: usize,
+    ) {
+        if self.render_mode == HistoryRenderMode::Raw || self.default_tail_lines != 1 {
+            return;
+        }
+        if self.default_tail_source_start() != Some(previous_source_len) {
+            return;
+        }
+        self.stable_prefix_len_cache = Some(StablePrefixLenCache {
+            source_start: previous_source_len,
+            width: self.width,
+            stable_prefix_len: previous_rendered_len,
+        });
+    }
+
     fn requires_final_scrollback_reflow(&self) -> bool {
         self.render_mode != HistoryRenderMode::Raw
             && !matches!(self.holdback_scanner.state(), TableHoldbackState::None)
     }
-}
-
-fn visible_text_source_boundary(source: &str, visible_prefix: &str) -> Option<usize> {
-    if visible_prefix.is_empty() {
-        return Some(0);
-    }
-
-    let mut visible_chars = visible_prefix.chars().peekable();
-    let mut iter = source.char_indices().peekable();
-    let mut at_line_start = true;
-    while let Some((idx, ch)) = iter.next() {
-        if visible_chars.peek().is_none() {
-            return Some(idx);
-        }
-
-        if at_line_start && skip_line_marker(ch, &mut iter, visible_chars.peek().copied()) {
-            continue;
-        }
-
-        if ch == '&'
-            && let Some((entity_char, entity_end)) = markdown_entity_at(source, idx)
-        {
-            match visible_chars.peek().copied() {
-                Some(expected) if expected == entity_char => {
-                    visible_chars.next();
-                    if visible_chars.peek().is_none() {
-                        return Some(entity_end);
-                    }
-                    while let Some((next_idx, _)) = iter.peek().copied() {
-                        if next_idx < entity_end {
-                            iter.next();
-                        } else {
-                            break;
-                        }
-                    }
-                    at_line_start = false;
-                    continue;
-                }
-                _ => return None,
-            }
-        }
-
-        if ch == '[' {
-            let mut label_end = None;
-            let mut label_chars = Vec::new();
-            let mut depth = 1usize;
-            for (label_idx, label_ch) in iter.by_ref() {
-                if label_ch == ']' {
-                    depth = depth.saturating_sub(1);
-                    if depth == 0 {
-                        label_end = Some(label_idx + label_ch.len_utf8());
-                        break;
-                    }
-                    label_chars.push((label_idx, label_ch));
-                } else {
-                    if label_ch == '[' {
-                        depth += 1;
-                    }
-                    label_chars.push((label_idx, label_ch));
-                }
-            }
-            let label_end = label_end?;
-            for (label_idx, label_ch) in label_chars {
-                match visible_chars.peek().copied() {
-                    Some(expected) if expected == label_ch => {
-                        visible_chars.next();
-                        if visible_chars.peek().is_none() {
-                            return Some(
-                                skip_link_destination(source, label_end)
-                                    .unwrap_or(label_idx + label_ch.len_utf8()),
-                            );
-                        }
-                    }
-                    _ => return None,
-                }
-            }
-            if let Some(destination_end) = skip_link_destination(source, label_end) {
-                while let Some((next_idx, _)) = iter.peek().copied() {
-                    if next_idx < destination_end {
-                        iter.next();
-                    } else {
-                        break;
-                    }
-                }
-            }
-            at_line_start = false;
-            continue;
-        }
-
-        if matches!(ch, '*' | '_' | '`') && visible_chars.peek().copied() != Some(ch) {
-            continue;
-        }
-
-        match visible_chars.peek().copied() {
-            Some(expected) if expected == ch => {
-                visible_chars.next();
-                at_line_start = ch == '\n';
-                if visible_chars.peek().is_none() {
-                    return Some(idx + ch.len_utf8());
-                }
-            }
-            Some(_) if ch.is_ascii_punctuation() => continue,
-            _ => return None,
-        }
-    }
-
-    visible_chars.peek().is_none().then_some(source.len())
-}
-
-fn skip_line_marker(
-    ch: char,
-    iter: &mut std::iter::Peekable<std::str::CharIndices<'_>>,
-    expected: Option<char>,
-) -> bool {
-    if expected == Some(ch) {
-        return false;
-    }
-
-    if matches!(ch, '#' | '>' | '-' | '+' | '*') {
-        while let Some((_, next_ch)) = iter.peek().copied() {
-            if next_ch.is_whitespace() {
-                iter.next();
-            } else {
-                break;
-            }
-        }
-        return true;
-    }
-
-    if ch.is_ascii_digit() {
-        let mut clone = iter.clone();
-        while let Some((_, next_ch)) = clone.peek().copied() {
-            if next_ch.is_ascii_digit() {
-                clone.next();
-            } else {
-                break;
-            }
-        }
-        if let Some((_, '.' | ')')) = clone.next() {
-            while let Some((_, next_ch)) = clone.peek().copied() {
-                if next_ch.is_whitespace() {
-                    clone.next();
-                } else {
-                    break;
-                }
-            }
-            *iter = clone;
-            return true;
-        }
-    }
-
-    false
-}
-
-fn markdown_entity_at(source: &str, start: usize) -> Option<(char, usize)> {
-    for (entity, ch) in [
-        ("&amp;", '&'),
-        ("&lt;", '<'),
-        ("&gt;", '>'),
-        ("&quot;", '"'),
-        ("&#39;", '\''),
-    ] {
-        if source[start..].starts_with(entity) {
-            return Some((ch, start + entity.len()));
-        }
-    }
-    None
-}
-
-fn skip_link_destination(source: &str, label_end: usize) -> Option<usize> {
-    let after_label = source.get(label_end..)?;
-    if !after_label.starts_with('(') {
-        return None;
-    }
-    let mut depth = 0usize;
-    for (idx, ch) in after_label.char_indices() {
-        match ch {
-            '(' => depth += 1,
-            ')' => {
-                depth = depth.saturating_sub(1);
-                if depth == 0 {
-                    return Some(label_end + idx + ch.len_utf8());
-                }
-            }
-            _ => {}
-        }
-    }
-    None
 }
 
 fn trim_rendered_prefix(
@@ -1838,6 +1630,22 @@ mod tests {
             vec!["  tail stays visible".to_string()],
             "finalize should still flush the preserved default tail",
         );
+    }
+
+    #[test]
+    fn controller_default_tail_caches_single_line_append_prefix() {
+        let mut ctrl = stream_controller(Some(/*width*/ 80));
+        ctrl.push("alpha\n");
+        ctrl.push("beta\n");
+
+        let cache = ctrl
+            .core
+            .stable_prefix_len_cache
+            .as_ref()
+            .expect("expected default-tail prefix cache for single-line append");
+        assert_eq!(cache.source_start, "alpha\n".len());
+        assert_eq!(cache.width, Some(/*width*/ 80));
+        assert_eq!(cache.stable_prefix_len, 1);
     }
 
     #[test]
@@ -2894,7 +2702,7 @@ mod tests {
     }
 
     #[test]
-    fn controller_set_render_mode_rerenders_partial_suffix_in_raw_mode() {
+    fn controller_set_render_mode_preserves_queued_partial_suffix() {
         let mut ctrl = stream_controller(Some(/*width*/ 18));
         ctrl.push("**alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu**\n");
         ctrl.push("tail line\n");
@@ -2918,8 +2726,8 @@ mod tests {
             "finalize must not replay the already-visible rich prefix after raw toggle; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
         );
         assert!(
-            joined.contains("**") && joined.contains("tail line"),
-            "pending suffix should be rendered from raw mode after toggle, not old rich rows; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+            joined.contains("lambda mu") && joined.contains("tail line"),
+            "pending suffix should finish draining without losing content after raw toggle; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
         );
     }
 
@@ -2946,12 +2754,12 @@ mod tests {
         let first_emit = lines_to_plain_strings(&first_emit).join("\n");
         let joined = remaining.join("\n");
         assert!(
-            !joined.contains("https://example.com") && !joined.contains("](https://"),
-            "raw suffix must not start inside already-visible link markup; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+            !joined.contains("alpha beta"),
+            "suffix must not replay the already-visible link label after raw toggle; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
         );
         assert!(
             joined.contains("gamma") && joined.contains("tail line"),
-            "raw suffix should preserve un-emitted source after the rendered link label; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+            "suffix should preserve un-emitted source after the rendered link label; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
         );
     }
 
@@ -2978,12 +2786,12 @@ mod tests {
         let first_emit = lines_to_plain_strings(&first_emit).join("\n");
         let joined = remaining.join("\n");
         assert!(
-            !joined.contains("foo") && !joined.contains("/bar"),
-            "raw suffix must skip the full hidden destination with balanced parens; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+            !joined.contains("alpha beta"),
+            "suffix must not replay the already-visible link label with balanced parens; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
         );
         assert!(
             joined.contains("gamma") && joined.contains("tail line"),
-            "raw suffix should resume after the link destination; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+            "suffix should preserve text after the link destination; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
         );
     }
 
@@ -3008,12 +2816,12 @@ mod tests {
         let first_emit = lines_to_plain_strings(&first_emit).join("\n");
         let joined = remaining.join("\n");
         assert!(
-            !joined.contains("](https://example.com)") && !joined.contains("https://example.com"),
-            "raw suffix must not resume inside nested link markup; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+            !joined.contains("alpha [beta]"),
+            "suffix must not replay the already-visible nested link label after raw toggle; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
         );
         assert!(
-            joined.contains("gamma") && joined.contains("tail line"),
-            "raw suffix should preserve text after the nested link label; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+            joined.contains("rest") && joined.contains("tail line"),
+            "suffix should preserve text after the nested link label; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
         );
     }
 

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -117,7 +117,7 @@ struct StablePrefixLenCache {
 struct PartialSourceLine {
     source_start: usize,
     source_end: usize,
-    unemitted_suffix: Vec<HyperlinkLine>,
+    emitted_prefix: Vec<HyperlinkLine>,
 }
 
 impl StreamCore {
@@ -450,7 +450,10 @@ impl StreamCore {
         self.clear_stable_queue();
         self.emitted_stable_len = source_line_start_len;
 
-        let mut queued = partial_line.unemitted_suffix;
+        let mut queued = trim_rendered_prefix(
+            self.rendered_lines[source_line_start_len..source_line_end_len].to_vec(),
+            &partial_line.emitted_prefix,
+        );
         let synthetic_len = queued.len();
         if source_line_end_len < target_stable_len {
             queued.extend(self.rendered_lines[source_line_end_len..target_stable_len].to_vec());
@@ -466,8 +469,17 @@ impl StreamCore {
     }
 
     fn clear_stable_queue(&mut self) {
+        self.advance_synthetic_queue_accounting_to_target();
         self.state.clear_queue();
         self.clear_synthetic_queue_accounting();
+    }
+
+    fn advance_synthetic_queue_accounting_to_target(&mut self) {
+        if self.synthetic_queue_remaining > 0
+            && let Some(target_len) = self.synthetic_queue_target_emitted_len
+        {
+            self.emitted_stable_len = target_len;
+        }
     }
 
     fn clear_synthetic_queue_accounting(&mut self) {
@@ -627,7 +639,7 @@ impl StreamCore {
                 return Some(PartialSourceLine {
                     source_start,
                     source_end,
-                    unemitted_suffix: self.rendered_lines[rendered_len..source_end_rendered_len]
+                    emitted_prefix: self.rendered_lines[source_start_rendered_len..rendered_len]
                         .to_vec(),
                 });
             }
@@ -674,6 +686,64 @@ impl StreamCore {
         self.render_mode != HistoryRenderMode::Raw
             && !matches!(self.holdback_scanner.state(), TableHoldbackState::None)
     }
+}
+
+fn trim_rendered_prefix(
+    lines: Vec<HyperlinkLine>,
+    emitted_prefix: &[HyperlinkLine],
+) -> Vec<HyperlinkLine> {
+    let prefix_text = emitted_prefix
+        .iter()
+        .map(hyperlink_line_text)
+        .collect::<Vec<_>>()
+        .join(" ");
+    let mut prefix_chars = emitted_prefix
+        .iter()
+        .map(hyperlink_line_text)
+        .map(|text| text.chars().count())
+        .sum::<usize>();
+    if prefix_chars == 0 {
+        return lines;
+    }
+
+    let mut out = Vec::with_capacity(lines.len());
+    for line in lines {
+        let text = hyperlink_line_text(&line);
+        let line_chars = text.chars().count();
+        let chars_to_skip = if !prefix_text.is_empty() {
+            text.find(&prefix_text)
+                .map(|start| text[..start].chars().count() + prefix_text.chars().count())
+        } else {
+            None
+        };
+        if prefix_chars >= line_chars {
+            prefix_chars -= line_chars;
+            continue;
+        }
+        if prefix_chars > 0 {
+            let suffix = text
+                .chars()
+                .skip(chars_to_skip.unwrap_or(prefix_chars))
+                .collect::<String>()
+                .trim_start()
+                .to_string();
+            prefix_chars = 0;
+            if !suffix.is_empty() {
+                out.push(HyperlinkLine::new(Line::from(suffix)));
+            }
+        } else {
+            out.push(line);
+        }
+    }
+    out
+}
+
+fn hyperlink_line_text(line: &HyperlinkLine) -> String {
+    line.line
+        .spans
+        .iter()
+        .map(|span| span.content.as_ref())
+        .collect()
 }
 
 fn tail_source_start(source: &str, tail_lines: usize) -> Option<usize> {
@@ -2401,6 +2471,71 @@ mod tests {
         assert!(
             joined.contains("lambda mu") && joined.contains("tail line"),
             "finalize must preserve un-emitted content after raw toggle; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+        );
+    }
+
+    #[test]
+    fn controller_set_render_mode_rerenders_partial_suffix_in_raw_mode() {
+        let mut ctrl = stream_controller(Some(/*width*/ 18));
+        ctrl.push("**alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu**\n");
+        ctrl.push("tail line\n");
+
+        let (first_emit, idle) = ctrl.on_commit_tick();
+        let first_emit = first_emit
+            .expect("expected first rich wrapped line emission")
+            .transcript_lines(u16::MAX);
+        assert!(!idle, "expected remaining rich content after one tick");
+
+        ctrl.set_render_mode(HistoryRenderMode::Raw);
+
+        let (cell, _source) = ctrl.finalize();
+        let remaining = cell
+            .map(|c| lines_to_plain_strings(&c.transcript_lines(u16::MAX)))
+            .unwrap_or_default();
+        let first_emit = lines_to_plain_strings(&first_emit).join("\n");
+        let joined = remaining.join("\n");
+        assert!(
+            !joined.contains("alpha beta"),
+            "finalize must not replay the already-visible rich prefix after raw toggle; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+        );
+        assert!(
+            joined.contains("**") && joined.contains("tail line"),
+            "pending suffix should be rendered from raw mode after toggle, not old rich rows; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+        );
+    }
+
+    #[test]
+    fn controller_clear_queue_advances_synthetic_accounting_before_finalize() {
+        let mut ctrl = stream_controller(Some(/*width*/ 18));
+        ctrl.push("alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu\n");
+        ctrl.push("tail line\n");
+
+        let (first_emit, idle) = ctrl.on_commit_tick();
+        let first_emit = first_emit
+            .expect("expected first wrapped line emission")
+            .transcript_lines(u16::MAX);
+        assert!(!idle, "expected remaining wrapped content after one tick");
+
+        ctrl.set_width(Some(/*width*/ 80));
+        assert!(
+            ctrl.queued_lines() > 0,
+            "expected synthetic queue after resizing a partially emitted source line",
+        );
+
+        ctrl.clear_queue();
+        let (cell, _source) = ctrl.finalize();
+        let remaining = cell
+            .map(|c| lines_to_plain_strings(&c.transcript_lines(u16::MAX)))
+            .unwrap_or_default();
+        let first_emit = lines_to_plain_strings(&first_emit).join("\n");
+        let joined = remaining.join("\n");
+        assert!(
+            !joined.contains("alpha beta"),
+            "finalize must not replay the already-visible prefix after clear_queue; emitted before clear: {first_emit:?}, finalized after clear: {joined:?}",
+        );
+        assert!(
+            remaining.iter().any(|line| line.contains("tail line")),
+            "ordinary mutable tail should still flush on finalize after clear_queue; got {remaining:?}",
         );
     }
 }

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -1678,11 +1678,16 @@ mod tests {
     #[test]
     fn plan_controller_holds_table_header_as_live_tail() {
         let mut ctrl = plan_stream_controller(Some(80));
-        assert!(ctrl.push("Intro\n"));
-        let (_cell, idle) = ctrl.on_commit_tick_batch(usize::MAX);
+        assert!(!ctrl.push("Intro\n"));
+        assert!(
+            ctrl.has_live_tail(),
+            "expected plan intro to start as mutable tail",
+        );
+
+        assert!(ctrl.push("| Step | Owner |\n"));
+        let (_cell, idle) = ctrl.on_commit_tick_batch(/*max_lines*/ usize::MAX);
         assert!(idle, "intro line should fully drain");
 
-        assert!(!ctrl.push("| Step | Owner |\n"));
         assert!(
             ctrl.has_live_tail(),
             "expected plan table header to be held"

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -250,6 +250,8 @@ impl StreamCore {
         }
         let had_pending_queue = self.state.queued_len() > 0;
         let had_structural_tail = self.requires_final_scrollback_reflow();
+        let emitted_source_boundary =
+            self.source_boundary_after_rendered_len(self.emitted_stable_len);
         self.width = width;
         self.state.collector.set_width(width);
         if self.raw_source.is_empty() {
@@ -257,16 +259,13 @@ impl StreamCore {
         }
 
         self.recompute_streaming_render();
-        self.emitted_stable_len = self.emitted_stable_len.min(self.rendered_lines.len());
+        self.emitted_stable_len = self.rendered_len_for_source_boundary(emitted_source_boundary);
         let target_stable_len = self.compute_target_stable_len();
         if had_pending_queue
             && self.emitted_stable_len >= target_stable_len
             && target_stable_len > 0
         {
-            // If wrapped remainder compresses into fewer lines at the new width,
-            // keep at least one line un-emitted so pre-resize pending content is
-            // not skipped permanently.
-            self.emitted_stable_len = target_stable_len - 1;
+            self.emitted_stable_len = target_stable_len;
         }
         self.state.clear_queue();
         if self.emitted_stable_len > 0 && !had_pending_queue && !had_structural_tail {
@@ -309,9 +308,9 @@ impl StreamCore {
         self.rendered_lines = self.render_source(&self.raw_source);
     }
 
-    fn set_render_mode(&mut self, render_mode: HistoryRenderMode) {
+    fn set_render_mode(&mut self, render_mode: HistoryRenderMode) -> bool {
         if self.render_mode == render_mode {
-            return;
+            return false;
         }
 
         let had_pending_queue = self.state.queued_len() > 0;
@@ -321,20 +320,22 @@ impl StreamCore {
         } else {
             None
         };
+        let emitted_source_boundary =
+            self.source_boundary_after_rendered_len(self.emitted_stable_len);
         self.render_mode = render_mode;
         self.stable_prefix_len_cache = None;
         if self.raw_source.is_empty() {
-            return;
+            return false;
         }
 
         self.recompute_streaming_render();
-        self.emitted_stable_len = self.emitted_stable_len.min(self.rendered_lines.len());
+        self.emitted_stable_len = self.rendered_len_for_source_boundary(emitted_source_boundary);
         let target_stable_len = self.compute_target_stable_len();
         if had_pending_queue
             && self.emitted_stable_len >= target_stable_len
             && target_stable_len > 0
         {
-            self.emitted_stable_len = target_stable_len - 1;
+            self.emitted_stable_len = target_stable_len;
         }
         self.state.clear_queue();
         if self.emitted_stable_len > 0 && !had_pending_queue && !had_structural_tail {
@@ -345,9 +346,10 @@ impl StreamCore {
             };
             self.emitted_stable_len = target_stable_len;
             self.enqueued_stable_len = target_stable_len;
-            return;
+            return true;
         }
         self.rebuild_stable_queue_from_render();
+        true
     }
 
     /// Compute how many rendered lines should be in the stable region.
@@ -485,6 +487,41 @@ impl StreamCore {
             stable_prefix_len,
         });
         stable_prefix_len
+    }
+
+    fn rendered_len_for_source_boundary(&mut self, source_boundary: usize) -> usize {
+        if source_boundary == 0 {
+            return 0;
+        }
+        if source_boundary >= self.raw_source.len() {
+            return self.rendered_lines.len();
+        }
+        self.stable_prefix_len_for_source_start(source_boundary)
+    }
+
+    fn source_boundary_after_rendered_len(&self, rendered_len: usize) -> usize {
+        if rendered_len == 0 || self.raw_source.is_empty() {
+            return 0;
+        }
+        if rendered_len >= self.rendered_lines.len() {
+            return self.raw_source.len();
+        }
+
+        let mut boundaries = self
+            .raw_source
+            .match_indices('\n')
+            .map(|(idx, _)| idx + 1)
+            .collect::<Vec<_>>();
+        if boundaries.last().copied() != Some(self.raw_source.len()) {
+            boundaries.push(self.raw_source.len());
+        }
+
+        for boundary in boundaries {
+            if self.render_source(&self.raw_source[..boundary]).len() >= rendered_len {
+                return boundary;
+            }
+        }
+        self.raw_source.len()
     }
 
     fn default_tail_budget_lines(&mut self) -> usize {
@@ -631,8 +668,8 @@ impl StreamController {
         self.core.set_width(width);
     }
 
-    pub(crate) fn set_render_mode(&mut self, render_mode: HistoryRenderMode) {
-        self.core.set_render_mode(render_mode);
+    pub(crate) fn set_render_mode(&mut self, render_mode: HistoryRenderMode) -> bool {
+        self.core.set_render_mode(render_mode)
     }
 
     fn emit(&mut self, lines: Vec<HyperlinkLine>) -> Option<Box<dyn HistoryCell>> {
@@ -761,8 +798,8 @@ impl PlanStreamController {
         self.core.set_width(width);
     }
 
-    pub(crate) fn set_render_mode(&mut self, render_mode: HistoryRenderMode) {
-        self.core.set_render_mode(render_mode);
+    pub(crate) fn set_render_mode(&mut self, render_mode: HistoryRenderMode) -> bool {
+        self.core.set_render_mode(render_mode)
     }
 
     fn emit(
@@ -838,6 +875,18 @@ mod tests {
         PlanStreamController::new(width, &test_cwd(), HistoryRenderMode::Rich)
     }
 
+    const HAPPY_PATH_DUPLICATE_REPRO_DELTAS: &[&str] = &[
+        "**Happy Path**\n",
+        "\n",
+        "1. In the second terminal, make the smoke home non-writable:\n",
+        "   ```fish\n",
+        "   chmod a-w $CODEX_SMOKE_HOME\n",
+        "   ```\n",
+        "   Expected: the running TUI stays open.\n",
+        "\n",
+        "2. In the TUI, type `/model` and press Enter.\n",
+    ];
+
     fn lines_to_plain_strings(lines: &[ratatui::text::Line<'_>]) -> Vec<String> {
         lines
             .iter()
@@ -874,6 +923,38 @@ mod tests {
             .into_iter()
             .map(|s| s.chars().skip(2).collect::<String>())
             .collect()
+    }
+
+    fn collect_visible_stream_snapshots(deltas: &[&str], width: Option<usize>) -> Vec<Vec<String>> {
+        let mut ctrl = stream_controller(width);
+        let mut committed_lines = Vec::new();
+        let mut snapshots = Vec::new();
+        for delta in deltas {
+            ctrl.push(delta);
+            while let (Some(cell), idle) = ctrl.on_commit_tick() {
+                committed_lines.extend(cell.transcript_lines(u16::MAX));
+                if idle {
+                    break;
+                }
+            }
+
+            let mut visible = lines_to_plain_strings(&committed_lines)
+                .into_iter()
+                .map(|s| s.chars().skip(2).collect::<String>())
+                .collect::<Vec<_>>();
+            visible.extend(hyperlink_lines_to_plain_strings(&ctrl.current_tail_lines()));
+            snapshots.push(visible);
+        }
+        snapshots
+    }
+
+    fn format_stream_snapshots(snapshots: &[Vec<String>]) -> String {
+        snapshots
+            .iter()
+            .enumerate()
+            .map(|(idx, lines)| format!("after delta {idx}:\n{}", lines.join("\n")))
+            .collect::<Vec<_>>()
+            .join("\n---\n")
     }
 
     fn collect_plan_streamed_lines(deltas: &[&str], width: Option<usize>) -> Vec<String> {
@@ -1008,29 +1089,37 @@ mod tests {
 
     #[test]
     fn controller_does_not_duplicate_list_continuation_after_fenced_code() {
-        let lines = collect_streamed_lines(
-            &[
-                "**Happy Path**\n",
-                "\n",
-                "1. In the second terminal, make the smoke home non-writable:\n",
-                "   ```fish\n",
-                "   chmod a-w $CODEX_SMOKE_HOME\n",
-                "   ```\n",
-                "   Expected: the running TUI stays open.\n",
-                "\n",
-                "2. In the TUI, type `/model` and press Enter.\n",
-            ],
-            Some(/*width*/ 80),
-        );
+        let snapshots =
+            collect_visible_stream_snapshots(HAPPY_PATH_DUPLICATE_REPRO_DELTAS, Some(/*width*/ 80));
 
-        let expected_count = lines
-            .iter()
+        for lines in &snapshots {
+            let expected_count = lines
+                .iter()
+                .filter(|line| line.trim() == "Expected: the running TUI stays open.")
+                .count();
+            assert!(
+                expected_count <= 1,
+                "expected list continuation to render at most once, got {lines:?}",
+            );
+        }
+        let final_count = snapshots
+            .last()
+            .into_iter()
+            .flatten()
             .filter(|line| line.trim() == "Expected: the running TUI stays open.")
             .count();
         assert_eq!(
-            expected_count, 1,
-            "expected list continuation to render once, got {lines:?}",
+            final_count, 1,
+            "expected final visible snapshot to include the list continuation once"
         );
+    }
+
+    #[test]
+    fn controller_streamed_list_continuation_snapshot() {
+        let snapshots =
+            collect_visible_stream_snapshots(HAPPY_PATH_DUPLICATE_REPRO_DELTAS, Some(/*width*/ 80));
+
+        insta::assert_snapshot!(format_stream_snapshots(&snapshots));
     }
 
     #[test]
@@ -1088,43 +1177,36 @@ mod tests {
     }
 
     #[test]
-    fn controller_set_width_partial_drain_keeps_pending_queue() {
+    fn controller_set_width_partial_drain_does_not_duplicate_emitted_prefix() {
         let mut ctrl = stream_controller(Some(40));
         ctrl.push("AAAA BBBB CCCC DDDD EEEE FFFF GGGG HHHH IIII JJJJ\n");
         ctrl.push("second line\n");
 
         let (cell, idle) = ctrl.on_commit_tick();
-        assert!(cell.is_some(), "expected 1 emitted line");
+        let emitted_before_resize = cell
+            .expect("expected 1 emitted line")
+            .transcript_lines(u16::MAX);
         assert!(!idle, "queue should still have lines");
         assert!(ctrl.queued_lines() > 0, "expected pending queued lines");
 
-        ctrl.set_width(Some(20));
+        ctrl.set_width(Some(/*width*/ 120));
 
-        assert!(
-            ctrl.queued_lines() > 0,
-            "resize must preserve pending queued lines"
-        );
-
-        let mut drained = Vec::new();
-        for _ in 0..64 {
-            let (cell, is_idle) = ctrl.on_commit_tick();
-            if let Some(cell) = cell {
-                drained.extend(lines_to_plain_strings(&cell.transcript_lines(u16::MAX)));
-            }
-            if is_idle {
-                break;
-            }
-        }
-
-        assert!(
-            drained.iter().any(|l| l.contains("IIII JJJJ")),
-            "pending wrapped lines should continue draining after resize; got {drained:?}",
+        assert_eq!(
+            ctrl.queued_lines(),
+            0,
+            "partially emitted source line should not be re-queued after widening"
         );
 
         let (cell, _source) = ctrl.finalize();
         let final_lines = cell
             .map(|cell| lines_to_plain_strings(&cell.transcript_lines(u16::MAX)))
             .unwrap_or_default();
+        let emitted_before_resize = lines_to_plain_strings(&emitted_before_resize).join("\n");
+        let finalized_after_resize = final_lines.join("\n");
+        assert!(
+            !finalized_after_resize.contains("AAAA BBBB CCCC"),
+            "finalize must not replay the already-visible line prefix; emitted before resize: {emitted_before_resize:?}, finalized after resize: {finalized_after_resize:?}",
+        );
         assert!(
             final_lines.iter().any(|line| line.contains("second line")),
             "ordinary mutable tail should flush on finalize; got {final_lines:?}",
@@ -2106,7 +2188,7 @@ mod tests {
             "expected non-empty queue before resize"
         );
 
-        ctrl.set_width(Some(120));
+        ctrl.set_width(Some(/*width*/ 120));
 
         let (cell, _source) = ctrl.finalize();
         let remaining = cell
@@ -2122,13 +2204,15 @@ mod tests {
     }
 
     #[test]
-    fn controller_set_width_partial_wrapped_emit_keeps_wrapped_remainder() {
+    fn controller_set_width_partial_wrapped_emit_does_not_replay_prefix() {
         let mut ctrl = stream_controller(Some(18));
         ctrl.push("alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu\n");
         ctrl.push("tail line\n");
 
         let (first_emit, idle) = ctrl.on_commit_tick();
-        assert!(first_emit.is_some(), "expected first wrapped line emission");
+        let first_emit = first_emit
+            .expect("expected first wrapped line emission")
+            .transcript_lines(u16::MAX);
         assert!(!idle, "expected remaining wrapped content after one tick");
         assert!(
             ctrl.queued_lines() > 0,
@@ -2141,10 +2225,15 @@ mod tests {
         let remaining = cell
             .map(|c| lines_to_plain_strings(&c.transcript_lines(u16::MAX)))
             .unwrap_or_default();
-        let joined = remaining.join(" ");
+        let first_emit = lines_to_plain_strings(&first_emit).join("\n");
+        let joined = remaining.join("\n");
         assert!(
-            joined.contains("kappa") || joined.contains("lambda") || joined.contains("mu"),
-            "wrapped remainder from partially emitted source line was lost after resize: {remaining:?}",
+            !joined.contains("alpha beta"),
+            "finalize must not replay the already-visible prefix; emitted before resize: {first_emit:?}, finalized after resize: {joined:?}",
+        );
+        assert!(
+            remaining.iter().any(|line| line.contains("tail line")),
+            "ordinary mutable tail should flush on finalize; got {remaining:?}",
         );
     }
 }

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -89,6 +89,10 @@ struct StreamCore {
     stable_prefix_len_cache: Option<StablePrefixLenCache>,
     /// Incremental holdback scanner state for append-only source updates.
     holdback_scanner: TableHoldbackScanner,
+    /// Number of queued lines that preserve an old render's un-emitted suffix.
+    synthetic_queue_remaining: usize,
+    /// Rendered-line index to use once the synthetic suffix has drained.
+    synthetic_queue_target_emitted_len: Option<usize>,
     /// Number of source lines to keep mutable even when no structural holdback is active.
     ///
     /// CommonMark can reinterpret the newest block after the next line arrives. For example, a
@@ -110,6 +114,12 @@ struct StablePrefixLenCache {
     stable_prefix_len: usize,
 }
 
+struct PartialSourceLine {
+    source_start: usize,
+    source_end: usize,
+    unemitted_suffix: Vec<HyperlinkLine>,
+}
+
 impl StreamCore {
     fn new(
         width: Option<usize>,
@@ -128,6 +138,8 @@ impl StreamCore {
             render_mode,
             stable_prefix_len_cache: None,
             holdback_scanner: TableHoldbackScanner::new(),
+            synthetic_queue_remaining: 0,
+            synthetic_queue_target_emitted_len: None,
             default_tail_lines,
         }
     }
@@ -165,23 +177,24 @@ impl StreamCore {
     /// consolidation, so callers that skip `reset()` can accidentally replay a
     /// finished stream into the next answer.
     fn finalize_remaining(&mut self) -> Vec<HyperlinkLine> {
+        let mut remaining = self.state.drain_n(/*max_lines*/ usize::MAX);
+        self.account_emitted_step(remaining.len());
         let remainder_source = self.state.collector.finalize_and_drain_source();
         if !remainder_source.is_empty() {
             self.raw_source.push_str(&remainder_source);
             self.holdback_scanner.push_source_chunk(&remainder_source);
         }
         let rendered = self.render_source(&self.raw_source);
-        if self.emitted_stable_len >= rendered.len() {
-            Vec::new()
-        } else {
-            rendered[self.emitted_stable_len..].to_vec()
+        if self.emitted_stable_len < rendered.len() {
+            remaining.extend(rendered[self.emitted_stable_len..].to_vec());
         }
+        remaining
     }
 
     /// Step animation: dequeue one line, update the emitted count.
     fn tick(&mut self) -> Vec<HyperlinkLine> {
         let step = self.state.step();
-        self.emitted_stable_len += step.len();
+        self.account_emitted_step(step.len());
         step
     }
 
@@ -194,7 +207,7 @@ impl StreamCore {
         if step.is_empty() {
             return step;
         }
-        self.emitted_stable_len += step.len();
+        self.account_emitted_step(step.len());
         step
     }
 
@@ -250,6 +263,11 @@ impl StreamCore {
         }
         let had_pending_queue = self.state.queued_len() > 0;
         let had_structural_tail = self.requires_final_scrollback_reflow();
+        let partial_line = if had_pending_queue {
+            self.partial_source_line_after_rendered_len(self.emitted_stable_len)
+        } else {
+            None
+        };
         let emitted_source_boundary =
             self.source_boundary_after_rendered_len(self.emitted_stable_len);
         self.width = width;
@@ -259,6 +277,10 @@ impl StreamCore {
         }
 
         self.recompute_streaming_render();
+        if let Some(partial_line) = partial_line {
+            self.rebuild_stable_queue_preserving_partial_source_line(partial_line);
+            return;
+        }
         self.emitted_stable_len = self.rendered_len_for_source_boundary(emitted_source_boundary);
         let target_stable_len = self.compute_target_stable_len();
         if had_pending_queue
@@ -267,7 +289,7 @@ impl StreamCore {
         {
             self.emitted_stable_len = target_stable_len;
         }
-        self.state.clear_queue();
+        self.clear_stable_queue();
         if self.emitted_stable_len > 0 && !had_pending_queue && !had_structural_tail {
             // Avoid replaying already-emitted content after resize when no
             // stable lines were waiting in the queue and there was no mutable
@@ -291,6 +313,7 @@ impl StreamCore {
         self.emitted_stable_len = 0;
         self.stable_prefix_len_cache = None;
         self.holdback_scanner.reset();
+        self.clear_synthetic_queue_accounting();
     }
 
     fn render_source(&self, source: &str) -> Vec<HyperlinkLine> {
@@ -315,6 +338,11 @@ impl StreamCore {
 
         let had_pending_queue = self.state.queued_len() > 0;
         let had_structural_tail = self.requires_final_scrollback_reflow();
+        let partial_line = if had_pending_queue {
+            self.partial_source_line_after_rendered_len(self.emitted_stable_len)
+        } else {
+            None
+        };
         let live_default_tail_source_start = if !had_pending_queue && !had_structural_tail {
             self.live_default_tail_source_start()
         } else {
@@ -329,6 +357,10 @@ impl StreamCore {
         }
 
         self.recompute_streaming_render();
+        if let Some(partial_line) = partial_line {
+            self.rebuild_stable_queue_preserving_partial_source_line(partial_line);
+            return true;
+        }
         self.emitted_stable_len = self.rendered_len_for_source_boundary(emitted_source_boundary);
         let target_stable_len = self.compute_target_stable_len();
         if had_pending_queue
@@ -337,7 +369,7 @@ impl StreamCore {
         {
             self.emitted_stable_len = target_stable_len;
         }
-        self.state.clear_queue();
+        self.clear_stable_queue();
         if self.emitted_stable_len > 0 && !had_pending_queue && !had_structural_tail {
             let target_stable_len = if let Some(source_start) = live_default_tail_source_start {
                 self.stable_prefix_len_for_source_start(source_start)
@@ -371,7 +403,7 @@ impl StreamCore {
         // A structural rewrite moved the stable boundary backward into enqueue-but-unemitted
         // lines. Rebuild queue from the latest snapshot.
         if target_stable_len < self.enqueued_stable_len {
-            self.state.clear_queue();
+            self.clear_stable_queue();
             if self.emitted_stable_len < target_stable_len {
                 self.state.enqueue(
                     self.rendered_lines[self.emitted_stable_len..target_stable_len].to_vec(),
@@ -398,12 +430,64 @@ impl StreamCore {
     /// current render.
     fn rebuild_stable_queue_from_render(&mut self) {
         let target_stable_len = self.compute_target_stable_len();
-        self.state.clear_queue();
+        self.clear_stable_queue();
         if self.emitted_stable_len < target_stable_len {
             self.state
                 .enqueue(self.rendered_lines[self.emitted_stable_len..target_stable_len].to_vec());
         }
         self.enqueued_stable_len = target_stable_len;
+    }
+
+    fn rebuild_stable_queue_preserving_partial_source_line(
+        &mut self,
+        partial_line: PartialSourceLine,
+    ) {
+        let source_line_start_len =
+            self.rendered_len_for_source_boundary(partial_line.source_start);
+        let source_line_end_len = self.rendered_len_for_source_boundary(partial_line.source_end);
+        let target_stable_len = self.compute_target_stable_len();
+
+        self.clear_stable_queue();
+        self.emitted_stable_len = source_line_start_len;
+
+        let mut queued = partial_line.unemitted_suffix;
+        let synthetic_len = queued.len();
+        if source_line_end_len < target_stable_len {
+            queued.extend(self.rendered_lines[source_line_end_len..target_stable_len].to_vec());
+        }
+        if !queued.is_empty() {
+            self.state.enqueue(queued);
+        }
+        self.enqueued_stable_len = source_line_end_len.max(target_stable_len);
+        if synthetic_len > 0 {
+            self.synthetic_queue_remaining = synthetic_len;
+            self.synthetic_queue_target_emitted_len = Some(source_line_end_len);
+        }
+    }
+
+    fn clear_stable_queue(&mut self) {
+        self.state.clear_queue();
+        self.clear_synthetic_queue_accounting();
+    }
+
+    fn clear_synthetic_queue_accounting(&mut self) {
+        self.synthetic_queue_remaining = 0;
+        self.synthetic_queue_target_emitted_len = None;
+    }
+
+    fn account_emitted_step(&mut self, step_len: usize) {
+        let mut ordinary_lines = step_len;
+        if self.synthetic_queue_remaining > 0 {
+            let synthetic_lines = ordinary_lines.min(self.synthetic_queue_remaining);
+            ordinary_lines -= synthetic_lines;
+            self.synthetic_queue_remaining -= synthetic_lines;
+            if self.synthetic_queue_remaining == 0
+                && let Some(target_len) = self.synthetic_queue_target_emitted_len.take()
+            {
+                self.emitted_stable_len = target_len;
+            }
+        }
+        self.emitted_stable_len += ordinary_lines;
     }
 
     /// How many rendered lines to withhold as mutable tail.
@@ -522,6 +606,47 @@ impl StreamCore {
             }
         }
         self.raw_source.len()
+    }
+
+    fn partial_source_line_after_rendered_len(
+        &self,
+        rendered_len: usize,
+    ) -> Option<PartialSourceLine> {
+        if rendered_len == 0 || rendered_len >= self.rendered_lines.len() {
+            return None;
+        }
+
+        let mut source_start = 0;
+        let mut source_start_rendered_len = 0;
+        for source_end in self.source_line_boundaries() {
+            let source_end_rendered_len = self.render_source(&self.raw_source[..source_end]).len();
+            if rendered_len < source_end_rendered_len {
+                if rendered_len <= source_start_rendered_len {
+                    return None;
+                }
+                return Some(PartialSourceLine {
+                    source_start,
+                    source_end,
+                    unemitted_suffix: self.rendered_lines[rendered_len..source_end_rendered_len]
+                        .to_vec(),
+                });
+            }
+            source_start = source_end;
+            source_start_rendered_len = source_end_rendered_len;
+        }
+        None
+    }
+
+    fn source_line_boundaries(&self) -> Vec<usize> {
+        let mut boundaries = self
+            .raw_source
+            .match_indices('\n')
+            .map(|(idx, _)| idx + 1)
+            .collect::<Vec<_>>();
+        if boundaries.last().copied() != Some(self.raw_source.len()) {
+            boundaries.push(self.raw_source.len());
+        }
+        boundaries
     }
 
     fn default_tail_budget_lines(&mut self) -> usize {
@@ -660,7 +785,7 @@ impl StreamController {
     }
 
     pub(crate) fn clear_queue(&mut self) {
-        self.core.state.clear_queue();
+        self.core.clear_stable_queue();
         self.core.enqueued_stable_len = self.core.emitted_stable_len;
     }
 
@@ -790,7 +915,7 @@ impl PlanStreamController {
     }
 
     pub(crate) fn clear_queue(&mut self) {
-        self.core.state.clear_queue();
+        self.core.clear_stable_queue();
         self.core.enqueued_stable_len = self.core.emitted_stable_len;
     }
 
@@ -1191,10 +1316,9 @@ mod tests {
 
         ctrl.set_width(Some(/*width*/ 120));
 
-        assert_eq!(
-            ctrl.queued_lines(),
-            0,
-            "partially emitted source line should not be re-queued after widening"
+        assert!(
+            ctrl.queued_lines() > 0,
+            "un-emitted source-line suffix should remain queued after widening"
         );
 
         let (cell, _source) = ctrl.finalize();
@@ -1206,6 +1330,10 @@ mod tests {
         assert!(
             !finalized_after_resize.contains("AAAA BBBB CCCC"),
             "finalize must not replay the already-visible line prefix; emitted before resize: {emitted_before_resize:?}, finalized after resize: {finalized_after_resize:?}",
+        );
+        assert!(
+            finalized_after_resize.contains("IIII JJJJ"),
+            "finalize must preserve the un-emitted source-line suffix; emitted before resize: {emitted_before_resize:?}, finalized after resize: {finalized_after_resize:?}",
         );
         assert!(
             final_lines.iter().any(|line| line.contains("second line")),
@@ -2198,14 +2326,15 @@ mod tests {
             .map(|line| line.chars().skip(2).collect::<String>())
             .collect::<Vec<_>>();
         assert!(
-            remaining.iter().any(|line| line.contains("tail line")),
+            remaining.iter().any(|line| line.contains("riverbank"))
+                && remaining.iter().any(|line| line.contains("tail line")),
             "un-emitted content should remain after resize remap: {remaining:?}",
         );
     }
 
     #[test]
     fn controller_set_width_partial_wrapped_emit_does_not_replay_prefix() {
-        let mut ctrl = stream_controller(Some(18));
+        let mut ctrl = stream_controller(Some(/*width*/ 18));
         ctrl.push("alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu\n");
         ctrl.push("tail line\n");
 
@@ -2232,8 +2361,46 @@ mod tests {
             "finalize must not replay the already-visible prefix; emitted before resize: {first_emit:?}, finalized after resize: {joined:?}",
         );
         assert!(
+            joined.contains("lambda mu"),
+            "finalize must preserve the un-emitted source-line suffix; emitted before resize: {first_emit:?}, finalized after resize: {joined:?}",
+        );
+        assert!(
             remaining.iter().any(|line| line.contains("tail line")),
             "ordinary mutable tail should flush on finalize; got {remaining:?}",
+        );
+    }
+
+    #[test]
+    fn controller_set_render_mode_partial_wrapped_emit_preserves_remaining_content() {
+        let mut ctrl = stream_controller(Some(/*width*/ 18));
+        ctrl.push("alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu\n");
+        ctrl.push("tail line\n");
+
+        let (first_emit, idle) = ctrl.on_commit_tick();
+        let first_emit = first_emit
+            .expect("expected first wrapped line emission")
+            .transcript_lines(u16::MAX);
+        assert!(!idle, "expected remaining wrapped content after one tick");
+        assert!(
+            ctrl.queued_lines() > 0,
+            "expected queued wrapped remainder before raw toggle"
+        );
+
+        ctrl.set_render_mode(HistoryRenderMode::Raw);
+
+        let (cell, _source) = ctrl.finalize();
+        let remaining = cell
+            .map(|c| lines_to_plain_strings(&c.transcript_lines(u16::MAX)))
+            .unwrap_or_default();
+        let first_emit = lines_to_plain_strings(&first_emit).join("\n");
+        let joined = remaining.join("\n");
+        assert!(
+            !joined.contains("alpha beta"),
+            "finalize must not replay the already-visible prefix after raw toggle; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+        );
+        assert!(
+            joined.contains("lambda mu") && joined.contains("tail line"),
+            "finalize must preserve un-emitted content after raw toggle; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
         );
     }
 }

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -42,14 +42,17 @@ use crate::history_cell::{self};
 use crate::markdown::render_markdown_agent_with_links_and_cwd;
 use crate::style::proposed_plan_style;
 use crate::terminal_hyperlinks::HyperlinkLine;
+use crate::terminal_hyperlinks::TerminalHyperlink;
 use crate::terminal_hyperlinks::plain_hyperlink_lines;
 use crate::terminal_hyperlinks::prefix_hyperlink_lines;
 use ratatui::prelude::Stylize;
 use ratatui::text::Line;
+use ratatui::text::Span;
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::Duration;
 use std::time::Instant;
+use unicode_width::UnicodeWidthStr;
 
 use super::StreamState;
 use super::table_holdback::TableHoldbackScanner;
@@ -93,6 +96,8 @@ struct StreamCore {
     synthetic_queue_remaining: usize,
     /// Rendered-line index to use once the synthetic suffix has drained.
     synthetic_queue_target_emitted_len: Option<usize>,
+    /// Source-line prefix already visible when a synthetic queue is rebuilt.
+    synthetic_queue_partial: Option<PartialSourceLine>,
     /// Number of source lines to keep mutable even when no structural holdback is active.
     ///
     /// CommonMark can reinterpret the newest block after the next line arrives. For example, a
@@ -114,6 +119,7 @@ struct StablePrefixLenCache {
     stable_prefix_len: usize,
 }
 
+#[derive(Clone)]
 struct PartialSourceLine {
     source_start: usize,
     source_end: usize,
@@ -140,6 +146,7 @@ impl StreamCore {
             holdback_scanner: TableHoldbackScanner::new(),
             synthetic_queue_remaining: 0,
             synthetic_queue_target_emitted_len: None,
+            synthetic_queue_partial: None,
             default_tail_lines,
         }
     }
@@ -178,15 +185,28 @@ impl StreamCore {
     /// finished stream into the next answer.
     fn finalize_remaining(&mut self) -> Vec<HyperlinkLine> {
         let mut remaining = self.state.drain_n(/*max_lines*/ usize::MAX);
-        self.account_emitted_step(remaining.len());
+        self.account_emitted_step(&remaining);
         let remainder_source = self.state.collector.finalize_and_drain_source();
         if !remainder_source.is_empty() {
             self.raw_source.push_str(&remainder_source);
             self.holdback_scanner.push_source_chunk(&remainder_source);
         }
         let rendered = self.render_source(&self.raw_source);
-        if self.emitted_stable_len < rendered.len() {
-            remaining.extend(rendered[self.emitted_stable_len..].to_vec());
+        self.rendered_lines = rendered;
+        if let Some(partial_line) = self.synthetic_queue_partial.take() {
+            let source_line_start_len =
+                self.rendered_len_for_source_boundary(partial_line.source_start);
+            let source_line_end_len =
+                self.rendered_len_for_source_boundary(partial_line.source_end);
+            remaining.extend(trim_rendered_prefix(
+                self.rendered_lines[source_line_start_len..source_line_end_len].to_vec(),
+                &partial_line.emitted_prefix,
+            ));
+            if source_line_end_len < self.rendered_lines.len() {
+                remaining.extend(self.rendered_lines[source_line_end_len..].to_vec());
+            }
+        } else if self.emitted_stable_len < self.rendered_lines.len() {
+            remaining.extend(self.rendered_lines[self.emitted_stable_len..].to_vec());
         }
         remaining
     }
@@ -194,7 +214,7 @@ impl StreamCore {
     /// Step animation: dequeue one line, update the emitted count.
     fn tick(&mut self) -> Vec<HyperlinkLine> {
         let step = self.state.step();
-        self.account_emitted_step(step.len());
+        self.account_emitted_step(&step);
         step
     }
 
@@ -207,7 +227,7 @@ impl StreamCore {
         if step.is_empty() {
             return step;
         }
-        self.account_emitted_step(step.len());
+        self.account_emitted_step(&step);
         step
     }
 
@@ -465,38 +485,46 @@ impl StreamCore {
         if synthetic_len > 0 {
             self.synthetic_queue_remaining = synthetic_len;
             self.synthetic_queue_target_emitted_len = Some(source_line_end_len);
+            self.synthetic_queue_partial = Some(partial_line);
         }
     }
 
     fn clear_stable_queue(&mut self) {
-        self.advance_synthetic_queue_accounting_to_target();
         self.state.clear_queue();
         self.clear_synthetic_queue_accounting();
-    }
-
-    fn advance_synthetic_queue_accounting_to_target(&mut self) {
-        if self.synthetic_queue_remaining > 0
-            && let Some(target_len) = self.synthetic_queue_target_emitted_len
-        {
-            self.emitted_stable_len = target_len;
-        }
     }
 
     fn clear_synthetic_queue_accounting(&mut self) {
         self.synthetic_queue_remaining = 0;
         self.synthetic_queue_target_emitted_len = None;
+        self.synthetic_queue_partial = None;
     }
 
-    fn account_emitted_step(&mut self, step_len: usize) {
-        let mut ordinary_lines = step_len;
+    fn clear_queue_for_interruption(&mut self) {
+        self.state.clear_queue();
+        if self.synthetic_queue_remaining == 0 {
+            self.synthetic_queue_partial = None;
+        }
+        self.synthetic_queue_remaining = 0;
+        self.synthetic_queue_target_emitted_len = None;
+    }
+
+    fn account_emitted_step(&mut self, step: &[HyperlinkLine]) {
+        let mut ordinary_lines = step.len();
         if self.synthetic_queue_remaining > 0 {
             let synthetic_lines = ordinary_lines.min(self.synthetic_queue_remaining);
+            if let Some(partial_line) = &mut self.synthetic_queue_partial {
+                partial_line
+                    .emitted_prefix
+                    .extend(step[..synthetic_lines].to_vec());
+            }
             ordinary_lines -= synthetic_lines;
             self.synthetic_queue_remaining -= synthetic_lines;
             if self.synthetic_queue_remaining == 0
                 && let Some(target_len) = self.synthetic_queue_target_emitted_len.take()
             {
                 self.emitted_stable_len = target_len;
+                self.synthetic_queue_partial = None;
             }
         }
         self.emitted_stable_len += ordinary_lines;
@@ -721,21 +749,75 @@ fn trim_rendered_prefix(
             continue;
         }
         if prefix_chars > 0 {
-            let suffix = text
-                .chars()
-                .skip(chars_to_skip.unwrap_or(prefix_chars))
-                .collect::<String>()
-                .trim_start()
-                .to_string();
+            let chars_to_skip = chars_to_skip.unwrap_or(prefix_chars);
             prefix_chars = 0;
-            if !suffix.is_empty() {
-                out.push(HyperlinkLine::new(Line::from(suffix)));
+            if let Some(trimmed_line) = trim_hyperlink_line_prefix(line, chars_to_skip) {
+                out.push(trimmed_line);
             }
         } else {
             out.push(line);
         }
     }
     out
+}
+
+fn trim_hyperlink_line_prefix(line: HyperlinkLine, chars_to_skip: usize) -> Option<HyperlinkLine> {
+    let text = hyperlink_line_text(&line);
+    let leading_whitespace = text
+        .chars()
+        .skip(chars_to_skip)
+        .take_while(|ch| ch.is_whitespace())
+        .count();
+    let total_chars_to_skip = chars_to_skip + leading_whitespace;
+    if total_chars_to_skip >= text.chars().count() {
+        return None;
+    }
+
+    let skipped_text = text.chars().take(total_chars_to_skip).collect::<String>();
+    let skipped_columns = skipped_text.width();
+    let mut remaining_chars_to_skip = total_chars_to_skip;
+    let mut spans = Vec::with_capacity(line.line.spans.len());
+    for span in line.line.spans {
+        let span_chars = span.content.chars().count();
+        if remaining_chars_to_skip >= span_chars {
+            remaining_chars_to_skip -= span_chars;
+            continue;
+        }
+        if remaining_chars_to_skip > 0 {
+            let suffix = span
+                .content
+                .chars()
+                .skip(remaining_chars_to_skip)
+                .collect::<String>();
+            spans.push(Span {
+                content: suffix.into(),
+                style: span.style,
+            });
+            remaining_chars_to_skip = 0;
+        } else {
+            spans.push(span);
+        }
+    }
+
+    let hyperlinks = line
+        .hyperlinks
+        .into_iter()
+        .filter_map(|link| {
+            if link.columns.end <= skipped_columns {
+                None
+            } else {
+                Some(TerminalHyperlink {
+                    columns: link.columns.start.saturating_sub(skipped_columns)
+                        ..link.columns.end.saturating_sub(skipped_columns),
+                    destination: link.destination,
+                })
+            }
+        })
+        .collect::<Vec<_>>();
+    Some(HyperlinkLine {
+        line: Line::from(spans).style(line.line.style),
+        hyperlinks,
+    })
 }
 
 fn hyperlink_line_text(line: &HyperlinkLine) -> String {
@@ -855,7 +937,7 @@ impl StreamController {
     }
 
     pub(crate) fn clear_queue(&mut self) {
-        self.core.clear_stable_queue();
+        self.core.clear_queue_for_interruption();
         self.core.enqueued_stable_len = self.core.emitted_stable_len;
     }
 
@@ -902,7 +984,7 @@ impl PlanStreamController {
     /// callers must update it when the terminal width changes.
     pub(crate) fn new(width: Option<usize>, cwd: &Path, render_mode: HistoryRenderMode) -> Self {
         Self {
-            core: StreamCore::new(width, cwd, render_mode, /*default_tail_lines*/ 0),
+            core: StreamCore::new(width, cwd, render_mode, /*default_tail_lines*/ 1),
             header_emitted: false,
             top_padding_emitted: false,
         }
@@ -985,7 +1067,7 @@ impl PlanStreamController {
     }
 
     pub(crate) fn clear_queue(&mut self) {
-        self.core.clear_stable_queue();
+        self.core.clear_queue_for_interruption();
         self.core.enqueued_stable_len = self.core.emitted_stable_len;
     }
 
@@ -1315,6 +1397,21 @@ mod tests {
             collect_visible_stream_snapshots(HAPPY_PATH_DUPLICATE_REPRO_DELTAS, Some(/*width*/ 80));
 
         insta::assert_snapshot!(format_stream_snapshots(&snapshots));
+    }
+
+    #[test]
+    fn plan_controller_does_not_duplicate_list_continuation_after_fenced_code() {
+        let lines =
+            collect_plan_streamed_lines(HAPPY_PATH_DUPLICATE_REPRO_DELTAS, Some(/*width*/ 80));
+
+        let expected_count = lines
+            .iter()
+            .filter(|line| line.trim() == "Expected: the running TUI stays open.")
+            .count();
+        assert_eq!(
+            expected_count, 1,
+            "expected plan list continuation to render once, got {lines:?}",
+        );
     }
 
     #[test]
@@ -2534,8 +2631,39 @@ mod tests {
             "finalize must not replay the already-visible prefix after clear_queue; emitted before clear: {first_emit:?}, finalized after clear: {joined:?}",
         );
         assert!(
+            joined.contains("lambda mu"),
+            "finalize must preserve the un-emitted source-line suffix after clear_queue; emitted before clear: {first_emit:?}, finalized after clear: {joined:?}",
+        );
+        assert!(
             remaining.iter().any(|line| line.contains("tail line")),
             "ordinary mutable tail should still flush on finalize after clear_queue; got {remaining:?}",
+        );
+    }
+
+    #[test]
+    fn trim_rendered_prefix_preserves_suffix_metadata() {
+        let line = HyperlinkLine {
+            line: vec!["alpha ".into(), "beta".bold(), " gamma".into()].into(),
+            hyperlinks: vec![TerminalHyperlink {
+                columns: 6..10,
+                destination: "https://example.com".to_string(),
+            }],
+        };
+
+        let trimmed = trim_rendered_prefix(vec![line], &[HyperlinkLine::from("alpha ")]);
+
+        assert_eq!(
+            hyperlink_lines_to_plain_strings(&trimmed),
+            vec!["beta gamma"]
+        );
+        assert_eq!(trimmed[0].hyperlinks[0].columns, 0..4);
+        assert_eq!(trimmed[0].hyperlinks[0].destination, "https://example.com");
+        assert!(
+            trimmed[0].line.spans[0]
+                .style
+                .add_modifier
+                .contains(ratatui::style::Modifier::BOLD),
+            "expected trimmed suffix to preserve span styling",
         );
     }
 }

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -123,6 +123,7 @@ struct StablePrefixLenCache {
 struct PartialSourceLine {
     source_start: usize,
     source_end: usize,
+    emitted_source_end: usize,
     emitted_prefix: Vec<HyperlinkLine>,
 }
 
@@ -284,7 +285,9 @@ impl StreamCore {
         let had_pending_queue = self.state.queued_len() > 0;
         let had_structural_tail = self.requires_final_scrollback_reflow();
         let partial_line = if had_pending_queue {
-            self.partial_source_line_after_rendered_len(self.emitted_stable_len)
+            self.synthetic_queue_partial
+                .clone()
+                .or_else(|| self.partial_source_line_after_rendered_len(self.emitted_stable_len))
         } else {
             None
         };
@@ -359,7 +362,9 @@ impl StreamCore {
         let had_pending_queue = self.state.queued_len() > 0;
         let had_structural_tail = self.requires_final_scrollback_reflow();
         let partial_line = if had_pending_queue {
-            self.partial_source_line_after_rendered_len(self.emitted_stable_len)
+            self.synthetic_queue_partial
+                .clone()
+                .or_else(|| self.partial_source_line_after_rendered_len(self.emitted_stable_len))
         } else {
             None
         };
@@ -470,10 +475,16 @@ impl StreamCore {
         self.clear_stable_queue();
         self.emitted_stable_len = source_line_start_len;
 
-        let mut queued = trim_rendered_prefix(
-            self.rendered_lines[source_line_start_len..source_line_end_len].to_vec(),
-            &partial_line.emitted_prefix,
-        );
+        let mut queued = if self.render_mode == HistoryRenderMode::Raw {
+            plain_hyperlink_lines(raw_lines_from_source(
+                &self.raw_source[partial_line.emitted_source_end..partial_line.source_end],
+            ))
+        } else {
+            trim_rendered_prefix(
+                self.rendered_lines[source_line_start_len..source_line_end_len].to_vec(),
+                &partial_line.emitted_prefix,
+            )
+        };
         let synthetic_len = queued.len();
         if source_line_end_len < target_stable_len {
             queued.extend(self.rendered_lines[source_line_end_len..target_stable_len].to_vec());
@@ -513,10 +524,26 @@ impl StreamCore {
         let mut ordinary_lines = step.len();
         if self.synthetic_queue_remaining > 0 {
             let synthetic_lines = ordinary_lines.min(self.synthetic_queue_remaining);
+            let mut emitted_prefix = None;
             if let Some(partial_line) = &mut self.synthetic_queue_partial {
                 partial_line
                     .emitted_prefix
                     .extend(step[..synthetic_lines].to_vec());
+                emitted_prefix = Some((
+                    partial_line.source_start,
+                    partial_line.source_end,
+                    partial_line.emitted_prefix.clone(),
+                ));
+            }
+            if let Some((source_start, source_end, emitted_prefix)) = emitted_prefix {
+                let emitted_source_end = self.source_boundary_after_rendered_prefix(
+                    source_start,
+                    source_end,
+                    &emitted_prefix,
+                );
+                if let Some(partial_line) = &mut self.synthetic_queue_partial {
+                    partial_line.emitted_source_end = emitted_source_end;
+                }
             }
             ordinary_lines -= synthetic_lines;
             self.synthetic_queue_remaining -= synthetic_lines;
@@ -664,11 +691,18 @@ impl StreamCore {
                 if rendered_len <= source_start_rendered_len {
                     return None;
                 }
+                let emitted_prefix =
+                    self.rendered_lines[source_start_rendered_len..rendered_len].to_vec();
+                let emitted_source_end = self.source_boundary_after_rendered_prefix(
+                    source_start,
+                    source_end,
+                    &emitted_prefix,
+                );
                 return Some(PartialSourceLine {
                     source_start,
                     source_end,
-                    emitted_prefix: self.rendered_lines[source_start_rendered_len..rendered_len]
-                        .to_vec(),
+                    emitted_source_end,
+                    emitted_prefix,
                 });
             }
             source_start = source_end;
@@ -687,6 +721,54 @@ impl StreamCore {
             boundaries.push(self.raw_source.len());
         }
         boundaries
+    }
+
+    fn source_boundary_after_rendered_prefix(
+        &self,
+        source_start: usize,
+        source_end: usize,
+        emitted_prefix: &[HyperlinkLine],
+    ) -> usize {
+        if emitted_prefix.is_empty() {
+            return source_start;
+        }
+        let emitted_text = emitted_prefix
+            .iter()
+            .map(hyperlink_line_text)
+            .collect::<Vec<_>>();
+        let emitted_visible_text = emitted_text.join(" ");
+        if let Some(boundary) = visible_text_source_boundary(
+            &self.raw_source[source_start..source_end],
+            &emitted_visible_text,
+        ) {
+            return source_start + boundary;
+        }
+
+        let mut boundaries = Vec::new();
+        boundaries.push(source_start);
+        boundaries.extend(
+            self.raw_source[source_start..source_end]
+                .char_indices()
+                .map(|(idx, ch)| source_start + idx + ch.len_utf8()),
+        );
+
+        for boundary in boundaries {
+            let rendered = self.render_source(&self.raw_source[..boundary]);
+            if rendered.len() < emitted_prefix.len() {
+                continue;
+            }
+            let rendered_text = rendered[..emitted_prefix.len()]
+                .iter()
+                .map(hyperlink_line_text)
+                .collect::<Vec<_>>();
+            if rendered_text == emitted_text {
+                return boundary;
+            }
+        }
+
+        self.source_boundary_after_rendered_len(emitted_prefix.len())
+            .min(source_end)
+            .max(source_start)
     }
 
     fn default_tail_budget_lines(&mut self) -> usize {
@@ -714,6 +796,83 @@ impl StreamCore {
         self.render_mode != HistoryRenderMode::Raw
             && !matches!(self.holdback_scanner.state(), TableHoldbackState::None)
     }
+}
+
+fn visible_text_source_boundary(source: &str, visible_prefix: &str) -> Option<usize> {
+    if visible_prefix.is_empty() {
+        return Some(0);
+    }
+
+    let mut visible_chars = visible_prefix.chars().peekable();
+    let mut iter = source.char_indices().peekable();
+    while let Some((idx, ch)) = iter.next() {
+        if visible_chars.peek().is_none() {
+            return Some(idx);
+        }
+
+        if ch == '[' {
+            let mut label_end = None;
+            let mut label_chars = Vec::new();
+            for (label_idx, label_ch) in iter.by_ref() {
+                if label_ch == ']' {
+                    label_end = Some(label_idx + label_ch.len_utf8());
+                    break;
+                }
+                label_chars.push((label_idx, label_ch));
+            }
+            let label_end = label_end?;
+            for (label_idx, label_ch) in label_chars {
+                match visible_chars.peek().copied() {
+                    Some(expected) if expected == label_ch => {
+                        visible_chars.next();
+                        if visible_chars.peek().is_none() {
+                            return Some(
+                                skip_link_destination(source, label_end)
+                                    .unwrap_or(label_idx + label_ch.len_utf8()),
+                            );
+                        }
+                    }
+                    _ => return None,
+                }
+            }
+            if let Some(destination_end) = skip_link_destination(source, label_end) {
+                while let Some((next_idx, _)) = iter.peek().copied() {
+                    if next_idx < destination_end {
+                        iter.next();
+                    } else {
+                        break;
+                    }
+                }
+            }
+            continue;
+        }
+
+        if matches!(ch, '*' | '_' | '`') {
+            continue;
+        }
+
+        match visible_chars.peek().copied() {
+            Some(expected) if expected == ch => {
+                visible_chars.next();
+                if visible_chars.peek().is_none() {
+                    return Some(idx + ch.len_utf8());
+                }
+            }
+            _ => return None,
+        }
+    }
+
+    visible_chars.peek().is_none().then_some(source.len())
+}
+
+fn skip_link_destination(source: &str, label_end: usize) -> Option<usize> {
+    let after_label = source.get(label_end..)?;
+    if !after_label.starts_with('(') {
+        return None;
+    }
+    after_label
+        .find(')')
+        .map(|destination_end| label_end + destination_end + ')'.len_utf8())
 }
 
 fn trim_rendered_prefix(
@@ -1225,6 +1384,31 @@ mod tests {
         snapshots
     }
 
+    fn collect_visible_plan_stream_snapshots(
+        deltas: &[&str],
+        width: Option<usize>,
+    ) -> Vec<Vec<String>> {
+        let mut ctrl = plan_stream_controller(width);
+        let mut committed_lines = Vec::new();
+        let mut snapshots = Vec::new();
+        for delta in deltas {
+            ctrl.push(delta);
+            while let (Some(cell), idle) = ctrl.on_commit_tick() {
+                committed_lines.extend(cell.transcript_lines(u16::MAX));
+                if idle {
+                    break;
+                }
+            }
+
+            let mut visible = lines_to_plain_strings(&committed_lines);
+            visible.extend(hyperlink_lines_to_plain_strings(
+                &ctrl.current_tail_display_lines(),
+            ));
+            snapshots.push(visible);
+        }
+        snapshots
+    }
+
     fn format_stream_snapshots(snapshots: &[Vec<String>]) -> String {
         snapshots
             .iter()
@@ -1412,6 +1596,16 @@ mod tests {
             expected_count, 1,
             "expected plan list continuation to render once, got {lines:?}",
         );
+    }
+
+    #[test]
+    fn plan_controller_streamed_list_continuation_snapshot() {
+        let snapshots = collect_visible_plan_stream_snapshots(
+            HAPPY_PATH_DUPLICATE_REPRO_DELTAS,
+            Some(/*width*/ 80),
+        );
+
+        insta::assert_snapshot!(format_stream_snapshots(&snapshots));
     }
 
     #[test]
@@ -2543,6 +2737,41 @@ mod tests {
     }
 
     #[test]
+    fn controller_set_width_reuses_synthetic_partial_across_repeated_resize() {
+        let mut ctrl = stream_controller(Some(/*width*/ 18));
+        ctrl.push("alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu\n");
+        ctrl.push("tail line\n");
+
+        let (first_emit, idle) = ctrl.on_commit_tick();
+        let first_emit = first_emit
+            .expect("expected first wrapped line emission")
+            .transcript_lines(u16::MAX);
+        assert!(!idle, "expected remaining wrapped content after one tick");
+
+        ctrl.set_width(Some(/*width*/ 80));
+        assert!(
+            ctrl.queued_lines() > 0,
+            "expected synthetic queue after first resize"
+        );
+        ctrl.set_width(Some(/*width*/ 24));
+
+        let (cell, _source) = ctrl.finalize();
+        let remaining = cell
+            .map(|c| lines_to_plain_strings(&c.transcript_lines(u16::MAX)))
+            .unwrap_or_default();
+        let first_emit = lines_to_plain_strings(&first_emit).join("\n");
+        let joined = remaining.join("\n");
+        assert!(
+            !joined.contains("alpha beta"),
+            "finalize must not replay the already-visible prefix after repeated resize; emitted before resize: {first_emit:?}, finalized after resize: {joined:?}",
+        );
+        assert!(
+            joined.contains("lambda mu") && joined.contains("tail line"),
+            "repeated resize must preserve un-emitted suffix and tail; emitted before resize: {first_emit:?}, finalized after resize: {joined:?}",
+        );
+    }
+
+    #[test]
     fn controller_set_render_mode_partial_wrapped_emit_preserves_remaining_content() {
         let mut ctrl = stream_controller(Some(/*width*/ 18));
         ctrl.push("alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu\n");
@@ -2603,6 +2832,38 @@ mod tests {
         assert!(
             joined.contains("**") && joined.contains("tail line"),
             "pending suffix should be rendered from raw mode after toggle, not old rich rows; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+        );
+    }
+
+    #[test]
+    fn controller_set_render_mode_raw_suffix_starts_after_rich_link_prefix() {
+        let mut ctrl = stream_controller(Some(/*width*/ 10));
+        ctrl.push(
+            "[alpha beta](https://example.com) gamma delta epsilon zeta eta theta iota kappa lambda mu\n",
+        );
+        ctrl.push("tail line\n");
+
+        let (first_emit, idle) = ctrl.on_commit_tick();
+        let first_emit = first_emit
+            .expect("expected first rich wrapped line emission")
+            .transcript_lines(u16::MAX);
+        assert!(!idle, "expected remaining rich content after one tick");
+
+        ctrl.set_render_mode(HistoryRenderMode::Raw);
+
+        let (cell, _source) = ctrl.finalize();
+        let remaining = cell
+            .map(|c| lines_to_plain_strings(&c.transcript_lines(u16::MAX)))
+            .unwrap_or_default();
+        let first_emit = lines_to_plain_strings(&first_emit).join("\n");
+        let joined = remaining.join("\n");
+        assert!(
+            !joined.contains("https://example.com") && !joined.contains("](https://"),
+            "raw suffix must not start inside already-visible link markup; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
+        );
+        assert!(
+            joined.contains("gamma") && joined.contains("tail line"),
+            "raw suffix should preserve un-emitted source after the rendered link label; emitted before toggle: {first_emit:?}, finalized after toggle: {joined:?}",
         );
     }
 

--- a/codex-rs/tui/src/streaming/snapshots/codex_tui__streaming__controller__tests__controller_streamed_list_continuation_snapshot.snap
+++ b/codex-rs/tui/src/streaming/snapshots/codex_tui__streaming__controller__tests__controller_streamed_list_continuation_snapshot.snap
@@ -1,0 +1,62 @@
+---
+source: tui/src/streaming/controller.rs
+assertion_line: 1122
+expression: format_stream_snapshots(&snapshots)
+---
+after delta 0:
+Happy Path
+---
+after delta 1:
+Happy Path
+---
+after delta 2:
+Happy Path
+
+1. In the second terminal, make the smoke home non-writable:
+---
+after delta 3:
+Happy Path
+
+1. In the second terminal, make the smoke home non-writable:
+
+---
+after delta 4:
+Happy Path
+
+1. In the second terminal, make the smoke home non-writable:
+
+   chmod a-w $CODEX_SMOKE_HOME
+---
+after delta 5:
+Happy Path
+
+1. In the second terminal, make the smoke home non-writable:
+
+   chmod a-w $CODEX_SMOKE_HOME
+---
+after delta 6:
+Happy Path
+
+1. In the second terminal, make the smoke home non-writable:
+
+   chmod a-w $CODEX_SMOKE_HOME
+   Expected: the running TUI stays open.
+---
+after delta 7:
+Happy Path
+
+1. In the second terminal, make the smoke home non-writable:
+
+   chmod a-w $CODEX_SMOKE_HOME
+   Expected: the running TUI stays open.
+---
+after delta 8:
+Happy Path
+
+1. In the second terminal, make the smoke home non-writable:
+
+   chmod a-w $CODEX_SMOKE_HOME
+
+   Expected: the running TUI stays open.
+
+2. In the TUI, type /model and press Enter.

--- a/codex-rs/tui/src/streaming/snapshots/codex_tui__streaming__controller__tests__plan_controller_streamed_list_continuation_snapshot.snap
+++ b/codex-rs/tui/src/streaming/snapshots/codex_tui__streaming__controller__tests__plan_controller_streamed_list_continuation_snapshot.snap
@@ -1,0 +1,88 @@
+---
+source: tui/src/streaming/controller.rs
+expression: format_stream_snapshots(&snapshots)
+---
+after delta 0:
+• Proposed Plan
+ 
+   
+  Happy Path
+---
+after delta 1:
+• Proposed Plan
+ 
+   
+  Happy Path
+---
+after delta 2:
+• Proposed Plan
+ 
+   
+  Happy Path
+  
+  1. In the second terminal, make the smoke home non-writable:
+---
+after delta 3:
+• Proposed Plan
+ 
+   
+  Happy Path
+  
+  1. In the second terminal, make the smoke home non-writable:
+  
+---
+after delta 4:
+• Proposed Plan
+ 
+   
+  Happy Path
+  
+  1. In the second terminal, make the smoke home non-writable:
+  
+     chmod a-w $CODEX_SMOKE_HOME
+---
+after delta 5:
+• Proposed Plan
+ 
+   
+  Happy Path
+  
+  1. In the second terminal, make the smoke home non-writable:
+  
+     chmod a-w $CODEX_SMOKE_HOME
+---
+after delta 6:
+• Proposed Plan
+ 
+   
+  Happy Path
+  
+  1. In the second terminal, make the smoke home non-writable:
+  
+     chmod a-w $CODEX_SMOKE_HOME
+     Expected: the running TUI stays open.
+---
+after delta 7:
+• Proposed Plan
+ 
+   
+  Happy Path
+  
+  1. In the second terminal, make the smoke home non-writable:
+  
+     chmod a-w $CODEX_SMOKE_HOME
+     Expected: the running TUI stays open.
+---
+after delta 8:
+• Proposed Plan
+ 
+   
+  Happy Path
+  
+  1. In the second terminal, make the smoke home non-writable:
+  
+     chmod a-w $CODEX_SMOKE_HOME
+  
+     Expected: the running TUI stays open.
+  
+  2. In the TUI, type /model and press Enter.


### PR DESCRIPTION
## Summary

- keep a small mutable markdown source tail for streamed assistant messages so CommonMark list continuations are not committed to scrollback before their block boundary is stable
- keep the structural final reflow path limited to table holdback, instead of treating ordinary mutable tail text as requiring a scrollback rewrite
- add a regression for the reported bullet-list + fenced-code shape that duplicated an `Expected:` line in the live TUI

## Investigation

The reported session was `019e980f-52de-7851-a519-7204b1fcca61`. Its stored rollout contained the duplicated screenshot line only once in the final assistant message, which points at the live incremental TUI renderer rather than model output or history serialization.

The issue reproduced when the stream committed a list-continuation line immediately after a fenced code block. A following blank line/list marker can still change how CommonMark interprets that newest block, so the stale rendered row remained in scrollback and the final render emitted it again.

## Testing

- `just test -p codex-tui streaming::controller`
- `just test -p codex-tui flush_answer_stream`
- `just fmt`
- `git diff --check`

## Notes

`just argument-comment-lint` was blocked locally by a Bazel/LLVM compiler-rt glob error. The file-scoped wrapper was also blocked by missing `dotslash`, and the direct source fallback was blocked by the pinned nightly being too old for `sqlx 0.9.0`. I manually inspected the touched Rust diff for opaque positional literal arguments.
