### PR TITLE
Require approval for repo-sensitive git commands

### DIFF
--- a/codex-rs/core/src/exec_policy_tests.rs
+++ b/codex-rs/core/src/exec_policy_tests.rs
@@ -1017,8 +1017,8 @@ prefix_rule(pattern=["git"], decision="prompt")
             sandbox_permissions: SandboxPermissions::UseDefault,
             prefix_rule: None,
         },
-        ExecApprovalRequirement::Skip {
-            bypass_sandbox: false,
+        ExecApprovalRequirement::NeedsApproval {
+            reason: None,
             proposed_execpolicy_amendment: Some(ExecPolicyAmendment::new(vec![
                 disallowed_git_path,
                 "status".to_string(),
@@ -1131,6 +1131,26 @@ fn known_safe_on_request_still_prompts_for_restricted_sandbox_escalation() {
                 permission_profile: &PermissionProfile::workspace_write(),
                 windows_sandbox_level: WindowsSandboxLevel::RestrictedToken,
                 sandbox_permissions: SandboxPermissions::RequireEscalated,
+                used_complex_parsing: false,
+                command_origin: ExecPolicyCommandOrigin::Generic,
+            },
+        )
+    );
+}
+
+#[test]
+fn git_status_requires_approval_for_untrusted_projects() {
+    let command = vec!["git".to_string(), "status".to_string()];
+
+    assert_eq!(
+        Decision::Prompt,
+        render_decision_for_unmatched_command(
+            &command,
+            UnmatchedCommandContext {
+                approval_policy: AskForApproval::UnlessTrusted,
+                permission_profile: &PermissionProfile::workspace_write(),
+                windows_sandbox_level: WindowsSandboxLevel::Disabled,
+                sandbox_permissions: SandboxPermissions::UseDefault,
                 used_complex_parsing: false,
                 command_origin: ExecPolicyCommandOrigin::Generic,
             },

--- a/codex-rs/shell-command/src/command_safety/is_dangerous_command.rs
+++ b/codex-rs/shell-command/src/command_safety/is_dangerous_command.rs
@@ -43,31 +43,6 @@ pub fn is_dangerous_powershell_words(command: &[String]) -> bool {
     }
 }
 
-fn is_git_global_option_with_value(arg: &str) -> bool {
-    matches!(
-        arg,
-        "-C" | "-c"
-            | "--config-env"
-            | "--exec-path"
-            | "--git-dir"
-            | "--namespace"
-            | "--super-prefix"
-            | "--work-tree"
-    )
-}
-
-fn is_git_global_option_with_inline_value(arg: &str) -> bool {
-    matches!(
-        arg,
-        s if s.starts_with("--config-env=")
-            || s.starts_with("--exec-path=")
-            || s.starts_with("--git-dir=")
-            || s.starts_with("--namespace=")
-            || s.starts_with("--super-prefix=")
-            || s.starts_with("--work-tree=")
-    ) || ((arg.starts_with("-C") || arg.starts_with("-c")) && arg.len() > 2)
-}
-
 pub(crate) fn executable_name_lookup_key(raw: &str) -> Option<String> {
     #[cfg(windows)]
     {
@@ -92,54 +67,6 @@ pub(crate) fn executable_name_lookup_key(raw: &str) -> Option<String> {
             .and_then(|name| name.to_str())
             .map(std::borrow::ToOwned::to_owned)
     }
-}
-
-/// Find the first matching git subcommand, skipping known global options that
-/// may appear before it (e.g., `-C`, `-c`, `--git-dir`).
-///
-/// Shared with `is_safe_command` to avoid git-global-option bypasses.
-pub(crate) fn find_git_subcommand<'a>(
-    command: &'a [String],
-    subcommands: &[&str],
-) -> Option<(usize, &'a str)> {
-    let cmd0 = command.first().map(String::as_str)?;
-    if executable_name_lookup_key(cmd0).as_deref() != Some("git") {
-        return None;
-    }
-
-    let mut skip_next = false;
-    for (idx, arg) in command.iter().enumerate().skip(1) {
-        if skip_next {
-            skip_next = false;
-            continue;
-        }
-
-        let arg = arg.as_str();
-
-        if is_git_global_option_with_inline_value(arg) {
-            continue;
-        }
-
-        if is_git_global_option_with_value(arg) {
-            skip_next = true;
-            continue;
-        }
-
-        if arg == "--" || arg.starts_with('-') {
-            continue;
-        }
-
-        if subcommands.contains(&arg) {
-            return Some((idx, arg));
-        }
-
-        // In git, the first non-option token is the subcommand. If it isn't
-        // one of the subcommands we're looking for, we must stop scanning to
-        // avoid misclassifying later positional args (e.g., branch names).
-        return None;
-    }
-
-    None
 }
 
 fn is_dangerous_to_call_with_exec(command: &[String]) -> bool {

--- a/codex-rs/shell-command/src/command_safety/is_safe_command.rs
+++ b/codex-rs/shell-command/src/command_safety/is_safe_command.rs
@@ -1,9 +1,5 @@
 use crate::bash::parse_shell_lc_plain_commands;
 use crate::command_safety::is_dangerous_command::executable_name_lookup_key;
-// Find the first matching git subcommand, skipping known global options that
-// may appear before it (e.g., `-C`, `-c`, `--git-dir`).
-// Implemented in `is_dangerous_command` and shared here.
-use crate::command_safety::is_dangerous_command::find_git_subcommand;
 #[cfg(windows)]
 use crate::command_safety::windows_safe_commands::is_safe_command_windows;
 #[cfg(windows)]
@@ -153,9 +149,6 @@ fn is_safe_to_call_with_exec(command: &[String]) -> bool {
             })
         }
 
-        // Git
-        Some("git") => is_safe_git_command(command),
-
         // Special-case `sed -n {N|M,N}p`
         Some("sed")
             if {
@@ -170,128 +163,6 @@ fn is_safe_to_call_with_exec(command: &[String]) -> bool {
         // ── anything else ─────────────────────────────────────────────────
         _ => false,
     }
-}
-
-pub(crate) fn is_safe_git_command(command: &[String]) -> bool {
-    let Some((subcommand_idx, subcommand)) =
-        find_git_subcommand(command, &["status", "log", "diff", "show", "branch"])
-    else {
-        return false;
-    };
-
-    let global_args = &command[1..subcommand_idx];
-    if git_has_unsafe_global_option(global_args) {
-        return false;
-    }
-
-    let subcommand_args = &command[subcommand_idx + 1..];
-
-    match subcommand {
-        "status" | "log" | "diff" | "show" => git_subcommand_args_are_read_only(subcommand_args),
-        "branch" => {
-            git_subcommand_args_are_read_only(subcommand_args)
-                && git_branch_is_read_only(subcommand_args)
-        }
-        other => {
-            debug_assert!(false, "unexpected git subcommand from matcher: {other}");
-            false
-        }
-    }
-}
-
-// Treat `git branch` as safe only when the arguments clearly indicate
-// a read-only query, not a branch mutation (create/rename/delete).
-fn git_branch_is_read_only(branch_args: &[String]) -> bool {
-    if branch_args.is_empty() {
-        // `git branch` with no additional args lists branches.
-        return true;
-    }
-
-    let mut saw_read_only_flag = false;
-    for arg in branch_args.iter().map(String::as_str) {
-        match arg {
-            "--list" | "-l" | "--show-current" | "-a" | "--all" | "-r" | "--remotes" | "-v"
-            | "-vv" | "--verbose" => {
-                saw_read_only_flag = true;
-            }
-            _ if arg.starts_with("--format=") => {
-                saw_read_only_flag = true;
-            }
-            _ => {
-                // Any other flag or positional argument may create, rename, or delete branches.
-                return false;
-            }
-        }
-    }
-
-    saw_read_only_flag
-}
-
-#[derive(Clone, Copy)]
-enum GitOptionPattern {
-    Exact(&'static str),
-    ShortWithInlineValue(&'static str),
-    Prefix(&'static str),
-}
-
-const UNSAFE_GIT_GLOBAL_OPTIONS: &[GitOptionPattern] = &[
-    GitOptionPattern::Exact("-C"),
-    GitOptionPattern::ShortWithInlineValue("-C"),
-    GitOptionPattern::Exact("-c"),
-    GitOptionPattern::ShortWithInlineValue("-c"),
-    GitOptionPattern::Exact("-p"),
-    GitOptionPattern::Exact("--config-env"),
-    GitOptionPattern::Prefix("--config-env="),
-    GitOptionPattern::Exact("--exec-path"),
-    GitOptionPattern::Prefix("--exec-path="),
-    GitOptionPattern::Exact("--git-dir"),
-    GitOptionPattern::Prefix("--git-dir="),
-    GitOptionPattern::Exact("--namespace"),
-    GitOptionPattern::Prefix("--namespace="),
-    GitOptionPattern::Exact("--paginate"),
-    GitOptionPattern::Exact("--super-prefix"),
-    GitOptionPattern::Prefix("--super-prefix="),
-    GitOptionPattern::Exact("--work-tree"),
-    GitOptionPattern::Prefix("--work-tree="),
-];
-
-const UNSAFE_GIT_SUBCOMMAND_OPTIONS: &[GitOptionPattern] = &[
-    GitOptionPattern::Exact("--output"),
-    GitOptionPattern::Prefix("--output="),
-    GitOptionPattern::Exact("--ext-diff"),
-    GitOptionPattern::Exact("--textconv"),
-    GitOptionPattern::Exact("--exec"),
-    GitOptionPattern::Prefix("--exec="),
-];
-
-impl GitOptionPattern {
-    fn matches(self, arg: &str) -> bool {
-        match self {
-            GitOptionPattern::Exact(option) => arg == option,
-            GitOptionPattern::ShortWithInlineValue(option) => {
-                arg.starts_with(option) && arg.len() > option.len()
-            }
-            GitOptionPattern::Prefix(prefix) => arg.starts_with(prefix),
-        }
-    }
-}
-
-fn git_matches_option_pattern(arg: &str, patterns: &[GitOptionPattern]) -> bool {
-    patterns.iter().any(|pattern| pattern.matches(arg))
-}
-
-fn git_has_unsafe_global_option(global_args: &[String]) -> bool {
-    global_args
-        .iter()
-        .map(String::as_str)
-        .any(|arg| git_matches_option_pattern(arg, UNSAFE_GIT_GLOBAL_OPTIONS))
-}
-
-fn git_subcommand_args_are_read_only(args: &[String]) -> bool {
-    !args
-        .iter()
-        .map(String::as_str)
-        .any(|arg| git_matches_option_pattern(arg, UNSAFE_GIT_SUBCOMMAND_OPTIONS))
 }
 
 // (bash parsing helpers implemented in crate::bash)
@@ -345,13 +216,6 @@ mod tests {
     #[test]
     fn known_safe_examples() {
         assert!(is_safe_to_call_with_exec(&vec_str(&["ls"])));
-        assert!(is_safe_to_call_with_exec(&vec_str(&["git", "status"])));
-        assert!(is_safe_to_call_with_exec(&vec_str(&["git", "branch"])));
-        assert!(is_safe_to_call_with_exec(&vec_str(&[
-            "git",
-            "branch",
-            "--show-current"
-        ])));
         assert!(is_safe_to_call_with_exec(&vec_str(&["base64"])));
         assert!(is_safe_to_call_with_exec(&vec_str(&[
             "sed", "-n", "1,5p", "file.txt"
@@ -377,153 +241,21 @@ mod tests {
     }
 
     #[test]
-    fn git_branch_mutating_flags_are_not_safe() {
-        assert!(!is_known_safe_command(&vec_str(&[
-            "git", "branch", "-d", "feature"
-        ])));
-        assert!(!is_known_safe_command(&vec_str(&[
-            "git",
-            "branch",
-            "new-branch"
-        ])));
-    }
-
-    #[test]
-    fn git_branch_global_options_respect_safety_rules() {
-        assert!(is_known_safe_command(&vec_str(&[
-            "git",
-            "branch",
-            "--show-current",
-        ])));
-        assert!(!is_known_safe_command(&vec_str(&[
-            "git", "branch", "-d", "feature",
-        ])));
-        assert!(!is_known_safe_command(&vec_str(&[
-            "bash",
-            "-lc",
-            "git branch -d feature",
-        ])));
-    }
-
-    #[test]
-    fn git_first_positional_is_the_subcommand() {
-        // In git, the first non-option token is the subcommand. Later positional
-        // args (like branch names) must not be treated as subcommands.
-        assert!(!is_known_safe_command(&vec_str(&[
-            "git", "checkout", "status",
-        ])));
-    }
-
-    #[test]
-    fn git_output_flags_are_not_safe() {
-        assert!(!is_known_safe_command(&vec_str(&[
-            "git",
-            "log",
-            "--output=/tmp/git-log-out-test",
-            "-n",
-            "1",
-        ])));
-        assert!(!is_known_safe_command(&vec_str(&[
-            "git",
-            "diff",
-            "--output",
-            "/tmp/git-diff-out-test",
-        ])));
-        assert!(!is_known_safe_command(&vec_str(&[
-            "git",
-            "show",
-            "--output=/tmp/git-show-out-test",
-            "HEAD",
-        ])));
-    }
-
-    #[test]
-    fn git_global_pagination_flags_are_not_safe() {
-        assert!(!is_known_safe_command(&vec_str(&[
-            "git",
-            "--paginate",
-            "log",
-            "-1",
-        ])));
-        assert!(!is_known_safe_command(&vec_str(&[
-            "git", "-p", "log", "-1",
-        ])));
-        assert!(!is_known_safe_command(&vec_str(&[
-            "bash",
-            "-lc",
-            "git --paginate log -1",
-        ])));
-        assert!(!is_known_safe_command(&vec_str(&[
-            "bash",
-            "-lc",
-            "git -p log -1",
-        ])));
-    }
-
-    #[test]
-    fn git_subcommand_patch_flags_remain_safe() {
-        assert!(is_known_safe_command(&vec_str(&["git", "log", "-p", "-1"])));
-        assert!(is_known_safe_command(&vec_str(&["git", "diff", "-p"])));
-        assert!(is_known_safe_command(&vec_str(&[
-            "git", "show", "-p", "HEAD",
-        ])));
-        assert!(is_known_safe_command(&vec_str(&[
-            "bash",
-            "-lc",
-            "git log -p -1",
-        ])));
-    }
-
-    #[test]
-    fn git_global_override_flags_are_not_safe() {
-        assert!(!is_known_safe_command(&vec_str(&[
-            "git", "-C", ".", "status",
-        ])));
-        assert!(!is_known_safe_command(&vec_str(&["git", "-C.", "status",])));
-        assert!(!is_known_safe_command(&vec_str(&[
-            "git",
-            "-c",
-            "core.pager=cat",
-            "log",
-            "-n",
-            "1",
-        ])));
-        assert!(!is_known_safe_command(&vec_str(&[
-            "git",
-            "-ccore.pager=cat",
-            "status",
-        ])));
-
+    fn git_commands_require_approval() {
         for args in [
-            vec_str(&["git", "--config-env", "core.pager=PAGER", "show", "HEAD"]),
-            vec_str(&["git", "--config-env=core.pager=PAGER", "show", "HEAD"]),
-            vec_str(&["git", "--git-dir", ".evil-git", "diff", "HEAD~1..HEAD"]),
-            vec_str(&["git", "--git-dir=.evil-git", "diff", "HEAD~1..HEAD"]),
-            vec_str(&["git", "--work-tree", ".", "status"]),
-            vec_str(&["git", "--work-tree=.", "status"]),
-            vec_str(&["git", "--exec-path", ".git/helpers", "show", "HEAD"]),
-            vec_str(&["git", "--exec-path=.git/helpers", "show", "HEAD"]),
-            vec_str(&["git", "--namespace", "attacker", "show", "HEAD"]),
-            vec_str(&["git", "--namespace=attacker", "show", "HEAD"]),
-            vec_str(&["git", "--super-prefix", "attacker/", "show", "HEAD"]),
-            vec_str(&["git", "--super-prefix=attacker/", "show", "HEAD"]),
+            vec_str(&["git", "status"]),
+            vec_str(&["git", "diff", "-p"]),
+            vec_str(&["git", "log", "-p", "-1"]),
+            vec_str(&["git", "show", "-p", "HEAD"]),
+            vec_str(&["git", "branch", "--show-current"]),
+            vec_str(&["bash", "-lc", "git status"]),
+            vec_str(&["bash", "-lc", "git log -p -1"]),
         ] {
             assert!(
                 !is_known_safe_command(&args),
-                "expected {args:?} to require approval due to unsafe git global option",
+                "expected {args:?} to require approval",
             );
         }
-
-        assert!(!is_known_safe_command(&vec_str(&[
-            "bash",
-            "-lc",
-            "git -C .project-deps/test-fixtures status",
-        ])));
-        assert!(!is_known_safe_command(&vec_str(&[
-            "bash",
-            "-lc",
-            "git --git-dir=.evil-git diff HEAD~1..HEAD",
-        ])));
     }
 
     #[test]
@@ -636,12 +368,12 @@ mod tests {
     }
 
     #[test]
-    fn windows_git_full_path_is_safe() {
+    fn windows_git_full_path_requires_approval() {
         if !cfg!(windows) {
             return;
         }
 
-        assert!(is_known_safe_command(&vec_str(&[
+        assert!(!is_known_safe_command(&vec_str(&[
             r"C:\Program Files\Git\cmd\git.exe",
             "status",
         ])));
@@ -651,11 +383,6 @@ mod tests {
     fn bash_lc_safe_examples() {
         assert!(is_known_safe_command(&vec_str(&["bash", "-lc", "ls"])));
         assert!(is_known_safe_command(&vec_str(&["bash", "-lc", "ls -1"])));
-        assert!(is_known_safe_command(&vec_str(&[
-            "bash",
-            "-lc",
-            "git status"
-        ])));
         assert!(is_known_safe_command(&vec_str(&[
             "bash",
             "-lc",
@@ -705,6 +432,11 @@ mod tests {
 
     #[test]
     fn bash_lc_unsafe_examples() {
+        assert!(!is_known_safe_command(&vec_str(&[
+            "bash",
+            "-lc",
+            "git status"
+        ])));
         assert!(
             !is_known_safe_command(&vec_str(&["bash", "-lc", "git", "status"])),
             "Four arg version is not known to be safe."

--- a/codex-rs/shell-command/src/command_safety/windows_safe_commands.rs
+++ b/codex-rs/shell-command/src/command_safety/windows_safe_commands.rs
@@ -1,4 +1,3 @@
-use crate::command_safety::is_safe_command::is_safe_git_command;
 use crate::command_safety::powershell_parser::PowershellParseOutcome;
 use crate::command_safety::powershell_parser::parse_with_powershell_ast;
 use std::path::Path;
@@ -188,8 +187,6 @@ pub(crate) fn is_safe_powershell_words(words: &[String]) -> bool {
         "select-object" | "select" => true,
         "get-item" => true,
 
-        "git" => is_safe_git_command(words),
-
         "rg" => is_safe_ripgrep(words),
 
         // Extra safety: explicitly prohibit common side-effecting cmdlets regardless of args.
@@ -242,7 +239,7 @@ mod tests {
             "Get-ChildItem -Path .",
         ])));
 
-        assert!(is_safe_command_windows(&vec_str(&[
+        assert!(!is_safe_command_windows(&vec_str(&[
             "powershell.exe",
             "-NoProfile",
             "-Command",
@@ -290,7 +287,7 @@ mod tests {
     }
 
     #[test]
-    fn allows_read_only_pipelines_and_git_usage() {
+    fn allows_read_only_pipelines_without_git_usage() {
         let Some(pwsh) = try_find_pwsh_executable_blocking() else {
             return;
         };
@@ -313,7 +310,7 @@ mod tests {
             "Get-Content foo.rs | Select-Object -Skip 200".to_string()
         ]));
 
-        assert!(is_safe_command_windows(&[
+        assert!(!is_safe_command_windows(&[
             pwsh.clone(),
             "-Command".to_string(),
             "git show HEAD:foo.rs".to_string()


### PR DESCRIPTION
## Summary
- require approval for Git commands that can execute repository-controlled helpers under untrusted approval policy
- add regression coverage for `git status` approval and remove obsolete Git safe-command parser code

## Validation
- `cargo test -p codex-shell-command`
- `cargo test -p codex-core exec_policy::tests::git_status_requires_approval_for_untrusted_projects --lib -- --exact`
- `cargo test -p codex-core exec_policy::tests::absolute_path_exec_approval_requirement_ignores_disallowed_host_executable_paths --lib -- --exact`
- `RUST_MIN_STACK=8388608 cargo test -p codex-core` (fails only on pre-existing `config::config_loader_tests::load_config_layers_includes_cloud_config_bundle`; reproduced unchanged at `0526cb56ac3501a02968010d03873993c319e290`)

## Security validation
- BUGB-17593 reproducer still shows plain `git status` executes a repository `core.fsmonitor` helper (`content=ran`).
- After this patch, the Codex approval path for unmatched `git status` under `AskForApproval::UnlessTrusted` returns `Decision::Prompt` instead of auto-allowing the helper-capable command.

<!-- security-validation-service:start -->
## Security validation result

- Validation: `security_report_validation_1a2292448db1`
- Report: `BUGB-17593`
- Repository SHA: `0526cb56ac3501a02968010d03873993c319e290`
- Fix PR SHA: `226bd153410084774ffcf7aff9f22930e417f420`
- Platform: `all`
- Status: `completed`
- Conclusion: `inconclusive`

Security validation did not pass. Review the failed or inconclusive cases below before treating this PR as fixed.

### Results

| Target | Platform | Status | Conclusion | Test case |
| --- | --- | --- | --- | --- |
| repository | linux | completed | reproduced | security-report-reproduction.BUGB-17593.linux |
| repository | macos | failed | inconclusive | security-report-reproduction.BUGB-17593.macos |
| repository | windows | completed | not_reproduced | security-report-reproduction.BUGB-17593.windows |
| fix_pr | linux | completed | inconclusive | security-report-reproduction.BUGB-17593.linux |
| fix_pr | linux | completed | passed | codex.git.metadata.protection.linux |
| fix_pr | macos | failed | inconclusive | security-report-reproduction.BUGB-17593.macos |
| fix_pr | macos | failed | inconclusive | codex.git.metadata.protection.macos |
| fix_pr | windows | completed | inconclusive | security-report-reproduction.BUGB-17593.windows |
| fix_pr | windows | completed | passed | codex.git.metadata.protection.windows |
<!-- security-validation-service:end -->