### PR TITLE
Stop running benchmark smoke tests from `just test`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -192,6 +192,12 @@ If you don’t have the tool:
 
 - `cargo install --locked cargo-insta`
 
+### Benchmarks
+
+cargo benchmarks can be run with `just bench`, use the divan crate to schedule them.
+
+Use `just bench-smoke` to dry-run the benchmark for a single iteration to ensure it works.
+
 ### Test assertions
 
 - Tests should use pretty_assertions::assert_eq for clearer diffs. Import this at the top of the test module if it isn't already.

--- a/justfile
+++ b/justfile
@@ -76,12 +76,10 @@ install:
 [unix]
 test *args:
     RUST_MIN_STACK={{ rust_min_stack }} cargo nextest run --no-fail-fast "$@"
-    just bench-smoke
 
 [windows]
 test *args:
     $env:RUST_MIN_STACK = "{{ rust_min_stack }}"; cargo nextest run --no-fail-fast @($args | Select-Object -Skip 1)
-    just bench-smoke
 
 # Run from the repository root so scripts that resolve paths from `cwd` see
 # the same layout they use in GitHub Actions.


### PR DESCRIPTION
## Why

`just test` should run the test suite without also compiling and executing benchmark smoke tests. Keeping benchmark validation explicit avoids adding unrelated work to every project-specific test invocation.

## What changed

- Remove the `just bench-smoke` step from the Unix and Windows `test` recipes.
- Document `just bench` and `just bench-smoke` as the explicit benchmark commands in `AGENTS.md`.

## Validation

- `just test -p codex-arg0`
- `just --dry-run test`
- `just --dry-run bench-smoke`