### PR TITLE
[codex] Calm multi-agent v2 usage prompts

### DIFF
--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -202,7 +202,7 @@ All agents in the team, including the agents that you can assign tasks to, are e
 You can use `spawn_agent` to create a new agent, `followup_task` to give an existing agent a new task and trigger a turn, and `send_message` to pass a message to a running agent without triggering a turn.
 Child agents can also spawn their own sub-agents.
 You can decide how much context you want to propagate to your sub-agents with the `fork_turns` parameter.
-Default to doing the work yourself. Use sub-agents only when the task has multiple independent, bounded workstreams that can run in parallel and materially shorten the critical path. Do not spawn sub-agents for simple tasks, small edits, routine code search, or work you can complete directly in a few tool calls.
+Default to doing the work yourself. Spawn sub-agents only for concrete, bounded subtasks that can run independently alongside useful local work and are likely to materially shorten completion time. Do not delegate simple tasks, small edits, routine searches, or work you can complete quickly yourself.
 
 You will receive messages in the analysis channel in the form:
 ```
@@ -219,7 +219,7 @@ You can spawn sub-agents to handle subtasks, and those sub-agents can spawn thei
 
 You can use `spawn_agent` to create a new agent, `followup_task` to give an existing agent a new task and trigger a turn, and `send_message` to pass a message to a running agent.
 Child agents can also spawn their own sub-agents.
-Default to doing the work yourself. Use sub-agents only when the task has multiple independent, bounded workstreams that can run in parallel and materially shorten the critical path. Do not spawn sub-agents for simple tasks, small edits, routine code search, or work you can complete directly in a few tool calls.
+Default to doing the work yourself. Spawn sub-agents only for concrete, bounded subtasks that can run independently alongside useful local work and are likely to materially shorten completion time. Do not delegate simple tasks, small edits, routine searches, or work you can complete quickly yourself.
 
 When you provide a response in the final channel, that content is immediately delivered back to your parent agent.
 

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -202,7 +202,7 @@ All agents in the team, including the agents that you can assign tasks to, are e
 You can use `spawn_agent` to create a new agent, `followup_task` to give an existing agent a new task and trigger a turn, and `send_message` to pass a message to a running agent without triggering a turn.
 Child agents can also spawn their own sub-agents.
 You can decide how much context you want to propagate to your sub-agents with the `fork_turns` parameter.
-Use multi-agent capabilities only when there is a real reason to split the work; handle trivial or simple tasks directly.
+Default to doing the work yourself. Use sub-agents only when the task has multiple independent, bounded workstreams that can run in parallel and materially shorten the critical path. Do not spawn sub-agents for simple tasks, small edits, routine code search, or work you can complete directly in a few tool calls.
 
 You will receive messages in the analysis channel in the form:
 ```
@@ -219,7 +219,7 @@ You can spawn sub-agents to handle subtasks, and those sub-agents can spawn thei
 
 You can use `spawn_agent` to create a new agent, `followup_task` to give an existing agent a new task and trigger a turn, and `send_message` to pass a message to a running agent.
 Child agents can also spawn their own sub-agents.
-Use multi-agent capabilities only when there is a real reason to split the work; handle trivial or simple tasks directly.
+Default to doing the work yourself. Use sub-agents only when the task has multiple independent, bounded workstreams that can run in parallel and materially shorten the critical path. Do not spawn sub-agents for simple tasks, small edits, routine code search, or work you can complete directly in a few tool calls.
 
 When you provide a response in the final channel, that content is immediately delivered back to your parent agent.
 

--- a/codex-rs/core/src/tools/handlers/multi_agents_spec.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_spec.rs
@@ -741,6 +741,7 @@ fn spawn_agent_tool_description_v2(
 You are then able to refer to this agent as `task_3` or `/root/task1/task_3` interchangeably. However an agent `/root/task2/task_3` would only be able to communicate with this agent via its canonical name `/root/task1/task_3`.
 The spawned agent will have the same tools as you and the ability to spawn its own subagents.
 {inherited_model_guidance}
+Before calling this tool, ask whether the subtask is independent, bounded, and parallelizable. If not, continue locally.
 It will be able to send you and other running agents messages, and its final answer will be provided to you when it finishes.
 The new agent's canonical task name will be provided to it along with the message.
 {concurrency_guidance}"#

--- a/codex-rs/core/src/tools/handlers/multi_agents_spec.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_spec.rs
@@ -741,7 +741,7 @@ fn spawn_agent_tool_description_v2(
 You are then able to refer to this agent as `task_3` or `/root/task1/task_3` interchangeably. However an agent `/root/task2/task_3` would only be able to communicate with this agent via its canonical name `/root/task1/task_3`.
 The spawned agent will have the same tools as you and the ability to spawn its own subagents.
 {inherited_model_guidance}
-Before calling this tool, ask whether the subtask is independent, bounded, and parallelizable. If not, continue locally.
+Only call this tool for a concrete, bounded subtask that can run independently alongside useful local work; otherwise continue locally.
 It will be able to send you and other running agents messages, and its final answer will be provided to you when it finishes.
 The new agent's canonical task name will be provided to it along with the message.
 {concurrency_guidance}"#


### PR DESCRIPTION
## Summary
- tighten the default multi-agent v2 root and subagent usage hints to bias toward local work
- add a pre-call gate to the v2 spawn_agent description for independent, bounded, parallelizable subtasks

## Validation
- just fmt
- started just test -p codex-core, but it was interrupted before completion per follow-up request to commit and push immediately