### PR TITLE
[codex] Stop guardian reviews when parent turns are interrupted

### DIFF
--- a/codex-rs/core/src/guardian/review.rs
+++ b/codex-rs/core/src/guardian/review.rs
@@ -338,6 +338,7 @@ async fn run_guardian_review(
     let (outcome, analytics_result) = Box::pin(run_guardian_review_session(
         session.clone(),
         turn.clone(),
+        review_id.clone(),
         request,
         retry_reason.clone(),
         schema,
@@ -660,6 +661,7 @@ pub(crate) fn spawn_approval_request_review(
 pub(super) async fn run_guardian_review_session(
     session: Arc<Session>,
     turn: Arc<TurnContext>,
+    review_id: String,
     request: GuardianApprovalRequest,
     retry_reason: Option<String>,
     schema: serde_json::Value,
@@ -744,6 +746,7 @@ pub(super) async fn run_guardian_review_session(
             .run_review(GuardianReviewSessionParams {
                 parent_session: Arc::clone(&session),
                 parent_turn: turn.clone(),
+                review_id,
                 spawn_config: guardian_config,
                 request,
                 retry_reason,

--- a/codex-rs/core/src/guardian/review_session.rs
+++ b/codex-rs/core/src/guardian/review_session.rs
@@ -68,6 +68,7 @@ pub(crate) enum GuardianReviewSessionOutcome {
 pub(crate) struct GuardianReviewSessionParams {
     pub(crate) parent_session: Arc<Session>,
     pub(crate) parent_turn: Arc<TurnContext>,
+    pub(crate) review_id: String,
     pub(crate) spawn_config: Config,
     pub(crate) request: GuardianApprovalRequest,
     pub(crate) retry_reason: Option<String>,
@@ -79,7 +80,7 @@ pub(crate) struct GuardianReviewSessionParams {
     pub(crate) external_cancel: Option<CancellationToken>,
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub(crate) struct GuardianReviewSessionManager {
     state: Arc<Mutex<GuardianReviewSessionState>>,
 }
@@ -88,6 +89,19 @@ pub(crate) struct GuardianReviewSessionManager {
 struct GuardianReviewSessionState {
     trunk: Option<Arc<GuardianReviewSession>>,
     ephemeral_reviews: Vec<Arc<GuardianReviewSession>>,
+    active_reviews: HashMap<String, ActiveGuardianReview>,
+}
+
+struct ActiveGuardianReview {
+    parent_turn_id: String,
+    cancel_token: CancellationToken,
+    review_session: Option<Arc<GuardianReviewSession>>,
+}
+
+struct ActiveGuardianReviewRegistration {
+    manager: GuardianReviewSessionManager,
+    review_id: String,
+    registered: bool,
 }
 
 struct GuardianReviewSession {
@@ -275,6 +289,29 @@ impl Drop for EphemeralReviewCleanup {
     }
 }
 
+impl ActiveGuardianReviewRegistration {
+    async fn unregister(mut self) {
+        self.registered = false;
+        self.manager.unregister_active_review(&self.review_id).await;
+    }
+}
+
+impl Drop for ActiveGuardianReviewRegistration {
+    fn drop(&mut self) {
+        if !self.registered {
+            return;
+        }
+
+        let manager = self.manager.clone();
+        let review_id = self.review_id.clone();
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            drop(handle.spawn(async move {
+                manager.unregister_active_review(&review_id).await;
+            }));
+        }
+    }
+}
+
 impl GuardianReviewSessionManager {
     pub(crate) async fn trunk_rollout_path(&self) -> Option<PathBuf> {
         let trunk = self.state.lock().await.trunk.clone()?;
@@ -289,13 +326,17 @@ impl GuardianReviewSessionManager {
     }
 
     pub(crate) async fn shutdown(&self) {
-        let (review_session, ephemeral_reviews) = {
+        let (review_session, ephemeral_reviews, active_reviews) = {
             let mut state = self.state.lock().await;
             (
                 state.trunk.take(),
                 std::mem::take(&mut state.ephemeral_reviews),
+                std::mem::take(&mut state.active_reviews),
             )
         };
+        for active_review in active_reviews.into_values() {
+            active_review.cancel_token.cancel();
+        }
         if let Some(review_session) = review_session {
             review_session.shutdown().await;
         }
@@ -304,11 +345,22 @@ impl GuardianReviewSessionManager {
         }
     }
 
+    pub(super) async fn run_review(
+        &self,
+        mut params: GuardianReviewSessionParams,
+    ) -> (GuardianReviewSessionOutcome, GuardianReviewAnalyticsResult) {
+        let (registration, cancel_token) = self.register_active_review(&params).await;
+        params.external_cancel = Some(cancel_token);
+        let outcome = Box::pin(self.run_review_inner(params)).await;
+        registration.unregister().await;
+        outcome
+    }
+
     #[expect(
         clippy::await_holding_invalid_type,
         reason = "review session selection and trunk spawning must stay serialized"
     )]
-    pub(super) async fn run_review(
+    async fn run_review_inner(
         &self,
         params: GuardianReviewSessionParams,
     ) -> (GuardianReviewSessionOutcome, GuardianReviewAnalyticsResult) {
@@ -408,6 +460,8 @@ impl GuardianReviewSessionManager {
         } else {
             GuardianReviewSessionKind::TrunkReused
         };
+        self.record_active_review_session(&params.review_id, Arc::clone(&trunk))
+            .await;
         let (outcome, keep_review_session, analytics_result) = Box::pin(run_review_on_session(
             trunk.as_ref(),
             &params,
@@ -428,6 +482,143 @@ impl GuardianReviewSessionManager {
             }
             (outcome, analytics_result)
         }
+    }
+
+    async fn register_active_review(
+        &self,
+        params: &GuardianReviewSessionParams,
+    ) -> (ActiveGuardianReviewRegistration, CancellationToken) {
+        let cancel_token = CancellationToken::new();
+        if let Some(external_cancel) = params.external_cancel.clone() {
+            if external_cancel.is_cancelled() {
+                cancel_token.cancel();
+            } else {
+                let cancel_token_for_task = cancel_token.clone();
+                drop(tokio::spawn(async move {
+                    tokio::select! {
+                        _ = external_cancel.cancelled() => cancel_token_for_task.cancel(),
+                        _ = cancel_token_for_task.cancelled() => {}
+                    }
+                }));
+            }
+        }
+
+        let previous = self.state.lock().await.active_reviews.insert(
+            params.review_id.clone(),
+            ActiveGuardianReview {
+                parent_turn_id: params.parent_turn.sub_id.clone(),
+                cancel_token: cancel_token.clone(),
+                review_session: None,
+            },
+        );
+        if previous.is_some() {
+            warn!(
+                review_id = %params.review_id,
+                "overwriting active guardian approval review"
+            );
+        }
+
+        (
+            ActiveGuardianReviewRegistration {
+                manager: self.clone(),
+                review_id: params.review_id.clone(),
+                registered: true,
+            },
+            cancel_token,
+        )
+    }
+
+    async fn unregister_active_review(&self, review_id: &str) {
+        self.state.lock().await.active_reviews.remove(review_id);
+    }
+
+    async fn record_active_review_session(
+        &self,
+        review_id: &str,
+        review_session: Arc<GuardianReviewSession>,
+    ) {
+        let mut state = self.state.lock().await;
+        if let Some(active_review) = state.active_reviews.get_mut(review_id) {
+            active_review.review_session = Some(review_session);
+        }
+    }
+
+    pub(crate) async fn cancel_active_reviews_for_turn(&self, parent_turn_id: &str) -> usize {
+        let active_reviews = {
+            let state = self.state.lock().await;
+            state
+                .active_reviews
+                .values()
+                .filter(|review| review.parent_turn_id == parent_turn_id)
+                .map(|review| review.cancel_token.clone())
+                .collect::<Vec<_>>()
+        };
+        let count = active_reviews.len();
+        for cancel_token in active_reviews {
+            cancel_token.cancel();
+        }
+        count
+    }
+
+    pub(crate) async fn wait_for_no_active_reviews_for_turn(
+        &self,
+        parent_turn_id: &str,
+        timeout: Duration,
+    ) {
+        let result = tokio::time::timeout(timeout, async {
+            while self.active_review_count_for_turn(parent_turn_id).await > 0 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+        if result.is_err() {
+            warn!(
+                parent_turn_id,
+                "timed out waiting for guardian approval reviews to abort"
+            );
+        }
+    }
+
+    pub(crate) async fn shutdown_active_reviews_for_turn(&self, parent_turn_id: &str) {
+        let active_reviews = {
+            let mut state = self.state.lock().await;
+            let mut active_reviews = Vec::new();
+            let mut retained_reviews = HashMap::new();
+            for (review_id, active_review) in std::mem::take(&mut state.active_reviews) {
+                if active_review.parent_turn_id == parent_turn_id {
+                    active_reviews.push(active_review);
+                } else {
+                    retained_reviews.insert(review_id, active_review);
+                }
+            }
+            state.active_reviews = retained_reviews;
+            active_reviews
+        };
+
+        for active_review in active_reviews {
+            active_review.cancel_token.cancel();
+            if let Some(review_session) = active_review.review_session {
+                review_session.shutdown_in_background();
+            }
+        }
+    }
+
+    async fn active_review_count_for_turn(&self, parent_turn_id: &str) -> usize {
+        self.state
+            .lock()
+            .await
+            .active_reviews
+            .values()
+            .filter(|review| review.parent_turn_id == parent_turn_id)
+            .count()
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn active_review_count_for_turn_for_test(
+        &self,
+        parent_turn_id: &str,
+    ) -> usize {
+        self.active_review_count_for_turn(parent_turn_id).await
     }
 
     #[cfg(test)]
@@ -567,6 +758,8 @@ impl GuardianReviewSessionManager {
         let mut cleanup =
             EphemeralReviewCleanup::new(Arc::clone(&self.state), Arc::clone(&review_session));
 
+        self.record_active_review_session(&params.review_id, Arc::clone(&review_session))
+            .await;
         let (outcome, _, analytics_result) = Box::pin(run_review_on_session(
             review_session.as_ref(),
             &params,
@@ -1124,6 +1317,7 @@ mod tests {
         GuardianReviewSessionParams {
             parent_session: Arc::new(session),
             parent_turn: Arc::new(turn),
+            review_id: "review-shell-1".to_string(),
             spawn_config,
             request: GuardianApprovalRequest::Shell {
                 id: "shell-1".to_string(),

--- a/codex-rs/core/src/guardian/tests.rs
+++ b/codex-rs/core/src/guardian/tests.rs
@@ -6,8 +6,12 @@ use crate::config::ManagedFeatures;
 use crate::config::NetworkProxySpec;
 use crate::config::test_config;
 use crate::guardian::approval_request::guardian_request_target_item_id;
+use crate::session::TurnInput;
 use crate::session::session::Session;
 use crate::session::turn_context::TurnContext;
+use crate::state::TaskKind;
+use crate::tasks::SessionTask;
+use crate::tasks::SessionTaskContext;
 use crate::test_support;
 use codex_analytics::GuardianApprovalRequestSource;
 use codex_config::ConfigLayerStack;
@@ -47,6 +51,7 @@ use codex_protocol::protocol::GuardianRiskLevel;
 use codex_protocol::protocol::GuardianUserAuthorization;
 use codex_protocol::protocol::ReviewDecision;
 use codex_protocol::protocol::RolloutItem;
+use codex_protocol::protocol::TurnAbortReason;
 use codex_protocol::protocol::TurnCompleteEvent;
 use core_test_support::PathBufExt;
 use core_test_support::TempDirExt;
@@ -77,6 +82,30 @@ use tokio_util::sync::CancellationToken;
 fn fixed_guardian_parent_session_id() -> ThreadId {
     ThreadId::from_string("11111111-1111-4111-8111-111111111111")
         .expect("fixed parent session id should be a valid UUID")
+}
+
+#[derive(Clone, Copy)]
+struct GuardianNeverEndingTask;
+
+impl SessionTask for GuardianNeverEndingTask {
+    fn kind(&self) -> TaskKind {
+        TaskKind::Regular
+    }
+
+    fn span_name(&self) -> &'static str {
+        "session_task.guardian_never_ending"
+    }
+
+    async fn run(
+        self: Arc<Self>,
+        _session: Arc<SessionTaskContext>,
+        _ctx: Arc<TurnContext>,
+        _input: Vec<TurnInput>,
+        cancellation_token: CancellationToken,
+    ) -> Option<String> {
+        cancellation_token.cancelled().await;
+        None
+    }
 }
 
 #[test]
@@ -1076,6 +1105,143 @@ async fn cancelled_guardian_review_emits_terminal_abort_without_warning() {
     assert!(warnings.is_empty());
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn interrupting_parent_turn_cancels_active_guardian_review() -> anyhow::Result<()> {
+    let (_gate_tx, gate_rx) = tokio::sync::oneshot::channel();
+    let (server, _) = start_streaming_sse_server(vec![vec![
+        StreamingSseChunk {
+            gate: None,
+            body: sse(vec![ev_response_created("resp-guardian-cancel")]),
+        },
+        StreamingSseChunk {
+            gate: Some(gate_rx),
+            body: sse(vec![
+                ev_assistant_message(
+                    "msg-guardian-cancel",
+                    &serde_json::json!({
+                        "risk_level": "low",
+                        "user_authorization": "high",
+                        "outcome": "allow",
+                        "rationale": "would have completed if not cancelled",
+                    })
+                    .to_string(),
+                ),
+                ev_completed("resp-guardian-cancel"),
+            ]),
+        },
+    ]])
+    .await;
+
+    let (mut session, mut turn, rx) =
+        crate::session::tests::make_session_and_context_with_rx().await;
+    let session_mut = Arc::get_mut(&mut session).expect("single session ref");
+    let turn_mut = Arc::get_mut(&mut turn).expect("single turn ref");
+    let mut config = (*turn_mut.config).clone();
+    config.model_provider.base_url = Some(format!("{}/v1", server.uri()));
+    config.user_instructions = None;
+    let config = Arc::new(config);
+    session_mut.services.models_manager = test_support::models_manager_with_provider(
+        config.codex_home.to_path_buf(),
+        Arc::clone(&session_mut.services.auth_manager),
+        config.model_provider.clone(),
+    );
+    turn_mut.config = Arc::clone(&config);
+    turn_mut.provider =
+        create_model_provider(config.model_provider.clone(), turn_mut.auth_manager.clone());
+    turn_mut.user_instructions = None;
+    seed_guardian_parent_history(&session, &turn).await;
+    session
+        .spawn_task(Arc::clone(&turn), Vec::new(), GuardianNeverEndingTask)
+        .await;
+
+    let review_session = Arc::clone(&session);
+    let review_turn = Arc::clone(&turn);
+    let mut review = tokio::spawn(async move {
+        review_approval_request(
+            &review_session,
+            &review_turn,
+            "review-shell-guardian-cancel".to_string(),
+            GuardianApprovalRequest::Shell {
+                id: "shell-guardian-cancel".to_string(),
+                command: vec!["git".to_string(), "push".to_string()],
+                cwd: test_path_buf("/repo/codex-rs/core").abs(),
+                sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
+                additional_permissions: None,
+                justification: Some("Push the docs fix.".to_string()),
+            },
+            /*retry_reason*/ None,
+        )
+        .await
+    });
+
+    tokio::select! {
+        wait_result = tokio::time::timeout(Duration::from_secs(10), async {
+            loop {
+                let review_count = session
+                    .guardian_review_session
+                    .active_review_count_for_turn_for_test(&turn.sub_id)
+                    .await;
+                if review_count == 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        }) => {
+            wait_result.expect("guardian review should register as active");
+        }
+        decision = &mut review => {
+            panic!("guardian review completed before cancellation: {decision:?}");
+        }
+    }
+
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            if !server.requests().await.is_empty() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("guardian review request should start");
+
+    session.interrupt_task().await;
+    let decision = tokio::time::timeout(Duration::from_secs(10), review)
+        .await
+        .expect("guardian review should abort")?;
+    assert_eq!(decision, ReviewDecision::Abort);
+    assert_eq!(
+        session
+            .guardian_review_session
+            .active_review_count_for_turn_for_test(&turn.sub_id)
+            .await,
+        0
+    );
+
+    let mut guardian_statuses = Vec::new();
+    let mut turn_aborted = false;
+    while let Ok(event) = rx.try_recv() {
+        match event.msg {
+            EventMsg::GuardianAssessment(event) => guardian_statuses.push(event.status),
+            EventMsg::TurnAborted(event) => {
+                turn_aborted = event.reason == TurnAbortReason::Interrupted;
+            }
+            _ => {}
+        }
+    }
+
+    assert_eq!(
+        guardian_statuses,
+        vec![
+            GuardianAssessmentStatus::InProgress,
+            GuardianAssessmentStatus::Aborted,
+        ]
+    );
+    assert!(turn_aborted, "expected parent turn to be interrupted");
+
+    Ok(())
+}
+
 #[test]
 fn guardian_timeout_message_distinguishes_timeout_from_policy_denial() {
     let message = guardian_timeout_message();
@@ -1332,6 +1498,7 @@ async fn guardian_request_model_for_auto_review_override(
     let outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
         turn,
+        "review-shell-model".to_string(),
         GuardianApprovalRequest::Shell {
             id: "shell-1".to_string(),
             command: vec!["git".to_string(), "push".to_string()],
@@ -1450,6 +1617,7 @@ async fn guardian_review_request_layout_matches_model_visible_request_snapshot()
     let outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
         Arc::clone(&turn),
+        "review-shell-layout".to_string(),
         request,
         Some("Sandbox denied outbound git push to github.com.".to_string()),
         guardian_output_schema(),
@@ -1628,6 +1796,7 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
     let first_outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
         Arc::clone(&turn),
+        "review-shell-1".to_string(),
         first_request,
         Some("First retry reason".to_string()),
         guardian_output_schema(),
@@ -1672,6 +1841,7 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
     let second_outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
         Arc::clone(&turn),
+        "review-shell-2".to_string(),
         second_request,
         Some("Second retry reason".to_string()),
         guardian_output_schema(),
@@ -1712,6 +1882,7 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
     let third_outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
         Arc::clone(&turn),
+        "review-shell-3".to_string(),
         third_request,
         Some("Third retry reason".to_string()),
         guardian_output_schema(),
@@ -1896,6 +2067,7 @@ async fn guardian_reused_trunk_ignores_stale_prior_turn_completion() -> anyhow::
     let first_outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
         Arc::clone(&turn),
+        "review-shell-stale-1".to_string(),
         GuardianApprovalRequest::Shell {
             id: "shell-1".to_string(),
             command: vec!["git".to_string(), "push".to_string()],
@@ -1938,6 +2110,7 @@ async fn guardian_reused_trunk_ignores_stale_prior_turn_completion() -> anyhow::
     let second_outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
         Arc::clone(&turn),
+        "review-shell-stale-2".to_string(),
         GuardianApprovalRequest::Shell {
             id: "shell-2".to_string(),
             command: vec!["git".to_string(), "push".to_string()],

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
+use std::time::Duration;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
@@ -3315,8 +3316,33 @@ impl Session {
 
     pub async fn interrupt_task(self: &Arc<Self>) {
         info!("interrupt received: abort current task, if any");
-        let had_active_turn = self.active_turn.lock().await.is_some();
+        let (had_active_turn, active_turn_id) = {
+            let active_turn = self.active_turn.lock().await;
+            (
+                active_turn.is_some(),
+                active_turn
+                    .as_ref()
+                    .and_then(|turn| turn.task.as_ref())
+                    .map(|task| task.turn_context.sub_id.clone()),
+            )
+        };
+        if let Some(active_turn_id) = active_turn_id.as_deref() {
+            let cancelled_guardian_review_count = self
+                .guardian_review_session
+                .cancel_active_reviews_for_turn(active_turn_id)
+                .await;
+            if cancelled_guardian_review_count > 0 {
+                self.guardian_review_session
+                    .wait_for_no_active_reviews_for_turn(active_turn_id, Duration::from_secs(5))
+                    .await;
+            }
+        }
         self.abort_all_tasks(TurnAbortReason::Interrupted).await;
+        if let Some(active_turn_id) = active_turn_id {
+            self.guardian_review_session
+                .shutdown_active_reviews_for_turn(&active_turn_id)
+                .await;
+        }
         if !had_active_turn {
             self.cancel_mcp_startup().await;
         }


### PR DESCRIPTION
Guardian approval reviews run in a separate reusable subagent session. Parent turn interruption only aborted the parent task, while normal guardian reviews had no cancellation token tied back to that turn, so the guardian could remain running and the UI never received its terminal aborted assessment.

Track in-flight guardian reviews by review ID and parent turn ID, merge their existing external cancellation with an internal token, and cancel/drain matching reviews before aborting the parent task. If a review does not drain promptly, shut down its child session during interrupt cleanup. This also preserves the guardian analytics path and trunk/ephemeral session reuse behavior on current main.

Add a streaming regression test that starts a parent task and an in-flight guardian review, interrupts the parent, and verifies the review returns Abort, unregisters itself, and emits InProgress followed by Aborted.

Validation:
- `cargo test -p codex-core interrupting_parent_turn_cancels_active_guardian_review -- --nocapture`
- `cargo test -p codex-core guardian::review_session::tests --lib`

References:
- CA-419: https://linear.app/openai/issue/CA-419/stop-guardian-subagent-when-parent-thread-stops
- Original implementation: https://github.com/openai/codex/commit/b4626d518b2f9736c85b44d01ea9b0a139184f9b