### PR TITLE
fix: validate linked worktree trust metadata

### DIFF
--- a/codex-rs/core/src/git_info_tests.rs
+++ b/codex-rs/core/src/git_info_tests.rs
@@ -615,6 +615,11 @@ async fn resolve_root_git_project_for_trust_detects_worktree_pointer_without_git
         format!("gitdir: {}\n", worktree_git_dir.display()),
     )
     .unwrap();
+    std::fs::write(
+        worktree_git_dir.join("gitdir"),
+        format!("{}\n", worktree_root.join(".git").display()),
+    )
+    .unwrap();
 
     let expected = repo_root.abs();
     let worktree_root = worktree_root.abs();
@@ -626,6 +631,30 @@ async fn resolve_root_git_project_for_trust_detects_worktree_pointer_without_git
     assert_eq!(
         resolve_root_git_project_for_trust(LOCAL_FS.as_ref(), &nested).await,
         Some(expected)
+    );
+}
+
+#[tokio::test]
+async fn resolve_root_git_project_for_trust_rejects_forged_worktree_pointer() {
+    let tmp = TempDir::new().expect("tempdir");
+    let trusted_repo = tmp.path().join("trusted");
+    let forged_repo = tmp.path().join("forged");
+    let forged_git_dir = trusted_repo
+        .join(".git")
+        .join("worktrees")
+        .join("feature-x");
+    std::fs::create_dir_all(&forged_git_dir).unwrap();
+    std::fs::create_dir_all(&forged_repo).unwrap();
+    std::fs::write(
+        forged_repo.join(".git"),
+        format!("gitdir: {}\n", forged_git_dir.display()),
+    )
+    .unwrap();
+
+    assert!(
+        resolve_root_git_project_for_trust(LOCAL_FS.as_ref(), &forged_repo.abs())
+            .await
+            .is_none()
     );
 }
 

--- a/codex-rs/git-utils/src/info.rs
+++ b/codex-rs/git-utils/src/info.rs
@@ -764,8 +764,38 @@ pub async fn resolve_root_git_project_for_trust(
     }
 
     let git_dir_path = AbsolutePathBuf::resolve_path_against_base(git_dir_rel, repo_root.as_path());
+    if !fs
+        .get_metadata(&git_dir_path, /*sandbox*/ None)
+        .await
+        .ok()?
+        .is_directory
+    {
+        return None;
+    }
+
     let worktrees_dir = git_dir_path.parent()?;
     if worktrees_dir.as_path().file_name() != Some(OsStr::new("worktrees")) {
+        return None;
+    }
+
+    // A linked worktree is valid only when its gitdir points back to this checkout's .git file.
+    let git_dir_backref = fs
+        .read_file_text(&git_dir_path.join("gitdir"), /*sandbox*/ None)
+        .await
+        .ok()?;
+    let git_dir_backref = git_dir_backref.trim();
+    if git_dir_backref.is_empty() {
+        return None;
+    }
+
+    let git_dir_backref_path =
+        AbsolutePathBuf::resolve_path_against_base(git_dir_backref, git_dir_path.as_path());
+    if fs
+        .canonicalize(&git_dir_backref_path, /*sandbox*/ None)
+        .await
+        .ok()?
+        != fs.canonicalize(&dot_git, /*sandbox*/ None).await.ok()?
+    {
         return None;
     }
 


### PR DESCRIPTION
## What?

Harden linked-worktree trust resolution so a forged `.git` pointer cannot inherit another project's trust entry.


## How?

- Require the resolved linked-worktree gitdir to exist and be a directory.
- Require the gitdir's `gitdir` back-reference to canonicalize back to the checkout `.git` file Codex discovered.
- Add a regression that fails on the forged pointer shape and keep positive coverage for valid linked worktree metadata.