### PR TITLE
Avoid reopening v2 descendants on resume

### DIFF
--- a/codex-rs/core/src/agent/control/residency.rs
+++ b/codex-rs/core/src/agent/control/residency.rs
@@ -136,9 +136,9 @@ impl V2Residency {
                 continue;
             }
             candidate_thread.ensure_rollout_materialized().await;
-            if let Err(err) = candidate_thread.flush_rollout().await {
+            if let Err(err) = candidate_thread.shutdown_and_wait().await {
                 warn!(
-                    "failed to flush v2 resident thread before unloading {candidate_thread_id}: {err}"
+                    "failed to shut down v2 resident thread before unloading {candidate_thread_id}: {err}"
                 );
                 self.touch(candidate_thread_id);
                 continue;

--- a/codex-rs/core/src/agent/control/residency.rs
+++ b/codex-rs/core/src/agent/control/residency.rs
@@ -136,9 +136,9 @@ impl V2Residency {
                 continue;
             }
             candidate_thread.ensure_rollout_materialized().await;
-            if let Err(err) = candidate_thread.shutdown_and_wait().await {
+            if let Err(err) = candidate_thread.flush_rollout().await {
                 warn!(
-                    "failed to shut down v2 resident thread before unloading {candidate_thread_id}: {err}"
+                    "failed to flush v2 resident thread before unloading {candidate_thread_id}: {err}"
                 );
                 self.touch(candidate_thread_id);
                 continue;

--- a/codex-rs/core/src/agent/control/residency.rs
+++ b/codex-rs/core/src/agent/control/residency.rs
@@ -225,7 +225,7 @@ pub(super) fn is_v2_resident_session_source(session_source: &SessionSource) -> b
 async fn is_unloadable(thread: &CodexThread) -> bool {
     matches!(
         thread.agent_status().await,
-        AgentStatus::Completed(_) | AgentStatus::Errored(_)
+        AgentStatus::Completed(_) | AgentStatus::Errored(_) | AgentStatus::Interrupted
     ) && thread.codex.session.active_turn.lock().await.is_none()
         && !thread
             .codex

--- a/codex-rs/core/src/agent/control/residency_tests.rs
+++ b/codex-rs/core/src/agent/control/residency_tests.rs
@@ -1,6 +1,5 @@
 use crate::ThreadManager;
 use crate::agent::AgentControl;
-use crate::agent::registry::AgentMetadata;
 use crate::codex_thread::CodexThread;
 use crate::config::Config;
 use crate::config::test_config;
@@ -66,7 +65,7 @@ async fn residency_slot_reservation_unloads_oldest_idle_v2_agent() {
 }
 
 #[tokio::test]
-async fn interrupted_v2_agent_reloads_after_residency_eviction() {
+async fn interrupted_v2_agent_is_lost_after_residency_eviction() {
     let mut config = test_config().await;
     let _ = config.features.enable(Feature::MultiAgentV2);
     config.multi_agent_v2.max_concurrent_threads_per_session = 2;
@@ -93,14 +92,6 @@ async fn interrupted_v2_agent_reloads_after_residency_eviction() {
     let first =
         spawn_v2_subagent(&control, &state, config.clone(), root.thread_id, "worker-1").await;
     first_slot.commit(first.thread_id);
-    control
-        .state
-        .reserve_spawn_slot(/*max_threads*/ None)
-        .expect("reserve logical agent slot")
-        .commit(AgentMetadata {
-            agent_id: Some(first.thread_id),
-            ..Default::default()
-        });
     mark_thread_interrupted(first.thread.as_ref()).await;
 
     let second_slot = control
@@ -117,15 +108,19 @@ async fn interrupted_v2_agent_reloads_after_residency_eviction() {
     second_slot.commit(second.thread_id);
     mark_thread_completed(second.thread.as_ref()).await;
 
-    control
+    let err = control
         .ensure_v2_agent_loaded(config, first.thread_id)
         .await
-        .expect("evicted interrupted agent should reload");
+        .expect_err("evicted interrupted agent should stay lost");
+    match err {
+        CodexErr::ThreadNotFound(thread_id) => assert_eq!(thread_id, first.thread_id),
+        err => panic!("expected ThreadNotFound, got {err:?}"),
+    }
 
     assert!(manager.get_thread(root.thread_id).await.is_ok());
-    assert!(manager.get_thread(first.thread_id).await.is_ok());
-    match manager.get_thread(second.thread_id).await {
-        Err(CodexErr::ThreadNotFound(thread_id)) => assert_eq!(thread_id, second.thread_id),
+    assert!(manager.get_thread(second.thread_id).await.is_ok());
+    match manager.get_thread(first.thread_id).await {
+        Err(CodexErr::ThreadNotFound(thread_id)) => assert_eq!(thread_id, first.thread_id),
         Err(err) => panic!("expected evicted thread to be missing, got {err:?}"),
         Ok(_) => panic!("expected evicted thread to be missing"),
     }

--- a/codex-rs/core/src/agent/control/residency_tests.rs
+++ b/codex-rs/core/src/agent/control/residency_tests.rs
@@ -12,6 +12,8 @@ use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SubAgentSource;
 use codex_protocol::protocol::ThreadSource;
+use codex_protocol::protocol::TurnAbortReason;
+use codex_protocol::protocol::TurnAbortedEvent;
 use codex_protocol::protocol::TurnCompleteEvent;
 use pretty_assertions::assert_eq;
 use std::sync::Arc;
@@ -50,6 +52,52 @@ async fn residency_slot_reservation_unloads_oldest_idle_v2_agent() {
         .reserve_v2_residency_slot(&state, &config, /*protected_thread_id*/ None)
         .await
         .expect("second resident slot should evict the first idle agent");
+    match manager.get_thread(first.thread_id).await {
+        Err(CodexErr::ThreadNotFound(thread_id)) => assert_eq!(thread_id, first.thread_id),
+        Err(err) => panic!("expected evicted thread to be missing, got {err:?}"),
+        Ok(_) => panic!("expected evicted thread to be missing"),
+    }
+    let second = spawn_v2_subagent(&control, &state, config, root.thread_id, "worker-2").await;
+    second_slot.commit(second.thread_id);
+
+    assert!(manager.get_thread(root.thread_id).await.is_ok());
+    assert!(manager.get_thread(second.thread_id).await.is_ok());
+}
+
+#[tokio::test]
+async fn residency_slot_reservation_unloads_oldest_interrupted_v2_agent() {
+    let mut config = test_config().await;
+    let _ = config.features.enable(Feature::MultiAgentV2);
+    config.multi_agent_v2.max_concurrent_threads_per_session = 2;
+    let temp_home = tempfile::tempdir().expect("create temp home");
+    config.codex_home = temp_home.path().to_path_buf().try_into().unwrap();
+    config.cwd = temp_home.path().to_path_buf().try_into().unwrap();
+    let manager = ThreadManager::with_models_provider_and_home_for_tests(
+        CodexAuth::from_api_key("dummy"),
+        config.model_provider.clone(),
+        config.codex_home.to_path_buf(),
+        Arc::new(codex_exec_server::EnvironmentManager::default_for_tests()),
+    );
+    let root = manager
+        .start_thread(config.clone())
+        .await
+        .expect("start root thread");
+    let control = manager.agent_control();
+    let state = control.upgrade().expect("thread manager should be live");
+
+    let first_slot = control
+        .reserve_v2_residency_slot(&state, &config, /*protected_thread_id*/ None)
+        .await
+        .expect("first resident slot");
+    let first =
+        spawn_v2_subagent(&control, &state, config.clone(), root.thread_id, "worker-1").await;
+    first_slot.commit(first.thread_id);
+    mark_thread_interrupted(first.thread.as_ref()).await;
+
+    let second_slot = control
+        .reserve_v2_residency_slot(&state, &config, /*protected_thread_id*/ None)
+        .await
+        .expect("second resident slot should evict the first interrupted idle agent");
     match manager.get_thread(first.thread_id).await {
         Err(CodexErr::ThreadNotFound(thread_id)) => assert_eq!(thread_id, first.thread_id),
         Err(err) => panic!("expected evicted thread to be missing, got {err:?}"),
@@ -102,6 +150,26 @@ async fn mark_thread_completed(thread: &CodexThread) {
             }),
         )
         .await;
+    clear_active_turn(thread).await;
+}
+
+async fn mark_thread_interrupted(thread: &CodexThread) {
+    let turn = thread.codex.session.new_default_turn().await;
+    thread
+        .codex
+        .session
+        .send_event(
+            turn.as_ref(),
+            EventMsg::TurnAborted(TurnAbortedEvent {
+                turn_id: turn.sub_id.clone(),
+                reason: TurnAbortReason::Interrupted,
+            }),
+        )
+        .await;
+    clear_active_turn(thread).await;
+}
+
+async fn clear_active_turn(thread: &CodexThread) {
     // The fixture has no task runner to clear the turn after the terminal event.
     *thread.codex.session.active_turn.lock().await = None;
 }

--- a/codex-rs/core/src/agent/control/residency_tests.rs
+++ b/codex-rs/core/src/agent/control/residency_tests.rs
@@ -1,5 +1,6 @@
 use crate::ThreadManager;
 use crate::agent::AgentControl;
+use crate::agent::registry::AgentMetadata;
 use crate::codex_thread::CodexThread;
 use crate::config::Config;
 use crate::config::test_config;
@@ -65,7 +66,7 @@ async fn residency_slot_reservation_unloads_oldest_idle_v2_agent() {
 }
 
 #[tokio::test]
-async fn residency_slot_reservation_unloads_oldest_interrupted_v2_agent() {
+async fn interrupted_v2_agent_reloads_after_residency_eviction() {
     let mut config = test_config().await;
     let _ = config.features.enable(Feature::MultiAgentV2);
     config.multi_agent_v2.max_concurrent_threads_per_session = 2;
@@ -92,6 +93,14 @@ async fn residency_slot_reservation_unloads_oldest_interrupted_v2_agent() {
     let first =
         spawn_v2_subagent(&control, &state, config.clone(), root.thread_id, "worker-1").await;
     first_slot.commit(first.thread_id);
+    control
+        .state
+        .reserve_spawn_slot(/*max_threads*/ None)
+        .expect("reserve logical agent slot")
+        .commit(AgentMetadata {
+            agent_id: Some(first.thread_id),
+            ..Default::default()
+        });
     mark_thread_interrupted(first.thread.as_ref()).await;
 
     let second_slot = control
@@ -103,11 +112,23 @@ async fn residency_slot_reservation_unloads_oldest_interrupted_v2_agent() {
         Err(err) => panic!("expected evicted thread to be missing, got {err:?}"),
         Ok(_) => panic!("expected evicted thread to be missing"),
     }
-    let second = spawn_v2_subagent(&control, &state, config, root.thread_id, "worker-2").await;
+    let second =
+        spawn_v2_subagent(&control, &state, config.clone(), root.thread_id, "worker-2").await;
     second_slot.commit(second.thread_id);
+    mark_thread_completed(second.thread.as_ref()).await;
+
+    control
+        .ensure_v2_agent_loaded(config, first.thread_id)
+        .await
+        .expect("evicted interrupted agent should reload");
 
     assert!(manager.get_thread(root.thread_id).await.is_ok());
-    assert!(manager.get_thread(second.thread_id).await.is_ok());
+    assert!(manager.get_thread(first.thread_id).await.is_ok());
+    match manager.get_thread(second.thread_id).await {
+        Err(CodexErr::ThreadNotFound(thread_id)) => assert_eq!(thread_id, second.thread_id),
+        Err(err) => panic!("expected evicted thread to be missing, got {err:?}"),
+        Ok(_) => panic!("expected evicted thread to be missing"),
+    }
 }
 
 async fn spawn_v2_subagent(

--- a/codex-rs/core/src/agent/control/residency_tests.rs
+++ b/codex-rs/core/src/agent/control/residency_tests.rs
@@ -182,8 +182,10 @@ async fn mark_thread_interrupted(thread: &CodexThread) {
         .send_event(
             turn.as_ref(),
             EventMsg::TurnAborted(TurnAbortedEvent {
-                turn_id: turn.sub_id.clone(),
+                turn_id: Some(turn.sub_id.clone()),
                 reason: TurnAbortReason::Interrupted,
+                completed_at: None,
+                duration_ms: None,
             }),
         )
         .await;

--- a/codex-rs/core/src/agent/control/spawn.rs
+++ b/codex-rs/core/src/agent/control/spawn.rs
@@ -532,7 +532,7 @@ impl AgentControl {
         )
         .await?;
         let state = self.upgrade()?;
-        if config.features.enabled(Feature::MultiAgentV2)
+        if config.multi_agent_version_from_features() == MultiAgentVersion::V2
             || resumed_multi_agent_version == MultiAgentVersion::V2
         {
             return Ok(resumed_thread_id);

--- a/codex-rs/core/src/agent/control/spawn.rs
+++ b/codex-rs/core/src/agent/control/spawn.rs
@@ -537,12 +537,14 @@ impl AgentControl {
         let Ok(resumed_thread) = state.get_thread(resumed_thread_id).await else {
             return Ok(resumed_thread_id);
         };
-        if resumed_thread.multi_agent_version() == Some(MultiAgentVersion::V2) {
-            return Ok(resumed_thread_id);
-        }
         let Some(state_db_ctx) = resumed_thread.state_db() else {
             return Ok(resumed_thread_id);
         };
+        if resumed_thread.multi_agent_version() == Some(MultiAgentVersion::V2) {
+            self.register_v2_open_descendants_from_store(&state_db_ctx, thread_id)
+                .await;
+            return Ok(resumed_thread_id);
+        }
 
         let mut resume_queue = VecDeque::from([(thread_id, root_depth)]);
         while let Some((parent_thread_id, parent_depth)) = resume_queue.pop_front() {
@@ -596,6 +598,74 @@ impl AgentControl {
         }
 
         Ok(resumed_thread_id)
+    }
+
+    async fn register_v2_open_descendants_from_store(
+        &self,
+        state_db_ctx: &codex_rollout::state_db::StateDbHandle,
+        root_thread_id: ThreadId,
+    ) {
+        let mut resume_queue = VecDeque::from([root_thread_id]);
+        while let Some(parent_thread_id) = resume_queue.pop_front() {
+            let child_ids = match state_db_ctx
+                .list_thread_spawn_children_with_status(
+                    parent_thread_id,
+                    DirectionalThreadSpawnEdgeStatus::Open,
+                )
+                .await
+            {
+                Ok(child_ids) => child_ids,
+                Err(err) => {
+                    warn!(
+                        "failed to load persisted thread-spawn children for {parent_thread_id}: {err}"
+                    );
+                    continue;
+                }
+            };
+
+            for child_thread_id in child_ids {
+                let child_metadata = match state_db_ctx.get_thread(child_thread_id).await {
+                    Ok(Some(child_metadata)) => child_metadata,
+                    Ok(None) => {
+                        warn!("missing thread metadata for open V2 child {child_thread_id}");
+                        resume_queue.push_back(child_thread_id);
+                        continue;
+                    }
+                    Err(err) => {
+                        warn!(
+                            "failed to load thread metadata for open V2 child {child_thread_id}: {err}"
+                        );
+                        resume_queue.push_back(child_thread_id);
+                        continue;
+                    }
+                };
+                let agent_path = child_metadata
+                    .agent_path
+                    .as_deref()
+                    .and_then(|agent_path| AgentPath::try_from(agent_path).ok())
+                    .or_else(|| {
+                        serde_json::from_str::<SessionSource>(&child_metadata.source)
+                            .or_else(|_| {
+                                serde_json::from_value(serde_json::Value::String(
+                                    child_metadata.source.clone(),
+                                ))
+                            })
+                            .ok()
+                            .and_then(|source| source.get_agent_path())
+                    });
+                if agent_path.is_none() {
+                    warn!("open V2 child {child_thread_id} is missing an agent path");
+                }
+                self.state.register_restored_thread(AgentMetadata {
+                    agent_id: Some(child_thread_id),
+                    agent_path,
+                    agent_nickname: child_metadata.agent_nickname,
+                    agent_role: child_metadata.agent_role,
+                    last_task_message: None,
+                });
+                resume_queue.push_back(child_thread_id);
+            }
+        }
     }
 
     async fn resume_single_agent_from_rollout(

--- a/codex-rs/core/src/agent/control/spawn.rs
+++ b/codex-rs/core/src/agent/control/spawn.rs
@@ -527,19 +527,17 @@ impl AgentControl {
         session_source: SessionSource,
     ) -> CodexResult<ThreadId> {
         let root_depth = thread_spawn_depth(&session_source).unwrap_or(0);
-        let resumed_thread_id = Box::pin(self.resume_single_agent_from_rollout(
-            config.clone(),
-            thread_id,
-            session_source,
-        ))
+        let (resumed_thread_id, resumed_multi_agent_version) = Box::pin(
+            self.resume_single_agent_from_rollout(config.clone(), thread_id, session_source),
+        )
         .await?;
         let state = self.upgrade()?;
+        if resumed_multi_agent_version == MultiAgentVersion::V2 {
+            return Ok(resumed_thread_id);
+        }
         let Ok(resumed_thread) = state.get_thread(resumed_thread_id).await else {
             return Ok(resumed_thread_id);
         };
-        if resumed_thread.multi_agent_version() == Some(MultiAgentVersion::V2) {
-            return Ok(resumed_thread_id);
-        }
         let Some(state_db_ctx) = resumed_thread.state_db() else {
             return Ok(resumed_thread_id);
         };
@@ -582,7 +580,7 @@ impl AgentControl {
                     ))
                     .await
                     {
-                        Ok(_) => true,
+                        Ok((_, _)) => true,
                         Err(err) => {
                             warn!("failed to resume descendant thread {child_thread_id}: {err}");
                             false
@@ -603,7 +601,7 @@ impl AgentControl {
         config: Config,
         thread_id: ThreadId,
         session_source: SessionSource,
-    ) -> CodexResult<ThreadId> {
+    ) -> CodexResult<(ThreadId, MultiAgentVersion)> {
         let state = self.upgrade()?;
         let state_db_ctx = state.state_db();
         let stored_thread = state
@@ -708,6 +706,6 @@ impl AgentControl {
         )
         .await;
 
-        Ok(resumed_thread.thread_id)
+        Ok((resumed_thread.thread_id, multi_agent_version))
     }
 }

--- a/codex-rs/core/src/agent/control/spawn.rs
+++ b/codex-rs/core/src/agent/control/spawn.rs
@@ -532,7 +532,9 @@ impl AgentControl {
         )
         .await?;
         let state = self.upgrade()?;
-        if resumed_multi_agent_version == MultiAgentVersion::V2 {
+        if config.features.enabled(Feature::MultiAgentV2)
+            || resumed_multi_agent_version == MultiAgentVersion::V2
+        {
             return Ok(resumed_thread_id);
         }
         let Ok(resumed_thread) = state.get_thread(resumed_thread_id).await else {

--- a/codex-rs/core/src/agent/control/spawn.rs
+++ b/codex-rs/core/src/agent/control/spawn.rs
@@ -540,6 +540,11 @@ impl AgentControl {
         let Some(state_db_ctx) = resumed_thread.state_db() else {
             return Ok(resumed_thread_id);
         };
+        if resumed_thread.multi_agent_version() == Some(MultiAgentVersion::V2) {
+            self.register_v2_open_descendants_from_store(&state_db_ctx, thread_id)
+                .await;
+            return Ok(resumed_thread_id);
+        }
 
         let mut resume_queue = VecDeque::from([(thread_id, root_depth)]);
         while let Some((parent_thread_id, parent_depth)) = resume_queue.pop_front() {
@@ -593,6 +598,74 @@ impl AgentControl {
         }
 
         Ok(resumed_thread_id)
+    }
+
+    async fn register_v2_open_descendants_from_store(
+        &self,
+        state_db_ctx: &codex_rollout::state_db::StateDbHandle,
+        root_thread_id: ThreadId,
+    ) {
+        let mut resume_queue = VecDeque::from([root_thread_id]);
+        while let Some(parent_thread_id) = resume_queue.pop_front() {
+            let child_ids = match state_db_ctx
+                .list_thread_spawn_children_with_status(
+                    parent_thread_id,
+                    DirectionalThreadSpawnEdgeStatus::Open,
+                )
+                .await
+            {
+                Ok(child_ids) => child_ids,
+                Err(err) => {
+                    warn!(
+                        "failed to load persisted thread-spawn children for {parent_thread_id}: {err}"
+                    );
+                    continue;
+                }
+            };
+
+            for child_thread_id in child_ids {
+                let child_metadata = match state_db_ctx.get_thread(child_thread_id).await {
+                    Ok(Some(child_metadata)) => child_metadata,
+                    Ok(None) => {
+                        warn!("missing thread metadata for open V2 child {child_thread_id}");
+                        resume_queue.push_back(child_thread_id);
+                        continue;
+                    }
+                    Err(err) => {
+                        warn!(
+                            "failed to load thread metadata for open V2 child {child_thread_id}: {err}"
+                        );
+                        resume_queue.push_back(child_thread_id);
+                        continue;
+                    }
+                };
+                let agent_path = child_metadata
+                    .agent_path
+                    .as_deref()
+                    .and_then(|agent_path| AgentPath::try_from(agent_path).ok())
+                    .or_else(|| {
+                        serde_json::from_str::<SessionSource>(&child_metadata.source)
+                            .or_else(|_| {
+                                serde_json::from_value(serde_json::Value::String(
+                                    child_metadata.source.clone(),
+                                ))
+                            })
+                            .ok()
+                            .and_then(|source| source.get_agent_path())
+                    });
+                if agent_path.is_none() {
+                    warn!("open V2 child {child_thread_id} is missing an agent path");
+                }
+                self.state.register_restored_thread(AgentMetadata {
+                    agent_id: Some(child_thread_id),
+                    agent_path,
+                    agent_nickname: child_metadata.agent_nickname,
+                    agent_role: child_metadata.agent_role,
+                    last_task_message: None,
+                });
+                resume_queue.push_back(child_thread_id);
+            }
+        }
     }
 
     async fn resume_single_agent_from_rollout(

--- a/codex-rs/core/src/agent/control/spawn.rs
+++ b/codex-rs/core/src/agent/control/spawn.rs
@@ -537,14 +537,12 @@ impl AgentControl {
         let Ok(resumed_thread) = state.get_thread(resumed_thread_id).await else {
             return Ok(resumed_thread_id);
         };
+        if resumed_thread.multi_agent_version() == Some(MultiAgentVersion::V2) {
+            return Ok(resumed_thread_id);
+        }
         let Some(state_db_ctx) = resumed_thread.state_db() else {
             return Ok(resumed_thread_id);
         };
-        if resumed_thread.multi_agent_version() == Some(MultiAgentVersion::V2) {
-            self.register_v2_open_descendants_from_store(&state_db_ctx, thread_id)
-                .await;
-            return Ok(resumed_thread_id);
-        }
 
         let mut resume_queue = VecDeque::from([(thread_id, root_depth)]);
         while let Some((parent_thread_id, parent_depth)) = resume_queue.pop_front() {
@@ -598,74 +596,6 @@ impl AgentControl {
         }
 
         Ok(resumed_thread_id)
-    }
-
-    async fn register_v2_open_descendants_from_store(
-        &self,
-        state_db_ctx: &codex_rollout::state_db::StateDbHandle,
-        root_thread_id: ThreadId,
-    ) {
-        let mut resume_queue = VecDeque::from([root_thread_id]);
-        while let Some(parent_thread_id) = resume_queue.pop_front() {
-            let child_ids = match state_db_ctx
-                .list_thread_spawn_children_with_status(
-                    parent_thread_id,
-                    DirectionalThreadSpawnEdgeStatus::Open,
-                )
-                .await
-            {
-                Ok(child_ids) => child_ids,
-                Err(err) => {
-                    warn!(
-                        "failed to load persisted thread-spawn children for {parent_thread_id}: {err}"
-                    );
-                    continue;
-                }
-            };
-
-            for child_thread_id in child_ids {
-                let child_metadata = match state_db_ctx.get_thread(child_thread_id).await {
-                    Ok(Some(child_metadata)) => child_metadata,
-                    Ok(None) => {
-                        warn!("missing thread metadata for open V2 child {child_thread_id}");
-                        resume_queue.push_back(child_thread_id);
-                        continue;
-                    }
-                    Err(err) => {
-                        warn!(
-                            "failed to load thread metadata for open V2 child {child_thread_id}: {err}"
-                        );
-                        resume_queue.push_back(child_thread_id);
-                        continue;
-                    }
-                };
-                let agent_path = child_metadata
-                    .agent_path
-                    .as_deref()
-                    .and_then(|agent_path| AgentPath::try_from(agent_path).ok())
-                    .or_else(|| {
-                        serde_json::from_str::<SessionSource>(&child_metadata.source)
-                            .or_else(|_| {
-                                serde_json::from_value(serde_json::Value::String(
-                                    child_metadata.source.clone(),
-                                ))
-                            })
-                            .ok()
-                            .and_then(|source| source.get_agent_path())
-                    });
-                if agent_path.is_none() {
-                    warn!("open V2 child {child_thread_id} is missing an agent path");
-                }
-                self.state.register_restored_thread(AgentMetadata {
-                    agent_id: Some(child_thread_id),
-                    agent_path,
-                    agent_nickname: child_metadata.agent_nickname,
-                    agent_role: child_metadata.agent_role,
-                    last_task_message: None,
-                });
-                resume_queue.push_back(child_thread_id);
-            }
-        }
     }
 
     async fn resume_single_agent_from_rollout(

--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -632,7 +632,7 @@ async fn ensure_v2_agent_loaded_reloads_registered_unloaded_agent() {
 }
 
 #[tokio::test]
-async fn resume_agent_from_rollout_registers_v2_descendants_without_reopening_them() {
+async fn resume_agent_from_rollout_does_not_reopen_v2_descendants() {
     let (home, mut config) = test_config().await;
     let _ = config.features.enable(Feature::MultiAgentV2);
     let _ = config.features.enable(Feature::Sqlite);
@@ -719,40 +719,6 @@ async fn resume_agent_from_rollout_registers_v2_descendants_without_reopening_th
     );
     assert_thread_not_loaded(&resumed_manager, worker_thread_id).await;
     assert_thread_not_loaded(&resumed_manager, reviewer_thread_id).await;
-
-    assert_eq!(
-        resumed_control
-            .resolve_agent_reference(parent_thread_id, &SessionSource::Exec, "worker")
-            .await
-            .expect("worker path should resolve after resume"),
-        worker_thread_id
-    );
-    assert_eq!(
-        resumed_control
-            .resolve_agent_reference(parent_thread_id, &SessionSource::Exec, "worker/reviewer")
-            .await
-            .expect("reviewer path should resolve after resume"),
-        reviewer_thread_id
-    );
-
-    resumed_control
-        .ensure_v2_agent_loaded(harness.config.clone(), worker_thread_id)
-        .await
-        .expect("restored worker should lazy reload");
-    let _ = resumed_manager
-        .get_thread(worker_thread_id)
-        .await
-        .expect("worker thread should be loaded on demand");
-    assert_thread_not_loaded(&resumed_manager, reviewer_thread_id).await;
-
-    resumed_control
-        .ensure_v2_agent_loaded(harness.config.clone(), reviewer_thread_id)
-        .await
-        .expect("restored reviewer should lazy reload");
-    let _ = resumed_manager
-        .get_thread(reviewer_thread_id)
-        .await
-        .expect("reviewer thread should be loaded on demand");
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -104,6 +104,10 @@ struct AgentControlHarness {
 impl AgentControlHarness {
     async fn new() -> Self {
         let (home, config) = test_config().await;
+        Self::new_with_config(home, config).await
+    }
+
+    async fn new_with_config(home: TempDir, config: Config) -> Self {
         let state_db = init_state_db(&config).await;
         let manager = ThreadManager::with_models_provider_home_and_state_for_tests(
             CodexAuth::from_api_key("dummy"),
@@ -247,6 +251,14 @@ async fn wait_for_live_thread_spawn_children(
     })
     .await
     .expect("expected persisted child tree");
+}
+
+async fn assert_thread_not_loaded(manager: &ThreadManager, thread_id: ThreadId) {
+    match manager.get_thread(thread_id).await {
+        Err(CodexErr::ThreadNotFound(id)) => assert_eq!(id, thread_id),
+        Err(err) => panic!("expected ThreadNotFound, got {err:?}"),
+        Ok(_) => panic!("expected thread not to be loaded"),
+    }
 }
 
 #[tokio::test]
@@ -532,22 +544,7 @@ async fn ensure_v2_agent_loaded_reloads_registered_unloaded_agent() {
     let (home, mut config) = test_config().await;
     let _ = config.features.enable(Feature::MultiAgentV2);
     let _ = config.features.enable(Feature::Sqlite);
-    let state_db = init_state_db(&config).await;
-    let manager = ThreadManager::with_models_provider_home_and_state_for_tests(
-        CodexAuth::from_api_key("dummy"),
-        config.model_provider.clone(),
-        config.codex_home.to_path_buf(),
-        std::sync::Arc::new(codex_exec_server::EnvironmentManager::default_for_tests()),
-        state_db.clone(),
-    );
-    let control = manager.agent_control();
-    let harness = AgentControlHarness {
-        _home: home,
-        config,
-        state_db,
-        manager,
-        control,
-    };
+    let harness = AgentControlHarness::new_with_config(home, config).await;
     let (parent_thread_id, _parent_thread) = harness.start_thread().await;
     let agent_path = AgentPath::try_from("/root/worker").expect("agent path");
     let spawned_agent = harness
@@ -632,6 +629,130 @@ async fn ensure_v2_agent_loaded_reloads_registered_unloaded_agent() {
         .into_iter()
         .find(|entry| *entry == expected);
     assert_eq!(captured, Some(expected));
+}
+
+#[tokio::test]
+async fn resume_agent_from_rollout_registers_v2_descendants_without_reopening_them() {
+    let (home, mut config) = test_config().await;
+    let _ = config.features.enable(Feature::MultiAgentV2);
+    let _ = config.features.enable(Feature::Sqlite);
+    let harness = AgentControlHarness::new_with_config(home, config).await;
+    let (parent_thread_id, parent_thread) = harness.start_thread().await;
+    let worker_path = AgentPath::root().join("worker").expect("worker path");
+    let worker_thread_id = harness
+        .control
+        .spawn_agent(
+            harness.config.clone(),
+            text_input("hello worker"),
+            Some(SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
+                parent_thread_id,
+                depth: 1,
+                agent_path: Some(worker_path.clone()),
+                agent_nickname: None,
+                agent_role: Some("worker".to_string()),
+            })),
+        )
+        .await
+        .expect("worker spawn should succeed");
+    let reviewer_path = worker_path.join("reviewer").expect("reviewer path");
+    let reviewer_thread_id = harness
+        .control
+        .spawn_agent(
+            harness.config.clone(),
+            text_input("hello reviewer"),
+            Some(SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
+                parent_thread_id: worker_thread_id,
+                depth: 2,
+                agent_path: Some(reviewer_path.clone()),
+                agent_nickname: None,
+                agent_role: Some("reviewer".to_string()),
+            })),
+        )
+        .await
+        .expect("reviewer spawn should succeed");
+
+    let worker_thread = harness
+        .manager
+        .get_thread(worker_thread_id)
+        .await
+        .expect("worker thread should exist");
+    let reviewer_thread = harness
+        .manager
+        .get_thread(reviewer_thread_id)
+        .await
+        .expect("reviewer thread should exist");
+    persist_thread_for_tree_resume(&parent_thread, "parent persisted").await;
+    persist_thread_for_tree_resume(&worker_thread, "worker persisted").await;
+    persist_thread_for_tree_resume(&reviewer_thread, "reviewer persisted").await;
+    wait_for_live_thread_spawn_children(&harness.control, parent_thread_id, &[worker_thread_id])
+        .await;
+    wait_for_live_thread_spawn_children(&harness.control, worker_thread_id, &[reviewer_thread_id])
+        .await;
+
+    let report = harness
+        .manager
+        .shutdown_all_threads_bounded(Duration::from_secs(5))
+        .await;
+    assert_eq!(report.submit_failed, Vec::<ThreadId>::new());
+    assert_eq!(report.timed_out, Vec::<ThreadId>::new());
+
+    let resumed_manager = ThreadManager::with_models_provider_home_and_state_for_tests(
+        CodexAuth::from_api_key("dummy"),
+        harness.config.model_provider.clone(),
+        harness.config.codex_home.to_path_buf(),
+        std::sync::Arc::new(codex_exec_server::EnvironmentManager::default_for_tests()),
+        harness.state_db.clone(),
+    );
+    let resumed_control = resumed_manager.agent_control();
+    let resumed_parent_thread_id = resumed_control
+        .resume_agent_from_rollout(
+            harness.config.clone(),
+            parent_thread_id,
+            SessionSource::Exec,
+        )
+        .await
+        .expect("v2 root resume should succeed");
+    assert_eq!(resumed_parent_thread_id, parent_thread_id);
+    assert_ne!(
+        resumed_control.get_status(parent_thread_id).await,
+        AgentStatus::NotFound
+    );
+    assert_thread_not_loaded(&resumed_manager, worker_thread_id).await;
+    assert_thread_not_loaded(&resumed_manager, reviewer_thread_id).await;
+
+    assert_eq!(
+        resumed_control
+            .resolve_agent_reference(parent_thread_id, &SessionSource::Exec, "worker")
+            .await
+            .expect("worker path should resolve after resume"),
+        worker_thread_id
+    );
+    assert_eq!(
+        resumed_control
+            .resolve_agent_reference(parent_thread_id, &SessionSource::Exec, "worker/reviewer")
+            .await
+            .expect("reviewer path should resolve after resume"),
+        reviewer_thread_id
+    );
+
+    resumed_control
+        .ensure_v2_agent_loaded(harness.config.clone(), worker_thread_id)
+        .await
+        .expect("restored worker should lazy reload");
+    let _ = resumed_manager
+        .get_thread(worker_thread_id)
+        .await
+        .expect("worker thread should be loaded on demand");
+    assert_thread_not_loaded(&resumed_manager, reviewer_thread_id).await;
+
+    resumed_control
+        .ensure_v2_agent_loaded(harness.config.clone(), reviewer_thread_id)
+        .await
+        .expect("restored reviewer should lazy reload");
+    let _ = resumed_manager
+        .get_thread(reviewer_thread_id)
+        .await
+        .expect("reviewer thread should be loaded on demand");
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/agent/registry.rs
+++ b/codex-rs/core/src/agent/registry.rs
@@ -118,6 +118,43 @@ impl AgentRegistry {
         }
     }
 
+    pub(crate) fn register_restored_thread(&self, agent_metadata: AgentMetadata) {
+        let Some(thread_id) = agent_metadata.agent_id else {
+            return;
+        };
+        let counts_agent = !agent_metadata
+            .agent_path
+            .as_ref()
+            .is_some_and(AgentPath::is_root);
+        let key = agent_metadata
+            .agent_path
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_else(|| format!("thread:{thread_id}"));
+        let inserted_counted_agent = {
+            let mut active_agents = self
+                .active_agents
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let previous_counted_agent =
+                active_agents
+                    .agent_tree
+                    .get(key.as_str())
+                    .is_some_and(|metadata| {
+                        metadata.agent_id.is_some()
+                            && !metadata.agent_path.as_ref().is_some_and(AgentPath::is_root)
+                    });
+            if let Some(agent_nickname) = agent_metadata.agent_nickname.clone() {
+                active_agents.used_agent_nicknames.insert(agent_nickname);
+            }
+            active_agents.agent_tree.insert(key, agent_metadata);
+            counts_agent && !previous_counted_agent
+        };
+        if inserted_counted_agent {
+            self.total_count.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
     pub(crate) fn register_root_thread(&self, thread_id: ThreadId) {
         let mut active_agents = self
             .active_agents

--- a/codex-rs/core/src/agent/registry.rs
+++ b/codex-rs/core/src/agent/registry.rs
@@ -118,43 +118,6 @@ impl AgentRegistry {
         }
     }
 
-    pub(crate) fn register_restored_thread(&self, agent_metadata: AgentMetadata) {
-        let Some(thread_id) = agent_metadata.agent_id else {
-            return;
-        };
-        let counts_agent = !agent_metadata
-            .agent_path
-            .as_ref()
-            .is_some_and(AgentPath::is_root);
-        let key = agent_metadata
-            .agent_path
-            .as_ref()
-            .map(ToString::to_string)
-            .unwrap_or_else(|| format!("thread:{thread_id}"));
-        let inserted_counted_agent = {
-            let mut active_agents = self
-                .active_agents
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let previous_counted_agent =
-                active_agents
-                    .agent_tree
-                    .get(key.as_str())
-                    .is_some_and(|metadata| {
-                        metadata.agent_id.is_some()
-                            && !metadata.agent_path.as_ref().is_some_and(AgentPath::is_root)
-                    });
-            if let Some(agent_nickname) = agent_metadata.agent_nickname.clone() {
-                active_agents.used_agent_nicknames.insert(agent_nickname);
-            }
-            active_agents.agent_tree.insert(key, agent_metadata);
-            counts_agent && !previous_counted_agent
-        };
-        if inserted_counted_agent {
-            self.total_count.fetch_add(1, Ordering::AcqRel);
-        }
-    }
-
     pub(crate) fn register_root_thread(&self, thread_id: ThreadId) {
         let mut active_agents = self
             .active_agents


### PR DESCRIPTION
## Why

Multi-agent v2 residency is intended to keep only the threads that need to be live. The existing rollout resume path still walked persisted open descendants and reopened the entire descendant tree when resuming a v2 root, which turns resume into an eager reload of work that should stay unloaded until it is explicitly needed.

The interrupted-agent path has a related residency issue. Interrupted agents remain open by design, so an idle interrupted resident should be eligible for eviction just like an idle completed or errored resident. Otherwise a resident set full of interrupted agents can consume every v2 slot and block later spawns or reloads with `AgentLimitReached`.

## What Changed

- Return early from `resume_agent_from_rollout` after resuming a v2 thread so persisted v2 descendants are not reopened eagerly.
- Treat idle `Interrupted` v2 residents as unloadable in the LRU residency path.
- Add focused coverage for v2 root resume leaving descendants unloaded and for eviction of an idle interrupted v2 resident when a new slot is needed.

## Verification

Added targeted `codex-core` tests covering:

- v2 root resume with persisted descendants, verifying only the root is loaded after resume.
- residency eviction of an idle interrupted v2 agent when the resident set is full.
