### PR TITLE
[codex] Load direnv environment into shell snapshots

### DIFF
--- a/codex-rs/core/src/shell_snapshot.rs
+++ b/codex-rs/core/src/shell_snapshot.rs
@@ -321,6 +321,10 @@ else
   rc="$HOME/.zshrc"
 fi
 [[ -r "$rc" ]] && . "$rc"
+# Starting in the workspace does not trigger direnv's chpwd or precmd hook.
+if (( $+functions[_direnv_hook] )); then
+  _direnv_hook
+fi
 print '# Snapshot file'
 print '# Unset all aliases to avoid conflicts with functions'
 print 'unalias -a 2>/dev/null || true'
@@ -361,6 +365,10 @@ fn bash_snapshot_script() -> String {
     let excluded = excluded_exports_regex();
     let script = r##"if [ -z "$BASH_ENV" ] && [ -r "$HOME/.bashrc" ]; then
   . "$HOME/.bashrc"
+fi
+# Starting in the workspace does not trigger direnv's prompt hook.
+if declare -F _direnv_hook >/dev/null; then
+  _direnv_hook
 fi
 echo '# Snapshot file'
 echo '# Unset all aliases to avoid conflicts with functions'

--- a/codex-rs/core/src/shell_snapshot_tests.rs
+++ b/codex-rs/core/src/shell_snapshot_tests.rs
@@ -80,6 +80,18 @@ fn assert_posix_snapshot_sections(snapshot: &str) {
     assert!(snapshot.contains("setopts "));
 }
 
+#[cfg(unix)]
+fn snapshot_exports(snapshot: &str) -> &str {
+    let exports = snapshot
+        .split_once("\n# exports ")
+        .expect("snapshot should include an exports section")
+        .1;
+    exports
+        .split_once('\n')
+        .expect("exports section should include a count")
+        .1
+}
+
 async fn get_snapshot(shell_type: ShellType) -> Result<String> {
     let dir = tempdir()?;
     let path = dir.path().join("snapshot.sh");
@@ -182,6 +194,65 @@ fn bash_snapshot_preserves_multiline_exports() -> Result<()> {
         validate.status.success(),
         "snapshot validation failed: {}",
         String::from_utf8_lossy(&validate.stderr)
+    );
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn bash_snapshot_runs_direnv_hook_before_capture() -> Result<()> {
+    let home = tempdir()?;
+    std::fs::write(
+        home.path().join(".bashrc"),
+        "_direnv_hook() { export CODEX_DIRENV_TEST=loaded; }\n",
+    )?;
+
+    let output = Command::new("/bin/bash")
+        .arg("-c")
+        .arg(bash_snapshot_script())
+        .env("HOME", home.path())
+        .env_remove("BASH_ENV")
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "snapshot command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        snapshot_exports(&stdout).contains("CODEX_DIRENV_TEST"),
+        "snapshot should capture exports from the direnv hook"
+    );
+
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn zsh_snapshot_runs_direnv_hook_before_capture() -> Result<()> {
+    let zdotdir = tempdir()?;
+    std::fs::write(
+        zdotdir.path().join(".zshrc"),
+        "_direnv_hook() { export CODEX_DIRENV_TEST=loaded; }\n",
+    )?;
+
+    let output = Command::new("/bin/zsh")
+        .arg("-c")
+        .arg(zsh_snapshot_script())
+        .env("ZDOTDIR", zdotdir.path())
+        .output()?;
+
+    assert!(
+        output.status.success(),
+        "snapshot command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        snapshot_exports(&stdout).contains("CODEX_DIRENV_TEST"),
+        "snapshot should capture exports from the direnv hook"
     );
 
     Ok(())


### PR DESCRIPTION
## Why

Codex captures a shell snapshot so commands can reuse the environment, functions, aliases, and shell options established by a user's shell configuration.

When Codex is launched from an existing terminal after entering a workspace, tools such as `direnv` have already updated that terminal's environment. When Codex is launched by a graphical application or another parent process, it may start directly in the workspace without the shell events that normally run `direnv`'s hook. Loading `.zshrc` or `.bashrc` defines the hook, but starting a shell with an existing working directory does not trigger the prompt or directory-change event that calls it.

As a result, the snapshot could capture the normal login environment instead of the workspace-local environment. The same checkout could then select different executables, virtual environments, or environment variables depending on how Codex was launched.

## What changed

- After loading `.zshrc`, invoke `_direnv_hook` when the function is defined.
- After loading `.bashrc`, invoke `_direnv_hook` when the function is defined.
- Run the hook before serializing exports and the rest of the shell snapshot.
- Add isolated Bash and macOS Zsh regression tests that define a hook in a temporary shell configuration and verify its exported environment is captured.

This uses the shell integration the user has already configured. If no `_direnv_hook` function is present, snapshot behavior is unchanged.

## Compatibility

- No command-line, app-server API, or configuration surface changes.
- No new dependency on the `direnv` executable.
- Existing `direnv` allow and deny behavior remains authoritative because the standard shell hook performs the evaluation.

## Verification

- `just test -p codex-core direnv_hook_before_capture`
- `just test -p codex-core 'suite::shell_snapshot'`
- `cargo clippy -p codex-core --tests --no-deps -- -D warnings`
