### PR TITLE
[ADE-4633] Add parent turn id to Codex turn analytics

### DIFF
--- a/codex-rs/analytics/src/analytics_client_tests.rs
+++ b/codex-rs/analytics/src/analytics_client_tests.rs
@@ -380,6 +380,7 @@ fn sample_turn_resolved_config(thread_id: &str, turn_id: &str) -> TurnResolvedCo
     TurnResolvedConfigFact {
         turn_id: turn_id.to_string(),
         thread_id: thread_id.to_string(),
+        parent_turn_id: None,
         num_input_images: 1,
         submission_type: None,
         ephemeral: false,
@@ -3437,6 +3438,7 @@ fn turn_event_serializes_expected_shape() {
             initialization_mode: ThreadInitializationMode::New,
             subagent_source: None,
             parent_thread_id: None,
+            parent_turn_id: None,
             model: Some("gpt-5".to_string()),
             model_provider: "openai".to_string(),
             sandbox_policy: Some("read_only"),
@@ -3509,6 +3511,7 @@ fn turn_event_serializes_expected_shape() {
                 "initialization_mode": "new",
                 "subagent_source": null,
                 "parent_thread_id": null,
+                "parent_turn_id": null,
                 "model": "gpt-5",
                 "model_provider": "openai",
                 "sandbox_policy": "read_only",
@@ -3826,6 +3829,7 @@ async fn turn_lifecycle_emits_turn_event() {
         json!("session-thread-2")
     );
     assert_eq!(payload["event_params"]["turn_id"], json!("turn-2"));
+    assert_eq!(payload["event_params"]["parent_turn_id"], json!(null));
     assert_eq!(
         payload["event_params"]["app_server_client"],
         json!({
@@ -3873,6 +3877,50 @@ async fn turn_lifecycle_emits_turn_event() {
         json!(13)
     );
     assert_eq!(payload["event_params"]["total_tokens"], json!(321));
+}
+
+#[tokio::test]
+async fn turn_lifecycle_emits_parent_turn_id() {
+    let mut reducer = AnalyticsReducer::default();
+    let mut out = Vec::new();
+
+    ingest_turn_prerequisites(
+        &mut reducer,
+        &mut out,
+        /*include_initialize*/ true,
+        /*include_resolved_config*/ false,
+        /*include_started*/ true,
+        /*include_token_usage*/ true,
+    )
+    .await;
+    let mut resolved_config = sample_turn_resolved_config("thread-2", "turn-2");
+    resolved_config.parent_turn_id = Some("parent-turn-1".to_string());
+    reducer
+        .ingest(
+            AnalyticsFact::Custom(CustomAnalyticsFact::TurnResolvedConfig(Box::new(
+                resolved_config,
+            ))),
+            &mut out,
+        )
+        .await;
+    reducer
+        .ingest(
+            AnalyticsFact::Notification(Box::new(sample_turn_completed_notification(
+                "thread-2",
+                "turn-2",
+                AppServerTurnStatus::Completed,
+                /*codex_error_info*/ None,
+            ))),
+            &mut out,
+        )
+        .await;
+
+    assert_eq!(out.len(), 1);
+    let payload = serde_json::to_value(&out[0]).expect("serialize turn event");
+    assert_eq!(
+        payload["event_params"]["parent_turn_id"],
+        json!("parent-turn-1")
+    );
 }
 
 #[tokio::test]

--- a/codex-rs/analytics/src/analytics_client_tests.rs
+++ b/codex-rs/analytics/src/analytics_client_tests.rs
@@ -2911,6 +2911,92 @@ async fn subagent_events_use_inherited_connection_unless_turn_connection_is_expl
 }
 
 #[tokio::test]
+async fn subagent_turn_lifecycle_emits_parent_turn_id() {
+    let mut reducer = AnalyticsReducer::default();
+    let mut events = Vec::new();
+
+    ingest_review_prerequisites(&mut reducer, &mut events).await;
+    reducer
+        .ingest(
+            AnalyticsFact::Custom(CustomAnalyticsFact::SubAgentThreadStarted(
+                SubAgentThreadStartedInput {
+                    session_id: "session-root".to_string(),
+                    thread_id: "thread-subagent".to_string(),
+                    parent_thread_id: Some("thread-1".to_string()),
+                    forked_from_thread_id: None,
+                    product_client_id: "codex-tui".to_string(),
+                    client_name: "codex-tui".to_string(),
+                    client_version: "1.0.0".to_string(),
+                    model: "gpt-5".to_string(),
+                    ephemeral: false,
+                    subagent_source: SubAgentSource::Review,
+                    created_at: 130,
+                },
+            )),
+            &mut events,
+        )
+        .await;
+    events.clear();
+
+    reducer
+        .ingest(
+            AnalyticsFact::Notification(Box::new(sample_turn_started_notification(
+                "thread-subagent",
+                "turn-subagent",
+            ))),
+            &mut events,
+        )
+        .await;
+    let mut resolved_config = sample_turn_resolved_config("thread-subagent", "turn-subagent");
+    resolved_config.parent_turn_id = Some("parent-turn-1".to_string());
+    reducer
+        .ingest(
+            AnalyticsFact::Custom(CustomAnalyticsFact::TurnResolvedConfig(Box::new(
+                resolved_config,
+            ))),
+            &mut events,
+        )
+        .await;
+    reducer
+        .ingest(
+            AnalyticsFact::Custom(CustomAnalyticsFact::TurnTokenUsage(Box::new(
+                sample_turn_token_usage_fact("thread-subagent", "turn-subagent"),
+            ))),
+            &mut events,
+        )
+        .await;
+    reducer
+        .ingest(
+            AnalyticsFact::Custom(CustomAnalyticsFact::TurnProfile(Box::new(
+                TurnProfileFact {
+                    turn_id: "turn-subagent".to_string(),
+                    profile: sample_turn_profile(),
+                },
+            ))),
+            &mut events,
+        )
+        .await;
+    reducer
+        .ingest(
+            AnalyticsFact::Notification(Box::new(sample_turn_completed_notification(
+                "thread-subagent",
+                "turn-subagent",
+                AppServerTurnStatus::Completed,
+                /*codex_error_info*/ None,
+            ))),
+            &mut events,
+        )
+        .await;
+
+    assert_eq!(events.len(), 1);
+    let payload = serde_json::to_value(&events[0]).expect("serialize subagent turn event");
+    assert_eq!(payload["event_params"]["thread_id"], "thread-subagent");
+    assert_eq!(payload["event_params"]["turn_id"], "turn-subagent");
+    assert_eq!(payload["event_params"]["parent_thread_id"], "thread-1");
+    assert_eq!(payload["event_params"]["parent_turn_id"], "parent-turn-1");
+}
+
+#[tokio::test]
 async fn subagent_tool_items_inherit_parent_connection_metadata() {
     let mut reducer = AnalyticsReducer::default();
     let mut events = Vec::new();
@@ -3877,50 +3963,6 @@ async fn turn_lifecycle_emits_turn_event() {
         json!(13)
     );
     assert_eq!(payload["event_params"]["total_tokens"], json!(321));
-}
-
-#[tokio::test]
-async fn turn_lifecycle_emits_parent_turn_id() {
-    let mut reducer = AnalyticsReducer::default();
-    let mut out = Vec::new();
-
-    ingest_turn_prerequisites(
-        &mut reducer,
-        &mut out,
-        /*include_initialize*/ true,
-        /*include_resolved_config*/ false,
-        /*include_started*/ true,
-        /*include_token_usage*/ true,
-    )
-    .await;
-    let mut resolved_config = sample_turn_resolved_config("thread-2", "turn-2");
-    resolved_config.parent_turn_id = Some("parent-turn-1".to_string());
-    reducer
-        .ingest(
-            AnalyticsFact::Custom(CustomAnalyticsFact::TurnResolvedConfig(Box::new(
-                resolved_config,
-            ))),
-            &mut out,
-        )
-        .await;
-    reducer
-        .ingest(
-            AnalyticsFact::Notification(Box::new(sample_turn_completed_notification(
-                "thread-2",
-                "turn-2",
-                AppServerTurnStatus::Completed,
-                /*codex_error_info*/ None,
-            ))),
-            &mut out,
-        )
-        .await;
-
-    assert_eq!(out.len(), 1);
-    let payload = serde_json::to_value(&out[0]).expect("serialize turn event");
-    assert_eq!(
-        payload["event_params"]["parent_turn_id"],
-        json!("parent-turn-1")
-    );
 }
 
 #[tokio::test]

--- a/codex-rs/analytics/src/events.rs
+++ b/codex-rs/analytics/src/events.rs
@@ -854,6 +854,7 @@ pub(crate) struct CodexTurnEventParams {
     pub(crate) initialization_mode: ThreadInitializationMode,
     pub(crate) subagent_source: Option<String>,
     pub(crate) parent_thread_id: Option<String>,
+    pub(crate) parent_turn_id: Option<String>,
     pub(crate) model: Option<String>,
     pub(crate) model_provider: String,
     pub(crate) sandbox_policy: Option<&'static str>,

--- a/codex-rs/analytics/src/facts.rs
+++ b/codex-rs/analytics/src/facts.rs
@@ -66,6 +66,7 @@ pub enum TurnSubmissionType {
 pub struct TurnResolvedConfigFact {
     pub turn_id: String,
     pub thread_id: String,
+    pub parent_turn_id: Option<String>,
     pub num_input_images: usize,
     pub submission_type: Option<TurnSubmissionType>,
     pub ephemeral: bool,

--- a/codex-rs/analytics/src/reducer.rs
+++ b/codex-rs/analytics/src/reducer.rs
@@ -630,7 +630,14 @@ impl AnalyticsReducer {
         let turn_id = input.turn_id.clone();
         let thread_id = input.thread_id.clone();
         let num_input_images = input.num_input_images;
+        let connection_id = self
+            .threads
+            .get(thread_id.as_str())
+            .and_then(|thread| thread.connection_id);
         let turn_state = self.turns.entry(turn_id.clone()).or_default();
+        if turn_state.connection_id.is_none() {
+            turn_state.connection_id = connection_id;
+        }
         turn_state.thread_id = Some(thread_id);
         turn_state.num_input_images = Some(num_input_images);
         turn_state.resolved_config = Some(input);

--- a/codex-rs/analytics/src/reducer.rs
+++ b/codex-rs/analytics/src/reducer.rs
@@ -2467,6 +2467,7 @@ fn codex_turn_event_params(
     let TurnResolvedConfigFact {
         turn_id: _resolved_turn_id,
         thread_id: _resolved_thread_id,
+        parent_turn_id,
         num_input_images: _resolved_num_input_images,
         submission_type,
         ephemeral,
@@ -2509,6 +2510,7 @@ fn codex_turn_event_params(
         initialization_mode: thread_metadata.initialization_mode,
         subagent_source: thread_metadata.subagent_source.clone(),
         parent_thread_id: thread_metadata.parent_thread_id.clone(),
+        parent_turn_id,
         model: Some(model),
         model_provider,
         sandbox_policy: Some(sandbox_policy_mode(

--- a/codex-rs/app-server/tests/suite/v2/analytics.rs
+++ b/codex-rs/app-server/tests/suite/v2/analytics.rs
@@ -156,6 +156,7 @@ async fn wait_for_matching_analytics_event(
                 tokio::time::sleep(Duration::from_millis(25)).await;
                 continue;
             };
+            let mut matching_events = Vec::new();
             for request in &requests {
                 if request.method != "POST"
                     || request.url.path() != "/codex/analytics-events/events"
@@ -170,6 +171,46 @@ async fn wait_for_matching_analytics_event(
                 if let Some(event) = events.iter().find(|event| matches(event)) {
                     return Ok::<Value, anyhow::Error>(event.clone());
                 }
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await?
+}
+
+pub(crate) async fn wait_for_analytics_events(
+    server: &MockServer,
+    read_timeout: Duration,
+    event_type: &str,
+    expected_len: usize,
+) -> Result<Vec<Value>> {
+    timeout(read_timeout, async {
+        loop {
+            let Some(requests) = server.received_requests().await else {
+                tokio::time::sleep(Duration::from_millis(25)).await;
+                continue;
+            };
+            let mut matching_events = Vec::new();
+            for request in &requests {
+                if request.method != "POST"
+                    || request.url.path() != "/codex/analytics-events/events"
+                {
+                    continue;
+                }
+                let payload: Value = serde_json::from_slice(&request.body)
+                    .map_err(|err| anyhow::anyhow!("invalid analytics payload: {err}"))?;
+                let Some(events) = payload["events"].as_array() else {
+                    continue;
+                };
+                matching_events.extend(
+                    events
+                        .iter()
+                        .filter(|event| event["event_type"] == event_type)
+                        .cloned(),
+                );
+            }
+            if matching_events.len() >= expected_len {
+                return Ok::<Vec<Value>, anyhow::Error>(matching_events);
             }
             tokio::time::sleep(Duration::from_millis(25)).await;
         }

--- a/codex-rs/app-server/tests/suite/v2/analytics.rs
+++ b/codex-rs/app-server/tests/suite/v2/analytics.rs
@@ -156,7 +156,6 @@ async fn wait_for_matching_analytics_event(
                 tokio::time::sleep(Duration::from_millis(25)).await;
                 continue;
             };
-            let mut matching_events = Vec::new();
             for request in &requests {
                 if request.method != "POST"
                     || request.url.path() != "/codex/analytics-events/events"

--- a/codex-rs/app-server/tests/suite/v2/turn_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start.rs
@@ -91,6 +91,7 @@ use wiremock::ResponseTemplate;
 
 use super::analytics::mount_analytics_capture;
 use super::analytics::wait_for_analytics_event;
+use super::analytics::wait_for_analytics_events;
 
 #[cfg(windows)]
 const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(25);
@@ -968,6 +969,152 @@ async fn turn_start_tracks_turn_event_analytics() -> Result<()> {
             "responseRequestCount": 2,
         })
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn spawned_child_turn_analytics_carry_direct_parent_turn_id() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    const CHILD_PROMPT: &str = "child: do work";
+    const PARENT_PROMPT: &str = "spawn a child and continue";
+    const SPAWN_CALL_ID: &str = "spawn-call-1";
+
+    let server = responses::start_mock_server().await;
+    let spawn_args = serde_json::to_string(&json!({
+        "message": CHILD_PROMPT,
+    }))?;
+    let _parent_turn = responses::mount_sse_once_match(
+        &server,
+        |req: &wiremock::Request| body_contains(req, PARENT_PROMPT),
+        responses::sse(vec![
+            responses::ev_response_created("resp-turn1-1"),
+            responses::ev_function_call_with_namespace(
+                SPAWN_CALL_ID,
+                "multi_agent_v1",
+                "spawn_agent",
+                &spawn_args,
+            ),
+            responses::ev_completed("resp-turn1-1"),
+        ]),
+    )
+    .await;
+    let _child_turn = responses::mount_sse_once_match(
+        &server,
+        |req: &wiremock::Request| {
+            body_contains(req, CHILD_PROMPT) && !body_contains(req, SPAWN_CALL_ID)
+        },
+        responses::sse(vec![
+            responses::ev_response_created("resp-child-1"),
+            responses::ev_assistant_message("msg-child-1", "child done"),
+            responses::ev_completed("resp-child-1"),
+        ]),
+    )
+    .await;
+    let _parent_follow_up = responses::mount_sse_once_match(
+        &server,
+        |req: &wiremock::Request| body_contains(req, SPAWN_CALL_ID),
+        responses::sse(vec![
+            responses::ev_response_created("resp-turn1-2"),
+            responses::ev_assistant_message("msg-turn1-2", "parent done"),
+            responses::ev_completed("resp-turn1-2"),
+        ]),
+    )
+    .await;
+
+    let codex_home = TempDir::new()?;
+    write_mock_responses_config_toml_with_chatgpt_base_url(
+        codex_home.path(),
+        &server.uri(),
+        &server.uri(),
+    )?;
+    let config_path = codex_home.path().join("config.toml");
+    let config = std::fs::read_to_string(&config_path)?;
+    let collab_feature_key = FEATURES
+        .iter()
+        .find(|spec| spec.id == Feature::Collab)
+        .map(|spec| spec.key)
+        .expect("collab feature key should be defined");
+    std::fs::write(
+        config_path,
+        format!("{config}\n[features]\n{collab_feature_key} = true\n"),
+    )?;
+    mount_analytics_capture(&server, codex_home.path()).await?;
+
+    let mut mcp = TestAppServer::new_without_managed_config(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let thread_req = mcp
+        .send_thread_start_request(ThreadStartParams {
+            model: Some("mock-model".to_string()),
+            ..Default::default()
+        })
+        .await?;
+    let thread_resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(thread_req)),
+    )
+    .await??;
+    let ThreadStartResponse { thread, .. } = to_response::<ThreadStartResponse>(thread_resp)?;
+
+    let turn_req = mcp
+        .send_turn_start_request(TurnStartParams {
+            thread_id: thread.id.clone(),
+            client_user_message_id: None,
+            input: vec![V2UserInput::Text {
+                text: PARENT_PROMPT.to_string(),
+                text_elements: Vec::new(),
+            }],
+            ..Default::default()
+        })
+        .await?;
+    let turn_resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(turn_req)),
+    )
+    .await??;
+    let TurnStartResponse { turn } = to_response::<TurnStartResponse>(turn_resp)?;
+
+    timeout(DEFAULT_READ_TIMEOUT, async {
+        let mut saw_parent_turn_completed = false;
+        let mut saw_child_turn_completed = false;
+        while !saw_parent_turn_completed || !saw_child_turn_completed {
+            let turn_completed_notif = mcp
+                .read_stream_until_notification_message("turn/completed")
+                .await?;
+            let turn_completed: TurnCompletedNotification = serde_json::from_value(
+                turn_completed_notif.params.expect("turn/completed params"),
+            )?;
+            if turn_completed.thread_id == thread.id && turn_completed.turn.id == turn.id {
+                saw_parent_turn_completed = true;
+            } else if turn_completed.thread_id != thread.id {
+                saw_child_turn_completed = true;
+            }
+        }
+        Ok::<(), anyhow::Error>(())
+    })
+    .await??;
+
+    let events =
+        wait_for_analytics_events(&server, DEFAULT_READ_TIMEOUT, "codex_turn_event", 2).await?;
+    let parent_turn_event = events
+        .iter()
+        .find(|event| {
+            event["event_params"]["thread_id"] == thread.id
+                && event["event_params"]["turn_id"] == turn.id
+        })
+        .expect("parent turn analytics event should be emitted");
+    let child_turn_event = events
+        .iter()
+        .find(|event| event["event_params"]["parent_thread_id"] == thread.id)
+        .expect("child turn analytics event should be emitted");
+
+    assert_eq!(
+        parent_turn_event["event_params"]["parent_turn_id"],
+        Value::Null
+    );
+    assert_eq!(child_turn_event["event_params"]["parent_turn_id"], turn.id);
 
     Ok(())
 }

--- a/codex-rs/app-server/tests/suite/v2/turn_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start.rs
@@ -1096,8 +1096,13 @@ async fn spawned_child_turn_analytics_carry_direct_parent_turn_id() -> Result<()
     })
     .await??;
 
-    let events =
-        wait_for_analytics_events(&server, DEFAULT_READ_TIMEOUT, "codex_turn_event", 2).await?;
+    let events = wait_for_analytics_events(
+        &server,
+        DEFAULT_READ_TIMEOUT,
+        "codex_turn_event",
+        /*expected_len*/ 2,
+    )
+    .await?;
     let parent_turn_event = events
         .iter()
         .find(|event| {

--- a/codex-rs/core/src/agent/control.rs
+++ b/codex-rs/core/src/agent/control.rs
@@ -65,6 +65,7 @@ pub(crate) struct SpawnAgentOptions {
     pub(crate) fork_parent_spawn_call_id: Option<String>,
     pub(crate) fork_mode: Option<SpawnAgentForkMode>,
     pub(crate) parent_thread_id: Option<ThreadId>,
+    pub(crate) parent_turn_id: Option<String>,
     pub(crate) environments: Option<Vec<TurnEnvironmentSelection>>,
 }
 
@@ -122,15 +123,26 @@ impl AgentControl {
     }
 
     /// Send rich user input items to an existing agent thread.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) async fn send_input(
         &self,
         agent_id: ThreadId,
         initial_operation: Op,
     ) -> CodexResult<String> {
+        self.send_input_with_parent_turn_id(agent_id, initial_operation, None)
+            .await
+    }
+
+    pub(crate) async fn send_input_with_parent_turn_id(
+        &self,
+        agent_id: ThreadId,
+        initial_operation: Op,
+        parent_turn_id: Option<String>,
+    ) -> CodexResult<String> {
         let state = self.upgrade()?;
         self.ensure_execution_capacity_for_op(agent_id, &initial_operation)
             .await?;
-        self.send_input_after_capacity_check(agent_id, &state, initial_operation)
+        self.send_input_after_capacity_check(agent_id, &state, initial_operation, parent_turn_id)
             .await
     }
 
@@ -139,6 +151,7 @@ impl AgentControl {
         agent_id: ThreadId,
         state: &Arc<ThreadManagerState>,
         initial_operation: Op,
+        parent_turn_id: Option<String>,
     ) -> CodexResult<String> {
         let last_task_message = match &initial_operation {
             Op::InterAgentCommunication { communication } => {
@@ -150,7 +163,9 @@ impl AgentControl {
             .handle_thread_request_result(
                 agent_id,
                 state,
-                state.send_op(agent_id, initial_operation).await,
+                state
+                    .send_op_with_parent_turn_id(agent_id, initial_operation, parent_turn_id)
+                    .await,
             )
             .await;
         if result.is_ok() {

--- a/codex-rs/core/src/agent/control.rs
+++ b/codex-rs/core/src/agent/control.rs
@@ -129,8 +129,12 @@ impl AgentControl {
         agent_id: ThreadId,
         initial_operation: Op,
     ) -> CodexResult<String> {
-        self.send_input_with_parent_turn_id(agent_id, initial_operation, None)
-            .await
+        self.send_input_with_parent_turn_id(
+            agent_id,
+            initial_operation,
+            /*parent_turn_id*/ None,
+        )
+        .await
     }
 
     pub(crate) async fn send_input_with_parent_turn_id(

--- a/codex-rs/core/src/agent/control/spawn.rs
+++ b/codex-rs/core/src/agent/control/spawn.rs
@@ -353,8 +353,13 @@ impl AgentControl {
         )
         .await;
 
-        self.send_input_after_capacity_check(new_thread.thread_id, &state, initial_operation)
-            .await?;
+        self.send_input_after_capacity_check(
+            new_thread.thread_id,
+            &state,
+            initial_operation,
+            options.parent_turn_id,
+        )
+        .await?;
         if multi_agent_version != MultiAgentVersion::V2 {
             let child_reference = agent_metadata
                 .agent_path

--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -197,7 +197,7 @@ pub(crate) async fn run_codex_thread_one_shot(
         auth_manager,
         models_manager,
         parent_session,
-        parent_ctx,
+        Arc::clone(&parent_ctx),
         child_cancel.clone(),
         subagent_source,
         initial_history,
@@ -205,13 +205,16 @@ pub(crate) async fn run_codex_thread_one_shot(
     .await?;
 
     // Send the initial input to kick off the one-shot turn.
-    io.submit(Op::UserInput {
-        items: input,
-        final_output_json_schema,
-        responsesapi_client_metadata: None,
-        additional_context: Default::default(),
-        thread_settings: Default::default(),
-    })
+    io.submit_with_parent_turn_id(
+        Op::UserInput {
+            items: input,
+            final_output_json_schema,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: Default::default(),
+        },
+        Some(parent_ctx.sub_id.clone()),
+    )
     .await?;
 
     // Bridge events so we can observe completion and shut down automatically.

--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -234,6 +234,7 @@ pub(crate) async fn run_codex_thread_one_shot(
                         id: "shutdown".to_string(),
                         op: Op::Shutdown {},
                         client_user_message_id: None,
+                        parent_turn_id: None,
                         trace: None,
                     })
                     .await;

--- a/codex-rs/core/src/codex_delegate_tests.rs
+++ b/codex-rs/core/src/codex_delegate_tests.rs
@@ -132,6 +132,7 @@ async fn forward_ops_preserves_submission_trace_context() {
         id: "sub-1".to_string(),
         op: Op::Interrupt,
         client_user_message_id: None,
+        parent_turn_id: None,
         trace: Some(codex_protocol::protocol::W3cTraceContext {
             traceparent: Some(
                 "00-1234567890abcdef1234567890abcdef-1234567890abcdef-01".to_string(),

--- a/codex-rs/core/src/codex_delegate_tests.rs
+++ b/codex-rs/core/src/codex_delegate_tests.rs
@@ -132,7 +132,7 @@ async fn forward_ops_preserves_submission_trace_context() {
         id: "sub-1".to_string(),
         op: Op::Interrupt,
         client_user_message_id: None,
-        parent_turn_id: None,
+        parent_turn_id: Some("parent-turn-1".to_string()),
         trace: Some(codex_protocol::protocol::W3cTraceContext {
             traceparent: Some(
                 "00-1234567890abcdef1234567890abcdef-1234567890abcdef-01".to_string(),
@@ -149,6 +149,7 @@ async fn forward_ops_preserves_submission_trace_context() {
         .expect("forwarded submission missing");
     assert_eq!(submission.id, forwarded.id);
     assert_eq!(submission.op, forwarded.op);
+    assert_eq!(submission.parent_turn_id, forwarded.parent_turn_id);
     assert_eq!(submission.trace, forwarded.trace);
 
     timeout(Duration::from_secs(1), forward)

--- a/codex-rs/core/src/codex_thread.rs
+++ b/codex-rs/core/src/codex_thread.rs
@@ -189,6 +189,16 @@ impl CodexThread {
         self.codex.submit(op).await
     }
 
+    pub(crate) async fn submit_with_parent_turn_id(
+        &self,
+        op: Op,
+        parent_turn_id: Option<String>,
+    ) -> CodexResult<String> {
+        self.codex
+            .submit_with_parent_turn_id(op, parent_turn_id)
+            .await
+    }
+
     /// Returns the session telemetry handle for thread-scoped production instrumentation.
     pub fn session_telemetry(&self) -> SessionTelemetry {
         self.codex.session.services.session_telemetry.clone()

--- a/codex-rs/core/src/guardian/review_session.rs
+++ b/codex-rs/core/src/guardian/review_session.rs
@@ -762,32 +762,35 @@ async fn run_review_on_session(
     let submit_result = run_before_review_deadline(
         deadline,
         params.external_cancel.as_ref(),
-        Box::pin(review_session.codex.submit(Op::UserInput {
-            items: prompt_items.items,
-            final_output_json_schema: Some(params.schema.clone()),
-            responsesapi_client_metadata: None,
-            additional_context: Default::default(),
-            thread_settings: codex_protocol::protocol::ThreadSettingsOverrides {
-                environments: Some(codex_protocol::protocol::TurnEnvironmentSelections::new(
-                    parent_turn_legacy_fallback_cwd,
-                    parent_turn_environments,
-                )),
-                approval_policy: Some(AskForApproval::Never),
-                sandbox_policy: None,
-                permission_profile: Some(guardian_permission_profile),
-                summary: Some(params.reasoning_summary),
-                personality: params.personality,
-                collaboration_mode: Some(codex_protocol::config_types::CollaborationMode {
-                    mode: codex_protocol::config_types::ModeKind::Default,
-                    settings: codex_protocol::config_types::Settings {
-                        model: params.model.clone(),
-                        reasoning_effort: params.reasoning_effort.clone(),
-                        developer_instructions: None,
-                    },
-                }),
-                ..Default::default()
+        Box::pin(review_session.codex.submit_with_parent_turn_id(
+            Op::UserInput {
+                items: prompt_items.items,
+                final_output_json_schema: Some(params.schema.clone()),
+                responsesapi_client_metadata: None,
+                additional_context: Default::default(),
+                thread_settings: codex_protocol::protocol::ThreadSettingsOverrides {
+                    environments: Some(codex_protocol::protocol::TurnEnvironmentSelections::new(
+                        parent_turn_legacy_fallback_cwd,
+                        parent_turn_environments,
+                    )),
+                    approval_policy: Some(AskForApproval::Never),
+                    sandbox_policy: None,
+                    permission_profile: Some(guardian_permission_profile),
+                    summary: Some(params.reasoning_summary),
+                    personality: params.personality,
+                    collaboration_mode: Some(codex_protocol::config_types::CollaborationMode {
+                        mode: codex_protocol::config_types::ModeKind::Default,
+                        settings: codex_protocol::config_types::Settings {
+                            model: params.model.clone(),
+                            reasoning_effort: params.reasoning_effort.clone(),
+                            developer_instructions: None,
+                        },
+                    }),
+                    ..Default::default()
+                },
             },
-        })),
+            Some(params.parent_turn.sub_id.clone()),
+        )),
     )
     .await;
     let child_turn_id = match submit_result {
@@ -1499,6 +1502,7 @@ mod tests {
             });
         }
         let params = test_review_params().await;
+        let expected_parent_turn_id = params.parent_turn.sub_id.clone();
 
         let review = tokio::spawn(async move {
             run_review_on_session(
@@ -1510,6 +1514,10 @@ mod tests {
             .await
         });
         let submission = rx_sub.recv().await.expect("guardian submission");
+        assert_eq!(
+            submission.parent_turn_id.as_deref(),
+            Some(expected_parent_turn_id.as_str())
+        );
         tx_event
             .send(turn_complete_event("prior-turn", Some("stale"), Some(9)))
             .await

--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -84,9 +84,17 @@ pub async fn user_input_or_turn(
     sess: &Arc<Session>,
     sub_id: String,
     op: Op,
+    parent_turn_id: Option<String>,
     client_user_message_id: Option<String>,
 ) {
-    user_input_or_turn_inner(sess, sub_id, op, client_user_message_id).await;
+    user_input_or_turn_inner(
+        sess,
+        sub_id,
+        op,
+        parent_turn_id,
+        client_user_message_id,
+    )
+    .await;
 }
 
 pub async fn update_thread_settings(
@@ -184,6 +192,7 @@ pub(super) async fn user_input_or_turn_inner(
     sess: &Arc<Session>,
     sub_id: String,
     op: Op,
+    parent_turn_id: Option<String>,
     client_user_message_id: Option<String>,
 ) {
     let Op::UserInput {
@@ -204,7 +213,10 @@ pub(super) async fn user_input_or_turn_inner(
     };
     updates.final_output_json_schema = Some(final_output_json_schema);
 
-    let Ok(current_context) = sess.new_turn_with_sub_id(sub_id.clone(), updates).await else {
+    let Ok(current_context) = sess
+        .new_turn_with_sub_id_and_parent_turn_id(sub_id.clone(), updates, parent_turn_id)
+        .await
+    else {
         // new_turn_with_sub_id already emits the error event.
         return;
     };
@@ -751,8 +763,14 @@ pub(super) async fn submission_loop(
                     false
                 }
                 Op::UserInput { .. } => {
-                    user_input_or_turn(&sess, sub.id.clone(), sub.op, sub.client_user_message_id)
-                        .await;
+                    user_input_or_turn(
+                        &sess,
+                        sub.id.clone(),
+                        sub.op,
+                        sub.parent_turn_id,
+                        sub.client_user_message_id,
+                    )
+                    .await;
                     false
                 }
                 Op::ThreadSettings { thread_settings } => {

--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -87,14 +87,7 @@ pub async fn user_input_or_turn(
     parent_turn_id: Option<String>,
     client_user_message_id: Option<String>,
 ) {
-    user_input_or_turn_inner(
-        sess,
-        sub_id,
-        op,
-        parent_turn_id,
-        client_user_message_id,
-    )
-    .await;
+    user_input_or_turn_inner(sess, sub_id, op, parent_turn_id, client_user_message_id).await;
 }
 
 pub async fn update_thread_settings(

--- a/codex-rs/core/src/session/input_queue.rs
+++ b/codex-rs/core/src/session/input_queue.rs
@@ -92,6 +92,15 @@ impl InputQueue {
             .any(|mail| mail.trigger_turn)
     }
 
+    pub(crate) async fn next_trigger_turn_parent_turn_id(&self) -> Option<String> {
+        self.mailbox_pending_mails
+            .lock()
+            .await
+            .iter()
+            .find(|mail| mail.trigger_turn)
+            .and_then(|mail| mail.parent_turn_id.clone())
+    }
+
     pub(crate) async fn drain_mailbox_input_items(&self) -> Vec<TurnInput> {
         self.mailbox_pending_mails
             .lock()
@@ -416,5 +425,35 @@ mod tests {
             ))
             .await;
         assert!(input_queue.has_trigger_turn_mailbox_items().await);
+    }
+
+    #[tokio::test]
+    async fn input_queue_tracks_next_trigger_turn_parent_turn_id() {
+        let input_queue = InputQueue::new();
+
+        input_queue
+            .enqueue_mailbox_communication(make_mail(
+                AgentPath::root(),
+                AgentPath::try_from("/root/worker").expect("agent path"),
+                "queued",
+                /*trigger_turn*/ false,
+            ))
+            .await;
+        input_queue
+            .enqueue_mailbox_communication(
+                make_mail(
+                    AgentPath::root(),
+                    AgentPath::try_from("/root/worker").expect("agent path"),
+                    "wake",
+                    /*trigger_turn*/ true,
+                )
+                .with_parent_turn_id(Some("parent-turn-1".to_string())),
+            )
+            .await;
+
+        assert_eq!(
+            input_queue.next_trigger_turn_parent_turn_id().await,
+            Some("parent-turn-1".to_string())
+        );
     }
 }

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -692,7 +692,8 @@ impl Codex {
 
     /// Submit the `op` wrapped in a `Submission` with a unique ID.
     pub async fn submit(&self, op: Op) -> CodexResult<String> {
-        self.submit_with_parent_turn_id(op, None).await
+        self.submit_with_parent_turn_id(op, /*parent_turn_id*/ None)
+            .await
     }
 
     pub(crate) async fn submit_with_parent_turn_id(
@@ -709,7 +710,7 @@ impl Codex {
         op: Op,
         trace: Option<W3cTraceContext>,
     ) -> CodexResult<String> {
-        self.submit_with_trace_and_parent_turn_id(op, trace, None)
+        self.submit_with_trace_and_parent_turn_id(op, trace, /*parent_turn_id*/ None)
             .await
     }
 

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -692,7 +692,16 @@ impl Codex {
 
     /// Submit the `op` wrapped in a `Submission` with a unique ID.
     pub async fn submit(&self, op: Op) -> CodexResult<String> {
-        self.submit_with_trace(op, /*trace*/ None).await
+        self.submit_with_parent_turn_id(op, None).await
+    }
+
+    pub(crate) async fn submit_with_parent_turn_id(
+        &self,
+        op: Op,
+        parent_turn_id: Option<String>,
+    ) -> CodexResult<String> {
+        self.submit_with_trace_and_parent_turn_id(op, /*trace*/ None, parent_turn_id)
+            .await
     }
 
     pub async fn submit_with_trace(
@@ -700,11 +709,22 @@ impl Codex {
         op: Op,
         trace: Option<W3cTraceContext>,
     ) -> CodexResult<String> {
+        self.submit_with_trace_and_parent_turn_id(op, trace, None)
+            .await
+    }
+
+    async fn submit_with_trace_and_parent_turn_id(
+        &self,
+        op: Op,
+        trace: Option<W3cTraceContext>,
+        parent_turn_id: Option<String>,
+    ) -> CodexResult<String> {
         let id = Uuid::now_v7().to_string();
         let sub = Submission {
             id: id.clone(),
             op,
             client_user_message_id: None,
+            parent_turn_id,
             trace,
         };
         self.submit_with_id(sub).await?;
@@ -723,6 +743,7 @@ impl Codex {
             id: id.clone(),
             op,
             client_user_message_id,
+            parent_turn_id: None,
             trace,
         };
         self.submit_with_id(sub).await?;
@@ -1145,6 +1166,7 @@ impl Session {
                 additional_context: Default::default(),
                 thread_settings: Default::default(),
             },
+            /*parent_turn_id*/ None,
             /*client_user_message_id*/ None,
         )
         .await;

--- a/codex-rs/core/src/session/review.rs
+++ b/codex-rs/core/src/session/review.rs
@@ -114,6 +114,7 @@ pub(super) async fn spawn_review_thread(
         reasoning_summary,
         session_source,
         parent_thread_id: parent_turn_context.parent_thread_id,
+        parent_turn_id: parent_turn_context.parent_turn_id.clone(),
         environments: parent_turn_context.environments.clone(),
         available_models,
         unified_exec_shell_mode,

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -5074,6 +5074,7 @@ pub(crate) async fn make_session_and_context() -> (Session, TurnContext) {
         resolved_turn_environments,
         session_configuration.cwd().clone(),
         "turn_id".to_string(),
+        /*parent_turn_id*/ None,
         skills_snapshot,
     );
 
@@ -6020,6 +6021,7 @@ async fn submit_with_id_captures_current_span_trace_context() {
                 id: "sub-1".into(),
                 op: Op::Interrupt,
                 client_user_message_id: None,
+                parent_turn_id: None,
                 trace: None,
             })
             .await
@@ -6092,6 +6094,7 @@ fn submission_dispatch_span_prefers_submission_trace_context() {
             id: "sub-1".into(),
             op: Op::Interrupt,
             client_user_message_id: None,
+            parent_turn_id: None,
             trace: Some(submission_trace),
         })
     });
@@ -6119,6 +6122,7 @@ fn submission_dispatch_span_uses_debug_for_realtime_audio() {
             },
         }),
         client_user_message_id: None,
+        parent_turn_id: None,
         trace: None,
     });
 
@@ -6184,6 +6188,7 @@ async fn user_turn_updates_approvals_reviewer() {
                 ..Default::default()
             },
         },
+        /*parent_turn_id*/ None,
         /*client_user_message_id*/ None,
     )
     .await;
@@ -6192,6 +6197,24 @@ async fn user_turn_updates_approvals_reviewer() {
     assert_eq!(
         state.session_configuration.approvals_reviewer,
         codex_config::types::ApprovalsReviewer::AutoReview
+    );
+}
+
+#[tokio::test]
+async fn new_turn_carries_parent_turn_id() {
+    let (session, _turn_context, _rx) = make_session_and_context_with_rx().await;
+    let turn_context = session
+        .new_turn_with_sub_id_and_parent_turn_id(
+            "child-turn".to_string(),
+            SessionSettingsUpdate::default(),
+            Some("parent-turn-1".to_string()),
+        )
+        .await
+        .expect("child turn context should build");
+
+    assert_eq!(
+        turn_context.parent_turn_id.as_deref(),
+        Some("parent-turn-1")
     );
 }
 
@@ -6432,6 +6455,7 @@ async fn spawn_task_turn_span_inherits_dispatch_trace_context() {
         id: "sub-1".into(),
         op: Op::Interrupt,
         client_user_message_id: None,
+        parent_turn_id: None,
         trace: Some(submission_trace.clone()),
     });
     let dispatch_span_id = dispatch_span.context().span().span_context().span_id();
@@ -7117,6 +7141,7 @@ where
         resolved_turn_environments,
         session_configuration.cwd().clone(),
         "turn_id".to_string(),
+        /*parent_turn_id*/ None,
         skills_snapshot,
     ));
 

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -697,6 +697,7 @@ async fn track_turn_resolved_config_analytics(
         .track_turn_resolved_config(TurnResolvedConfigFact {
             turn_id: turn_context.sub_id.clone(),
             thread_id: sess.thread_id.to_string(),
+            parent_turn_id: turn_context.parent_turn_id.clone(),
             num_input_images: input
                 .iter()
                 .filter_map(|item| match item {

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -592,7 +592,7 @@ impl Session {
         sub_id: String,
         updates: SessionSettingsUpdate,
     ) -> CodexResult<Arc<TurnContext>> {
-        self.new_turn_with_sub_id_and_parent_turn_id(sub_id, updates, None)
+        self.new_turn_with_sub_id_and_parent_turn_id(sub_id, updates, /*parent_turn_id*/ None)
             .await
     }
 

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -113,6 +113,7 @@ pub struct TurnContext {
     pub(crate) reasoning_summary: ReasoningSummaryConfig,
     pub(crate) session_source: SessionSource,
     pub(crate) parent_thread_id: Option<ThreadId>,
+    pub(crate) parent_turn_id: Option<String>,
     pub(crate) environments: TurnEnvironmentSnapshot,
     /// The session's absolute working directory. All relative paths provided
     /// by the model as well as sandbox policies are resolved against this path
@@ -267,6 +268,7 @@ impl TurnContext {
             reasoning_summary: self.reasoning_summary,
             session_source: self.session_source.clone(),
             parent_thread_id: self.parent_thread_id,
+            parent_turn_id: self.parent_turn_id.clone(),
             environments: self.environments.clone(),
             #[allow(deprecated)]
             cwd: self.cwd.clone(),
@@ -493,6 +495,7 @@ impl Session {
         environments: TurnEnvironmentSnapshot,
         cwd: AbsolutePathBuf,
         sub_id: String,
+        parent_turn_id: Option<String>,
         skills_snapshot: HostSkillsSnapshot,
     ) -> TurnContext {
         let reasoning_effort = session_configuration.collaboration_mode.reasoning_effort();
@@ -550,6 +553,7 @@ impl Session {
             reasoning_summary,
             session_source,
             parent_thread_id: session_configuration.parent_thread_id,
+            parent_turn_id,
             environments,
             #[allow(deprecated)]
             cwd,
@@ -582,10 +586,21 @@ impl Session {
         }
     }
 
+    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) async fn new_turn_with_sub_id(
         &self,
         sub_id: String,
         updates: SessionSettingsUpdate,
+    ) -> CodexResult<Arc<TurnContext>> {
+        self.new_turn_with_sub_id_and_parent_turn_id(sub_id, updates, None)
+            .await
+    }
+
+    pub(crate) async fn new_turn_with_sub_id_and_parent_turn_id(
+        &self,
+        sub_id: String,
+        updates: SessionSettingsUpdate,
+        parent_turn_id: Option<String>,
     ) -> CodexResult<Arc<TurnContext>> {
         let notify_config_contributors = !self.services.extensions.config_contributors().is_empty();
         let update_result: CodexResult<_> = {
@@ -647,6 +662,7 @@ impl Session {
                 sub_id,
                 session_configuration,
                 updates.final_output_json_schema,
+                parent_turn_id,
             )
             .await)
     }
@@ -656,11 +672,13 @@ impl Session {
         sub_id: String,
         session_configuration: SessionConfiguration,
         final_output_json_schema: Option<Option<Value>>,
+        parent_turn_id: Option<String>,
     ) -> Arc<TurnContext> {
         self.new_turn_context_from_configuration(
             sub_id,
             session_configuration,
             final_output_json_schema,
+            parent_turn_id,
             TurnMultiAgentRuntime::ResolveAndStore,
         )
         .await
@@ -675,6 +693,7 @@ impl Session {
             sub_id,
             session_configuration,
             /*final_output_json_schema*/ None,
+            /*parent_turn_id*/ None,
             TurnMultiAgentRuntime::Preview,
         )
         .await
@@ -686,6 +705,7 @@ impl Session {
         sub_id: String,
         session_configuration: SessionConfiguration,
         final_output_json_schema: Option<Option<Value>>,
+        parent_turn_id: Option<String>,
         multi_agent_runtime: TurnMultiAgentRuntime,
     ) -> Arc<TurnContext> {
         let turn_environments = self.services.turn_environments.snapshot().await;
@@ -763,6 +783,7 @@ impl Session {
             turn_environments,
             cwd,
             sub_id,
+            parent_turn_id,
             skills_snapshot,
         );
         turn_context.realtime_active = self.conversation.running_state().await.is_some();
@@ -802,11 +823,21 @@ impl Session {
     }
 
     pub(crate) async fn new_default_turn_with_sub_id(&self, sub_id: String) -> Arc<TurnContext> {
+        self.new_default_turn_with_sub_id_and_parent_turn_id(sub_id, /*parent_turn_id*/ None)
+            .await
+    }
+
+    pub(crate) async fn new_default_turn_with_sub_id_and_parent_turn_id(
+        &self,
+        sub_id: String,
+        parent_turn_id: Option<String>,
+    ) -> Arc<TurnContext> {
         let session_configuration = self.default_turn_configuration().await;
         self.new_turn_from_configuration(
             sub_id,
             session_configuration,
             /*final_output_json_schema*/ None,
+            parent_turn_id,
         )
         .await
     }

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -476,7 +476,10 @@ impl Session {
             *active_turn = Some(ActiveTurn::default());
         }
 
-        let turn_context = self.new_default_turn_with_sub_id(sub_id).await;
+        let parent_turn_id = self.input_queue.next_trigger_turn_parent_turn_id().await;
+        let turn_context = self
+            .new_default_turn_with_sub_id_and_parent_turn_id(sub_id, parent_turn_id)
+            .await;
         self.maybe_emit_unknown_model_warning_for_turn(turn_context.as_ref())
             .await;
         self.start_task(turn_context, Vec::new(), RegularTask::new())

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -1072,7 +1072,8 @@ impl ThreadManagerState {
 
     /// Send an operation to a thread by ID.
     pub(crate) async fn send_op(&self, thread_id: ThreadId, op: Op) -> CodexResult<String> {
-        self.send_op_with_parent_turn_id(thread_id, op, None).await
+        self.send_op_with_parent_turn_id(thread_id, op, /*parent_turn_id*/ None)
+            .await
     }
 
     pub(crate) async fn send_op_with_parent_turn_id(

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -88,7 +88,7 @@ const THREAD_CREATED_CHANNEL_CAPACITY: usize = 1024;
 /// must not be toggled.
 static FORCE_TEST_THREAD_MANAGER_BEHAVIOR: AtomicBool = AtomicBool::new(false);
 
-type CapturedOps = Vec<(ThreadId, Op)>;
+type CapturedOps = Vec<(ThreadId, Op, Option<String>)>;
 type SharedCapturedOps = Arc<std::sync::Mutex<CapturedOps>>;
 
 pub(crate) fn set_thread_manager_test_mode_for_tests(enabled: bool) {
@@ -979,6 +979,21 @@ impl ThreadManager {
         self.state
             .ops_log
             .as_ref()
+            .and_then(|ops_log| {
+                ops_log.lock().ok().map(|log| {
+                    log.iter()
+                        .map(|(thread_id, op, _parent_turn_id)| (*thread_id, op.clone()))
+                        .collect()
+                })
+            })
+            .unwrap_or_default()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn captured_ops_with_parent_turn_ids(&self) -> Vec<(ThreadId, Op, Option<String>)> {
+        self.state
+            .ops_log
+            .as_ref()
             .and_then(|ops_log| ops_log.lock().ok().map(|log| log.clone()))
             .unwrap_or_default()
     }
@@ -1057,13 +1072,22 @@ impl ThreadManagerState {
 
     /// Send an operation to a thread by ID.
     pub(crate) async fn send_op(&self, thread_id: ThreadId, op: Op) -> CodexResult<String> {
+        self.send_op_with_parent_turn_id(thread_id, op, None).await
+    }
+
+    pub(crate) async fn send_op_with_parent_turn_id(
+        &self,
+        thread_id: ThreadId,
+        op: Op,
+        parent_turn_id: Option<String>,
+    ) -> CodexResult<String> {
         let thread = self.get_thread(thread_id).await?;
         if let Some(ops_log) = &self.ops_log
             && let Ok(mut log) = ops_log.lock()
         {
-            log.push((thread_id, op.clone()));
+            log.push((thread_id, op.clone(), parent_turn_id.clone()));
         }
-        thread.submit(op).await
+        thread.submit_with_parent_turn_id(op, parent_turn_id).await
     }
 
     /// Remove a thread from the manager by ID, returning it when present.

--- a/codex-rs/core/src/tools/handlers/agent_jobs.rs
+++ b/codex-rs/core/src/tools/handlers/agent_jobs.rs
@@ -209,6 +209,7 @@ async fn run_agent_job_loop(
                         )))),
                         SpawnAgentOptions {
                             parent_thread_id: Some(session.thread_id),
+                            parent_turn_id: Some(turn.sub_id.clone()),
                             environments: Some(turn.environments.to_selections()),
                             ..Default::default()
                         },

--- a/codex-rs/core/src/tools/handlers/multi_agents/send_input.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents/send_input.rs
@@ -66,6 +66,8 @@ impl Handler {
                 .await
                 .map_err(|err| collab_agent_error(receiver_thread_id, err))?;
         }
+        let parent_turn_id =
+            direct_parent_turn_id_for_receiver(&session, turn.as_ref(), receiver_thread_id).await;
         session
             .send_event(
                 &turn,
@@ -81,7 +83,7 @@ impl Handler {
             .await;
         let agent_control = session.services.agent_control.clone();
         let result = agent_control
-            .send_input(receiver_thread_id, input_items)
+            .send_input_with_parent_turn_id(receiver_thread_id, input_items, parent_turn_id)
             .await
             .map_err(|err| collab_agent_error(receiver_thread_id, err));
         let status = session

--- a/codex-rs/core/src/tools/handlers/multi_agents/spawn.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents/spawn.rs
@@ -131,6 +131,7 @@ async fn handle_spawn_agent(
             fork_parent_spawn_call_id: args.fork_context.then(|| call_id.clone()),
             fork_mode: args.fork_context.then_some(SpawnAgentForkMode::FullHistory),
             parent_thread_id: Some(session.thread_id),
+            parent_turn_id: Some(turn.sub_id.clone()),
             environments: Some(turn.environments.to_selections()),
         },
     ))

--- a/codex-rs/core/src/tools/handlers/multi_agents_common.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_common.rs
@@ -194,6 +194,20 @@ pub(crate) fn parse_collab_input(
     }
 }
 
+pub(crate) async fn direct_parent_turn_id_for_receiver(
+    session: &Session,
+    turn: &TurnContext,
+    receiver_thread_id: ThreadId,
+) -> Option<String> {
+    session
+        .services
+        .agent_control
+        .get_agent_config_snapshot(receiver_thread_id)
+        .await
+        .filter(|snapshot| snapshot.parent_thread_id == Some(session.thread_id))
+        .map(|_| turn.sub_id.clone())
+}
+
 /// Builds the base config snapshot for a newly spawned sub-agent.
 ///
 /// The returned config starts from the parent's effective config and then refreshes the

--- a/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
@@ -307,6 +307,64 @@ async fn spawn_agent_uses_explorer_role_and_preserves_approval_policy() {
 }
 
 #[tokio::test]
+async fn spawn_agent_options_forward_parent_turn_id() {
+    let (mut session, turn) = make_session_and_context().await;
+    let parent_turn_id = turn.sub_id.clone();
+    let manager = thread_manager();
+    let root = manager
+        .start_thread((*turn.config).clone())
+        .await
+        .expect("root thread should start");
+    session.services.agent_control = manager.agent_control();
+    let child = session
+        .services
+        .agent_control
+        .spawn_agent_with_metadata(
+            (*turn.config).clone(),
+            Op::ThreadSettings {
+                thread_settings: Default::default(),
+            },
+            Some(SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
+                parent_thread_id: root.thread_id,
+                depth: 1,
+                agent_path: Some(AgentPath::try_from("/root/worker").expect("agent path")),
+                agent_nickname: None,
+                agent_role: None,
+            })),
+            crate::agent::control::SpawnAgentOptions {
+                parent_thread_id: Some(root.thread_id),
+                parent_turn_id: Some(parent_turn_id.clone()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("child thread should spawn");
+    let child_thread = manager
+        .get_thread(child.thread_id)
+        .await
+        .expect("child thread should exist");
+    assert_eq!(
+        manager
+            .captured_ops_with_parent_turn_ids()
+            .into_iter()
+            .find_map(|(thread_id, op, captured_parent_turn_id)| {
+                (thread_id == child.thread_id && matches!(op, Op::ThreadSettings { .. }))
+                    .then_some(captured_parent_turn_id)
+            }),
+        Some(Some(parent_turn_id))
+    );
+
+    child_thread
+        .submit(Op::Shutdown {})
+        .await
+        .expect("shutdown should submit");
+    root.thread
+        .submit(Op::Shutdown {})
+        .await
+        .expect("shutdown should submit");
+}
+
+#[tokio::test]
 async fn spawn_agent_fork_context_rejects_agent_type_override() {
     let (mut session, mut turn) = make_session_and_context().await;
     let role_name = install_role_with_model_override(&mut turn).await;
@@ -1983,6 +2041,7 @@ async fn multi_agent_v2_followup_task_completion_notifies_parent_on_every_turn()
     session.thread_id = root.thread_id;
     let session = Arc::new(session);
     let turn = Arc::new(turn);
+    let parent_turn_id = turn.sub_id.clone();
 
     SpawnAgentHandlerV2::default()
         .handle(invocation(
@@ -2036,6 +2095,16 @@ async fn multi_agent_v2_followup_task_completion_notifies_parent_on_every_turn()
         ))
         .await
         .expect("followup_task should succeed");
+    assert!(manager.captured_ops().iter().any(|(id, op)| {
+        *id == agent_id
+            && matches!(
+                op,
+                Op::InterAgentCommunication { communication }
+                    if communication.parent_turn_id.as_deref() == Some(parent_turn_id.as_str())
+                        && communication.encrypted_content.as_deref() == Some("continue")
+                        && communication.trigger_turn
+            )
+    }));
 
     assert!(manager.captured_ops().iter().any(|(id, op)| {
         *id == agent_id
@@ -2729,6 +2798,63 @@ async fn send_input_accepts_structured_items() {
 
     let _ = thread
         .thread
+        .submit(Op::Shutdown {})
+        .await
+        .expect("shutdown should submit");
+}
+
+#[tokio::test]
+async fn direct_parent_turn_id_for_receiver_identifies_direct_child() {
+    let (mut session, turn) = make_session_and_context().await;
+    let parent_turn_id = turn.sub_id.clone();
+    let manager = thread_manager();
+    let root = manager
+        .start_thread((*turn.config).clone())
+        .await
+        .expect("root thread should start");
+    session.services.agent_control = manager.agent_control();
+    session.thread_id = root.thread_id;
+    let child = session
+        .services
+        .agent_control
+        .spawn_agent_with_metadata(
+            (*turn.config).clone(),
+            Op::ThreadSettings {
+                thread_settings: Default::default(),
+            },
+            Some(SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
+                parent_thread_id: root.thread_id,
+                depth: 1,
+                agent_path: Some(AgentPath::try_from("/root/worker").expect("agent path")),
+                agent_nickname: None,
+                agent_role: None,
+            })),
+            crate::agent::control::SpawnAgentOptions {
+                parent_thread_id: Some(root.thread_id),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("child thread should spawn");
+    let child_thread = manager
+        .get_thread(child.thread_id)
+        .await
+        .expect("child thread should exist");
+
+    assert_eq!(
+        direct_parent_turn_id_for_receiver(&session, &turn, child.thread_id).await,
+        Some(parent_turn_id)
+    );
+    assert_eq!(
+        direct_parent_turn_id_for_receiver(&session, &turn, root.thread_id).await,
+        None
+    );
+
+    child_thread
+        .submit(Op::Shutdown {})
+        .await
+        .expect("shutdown should submit");
+    root.thread
         .submit(Op::Shutdown {})
         .await
         .expect("shutdown should submit");

--- a/codex-rs/core/src/tools/handlers/multi_agents_v2.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_v2.rs
@@ -44,6 +44,7 @@ pub(super) fn communication_from_tool_message(
     author: AgentPath,
     recipient: AgentPath,
     message: String,
+    parent_turn_id: Option<String>,
 ) -> InterAgentCommunication {
     InterAgentCommunication::new_encrypted(
         author,
@@ -52,4 +53,5 @@ pub(super) fn communication_from_tool_message(
         message,
         /*trigger_turn*/ true,
     )
+    .with_parent_turn_id(parent_turn_id)
 }

--- a/codex-rs/core/src/tools/handlers/multi_agents_v2/message_tool.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_v2/message_tool.rs
@@ -100,8 +100,18 @@ pub(crate) async fn handle_message_string_tool(
         .session_source
         .get_agent_path()
         .unwrap_or_else(AgentPath::root);
-    let mut communication =
-        communication_from_tool_message(author, receiver_agent_path.clone(), message);
+    let parent_turn_id = match mode {
+        MessageDeliveryMode::QueueOnly => None,
+        MessageDeliveryMode::TriggerTurn => {
+            direct_parent_turn_id_for_receiver(&session, turn.as_ref(), receiver_thread_id).await
+        }
+    };
+    let mut communication = communication_from_tool_message(
+        author,
+        receiver_agent_path.clone(),
+        message,
+        parent_turn_id,
+    );
     communication
         .metadata
         .get_or_insert_with(ResponseItemMetadata::default)

--- a/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs
@@ -118,8 +118,12 @@ async fn handle_spawn_agent(
                         .session_source
                         .get_agent_path()
                         .unwrap_or_else(AgentPath::root);
-                    let mut communication =
-                        communication_from_tool_message(author, new_agent_path.clone(), message);
+                    let mut communication = communication_from_tool_message(
+                        author,
+                        new_agent_path.clone(),
+                        message,
+                        Some(turn.sub_id.clone()),
+                    );
                     communication
                         .metadata
                         .get_or_insert_with(ResponseItemMetadata::default)
@@ -133,6 +137,7 @@ async fn handle_spawn_agent(
                 fork_parent_spawn_call_id: fork_mode.as_ref().map(|_| call_id.clone()),
                 fork_mode,
                 parent_thread_id: Some(session.thread_id),
+                parent_turn_id: Some(turn.sub_id.clone()),
                 environments: Some(turn.environments.to_selections()),
             },
         ),

--- a/codex-rs/mcp-server/src/codex_tool_runner.rs
+++ b/codex-rs/mcp-server/src/codex_tool_runner.rs
@@ -114,6 +114,7 @@ pub async fn run_codex_tool_session(
             thread_settings: Default::default(),
         },
         client_user_message_id: None,
+        parent_turn_id: None,
         trace: None,
     };
 

--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -545,6 +545,7 @@ impl MessageProcessor {
                 id: request_id_string,
                 op: codex_protocol::protocol::Op::Interrupt,
                 client_user_message_id: None,
+                parent_turn_id: None,
                 trace: None,
             })
             .await

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -154,6 +154,8 @@ pub struct Submission {
     pub op: Op,
     /// Client-provided id for the user message represented by `Op::UserInput`.
     pub client_user_message_id: Option<String>,
+    /// Direct parent-thread turn that triggered this child turn, when known.
+    pub parent_turn_id: Option<String>,
     /// Optional W3C trace carrier propagated across async submission handoffs.
     pub trace: Option<W3cTraceContext>,
 }
@@ -687,6 +689,11 @@ pub struct InterAgentCommunication {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub metadata: Option<ResponseItemMetadata>,
+    /// Runtime-only direct parent turn lineage for analytics turn construction.
+    #[serde(skip)]
+    #[schemars(skip)]
+    #[ts(skip)]
+    pub parent_turn_id: Option<String>,
     pub trigger_turn: bool,
 }
 
@@ -705,6 +712,7 @@ impl InterAgentCommunication {
             content,
             encrypted_content: None,
             metadata: None,
+            parent_turn_id: None,
             trigger_turn,
         }
     }
@@ -723,8 +731,14 @@ impl InterAgentCommunication {
             content: String::new(),
             encrypted_content: Some(encrypted_content),
             metadata: None,
+            parent_turn_id: None,
             trigger_turn,
         }
+    }
+
+    pub fn with_parent_turn_id(mut self, parent_turn_id: Option<String>) -> Self {
+        self.parent_turn_id = parent_turn_id;
+        self
     }
 
     pub fn to_response_input_item(&self) -> ResponseInputItem {
@@ -4256,11 +4270,13 @@ mod tests {
             content: "review the diff".to_string(),
             encrypted_content: None,
             metadata: None,
+            parent_turn_id: Some("parent-turn-1".to_string()),
             trigger_turn: true,
         };
 
+        let response_input_item = communication.to_response_input_item();
         assert_eq!(
-            communication.to_response_input_item(),
+            response_input_item,
             ResponseInputItem::Message {
                 role: "assistant".to_string(),
                 content: vec![ContentItem::OutputText {
@@ -4269,6 +4285,13 @@ mod tests {
                 phase: Some(MessagePhase::Commentary),
             }
         );
+        let ResponseInputItem::Message { content, .. } = response_input_item else {
+            panic!("inter-agent communication should serialize as a message");
+        };
+        let [ContentItem::OutputText { text }] = content.as_slice() else {
+            panic!("inter-agent communication should serialize one text item");
+        };
+        assert!(!text.contains("parent_turn_id"));
     }
 
     #[test]


### PR DESCRIPTION
## What?

- Carry nullable `parent_turn_id` from internal runtime handoffs through turn context and into emitted `codex_turn_event` analytics.
- Stamp only direct parent-to-child turn starts known by the runtime: v1/v2 multi-agent spawn and follow-up, CSV agent-job workers, delegated review, and Guardian review.
- Keep v2 mailbox transit metadata runtime-only with serde, schema, and TypeScript skips.
- Preserve the app-server connection for autonomous child turns so their analytics events emit.
- Add protocol, reducer, core, and app-server coverage for populated and null lineage.

## Why?

`parent_thread_id` identifies a child thread's lineage, but it does not identify the exact parent turn that triggered a child turn. Downstream analytics need that direct turn-level join when the runtime can prove it. Root turns and ambiguous handoffs keep `parent_turn_id = null`.

This does not block turn execution. The turn path attaches the id and enqueues analytics with `try_send`; reduction and HTTP delivery run in the existing background analytics worker. If the queue is full, Codex drops the analytics fact with a warning instead of waiting. The new awaited operations are bounded in-memory lookups for known child relationships and v2 mailbox lineage, not analytics delivery.

## How?

```mermaid
flowchart LR
  A["Parent turn has turn.sub_id"] --> B{"How does child work start?"}
  B -->|"v1/v2 spawn, follow-up, delegate, Guardian, agent job"| C["Submission.parent_turn_id = parent turn id"]
  B -->|"v2 turn-triggering mailbox message"| D["InterAgentCommunication.parent_turn_id runtime-only"]
  D --> E["InputQueue retains next trigger parent_turn_id"]
  E --> C
  B -->|"root or ambiguous work"| N["parent_turn_id = null"]

  C --> F["Build TurnContext.parent_turn_id"]
  N --> F
  F --> G["Build TurnResolvedConfigFact"]
  G --> H["try_send to analytics queue"]
  H --> I["Background reducer builds CodexTurnEventParams"]
  H -. "queue full" .-> X["Warn and drop analytics; turn continues"]
  I --> J["POST codex_turn_event with parent_turn_id"]
  J --> K["Companion PR materializes analytics.codex.fact_turns"]

  L["Child thread records inherited app-server connection"] --> I
```

The direct-parent value is turn-scoped rather than thread metadata because later child follow-up turns can be triggered by different parent turns. Queue-only v2 mail does not receive lineage unless it actually starts a turn.

## End-to-End Test

The manual scenarios below were captured on the same feature commits before the latest base-only rebase. Post-rebase focused validation is listed separately.

- Built the branch locally; the resulting CLI reported `codex-cli 0.0.0`.
- A one-shot `codex exec` spawned exactly one isolated child. Root turn `019ecde4-8722-77d3-987c-e5ce471307a2` produced child turn `019ecde4-aa09-7f20-a30c-bf21ecc9823b` with matching direct lineage.
- A fresh persisted session was resumed and then spawned a child. Resumed root turn `019ecde5-478e-7970-8f75-b42fe7dd0d0a` produced child turn `019ecde5-7332-7832-815a-a44761cc1fc7` with matching direct lineage.
- The rebuilt runtime was run against codex-backend from the companion PR. All 6 emitted analytics requests returned HTTP 200 with every event accepted and none skipped.
- In that combined run, root turn `019ecdf2-6106-7913-9870-87fcde7e6525` had null parent fields. Child turn `019ecdf2-7bd5-7be1-939f-525e5c077c51` had `parent_thread_id = session_id = 019ecdf2-5e30-7a40-ba35-fb21183a60ba` and `parent_turn_id = 019ecdf2-6106-7913-9870-87fcde7e6525`.
- The backend emitted both `Codex turn event params` logs after schema construction and analytics tracking.

## Post-Rebase Validation

Rebased onto `origin/main` at `b668abb488`.

- `codex-core parent_turn`: 5 passed.
- Analytics lifecycle, protocol serialization, delegate forwarding, and v2 follow-up focused tests: 4 passed.
- App-server child analytics integration test: 1 passed; it observed root `parent_turn_id = null` and child `parent_turn_id = root turn id`.
- Final-head GitHub CI is green. Two first-attempt macOS jobs failed in untouched timing/image tests (`code-mode` on both architectures and RMCP image resizing on aarch64); both failed-only reruns passed.
- Scoped `just fix` across the five affected packages completed cleanly.
- Final `just fmt` completed and left the worktree unchanged. No tests were run after final formatting.

An earlier broad `CODEX_SKIP_BWRAP_BUILD=1 just test` attempt was not clean in this devbox: nextest ran 10,958 tests, with 10,933 passing, 26 skipped, 24 environment-sensitive failures, and one timeout. The failures involved the enclosing `/tmp` Git repository, inherited sandbox state, unavailable AF_UNIX/Python entropy behavior, a missing stdin probe, remote-control/MCP timing, and image preparation; none exercised parent-turn analytics. All affected focused tests passed.

## Cross-Repo Companion

Schema, backend ingestion, and `analytics.codex.fact_turns`: https://github.com/openai/openai/pull/1007842
