### PR TITLE
Cover managed deny-read in Windows shell execution

### DIFF
--- a/codex-rs/core/tests/suite/windows_sandbox.rs
+++ b/codex-rs/core/tests/suite/windows_sandbox.rs
@@ -15,27 +15,14 @@ use codex_protocol::permissions::FileSystemSandboxEntry;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::FileSystemSpecialPath;
 use codex_protocol::permissions::NetworkSandboxPolicy;
-use codex_protocol::protocol::EventMsg;
-use codex_protocol::protocol::Op;
-use codex_protocol::user_input::UserInput;
 use core_test_support::PathExt;
-use core_test_support::responses::ev_assistant_message;
-use core_test_support::responses::ev_completed;
-use core_test_support::responses::ev_function_call;
-use core_test_support::responses::ev_response_created;
-use core_test_support::responses::mount_sse_sequence;
-use core_test_support::responses::sse;
-use core_test_support::responses::start_mock_server;
-use core_test_support::test_codex::test_codex;
-use core_test_support::wait_for_event;
+use core_test_support::load_default_config_for_test_with_cloud_config_bundle;
 use pretty_assertions::assert_eq;
-use serde_json::json;
 use serial_test::serial;
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::path::Path;
 use std::path::PathBuf;
-use std::sync::Arc;
 use tempfile::TempDir;
 
 struct EnvVarGuard {
@@ -341,22 +328,23 @@ async fn windows_elevated_enforces_deny_read_and_protects_setup_marker() -> anyh
 #[serial(codex_home)]
 async fn windows_elevated_enforces_managed_deny_read_for_shell_subprocess() -> anyhow::Result<()> {
     stage_windows_sandbox_helpers()?;
-    let codex_home = Arc::new(TempDir::new()?);
-    let _codex_home_guard = EnvVarGuard::set("CODEX_HOME", codex_home.path().as_os_str());
+    let sandbox_home =
+        codex_home_for_windows_sandbox_test("windows-elevated-managed-deny-read-codex-home")?;
+    let _codex_home_guard = EnvVarGuard::set("CODEX_HOME", sandbox_home.path().as_os_str());
+    let config_home = TempDir::new()?;
     std::fs::write(
-        codex_home.path().join(CONFIG_TOML_FILE),
+        config_home.path().join(CONFIG_TOML_FILE),
         r#"[windows]
 sandbox = "elevated"
 "#,
     )?;
 
-    let protected_dir = TempDir::new()?;
-    let denied_path = protected_dir.path().join("secret.env");
-    let allowed_path = protected_dir.path().join("public.txt");
+    let workspace = TempDir::new()?;
+    let cwd = dunce::canonicalize(workspace.path())?.abs();
+    let denied_path = cwd.join("secret.env");
+    let allowed_path = cwd.join("public.txt");
     std::fs::write(&denied_path, "managed secret\n")?;
     std::fs::write(&allowed_path, "public ok\n")?;
-    let denied_path = dunce::canonicalize(denied_path)?.abs();
-    let allowed_path = dunce::canonicalize(allowed_path)?.abs();
     let denied_path_toml = toml::Value::String(denied_path.to_string_lossy().into()).to_string();
     let requirements = format!(
         r#"[permissions.filesystem]
@@ -367,26 +355,18 @@ allowed_sandbox_implementations = ["elevated"]
 "#
     );
 
-    let server = start_mock_server().await;
-    let mut builder = test_codex()
-        .with_home(Arc::clone(&codex_home))
-        .with_cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(requirements),
-        )
-        .with_windows_cmd_shell()
-        .with_config(|config| {
-            config.permissions.windows_sandbox_private_desktop = false;
-        });
-    let fixture = builder.build(&server).await?;
-
+    let config = load_default_config_for_test_with_cloud_config_bundle(
+        &config_home,
+        CloudConfigBundleFixture::loader_with_enterprise_requirement(requirements),
+    )
+    .await;
     assert_eq!(
-        fixture.config.permissions.windows_sandbox_mode,
+        config.permissions.windows_sandbox_mode,
         Some(codex_config::types::WindowsSandboxModeToml::Elevated)
     );
+    let permission_profile = config.permissions.effective_permission_profile();
     assert!(
-        fixture
-            .session_configured
-            .permission_profile
+        permission_profile
             .file_system_sandbox_policy()
             .entries
             .iter()
@@ -397,73 +377,58 @@ allowed_sandbox_implementations = ["elevated"]
                         FileSystemPath::Path { path } if path == &denied_path
                     )
             }),
