### PR TITLE
Add spans to build_tool_router

### DIFF
--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -152,8 +152,11 @@ pub(crate) fn build_tool_router(
     turn_context: &TurnContext,
     params: ToolRouterParams<'_>,
 ) -> ToolRouter {
-    let (model_visible_specs, registry) = build_tool_specs_and_registry(turn_context, params);
-    ToolRouter::from_parts(registry, model_visible_specs)
+    tracing::trace_span!("build_tool_router").in_scope(|| {
+        let (model_visible_specs, registry) = tracing::trace_span!("build_tool_specs_and_registry")
+            .in_scope(|| build_tool_specs_and_registry(turn_context, params));
+        ToolRouter::from_parts(registry, model_visible_specs)
+    })
 }
 
 fn build_tool_specs_and_registry(
@@ -180,10 +183,13 @@ fn build_tool_specs_and_registry(
         wait_agent_timeouts: wait_agent_timeout_options(turn_context),
     };
     let mut planned_tools = PlannedTools::default();
-    add_tool_sources(&context, &mut planned_tools);
-    append_tool_search_executor(&context, &mut planned_tools);
+    tracing::trace_span!("build_tool_specs_and_registry.add_tool_sources")
+        .in_scope(|| add_tool_sources(&context, &mut planned_tools));
+    tracing::trace_span!("build_tool_specs_and_registry.append_tool_search_executor")
+        .in_scope(|| append_tool_search_executor(&context, &mut planned_tools));
     prepend_code_mode_executors(&context, &mut planned_tools);
-    build_model_visible_specs_and_registry(turn_context, planned_tools)
+    tracing::trace_span!("build_tool_specs_and_registry.build_model_visible_specs_and_registry")
+        .in_scope(|| build_model_visible_specs_and_registry(turn_context, planned_tools))
 }
 
 fn build_model_visible_specs_and_registry(

--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -86,6 +86,7 @@ use codex_tools::shell_type_for_model_and_features;
 use std::collections::BTreeMap;
 use std::collections::HashSet;
 use std::sync::Arc;
+use tracing::instrument;
 use tracing::warn;
 
 const MULTI_AGENT_V2_NAMESPACE_DESCRIPTION: &str = "Tools for spawning and managing sub-agents.";
@@ -148,17 +149,16 @@ struct CoreToolPlanContext<'a> {
     wait_agent_timeouts: WaitAgentTimeoutOptions,
 }
 
+#[instrument(level = "trace", skip_all)]
 pub(crate) fn build_tool_router(
     turn_context: &TurnContext,
     params: ToolRouterParams<'_>,
 ) -> ToolRouter {
-    tracing::trace_span!("build_tool_router").in_scope(|| {
-        let (model_visible_specs, registry) = tracing::trace_span!("build_tool_specs_and_registry")
-            .in_scope(|| build_tool_specs_and_registry(turn_context, params));
-        ToolRouter::from_parts(registry, model_visible_specs)
-    })
+    let (model_visible_specs, registry) = build_tool_specs_and_registry(turn_context, params);
+    ToolRouter::from_parts(registry, model_visible_specs)
 }
 
+#[instrument(level = "trace", skip_all)]
 fn build_tool_specs_and_registry(
     turn_context: &TurnContext,
     params: ToolRouterParams<'_>,
@@ -183,15 +183,13 @@ fn build_tool_specs_and_registry(
         wait_agent_timeouts: wait_agent_timeout_options(turn_context),
     };
     let mut planned_tools = PlannedTools::default();
-    tracing::trace_span!("build_tool_specs_and_registry.add_tool_sources")
-        .in_scope(|| add_tool_sources(&context, &mut planned_tools));
-    tracing::trace_span!("build_tool_specs_and_registry.append_tool_search_executor")
-        .in_scope(|| append_tool_search_executor(&context, &mut planned_tools));
+    add_tool_sources(&context, &mut planned_tools);
+    append_tool_search_executor(&context, &mut planned_tools);
     prepend_code_mode_executors(&context, &mut planned_tools);
-    tracing::trace_span!("build_tool_specs_and_registry.build_model_visible_specs_and_registry")
-        .in_scope(|| build_model_visible_specs_and_registry(turn_context, planned_tools))
+    build_model_visible_specs_and_registry(turn_context, planned_tools)
 }
 
+#[instrument(level = "trace", skip_all)]
 fn build_model_visible_specs_and_registry(
     turn_context: &TurnContext,
     planned_tools: PlannedTools,
@@ -563,6 +561,7 @@ fn code_mode_namespace_descriptions(
     namespace_descriptions
 }
 
+#[instrument(level = "trace", skip_all)]
 fn add_tool_sources(context: &CoreToolPlanContext<'_>, planned_tools: &mut PlannedTools) {
     add_shell_tools(context, planned_tools);
     add_mcp_resource_tools(context, planned_tools);
@@ -843,6 +842,7 @@ fn add_extension_tools(context: &CoreToolPlanContext<'_>, planned_tools: &mut Pl
     );
 }
 
+#[instrument(level = "trace", skip_all)]
 fn append_tool_search_executor(
     context: &CoreToolPlanContext<'_>,
     planned_tools: &mut PlannedTools,


### PR DESCRIPTION
## Why
- Local profiling shows `append_tool_search_executor` averages ~113ms per call. Adding a span lets us track this cost as we optimize in follow-up PRs, either by reducing the work or avoiding repeated rebuilds when inputs have not changed.
- While we're here, we can add spans to `build_tool_router` and other sub-calls which code analysis shows may have additional opportunities for improvement.

## What changed
Add function-level trace spans around `build_tool_router`, `build_tool_specs_and_registry`, `add_tool_sources`, `append_tool_search_executor`, and `build_model_visible_specs_and_registry`

## Verification
Trigger Codex rollout and observe new spans are included