### PR TITLE
fix(tui): avoid doubled blank rows while streaming

### DIFF
--- a/codex-rs/tui/src/history_cell/messages.rs
+++ b/codex-rs/tui/src/history_cell/messages.rs
@@ -423,7 +423,7 @@ impl HistoryCell for StreamingAgentTailCell {
     fn display_hyperlink_lines(&self, _width: u16) -> Vec<HyperlinkLine> {
         // Tail lines are already rendered at the controller's current stream width.
         // Re-wrapping them here can split table borders and produce malformed in-flight rows.
-        prefix_hyperlink_lines(
+        let mut lines = prefix_hyperlink_lines(
             self.lines.clone(),
             if self.is_first_line {
                 "• ".dim()
@@ -431,7 +431,19 @@ impl HistoryCell for StreamingAgentTailCell {
                 "  ".into()
             },
             "  ".into(),
-        )
+        );
+        for line in &mut lines {
+            if line
+                .line
+                .spans
+                .iter()
+                .all(|span| span.content.chars().all(char::is_whitespace))
+            {
+                line.line = Line::default().style(line.line.style);
+                line.hyperlinks.clear();
+            }
+        }
+        lines
     }
 
     fn transcript_hyperlink_lines(&self, width: u16) -> Vec<HyperlinkLine> {

--- a/codex-rs/tui/src/history_cell/tests.rs
+++ b/codex-rs/tui/src/history_cell/tests.rs
@@ -45,6 +45,24 @@ fn test_cwd() -> PathBuf {
     std::env::temp_dir()
 }
 
+#[test]
+fn streaming_agent_tail_blank_line_uses_one_viewport_row() {
+    let cell = StreamingAgentTailCell::new(
+        vec![
+            HyperlinkLine::from("first"),
+            HyperlinkLine::from(""),
+            HyperlinkLine::from("second"),
+        ],
+        /*is_first_line*/ false,
+    );
+
+    let lines = cell.display_lines(/*width*/ 80);
+    insta::assert_snapshot!(render_lines(&lines).join("\n"), @"  first
+
+  second");
+    assert_eq!(cell.desired_height(/*width*/ 80), 3);
+}
+
 fn stdio_server_config(
     command: &str,
     args: Vec<&str>,


### PR DESCRIPTION
## Summary

During assistant-message streaming, blank markdown lines in the transient active tail were prefixed with two spaces. Ratatui measured those whitespace-only lines as two viewport rows, so list- and table-heavy answers showed doubled vertical gaps while streaming and then visibly compacted when finalized into scrollback.

- keep whitespace-only `StreamingAgentTailCell` lines structurally empty while preserving nonblank message prefixes
- clear impossible hyperlink metadata when normalizing a blank tail line
- add an inline snapshot and height regression proving one blank markdown line occupies one viewport row

Related to #26618, but fixes a separate live-tail row-height issue rather than stale committed markdown content.

## How to Test

Recommended before/after reproduction:

1. Start the latest Codex build without this change.
2. Submit this exact prompt:

   > Send 20 different lists: bullets vs numbered, simple vs complex with paragraphs in between items, etc. Intertwine them with some tables and some paragraphs.

3. While the answer streams, observe duplicated vertical gaps around list items and paragraphs. When the answer finishes, observe the spacing compact.
4. Start this branch with `just c` and submit the same prompt.
5. Confirm each intended blank markdown line occupies one terminal row throughout streaming and that the spacing does not compact or jump when the answer finishes.
6. As a focused regression, verify the sections after the first table, especially loose lists with paragraphs between items; those blank rows should remain stable throughout streaming.

Targeted tests:

- `just test -p codex-tui streaming_agent_tail_blank_line_uses_one_viewport_row`
- `just test -p codex-tui history_cell::tests`

## Test Notes

- Verified the exact prompt above in a real tmux TUI using latest Codex and this branch as the before/after comparison.
- The full `just test -p codex-tui` run completed 2,782 of 2,784 tests successfully. Two unrelated guardian feature-flag tests fail reproducibly in isolation because the expected `OverrideTurnContext` message is absent.
- `just argument-comment-lint` is blocked locally by the existing Bazel `compiler-rt` missing-header glob error; the touched Rust diff was inspected manually for opaque positional literals.