-        "managed deny-read path should reach the configured session"
+        "managed deny-read path should reach the runtime permission profile"
     );
 
-    let call_id = "managed-deny-read";
-    let command = format!(
-        "(type \"{}\" 1>NUL 2>NUL && echo SECRET-READ || echo SECRET-DENIED) & type \"{}\"",
-        denied_path.display(),
-        allowed_path.display()
-    );
-    let args = json!({
-        "command": command,
-        "login": false,
-        "timeout_ms": 10_000,
-    });
-    let request_log = mount_sse_sequence(
-        &server,
-        vec![
-            sse(vec![
-                ev_response_created("resp-1"),
-                ev_function_call(call_id, "shell_command", &serde_json::to_string(&args)?),
-                ev_completed("resp-1"),
-            ]),
-            sse(vec![
-                ev_assistant_message("msg-1", "done"),
-                ev_completed("resp-2"),
-            ]),
-        ],
+    let ExecToolCallOutput {
+        exit_code,
+        stdout,
+        ..
+    } = process_exec_tool_call(
+        ExecParams {
+            command: vec![
+                "cmd.exe".to_string(),
+                "/D".to_string(),
+                "/C".to_string(),
+                "(type secret.env 1>NUL 2>NUL && echo SECRET-READ || echo SECRET-DENIED) & type public.txt"
+                    .to_string(),
+            ],
+            cwd: cwd.clone(),
+            expiration: 10_000.into(),
+            capture_policy: ExecCapturePolicy::ShellTool,
+            env: HashMap::new(),
+            network: None,
+            sandbox_permissions: SandboxPermissions::UseDefault,
+            windows_sandbox_level: WindowsSandboxLevel::Elevated,
+            windows_sandbox_private_desktop: false,
+            justification: None,
+            arg0: None,
+        },
+        &permission_profile,
+        &cwd,
+        std::slice::from_ref(&cwd),
+        &None,
+        /*use_legacy_landlock*/ false,
+        /*stdout_stream*/ None,
     )
-    .await;
+    .await?;
 
-    fixture
-        .codex
-        .submit(Op::UserInput {
-            items: vec![UserInput::Text {
-                text: "read the fixture files".into(),
-                text_elements: Vec::new(),
-            }],
-            environments: None,
-            final_output_json_schema: None,
-            responsesapi_client_metadata: None,
-            additional_context: Default::default(),
-            thread_settings: Default::default(),
-        })
-        .await?;
-    wait_for_event(&fixture.codex, |event| {
-        matches!(event, EventMsg::TurnComplete(_))
-    })
-    .await;
-
-    let output = request_log
-        .function_call_output_text(call_id)
-        .context("shell output present")?;
+    assert_eq!(exit_code, 0, "sandboxed command should complete");
     assert!(
-        output.contains("SECRET-DENIED"),
-        "managed deny-read should block the subprocess read: {output}"
+        stdout.text.contains("SECRET-DENIED"),
+        "managed deny-read should block the subprocess read: {stdout:?}"
     );
     assert!(
-        !output.contains("SECRET-READ"),
-        "managed deny-read must not allow the subprocess read: {output}"
+        !stdout.text.contains("SECRET-READ"),
+        "managed deny-read must not allow the subprocess read: {stdout:?}"
     );
     assert!(
-        output.contains("public ok"),
-        "allowed reads should still work: {output}"
+        stdout.text.contains("public ok"),
+        "allowed reads should still work: {stdout:?}"
     );
     assert!(
-        !output.contains("managed secret"),
-        "denied file contents leaked into shell output: {output}"
+        !stdout.text.contains("managed secret"),
+        "denied file contents leaked into shell output: {stdout:?}"
     );
     Ok(())
 }

