### PR TITLE
[codex] Add max reasoning effort

### DIFF
--- a/codex-rs/core/tests/suite/remote_models.rs
+++ b/codex-rs/core/tests/suite/remote_models.rs
@@ -332,7 +332,7 @@ async fn remote_models_long_model_slug_is_sent_with_custom_reasoning() -> Result
         /*priority*/ 1_000,
         TruncationPolicyConfig::bytes(/*limit*/ 10_000),
     );
-    let custom_reasoning_effort = ReasoningEffort::Custom("max".to_string());
+    let custom_reasoning_effort = ReasoningEffort::Custom("future".to_string());
     remote_model.default_reasoning_level = Some(custom_reasoning_effort.clone());
     remote_model.supported_reasoning_levels = vec![
         ReasoningEffortPreset {

--- a/codex-rs/protocol/src/openai_models.rs
+++ b/codex-rs/protocol/src/openai_models.rs
@@ -45,6 +45,7 @@ pub enum ReasoningEffort {
     Medium,
     High,
     XHigh,
+    Max,
     /// A model-defined effort value that this client does not know yet.
     Custom(String),
 }
@@ -59,6 +60,7 @@ impl ReasoningEffort {
             Self::Medium => "medium",
             Self::High => "high",
             Self::XHigh => "xhigh",
+            Self::Max => "max",
             Self::Custom(effort) => effort,
         }
     }
@@ -123,6 +125,7 @@ impl FromStr for ReasoningEffort {
             "medium" => Ok(Self::Medium),
             "high" => Ok(Self::High),
             "xhigh" => Ok(Self::XHigh),
+            "max" => Ok(Self::Max),
             "" => Err("reasoning_effort must not be empty".to_string()),
             effort => Ok(Self::Custom(effort.to_string())),
         }
@@ -693,8 +696,8 @@ mod tests {
 
     #[test]
     fn reasoning_effort_accepts_known_and_custom_values() {
-        let custom = ReasoningEffort::Custom("max".to_string());
-        let deserialized = from_str::<ReasoningEffort>(r#""max""#)
+        let custom = ReasoningEffort::Custom("future".to_string());
+        let deserialized = from_str::<ReasoningEffort>(r#""future""#)
             .expect("custom reasoning effort should deserialize");
         let serialized = to_string(&custom).expect("custom reasoning effort should serialize");
 
@@ -708,10 +711,10 @@ mod tests {
             ),
             (
                 Ok(ReasoningEffort::High),
-                Ok(custom.clone()),
+                Ok(ReasoningEffort::Max),
                 custom,
-                r#""max""#.to_string(),
-                "max".to_string(),
+                r#""future""#.to_string(),
+                "future".to_string(),
             )
         );
     }

--- a/codex-rs/tui/src/chatwidget/model_popups.rs
+++ b/codex-rs/tui/src/chatwidget/model_popups.rs
@@ -356,6 +356,11 @@ impl ChatWidget {
 
         let warn_effort = if supported
             .iter()
+            .any(|option| option.effort == ReasoningEffortConfig::Max)
+        {
+            Some(ReasoningEffortConfig::Max)
+        } else if supported
+            .iter()
             .any(|option| option.effort == ReasoningEffortConfig::XHigh)
         {
             Some(ReasoningEffortConfig::XHigh)
@@ -505,6 +510,7 @@ impl ChatWidget {
             ReasoningEffortConfig::Medium => "Medium".to_string(),
             ReasoningEffortConfig::High => "High".to_string(),
             ReasoningEffortConfig::XHigh => "Extra high".to_string(),
+            ReasoningEffortConfig::Max => "Max".to_string(),
             ReasoningEffortConfig::Custom(value) => value.clone(),
         }
     }

--- a/codex-rs/tui/src/chatwidget/reasoning_shortcuts.rs
+++ b/codex-rs/tui/src/chatwidget/reasoning_shortcuts.rs
@@ -225,7 +225,7 @@ mod tests {
 
     #[test]
     fn next_reasoning_effort_uses_advertised_order_for_custom_levels() {
-        let custom_effort = ReasoningEffortConfig::Custom("max".to_string());
+        let custom_effort = ReasoningEffortConfig::Custom("future".to_string());
         let choices = vec![
             ReasoningEffortConfig::High,
             ReasoningEffortConfig::Low,

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__model_reasoning_selection_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__model_reasoning_selection_popup.snap
@@ -6,7 +6,7 @@ expression: popup
 
   1. Low               Fast responses with lighter reasoning
   2. Medium (default)  Balances speed and reasoning depth for everyday tasks
-  3. max               Maximum available reasoning
+  3. Max               Maximum available reasoning
 › 4. High (current)    Greater reasoning depth for complex problems
   5. Extra high        Extra high reasoning depth for complex problems
 

--- a/codex-rs/tui/src/chatwidget/tests/popups_and_settings.rs
+++ b/codex-rs/tui/src/chatwidget/tests/popups_and_settings.rs
@@ -2409,7 +2409,7 @@ async fn model_reasoning_selection_popup_snapshot() {
     preset.supported_reasoning_efforts.insert(
         2,
         ReasoningEffortPreset {
-            effort: ReasoningEffortConfig::Custom("max".to_string()),
+            effort: ReasoningEffortConfig::Max,
             description: "Maximum available reasoning".to_string(),
         },
     );
@@ -2422,7 +2422,7 @@ async fn model_reasoning_selection_popup_snapshot() {
 #[tokio::test]
 async fn model_reasoning_selection_popup_applies_custom_effort() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.4")).await;
-    let custom_effort = ReasoningEffortConfig::Custom("max".to_string());
+    let custom_effort = ReasoningEffortConfig::Custom("future".to_string());
     chat.set_reasoning_effort(Some(ReasoningEffortConfig::XHigh));
 
     let mut preset = get_available_model(&chat, "gpt-5.4");


### PR DESCRIPTION
## Summary
- add `max` as a first-class `ReasoningEffort` value in the shared models protocol
- display `max` canonically in model reasoning selection and treat it as the highest warning level
- retain coverage for arbitrary model-defined effort values using a separate future value

Companion model catalog change: https://github.com/openai/openai/pull/1000269

## Validation
- `cargo fmt -- --config imports_granularity=Item`
- local tests not run per request; relying on CI