### PR TITLE
Update web search citation prompt

### DIFF
--- a/codex-rs/ext/web-search/web_run_description.md
+++ b/codex-rs/ext/web-search/web_run_description.md
@@ -77,4 +77,4 @@ Responses may not excessively quote or draw on a specific source. There are seve
 
 ---
 
-Make sure to provide links to the sources you used in your response.
+Cite your sources by using markdown links to the sites you used in your response. Do NOT use citations in the `turnX` style.


### PR DESCRIPTION
## Summary

- Update the web search tool prompt to require Markdown links for cited sources.
- Explicitly tell the model not to use `turnX`-style citations in responses.

## Context

https://openai.slack.com/archives/C0AU83S0ZQU/p1780964147777649?thread_ts=1780352049.512299&cid=C0AU83S0ZQU

## Test plan

- `git diff --check`
- `python3 scripts/format.py --check` (fails only on Rust formatter setup: rustup cannot create temp files under `/home/dev-user/.rustup`; Just and Python formatter checks pass when using temp cache dirs)
