### PR TITLE
[plugins] Support marketplace metadata for git plugins

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/plugin_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_list.rs
@@ -1342,6 +1342,86 @@ async fn plugin_list_accepts_legacy_string_default_prompt() -> Result<()> {
 }
 
 #[tokio::test]
+async fn plugin_list_returns_git_source_marketplace_metadata_before_install() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    let repo_root = TempDir::new()?;
+    std::fs::create_dir_all(repo_root.path().join(".git"))?;
+    std::fs::create_dir_all(repo_root.path().join(".agents/plugins"))?;
+    write_plugins_enabled_config(codex_home.path())?;
+    std::fs::write(
+        repo_root.path().join(".agents/plugins/marketplace.json"),
+        r#"{
+  "name": "debug",
+  "plugins": [
+    {
+      "name": "plans-md",
+      "displayName": "PLANS.md",
+      "description": "Make Codex get work done with durable plan files.",
+      "keywords": ["planning", "agents"],
+      "source": {
+        "source": "url",
+        "url": "AaronFriel/plans.md",
+        "ref": "main",
+        "sha": "abc123"
+      }
+    }
+  ]
+}"#,
+    )?;
+
+    let mut mcp = TestAppServer::new(codex_home.path()).await?;
+    timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;
+
+    let request_id = mcp
+        .send_plugin_list_request(PluginListParams {
+            cwds: Some(vec![AbsolutePathBuf::try_from(repo_root.path())?]),
+            marketplace_kinds: None,
+        })
+        .await?;
+
+    let response: JSONRPCResponse = timeout(
+        DEFAULT_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    let response: PluginListResponse = to_response(response)?;
+
+    let plugin = response
+        .marketplaces
+        .iter()
+        .flat_map(|marketplace| marketplace.plugins.iter())
+        .find(|plugin| plugin.name == "plans-md")
+        .expect("expected plans-md entry");
+
+    assert_eq!(plugin.id, "plans-md@debug");
+    assert_eq!(plugin.installed, false);
+    assert_eq!(
+        plugin.source,
+        PluginSource::Git {
+            url: "https://github.com/AaronFriel/plans.md.git".to_string(),
+            path: None,
+            ref_name: Some("main".to_string()),
+            sha: Some("abc123".to_string()),
+        }
+    );
+    assert_eq!(
+        plugin.keywords,
+        vec!["planning".to_string(), "agents".to_string()]
+    );
+    assert_eq!(
+        plugin.interface.as_ref().map(|interface| (
+            interface.display_name.as_deref(),
+            interface.short_description.as_deref(),
+        )),
+        Some((
+            Some("PLANS.md"),
+            Some("Make Codex get work done with durable plan files."),
+        ))
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn plugin_list_returns_installed_git_source_interface_from_cache() -> Result<()> {
     let codex_home = TempDir::new()?;
     let repo_root = TempDir::new()?;
@@ -1359,6 +1439,9 @@ async fn plugin_list_returns_installed_git_source_interface_from_cache() -> Resu
   "plugins": [
     {{
       "name": "toolkit",
+      "displayName": "Marketplace Toolkit",
+      "description": "Marketplace fallback description",
+      "keywords": ["marketplace-keyword"],
       "source": {{
         "source": "git-subdir",
         "url": "{missing_remote_repo_url}",
@@ -1376,6 +1459,7 @@ async fn plugin_list_returns_installed_git_source_interface_from_cache() -> Resu
         cached_plugin_root.join(".codex-plugin/plugin.json"),
         r##"{
   "name": "toolkit",
+  "keywords": ["cache-keyword"],
   "interface": {
     "displayName": "Toolkit",
     "shortDescription": "Search cached data",
@@ -1423,6 +1507,7 @@ enabled = true
     assert_eq!(plugin.id, "toolkit@debug");
     assert_eq!(plugin.installed, true);
     assert_eq!(plugin.enabled, true);
+    assert_eq!(plugin.keywords, vec!["cache-keyword".to_string()]);
     assert_eq!(
         plugin.source,
         PluginSource::Git {

--- a/codex-rs/core-plugins/src/manager.rs
+++ b/codex-rs/core-plugins/src/manager.rs
@@ -983,6 +983,7 @@ impl PluginsManager {
                         let enabled = enabled_plugins.contains(&plugin_key);
                         let mut interface = plugin.interface;
                         let mut local_version = plugin.local_version;
+                        let mut keywords = plugin.keywords;
                         if installed
                             && matches!(&plugin.source, MarketplacePluginSource::Git { .. })
                             && let Some(plugin_id) = plugin_id.as_ref()
@@ -990,6 +991,7 @@ impl PluginsManager {
                             && let Some(manifest) = load_plugin_manifest(plugin_root.as_path())
                         {
                             local_version = manifest.version.clone();
+                            keywords = manifest.keywords;
                             let marketplace_category = interface
                                 .as_ref()
                                 .and_then(|interface| interface.category.clone());
@@ -1011,7 +1013,7 @@ impl PluginsManager {
                             local_version,
                             source: plugin.source,
                             policy: plugin.policy,
-                            keywords: plugin.keywords,
+                            keywords,
                             interface,
                         })
                     })

--- a/codex-rs/core-plugins/src/marketplace.rs
+++ b/codex-rs/core-plugins/src/marketplace.rs
@@ -28,6 +28,7 @@ pub struct ResolvedMarketplacePlugin {
     pub policy: MarketplacePluginPolicy,
     pub interface: Option<PluginManifestInterface>,
     pub manifest: Option<crate::manifest::PluginManifest>,
+    pub keywords: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -303,18 +304,13 @@ pub fn load_marketplace(path: &AbsolutePathBuf) -> Result<Marketplace, Marketpla
             .manifest
             .as_ref()
             .and_then(|manifest| manifest.version.clone());
-        let keywords = plugin
-            .manifest
-            .map(|manifest| manifest.keywords)
-            .unwrap_or_default();
-
         plugins.push(MarketplacePlugin {
             name: plugin.plugin_id.plugin_name,
             local_version,
             source: plugin.source,
             policy: plugin.policy,
             interface: plugin.interface,
-            keywords,
+            keywords: plugin.keywords,
         });
     }
 
@@ -412,8 +408,11 @@ fn resolve_marketplace_plugin_entry(
     let RawMarketplaceManifestPlugin {
         name,
         source,
+        display_name,
+        description,
         policy,
         category,
+        keywords,
     } = plugin;
     let Some(source) = resolve_supported_plugin_source(marketplace_path, &name, source) else {
         return Ok(None);
@@ -423,12 +422,18 @@ fn resolve_marketplace_plugin_entry(
         MarketplacePluginSource::Local { path } => load_plugin_manifest(path.as_path()),
         MarketplacePluginSource::Git { .. } => None,
     };
-    let interface = plugin_interface_with_marketplace_category(
+    let interface = plugin_interface_with_marketplace_metadata(
         manifest
             .as_ref()
             .and_then(|manifest| manifest.interface.clone()),
+        display_name,
+        description,
         category,
     );
+    let keywords = match manifest.as_ref() {
+        Some(manifest) if !manifest.keywords.is_empty() => manifest.keywords.clone(),
+        _ => keywords,
+    };
 
     Ok(Some(ResolvedMarketplacePlugin {
         plugin_id: PluginId::new(name, marketplace_name.to_string()).map_err(|err| match err {
@@ -442,6 +447,7 @@ fn resolve_marketplace_plugin_entry(
         },
         interface,
         manifest,
+        keywords,
     }))
 }
 
@@ -698,6 +704,27 @@ pub fn plugin_interface_with_marketplace_category(
     interface
 }
 
+fn plugin_interface_with_marketplace_metadata(
+    mut interface: Option<PluginManifestInterface>,
+    display_name: Option<String>,
+    description: Option<String>,
+    category: Option<String>,
+) -> Option<PluginManifestInterface> {
+    if let Some(display_name) = display_name {
+        let interface = interface.get_or_insert_with(PluginManifestInterface::default);
+        if interface.display_name.is_none() {
+            interface.display_name = Some(display_name);
+        }
+    }
+    if let Some(description) = description {
+        let interface = interface.get_or_insert_with(PluginManifestInterface::default);
+        if interface.short_description.is_none() {
+            interface.short_description = Some(description);
+        }
+    }
+    plugin_interface_with_marketplace_category(interface, category)
+}
+
 #[doc(hidden)]
 pub fn marketplace_root_dir(
     marketplace_path: &AbsolutePathBuf,
@@ -736,9 +763,15 @@ struct RawMarketplaceManifestPlugin {
     name: String,
     source: RawMarketplaceManifestPluginSource,
     #[serde(default)]
+    display_name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
     policy: RawMarketplaceManifestPluginPolicy,
     #[serde(default)]
     category: Option<String>,
+    #[serde(default)]
+    keywords: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]

--- a/codex-rs/core-plugins/src/marketplace_tests.rs
+++ b/codex-rs/core-plugins/src/marketplace_tests.rs
@@ -65,6 +65,7 @@ fn find_marketplace_plugin_finds_repo_marketplace_plugin() {
             },
             interface: None,
             manifest: None,
+            keywords: Vec::new(),
         }
     );
 }
@@ -108,6 +109,7 @@ fn find_marketplace_plugin_supports_alternate_layout_and_string_local_source() {
             },
             interface: None,
             manifest: None,
+            keywords: Vec::new(),
         }
     );
 }
@@ -162,6 +164,7 @@ fn find_marketplace_plugin_supports_git_subdir_sources() {
             },
             interface: None,
             manifest: None,
+            keywords: Vec::new(),
         }
     );
 }
@@ -1071,6 +1074,9 @@ fn list_marketplaces_keeps_remote_and_local_plugin_sources() {
     },
     {
       "name": "url-plugin",
+      "displayName": "URL Plugin",
+      "description": "Install a plugin from another repository.",
+      "keywords": ["remote", "plugin"],
       "source": {
         "source": "url",
         "url": "https://github.com/example/plugin"
@@ -1130,8 +1136,25 @@ fn list_marketplaces_keeps_remote_and_local_plugin_sources() {
                     authentication: MarketplacePluginAuthPolicy::OnInstall,
                     products: None,
                 },
-                interface: None,
-                keywords: Vec::new(),
+                interface: Some(PluginManifestInterface {
+                    display_name: Some("URL Plugin".to_string()),
+                    short_description: Some(
+                        "Install a plugin from another repository.".to_string(),
+                    ),
+                    long_description: None,
+                    developer_name: None,
+                    category: None,
+                    capabilities: Vec::new(),
+                    website_url: None,
+                    privacy_policy_url: None,
+                    terms_of_service_url: None,
+                    default_prompt: None,
+                    brand_color: None,
+                    composer_icon: None,
+                    logo: None,
+                    screenshots: Vec::new(),
+                }),
+                keywords: vec!["remote".to_string(), "plugin".to_string()],
             },
             MarketplacePlugin {
                 name: "git-subdir-plugin".to_string(),

--- a/codex-rs/skills/src/assets/samples/plugin-creator/SKILL.md
+++ b/codex-rs/skills/src/assets/samples/plugin-creator/SKILL.md
@@ -118,7 +118,8 @@ See `references/installing-and-updating.md` for the expected cachebuster and rei
 - In either location, the generated source path remains `./plugins/<plugin-name>`.
 - Marketplace root metadata supports top-level `name` plus optional `interface.displayName`.
 - Treat plugin order in `plugins[]` as render order in Codex. Append new entries unless a user explicitly asks to reorder the list.
-- `displayName` belongs inside the marketplace `interface` object, not individual `plugins[]` entries.
+- For local plugin entries, presentation metadata comes from the plugin's `.codex-plugin/plugin.json`.
+- For Git-source plugin entries, add plugin-entry `displayName`, `description`, and `keywords` when the plugin is not installed yet and Codex cannot read its plugin manifest.
 - Each generated marketplace entry must include all of:
   - `policy.installation`
   - `policy.authentication`

--- a/codex-rs/skills/src/assets/samples/plugin-creator/references/plugin-json-spec.md
+++ b/codex-rs/skills/src/assets/samples/plugin-creator/references/plugin-json-spec.md
@@ -141,14 +141,20 @@ personal marketplace unless the caller explicitly requests a repo-local destinat
 ### Plugin entry fields
 
 - `name` (`string`): Plugin identifier. Match the plugin folder name and `plugin.json` `name`.
+- `displayName` (`string`, optional): User-facing title for Git-source entries before the plugin is installed.
+- `description` (`string`, optional): Short description for Git-source entries before the plugin is installed.
+- `keywords` (`array` of `string`, optional): Search/discovery tags for Git-source entries before the plugin is installed.
 - `source` (`object`): Plugin source descriptor.
-  - `source` (`string`): Use `local` for this repo workflow.
-  - `path` (`string`): Relative plugin path based on the marketplace root.
+  - `source` (`string`): Use `local` for plugins in this marketplace repo, `url` for a plugin in another Git repo, or `git-subdir` for a plugin in a subdirectory of another Git repo.
+  - `path` (`string`): Relative plugin path based on the marketplace root for local sources, or the plugin subdirectory for `git-subdir` sources.
     - Personal plugin in `~/.agents/plugins/marketplace.json`: `./plugins/<plugin-name>`
     - Repo/team plugin: `./plugins/<plugin-name>`
   - The same relative path convention is used for both personal and repo/team marketplaces.
     - Example: with `~/.agents/plugins/marketplace.json`, `./plugins/<plugin-name>` resolves to
       `~/plugins/<plugin-name>`.
+  - `url` (`string`): Git repository URL or GitHub `owner/repo` shorthand for `url` and `git-subdir` sources.
+  - `ref` (`string`, optional): Git ref to install from.
+  - `sha` (`string`, optional): Expected commit SHA for the source.
 - `policy` (`object`): Marketplace policy block. Always include it.
   - `installation` (`string`): Availability policy.
     - Allowed values: `NOT_AVAILABLE`, `AVAILABLE`, `INSTALLED_BY_DEFAULT`
@@ -161,7 +167,8 @@ personal marketplace unless the caller explicitly requests a repo-local destinat
 
 ### Marketplace generation rules
 
-- `displayName` belongs under the top-level `interface` object, not individual plugin entries.
+- `displayName` belongs under the top-level `interface` object for the marketplace title.
+- Git-source plugin entries may also include `displayName`, `description`, and `keywords` so Codex can render useful metadata before the plugin is installed.
 - When creating a new marketplace file from scratch, seed `interface.displayName` alongside top-level `name`.
 - Always include `policy.installation`, `policy.authentication`, and `category` on every generated or updated plugin entry.
 - Treat `policy.products` as an override and omit it unless explicitly requested.


### PR DESCRIPTION
## Why

Git-source marketplace entries do not have a local `plugin.json` until installation. As a result, `plugin/list` cannot show a useful name, description, or keywords before the user installs the plugin.

## What changed

- Read `displayName`, `description`, and `keywords` from Git-source marketplace entries.
- Use installed `plugin.json` metadata when it is available, while using marketplace metadata before installation.
- Return the metadata from `plugin/list` and cover the pre-install behavior with an app-server test.
- Document Git-source fields and source variants in the bundled plugin-creator skill.

## Validation

- `cargo test -p codex-core-plugins`
- `cargo test -p codex-app-server plugin_list_returns_git_source_marketplace_metadata_before_install`
- `just fix -p codex-core-plugins`
- `just fix -p codex-app-server`
- `just fmt`
- `just argument-comment-lint`
