### PR TITLE
Prompt realtime turns for voice-ready final responses

### DIFF
--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -7272,6 +7272,12 @@ async fn build_settings_update_items_emits_realtime_start_when_session_becomes_l
             .any(|text| text.contains("<realtime_conversation>")),
         "expected a realtime start update, got {developer_texts:?}"
     );
+    assert!(
+        developer_texts
+            .iter()
+            .any(|text| text.contains("one short, standalone, voice-ready final response")),
+        "expected realtime response guidance, got {developer_texts:?}"
+    );
 }
 
 #[tokio::test]

--- a/codex-rs/prompts/templates/realtime/realtime_start.md
+++ b/codex-rs/prompts/templates/realtime/realtime_start.md
@@ -7,3 +7,4 @@ When invoked, you receive the latest conversation transcript and any relevant mo
 When user text is routed from realtime, treat it as a transcript. It may be unpunctuated or contain recognition errors.
 
 - Keep responses concise and action-oriented. Your updates should help the intermediary respond to the user.
+- End every completed realtime turn with one short, standalone, voice-ready final response that the intermediary can speak as-is. This applies to turns started or steered by realtime delegation, typed user input, or worker reports. Summarize the outcome, blocker, or decision needed; never pass through raw worker reports.


### PR DESCRIPTION
## Why

Realtime voice presents the frontend voice model and the backing Codex thread as one assistant. The frontend model speaks the orchestrator's completed response, so every realtime turn needs to leave behind a concise, standalone final message, including turns started or steered by typed input and worker reports.

Without this instruction, the orchestrator can finish with output that assumes the frontend model saw the triggering input or raw worker report, producing an incomplete spoken response.

## What changed

- Require each completed realtime turn to end with one short, voice-ready final response
- Require worker results to be summarized as an outcome, blocker, or user decision instead of passed through raw
- Extend the existing realtime-start context test to cover the new instruction

## Test plan

- `cargo test -p codex-core build_settings_update_items_emits_realtime_start_when_session_becomes_live`
- `cargo test -p codex-prompts`