### PR TITLE
fix(tui): prevent startup transcript flashes

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -472,10 +472,12 @@ struct SessionSummary {
 }
 
 /// Marks replay whose terminal writes are deferred until `transcript_cells` is complete.
-#[derive(Debug, Default)]
-struct InitialHistoryReplayBuffer {
+#[derive(Debug)]
+pub(super) struct InitialHistoryReplayBuffer {
     source_start: usize,
     awaiting_session_header: bool,
+    preserved_session_header: Option<Arc<dyn HistoryCell>>,
+    had_emitted_history_lines: bool,
 }
 
 pub(crate) struct App {

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -472,8 +472,11 @@ struct SessionSummary {
 }
 
 /// Marks replay whose terminal writes are deferred until `transcript_cells` is complete.
-#[derive(Debug)]
-struct InitialHistoryReplayBuffer;
+#[derive(Debug, Default)]
+struct InitialHistoryReplayBuffer {
+    source_start: usize,
+    awaiting_session_header: bool,
+}
 
 pub(crate) struct App {
     model_catalog: Arc<ModelCatalog>,

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -471,11 +471,9 @@ struct SessionSummary {
     resume_hint: Option<String>,
 }
 
-#[derive(Debug, Default)]
-struct InitialHistoryReplayBuffer {
-    retained_lines: VecDeque<crate::terminal_hyperlinks::HyperlinkLine>,
-    render_from_transcript_tail: bool,
-}
+/// Marks replay whose terminal writes are deferred until `transcript_cells` is complete.
+#[derive(Debug)]
+struct InitialHistoryReplayBuffer;
 
 pub(crate) struct App {
     model_catalog: Arc<ModelCatalog>,

--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -190,12 +190,6 @@ impl App {
 
                 tui.frame_requester().schedule_frame();
             }
-            AppEvent::BeginInitialHistoryReplayBuffer => {
-                self.begin_initial_history_replay_buffer();
-            }
-            AppEvent::BeginThreadSwitchHistoryReplayBuffer => {
-                self.begin_thread_switch_history_replay_buffer();
-            }
             AppEvent::InsertHistoryCell(cell) => {
                 let cell: Arc<dyn HistoryCell> = cell.into();
                 if let Some(Overlay::Transcript(t)) = &mut self.overlay {
@@ -205,7 +199,6 @@ impl App {
                 self.transcript_cells.push(cell.clone());
                 if self.initial_history_replay_buffer.as_ref().is_some() {
                     self.insert_history_cell_lines_with_initial_replay_buffer(
-                        tui,
                         cell.as_ref(),
                         self.chat_widget
                             .history_wrap_width(tui.terminal.last_known_screen_size.width),

--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -190,6 +190,9 @@ impl App {
 
                 tui.frame_requester().schedule_frame();
             }
+            AppEvent::BeginHistoryReplay => {
+                self.begin_history_replay();
+            }
             AppEvent::InsertHistoryCell(cell) => {
                 let cell: Arc<dyn HistoryCell> = cell.into();
                 if let Some(Overlay::Transcript(t)) = &mut self.overlay {
@@ -204,7 +207,7 @@ impl App {
                         replay.awaiting_session_header
                             && cell.as_any().is::<history_cell::SessionInfoCell>()
                     });
-                if self.initial_history_replay_buffer.is_none() || replayed_session_header {
+                if self.initial_history_replay_buffer.is_none() {
                     self.insert_history_cell_lines(
                         tui,
                         cell.as_ref(),
@@ -218,6 +221,7 @@ impl App {
                     replay.awaiting_session_header = false;
                     if replayed_session_header {
                         replay.source_start = self.transcript_cells.len();
+                        replay.preserved_session_header = Some(cell);
                     }
                 }
             }

--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -197,13 +197,28 @@ impl App {
                     tui.frame_requester().schedule_frame();
                 }
                 self.transcript_cells.push(cell.clone());
-                if self.initial_history_replay_buffer.is_none() {
+                let replayed_session_header = self
+                    .initial_history_replay_buffer
+                    .as_ref()
+                    .is_some_and(|replay| {
+                        replay.awaiting_session_header
+                            && cell.as_any().is::<history_cell::SessionInfoCell>()
+                    });
+                if self.initial_history_replay_buffer.is_none() || replayed_session_header {
                     self.insert_history_cell_lines(
                         tui,
                         cell.as_ref(),
                         self.chat_widget
                             .history_wrap_width(tui.terminal.last_known_screen_size.width),
                     );
+                }
+                if let Some(replay) = &mut self.initial_history_replay_buffer
+                    && replay.awaiting_session_header
+                {
+                    replay.awaiting_session_header = false;
+                    if replayed_session_header {
+                        replay.source_start = self.transcript_cells.len();
+                    }
                 }
             }
             AppEvent::EndHistoryReplay => {

--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -197,13 +197,7 @@ impl App {
                     tui.frame_requester().schedule_frame();
                 }
                 self.transcript_cells.push(cell.clone());
-                if self.initial_history_replay_buffer.as_ref().is_some() {
-                    self.insert_history_cell_lines_with_initial_replay_buffer(
-                        cell.as_ref(),
-                        self.chat_widget
-                            .history_wrap_width(tui.terminal.last_known_screen_size.width),
-                    );
-                } else {
+                if self.initial_history_replay_buffer.is_none() {
                     self.insert_history_cell_lines(
                         tui,
                         cell.as_ref(),
@@ -212,8 +206,8 @@ impl App {
                     );
                 }
             }
-            AppEvent::EndInitialHistoryReplayBuffer => {
-                self.finish_initial_history_replay_buffer(tui);
+            AppEvent::EndHistoryReplay => {
+                self.finish_history_replay(tui);
             }
             AppEvent::ConsolidateAgentMessage {
                 source,

--- a/codex-rs/tui/src/app/resize_reflow.rs
+++ b/codex-rs/tui/src/app/resize_reflow.rs
@@ -117,7 +117,10 @@ impl App {
     pub(super) fn begin_history_replay(&mut self) {
         if self.terminal_resize_reflow_enabled() && self.overlay.is_none() {
             self.transcript_reflow.clear_pending_reflow();
-            self.initial_history_replay_buffer = Some(InitialHistoryReplayBuffer);
+            self.initial_history_replay_buffer = Some(InitialHistoryReplayBuffer {
+                awaiting_session_header: true,
+                ..Default::default()
+            });
         }
     }
 
@@ -134,18 +137,28 @@ impl App {
 
     /// Render replayed history once from source after all replay events have been applied.
     pub(super) fn finish_history_replay(&mut self, tui: &mut tui::Tui) {
-        if self.initial_history_replay_buffer.take().is_none() {
+        let Some(replay) = self.initial_history_replay_buffer.take() else {
             return;
-        }
+        };
 
-        let width = tui.terminal.last_known_screen_size.width;
-        let reflowed_lines = self.render_transcript_lines_for_reflow(width).lines;
+        let terminal_width = tui.terminal.last_known_screen_size.width;
+        let reflowed_lines = self.render_history_replay_lines(replay.source_start, terminal_width);
         if !reflowed_lines.is_empty() {
             tui.insert_history_hyperlink_lines_with_wrap_policy(
                 reflowed_lines,
                 self.history_line_wrap_policy(),
             );
         }
+    }
+
+    pub(super) fn render_history_replay_lines(
+        &mut self,
+        source_start: usize,
+        terminal_width: u16,
+    ) -> Vec<HyperlinkLine> {
+        let width = self.chat_widget.history_wrap_width(terminal_width);
+        self.render_transcript_lines_for_reflow_from(source_start, width)
+            .lines
     }
 
     pub(crate) fn history_line_wrap_policy(&self) -> HistoryLineWrapPolicy {
@@ -414,12 +427,20 @@ impl App {
     /// were a new top-level history item. The final row trim happens after separators are restored,
     /// so the returned rows obey the cap exactly.
     pub(super) fn render_transcript_lines_for_reflow(&mut self, width: u16) -> ReflowRenderResult {
+        self.render_transcript_lines_for_reflow_from(/*source_start*/ 0, width)
+    }
+
+    fn render_transcript_lines_for_reflow_from(
+        &mut self,
+        source_start: usize,
+        width: u16,
+    ) -> ReflowRenderResult {
         let row_cap = self.resize_reflow_max_rows();
         let mut cell_displays = VecDeque::new();
         let mut rendered_rows = 0usize;
         let mut start = self.transcript_cells.len();
 
-        while start > 0 {
+        while start > source_start {
             start -= 1;
             let cell = self.transcript_cells[start].clone();
             let lines = cell
@@ -435,7 +456,7 @@ impl App {
             }
         }
 
-        while start > 0
+        while start > source_start
             && cell_displays
                 .front()
                 .is_some_and(|display| display.is_stream_continuation)

--- a/codex-rs/tui/src/app/resize_reflow.rs
+++ b/codex-rs/tui/src/app/resize_reflow.rs
@@ -472,7 +472,7 @@ impl App {
             });
         }
 
-        let mut has_emitted_history_lines = false;
+        let mut has_emitted_history_lines = source_start > 0;
         let mut reflowed_lines = Vec::new();
         for display in cell_displays {
             if !display.lines.is_empty() && !display.is_stream_continuation {

--- a/codex-rs/tui/src/app/resize_reflow.rs
+++ b/codex-rs/tui/src/app/resize_reflow.rs
@@ -121,6 +121,7 @@ impl App {
     /// transcript ownership, so overlay replay continues through the normal deferred-history path.
     pub(super) fn begin_initial_history_replay_buffer(&mut self) {
         if self.terminal_resize_reflow_enabled() && self.overlay.is_none() {
+            self.transcript_reflow.clear_pending_reflow();
             self.initial_history_replay_buffer = Some(Default::default());
         }
     }
@@ -131,15 +132,26 @@ impl App {
     /// defer terminal writes until the replay is complete and reuse the resize-reflow tail renderer
     /// so only the rows the terminal would retain are formatted and inserted.
     pub(super) fn begin_thread_switch_history_replay_buffer(&mut self) {
-        if self.terminal_resize_reflow_enabled()
-            && self.resize_reflow_max_rows().is_some()
-            && self.overlay.is_none()
-        {
+        if self.terminal_resize_reflow_enabled() && self.overlay.is_none() {
+            self.transcript_reflow.clear_pending_reflow();
             self.initial_history_replay_buffer = Some(InitialHistoryReplayBuffer {
                 retained_lines: VecDeque::new(),
                 render_from_transcript_tail: true,
             });
         }
+    }
+
+    /// Fold stream-consolidation repair into the source-backed render that ends startup replay.
+    pub(super) fn absorb_reflow_into_initial_history_replay(&mut self) -> bool {
+        let Some(buffer) = &mut self.initial_history_replay_buffer else {
+            return false;
+        };
+
+        buffer.retained_lines.clear();
+        buffer.render_from_transcript_tail = true;
+        self.transcript_reflow.clear_pending_reflow();
+        self.transcript_reflow.clear_stream_flags();
+        true
     }
 
     /// Flush retained initial resume replay rows into terminal scrollback.
@@ -152,17 +164,19 @@ impl App {
             return;
         };
 
-        if buffer.retained_lines.is_empty() {
-            if buffer.render_from_transcript_tail {
-                let width = tui.terminal.last_known_screen_size.width;
-                let reflowed_lines = self.render_transcript_lines_for_reflow(width).lines;
-                if !reflowed_lines.is_empty() {
-                    tui.insert_history_hyperlink_lines_with_wrap_policy(
-                        reflowed_lines,
-                        self.history_line_wrap_policy(),
-                    );
-                }
+        if buffer.render_from_transcript_tail {
+            let width = tui.terminal.last_known_screen_size.width;
+            let reflowed_lines = self.render_transcript_lines_for_reflow(width).lines;
+            if !reflowed_lines.is_empty() {
+                tui.insert_history_hyperlink_lines_with_wrap_policy(
+                    reflowed_lines,
+                    self.history_line_wrap_policy(),
+                );
             }
+            return;
+        }
+
+        if buffer.retained_lines.is_empty() {
             return;
         }
 
@@ -175,7 +189,6 @@ impl App {
 
     pub(super) fn insert_history_cell_lines_with_initial_replay_buffer(
         &mut self,
-        tui: &mut tui::Tui,
         cell: &dyn HistoryCell,
         width: u16,
     ) {
@@ -194,16 +207,12 @@ impl App {
         }
 
         let max_rows = self.resize_reflow_max_rows();
+        let overlay_active = self.overlay.is_some();
         if let Some(buffer) = &mut self.initial_history_replay_buffer {
-            if let Some(max_rows) = max_rows {
-                Self::buffer_initial_history_replay_display_lines(buffer, display, max_rows);
-            } else if self.overlay.is_some() {
+            if overlay_active {
                 self.deferred_history_lines.extend(display);
             } else {
-                tui.insert_history_hyperlink_lines_with_wrap_policy(
-                    display,
-                    self.history_line_wrap_policy(),
-                );
+                Self::buffer_initial_history_replay_display_lines(buffer, display, max_rows);
             }
         }
     }
@@ -224,11 +233,13 @@ impl App {
     pub(super) fn buffer_initial_history_replay_display_lines(
         buffer: &mut InitialHistoryReplayBuffer,
         display: Vec<HyperlinkLine>,
-        max_rows: usize,
+        max_rows: Option<usize>,
     ) {
         buffer.retained_lines.extend(display);
-        while buffer.retained_lines.len() > max_rows {
-            buffer.retained_lines.pop_front();
+        if let Some(max_rows) = max_rows {
+            while buffer.retained_lines.len() > max_rows {
+                buffer.retained_lines.pop_front();
+            }
         }
     }
 
@@ -241,20 +252,6 @@ impl App {
         crate::resize_reflow_cap::resize_reflow_max_rows(self.config.terminal_resize_reflow)
     }
 
-    fn clear_terminal_for_resize_replay(&mut self, tui: &mut tui::Tui) -> Result<()> {
-        if tui.is_alt_screen_active() {
-            tui.terminal.clear_visible_screen()?;
-        } else {
-            tui.terminal.clear_scrollback_and_visible_screen_ansi()?;
-        }
-        let mut area = tui.terminal.viewport_area;
-        if area.y > 0 {
-            area.y = 0;
-            tui.terminal.set_viewport_area(area);
-        }
-        Ok(())
-    }
-
     /// Finish stream consolidation by repairing any resize work that happened during streaming.
     ///
     /// This is called after agent-message stream cells have either been replaced by an
@@ -265,6 +262,9 @@ impl App {
     pub(super) fn maybe_finish_stream_reflow(&mut self, tui: &mut tui::Tui) -> Result<()> {
         if !self.terminal_resize_reflow_enabled() {
             self.transcript_reflow.clear();
+            return Ok(());
+        }
+        if self.absorb_reflow_into_initial_history_replay() {
             return Ok(());
         }
 
@@ -296,6 +296,9 @@ impl App {
             self.transcript_reflow.clear();
             return Ok(());
         }
+        if self.absorb_reflow_into_initial_history_replay() {
+            return Ok(());
+        }
         self.schedule_immediate_resize_reflow(tui);
         self.maybe_run_resize_reflow(tui)?;
         if !self.transcript_reflow.has_pending_reflow() {
@@ -319,9 +322,15 @@ impl App {
         let width = self.transcript_reflow.note_width(size.width);
         let reflow_needed = self.transcript_reflow.reflow_needed_for_width(size.width);
         let height_changed = size.height != last_known_screen_size.height;
-        let should_rebuild_transcript = reflow_needed || height_changed;
+        let resize_requires_rebuild = reflow_needed || height_changed;
+        let replay_in_progress = self.initial_history_replay_buffer.is_some();
+        let should_rebuild_transcript = resize_requires_rebuild && !replay_in_progress;
         if width.changed || width.initialized {
             self.chat_widget.on_terminal_resize(size.width);
+        }
+        if resize_requires_rebuild && let Some(buffer) = &mut self.initial_history_replay_buffer {
+            buffer.retained_lines.clear();
+            buffer.render_from_transcript_tail = true;
         }
         if should_rebuild_transcript {
             if self.terminal_resize_reflow_enabled() {
@@ -446,7 +455,7 @@ impl App {
 
         // Drop any queued pre-resize/pre-consolidation inserts before rebuilding from cells.
         tui.clear_pending_history_lines();
-        self.clear_terminal_for_resize_replay(tui)?;
+        tui.request_terminal_replay_clear();
 
         self.deferred_history_lines.clear();
         if !reflowed_lines.is_empty() {
@@ -475,7 +484,7 @@ impl App {
         };
 
         tui.clear_pending_history_lines();
-        self.clear_terminal_for_resize_replay(tui)?;
+        tui.request_terminal_replay_clear();
 
         self.deferred_history_lines.clear();
         if !reflowed_lines.is_empty() {

--- a/codex-rs/tui/src/app/resize_reflow.rs
+++ b/codex-rs/tui/src/app/resize_reflow.rs
@@ -118,8 +118,10 @@ impl App {
         if self.terminal_resize_reflow_enabled() && self.overlay.is_none() {
             self.transcript_reflow.clear_pending_reflow();
             self.initial_history_replay_buffer = Some(InitialHistoryReplayBuffer {
+                source_start: self.transcript_cells.len(),
                 awaiting_session_header: true,
-                ..Default::default()
+                preserved_session_header: None,
+                had_emitted_history_lines: self.has_emitted_history_lines,
             });
         }
     }
@@ -142,7 +144,7 @@ impl App {
         };
 
         let terminal_width = tui.terminal.last_known_screen_size.width;
-        let reflowed_lines = self.render_history_replay_lines(replay.source_start, terminal_width);
+        let reflowed_lines = self.render_history_replay_lines(replay, terminal_width);
         if !reflowed_lines.is_empty() {
             tui.insert_history_hyperlink_lines_with_wrap_policy(
                 reflowed_lines,
@@ -153,12 +155,24 @@ impl App {
 
     pub(super) fn render_history_replay_lines(
         &mut self,
-        source_start: usize,
+        replay: InitialHistoryReplayBuffer,
         terminal_width: u16,
     ) -> Vec<HyperlinkLine> {
         let width = self.chat_widget.history_wrap_width(terminal_width);
-        self.render_transcript_lines_for_reflow_from(source_start, width)
-            .lines
+        self.has_emitted_history_lines = replay.had_emitted_history_lines;
+        let mut lines = replay
+            .preserved_session_header
+            .map(|header| self.display_lines_for_history_insert(header.as_ref(), width))
+            .unwrap_or_default();
+        lines.extend(
+            self.render_transcript_lines_for_reflow_from(
+                replay.source_start,
+                width,
+                self.has_emitted_history_lines,
+            )
+            .lines,
+        );
+        lines
     }
 
     pub(crate) fn history_line_wrap_policy(&self) -> HistoryLineWrapPolicy {
@@ -427,13 +441,16 @@ impl App {
     /// were a new top-level history item. The final row trim happens after separators are restored,
     /// so the returned rows obey the cap exactly.
     pub(super) fn render_transcript_lines_for_reflow(&mut self, width: u16) -> ReflowRenderResult {
-        self.render_transcript_lines_for_reflow_from(/*source_start*/ 0, width)
+        self.render_transcript_lines_for_reflow_from(
+            /*source_start*/ 0, width, /*had_emitted_history_lines*/ false,
+        )
     }
 
     fn render_transcript_lines_for_reflow_from(
         &mut self,
         source_start: usize,
         width: u16,
+        had_emitted_history_lines: bool,
     ) -> ReflowRenderResult {
         let row_cap = self.resize_reflow_max_rows();
         let mut cell_displays = VecDeque::new();
@@ -472,7 +489,7 @@ impl App {
             });
         }
 
-        let mut has_emitted_history_lines = source_start > 0;
+        let mut has_emitted_history_lines = had_emitted_history_lines;
         let mut reflowed_lines = Vec::new();
         for display in cell_displays {
             if !display.lines.is_empty() && !display.is_stream_continuation {
@@ -490,7 +507,7 @@ impl App {
             let trimmed_line_count = reflowed_lines.len() - max_rows;
             reflowed_lines = reflowed_lines.split_off(trimmed_line_count);
         }
-        self.has_emitted_history_lines = !reflowed_lines.is_empty();
+        self.has_emitted_history_lines = had_emitted_history_lines || !reflowed_lines.is_empty();
 
         ReflowRenderResult {
             lines: reflowed_lines,

--- a/codex-rs/tui/src/app/resize_reflow.rs
+++ b/codex-rs/tui/src/app/resize_reflow.rs
@@ -113,107 +113,38 @@ impl App {
         self.config.features.enabled(Feature::TerminalResizeReflow)
     }
 
-    /// Start retaining initial resume replay rows before they are written to scrollback.
-    ///
-    /// Resume replay can insert thousands of already-finalized history cells before the first draw.
-    /// When resize reflow is enabled, buffering here lets the same row cap used by resize rebuilds
-    /// apply to the startup write. Starting this buffer while an overlay owns rendering would split
-    /// transcript ownership, so overlay replay continues through the normal deferred-history path.
-    pub(super) fn begin_initial_history_replay_buffer(&mut self) {
+    /// Defer resume or thread-switch history writes until replay has rebuilt `transcript_cells`.
+    pub(super) fn begin_history_replay(&mut self) {
         if self.terminal_resize_reflow_enabled() && self.overlay.is_none() {
             self.transcript_reflow.clear_pending_reflow();
-            self.initial_history_replay_buffer = Some(Default::default());
+            self.initial_history_replay_buffer = Some(InitialHistoryReplayBuffer);
         }
     }
 
-    /// Start retaining a thread-switch transcript replay without rendering each historical cell.
-    ///
-    /// Thread switches already rebuild `transcript_cells` from source. When a row cap exists, we can
-    /// defer terminal writes until the replay is complete and reuse the resize-reflow tail renderer
-    /// so only the rows the terminal would retain are formatted and inserted.
-    pub(super) fn begin_thread_switch_history_replay_buffer(&mut self) {
-        if self.terminal_resize_reflow_enabled() && self.overlay.is_none() {
-            self.transcript_reflow.clear_pending_reflow();
-            self.initial_history_replay_buffer = Some(InitialHistoryReplayBuffer {
-                retained_lines: VecDeque::new(),
-                render_from_transcript_tail: true,
-            });
-        }
-    }
-
-    /// Fold stream-consolidation repair into the source-backed render that ends startup replay.
-    pub(super) fn absorb_reflow_into_initial_history_replay(&mut self) -> bool {
-        let Some(buffer) = &mut self.initial_history_replay_buffer else {
+    /// Fold stream-consolidation repair into the source-backed render that ends history replay.
+    pub(super) fn absorb_reflow_into_history_replay(&mut self) -> bool {
+        if self.initial_history_replay_buffer.is_none() {
             return false;
-        };
+        }
 
-        buffer.retained_lines.clear();
-        buffer.render_from_transcript_tail = true;
         self.transcript_reflow.clear_pending_reflow();
         self.transcript_reflow.clear_stream_flags();
         true
     }
 
-    /// Flush retained initial resume replay rows into terminal scrollback.
-    ///
-    /// The buffer stores display lines, not cells, because the cap is measured in terminal rows.
-    /// This mirrors terminal scrollback behavior and avoids making startup replay cheaper or more
-    /// expensive than a later resize rebuild of the same transcript.
-    pub(super) fn finish_initial_history_replay_buffer(&mut self, tui: &mut tui::Tui) {
-        let Some(buffer) = self.initial_history_replay_buffer.take() else {
-            return;
-        };
-
-        if buffer.render_from_transcript_tail {
-            let width = tui.terminal.last_known_screen_size.width;
-            let reflowed_lines = self.render_transcript_lines_for_reflow(width).lines;
-            if !reflowed_lines.is_empty() {
-                tui.insert_history_hyperlink_lines_with_wrap_policy(
-                    reflowed_lines,
-                    self.history_line_wrap_policy(),
-                );
-            }
+    /// Render replayed history once from source after all replay events have been applied.
+    pub(super) fn finish_history_replay(&mut self, tui: &mut tui::Tui) {
+        if self.initial_history_replay_buffer.take().is_none() {
             return;
         }
 
-        if buffer.retained_lines.is_empty() {
-            return;
-        }
-
-        let retained_lines = buffer.retained_lines.into_iter().collect::<Vec<_>>();
-        tui.insert_history_hyperlink_lines_with_wrap_policy(
-            retained_lines,
-            self.history_line_wrap_policy(),
-        );
-    }
-
-    pub(super) fn insert_history_cell_lines_with_initial_replay_buffer(
-        &mut self,
-        cell: &dyn HistoryCell,
-        width: u16,
-    ) {
-        if self
-            .initial_history_replay_buffer
-            .as_ref()
-            .is_some_and(|buffer| buffer.render_from_transcript_tail)
-        {
-            return;
-        }
-
-        let display = self.display_lines_for_history_insert(cell, width);
-
-        if display.is_empty() {
-            return;
-        }
-
-        let max_rows = self.resize_reflow_max_rows();
-        let overlay_active = self.overlay.is_some();
-        if let Some(buffer) = &mut self.initial_history_replay_buffer {
-            if overlay_active {
-                self.deferred_history_lines.extend(display);
-            } else {
-                Self::buffer_initial_history_replay_display_lines(buffer, display, max_rows);
-            }
+        let width = tui.terminal.last_known_screen_size.width;
+        let reflowed_lines = self.render_transcript_lines_for_reflow(width).lines;
+        if !reflowed_lines.is_empty() {
+            tui.insert_history_hyperlink_lines_with_wrap_policy(
+                reflowed_lines,
+                self.history_line_wrap_policy(),
+            );
         }
     }
 
@@ -222,24 +153,6 @@ impl App {
             HistoryLineWrapPolicy::Terminal
         } else {
             HistoryLineWrapPolicy::PreWrap
-        }
-    }
-
-    /// Retain only the newest rendered rows for initial resume replay.
-    ///
-    /// The oldest rows are dropped first because terminal scrollback caps preserve the tail of the
-    /// transcript. Keeping this policy local to display lines is important: trimming source cells
-    /// here would make copy, transcript overlay, and future replay paths disagree about history.
-    pub(super) fn buffer_initial_history_replay_display_lines(
-        buffer: &mut InitialHistoryReplayBuffer,
-        display: Vec<HyperlinkLine>,
-        max_rows: Option<usize>,
-    ) {
-        buffer.retained_lines.extend(display);
-        if let Some(max_rows) = max_rows {
-            while buffer.retained_lines.len() > max_rows {
-                buffer.retained_lines.pop_front();
-            }
         }
     }
 
@@ -264,7 +177,7 @@ impl App {
             self.transcript_reflow.clear();
             return Ok(());
         }
-        if self.absorb_reflow_into_initial_history_replay() {
+        if self.absorb_reflow_into_history_replay() {
             return Ok(());
         }
 
@@ -296,7 +209,7 @@ impl App {
             self.transcript_reflow.clear();
             return Ok(());
         }
-        if self.absorb_reflow_into_initial_history_replay() {
+        if self.absorb_reflow_into_history_replay() {
             return Ok(());
         }
         self.schedule_immediate_resize_reflow(tui);
@@ -327,10 +240,6 @@ impl App {
         let should_rebuild_transcript = resize_requires_rebuild && !replay_in_progress;
         if width.changed || width.initialized {
             self.chat_widget.on_terminal_resize(size.width);
-        }
-        if resize_requires_rebuild && let Some(buffer) = &mut self.initial_history_replay_buffer {
-            buffer.retained_lines.clear();
-            buffer.render_from_transcript_tail = true;
         }
         if should_rebuild_transcript {
             if self.terminal_resize_reflow_enabled() {

--- a/codex-rs/tui/src/app/tests.rs
+++ b/codex-rs/tui/src/app/tests.rs
@@ -4031,7 +4031,7 @@ async fn initial_replay_buffer_keeps_recent_rows_when_row_cap_present() {
                 .as_mut()
                 .expect("initial replay buffer active"),
             vec![Line::from(format!("line {index}")).into()],
-            /*max_rows*/ 3,
+            /*max_rows*/ Some(3),
         );
     }
 
@@ -4070,14 +4070,87 @@ async fn thread_switch_replay_buffer_uses_transcript_tail_mode_when_row_cap_pres
 }
 
 #[tokio::test]
-async fn thread_switch_replay_buffer_is_disabled_without_row_cap() {
+async fn thread_switch_replay_buffer_uses_transcript_tail_without_row_cap() {
     let (mut app, _rx, _op_rx) = make_test_app_with_channels().await;
     enable_terminal_resize_reflow(&mut app);
     app.config.terminal_resize_reflow.max_rows = TerminalResizeReflowMaxRows::Disabled;
 
     app.begin_thread_switch_history_replay_buffer();
 
-    assert!(app.initial_history_replay_buffer.is_none());
+    let buffer = app
+        .initial_history_replay_buffer
+        .as_ref()
+        .expect("thread switch replay buffer should be active");
+    assert!(buffer.render_from_transcript_tail);
+    assert!(buffer.retained_lines.is_empty());
+}
+
+#[tokio::test]
+async fn uncapped_initial_replay_buffer_keeps_all_rows() {
+    let (mut app, _rx, _op_rx) = make_test_app_with_channels().await;
+    enable_terminal_resize_reflow(&mut app);
+    app.config.terminal_resize_reflow.max_rows = TerminalResizeReflowMaxRows::Disabled;
+
+    app.begin_initial_history_replay_buffer();
+    App::buffer_initial_history_replay_display_lines(
+        app.initial_history_replay_buffer
+            .as_mut()
+            .expect("initial replay buffer active"),
+        vec![Line::from("first").into(), Line::from("second").into()],
+        /*max_rows*/ None,
+    );
+
+    let buffer = app
+        .initial_history_replay_buffer
+        .as_ref()
+        .expect("initial replay buffer should remain active");
+    assert_eq!(
+        buffer
+            .retained_lines
+            .iter()
+            .map(rendered_line_text)
+            .collect::<Vec<_>>(),
+        vec!["first".to_string(), "second".to_string()]
+    );
+}
+
+#[tokio::test]
+async fn initial_replay_defers_resize_reflow_and_switches_to_tail_render() {
+    let (mut app, _rx, _op_rx) = make_test_app_with_channels().await;
+    enable_terminal_resize_reflow(&mut app);
+    app.config.terminal_resize_reflow.max_rows = TerminalResizeReflowMaxRows::Disabled;
+    app.transcript_reflow
+        .schedule_debounced(/*target_width*/ Some(118));
+    assert!(app.transcript_reflow.has_pending_reflow());
+
+    app.begin_initial_history_replay_buffer();
+    let frame_requester = crate::tui::FrameRequester::test_dummy();
+
+    assert!(!app.transcript_reflow.has_pending_reflow());
+    App::buffer_initial_history_replay_display_lines(
+        app.initial_history_replay_buffer
+            .as_mut()
+            .expect("initial replay buffer active"),
+        vec![Line::from("stale stream row").into()],
+        /*max_rows*/ None,
+    );
+    app.transcript_reflow
+        .schedule_debounced(/*target_width*/ Some(118));
+    assert!(app.absorb_reflow_into_initial_history_replay());
+    assert!(!app.transcript_reflow.has_pending_reflow());
+    assert!(!app.handle_draw_size_change(
+        ratatui::layout::Size::new(/*width*/ 118, /*height*/ 24),
+        ratatui::layout::Size::new(/*width*/ 118, /*height*/ 35),
+        &frame_requester,
+    ));
+
+    assert!(!app.transcript_reflow.has_pending_reflow());
+    let buffer = app
+        .initial_history_replay_buffer
+        .as_ref()
+        .expect("initial replay buffer should remain active");
+    assert!(buffer.render_from_transcript_tail);
+    assert!(buffer.retained_lines.is_empty());
 }
 
 #[tokio::test]

--- a/codex-rs/tui/src/app/tests.rs
+++ b/codex-rs/tui/src/app/tests.rs
@@ -386,6 +386,57 @@ async fn enqueue_primary_thread_session_replays_turns_before_initial_prompt_subm
 }
 
 #[tokio::test]
+async fn enqueue_primary_thread_session_orders_replay_after_queued_history() -> Result<()> {
+    let (mut app, mut app_event_rx, _op_rx) = make_test_app_with_channels().await;
+    enable_terminal_resize_reflow(&mut app);
+    app.app_event_tx.send(AppEvent::InsertHistoryCell(Box::new(
+        PlainHistoryCell::new(vec![Line::from("startup warning")]),
+    )));
+
+    app.enqueue_primary_thread_session(
+        test_thread_session(ThreadId::new(), test_path_buf("/tmp/project")),
+        vec![test_turn("turn-1", TurnStatus::Completed, Vec::new())],
+    )
+    .await?;
+
+    let events = std::iter::from_fn(|| app_event_rx.try_recv().ok()).collect::<Vec<_>>();
+    let warning = events
+        .iter()
+        .position(|event| match event {
+            AppEvent::InsertHistoryCell(cell) => {
+                lines_to_single_string(&cell.transcript_lines(/*width*/ 80))
+                    .contains("startup warning")
+            }
+            _ => false,
+        })
+        .expect("queued warning");
+    let begin = events
+        .iter()
+        .position(|event| matches!(event, AppEvent::BeginHistoryReplay))
+        .expect("replay start");
+    let header = events
+        .iter()
+        .position(|event| {
+            matches!(
+                event,
+                AppEvent::InsertHistoryCell(cell)
+                    if cell.as_any().is::<history_cell::SessionInfoCell>()
+            )
+        })
+        .expect("session header");
+    let end = events
+        .iter()
+        .position(|event| matches!(event, AppEvent::EndHistoryReplay))
+        .expect("replay end");
+
+    assert!(warning < begin);
+    assert!(begin < header);
+    assert!(header < end);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn reset_thread_event_state_aborts_listener_tasks() {
     struct NotifyOnDrop(Option<tokio::sync::oneshot::Sender<()>>);
 
@@ -4023,10 +4074,17 @@ async fn history_replay_activates_without_row_cap() {
     let (mut app, _rx, _op_rx) = make_test_app_with_channels().await;
     enable_terminal_resize_reflow(&mut app);
     app.config.terminal_resize_reflow.max_rows = TerminalResizeReflowMaxRows::Disabled;
+    app.transcript_cells = vec![plain_line_cell("existing")];
+    app.has_emitted_history_lines = true;
 
     app.begin_history_replay();
 
-    assert!(app.initial_history_replay_buffer.is_some());
+    let replay = app
+        .initial_history_replay_buffer
+        .as_ref()
+        .expect("history replay");
+    assert_eq!(replay.source_start, 1);
+    assert!(replay.had_emitted_history_lines);
 }
 
 #[tokio::test]
@@ -4064,11 +4122,24 @@ async fn capped_history_replay_excludes_preserved_header_from_source_render() {
         /*auth_plan*/ None,
         /*show_fast_status*/ false,
     ));
-    let expected = vec![Line::from("tail").into()];
-    app.transcript_cells = vec![header, plain_line_cell("tail")];
+    let tail = plain_line_cell("tail");
+    let mut expected = header
+        .display_hyperlink_lines_for_mode(/*width*/ 80, app.chat_widget.history_render_mode());
+    expected.extend(tail.display_hyperlink_lines_for_mode(
+        /*width*/ 80,
+        app.chat_widget.history_render_mode(),
+    ));
+    app.transcript_cells = vec![header.clone(), tail];
 
-    let rendered =
-        app.render_history_replay_lines(/*source_start*/ 1, /*terminal_width*/ 80);
+    let rendered = app.render_history_replay_lines(
+        InitialHistoryReplayBuffer {
+            source_start: 1,
+            awaiting_session_header: false,
+            preserved_session_header: Some(header),
+            had_emitted_history_lines: false,
+        },
+        /*terminal_width*/ 80,
+    );
 
     assert_eq!(rendered, expected);
 }
@@ -4083,10 +4154,19 @@ async fn history_replay_preserves_separator_after_session_header_snapshot() {
         plain_line_cell("second message"),
     ];
 
-    let replayed =
-        app.render_history_replay_lines(/*source_start*/ 1, /*terminal_width*/ 80);
-    let rendered = std::iter::once("session header".to_string())
-        .chain(replayed.iter().map(rendered_line_text))
+    let header = app.transcript_cells[0].clone();
+    let rendered = app
+        .render_history_replay_lines(
+            InitialHistoryReplayBuffer {
+                source_start: 1,
+                awaiting_session_header: false,
+                preserved_session_header: Some(header),
+                had_emitted_history_lines: false,
+            },
+            /*terminal_width*/ 80,
+        )
+        .iter()
+        .map(rendered_line_text)
         .collect::<Vec<_>>()
         .join("\n");
 
@@ -4111,8 +4191,80 @@ async fn history_replay_uses_pet_reserved_width() {
         cell.display_hyperlink_lines_for_mode(width, app.chat_widget.history_render_mode());
     app.transcript_cells = vec![cell];
 
-    let rendered =
-        app.render_history_replay_lines(/*source_start*/ 0, /*terminal_width*/ 40);
+    let rendered = app.render_history_replay_lines(
+        InitialHistoryReplayBuffer {
+            source_start: 0,
+            awaiting_session_header: false,
+            preserved_session_header: None,
+            had_emitted_history_lines: false,
+        },
+        /*terminal_width*/ 40,
+    );
+
+    assert_eq!(rendered, expected);
+}
+
+#[tokio::test]
+async fn history_replay_preserves_emitted_state_after_empty_suffix() {
+    let (mut app, _rx, _op_rx) = make_test_app_with_channels().await;
+    let header = plain_line_cell("session header");
+    let empty: Arc<dyn HistoryCell> = Arc::new(PlainHistoryCell::new(Vec::new()));
+    app.transcript_cells = vec![header.clone(), empty];
+
+    let rendered = app.render_history_replay_lines(
+        InitialHistoryReplayBuffer {
+            source_start: 1,
+            awaiting_session_header: false,
+            preserved_session_header: Some(header.clone()),
+            had_emitted_history_lines: false,
+        },
+        /*terminal_width*/ 80,
+    );
+
+    assert_eq!(
+        rendered,
+        header.display_hyperlink_lines_for_mode(
+            /*width*/ 80,
+            app.chat_widget.history_render_mode(),
+        )
+    );
+    assert!(app.has_emitted_history_lines);
+}
+
+#[tokio::test]
+async fn history_replay_renders_preserved_header_at_final_width() {
+    let (mut app, _rx, _op_rx) = make_test_app_with_channels().await;
+    let session = test_thread_session(ThreadId::new(), test_path_buf("/tmp/project"));
+    let header: Arc<dyn HistoryCell> = Arc::new(new_session_info(
+        app.chat_widget.config_ref(),
+        app.chat_widget.current_model(),
+        &session,
+        /*is_first_event*/ false,
+        /*tooltip_override*/ None,
+        /*auth_plan*/ None,
+        /*show_fast_status*/ false,
+    ));
+    let final_width = 32;
+    let expected =
+        header.display_hyperlink_lines_for_mode(final_width, app.chat_widget.history_render_mode());
+    assert_ne!(
+        expected,
+        header.display_hyperlink_lines_for_mode(
+            /*width*/ 80,
+            app.chat_widget.history_render_mode(),
+        )
+    );
+    app.transcript_cells = vec![header.clone()];
+
+    let rendered = app.render_history_replay_lines(
+        InitialHistoryReplayBuffer {
+            source_start: 1,
+            awaiting_session_header: false,
+            preserved_session_header: Some(header),
+            had_emitted_history_lines: false,
+        },
+        final_width,
+    );
 
     assert_eq!(rendered, expected);
 }

--- a/codex-rs/tui/src/app/tests.rs
+++ b/codex-rs/tui/src/app/tests.rs
@@ -4030,6 +4030,71 @@ async fn history_replay_activates_without_row_cap() {
 }
 
 #[tokio::test]
+async fn capped_history_replay_excludes_preserved_header_from_source_render() {
+    let (mut app, _rx, _op_rx) = make_test_app_with_channels().await;
+    app.config.terminal_resize_reflow.max_rows = TerminalResizeReflowMaxRows::Limit(1);
+    let session = ThreadSessionState {
+        thread_id: ThreadId::new(),
+        forked_from_id: None,
+        fork_parent_title: None,
+        thread_name: None,
+        model: "gpt-test".to_string(),
+        model_provider_id: "test-provider".to_string(),
+        service_tier: None,
+        approval_policy: AskForApproval::Never,
+        approvals_reviewer: ApprovalsReviewer::User,
+        permission_profile: PermissionProfile::read_only(),
+        active_permission_profile: None,
+        cwd: test_path_buf("/tmp/project").abs(),
+        runtime_workspace_roots: Vec::new(),
+        instruction_source_paths: Vec::new(),
+        reasoning_effort: None,
+        collaboration_mode: None,
+        personality: None,
+        message_history: None,
+        network_proxy: None,
+        rollout_path: Some(PathBuf::new()),
+    };
+    let header = Arc::new(new_session_info(
+        app.chat_widget.config_ref(),
+        app.chat_widget.current_model(),
+        &session,
+        /*is_first_event*/ false,
+        /*tooltip_override*/ None,
+        /*auth_plan*/ None,
+        /*show_fast_status*/ false,
+    ));
+    let expected = vec![Line::from("tail").into()];
+    app.transcript_cells = vec![header, plain_line_cell("tail")];
+
+    let rendered =
+        app.render_history_replay_lines(/*source_start*/ 1, /*terminal_width*/ 80);
+
+    assert_eq!(rendered, expected);
+}
+
+#[tokio::test]
+async fn history_replay_uses_pet_reserved_width() {
+    let (mut app, _rx, _op_rx) = make_test_app_with_channels().await;
+    app.chat_widget
+        .set_pet_image_support_for_tests(crate::pets::PetImageSupport::Supported(
+            crate::pets::ImageProtocol::Kitty,
+        ));
+    app.chat_widget
+        .install_test_ambient_pet_for_tests(/*animations_enabled*/ false);
+    let cell = plain_line_cell("one two three four five six seven eight nine ten");
+    let width = app.chat_widget.history_wrap_width(/*width*/ 40);
+    let expected =
+        cell.display_hyperlink_lines_for_mode(width, app.chat_widget.history_render_mode());
+    app.transcript_cells = vec![cell];
+
+    let rendered =
+        app.render_history_replay_lines(/*source_start*/ 0, /*terminal_width*/ 40);
+
+    assert_eq!(rendered, expected);
+}
+
+#[tokio::test]
 async fn history_replay_defers_resize_and_consolidation_reflows() {
     let (mut app, _rx, _op_rx) = make_test_app_with_channels().await;
     enable_terminal_resize_reflow(&mut app);

--- a/codex-rs/tui/src/app/tests.rs
+++ b/codex-rs/tui/src/app/tests.rs
@@ -4074,6 +4074,29 @@ async fn capped_history_replay_excludes_preserved_header_from_source_render() {
 }
 
 #[tokio::test]
+async fn history_replay_preserves_separator_after_session_header_snapshot() {
+    let (mut app, _rx, _op_rx) = make_test_app_with_channels().await;
+    app.config.terminal_resize_reflow.max_rows = TerminalResizeReflowMaxRows::Disabled;
+    app.transcript_cells = vec![
+        plain_line_cell("session header"),
+        plain_line_cell("first message"),
+        plain_line_cell("second message"),
+    ];
+
+    let replayed =
+        app.render_history_replay_lines(/*source_start*/ 1, /*terminal_width*/ 80);
+    let rendered = std::iter::once("session header".to_string())
+        .chain(replayed.iter().map(rendered_line_text))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert_app_snapshot!(
+        "history_replay_preserves_separator_after_session_header",
+        rendered,
+    );
+}
+
+#[tokio::test]
 async fn history_replay_uses_pet_reserved_width() {
     let (mut app, _rx, _op_rx) = make_test_app_with_channels().await;
     app.chat_widget

--- a/codex-rs/tui/src/app/tests.rs
+++ b/codex-rs/tui/src/app/tests.rs
@@ -4019,103 +4019,18 @@ async fn uncapped_resize_reflow_renders_all_cells_under_row_limit() {
 }
 
 #[tokio::test]
-async fn initial_replay_buffer_keeps_recent_rows_when_row_cap_present() {
-    let (mut app, _rx, _op_rx) = make_test_app_with_channels().await;
-    enable_terminal_resize_reflow(&mut app);
-    app.config.terminal_resize_reflow.max_rows = TerminalResizeReflowMaxRows::Limit(3);
-
-    app.begin_initial_history_replay_buffer();
-    for index in 0..5 {
-        App::buffer_initial_history_replay_display_lines(
-            app.initial_history_replay_buffer
-                .as_mut()
-                .expect("initial replay buffer active"),
-            vec![Line::from(format!("line {index}")).into()],
-            /*max_rows*/ Some(3),
-        );
-    }
-
-    let buffer = app
-        .initial_history_replay_buffer
-        .as_ref()
-        .expect("initial replay buffer should remain active");
-    assert_eq!(
-        buffer
-            .retained_lines
-            .iter()
-            .map(rendered_line_text)
-            .collect::<Vec<_>>(),
-        vec![
-            "line 2".to_string(),
-            "line 3".to_string(),
-            "line 4".to_string(),
-        ]
-    );
-}
-
-#[tokio::test]
-async fn thread_switch_replay_buffer_uses_transcript_tail_mode_when_row_cap_present() {
-    let (mut app, _rx, _op_rx) = make_test_app_with_channels().await;
-    enable_terminal_resize_reflow(&mut app);
-    app.config.terminal_resize_reflow.max_rows = TerminalResizeReflowMaxRows::Limit(3);
-
-    app.begin_thread_switch_history_replay_buffer();
-
-    let buffer = app
-        .initial_history_replay_buffer
-        .as_ref()
-        .expect("thread switch replay buffer should be active");
-    assert!(buffer.render_from_transcript_tail);
-    assert!(buffer.retained_lines.is_empty());
-}
-
-#[tokio::test]
-async fn thread_switch_replay_buffer_uses_transcript_tail_without_row_cap() {
+async fn history_replay_activates_without_row_cap() {
     let (mut app, _rx, _op_rx) = make_test_app_with_channels().await;
     enable_terminal_resize_reflow(&mut app);
     app.config.terminal_resize_reflow.max_rows = TerminalResizeReflowMaxRows::Disabled;
 
-    app.begin_thread_switch_history_replay_buffer();
+    app.begin_history_replay();
 
-    let buffer = app
-        .initial_history_replay_buffer
-        .as_ref()
-        .expect("thread switch replay buffer should be active");
-    assert!(buffer.render_from_transcript_tail);
-    assert!(buffer.retained_lines.is_empty());
+    assert!(app.initial_history_replay_buffer.is_some());
 }
 
 #[tokio::test]
-async fn uncapped_initial_replay_buffer_keeps_all_rows() {
-    let (mut app, _rx, _op_rx) = make_test_app_with_channels().await;
-    enable_terminal_resize_reflow(&mut app);
-    app.config.terminal_resize_reflow.max_rows = TerminalResizeReflowMaxRows::Disabled;
-
-    app.begin_initial_history_replay_buffer();
-    App::buffer_initial_history_replay_display_lines(
-        app.initial_history_replay_buffer
-            .as_mut()
-            .expect("initial replay buffer active"),
-        vec![Line::from("first").into(), Line::from("second").into()],
-        /*max_rows*/ None,
-    );
-
-    let buffer = app
-        .initial_history_replay_buffer
-        .as_ref()
-        .expect("initial replay buffer should remain active");
-    assert_eq!(
-        buffer
-            .retained_lines
-            .iter()
-            .map(rendered_line_text)
-            .collect::<Vec<_>>(),
-        vec!["first".to_string(), "second".to_string()]
-    );
-}
-
-#[tokio::test]
-async fn initial_replay_defers_resize_reflow_and_switches_to_tail_render() {
+async fn history_replay_defers_resize_and_consolidation_reflows() {
     let (mut app, _rx, _op_rx) = make_test_app_with_channels().await;
     enable_terminal_resize_reflow(&mut app);
     app.config.terminal_resize_reflow.max_rows = TerminalResizeReflowMaxRows::Disabled;
@@ -4123,20 +4038,13 @@ async fn initial_replay_defers_resize_reflow_and_switches_to_tail_render() {
         .schedule_debounced(/*target_width*/ Some(118));
     assert!(app.transcript_reflow.has_pending_reflow());
 
-    app.begin_initial_history_replay_buffer();
+    app.begin_history_replay();
     let frame_requester = crate::tui::FrameRequester::test_dummy();
 
     assert!(!app.transcript_reflow.has_pending_reflow());
-    App::buffer_initial_history_replay_display_lines(
-        app.initial_history_replay_buffer
-            .as_mut()
-            .expect("initial replay buffer active"),
-        vec![Line::from("stale stream row").into()],
-        /*max_rows*/ None,
-    );
     app.transcript_reflow
         .schedule_debounced(/*target_width*/ Some(118));
-    assert!(app.absorb_reflow_into_initial_history_replay());
+    assert!(app.absorb_reflow_into_history_replay());
     assert!(!app.transcript_reflow.has_pending_reflow());
     assert!(!app.handle_draw_size_change(
         ratatui::layout::Size::new(/*width*/ 118, /*height*/ 24),
@@ -4145,12 +4053,7 @@ async fn initial_replay_defers_resize_reflow_and_switches_to_tail_render() {
     ));
 
     assert!(!app.transcript_reflow.has_pending_reflow());
-    let buffer = app
-        .initial_history_replay_buffer
-        .as_ref()
-        .expect("initial replay buffer should remain active");
-    assert!(buffer.render_from_transcript_tail);
-    assert!(buffer.retained_lines.is_empty());
+    assert!(app.initial_history_replay_buffer.is_some());
 }
 
 #[tokio::test]

--- a/codex-rs/tui/src/app/thread_routing.rs
+++ b/codex-rs/tui/src/app/thread_routing.rs
@@ -1074,8 +1074,7 @@ impl App {
         let should_buffer_initial_replay =
             self.terminal_resize_reflow_enabled() && !turns.is_empty();
         if should_buffer_initial_replay {
-            self.app_event_tx
-                .send(AppEvent::BeginInitialHistoryReplayBuffer);
+            self.begin_initial_history_replay_buffer();
         }
         self.chat_widget
             .replay_thread_turns(turns, ReplayKind::ResumeInitialMessages);
@@ -1264,8 +1263,7 @@ impl App {
         let should_buffer_replay = self.terminal_resize_reflow_enabled()
             && (!snapshot.turns.is_empty() || !snapshot.events.is_empty());
         if should_buffer_replay {
-            self.app_event_tx
-                .send(AppEvent::BeginThreadSwitchHistoryReplayBuffer);
+            self.begin_thread_switch_history_replay_buffer();
         }
         let suppress_replay_notices =
             replay_filter::snapshot_has_pending_interactive_request(&snapshot);

--- a/codex-rs/tui/src/app/thread_routing.rs
+++ b/codex-rs/tui/src/app/thread_routing.rs
@@ -1070,12 +1070,12 @@ impl App {
         self.activate_thread_channel(thread_id).await;
         self.chat_widget
             .set_initial_user_message_submit_suppressed(/*suppressed*/ true);
-        self.chat_widget.handle_thread_session(session);
         let should_buffer_initial_replay =
             self.terminal_resize_reflow_enabled() && !turns.is_empty();
         if should_buffer_initial_replay {
-            self.begin_history_replay();
+            self.app_event_tx.send(AppEvent::BeginHistoryReplay);
         }
+        self.chat_widget.handle_thread_session(session);
         self.chat_widget
             .replay_thread_turns(turns, ReplayKind::ResumeInitialMessages);
         if should_buffer_initial_replay {
@@ -1262,7 +1262,7 @@ impl App {
         let should_buffer_replay = self.terminal_resize_reflow_enabled()
             && (!snapshot.turns.is_empty() || !snapshot.events.is_empty());
         if should_buffer_replay {
-            self.begin_history_replay();
+            self.app_event_tx.send(AppEvent::BeginHistoryReplay);
         }
         let suppress_replay_notices =
             replay_filter::snapshot_has_pending_interactive_request(&snapshot);

--- a/codex-rs/tui/src/app/thread_routing.rs
+++ b/codex-rs/tui/src/app/thread_routing.rs
@@ -1074,13 +1074,12 @@ impl App {
         let should_buffer_initial_replay =
             self.terminal_resize_reflow_enabled() && !turns.is_empty();
         if should_buffer_initial_replay {
-            self.begin_initial_history_replay_buffer();
+            self.begin_history_replay();
         }
         self.chat_widget
             .replay_thread_turns(turns, ReplayKind::ResumeInitialMessages);
         if should_buffer_initial_replay {
-            self.app_event_tx
-                .send(AppEvent::EndInitialHistoryReplayBuffer);
+            self.app_event_tx.send(AppEvent::EndHistoryReplay);
         }
         let pending = std::mem::take(&mut self.pending_primary_events);
         for pending_event in pending {
@@ -1263,7 +1262,7 @@ impl App {
         let should_buffer_replay = self.terminal_resize_reflow_enabled()
             && (!snapshot.turns.is_empty() || !snapshot.events.is_empty());
         if should_buffer_replay {
-            self.begin_thread_switch_history_replay_buffer();
+            self.begin_history_replay();
         }
         let suppress_replay_notices =
             replay_filter::snapshot_has_pending_interactive_request(&snapshot);
@@ -1291,8 +1290,7 @@ impl App {
             self.handle_thread_event_replay(event);
         }
         if should_buffer_replay {
-            self.app_event_tx
-                .send(AppEvent::EndInitialHistoryReplayBuffer);
+            self.app_event_tx.send(AppEvent::EndHistoryReplay);
         }
         self.chat_widget
             .set_queue_autosend_suppressed(/*suppressed*/ false);

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -577,8 +577,8 @@ pub(crate) enum AppEvent {
 
     InsertHistoryCell(Box<dyn HistoryCell>),
 
-    /// Finish buffering initial resume replay after all replay events have been queued.
-    EndInitialHistoryReplayBuffer,
+    /// Render deferred history after all resume or thread-switch replay events have been queued.
+    EndHistoryReplay,
 
     /// Replace the contiguous run of streaming `AgentMessageCell`s at the end of
     /// the transcript with a single `AgentMarkdownCell` that stores the raw

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -575,13 +575,6 @@ pub(crate) enum AppEvent {
         result: Result<SkillsListResponse, String>,
     },
 
-    /// Begin buffering initial resume replay rows before they are written to scrollback.
-    BeginInitialHistoryReplayBuffer,
-
-    /// Begin buffering thread-switch replay cells so the final scrollback write can reuse the
-    /// resize-reflow tail renderer.
-    BeginThreadSwitchHistoryReplayBuffer,
-
     InsertHistoryCell(Box<dyn HistoryCell>),
 
     /// Finish buffering initial resume replay after all replay events have been queued.

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -577,6 +577,9 @@ pub(crate) enum AppEvent {
 
     InsertHistoryCell(Box<dyn HistoryCell>),
 
+    /// Start deferring replay history at this exact point in the app-event queue.
+    BeginHistoryReplay,
+
     /// Render deferred history after all resume or thread-switch replay events have been queued.
     EndHistoryReplay,
 

--- a/codex-rs/tui/src/snapshots/codex_tui__app__tests__history_replay_preserves_separator_after_session_header.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__app__tests__history_replay_preserves_separator_after_session_header.snap
@@ -1,0 +1,9 @@
+---
+source: tui/src/app/tests.rs
+expression: rendered
+---
+session header
+
+first message
+
+second message

--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -84,6 +84,22 @@ fn should_emit_notification(condition: NotificationCondition, terminal_focused: 
     }
 }
 
+fn run_synchronized_draw<W, T>(
+    writer: &mut W,
+    replay_clear_pending: &mut bool,
+    operations: impl FnOnce(&mut W) -> Result<T>,
+) -> Result<T>
+where
+    W: Write,
+{
+    let replay_clear_requested = *replay_clear_pending;
+    let result = writer.sync_update(operations)?;
+    if replay_clear_requested && result.is_ok() {
+        *replay_clear_pending = false;
+    }
+    result
+}
+
 impl Drop for Tui {
     fn drop(&mut self) {
         if let Err(err) = self.clear_ambient_pet_image() {
@@ -97,10 +113,12 @@ mod tests {
     use std::io::Write as _;
 
     use super::clear_for_viewport_change;
+    use super::run_synchronized_draw;
     use super::should_emit_notification;
     use crate::custom_terminal::Terminal as CustomTerminal;
     use crate::test_backend::VT100Backend;
     use codex_config::types::NotificationCondition;
+    use pretty_assertions::assert_eq;
     use ratatui::layout::Position;
     use ratatui::layout::Rect;
 
@@ -167,6 +185,76 @@ mod tests {
             !rows.iter().skip(1).any(|row| row.contains("stale")),
             "expected stale cells inside the new viewport to be cleared, rows: {rows:?}"
         );
+    }
+
+    #[test]
+    fn synchronized_draw_wraps_replay_clear_and_repaint() {
+        let mut output = Vec::new();
+        let mut replay_clear_pending = true;
+        let replay_clear_requested = replay_clear_pending;
+
+        let value = run_synchronized_draw(&mut output, &mut replay_clear_pending, |writer| {
+            assert!(replay_clear_requested);
+            writer.write_all(b"clear")?;
+            writer.write_all(b"replay")?;
+            Ok(42)
+        })
+        .expect("synchronized draw");
+
+        assert_eq!(value, 42);
+        assert!(!replay_clear_pending);
+        assert_eq!(output, b"\x1b[?2026hclearreplay\x1b[?2026l");
+    }
+
+    #[test]
+    fn synchronized_draw_retries_replay_clear_after_render_error() {
+        let mut output = Vec::new();
+        let mut replay_clear_pending = true;
+        let replay_clear_requested = replay_clear_pending;
+
+        let error = run_synchronized_draw(&mut output, &mut replay_clear_pending, |writer| {
+            assert!(replay_clear_requested);
+            writer.write_all(b"clear")?;
+            Err::<(), _>(std::io::Error::other("render failed"))
+        })
+        .expect_err("draw should fail");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert!(replay_clear_pending);
+        assert_eq!(output, b"\x1b[?2026hclear\x1b[?2026l");
+    }
+
+    #[test]
+    fn synchronized_draw_retries_replay_clear_after_sync_flush_error() {
+        struct FailOnFlush {
+            output: Vec<u8>,
+        }
+
+        impl std::io::Write for FailOnFlush {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.output.extend_from_slice(buf);
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> std::io::Result<()> {
+                Err(std::io::Error::other("flush failed"))
+            }
+        }
+
+        let mut writer = FailOnFlush { output: Vec::new() };
+        let mut replay_clear_pending = true;
+        let replay_clear_requested = replay_clear_pending;
+
+        let error = run_synchronized_draw(&mut writer, &mut replay_clear_pending, |writer| {
+            assert!(replay_clear_requested);
+            writer.write_all(b"clear")?;
+            Ok(())
+        })
+        .expect_err("sync flush should fail");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert!(replay_clear_pending);
+        assert_eq!(writer.output, b"\x1b[?2026hclear\x1b[?2026l");
     }
 }
 
@@ -498,6 +586,8 @@ pub struct Tui {
     suspend_context: SuspendContext,
     // True when overlay alt-screen UI is active
     alt_screen_active: Arc<AtomicBool>,
+    // Rebuilds clear the terminal inside the next synchronized draw before replaying history.
+    terminal_replay_clear_pending: bool,
     // True when terminal/tab is focused; updated internally from crossterm events
     terminal_focused: Arc<AtomicBool>,
     enhanced_keys_supported: bool,
@@ -554,6 +644,7 @@ impl Tui {
             #[cfg(unix)]
             suspend_context: SuspendContext::new(),
             alt_screen_active: Arc::new(AtomicBool::new(false)),
+            terminal_replay_clear_pending: false,
             terminal_focused: Arc::new(AtomicBool::new(true)),
             enhanced_keys_supported,
             notification_backend: Some(detect_backend(NotificationMethod::default())),
@@ -588,6 +679,10 @@ impl Tui {
 
     pub fn is_alt_screen_active(&self) -> bool {
         self.alt_screen_active.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn request_terminal_replay_clear(&mut self) {
+        self.terminal_replay_clear_pending = true;
     }
 
     // Drop crossterm EventStream to avoid stdin conflicts with other processes.
@@ -768,6 +863,20 @@ impl Tui {
         self.pending_history_lines.clear();
     }
 
+    fn clear_terminal_for_replay(&mut self) -> Result<()> {
+        if self.is_alt_screen_active() {
+            self.terminal.clear_visible_screen()?;
+        } else {
+            self.terminal.clear_scrollback_and_visible_screen_ansi()?;
+        }
+        let mut area = self.terminal.viewport_area;
+        if area.y > 0 {
+            area.y = 0;
+            self.terminal.set_viewport_area(area);
+        }
+        Ok(())
+    }
+
     /// Resize the inline viewport for the resize-reflow path.
     ///
     /// Unlike the legacy draw path, this path does not scroll rows above the viewport when the
@@ -852,14 +961,24 @@ impl Tui {
 
         // Precompute any viewport updates that need a cursor-position query before entering
         // the synchronized update, to avoid racing with the event reader.
-        let mut pending_viewport_area = self.pending_viewport_area()?;
+        let mut pending_viewport_area = if self.terminal_replay_clear_pending {
+            None
+        } else {
+            self.pending_viewport_area()?
+        };
 
         ensure_virtual_terminal_processing()?;
 
-        stdout().sync_update(|_| {
+        let mut replay_clear_pending = self.terminal_replay_clear_pending;
+        let replay_clear_requested = replay_clear_pending;
+        let result = run_synchronized_draw(&mut stdout(), &mut replay_clear_pending, |_| {
             #[cfg(unix)]
             if let Some(prepared) = prepared_resume.take() {
                 prepared.apply(&mut self.terminal)?;
+            }
+
+            if replay_clear_requested {
+                self.clear_terminal_for_replay()?;
             }
 
             let terminal = &mut self.terminal;
@@ -910,7 +1029,9 @@ impl Tui {
             terminal.draw(|frame| {
                 draw_fn(frame);
             })
-        })?
+        });
+        self.terminal_replay_clear_pending = replay_clear_pending;
+        result
     }
 
     pub fn draw_ambient_pet_image(
@@ -988,10 +1109,16 @@ impl Tui {
 
         ensure_virtual_terminal_processing()?;
 
-        stdout().sync_update(|_| {
+        let mut replay_clear_pending = self.terminal_replay_clear_pending;
+        let replay_clear_requested = replay_clear_pending;
+        let result = run_synchronized_draw(&mut stdout(), &mut replay_clear_pending, |_| {
             #[cfg(unix)]
             if let Some(prepared) = prepared_resume.take() {
                 prepared.apply(&mut self.terminal)?;
+            }
+
+            if replay_clear_requested {
+                self.clear_terminal_for_replay()?;
             }
 
             let terminal = &mut self.terminal;
@@ -1024,7 +1151,9 @@ impl Tui {
             terminal.draw(|frame| {
                 draw_fn(frame);
             })
-        })?
+        });
+        self.terminal_replay_clear_pending = replay_clear_pending;
+        result
     }
 
     fn pending_viewport_area(&mut self) -> Result<Option<Rect>> {

--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -59,7 +59,11 @@ mod frame_requester;
 #[cfg(unix)]
 mod job_control;
 mod keyboard_modes;
+mod replay_clear;
 mod terminal_stderr;
+
+use self::replay_clear::ReplayClearState;
+use self::replay_clear::run_synchronized_draw;
 
 /// Target frame interval for UI redraw scheduling.
 pub(crate) const TARGET_FRAME_INTERVAL: Duration = frame_rate_limiter::MIN_FRAME_INTERVAL;
@@ -84,16 +88,6 @@ fn should_emit_notification(condition: NotificationCondition, terminal_focused: 
     }
 }
 
-fn run_synchronized_draw<W, T>(
-    writer: &mut W,
-    operations: impl FnOnce(&mut W) -> Result<T>,
-) -> Result<T>
-where
-    W: Write,
-{
-    writer.sync_update(operations)?
-}
-
 impl Drop for Tui {
     fn drop(&mut self) {
         if let Err(err) = self.clear_ambient_pet_image() {
@@ -107,12 +101,10 @@ mod tests {
     use std::io::Write as _;
 
     use super::clear_for_viewport_change;
-    use super::run_synchronized_draw;
     use super::should_emit_notification;
     use crate::custom_terminal::Terminal as CustomTerminal;
     use crate::test_backend::VT100Backend;
     use codex_config::types::NotificationCondition;
-    use pretty_assertions::assert_eq;
     use ratatui::layout::Position;
     use ratatui::layout::Rect;
 
@@ -179,79 +171,6 @@ mod tests {
             !rows.iter().skip(1).any(|row| row.contains("stale")),
             "expected stale cells inside the new viewport to be cleared, rows: {rows:?}"
         );
-    }
-
-    #[test]
-    fn synchronized_draw_wraps_replay_clear_and_repaint() {
-        let mut output = Vec::new();
-        let mut replay_clear_pending = true;
-        let replay_clear_requested = replay_clear_pending;
-
-        let value = run_synchronized_draw(&mut output, |writer| {
-            assert!(replay_clear_requested);
-            writer.write_all(b"clear")?;
-            writer.write_all(b"replay")?;
-            replay_clear_pending = false;
-            Ok(42)
-        })
-        .expect("synchronized draw");
-
-        assert_eq!(value, 42);
-        assert!(!replay_clear_pending);
-        assert_eq!(output, b"\x1b[?2026hclearreplay\x1b[?2026l");
-    }
-
-    #[test]
-    fn synchronized_draw_retries_replay_clear_after_render_error() {
-        let mut output = Vec::new();
-        let replay_clear_pending = true;
-        let replay_clear_requested = replay_clear_pending;
-
-        let error = run_synchronized_draw(&mut output, |writer| {
-            assert!(replay_clear_requested);
-            writer.write_all(b"clear")?;
-            Err::<(), _>(std::io::Error::other("render failed"))
-        })
-        .expect_err("draw should fail");
-
-        assert_eq!(error.kind(), std::io::ErrorKind::Other);
-        assert!(replay_clear_pending);
-        assert_eq!(output, b"\x1b[?2026hclear\x1b[?2026l");
-    }
-
-    #[test]
-    fn synchronized_draw_does_not_retry_clear_after_replay_is_committed() {
-        struct FailOnFlush {
-            output: Vec<u8>,
-        }
-
-        impl std::io::Write for FailOnFlush {
-            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-                self.output.extend_from_slice(buf);
-                Ok(buf.len())
-            }
-
-            fn flush(&mut self) -> std::io::Result<()> {
-                Err(std::io::Error::other("flush failed"))
-            }
-        }
-
-        let mut writer = FailOnFlush { output: Vec::new() };
-        let mut replay_clear_pending = true;
-        let replay_clear_requested = replay_clear_pending;
-
-        let error = run_synchronized_draw(&mut writer, |writer| {
-            assert!(replay_clear_requested);
-            writer.write_all(b"clear")?;
-            writer.write_all(b"replay")?;
-            replay_clear_pending = false;
-            Ok(())
-        })
-        .expect_err("sync flush should fail");
-
-        assert_eq!(error.kind(), std::io::ErrorKind::Other);
-        assert!(!replay_clear_pending);
-        assert_eq!(writer.output, b"\x1b[?2026hclearreplay\x1b[?2026l");
     }
 }
 
@@ -584,7 +503,7 @@ pub struct Tui {
     // True when overlay alt-screen UI is active
     alt_screen_active: Arc<AtomicBool>,
     // Rebuilds clear the terminal inside the next synchronized draw before replaying history.
-    terminal_replay_clear_pending: bool,
+    replay_clear: ReplayClearState,
     // True when terminal/tab is focused; updated internally from crossterm events
     terminal_focused: Arc<AtomicBool>,
     enhanced_keys_supported: bool,
@@ -641,7 +560,7 @@ impl Tui {
             #[cfg(unix)]
             suspend_context: SuspendContext::new(),
             alt_screen_active: Arc::new(AtomicBool::new(false)),
-            terminal_replay_clear_pending: false,
+            replay_clear: ReplayClearState::default(),
             terminal_focused: Arc::new(AtomicBool::new(true)),
             enhanced_keys_supported,
             notification_backend: Some(detect_backend(NotificationMethod::default())),
@@ -679,7 +598,7 @@ impl Tui {
     }
 
     pub(crate) fn request_terminal_replay_clear(&mut self) {
-        self.terminal_replay_clear_pending = true;
+        self.replay_clear.request();
     }
 
     // Drop crossterm EventStream to avoid stdin conflicts with other processes.
@@ -958,7 +877,7 @@ impl Tui {
 
         // Precompute any viewport updates that need a cursor-position query before entering
         // the synchronized update, to avoid racing with the event reader.
-        let mut pending_viewport_area = if self.terminal_replay_clear_pending {
+        let mut pending_viewport_area = if self.replay_clear.is_pending() {
             None
         } else {
             self.pending_viewport_area()?
@@ -966,15 +885,14 @@ impl Tui {
 
         ensure_virtual_terminal_processing()?;
 
-        let mut replay_clear_pending = self.terminal_replay_clear_pending;
-        let replay_clear_requested = replay_clear_pending;
+        let mut replay_clear = self.replay_clear.begin_draw();
         let result = run_synchronized_draw(&mut stdout(), |_| {
             #[cfg(unix)]
             if let Some(prepared) = prepared_resume.take() {
                 prepared.apply(&mut self.terminal)?;
             }
 
-            if replay_clear_requested {
+            if replay_clear.requested() {
                 self.clear_terminal_for_replay()?;
             }
 
@@ -1008,9 +926,7 @@ impl Tui {
                 &mut self.pending_history_lines,
                 self.is_zellij,
             )?;
-            if replay_clear_requested {
-                replay_clear_pending = false;
-            }
+            replay_clear.commit_replay();
 
             // Update the y position for suspending so Ctrl-Z can place the cursor correctly.
             #[cfg(unix)]
@@ -1030,7 +946,7 @@ impl Tui {
                 draw_fn(frame);
             })
         });
-        self.terminal_replay_clear_pending = replay_clear_pending;
+        self.replay_clear.finish_draw(replay_clear);
         result
     }
 
@@ -1109,15 +1025,14 @@ impl Tui {
 
         ensure_virtual_terminal_processing()?;
 
-        let mut replay_clear_pending = self.terminal_replay_clear_pending;
-        let replay_clear_requested = replay_clear_pending;
+        let mut replay_clear = self.replay_clear.begin_draw();
         let result = run_synchronized_draw(&mut stdout(), |_| {
             #[cfg(unix)]
             if let Some(prepared) = prepared_resume.take() {
                 prepared.apply(&mut self.terminal)?;
             }
 
-            if replay_clear_requested {
+            if replay_clear.requested() {
                 self.clear_terminal_for_replay()?;
             }
 
@@ -1129,9 +1044,7 @@ impl Tui {
                 &mut self.pending_history_lines,
                 self.is_zellij,
             )?;
-            if replay_clear_requested {
-                replay_clear_pending = false;
-            }
+            replay_clear.commit_replay();
 
             if needs_full_repaint {
                 terminal.invalidate_viewport();
@@ -1155,7 +1068,7 @@ impl Tui {
                 draw_fn(frame);
             })
         });
-        self.terminal_replay_clear_pending = replay_clear_pending;
+        self.replay_clear.finish_draw(replay_clear);
         result
     }
 

--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -86,18 +86,12 @@ fn should_emit_notification(condition: NotificationCondition, terminal_focused: 
 
 fn run_synchronized_draw<W, T>(
     writer: &mut W,
-    replay_clear_pending: &mut bool,
     operations: impl FnOnce(&mut W) -> Result<T>,
 ) -> Result<T>
 where
     W: Write,
 {
-    let replay_clear_requested = *replay_clear_pending;
-    let result = writer.sync_update(operations)?;
-    if replay_clear_requested && result.is_ok() {
-        *replay_clear_pending = false;
-    }
-    result
+    writer.sync_update(operations)?
 }
 
 impl Drop for Tui {
@@ -193,10 +187,11 @@ mod tests {
         let mut replay_clear_pending = true;
         let replay_clear_requested = replay_clear_pending;
 
-        let value = run_synchronized_draw(&mut output, &mut replay_clear_pending, |writer| {
+        let value = run_synchronized_draw(&mut output, |writer| {
             assert!(replay_clear_requested);
             writer.write_all(b"clear")?;
             writer.write_all(b"replay")?;
+            replay_clear_pending = false;
             Ok(42)
         })
         .expect("synchronized draw");
@@ -209,10 +204,10 @@ mod tests {
     #[test]
     fn synchronized_draw_retries_replay_clear_after_render_error() {
         let mut output = Vec::new();
-        let mut replay_clear_pending = true;
+        let replay_clear_pending = true;
         let replay_clear_requested = replay_clear_pending;
 
-        let error = run_synchronized_draw(&mut output, &mut replay_clear_pending, |writer| {
+        let error = run_synchronized_draw(&mut output, |writer| {
             assert!(replay_clear_requested);
             writer.write_all(b"clear")?;
             Err::<(), _>(std::io::Error::other("render failed"))
@@ -225,7 +220,7 @@ mod tests {
     }
 
     #[test]
-    fn synchronized_draw_retries_replay_clear_after_sync_flush_error() {
+    fn synchronized_draw_does_not_retry_clear_after_replay_is_committed() {
         struct FailOnFlush {
             output: Vec<u8>,
         }
@@ -245,16 +240,18 @@ mod tests {
         let mut replay_clear_pending = true;
         let replay_clear_requested = replay_clear_pending;
 
-        let error = run_synchronized_draw(&mut writer, &mut replay_clear_pending, |writer| {
+        let error = run_synchronized_draw(&mut writer, |writer| {
             assert!(replay_clear_requested);
             writer.write_all(b"clear")?;
+            writer.write_all(b"replay")?;
+            replay_clear_pending = false;
             Ok(())
         })
         .expect_err("sync flush should fail");
 
         assert_eq!(error.kind(), std::io::ErrorKind::Other);
-        assert!(replay_clear_pending);
-        assert_eq!(writer.output, b"\x1b[?2026hclear\x1b[?2026l");
+        assert!(!replay_clear_pending);
+        assert_eq!(writer.output, b"\x1b[?2026hclearreplay\x1b[?2026l");
     }
 }
 
@@ -971,7 +968,7 @@ impl Tui {
 
         let mut replay_clear_pending = self.terminal_replay_clear_pending;
         let replay_clear_requested = replay_clear_pending;
-        let result = run_synchronized_draw(&mut stdout(), &mut replay_clear_pending, |_| {
+        let result = run_synchronized_draw(&mut stdout(), |_| {
             #[cfg(unix)]
             if let Some(prepared) = prepared_resume.take() {
                 prepared.apply(&mut self.terminal)?;
@@ -1011,6 +1008,9 @@ impl Tui {
                 &mut self.pending_history_lines,
                 self.is_zellij,
             )?;
+            if replay_clear_requested {
+                replay_clear_pending = false;
+            }
 
             // Update the y position for suspending so Ctrl-Z can place the cursor correctly.
             #[cfg(unix)]
@@ -1111,7 +1111,7 @@ impl Tui {
 
         let mut replay_clear_pending = self.terminal_replay_clear_pending;
         let replay_clear_requested = replay_clear_pending;
-        let result = run_synchronized_draw(&mut stdout(), &mut replay_clear_pending, |_| {
+        let result = run_synchronized_draw(&mut stdout(), |_| {
             #[cfg(unix)]
             if let Some(prepared) = prepared_resume.take() {
                 prepared.apply(&mut self.terminal)?;
@@ -1129,6 +1129,9 @@ impl Tui {
                 &mut self.pending_history_lines,
                 self.is_zellij,
             )?;
+            if replay_clear_requested {
+                replay_clear_pending = false;
+            }
 
             if needs_full_repaint {
                 terminal.invalidate_viewport();

--- a/codex-rs/tui/src/tui/replay_clear.rs
+++ b/codex-rs/tui/src/tui/replay_clear.rs
@@ -1,0 +1,63 @@
+use std::io::Result;
+use std::io::Write;
+
+use crossterm::SynchronizedUpdate;
+
+#[derive(Debug, Default)]
+pub(super) struct ReplayClearState {
+    pending: bool,
+}
+
+impl ReplayClearState {
+    pub(super) fn request(&mut self) {
+        self.pending = true;
+    }
+
+    pub(super) fn is_pending(&self) -> bool {
+        self.pending
+    }
+
+    pub(super) fn begin_draw(&self) -> ReplayClearDraw {
+        ReplayClearDraw {
+            requested: self.pending,
+            replay_committed: false,
+        }
+    }
+
+    pub(super) fn finish_draw(&mut self, draw: ReplayClearDraw) {
+        if draw.replay_committed {
+            self.pending = false;
+        }
+    }
+}
+
+pub(super) struct ReplayClearDraw {
+    requested: bool,
+    replay_committed: bool,
+}
+
+impl ReplayClearDraw {
+    pub(super) fn requested(&self) -> bool {
+        self.requested
+    }
+
+    pub(super) fn commit_replay(&mut self) {
+        if self.requested {
+            self.replay_committed = true;
+        }
+    }
+}
+
+pub(super) fn run_synchronized_draw<W, T>(
+    writer: &mut W,
+    operations: impl FnOnce(&mut W) -> Result<T>,
+) -> Result<T>
+where
+    W: Write,
+{
+    writer.sync_update(operations)?
+}
+
+#[cfg(test)]
+#[path = "replay_clear_tests.rs"]
+mod tests;

--- a/codex-rs/tui/src/tui/replay_clear.rs
+++ b/codex-rs/tui/src/tui/replay_clear.rs
@@ -1,3 +1,9 @@
+//! Coordinates clearing and replaying terminal history inside one synchronized draw.
+//!
+//! A requested clear remains pending until buffered history has been written successfully. Once
+//! replay is committed, later draw or terminal-flush failures must not retry the clear because the
+//! buffered lines have already been consumed.
+
 use std::io::Result;
 use std::io::Write;
 

--- a/codex-rs/tui/src/tui/replay_clear_tests.rs
+++ b/codex-rs/tui/src/tui/replay_clear_tests.rs
@@ -1,0 +1,85 @@
+use std::io::Write as _;
+
+use pretty_assertions::assert_eq;
+
+use super::ReplayClearState;
+use super::run_synchronized_draw;
+
+#[test]
+fn synchronized_draw_wraps_replay_clear_and_repaint() {
+    let mut output = Vec::new();
+    let mut state = ReplayClearState::default();
+    state.request();
+    let mut draw = state.begin_draw();
+
+    let value = run_synchronized_draw(&mut output, |writer| {
+        assert!(draw.requested());
+        writer.write_all(b"clear")?;
+        writer.write_all(b"replay")?;
+        draw.commit_replay();
+        Ok(42)
+    })
+    .expect("synchronized draw");
+    state.finish_draw(draw);
+
+    assert_eq!(value, 42);
+    assert!(!state.is_pending());
+    assert_eq!(output, b"\x1b[?2026hclearreplay\x1b[?2026l");
+}
+
+#[test]
+fn synchronized_draw_retries_replay_clear_after_render_error() {
+    let mut output = Vec::new();
+    let mut state = ReplayClearState::default();
+    state.request();
+    let draw = state.begin_draw();
+
+    let error = run_synchronized_draw(&mut output, |writer| {
+        assert!(draw.requested());
+        writer.write_all(b"clear")?;
+        Err::<(), _>(std::io::Error::other("render failed"))
+    })
+    .expect_err("draw should fail");
+    state.finish_draw(draw);
+
+    assert_eq!(error.kind(), std::io::ErrorKind::Other);
+    assert!(state.is_pending());
+    assert_eq!(output, b"\x1b[?2026hclear\x1b[?2026l");
+}
+
+#[test]
+fn synchronized_draw_does_not_retry_clear_after_replay_is_committed() {
+    struct FailOnFlush {
+        output: Vec<u8>,
+    }
+
+    impl std::io::Write for FailOnFlush {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.output.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Err(std::io::Error::other("flush failed"))
+        }
+    }
+
+    let mut writer = FailOnFlush { output: Vec::new() };
+    let mut state = ReplayClearState::default();
+    state.request();
+    let mut draw = state.begin_draw();
+
+    let error = run_synchronized_draw(&mut writer, |writer| {
+        assert!(draw.requested());
+        writer.write_all(b"clear")?;
+        writer.write_all(b"replay")?;
+        draw.commit_replay();
+        Ok(())
+    })
+    .expect_err("sync flush should fail");
+    state.finish_draw(draw);
+
+    assert_eq!(error.kind(), std::io::ErrorKind::Other);
+    assert!(!state.is_pending());
+    assert_eq!(writer.output, b"\x1b[?2026hclearreplay\x1b[?2026l");
+}


### PR DESCRIPTION
## Why

Long resumed sessions could visibly flash several times while their transcript was restored. The resize-reflow clear was emitted before synchronized output began, and startup replay could also stream batches or run historical consolidation reflows before the final transcript was ready.

This exposed intermediate blank or partially replayed terminal states even though later interactive resizes rendered correctly.

Fixes #25622.

## What Changed

- defer resize/backtrack terminal clears until the synchronized draw that performs the replay and repaint
- preserve pending clears across render or flush failures so a later draw retries them
- begin initial and thread-switch replay deferral synchronously before replay events are queued
- suppress per-cell terminal writes during replay, then render once from the completed transcript source
- absorb startup resize and stream-consolidation reflows into that final source-backed render
- add coverage for synchronized clear/repaint ordering, retry behavior, uncapped replay, and startup reflow suppression

## How to Test

1. Enable `terminal_resize_reflow` and resume a long session in the normal inline TUI.
2. Confirm the restored transcript appears once without intermediate blank-screen flashes.
3. Resize the terminal height and width after startup.
4. Confirm the transcript still reflows correctly without exposing a cleared screen.
5. Repeat inside tmux while capturing the raw pane output and verify any resize clear is enclosed by `ESC[?2026h` and `ESC[?2026l`.

Manual tmux validation of the startup path changed from one `ESC[2J`/`ESC[3J` clear plus a redundant replay transaction to zero startup clears and one synchronized history replay.

Targeted tests:

- `just test -p codex-tui history_replay_defers_resize_and_consolidation_reflows`
- `just test -p codex-tui history_replay_activates_without_row_cap`
- `just test -p codex-tui synchronized_draw`

The full `just test -p codex-tui` run passed 2,783 tests. Two unrelated Guardian feature-flag tests fail identically on `main`.
