### PR TITLE
[codex] Keep child MCP warnings out of parent transcript

### DIFF
--- a/codex-rs/tui/src/chatwidget/mcp_startup.rs
+++ b/codex-rs/tui/src/chatwidget/mcp_startup.rs
@@ -263,6 +263,14 @@ impl ChatWidget {
         &mut self,
         notification: McpServerStatusUpdatedNotification,
     ) {
+        // Keep transcript ownership intact even if routing state delivers a child update here.
+        if let (Some(notification_thread_id), Some(thread_id)) =
+            (notification.thread_id.as_deref(), self.thread_id())
+            && notification_thread_id != thread_id.to_string()
+        {
+            return;
+        }
+
         let status = match notification.status {
             McpServerStartupState::Starting => McpStartupStatus::Starting,
             McpServerStartupState::Ready => McpStartupStatus::Ready,

--- a/codex-rs/tui/src/chatwidget/tests/mcp_startup.rs
+++ b/codex-rs/tui/src/chatwidget/tests/mcp_startup.rs
@@ -26,6 +26,36 @@ fn notify_mcp_status_error(chat: &mut ChatWidget, name: &str, error: &str) {
 }
 
 #[tokio::test]
+async fn mcp_startup_ignores_status_for_other_thread() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    chat.show_welcome_banner = false;
+    chat.set_mcp_startup_expected_servers(["sentry".to_string()]);
+    let parent_thread_id = ThreadId::new();
+    let child_thread_id = ThreadId::new();
+    chat.thread_id = Some(parent_thread_id);
+
+    for status in [
+        McpServerStartupState::Starting,
+        McpServerStartupState::Failed,
+    ] {
+        chat.handle_server_notification(
+            ServerNotification::McpServerStatusUpdated(McpServerStatusUpdatedNotification {
+                thread_id: Some(child_thread_id.to_string()),
+                name: "sentry".to_string(),
+                status,
+                error: matches!(status, McpServerStartupState::Failed)
+                    .then(|| "sentry is not logged in".to_string()),
+            }),
+            /*replay_kind*/ None,
+        );
+    }
+
+    assert!(drain_insert_history(&mut rx).is_empty());
+    assert!(!chat.bottom_pane.is_task_running());
+    assert!(chat.mcp_startup_status.is_none());
+}
+
+#[tokio::test]
 async fn mcp_startup_dedupes_same_round_duplicate_failure_warning() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
     chat.show_welcome_banner = false;


### PR DESCRIPTION
## Why

MCP startup status notifications are thread-owned, but `ChatWidget` trusted upstream routing. If routing state delivered a tagged child notification to the active parent widget, the child MCP failure could still mutate the parent's startup state and transcript.

## What changed

- Validate a tagged MCP status notification against the visible `ChatWidget` thread before updating startup UI or history.
- Cover child `Starting` and `Failed` notifications delivered to a parent widget, asserting that they produce no parent history or status mutation.

## User impact

Subagent MCP startup failures remain scoped to the child transcript instead of appearing as duplicate warnings in the parent transcript.

## Testing

- `just test -p codex-tui mcp_startup_ignores_status_for_other_thread`
- `just test -p codex-tui primary_thread_ignores_child_mcp_startup_notifications`
- `just fmt`
