### PR TITLE
Disable parallel tool calls in code mode

### DIFF
--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -223,7 +223,7 @@ async fn run_remote_compact_task_inner_impl(
     let prompt = Prompt {
         input: prompt_input,
         tools: tool_router.model_visible_specs(),
-        parallel_tool_calls: turn_context.model_info.supports_parallel_tool_calls,
+        parallel_tool_calls: turn_context.supports_parallel_tool_calls(),
         base_instructions,
         personality: turn_context.personality,
         output_schema: None,

--- a/codex-rs/core/src/compact_remote_v2.rs
+++ b/codex-rs/core/src/compact_remote_v2.rs
@@ -236,7 +236,7 @@ async fn run_remote_compact_task_inner_impl(
     let prompt = Prompt {
         input,
         tools: tool_router.model_visible_specs(),
-        parallel_tool_calls: turn_context.model_info.supports_parallel_tool_calls,
+        parallel_tool_calls: turn_context.supports_parallel_tool_calls(),
         base_instructions,
         personality: turn_context.personality,
         output_schema: None,

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -87,7 +87,6 @@ use codex_protocol::models::ContentItem;
 use codex_protocol::models::MessagePhase;
 use codex_protocol::models::ResponseInputItem;
 use codex_protocol::models::ResponseItem;
-use codex_protocol::openai_models::ToolMode;
 use codex_protocol::protocol::AgentMessageContentDeltaEvent;
 use codex_protocol::protocol::AgentReasoningSectionBreakEvent;
 use codex_protocol::protocol::CodexErrorInfo;
@@ -949,15 +948,10 @@ pub(crate) fn build_prompt(
     turn_context: &TurnContext,
     base_instructions: BaseInstructions,
 ) -> Prompt {
-    let tool_mode_supports_parallel_calls = match turn_context.tool_mode {
-        ToolMode::Direct => true,
-        ToolMode::CodeMode | ToolMode::CodeModeOnly => false,
-    };
     Prompt {
         input,
         tools: router.model_visible_specs(),
-        parallel_tool_calls: turn_context.model_info.supports_parallel_tool_calls
-            && tool_mode_supports_parallel_calls,
+        parallel_tool_calls: turn_context.supports_parallel_tool_calls(),
         base_instructions,
         personality: turn_context.personality,
         output_schema: turn_context.final_output_json_schema.clone(),

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -87,6 +87,7 @@ use codex_protocol::models::ContentItem;
 use codex_protocol::models::MessagePhase;
 use codex_protocol::models::ResponseInputItem;
 use codex_protocol::models::ResponseItem;
+use codex_protocol::openai_models::ToolMode;
 use codex_protocol::protocol::AgentMessageContentDeltaEvent;
 use codex_protocol::protocol::AgentReasoningSectionBreakEvent;
 use codex_protocol::protocol::CodexErrorInfo;
@@ -948,10 +949,15 @@ pub(crate) fn build_prompt(
     turn_context: &TurnContext,
     base_instructions: BaseInstructions,
 ) -> Prompt {
+    let tool_mode_supports_parallel_calls = match turn_context.tool_mode {
+        ToolMode::Direct => true,
+        ToolMode::CodeMode | ToolMode::CodeModeOnly => false,
+    };
     Prompt {
         input,
         tools: router.model_visible_specs(),
-        parallel_tool_calls: turn_context.model_info.supports_parallel_tool_calls,
+        parallel_tool_calls: turn_context.model_info.supports_parallel_tool_calls
+            && tool_mode_supports_parallel_calls,
         base_instructions,
         personality: turn_context.personality,
         output_schema: turn_context.final_output_json_schema.clone(),

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -169,6 +169,13 @@ impl TurnContext {
         ToolEnvironmentMode::from_count(self.environments.turn_environments.len())
     }
 
+    pub(crate) fn supports_parallel_tool_calls(&self) -> bool {
+        match self.tool_mode {
+            ToolMode::Direct => self.model_info.supports_parallel_tool_calls,
+            ToolMode::CodeMode | ToolMode::CodeModeOnly => false,
+        }
+    }
+
     pub(crate) async fn with_model(
         &self,
         model: String,

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -511,6 +511,59 @@ async fn remote_compact_replaces_history_for_followups() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_compact_disables_parallel_tool_calls_in_locally_enabled_code_mode() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let harness = TestCodexHarness::with_builder(
+        test_codex()
+            .with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing())
+            .with_model_info_override("gpt-5.4", |model_info| {
+                model_info.supports_parallel_tool_calls = true;
+            })
+            .with_config(|config| {
+                let _ = config.features.enable(Feature::CodeMode);
+            }),
+    )
+    .await?;
+    let codex = harness.test().codex.clone();
+    let response_mock = responses::mount_sse_once(
+        harness.server(),
+        responses::sse(vec![
+            responses::ev_assistant_message("m1", "FIRST_REMOTE_REPLY"),
+            responses::ev_completed("resp-1"),
+        ]),
+    )
+    .await;
+    let compact_mock =
+        responses::mount_compact_json_once(harness.server(), json!({ "output": [] })).await;
+
+    codex
+        .submit(Op::UserInput {
+            environments: None,
+            items: vec![UserInput::Text {
+                text: "hello remote compact".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: Default::default(),
+        })
+        .await?;
+    wait_for_turn_complete(&codex).await;
+    codex.submit(Op::Compact).await?;
+    wait_for_turn_complete(&codex).await;
+
+    response_mock.single_request();
+    assert_eq!(
+        compact_mock.single_request().body_json()["parallel_tool_calls"],
+        false
+    );
+
+    Ok(())
+}
+
 async fn assert_remote_manual_compact_request_parity(
     auth: CodexAuth,
     configured_service_tier: Option<ServiceTier>,
@@ -792,8 +845,12 @@ async fn remote_compact_v2_reuses_compaction_trigger_for_followups() -> Result<(
     let harness = TestCodexHarness::with_builder(
         test_codex()
             .with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing())
+            .with_model_info_override("gpt-5.4", |model_info| {
+                model_info.supports_parallel_tool_calls = true;
+            })
             .with_config(|config| {
                 let _ = config.features.enable(Feature::RemoteCompactionV2);
+                let _ = config.features.enable(Feature::CodeMode);
             }),
     )
     .await?;
@@ -859,6 +916,7 @@ async fn remote_compact_v2_reuses_compaction_trigger_for_followups() -> Result<(
 
     let response_requests = responses_mock.requests();
     let compact_request = &response_requests[1];
+    assert_eq!(compact_request.body_json()["parallel_tool_calls"], false);
     assert!(
         compact_request
             .header("x-codex-beta-features")

--- a/codex-rs/core/tests/suite/model_runtime_selectors.rs
+++ b/codex-rs/core/tests/suite/model_runtime_selectors.rs
@@ -147,6 +147,7 @@ async fn remote_tool_mode_selector_overrides_feature_flags() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let mut direct_model = remote_model("test-tool-mode-direct");
+    direct_model.supports_parallel_tool_calls = true;
     direct_model.tool_mode = Some(ToolMode::Direct);
     let direct_body = response_body_for_remote_model(direct_model, |config| {
         config
@@ -163,8 +164,10 @@ async fn remote_tool_mode_selector_overrides_feature_flags() -> Result<()> {
                 && name != codex_code_mode::WAIT_TOOL_NAME),
         "direct mode should override enabled code mode flags: {direct_tools:?}"
     );
+    assert_eq!(direct_body["parallel_tool_calls"], true);
 
     let mut code_mode_only_model = remote_model("test-tool-mode-code-mode-only");
+    code_mode_only_model.supports_parallel_tool_calls = true;
     code_mode_only_model.tool_mode = Some(ToolMode::CodeModeOnly);
     code_mode_only_model.input_modalities = vec![InputModality::Text, InputModality::Image];
     let code_mode_only_body = response_body_for_remote_model(code_mode_only_model, |_| {}).await?;
@@ -179,6 +182,18 @@ async fn remote_tool_mode_selector_overrides_feature_flags() -> Result<()> {
             "image_generation".to_string(),
         ]
     );
+    assert_eq!(code_mode_only_body["parallel_tool_calls"], false);
+
+    let mut local_code_mode_model = remote_model("test-tool-mode-local-code-mode");
+    local_code_mode_model.supports_parallel_tool_calls = true;
+    let local_code_mode_body = response_body_for_remote_model(local_code_mode_model, |config| {
+        config
+            .features
+            .enable(Feature::CodeMode)
+            .expect("test config should allow feature update");
+    })
+    .await?;
+    assert_eq!(local_code_mode_body["parallel_tool_calls"], false);
 
     Ok(())
 }


### PR DESCRIPTION
## Why

Code mode exposes a different tool interface from direct function calling. Allowing the Responses API to request parallel tool calls while that interface is active can expose combinations that code-mode models are not expected to use. Parallel-call eligibility should therefore depend on the resolved per-turn tool mode, rather than only the general parallel-tool capability declared by model metadata.

This also needs to apply consistently to ordinary turns and remote compaction requests. Responses Lite remains an independent transport constraint: it can be used without enabling code mode and continues to disable parallel tool calls separately.

## What changed

- Centralize parallel-tool eligibility on the resolved `TurnContext.tool_mode`.
- Allow parallel tool calls only when the resolved mode is `ToolMode::Direct` and the model advertises support.
- Apply the same policy to ordinary prompts and both remote compaction implementations.
- Preserve model-declared direct mode when local code-mode feature flags are enabled.
- Add end-to-end request coverage for model-selected modes and locally enabled `CodeMode`, including both compaction paths.

## Testing

- `just test -p codex-core remote_tool_mode_selector_overrides_feature_flags`
- `just test -p codex-core remote_compact_disables_parallel_tool_calls_in_locally_enabled_code_mode`
- `just test -p codex-core remote_compact_v2_reuses_compaction_trigger_for_followups`