### PR TITLE
cli: add -P sandbox permissions profile alias

### DIFF
--- a/codex-rs/cli/src/lib.rs
+++ b/codex-rs/cli/src/lib.rs
@@ -26,7 +26,7 @@ pub use login::run_logout;
 #[derive(Debug, Parser)]
 pub struct SeatbeltCommand {
     /// Named permissions profile to apply from the active configuration stack.
-    #[arg(long = "permissions-profile", value_name = "NAME")]
+    #[arg(long = "permissions-profile", short = 'P', value_name = "NAME")]
     pub permissions_profile: Option<String>,
 
     /// Layer $CODEX_HOME/<name>.config.toml on top of the base user config.
@@ -74,7 +74,7 @@ fn parse_allow_unix_socket_path(raw: &str) -> Result<AbsolutePathBuf, String> {
 #[derive(Debug, Parser)]
 pub struct LandlockCommand {
     /// Named permissions profile to apply from the active configuration stack.
-    #[arg(long = "permissions-profile", value_name = "NAME")]
+    #[arg(long = "permissions-profile", short = 'P', value_name = "NAME")]
     pub permissions_profile: Option<String>,
 
     /// Layer $CODEX_HOME/<name>.config.toml on top of the base user config.
@@ -109,7 +109,7 @@ pub struct LandlockCommand {
 #[derive(Debug, Parser)]
 pub struct WindowsCommand {
     /// Named permissions profile to apply from the active configuration stack.
-    #[arg(long = "permissions-profile", value_name = "NAME")]
+    #[arg(long = "permissions-profile", short = 'P', value_name = "NAME")]
     pub permissions_profile: Option<String>,
 
     /// Layer $CODEX_HOME/<name>.config.toml on top of the base user config.

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -2882,6 +2882,21 @@ mod tests {
 
     #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
     #[test]
+    fn sandbox_parses_permissions_profile_short_alias() {
+        let cli =
+            MultitoolCli::try_parse_from(["codex", "sandbox", "-P", ":workspace", "--", "echo"])
+                .expect("parse");
+
+        let Some(Subcommand::Sandbox(command)) = cli.subcommand else {
+            panic!("expected sandbox command");
+        };
+
+        assert_eq!(command.permissions_profile.as_deref(), Some(":workspace"));
+        assert_eq!(command.command, vec!["echo"]);
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+    #[test]
     fn sandbox_parses_config_profile() {
         let cli =
             MultitoolCli::try_parse_from(["codex", "sandbox", "--profile", "work", "--", "echo"])


### PR DESCRIPTION
## Why

`codex sandbox --permissions-profile` is useful when running commands under a named permissions profile, but the long option is cumbersome for a debugging-oriented command. `-p` is already used for the config profile selector, so `-P` gives the permissions profile selector a compact, non-conflicting alias.

## What Changed

- Added `short = 'P'` to the `permissions_profile` option for the macOS, Linux, and Windows sandbox command structs in [`codex-rs/cli/src/lib.rs`](https://github.com/openai/codex/blob/6d9f9c5cdcaa0a156aa2dabbde259ae5e9e8bc0b/codex-rs/cli/src/lib.rs#L29-L112).
- Added parser coverage for `codex sandbox -P :workspace -- echo` in [`codex-rs/cli/src/main.rs`](https://github.com/openai/codex/blob/6d9f9c5cdcaa0a156aa2dabbde259ae5e9e8bc0b/codex-rs/cli/src/main.rs#L2883-L2896).

## Verification

- `just test -p codex-cli` passed, including the new `sandbox_parses_permissions_profile_short_alias` parser test.