--- a/codex-rs/core/tests/suite/windows_sandbox.rs
+++ b/codex-rs/core/tests/suite/windows_sandbox.rs
@@ -345,7 +345,9 @@ async fn windows_elevated_enforces_managed_deny_read_for_shell_subprocess() -> a
     let _codex_home_guard = EnvVarGuard::set("CODEX_HOME", codex_home.path().as_os_str());
     std::fs::write(
         codex_home.path().join(CONFIG_TOML_FILE),
-        r#"[windows]
+        r#"sandbox_mode = "workspace-write"
+
+[windows]
 sandbox = "elevated"
 "#,
     )?;

--- a/codex-rs/core/tests/suite/windows_sandbox.rs
+++ b/codex-rs/core/tests/suite/windows_sandbox.rs
@@ -1,4 +1,6 @@
 use anyhow::Context;
+use codex_config::CONFIG_TOML_FILE;
+use codex_config::test_support::CloudConfigBundleFixture;
 use codex_core::exec::ExecCapturePolicy;
 use codex_core::exec::ExecParams;
 use codex_core::exec::process_exec_tool_call;
@@ -13,13 +15,27 @@ use codex_protocol::permissions::FileSystemSandboxEntry;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::FileSystemSpecialPath;
 use codex_protocol::permissions::NetworkSandboxPolicy;
+use codex_protocol::protocol::EventMsg;
+use codex_protocol::protocol::Op;
+use codex_protocol::user_input::UserInput;
 use core_test_support::PathExt;
+use core_test_support::responses::ev_assistant_message;
+use core_test_support::responses::ev_completed;
+use core_test_support::responses::ev_function_call;
+use core_test_support::responses::ev_response_created;
+use core_test_support::responses::mount_sse_sequence;
+use core_test_support::responses::sse;
+use core_test_support::responses::start_mock_server;
+use core_test_support::test_codex::test_codex;
+use core_test_support::wait_for_event;
 use pretty_assertions::assert_eq;
