### PR TITLE
Add span to `append_tool_search_executor`

### DIFF
--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -181,7 +181,8 @@ fn build_tool_specs_and_registry(
     };
     let mut planned_tools = PlannedTools::default();
     add_tool_sources(&context, &mut planned_tools);
-    append_tool_search_executor(&context, &mut planned_tools);
+    tracing::trace_span!("append_tool_search_executor")
+        .in_scope(|| append_tool_search_executor(&context, &mut planned_tools));
     prepend_code_mode_executors(&context, &mut planned_tools);
     build_model_visible_specs_and_registry(turn_context, planned_tools)
 }


### PR DESCRIPTION
## Why
Local profiling shows `append_tool_search_executor` averages ~113ms per call. Adding a span lets us track this cost as we optimize in follow-up PRs, either by reducing the work or avoiding repeated rebuilds when inputs have not changed.

## What changed
Add span to `append_tool_search_executor` 

## Verification
Trigger Codex rollout and observe span is included for `append_tool_search_executor`