### PR TITLE
Allow /bin/ps in macOS seatbelt policy

### DIFF
--- a/codex-rs/exec/tests/suite/sandbox.rs
+++ b/codex-rs/exec/tests/suite/sandbox.rs
@@ -274,6 +274,51 @@ async fn python_getpwuid_works_under_sandbox() {
     assert!(status.success(), "python exited with {status:?}");
 }
 
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn bin_ps_runs_under_workspace_write_sandbox() {
+    core_test_support::skip_if_sandbox!();
+
+    let permission_profile = PermissionProfile::workspace_write_with(
+        &[],
+        NetworkSandboxPolicy::Restricted,
+        /*exclude_tmpdir_env_var*/ true,
+        /*exclude_slash_tmp*/ true,
+    );
+    let command_cwd = AbsolutePathBuf::current_dir().expect("should be able to get current dir");
+    let sandbox_cwd = command_cwd.clone();
+
+    let child = spawn_command_under_sandbox(
+        vec![
+            "/bin/ps".to_string(),
+            "-p".to_string(),
+            std::process::id().to_string(),
+        ],
+        command_cwd,
+        &permission_profile,
+        &sandbox_cwd,
+        StdioPolicy::RedirectForShellTool,
+        HashMap::new(),
+    )
+    .await
+    .expect("should be able to spawn /bin/ps under sandbox");
+
+    let output = child
+        .wait_with_output()
+        .await
+        .expect("should be able to wait for /bin/ps child");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "/bin/ps under sandbox exited with {:?}, stderr: {stderr}",
+        output.status
+    );
+    assert!(
+        !stderr.contains("Operation not permitted"),
+        "/bin/ps under sandbox should not hit permission errors, stderr: {stderr}"
+    );
+}
+
 #[tokio::test]
 async fn sandbox_distinguishes_command_and_policy_cwds() {
     core_test_support::skip_if_sandbox!();

--- a/codex-rs/sandboxing/src/seatbelt_base_policy.sbpl
+++ b/codex-rs/sandboxing/src/seatbelt_base_policy.sbpl
@@ -12,6 +12,10 @@
 (allow process-fork)
 (allow signal (target same-sandbox))
 
+; Permit /bin/ps to run without sandboxing so Homebrew's `brew shellenv`
+; can detect the shell even though /bin/ps is setuid.
+(allow process-exec (path "/bin/ps") (with no-sandbox))
+
 ; process-info
 (allow process-info* (target same-sandbox))
 

--- a/codex-rs/sandboxing/src/seatbelt_tests.rs
+++ b/codex-rs/sandboxing/src/seatbelt_tests.rs
@@ -109,6 +109,16 @@ fn base_policy_allows_node_cpu_sysctls() {
 }
 
 #[test]
+fn base_policy_allows_bin_ps_without_sandboxing() {
+    let expected = r#"(allow process-exec (path "/bin/ps") (with no-sandbox))"#;
+
+    assert!(
+        MACOS_SEATBELT_BASE_POLICY.contains(expected),
+        "base policy must allow /bin/ps to run without sandboxing:\n{MACOS_SEATBELT_BASE_POLICY}"
+    );
+}
+
+#[test]
 fn base_policy_allows_kmp_registration_shm_read_create_and_unlink() {
     let expected = r##"(allow ipc-posix-shm-read-data
   ipc-posix-shm-write-create


### PR DESCRIPTION
## Summary
- Allow `/bin/ps` to execute without sandboxing in the macOS Seatbelt base policy so Homebrew can run `brew shellenv` despite `/bin/ps` being setuid.
- Add policy unit coverage for the `/bin/ps` carveout.
- Add a macOS sandbox integration test that runs `/bin/ps` directly under a workspace-write sandbox, avoiding a Homebrew dependency in CI.

Revives the intent of #7220 against the current sandboxing/exec crate layout.

## Testing
- `just fmt`
- `just test -p codex-sandboxing`
- `just test -p codex-exec` *(new sandbox test passed; full crate run had unrelated local failures from `/etc/codex/requirements.toml` disallowing danger-full-access and mocked API retry/404 behavior: `exec_bypass_preserves_never_for_auto_review_config`, `exec_resume_accepts_global_flags_after_subcommand`, `test_apply_patch_freeform_tool`, `test_apply_patch_tool`)*
- `just test -p codex-exec suite::sandbox::bin_ps_runs_under_workspace_write_sandbox`
- `just fix -p codex-sandboxing`
- `just fix -p codex-exec`