+use serde_json::json;
 use serial_test::serial;
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
 use tempfile::TempDir;
 
 struct EnvVarGuard {
@@ -317,6 +333,137 @@ async fn windows_elevated_enforces_deny_read_and_protects_setup_marker() -> anyh
     assert!(
         sandbox_setup_is_complete(codex_home.path()),
         "setup should remain ready after the tamper attempt"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial(codex_home)]
+async fn windows_elevated_enforces_managed_deny_read_for_shell_subprocess() -> anyhow::Result<()> {
+    stage_windows_sandbox_helpers()?;
+    let codex_home = Arc::new(TempDir::new()?);
+    let _codex_home_guard = EnvVarGuard::set("CODEX_HOME", codex_home.path().as_os_str());
+    std::fs::write(
+        codex_home.path().join(CONFIG_TOML_FILE),
+        r#"[windows]
+sandbox = "elevated"
+"#,
+    )?;
+
+    let protected_dir = TempDir::new()?;
+    let denied_path = protected_dir.path().join("secret.env");
+    let allowed_path = protected_dir.path().join("public.txt");
+    std::fs::write(&denied_path, "managed secret\n")?;
+    std::fs::write(&allowed_path, "public ok\n")?;
+    let denied_path = dunce::canonicalize(denied_path)?.abs();
+    let allowed_path = dunce::canonicalize(allowed_path)?.abs();
+    let denied_path_toml = toml::Value::String(denied_path.to_string_lossy().into()).to_string();
+    let requirements = format!(
+        r#"[permissions.filesystem]
+deny_read = [{denied_path_toml}]
+
+[windows]
+allowed_sandbox_implementations = ["elevated"]
+"#
+    );
+
+    let server = start_mock_server().await;
+    let mut builder = test_codex()
+        .with_home(Arc::clone(&codex_home))
+        .with_cloud_config_bundle(
+            CloudConfigBundleFixture::loader_with_enterprise_requirement(requirements),
+        )
+        .with_windows_cmd_shell()
+        .with_config(|config| {
+            config.permissions.windows_sandbox_private_desktop = false;
+        });
+    let fixture = builder.build(&server).await?;
+
+    assert_eq!(
+        fixture.config.permissions.windows_sandbox_mode,
+        Some(codex_config::types::WindowsSandboxModeToml::Elevated)
+    );
+    assert!(
+        fixture
+            .session_configured
+            .permission_profile
+            .file_system_sandbox_policy()
+            .entries
+            .iter()
+            .any(|entry| {
+                entry.access == FileSystemAccessMode::Deny
+                    && matches!(
+                        &entry.path,
+                        FileSystemPath::Path { path } if path == &denied_path
+                    )
+            }),
+        "managed deny-read path should reach the configured session"
+    );
+
+    let call_id = "managed-deny-read";
+    let command = format!(
+        "(type \"{}\" 1>NUL 2>NUL && echo SECRET-READ || echo SECRET-DENIED) & type \"{}\"",
+        denied_path.display(),
+        allowed_path.display()
+    );
+    let args = json!({
+        "command": command,
+        "login": false,
+        "timeout_ms": 10_000,
+    });
+    let request_log = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                ev_function_call(call_id, "shell_command", &serde_json::to_string(&args)?),
+                ev_completed("resp-1"),
+            ]),
+            sse(vec![
+                ev_assistant_message("msg-1", "done"),
+                ev_completed("resp-2"),
+            ]),
+        ],
+    )
+    .await;
+
+    fixture
+        .codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "read the fixture files".into(),
+                text_elements: Vec::new(),
+            }],
+            environments: None,
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: Default::default(),
+        })
+        .await?;
+    wait_for_event(&fixture.codex, |event| {
+        matches!(event, EventMsg::TurnComplete(_))
+    })
+    .await;
+
+    let output = request_log
+        .function_call_output_text(call_id)
+        .context("shell output present")?;
+    assert!(
+        output.contains("SECRET-DENIED"),
+        "managed deny-read should block the subprocess read: {output}"
+    );
+    assert!(
+        !output.contains("SECRET-READ"),
+        "managed deny-read must not allow the subprocess read: {output}"
+    );
+    assert!(
+        output.contains("public ok"),
+        "allowed reads should still work: {output}"
+    );
+    assert!(
+        !output.contains("managed secret"),
+        "denied file contents leaked into shell output: {output}"
     );
     Ok(())
 }

--- a/codex-rs/core/tests/suite/windows_sandbox.rs
+++ b/codex-rs/core/tests/suite/windows_sandbox.rs
@@ -334,7 +334,9 @@ async fn windows_elevated_enforces_managed_deny_read_for_shell_subprocess() -> a
     let config_home = TempDir::new()?;
     std::fs::write(
         config_home.path().join(CONFIG_TOML_FILE),
-        r#"[windows]
+        r#"sandbox_mode = "workspace-write"
+
+[windows]
 sandbox = "elevated"
 "#,
     )?;
@@ -355,11 +357,12 @@ allowed_sandbox_implementations = ["elevated"]
 "#
     );
 
