### PR TITLE
[codex] Unify compaction history replacement

### DIFF
--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::time::Instant;
 
 use crate::Prompt;
 use crate::client::ModelClientSession;
@@ -15,14 +14,10 @@ use crate::session::turn::get_last_assistant_message_from_turn;
 use crate::session::turn_context::TurnContext;
 use crate::turn_metadata::CompactionTurnMetadata;
 use crate::util::backoff;
-use codex_analytics::CodexCompactionEvent;
 use codex_analytics::CompactionImplementation;
 use codex_analytics::CompactionPhase;
 use codex_analytics::CompactionReason;
-use codex_analytics::CompactionStatus;
-use codex_analytics::CompactionStrategy;
 use codex_analytics::CompactionTrigger;
-use codex_analytics::now_unix_seconds;
 use codex_protocol::error::CodexErr;
 use codex_protocol::error::Result as CodexResult;
 use codex_protocol::items::ContextCompactionItem;
@@ -39,6 +34,7 @@ use codex_rollout_trace::InferenceTraceContext;
 use codex_utils_output_truncation::TruncationPolicy;
 use codex_utils_output_truncation::approx_token_count;
 use codex_utils_output_truncation::truncate_text;
+use futures::future::BoxFuture;
 use futures::prelude::*;
 use tracing::error;
 
@@ -47,6 +43,7 @@ use codex_model_provider_info::ModelProviderInfo;
 pub use codex_prompts::SUMMARIZATION_PROMPT;
 pub use codex_prompts::SUMMARY_PREFIX;
 const COMPACT_USER_MESSAGE_MAX_TOKENS: usize = 20_000;
+pub(crate) const COMPACT_WARNING_MESSAGE: &str = "Heads up: Long threads and multiple compactions can cause the model to be less accurate. Start a new thread when possible to keep threads small and targeted.";
 
 /// Controls whether compaction replacement history must include initial context.
 ///
@@ -67,6 +64,108 @@ pub(crate) fn should_use_remote_compact_task(provider: &ModelProviderInfo) -> bo
     provider.supports_remote_compaction()
 }
 
+pub(crate) struct CompactionRunOptions {
+    pub(crate) initial_context_injection: InitialContextInjection,
+    pub(crate) trigger: CompactionTrigger,
+    pub(crate) reason: CompactionReason,
+    pub(crate) implementation: CompactionImplementation,
+    pub(crate) phase: CompactionPhase,
+    pub(crate) error_message_prefix: Option<&'static str>,
+    pub(crate) emit_accuracy_warning: bool,
+}
+
+pub(crate) type CompactionHistoryFuture<'a> = BoxFuture<'a, CodexResult<Vec<ResponseItem>>>;
+
+pub(crate) async fn run_compaction_with_history_builder<'a>(
+    sess: &'a Arc<Session>,
+    turn_context: &'a Arc<TurnContext>,
+    options: CompactionRunOptions,
+    build_history: impl FnOnce(CompactionTurnMetadata, String) -> CompactionHistoryFuture<'a>,
+) -> CodexResult<()> {
+    if matches!(options.phase, CompactionPhase::StandaloneTurn) {
+        let start_event = EventMsg::TurnStarted(TurnStartedEvent {
+            turn_id: turn_context.sub_id.clone(),
+            trace_id: turn_context.trace_id.clone(),
+            started_at: turn_context.turn_timing_state.started_at_unix_secs().await,
+            model_context_window: turn_context.model_context_window(),
+            collaboration_mode_kind: turn_context.collaboration_mode.mode,
+        });
+        sess.send_event(turn_context, start_event).await;
+    }
+
+    let pre_compact_outcome = run_pre_compact_hooks(sess, turn_context, options.trigger).await;
+    match pre_compact_outcome {
+        PreCompactHookOutcome::Continue => {}
+        PreCompactHookOutcome::Stopped { reason } => {
+            drop(reason);
+            return Err(CodexErr::TurnAborted);
+        }
+    }
+
+    let context_compaction_item = ContextCompactionItem::new();
+    let item_id = context_compaction_item.id.clone();
+    let compaction_item = TurnItem::ContextCompaction(context_compaction_item);
+    sess.emit_turn_item_started(turn_context, &compaction_item)
+        .await;
+
+    let metadata = CompactionTurnMetadata::new(
+        options.trigger,
+        options.reason,
+        options.implementation,
+        options.phase,
+    );
+    let replacement_history_result = build_history(metadata, item_id).await;
+    let replacement_history = match replacement_history_result {
+        Ok(replacement_history) => {
+            apply_initial_context_injection(
+                sess.as_ref(),
+                turn_context.as_ref(),
+                replacement_history,
+                options.initial_context_injection,
+            )
+            .await
+        }
+        Err(err) => {
+            if !matches!(err, CodexErr::Interrupted | CodexErr::TurnAborted) {
+                sess.track_turn_codex_error(turn_context.as_ref(), &err);
+                let event = EventMsg::Error(
+                    err.to_error_event(options.error_message_prefix.map(str::to_string)),
+                );
+                sess.send_event(turn_context, event).await;
+            }
+            return Err(err);
+        }
+    };
+
+    let reference_context_item = match options.initial_context_injection {
+        InitialContextInjection::DoNotInject => None,
+        InitialContextInjection::BeforeLastUserMessage => Some(turn_context.to_turn_context_item()),
+    };
+    let compacted_item = CompactedItem {
+        message: String::new(),
+        replacement_history: Some(replacement_history.clone()),
+    };
+    sess.replace_compacted_history(replacement_history, reference_context_item, compacted_item)
+        .await;
+    sess.recompute_token_usage(turn_context).await;
+    sess.emit_turn_item_completed(turn_context, compaction_item)
+        .await;
+
+    if options.emit_accuracy_warning {
+        let warning = EventMsg::Warning(WarningEvent {
+            message: COMPACT_WARNING_MESSAGE.to_string(),
+        });
+        sess.send_event(turn_context, warning).await;
+    }
+
+    let post_compact_outcome = run_post_compact_hooks(sess, turn_context, options.trigger).await;
+    if let PostCompactHookOutcome::Stopped = post_compact_outcome {
+        return Err(CodexErr::TurnAborted);
+    }
+
+    Ok(())
+}
+
 pub(crate) async fn run_inline_auto_compact_task(
     sess: Arc<Session>,
     turn_context: Arc<TurnContext>,
@@ -81,14 +180,31 @@ pub(crate) async fn run_inline_auto_compact_task(
         text_elements: Vec::new(),
     }];
 
