### PR TITLE
ci: use bazel environment for BuildBuddy secret

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -50,6 +50,9 @@ jobs:
 
     # Configure a human readable name for each job
     name: Bazel test on ${{ matrix.os }} for ${{ matrix.target }}
+    environment:
+      name: bazel
+      deployment: false
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -152,6 +155,9 @@ jobs:
       group: codex-runners
       labels: codex-windows-x64
     name: Bazel test on windows-latest for x86_64-pc-windows-gnullvm shard ${{ matrix.shard }}/4
+    environment:
+      name: bazel
+      deployment: false
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -264,6 +270,9 @@ jobs:
       group: codex-runners
       labels: codex-windows-x64
     name: Bazel test on windows-latest for x86_64-pc-windows-gnullvm (native main)
+    environment:
+      name: bazel
+      deployment: false
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -352,6 +361,9 @@ jobs:
               labels: codex-windows-x64
     runs-on: ${{ matrix.runs_on || matrix.os }}
     name: Bazel clippy on ${{ matrix.os }} for ${{ matrix.target }}
+    environment:
+      name: bazel
+      deployment: false
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -445,6 +457,9 @@ jobs:
               labels: codex-windows-x64
     runs-on: ${{ matrix.runs_on || matrix.os }}
     name: Verify release build on ${{ matrix.os }} for ${{ matrix.target }}
+    environment:
+      name: bazel
+      deployment: false
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -98,6 +98,9 @@ jobs:
     name: Argument comment lint - ${{ matrix.name }}
     runs-on: ${{ matrix.runs_on || matrix.runner }}
     timeout-minutes: 30
+    environment:
+      name: bazel
+      deployment: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -159,6 +159,9 @@ jobs:
     runs-on: ${{ matrix.runs_on || matrix.runner }}
     timeout-minutes: ${{ matrix.timeout_minutes }}
     needs: changed
+    environment:
+      name: bazel
+      deployment: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rusty-v8-release.yml
+++ b/.github/workflows/rusty-v8-release.yml
@@ -64,6 +64,9 @@ jobs:
     permissions:
       contents: read
       actions: read
+    environment:
+      name: bazel
+      deployment: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -46,6 +46,9 @@ jobs:
       group: codex-runners
       labels: codex-linux-x64
     timeout-minutes: 10
+    environment:
+      name: bazel
+      deployment: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/v8-canary.yml
+++ b/.github/workflows/v8-canary.yml
@@ -80,6 +80,9 @@ jobs:
     permissions:
       contents: read
       actions: read
+    environment:
+      name: bazel
+      deployment: false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Why

`BUILDBUDDY_API_KEY` now lives in the `bazel` GitHub Actions environment as an environment secret. Jobs that need BuildBuddy credentials must opt into that environment so `${{ secrets.BUILDBUDDY_API_KEY }}` resolves from the protected environment secret instead of relying on an unscoped repository/organization secret.

This follows the same environment-secret migration pattern as #26466.

## What Changed

- Attach each workflow job that reads `BUILDBUDDY_API_KEY` to the `bazel` environment.
- Set `deployment: false` on those job-level environment blocks.

`deployment: false` lets the job enter the `bazel` environment to access its environment secrets without creating GitHub deployment records for these CI jobs. That keeps the environment as a secret/access-control boundary without making ordinary Bazel CI runs look like deploys.

## Validation

- Parsed the modified workflow YAML files with Ruby's YAML parser.
- Checked the modified workflow files for trailing whitespace.