-    let config = load_default_config_for_test_with_cloud_config_bundle(
+    let mut config = load_default_config_for_test_with_cloud_config_bundle(
         &config_home,
         CloudConfigBundleFixture::loader_with_enterprise_requirement(requirements),
     )
     .await;
+    config.permissions.set_workspace_roots(vec![cwd.clone()]);
     assert_eq!(
         config.permissions.windows_sandbox_mode,
         Some(codex_config::types::WindowsSandboxModeToml::Elevated)

--- a/codex-rs/core/tests/suite/windows_sandbox.rs
+++ b/codex-rs/core/tests/suite/windows_sandbox.rs
@@ -334,9 +334,7 @@ async fn windows_elevated_enforces_managed_deny_read_for_shell_subprocess() -> a
     let config_home = TempDir::new()?;
     std::fs::write(
         config_home.path().join(CONFIG_TOML_FILE),
-        r#"sandbox_mode = "workspace-write"
-
-[windows]
+        r#"[windows]
 sandbox = "elevated"
 "#,
     )?;
@@ -357,12 +355,11 @@ allowed_sandbox_implementations = ["elevated"]
 "#
     );
 
-    let mut config = load_default_config_for_test_with_cloud_config_bundle(
+    let config = load_default_config_for_test_with_cloud_config_bundle(
         &config_home,
         CloudConfigBundleFixture::loader_with_enterprise_requirement(requirements),
     )
     .await;
-    config.permissions.set_workspace_roots(vec![cwd.clone()]);
     assert_eq!(
         config.permissions.windows_sandbox_mode,
         Some(codex_config::types::WindowsSandboxModeToml::Elevated)

--- a/codex-rs/core/tests/suite/windows_sandbox.rs
+++ b/codex-rs/core/tests/suite/windows_sandbox.rs
@@ -354,11 +354,8 @@ sandbox = "elevated"
 
     let protected_dir = TempDir::new()?;
     let denied_path = protected_dir.path().join("secret.env");
-    let allowed_path = protected_dir.path().join("public.txt");
     std::fs::write(&denied_path, "managed secret\n")?;
-    std::fs::write(&allowed_path, "public ok\n")?;
     let denied_path = dunce::canonicalize(denied_path)?.abs();
-    let allowed_path = dunce::canonicalize(allowed_path)?.abs();
     let denied_path_toml = toml::Value::String(denied_path.to_string_lossy().into()).to_string();
     let requirements = format!(
         r#"[permissions.filesystem]
@@ -404,9 +401,8 @@ allowed_sandbox_implementations = ["elevated"]
 
     let call_id = "managed-deny-read";
     let command = format!(
-        "(type \"{}\" 1>NUL 2>NUL && echo SECRET-READ || echo SECRET-DENIED) & type \"{}\"",
-        denied_path.display(),
-        allowed_path.display()
+        "type \"{}\" 1>NUL 2>NUL && echo SECRET-READ || echo SECRET-DENIED",
+        denied_path.display()
     );
     let args = json!({
         "command": command,
@@ -458,10 +454,6 @@ allowed_sandbox_implementations = ["elevated"]
     assert!(
         !output.contains("SECRET-READ"),
         "managed deny-read must not allow the subprocess read: {output}"
-    );
-    assert!(
-        output.contains("public ok"),
-        "allowed reads should still work: {output}"
     );
     assert!(
         !output.contains("managed secret"),

--- a/codex-rs/core/tests/suite/windows_sandbox.rs
+++ b/codex-rs/core/tests/suite/windows_sandbox.rs
@@ -15,14 +15,27 @@ use codex_protocol::permissions::FileSystemSandboxEntry;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::FileSystemSpecialPath;
 use codex_protocol::permissions::NetworkSandboxPolicy;
+use codex_protocol::protocol::EventMsg;
+use codex_protocol::protocol::Op;
+use codex_protocol::user_input::UserInput;
 use core_test_support::PathExt;
-use core_test_support::load_default_config_for_test_with_cloud_config_bundle;
+use core_test_support::responses::ev_assistant_message;
+use core_test_support::responses::ev_completed;
+use core_test_support::responses::ev_function_call;
+use core_test_support::responses::ev_response_created;
+use core_test_support::responses::mount_sse_sequence;
+use core_test_support::responses::sse;
+use core_test_support::responses::start_mock_server;
+use core_test_support::test_codex::test_codex;
+use core_test_support::wait_for_event;
 use pretty_assertions::assert_eq;
+use serde_json::json;
 use serial_test::serial;
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
 use tempfile::TempDir;
 
 struct EnvVarGuard {
@@ -328,23 +341,22 @@ async fn windows_elevated_enforces_deny_read_and_protects_setup_marker() -> anyh
 #[serial(codex_home)]
 async fn windows_elevated_enforces_managed_deny_read_for_shell_subprocess() -> anyhow::Result<()> {
     stage_windows_sandbox_helpers()?;
-    let sandbox_home =
-        codex_home_for_windows_sandbox_test("windows-elevated-managed-deny-read-codex-home")?;
-    let _codex_home_guard = EnvVarGuard::set("CODEX_HOME", sandbox_home.path().as_os_str());
-    let config_home = TempDir::new()?;
+    let codex_home = Arc::new(TempDir::new()?);
+    let _codex_home_guard = EnvVarGuard::set("CODEX_HOME", codex_home.path().as_os_str());
     std::fs::write(
-        config_home.path().join(CONFIG_TOML_FILE),
+        codex_home.path().join(CONFIG_TOML_FILE),
         r#"[windows]
 sandbox = "elevated"
 "#,
     )?;
 
-    let workspace = TempDir::new()?;
-    let cwd = dunce::canonicalize(workspace.path())?.abs();
-    let denied_path = cwd.join("secret.env");
-    let allowed_path = cwd.join("public.txt");
+    let protected_dir = TempDir::new()?;
+    let denied_path = protected_dir.path().join("secret.env");
+    let allowed_path = protected_dir.path().join("public.txt");
     std::fs::write(&denied_path, "managed secret\n")?;
     std::fs::write(&allowed_path, "public ok\n")?;
+    let denied_path = dunce::canonicalize(denied_path)?.abs();
+    let allowed_path = dunce::canonicalize(allowed_path)?.abs();
     let denied_path_toml = toml::Value::String(denied_path.to_string_lossy().into()).to_string();
     let requirements = format!(
         r#"[permissions.filesystem]
@@ -355,18 +367,26 @@ allowed_sandbox_implementations = ["elevated"]
 "#
     );
 
-    let config = load_default_config_for_test_with_cloud_config_bundle(
-        &config_home,
-        CloudConfigBundleFixture::loader_with_enterprise_requirement(requirements),
-    )
-    .await;
+    let server = start_mock_server().await;
+    let mut builder = test_codex()
+        .with_home(Arc::clone(&codex_home))
+        .with_cloud_config_bundle(
+            CloudConfigBundleFixture::loader_with_enterprise_requirement(requirements),
+        )
+        .with_windows_cmd_shell()
+        .with_config(|config| {
+            config.permissions.windows_sandbox_private_desktop = false;
+        });
+    let fixture = builder.build(&server).await?;
+
     assert_eq!(
-        config.permissions.windows_sandbox_mode,
+        fixture.config.permissions.windows_sandbox_mode,
         Some(codex_config::types::WindowsSandboxModeToml::Elevated)
     );
-    let permission_profile = config.permissions.effective_permission_profile();
     assert!(
-        permission_profile
+        fixture
+            .session_configured
+            .permission_profile
             .file_system_sandbox_policy()
             .entries
             .iter()
@@ -377,58 +397,73 @@ allowed_sandbox_implementations = ["elevated"]
                         FileSystemPath::Path { path } if path == &denied_path
                     )
             }),
-        "managed deny-read path should reach the runtime permission profile"
+        "managed deny-read path should reach the configured session"
     );
 
-    let ExecToolCallOutput {
-        exit_code,
-        stdout,
-        ..
-    } = process_exec_tool_call(
-        ExecParams {
-            command: vec![
-                "cmd.exe".to_string(),
-                "/D".to_string(),
-                "/C".to_string(),
-                "(type secret.env 1>NUL 2>NUL && echo SECRET-READ || echo SECRET-DENIED) & type public.txt"
-                    .to_string(),
-            ],
-            cwd: cwd.clone(),
-            expiration: 10_000.into(),
-            capture_policy: ExecCapturePolicy::ShellTool,
-            env: HashMap::new(),
-            network: None,
-            sandbox_permissions: SandboxPermissions::UseDefault,
-            windows_sandbox_level: WindowsSandboxLevel::Elevated,
-            windows_sandbox_private_desktop: false,
-            justification: None,
-            arg0: None,
-        },
-        &permission_profile,
-        &cwd,
-        std::slice::from_ref(&cwd),
-        &None,
-        /*use_legacy_landlock*/ false,
-        /*stdout_stream*/ None,
+    let call_id = "managed-deny-read";
+    let command = format!(
+        "(type \"{}\" 1>NUL 2>NUL && echo SECRET-READ || echo SECRET-DENIED) & type \"{}\"",
+        denied_path.display(),
+        allowed_path.display()
+    );
+    let args = json!({
+        "command": command,
+        "login": false,
+        "timeout_ms": 10_000,
+    });
+    let request_log = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                ev_function_call(call_id, "shell_command", &serde_json::to_string(&args)?),
+                ev_completed("resp-1"),
+            ]),
+            sse(vec![
+                ev_assistant_message("msg-1", "done"),
+                ev_completed("resp-2"),
+            ]),
+        ],
     )
-    .await?;
+    .await;
 
-    assert_eq!(exit_code, 0, "sandboxed command should complete");
+    fixture
+        .codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "read the fixture files".into(),
+                text_elements: Vec::new(),
+            }],
+            environments: None,
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: Default::default(),
+        })
+        .await?;
+    wait_for_event(&fixture.codex, |event| {
+        matches!(event, EventMsg::TurnComplete(_))
+    })
+    .await;
+
+    let output = request_log
+        .function_call_output_text(call_id)
+        .context("shell output present")?;
     assert!(
-        stdout.text.contains("SECRET-DENIED"),
-        "managed deny-read should block the subprocess read: {stdout:?}"
+        output.contains("SECRET-DENIED"),
+        "managed deny-read should block the subprocess read: {output}"
     );
     assert!(
-        !stdout.text.contains("SECRET-READ"),
-        "managed deny-read must not allow the subprocess read: {stdout:?}"
+        !output.contains("SECRET-READ"),
+        "managed deny-read must not allow the subprocess read: {output}"
     );
     assert!(
-        stdout.text.contains("public ok"),
-        "allowed reads should still work: {stdout:?}"
+        output.contains("public ok"),
+        "allowed reads should still work: {output}"
     );
     assert!(
-        !stdout.text.contains("managed secret"),
-        "denied file contents leaked into shell output: {stdout:?}"
+        !output.contains("managed secret"),
+        "denied file contents leaked into shell output: {output}"
     );
     Ok(())
 }