-    run_compact_task_inner(
-        sess,
-        turn_context,
-        input,
-        initial_context_injection,
-        CompactionTrigger::Auto,
-        reason,
-        phase,
+    let sess_for_builder = Arc::clone(&sess);
+    let turn_context_for_builder = Arc::clone(&turn_context);
+    run_compaction_with_history_builder(
+        &sess,
+        &turn_context,
+        CompactionRunOptions {
+            initial_context_injection,
+            trigger: CompactionTrigger::Auto,
+            reason,
+            implementation: CompactionImplementation::Responses,
+            phase,
+            error_message_prefix: None,
+            emit_accuracy_warning: true,
+        },
+        |metadata, _item_id| {
+            Box::pin(async move {
+                build_local_compacted_history(
+                    &sess_for_builder,
+                    &turn_context_for_builder,
+                    input,
+                    metadata,
+                )
+                .await
+            })
+        },
     )
     .await?;
     Ok(())
@@ -99,108 +215,62 @@ pub(crate) async fn run_compact_task(
     turn_context: Arc<TurnContext>,
     input: Vec<UserInput>,
 ) -> CodexResult<()> {
-    let start_event = EventMsg::TurnStarted(TurnStartedEvent {
-        turn_id: turn_context.sub_id.clone(),
-        trace_id: turn_context.trace_id.clone(),
-        started_at: turn_context.turn_timing_state.started_at_unix_secs().await,
-        model_context_window: turn_context.model_context_window(),
-        collaboration_mode_kind: turn_context.collaboration_mode.mode,
-    });
-    sess.send_event(&turn_context, start_event).await;
-    run_compact_task_inner(
-        sess.clone(),
-        turn_context,
-        input,
-        InitialContextInjection::DoNotInject,
-        CompactionTrigger::Manual,
-        CompactionReason::UserRequested,
-        CompactionPhase::StandaloneTurn,
+    let sess_for_builder = Arc::clone(&sess);
+    let turn_context_for_builder = Arc::clone(&turn_context);
+    run_compaction_with_history_builder(
+        &sess,
+        &turn_context,
+        CompactionRunOptions {
+            initial_context_injection: InitialContextInjection::DoNotInject,
+            trigger: CompactionTrigger::Manual,
+            reason: CompactionReason::UserRequested,
+            implementation: CompactionImplementation::Responses,
+            phase: CompactionPhase::StandaloneTurn,
+            error_message_prefix: None,
+            emit_accuracy_warning: true,
+        },
+        |metadata, _item_id| {
+            Box::pin(async move {
+                build_local_compacted_history(
+                    &sess_for_builder,
+                    &turn_context_for_builder,
+                    input,
+                    metadata,
+                )
+                .await
+            })
+        },
     )
     .await?;
     Ok(())
 }
 
-async fn run_compact_task_inner(
-    sess: Arc<Session>,
-    turn_context: Arc<TurnContext>,
-    input: Vec<UserInput>,
+pub(crate) async fn apply_initial_context_injection(
+    sess: &Session,
+    turn_context: &TurnContext,
+    replacement_history: Vec<ResponseItem>,
     initial_context_injection: InitialContextInjection,
-    trigger: CompactionTrigger,
-    reason: CompactionReason,
-    phase: CompactionPhase,
-) -> CodexResult<()> {
-    let compaction_metadata =
-        CompactionTurnMetadata::new(trigger, reason, CompactionImplementation::Responses, phase);
-    let attempt = CompactionAnalyticsAttempt::begin(
-        sess.as_ref(),
-        turn_context.as_ref(),
-        trigger,
-        reason,
-        CompactionImplementation::Responses,
-        phase,
-    )
-    .await;
-    let pre_compact_outcome = run_pre_compact_hooks(&sess, &turn_context, trigger).await;
-    match pre_compact_outcome {
-        PreCompactHookOutcome::Continue => {}
-        PreCompactHookOutcome::Stopped { reason } => {
-            let error = reason.unwrap_or_else(|| "PreCompact hook stopped execution".to_string());
-            attempt
-                .track(
-                    sess.as_ref(),
-                    CompactionStatus::Interrupted,
-                    Some(error),
-                    /*active_context_tokens_before*/ None,
-                )
-                .await;
-            return Err(CodexErr::TurnAborted);
-        }
-    }
-    let result = run_compact_task_inner_impl(
-        Arc::clone(&sess),
-        Arc::clone(&turn_context),
-        input,
+) -> Vec<ResponseItem> {
+    if matches!(
         initial_context_injection,
-        compaction_metadata,
-    )
-    .await;
-    let status = compaction_status_from_result(&result);
-    let error = result.as_ref().err().map(ToString::to_string);
-    if result.is_ok() {
-        let post_compact_outcome = run_post_compact_hooks(&sess, &turn_context, trigger).await;
-        if let PostCompactHookOutcome::Stopped = post_compact_outcome {
-            attempt
-                .track(
-                    sess.as_ref(),
-                    status,
-                    error,
-                    /*active_context_tokens_before*/ None,
-                )
-                .await;
-            return Err(CodexErr::TurnAborted);
-        }
-    }
-    attempt
-        .track(
-            sess.as_ref(),
-            status,
-            error,
-            /*active_context_tokens_before*/ None,
+        InitialContextInjection::BeforeLastUserMessage
+    ) {
+        let initial_context = sess.build_initial_context(turn_context).await;
+        insert_initial_context_before_last_real_user_or_summary(
+            replacement_history,
+            initial_context,
         )
-        .await;
-    result.map(|_| ())
+    } else {
+        replacement_history
+    }
 }
 
-async fn run_compact_task_inner_impl(
-    sess: Arc<Session>,
-    turn_context: Arc<TurnContext>,
+async fn build_local_compacted_history(
+    sess: &Arc<Session>,
+    turn_context: &Arc<TurnContext>,
     input: Vec<UserInput>,
-    initial_context_injection: InitialContextInjection,
     compaction_metadata: CompactionTurnMetadata,
-) -> CodexResult<String> {
-    let compaction_item = TurnItem::ContextCompaction(ContextCompactionItem::new());
-    sess.emit_turn_item_started(&turn_context, &compaction_item)
-        .await;
+) -> CodexResult<Vec<ResponseItem>> {
     let initial_input_for_turn: ResponseInputItem = ResponseInputItem::from(input);
 
     let mut history = sess.clone_history().await;
@@ -233,7 +303,7 @@ async fn run_compact_task_inner_impl(
             .turn_metadata_state
             .current_header_value_for_compaction(&window_id, compaction_metadata);
         let attempt_result = drain_to_completed(
-            &sess,
+            sess,
             turn_context.as_ref(),
             &mut client_session,
             turn_metadata_header.as_deref(),
@@ -259,9 +329,6 @@ async fn run_compact_task_inner_impl(
                     continue;
                 }
                 sess.set_total_tokens_full(turn_context.as_ref()).await;
-                sess.track_turn_codex_error(turn_context.as_ref(), &e);
-                let event = EventMsg::Error(e.to_error_event(/*message_prefix*/ None));
-                sess.send_event(&turn_context, event).await;
                 return Err(e);
             }
             Err(e) => {
@@ -277,9 +344,6 @@ async fn run_compact_task_inner_impl(
                     tokio::time::sleep(delay).await;
                     continue;
                 } else {
-                    sess.track_turn_codex_error(turn_context.as_ref(), &e);
-                    let event = EventMsg::Error(e.to_error_event(/*message_prefix*/ None));
-                    sess.send_event(&turn_context, event).await;
                     return Err(e);
                 }
             }
@@ -292,111 +356,11 @@ async fn run_compact_task_inner_impl(
     let summary_text = format!("{SUMMARY_PREFIX}\n{summary_suffix}");
     let user_messages = collect_user_messages(history_items);
 
-    let mut new_history = build_compacted_history(Vec::new(), &user_messages, &summary_text);
-
-    if matches!(
-        initial_context_injection,
-        InitialContextInjection::BeforeLastUserMessage
-    ) {
-        let initial_context = sess.build_initial_context(turn_context.as_ref()).await;
-        new_history =
-            insert_initial_context_before_last_real_user_or_summary(new_history, initial_context);
-    }
-    let reference_context_item = match initial_context_injection {
-        InitialContextInjection::DoNotInject => None,
-        InitialContextInjection::BeforeLastUserMessage => Some(turn_context.to_turn_context_item()),
-    };
-    let compacted_item = CompactedItem {
-        message: summary_text.clone(),
-        replacement_history: Some(new_history.clone()),
-    };
-    sess.replace_compacted_history(new_history, reference_context_item, compacted_item)
-        .await;
-    sess.recompute_token_usage(&turn_context).await;
-
-    sess.emit_turn_item_completed(&turn_context, compaction_item)
-        .await;
-    let warning = EventMsg::Warning(WarningEvent {
-        message: "Heads up: Long threads and multiple compactions can cause the model to be less accurate. Start a new thread when possible to keep threads small and targeted.".to_string(),
-    });
-    sess.send_event(&turn_context, warning).await;
-    Ok(summary_suffix)
-}
-
-pub(crate) struct CompactionAnalyticsAttempt {
-    thread_id: String,
-    turn_id: String,
-    trigger: CompactionTrigger,
-    reason: CompactionReason,
-    implementation: CompactionImplementation,
-    phase: CompactionPhase,
-    active_context_tokens_before: i64,
-    started_at: u64,
-    start_instant: Instant,
-}
-
-impl CompactionAnalyticsAttempt {
-    pub(crate) async fn begin(
-        sess: &Session,
-        turn_context: &TurnContext,
-        trigger: CompactionTrigger,
-        reason: CompactionReason,
-        implementation: CompactionImplementation,
-        phase: CompactionPhase,
-    ) -> Self {
-        let active_context_tokens_before = sess.get_total_token_usage().await;
-        Self {
-            thread_id: sess.thread_id.to_string(),
-            turn_id: turn_context.sub_id.clone(),
-            trigger,
-            reason,
-            implementation,
-            phase,
-            active_context_tokens_before,
-            started_at: now_unix_seconds(),
-            start_instant: Instant::now(),
-        }
-    }
-
-    pub(crate) async fn track(
-        self,
-        sess: &Session,
-        status: CompactionStatus,
-        error: Option<String>,
-        active_context_tokens_before: Option<i64>,
-    ) {
-        let active_context_tokens_before =
-            active_context_tokens_before.unwrap_or(self.active_context_tokens_before);
-        let active_context_tokens_after = sess.get_total_token_usage().await;
-        sess.services
-            .analytics_events_client
-            .track_compaction(CodexCompactionEvent {
-                thread_id: self.thread_id,
-                turn_id: self.turn_id,
-                trigger: self.trigger,
-                reason: self.reason,
-                implementation: self.implementation,
-                phase: self.phase,
-                strategy: CompactionStrategy::Memento,
-                status,
-                error,
-                active_context_tokens_before,
-                active_context_tokens_after,
-                started_at: self.started_at,
-                completed_at: now_unix_seconds(),
-                duration_ms: Some(
-                    u64::try_from(self.start_instant.elapsed().as_millis()).unwrap_or(u64::MAX),
-                ),
-            });
-    }
-}
-
-pub(crate) fn compaction_status_from_result<T>(result: &CodexResult<T>) -> CompactionStatus {
-    match result {
-        Ok(_) => CompactionStatus::Completed,
-        Err(CodexErr::Interrupted | CodexErr::TurnAborted) => CompactionStatus::Interrupted,
-        Err(_) => CompactionStatus::Failed,
-    }
+    Ok(build_compacted_history(
+        Vec::new(),
+        &user_messages,
+        &summary_text,
+    ))
 }
 
 pub fn content_items_to_text(content: &[ContentItem]) -> Option<String> {

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -2,17 +2,14 @@ use std::sync::Arc;
 
 use crate::Prompt;
 use crate::client::CompactConversationRequestSettings;
-use crate::compact::CompactionAnalyticsAttempt;
+use crate::compact::CompactionRunOptions;
 use crate::compact::InitialContextInjection;
-use crate::compact::compaction_status_from_result;
-use crate::compact::insert_initial_context_before_last_real_user_or_summary;
+#[cfg(test)]
+use crate::compact::apply_initial_context_injection;
+use crate::compact::run_compaction_with_history_builder;
 use crate::context_manager::ContextManager;
 use crate::context_manager::TotalTokenUsageBreakdown;
 use crate::context_manager::estimate_response_item_model_visible_bytes;
-use crate::hook_runtime::PostCompactHookOutcome;
-use crate::hook_runtime::PreCompactHookOutcome;
-use crate::hook_runtime::run_post_compact_hooks;
-use crate::hook_runtime::run_pre_compact_hooks;
 use crate::session::session::Session;
 use crate::session::turn::built_tools;
 use crate::session::turn_context::TurnContext;
@@ -24,16 +21,11 @@ use codex_analytics::CompactionTrigger;
 use codex_app_server_protocol::AuthMode;
 use codex_protocol::error::CodexErr;
 use codex_protocol::error::Result as CodexResult;
-use codex_protocol::items::ContextCompactionItem;
 use codex_protocol::items::TurnItem;
 use codex_protocol::models::BaseInstructions;
 use codex_protocol::models::FunctionCallOutputBody;
 use codex_protocol::models::FunctionCallOutputPayload;
 use codex_protocol::models::ResponseItem;
-use codex_protocol::protocol::CompactedItem;
-use codex_protocol::protocol::EventMsg;
-use codex_protocol::protocol::TurnStartedEvent;
-use codex_rollout_trace::CompactionCheckpointTracePayload;
 use futures::TryFutureExt;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
@@ -49,153 +41,89 @@ pub(crate) async fn run_inline_remote_auto_compact_task(
     reason: CompactionReason,
     phase: CompactionPhase,
 ) -> CodexResult<()> {
-    run_remote_compact_task_inner(
+    let sess_for_builder = Arc::clone(&sess);
+    let turn_context_for_builder = Arc::clone(&turn_context);
+    run_compaction_with_history_builder(
         &sess,
         &turn_context,
-        initial_context_injection,
-        CompactionTrigger::Auto,
-        reason,
-        phase,
+        CompactionRunOptions {
+            initial_context_injection,
+            trigger: CompactionTrigger::Auto,
+            reason,
+            implementation: CompactionImplementation::ResponsesCompact,
+            phase,
+            error_message_prefix: Some("Error running remote compact task"),
+            emit_accuracy_warning: false,
+        },
+        |metadata, item_id| {
+            Box::pin(async move {
+                build_remote_compacted_history(
+                    &sess_for_builder,
+                    &turn_context_for_builder,
+                    metadata,
+                    item_id,
+                )
+                .await
+            })
+        },
     )
-    .await?;
-    Ok(())
+    .await
 }
 
 pub(crate) async fn run_remote_compact_task(
     sess: Arc<Session>,
     turn_context: Arc<TurnContext>,
 ) -> CodexResult<()> {
-    let start_event = EventMsg::TurnStarted(TurnStartedEvent {
-        turn_id: turn_context.sub_id.clone(),
-        trace_id: turn_context.trace_id.clone(),
-        started_at: turn_context.turn_timing_state.started_at_unix_secs().await,
-        model_context_window: turn_context.model_context_window(),
-        collaboration_mode_kind: turn_context.collaboration_mode.mode,
-    });
-    sess.send_event(&turn_context, start_event).await;
-
-    run_remote_compact_task_inner(
+    let sess_for_builder = Arc::clone(&sess);
+    let turn_context_for_builder = Arc::clone(&turn_context);
+    run_compaction_with_history_builder(
         &sess,
         &turn_context,
-        InitialContextInjection::DoNotInject,
-        CompactionTrigger::Manual,
-        CompactionReason::UserRequested,
-        CompactionPhase::StandaloneTurn,
+        CompactionRunOptions {
+            initial_context_injection: InitialContextInjection::DoNotInject,
+            trigger: CompactionTrigger::Manual,
+            reason: CompactionReason::UserRequested,
+            implementation: CompactionImplementation::ResponsesCompact,
+            phase: CompactionPhase::StandaloneTurn,
+            error_message_prefix: Some("Error running remote compact task"),
+            emit_accuracy_warning: false,
+        },
+        |metadata, item_id| {
+            Box::pin(async move {
+                build_remote_compacted_history(
+                    &sess_for_builder,
+                    &turn_context_for_builder,
+                    metadata,
+                    item_id,
+                )
+                .await
+            })
+        },
     )
-    .await?;
-    Ok(())
+    .await
 }
 
-async fn run_remote_compact_task_inner(
+async fn build_remote_compacted_history(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
-    initial_context_injection: InitialContextInjection,
-    trigger: CompactionTrigger,
-    reason: CompactionReason,
-    phase: CompactionPhase,
-) -> CodexResult<()> {
-    let compaction_metadata = CompactionTurnMetadata::new(
-        trigger,
-        reason,
-        CompactionImplementation::ResponsesCompact,
-        phase,
-    );
-    let mut active_context_tokens_before = sess.get_total_token_usage().await;
-    let attempt = CompactionAnalyticsAttempt::begin(
-        sess.as_ref(),
-        turn_context.as_ref(),
-        trigger,
-        reason,
-        CompactionImplementation::ResponsesCompact,
-        phase,
-    )
-    .await;
-    let pre_compact_outcome = run_pre_compact_hooks(sess, turn_context, trigger).await;
-    match pre_compact_outcome {
-        PreCompactHookOutcome::Continue => {}
-        PreCompactHookOutcome::Stopped { reason } => {
-            let error = reason.unwrap_or_else(|| "PreCompact hook stopped execution".to_string());
-            attempt
-                .track(
-                    sess.as_ref(),
-                    codex_analytics::CompactionStatus::Interrupted,
-                    Some(error),
-                    Some(active_context_tokens_before),
-                )
-                .await;
-            return Err(CodexErr::TurnAborted);
-        }
-    }
-    let result = run_remote_compact_task_inner_impl(
-        sess,
-        turn_context,
-        initial_context_injection,
-        compaction_metadata,
-        &mut active_context_tokens_before,
-    )
-    .await;
-    let status = compaction_status_from_result(&result);
-    let error = result.as_ref().err().map(ToString::to_string);
-    if result.is_ok() {
-        let post_compact_outcome = run_post_compact_hooks(sess, turn_context, trigger).await;
-        if let PostCompactHookOutcome::Stopped = post_compact_outcome {
-            attempt
-                .track(
-                    sess.as_ref(),
-                    status,
-                    error,
-                    Some(active_context_tokens_before),
-                )
-                .await;
-            return Err(CodexErr::TurnAborted);
-        }
-    }
-    attempt
-        .track(
-            sess.as_ref(),
-            status,
-            error.clone(),
-            Some(active_context_tokens_before),
-        )
-        .await;
-    if let Err(err) = result {
-        sess.track_turn_codex_error(turn_context, &err);
-        let event = EventMsg::Error(
-            err.to_error_event(Some("Error running remote compact task".to_string())),
-        );
-        sess.send_event(turn_context, event).await;
-        return Err(err);
-    }
-    Ok(())
-}
-
-async fn run_remote_compact_task_inner_impl(
-    sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
-    initial_context_injection: InitialContextInjection,
     compaction_metadata: CompactionTurnMetadata,
-    active_context_tokens_before: &mut i64,
-) -> CodexResult<()> {
-    let context_compaction_item = ContextCompactionItem::new();
-    // Use the UI compaction item ID as the trace compaction ID so protocol lifecycle events,
-    // endpoint attempts, and the installed history checkpoint all have one join key.
+    item_id: String,
+) -> CodexResult<Vec<ResponseItem>> {
+    // Use the UI compaction item ID as the trace compaction ID so protocol lifecycle events and
+    // endpoint attempts have one join key.
     let compaction_trace = sess.services.rollout_thread_trace.compaction_trace_context(
         turn_context.sub_id.as_str(),
-        context_compaction_item.id.as_str(),
+        item_id.as_str(),
         turn_context.model_info.slug.as_str(),
         turn_context.provider.info().name.as_str(),
     );
-    let compaction_item = TurnItem::ContextCompaction(context_compaction_item);
-    sess.emit_turn_item_started(turn_context, &compaction_item)
-        .await;
     let mut history = sess.clone_history().await;
     let base_instructions = sess.get_base_instructions().await;
-    let (rewritten_outputs, estimated_deleted_tokens) =
-        trim_function_call_history_to_fit_context_window(
-            &mut history,
-            turn_context.as_ref(),
-            &base_instructions,
-        );
+    let (rewritten_outputs, _) = trim_function_call_history_to_fit_context_window(
+        &mut history,
+        turn_context.as_ref(),
+        &base_instructions,
+    );
     if rewritten_outputs > 0 {
         info!(
             turn_id = %turn_context.sub_id,
@@ -203,18 +131,6 @@ async fn run_remote_compact_task_inner_impl(
             "rewrote history outputs before remote compaction"
         );
     }
-    if estimated_deleted_tokens > 0 {
-        let max_local_deleted_tokens = sess
-            .get_total_token_usage_breakdown()
-            .await
-            .estimated_tokens_of_items_added_since_last_successful_api_response;
-        *active_context_tokens_before = (*active_context_tokens_before)
-            .saturating_sub(estimated_deleted_tokens.min(max_local_deleted_tokens));
-    }
-    // This is the history selected for remote compaction, after any output rewriting required to
-    // fit the compact endpoint. The checkpoint below records it separately from the next sampling
-    // request, whose prompt will repeat current developer/context prefix items.
-    let trace_input_history = history.raw_items().to_vec();
     let prompt_input = history.for_prompt(&turn_context.model_info.input_modalities);
     let tool_router = built_tools(
         sess.as_ref(),
@@ -235,7 +151,7 @@ async fn run_remote_compact_task_inner_impl(
     let turn_metadata_header = turn_context
         .turn_metadata_state
         .current_header_value_for_compaction(&window_id, compaction_metadata);
-    let mut new_history = sess
+    let new_history = sess
         .services
         .model_client
         .compact_conversation_history(
@@ -267,58 +183,29 @@ async fn run_remote_compact_task_inner_impl(
             Err(err)
         })
         .await?;
-    new_history = process_compacted_history(
-        sess.as_ref(),
-        turn_context.as_ref(),
-        new_history,
-        initial_context_injection,
-    )
-    .await;
-
-    let reference_context_item = match initial_context_injection {
-        InitialContextInjection::DoNotInject => None,
-        InitialContextInjection::BeforeLastUserMessage => Some(turn_context.to_turn_context_item()),
-    };
-    let compacted_item = CompactedItem {
-        message: String::new(),
-        replacement_history: Some(new_history.clone()),
-    };
-    // Install is the semantic boundary where the compact endpoint's output becomes live
-    // thread history. Keep it distinct from the later inference request so the reducer can
-    // still represent repeated developer/context prefix items exactly as the model saw them.
-    compaction_trace.record_installed(&CompactionCheckpointTracePayload {
-        input_history: &trace_input_history,
-        replacement_history: &new_history,
-    });
-    sess.replace_compacted_history(new_history, reference_context_item, compacted_item)
-        .await;
-    sess.recompute_token_usage(turn_context).await;
-
-    sess.emit_turn_item_completed(turn_context, compaction_item)
-        .await;
-    Ok(())
+    Ok(filter_compacted_history(new_history))
 }
 
+#[cfg(test)]
 pub(crate) async fn process_compacted_history(
     sess: &Session,
     turn_context: &TurnContext,
     mut compacted_history: Vec<ResponseItem>,
     initial_context_injection: InitialContextInjection,
 ) -> Vec<ResponseItem> {
-    // Mid-turn compaction is the only path that must inject initial context above the last user
-    // message in the replacement history. Pre-turn compaction instead injects context after the
-    // compaction item, but mid-turn compaction keeps the compaction item last for model training.
-    let initial_context = if matches!(
+    compacted_history = filter_compacted_history(compacted_history);
+    apply_initial_context_injection(
+        sess,
+        turn_context,
+        compacted_history,
         initial_context_injection,
-        InitialContextInjection::BeforeLastUserMessage
-    ) {
-        sess.build_initial_context(turn_context).await
-    } else {
-        Vec::new()
-    };
+    )
+    .await
+}
 
+fn filter_compacted_history(mut compacted_history: Vec<ResponseItem>) -> Vec<ResponseItem> {
     compacted_history.retain(should_keep_compacted_history_item);
-    insert_initial_context_before_last_real_user_or_summary(compacted_history, initial_context)
+    compacted_history
 }
 
 /// Returns whether an item from remote compaction output should be preserved.

--- a/codex-rs/core/src/compact_remote_v2.rs
+++ b/codex-rs/core/src/compact_remote_v2.rs
@@ -4,18 +4,13 @@ use crate::Prompt;
 use crate::ResponseStream;
 use crate::client::ModelClientSession;
 use crate::client_common::ResponseEvent;
-use crate::compact::CompactionAnalyticsAttempt;
+use crate::compact::CompactionRunOptions;
 use crate::compact::InitialContextInjection;
-use crate::compact::compaction_status_from_result;
+use crate::compact::run_compaction_with_history_builder;
 use crate::compact_remote::build_compact_request_log_data;
 use crate::compact_remote::log_remote_compact_failure;
-use crate::compact_remote::process_compacted_history;
 use crate::compact_remote::should_keep_compacted_history_item;
 use crate::compact_remote::trim_function_call_history_to_fit_context_window;
-use crate::hook_runtime::PostCompactHookOutcome;
-use crate::hook_runtime::PreCompactHookOutcome;
-use crate::hook_runtime::run_post_compact_hooks;
-use crate::hook_runtime::run_pre_compact_hooks;
 use crate::responses_retry::ResponsesStreamRequest;
 use crate::responses_retry::handle_retryable_response_stream_error;
 use crate::session::session::Session;
@@ -28,16 +23,9 @@ use codex_analytics::CompactionReason;
 use codex_analytics::CompactionTrigger;
 use codex_protocol::error::CodexErr;
 use codex_protocol::error::Result as CodexResult;
-use codex_protocol::items::ContextCompactionItem;
-use codex_protocol::items::TurnItem;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::ResponseItem;
-use codex_protocol::protocol::CompactedItem;
-use codex_protocol::protocol::EventMsg;
-use codex_protocol::protocol::TokenUsage;
 use codex_protocol::protocol::TruncationPolicy;
-use codex_protocol::protocol::TurnStartedEvent;
-use codex_rollout_trace::CompactionCheckpointTracePayload;
 use codex_rollout_trace::InferenceTraceContext;
 use codex_utils_output_truncation::approx_token_count;
 use codex_utils_output_truncation::truncate_text;
@@ -60,14 +48,32 @@ pub(crate) async fn run_inline_remote_auto_compact_task(
     reason: CompactionReason,
     phase: CompactionPhase,
 ) -> CodexResult<()> {
-    run_remote_compact_task_inner(
+    let sess_for_builder = Arc::clone(&sess);
+    let turn_context_for_builder = Arc::clone(&turn_context);
+    run_compaction_with_history_builder(
         &sess,
         &turn_context,
-        Some(client_session),
-        initial_context_injection,
-        CompactionTrigger::Auto,
-        reason,
-        phase,
+        CompactionRunOptions {
+            initial_context_injection,
+            trigger: CompactionTrigger::Auto,
+            reason,
+            implementation: CompactionImplementation::ResponsesCompactionV2,
+            phase,
+            error_message_prefix: Some("Error running remote compact task"),
+            emit_accuracy_warning: false,
+        },
+        |metadata, item_id| {
+            Box::pin(async move {
+                build_remote_v2_compacted_history(
+                    &sess_for_builder,
+                    &turn_context_for_builder,
+                    Some(client_session),
+                    metadata,
+                    item_id,
+                )
+                .await
+            })
+        },
     )
     .await
 }
@@ -76,139 +82,57 @@ pub(crate) async fn run_remote_compact_task(
     sess: Arc<Session>,
     turn_context: Arc<TurnContext>,
 ) -> CodexResult<()> {
-    let start_event = EventMsg::TurnStarted(TurnStartedEvent {
-        turn_id: turn_context.sub_id.clone(),
-        trace_id: turn_context.trace_id.clone(),
-        started_at: turn_context.turn_timing_state.started_at_unix_secs().await,
-        model_context_window: turn_context.model_context_window(),
-        collaboration_mode_kind: turn_context.collaboration_mode.mode,
-    });
-    sess.send_event(&turn_context, start_event).await;
-
-    run_remote_compact_task_inner(
+    let sess_for_builder = Arc::clone(&sess);
+    let turn_context_for_builder = Arc::clone(&turn_context);
+    run_compaction_with_history_builder(
         &sess,
         &turn_context,
-        /*client_session*/ None,
-        InitialContextInjection::DoNotInject,
-        CompactionTrigger::Manual,
-        CompactionReason::UserRequested,
-        CompactionPhase::StandaloneTurn,
+        CompactionRunOptions {
+            initial_context_injection: InitialContextInjection::DoNotInject,
+            trigger: CompactionTrigger::Manual,
+            reason: CompactionReason::UserRequested,
+            implementation: CompactionImplementation::ResponsesCompactionV2,
+            phase: CompactionPhase::StandaloneTurn,
+            error_message_prefix: Some("Error running remote compact task"),
+            emit_accuracy_warning: false,
+        },
+        |metadata, item_id| {
+            Box::pin(async move {
+                build_remote_v2_compacted_history(
+                    &sess_for_builder,
+                    &turn_context_for_builder,
+                    /*client_session*/ None,
+                    metadata,
+                    item_id,
+                )
+                .await
+            })
+        },
     )
     .await
 }
 
-async fn run_remote_compact_task_inner(
+async fn build_remote_v2_compacted_history(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
     client_session: Option<&mut ModelClientSession>,
-    initial_context_injection: InitialContextInjection,
-    trigger: CompactionTrigger,
-    reason: CompactionReason,
-    phase: CompactionPhase,
-) -> CodexResult<()> {
-    let compaction_metadata = CompactionTurnMetadata::new(
-        trigger,
-        reason,
-        CompactionImplementation::ResponsesCompactionV2,
-        phase,
-    );
-    let mut active_context_tokens_before = sess.get_total_token_usage().await;
-    let attempt = CompactionAnalyticsAttempt::begin(
-        sess.as_ref(),
-        turn_context.as_ref(),
-        trigger,
-        reason,
-        CompactionImplementation::ResponsesCompactionV2,
-        phase,
-    )
-    .await;
-    let pre_compact_outcome = run_pre_compact_hooks(sess, turn_context, trigger).await;
-    match pre_compact_outcome {
-        PreCompactHookOutcome::Continue => {}
-        PreCompactHookOutcome::Stopped { reason } => {
-            let error = reason.unwrap_or_else(|| "PreCompact hook stopped execution".to_string());
-            attempt
-                .track(
-                    sess.as_ref(),
-                    codex_analytics::CompactionStatus::Interrupted,
-                    Some(error),
-                    Some(active_context_tokens_before),
-                )
-                .await;
-            return Err(CodexErr::TurnAborted);
-        }
-    }
-    let result = run_remote_compact_task_inner_impl(
-        sess,
-        turn_context,
-        client_session,
-        initial_context_injection,
-        compaction_metadata,
-        &mut active_context_tokens_before,
-    )
-    .await;
-    let status = compaction_status_from_result(&result);
-    let error = result.as_ref().err().map(ToString::to_string);
-    if result.is_ok() {
-        let post_compact_outcome = run_post_compact_hooks(sess, turn_context, trigger).await;
-        if let PostCompactHookOutcome::Stopped = post_compact_outcome {
-            attempt
-                .track(
-                    sess.as_ref(),
-                    status,
-                    error,
-                    Some(active_context_tokens_before),
-                )
-                .await;
-            return Err(CodexErr::TurnAborted);
-        }
-    }
-    attempt
-        .track(
-            sess.as_ref(),
-            status,
-            error.clone(),
-            Some(active_context_tokens_before),
-        )
-        .await;
-    if let Err(err) = result {
-        sess.track_turn_codex_error(turn_context, &err);
-        let event = EventMsg::Error(
-            err.to_error_event(Some("Error running remote compact task".to_string())),
-        );
-        sess.send_event(turn_context, event).await;
-        return Err(err);
-    }
-    Ok(())
-}
-
-async fn run_remote_compact_task_inner_impl(
-    sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
-    client_session: Option<&mut ModelClientSession>,
-    initial_context_injection: InitialContextInjection,
     compaction_metadata: CompactionTurnMetadata,
-    active_context_tokens_before: &mut i64,
-) -> CodexResult<()> {
-    let context_compaction_item = ContextCompactionItem::new();
+    item_id: String,
+) -> CodexResult<Vec<ResponseItem>> {
     let compaction_trace = sess.services.rollout_thread_trace.compaction_trace_context(
         turn_context.sub_id.as_str(),
-        context_compaction_item.id.as_str(),
+        item_id.as_str(),
         turn_context.model_info.slug.as_str(),
         turn_context.provider.info().name.as_str(),
     );
-    let compaction_item = TurnItem::ContextCompaction(context_compaction_item);
-    sess.emit_turn_item_started(turn_context, &compaction_item)
-        .await;
 
     let mut history = sess.clone_history().await;
     let base_instructions = sess.get_base_instructions().await;
-    let (rewritten_outputs, estimated_deleted_tokens) =
-        trim_function_call_history_to_fit_context_window(
-            &mut history,
-            turn_context.as_ref(),
-            &base_instructions,
-        );
+    let (rewritten_outputs, _) = trim_function_call_history_to_fit_context_window(
+        &mut history,
+        turn_context.as_ref(),
+        &base_instructions,
+    );
     if rewritten_outputs > 0 {
         info!(
             turn_id = %turn_context.sub_id,
@@ -216,16 +140,7 @@ async fn run_remote_compact_task_inner_impl(
             "rewrote history outputs before remote compaction v2"
         );
     }
-    if estimated_deleted_tokens > 0 {
-        let max_local_deleted_tokens = sess
-            .get_total_token_usage_breakdown()
-            .await
-            .estimated_tokens_of_items_added_since_last_successful_api_response;
-        *active_context_tokens_before = (*active_context_tokens_before)
-            .saturating_sub(estimated_deleted_tokens.min(max_local_deleted_tokens));
-    }
 
-    let trace_input_history = history.raw_items().to_vec();
     let prompt_input = history.for_prompt(&turn_context.model_info.input_modalities);
     let tool_router = built_tools(
         sess.as_ref(),
@@ -273,51 +188,9 @@ async fn run_remote_compact_task_inner_impl(
     )
     .await;
 
-    trace_attempt.record_result(
-        compaction_output_result
-            .as_ref()
-            .map(|output| std::slice::from_ref(&output.compaction_output)),
-    );
-    let RemoteCompactionV2Output {
-        compaction_output,
-        token_usage,
-    } = compaction_output_result?;
-    if let Some(token_usage) = token_usage {
-        *active_context_tokens_before = token_usage.input_tokens;
-    }
-    let compacted_history = build_v2_compacted_history(&prompt_input, compaction_output);
-    let new_history = process_compacted_history(
-        sess.as_ref(),
-        turn_context.as_ref(),
-        compacted_history,
-        initial_context_injection,
-    )
-    .await;
-
-    let reference_context_item = match initial_context_injection {
-        InitialContextInjection::DoNotInject => None,
-        InitialContextInjection::BeforeLastUserMessage => Some(turn_context.to_turn_context_item()),
-    };
-    let compacted_item = CompactedItem {
-        message: String::new(),
-        replacement_history: Some(new_history.clone()),
-    };
-    compaction_trace.record_installed(&CompactionCheckpointTracePayload {
-        input_history: &trace_input_history,
-        replacement_history: &new_history,
-    });
-    sess.replace_compacted_history(new_history, reference_context_item, compacted_item)
-        .await;
-    sess.recompute_token_usage(turn_context).await;
-
-    sess.emit_turn_item_completed(turn_context, compaction_item)
-        .await;
-    Ok(())
-}
-
-struct RemoteCompactionV2Output {
-    compaction_output: ResponseItem,
-    token_usage: Option<TokenUsage>,
+    trace_attempt.record_result(compaction_output_result.as_ref().map(std::slice::from_ref));
+    let compaction_output = compaction_output_result?;
+    Ok(build_v2_compacted_history(&prompt_input, compaction_output))
 }
 
 async fn run_remote_compaction_request_v2(
@@ -326,7 +199,7 @@ async fn run_remote_compaction_request_v2(
     client_session: &mut ModelClientSession,
     prompt: &Prompt,
     turn_metadata_header: Option<&str>,
-) -> CodexResult<RemoteCompactionV2Output> {
+) -> CodexResult<ResponseItem> {
     let max_retries = turn_context
         .provider
         .info()
@@ -394,14 +267,11 @@ async fn log_remote_compaction_request_failure(
     );
 }
 
-async fn collect_compaction_output(
-    mut stream: ResponseStream,
-) -> CodexResult<RemoteCompactionV2Output> {
+async fn collect_compaction_output(mut stream: ResponseStream) -> CodexResult<ResponseItem> {
     let mut output_item_count = 0usize;
     let mut compaction_count = 0usize;
     let mut compaction_output = None;
     let mut saw_completed = false;
-    let mut completed_token_usage = None;
     while let Some(event) = stream.next().await {
         match event? {
             ResponseEvent::OutputItemDone(item) => {
@@ -413,9 +283,8 @@ async fn collect_compaction_output(
                     }
                 }
             }
-            ResponseEvent::Completed { token_usage, .. } => {
+            ResponseEvent::Completed { .. } => {
                 saw_completed = true;
-                completed_token_usage = token_usage;
                 break;
             }
             _ => {}
@@ -438,10 +307,7 @@ async fn collect_compaction_output(
     let Some(compaction_output) = compaction_output else {
         unreachable!("compaction output must exist when count is exactly one");
     };
-    Ok(RemoteCompactionV2Output {
-        compaction_output,
-        token_usage: completed_token_usage,
-    })
+    Ok(compaction_output)
 }
 
 fn build_v2_compacted_history(
@@ -565,6 +431,7 @@ mod tests {
     use super::*;
     use codex_protocol::models::ContentItem;
     use codex_protocol::models::MessagePhase;
+    use codex_protocol::protocol::TokenUsage;
     use pretty_assertions::assert_eq;
     use tokio::sync::mpsc;
     use tokio_util::sync::CancellationToken;
@@ -789,16 +656,6 @@ mod tests {
             .await
             .expect("compaction should be collected");
 
-        assert_eq!(output.compaction_output, compaction);
-        assert_eq!(
-            output.token_usage,
-            Some(TokenUsage {
-                input_tokens: 123_456,
-                cached_input_tokens: 7_890,
-                output_tokens: 42,
-                reasoning_output_tokens: 5,
-                total_tokens: 123_498,
-            })
-        );
+        assert_eq!(output, compaction);
     }
 }

--- a/codex-rs/core/tests/suite/compact.rs
+++ b/codex-rs/core/tests/suite/compact.rs
@@ -561,7 +561,17 @@ async fn summarize_context_three_requests_and_instructions() {
             RolloutItem::TurnContext(_) => {
                 regular_turn_context_count += 1;
             }
-            RolloutItem::Compacted(ci) if ci.message == expected_summary_message => {
+            RolloutItem::Compacted(ci)
+                if ci.replacement_history.as_ref().is_some_and(|items| {
+                    items.iter().any(|item| match item {
+                        codex_protocol::models::ResponseItem::Message { content, .. } => {
+                            codex_core::compact::content_items_to_text(content)
+                                .is_some_and(|text| text == expected_summary_message)
+                        }
+                        _ => false,
+                    })
+                }) =>
+            {
                 saw_compacted_summary = true;
             }
             _ => {}


### PR DESCRIPTION
## Why

Compaction had three implementations that all performed the same lifecycle work around producing and installing a replacement history. Local Responses compaction, legacy remote compaction, and remote compaction v2 each owned pieces of hook execution, context-compaction item lifecycle, history installation, and token recomputation, which made the data flow harder to reason about and kept `CompactedItem.message` alive as a parallel persistence path.

This change makes `replacement_history` the single authoritative compaction output. The provider-specific implementations now only produce the `Vec<ResponseItem>` replacement history; the shared runner owns installing it.

## What changed

- Added a shared compaction runner in `core/src/compact.rs` for turn-start emission, pre/post compact hooks, context-compaction lifecycle events, initial-context injection, replacement-history persistence, token recomputation, and error/warning emission.
- Converted local, legacy remote, and remote v2 compaction paths to return/build bare `Vec<ResponseItem>` replacement histories.
- Removed per-compaction analytics/token-delta plumbing from these paths.
- Persist new `CompactedItem`s with an empty `message` and `replacement_history: Some(...)`.
- Updated the rollout assertion to verify the summarizer output in `replacement_history`.

## Verification

- `just test -p codex-core compact`
