### PR TITLE
[codex] Require complete main-agent skill reads

### DIFF
--- a/codex-rs/core-skills/src/render.rs
+++ b/codex-rs/core-skills/src/render.rs
@@ -28,16 +28,16 @@ pub const SKILLS_HOW_TO_USE_WITH_ABSOLUTE_PATHS: &str = r###"- Discovery: The li
 - Trigger rules: If the user names a skill (with `$SkillName` or plain text) OR the task clearly matches a skill's description shown above, you must use that skill for that turn. Multiple mentions mean use them all. Do not carry skills across turns unless re-mentioned.
 - Missing/blocked: If a named skill isn't in the list or the path can't be read, say so briefly and continue with the best fallback.
 - How to use a skill (progressive disclosure):
-  1) After deciding to use a skill, open its `SKILL.md`. Read only enough to follow the workflow.
+  1) After deciding to use a skill, the main agent must open and read its `SKILL.md` completely before taking task actions. If a read is truncated or paginated, continue until EOF.
   2) When `SKILL.md` references relative paths (e.g., `scripts/foo.py`), resolve them relative to the skill directory listed above first, and only consider other paths if needed.
-  3) If `SKILL.md` points to extra folders such as `references/`, load only the specific files needed for the request; don't bulk-load everything.
+  3) If `SKILL.md` points to extra folders such as `references/`, use its routing instructions to identify the files required for the task. The main agent must read each required instruction or reference file itself before acting on it. Do not delegate reading, summarizing, or interpreting skill instructions to a subagent. Subagents may still perform task work when the selected skill allows it.
   4) If `scripts/` exist, prefer running or patching them instead of retyping large code blocks.
   5) If `assets/` or templates exist, reuse them instead of recreating from scratch.
 - Coordination and sequencing:
   - If multiple skills apply, choose the minimal set that covers the request and state the order you'll use them.
   - Announce which skill(s) you're using and why (one short line). If you skip an obvious skill, say why.
 - Context hygiene:
-  - Keep context small: summarize long sections instead of pasting them; only load extra files when needed.
+  - Progressive disclosure applies to selecting relevant files, not partially reading a selected instruction file. Do not load unrelated references, scripts, or assets.
   - Avoid deep reference-chasing: prefer opening only files directly linked from `SKILL.md` unless you're blocked.
   - When variants exist (frameworks, providers, domains), pick only the relevant reference file(s) and note that choice.
 - Safety and fallback: If a skill can't be applied cleanly (missing files, unclear instructions), state the issue, pick the next-best approach, and continue."###;
@@ -45,16 +45,16 @@ pub const SKILLS_HOW_TO_USE_WITH_ALIASES: &str = r###"- Discovery: The list abov
 - Trigger rules: If the user names a skill (with `$SkillName` or plain text) OR the task clearly matches a skill's description shown above, you must use that skill for that turn. Multiple mentions mean use them all. Do not carry skills across turns unless re-mentioned.
 - Missing/blocked: If a named skill isn't in the list or the path can't be read, say so briefly and continue with the best fallback.
 - How to use a skill (progressive disclosure):
-  1) After deciding to use a skill, expand the listed short `path` with the matching alias from `### Skill roots`, then open its `SKILL.md`. Read only enough to follow the workflow.
+  1) After deciding to use a skill, the main agent must expand the listed short `path` with the matching alias from `### Skill roots`, then open and read its `SKILL.md` completely before taking task actions. If a read is truncated or paginated, continue until EOF.
   2) When `SKILL.md` references relative paths (e.g., `scripts/foo.py`), resolve them relative to the directory containing that expanded `SKILL.md` first, and only consider other paths if needed.
-  3) If `SKILL.md` points to extra folders such as `references/`, load only the specific files needed for the request; don't bulk-load everything.
+  3) If `SKILL.md` points to extra folders such as `references/`, use its routing instructions to identify the files required for the task. The main agent must read each required instruction or reference file itself before acting on it. Do not delegate reading, summarizing, or interpreting skill instructions to a subagent. Subagents may still perform task work when the selected skill allows it.
   4) If `scripts/` exist, prefer running or patching them instead of retyping large code blocks.
   5) If `assets/` or templates exist, reuse them instead of recreating from scratch.
 - Coordination and sequencing:
   - If multiple skills apply, choose the minimal set that covers the request and state the order you'll use them.
   - Announce which skill(s) you're using and why (one short line). If you skip an obvious skill, say why.
 - Context hygiene:
-  - Keep context small: summarize long sections instead of pasting them; only load extra files when needed.
+  - Progressive disclosure applies to selecting relevant files, not partially reading a selected instruction file. Do not load unrelated references, scripts, or assets.
   - Avoid deep reference-chasing: prefer opening only files directly linked from `SKILL.md` unless you're blocked.
   - When variants exist (frameworks, providers, domains), pick only the relevant reference file(s) and note that choice.
 - Safety and fallback: If a skill can't be applied cleanly (missing files, unclear instructions), state the issue, pick the next-best approach, and continue."###;
@@ -980,6 +980,30 @@ mod tests {
             budget,
             SkillPathAliases::default(),
         )
+    }
+
+    #[test]
+    fn skill_usage_instructions_require_complete_main_agent_reads() {
+        for instructions in [
+            SKILLS_HOW_TO_USE_WITH_ABSOLUTE_PATHS,
+            SKILLS_HOW_TO_USE_WITH_ALIASES,
+        ] {
+            assert!(instructions.contains("read its `SKILL.md` completely"));
+            assert!(instructions.contains("continue until EOF"));
+            assert!(instructions.contains(
+                "The main agent must read each required instruction or reference file itself"
+            ));
+            assert!(instructions.contains(
+                "Do not delegate reading, summarizing, or interpreting skill instructions"
+            ));
+            assert!(instructions.contains(
+                "Subagents may still perform task work when the selected skill allows it"
+            ));
+            assert!(instructions.contains(
+                "Progressive disclosure applies to selecting relevant files, not partially reading a selected instruction file"
+            ));
+            assert!(!instructions.contains("Read only enough to follow the workflow"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- require the main agent to read selected `SKILL.md` files completely, continuing truncated or paginated reads through EOF
- require the main agent to personally read task-required instruction references instead of delegating their interpretation
- clarify that progressive disclosure selects relevant files without permitting partial reads
- preserve subagent use for task work when the selected skill allows it
- cover both absolute-path and aliased-root prompt variants

## Why
Partial reads can skip routing and verification requirements later in skill instructions. Delegated summaries can also omit constraints the main agent needs to follow. The existing "Read only enough" wording made both behaviors appear acceptable.

## Impact
Agents should follow complete selected skill instructions while continuing to avoid unrelated references, scripts, and assets. Subagents remain available for task execution where permitted.

## Test plan
- `just test -p codex-core-skills` (101 passed)
- `just fmt`
- `git diff --check`