### PR DESCRIPTION
# Why

A customer using Codex CLI `0.137.0` reported that an obfuscated Python subprocess could read a file covered by an enterprise `permissions.filesystem.deny_read` requirement while the elevated Windows sandbox was selected.

The existing Windows coverage constructs a `PermissionProfile` directly. It proves the elevated ACL mechanism works, but it does not cover the full path from an enterprise cloud requirement through session configuration and a real shell tool call.

The report did not reproduce as a Codex runtime bug:

- Current `main` blocks the subprocess read in the new end-to-end test.
- Current `main` with the post-`0.137.0` exec policy refactor (`#25700`) reverted also blocks it.
- Current `main` with both that refactor and the post-`0.137.0` setup-marker change (`#26074`) reverted also blocks it.
- An exact `0.137.0` CI run was blocked before tests by unrelated stale Bazel crate-resolution metadata.
- The supplied sandbox log executes `Get-Content` against `C:\kento\.env`, while the supplied managed policy denies `C:\test\.env`. The obfuscated Python source does not reveal which path it reads.

This points to a path or effective-policy mismatch in the reported session rather than the elevated Windows backend ignoring `deny_read`.

# What

- Add a Windows-only end-to-end regression that loads `deny_read` from an enterprise cloud requirements bundle.
- Select the elevated backend through local `[windows] sandbox = "elevated"` and managed `allowed_sandbox_implementations = ["elevated"]`.
- Start a real Codex session and invoke `shell_command` against the denied file.
- Assert the managed deny reaches the configured session and the sandboxed subprocess cannot read or print the file.

There is no runtime change in this PR because CI did not reproduce a bypass.
