### PR TITLE
Add HTTP window ID to Responses client metadata

### DIFF
--- a/codex-rs/codex-api/src/common.rs
+++ b/codex-rs/codex-api/src/common.rs
@@ -38,6 +38,8 @@ pub struct CompactionInput<'a> {
     pub prompt_cache_key: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<TextControls>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_metadata: Option<HashMap<String, String>>,
 }
 
 /// Canonical input payload for the memory summarize endpoint.

--- a/codex-rs/codex-api/src/common.rs
+++ b/codex-rs/codex-api/src/common.rs
@@ -38,8 +38,6 @@ pub struct CompactionInput<'a> {
     pub prompt_cache_key: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<TextControls>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub client_metadata: Option<HashMap<String, String>>,
 }
 
 /// Canonical input payload for the memory summarize endpoint.

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -802,10 +802,16 @@ impl ModelClient {
             service_tier,
             prompt_cache_key,
             text,
-            client_metadata: Some(HashMap::from([(
-                X_CODEX_INSTALLATION_ID_HEADER.to_string(),
-                self.state.installation_id.clone(),
-            )])),
+            client_metadata: Some(HashMap::from([
+                (
+                    X_CODEX_INSTALLATION_ID_HEADER.to_string(),
+                    self.state.installation_id.clone(),
+                ),
+                (
+                    X_CODEX_WINDOW_ID_HEADER.to_string(),
+                    self.current_window_id(),
+                ),
+            ])),
         };
         Ok(request)
     }

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -499,7 +499,6 @@ impl ModelClient {
             service_tier,
             prompt_cache_key,
             text,
-            client_metadata,
             ..
         } = request;
         let payload = ApiCompactionInput {
@@ -512,7 +511,6 @@ impl ModelClient {
             service_tier: service_tier.as_deref(),
             prompt_cache_key: prompt_cache_key.as_deref(),
             text,
-            client_metadata,
         };
 
         let mut extra_headers = ApiHeaderMap::new();

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -499,6 +499,7 @@ impl ModelClient {
             service_tier,
             prompt_cache_key,
             text,
+            client_metadata,
             ..
         } = request;
         let payload = ApiCompactionInput {
@@ -511,6 +512,7 @@ impl ModelClient {
             service_tier: service_tier.as_deref(),
             prompt_cache_key: prompt_cache_key.as_deref(),
             text,
+            client_metadata,
         };
 
         let mut extra_headers = ApiHeaderMap::new();

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -158,6 +158,10 @@ async fn responses_stream_includes_subagent_header_on_review() {
         request.body_json()["client_metadata"]["x-codex-installation-id"].as_str(),
         Some(TEST_INSTALLATION_ID)
     );
+    assert_eq!(
+        request.body_json()["client_metadata"]["x-codex-window-id"].as_str(),
+        Some(expected_window_id.as_str())
+    );
     assert_eq!(request.header("x-codex-sandbox"), None);
 }
 

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -696,14 +696,7 @@ async fn assert_remote_manual_compact_request_parity(
     let expected_compact_object = expected_compact_body_without_input
         .as_object_mut()
         .expect("responses request body should be an object");
-    for field in [
-        "input",
-        "client_metadata",
-        "include",
-        "store",
-        "stream",
-        "tool_choice",
-    ] {
+    for field in ["input", "include", "store", "stream", "tool_choice"] {
         expected_compact_object.remove(field);
     }
     if expected_service_tier.is_none() {
@@ -734,6 +727,11 @@ async fn assert_remote_manual_compact_request_parity(
             "service_tier": expected_service_tier,
         }),
         "compact requests should carry the same shared request fields as /responses"
+    );
+    assert_eq!(
+        compact_body["client_metadata"]["x-codex-window-id"],
+        normal_body["client_metadata"]["x-codex-window-id"],
+        "legacy compact requests should preserve the current window ID in client metadata"
     );
 
     insta::assert_snapshot!(

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -884,6 +884,10 @@ async fn remote_compact_v2_reuses_compaction_trigger_for_followups() -> Result<(
         compact_request.header("x-codex-window-id").as_deref()
     );
     assert_eq!(
+        compact_request.body_json()["client_metadata"]["x-codex-window-id"].as_str(),
+        compact_metadata["window_id"].as_str()
+    );
+    assert_eq!(
         compact_metadata["compaction"],
         json!({
             "trigger": "manual",

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -696,7 +696,14 @@ async fn assert_remote_manual_compact_request_parity(
     let expected_compact_object = expected_compact_body_without_input
         .as_object_mut()
         .expect("responses request body should be an object");
-    for field in ["input", "include", "store", "stream", "tool_choice"] {
+    for field in [
+        "input",
+        "client_metadata",
+        "include",
+        "store",
+        "stream",
+        "tool_choice",
+    ] {
         expected_compact_object.remove(field);
     }
     if expected_service_tier.is_none() {
@@ -727,11 +734,6 @@ async fn assert_remote_manual_compact_request_parity(
             "service_tier": expected_service_tier,
         }),
         "compact requests should carry the same shared request fields as /responses"
-    );
-    assert_eq!(
-        compact_body["client_metadata"]["x-codex-window-id"],
-        normal_body["client_metadata"]["x-codex-window-id"],
-        "legacy compact requests should preserve the current window ID in client metadata"
     );
 
     insta::assert_snapshot!(

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_manual_compact_api_auth_prompt_cache_key_request_diff.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_manual_compact_api_auth_prompt_cache_key_request_diff.snap
@@ -6,6 +6,10 @@ Scenario: After five varied API-key-auth turns, remote manual compaction omits s
 
 --- Last Normal /responses Request
 +++ Remote /responses/compact Request
+-  "client_metadata": {
+-    "x-codex-installation-id": "<UUID>",
+-    "x-codex-window-id": "<UUID>:0"
+-  },
 -  "include": [
 -    "reasoning.encrypted_content"
 -  ],

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_manual_compact_api_auth_prompt_cache_key_request_diff.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_manual_compact_api_auth_prompt_cache_key_request_diff.snap
@@ -6,10 +6,6 @@ Scenario: After five varied API-key-auth turns, remote manual compaction omits s
 
 --- Last Normal /responses Request
 +++ Remote /responses/compact Request
--  "client_metadata": {
--    "x-codex-installation-id": "<UUID>",
--    "x-codex-window-id": "<UUID>:0"
--  },
 -  "include": [
 -    "reasoning.encrypted_content"
 -  ],

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_manual_compact_api_auth_prompt_cache_key_request_diff.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_manual_compact_api_auth_prompt_cache_key_request_diff.snap
@@ -7,7 +7,8 @@ Scenario: After five varied API-key-auth turns, remote manual compaction omits s
 --- Last Normal /responses Request
 +++ Remote /responses/compact Request
 -  "client_metadata": {
--    "x-codex-installation-id": "<UUID>"
+-    "x-codex-installation-id": "<UUID>",
+-    "x-codex-window-id": "<UUID>:0"
 -  },
 -  "include": [
 -    "reasoning.encrypted_content"

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_manual_compact_chatgpt_auth_service_tier_prompt_cache_key_request_diff.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_manual_compact_chatgpt_auth_service_tier_prompt_cache_key_request_diff.snap
@@ -7,7 +7,8 @@ Scenario: After five varied ChatGPT-auth turns, remote manual compaction reuses 
 --- Last Normal /responses Request
 +++ Remote /responses/compact Request
 -  "client_metadata": {
--    "x-codex-installation-id": "<UUID>"
+-    "x-codex-installation-id": "<UUID>",
+-    "x-codex-window-id": "<UUID>:0"
 -  },
 -  "include": [
 -    "reasoning.encrypted_content"

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_manual_compact_chatgpt_auth_service_tier_prompt_cache_key_request_diff.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_manual_compact_chatgpt_auth_service_tier_prompt_cache_key_request_diff.snap
@@ -6,6 +6,10 @@ Scenario: After five varied ChatGPT-auth turns, remote manual compaction reuses 
 
 --- Last Normal /responses Request
 +++ Remote /responses/compact Request
+-  "client_metadata": {
+-    "x-codex-installation-id": "<UUID>",
+-    "x-codex-window-id": "<UUID>:0"
+-  },
 -  "include": [
 -    "reasoning.encrypted_content"
 -  ],

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_manual_compact_chatgpt_auth_service_tier_prompt_cache_key_request_diff.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_manual_compact_chatgpt_auth_service_tier_prompt_cache_key_request_diff.snap
@@ -6,10 +6,6 @@ Scenario: After five varied ChatGPT-auth turns, remote manual compaction reuses 
 
 --- Last Normal /responses Request
 +++ Remote /responses/compact Request
--  "client_metadata": {
--    "x-codex-installation-id": "<UUID>",
--    "x-codex-window-id": "<UUID>:0"
--  },
 -  "include": [
 -    "reasoning.encrypted_content"
 -  ],


### PR DESCRIPTION
## Summary

- Keep the existing `x-codex-window-id` HTTP header unchanged.
- Also send the same window ID in Responses `client_metadata`, allowing supported backend paths to surface it as `x-client-meta-x-codex-window-id`.
- Cover normal HTTP Responses and remote compaction v2 requests without changing window generation or compaction behavior.

## Why

In the `2026-06-06T23` production hour, all 28,729 HTTP compaction requests had `window_id` in `x-codex-turn-metadata`, but only 73 retained the direct `x-codex-window-id` header. The request-body `client_metadata` path is already used for installation ID and is preserved through supported Responses API paths.

This is additive metadata only. It does not change the direct header, request count, model input, compaction routing, window generation, or user response behavior.

Legacy `/v1/responses/compact` is intentionally unchanged. Its current server-side `CompressBody` schema does not accept `client_metadata` and rejects unknown fields, so supporting that path requires a backend schema change before the Codex client can safely send this field.

## Validation

- Current head: `219baef3c`, rebased onto `origin/main` at `26d932983`.
- The post-rebase diff remains limited to the original five files (`22` insertions, `6` deletions); the legacy experiment remains fully reverted.
- `just test -p codex-core responses_stream_includes_subagent_header_on_review`: passed; validates normal HTTP Responses metadata.
- `just test -p codex-core remote_compact_v2_reuses_compaction_trigger_for_followups`: passed; validates remote compaction v2.
- `just test -p codex-core remote_manual_compact_chatgpt_auth_reuses_service_tier_and_prompt_cache_key`: passed; validates that legacy compact keeps its accepted payload shape.
- `just test -p codex-core remote_manual_compact_api_auth_omits_service_tier_and_reuses_prompt_cache_key`: passed; validates the legacy API-key payload as well.
- `just fmt`: passed; an unrelated root `justfile` rewrite produced by the formatter was discarded.
- `git diff --check origin/main...HEAD`: passed.

The focused server pytest could not start in the local monorepo environment because test setup is missing the `dotenv` module. Server source and tests explicitly show that `CompressBody` omits `client_metadata` and `/v1/responses/compact` returns HTTP 400 for unknown body fields.
