### PR TITLE
Prevent plugin refresh from delaying TUI shutdown

### DIFF
--- a/codex-rs/app-server/src/extensions.rs
+++ b/codex-rs/app-server/src/extensions.rs
@@ -86,13 +86,13 @@ pub(crate) fn app_server_extension_event_sink(
     thread_state_manager: ThreadStateManager,
 ) -> Arc<dyn ExtensionEventSink> {
     Arc::new(AppServerExtensionEventSink {
-        outgoing,
+        outgoing: Arc::downgrade(&outgoing),
         thread_state_manager,
     })
 }
 
 struct AppServerExtensionEventSink {
-    outgoing: Arc<OutgoingMessageSender>,
+    outgoing: Weak<OutgoingMessageSender>,
     thread_state_manager: ThreadStateManager,
 }
 
@@ -118,7 +118,9 @@ impl ExtensionEventSink for AppServerExtensionEventSink {
                         "failed to enqueue extension goal update for {thread_id}: listener command channel is closed"
                     );
                 }
-                let outgoing = Arc::clone(&self.outgoing);
+                let Some(outgoing) = self.outgoing.upgrade() else {
+                    return;
+                };
                 tokio::spawn(async move {
                     outgoing
                         .send_server_notification(ServerNotification::ThreadGoalUpdated(
@@ -234,5 +236,40 @@ mod tests {
                 },
             }),
         }
+    }
+
+    #[test]
+    fn app_server_event_sink_does_not_retain_outgoing_sender() {
+        let (outgoing_tx, mut outgoing_rx) = mpsc::channel(4);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            outgoing_tx,
+            AnalyticsEventsClient::disabled(),
+        ));
+        let sink =
+            app_server_extension_event_sink(Arc::clone(&outgoing), ThreadStateManager::new());
+        drop(outgoing);
+
+        sink.emit(Event {
+            id: "call-1".to_string(),
+            msg: EventMsg::ThreadGoalUpdated(ThreadGoalUpdatedEvent {
+                thread_id: ThreadId::default(),
+                turn_id: None,
+                goal: CoreThreadGoal {
+                    thread_id: ThreadId::default(),
+                    objective: "do not retain sender".to_string(),
+                    status: ThreadGoalStatus::Active,
+                    token_budget: None,
+                    tokens_used: 0,
+                    time_used_seconds: 0,
+                    created_at: 0,
+                    updated_at: 0,
+                },
+            }),
+        });
+
+        assert!(matches!(
+            outgoing_rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Disconnected)
+        ));
     }
 }

--- a/codex-rs/app-server/src/extensions.rs
+++ b/codex-rs/app-server/src/extensions.rs
@@ -240,7 +240,7 @@ mod tests {
 
     #[test]
     fn app_server_event_sink_does_not_retain_outgoing_sender() {
-        let (outgoing_tx, mut outgoing_rx) = mpsc::channel(4);
+        let (outgoing_tx, mut outgoing_rx) = mpsc::channel(/*buffer*/ 4);
         let outgoing = Arc::new(OutgoingMessageSender::new(
             outgoing_tx,
             AnalyticsEventsClient::disabled(),

--- a/codex-rs/app-server/src/extensions.rs
+++ b/codex-rs/app-server/src/extensions.rs
@@ -162,6 +162,8 @@ pub(crate) fn guardian_agent_spawner(
 mod tests {
     use std::time::Duration;
 
+    use crate::outgoing_message::OutgoingEnvelope;
+    use crate::outgoing_message::OutgoingMessage;
     use codex_protocol::protocol::ThreadGoal as CoreThreadGoal;
     use codex_protocol::protocol::ThreadGoalStatus;
     use codex_protocol::protocol::ThreadGoalUpdatedEvent;
@@ -215,6 +217,52 @@ mod tests {
                 "cleared".to_string()
             ],
             observed
+        );
+    }
+
+    #[tokio::test]
+    async fn app_server_event_sink_sends_fallback_while_sender_is_alive() {
+        let (outgoing_tx, mut outgoing_rx) = mpsc::channel(/*buffer*/ 4);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            outgoing_tx,
+            AnalyticsEventsClient::disabled(),
+        ));
+        let sink =
+            app_server_extension_event_sink(Arc::clone(&outgoing), ThreadStateManager::new());
+        let thread_id = ThreadId::default();
+        let event = thread_goal_updated_event(thread_id, "turn-1");
+
+        sink.emit(event);
+
+        let envelope = timeout(Duration::from_secs(/*secs*/ 1), outgoing_rx.recv())
+            .await
+            .expect("timed out waiting for fallback notification")
+            .expect("outgoing channel closed unexpectedly");
+        let OutgoingEnvelope::Broadcast {
+            message:
+                OutgoingMessage::AppServerNotification(ServerNotification::ThreadGoalUpdated(
+                    notification,
+                )),
+        } = envelope
+        else {
+            panic!("expected a global thread goal update notification");
+        };
+        assert_eq!(
+            notification,
+            ThreadGoalUpdatedNotification {
+                thread_id: thread_id.to_string(),
+                turn_id: Some("turn-1".to_string()),
+                goal: ThreadGoal {
+                    thread_id: thread_id.to_string(),
+                    objective: "wire extension events".to_string(),
+                    status: codex_app_server_protocol::ThreadGoalStatus::Active,
+                    token_budget: Some(123),
+                    tokens_used: 45,
+                    time_used_seconds: 6,
+                    created_at: 7,
+                    updated_at: 8,
+                },
+            }
         );
     }
 

--- a/codex-rs/app-server/src/in_process.rs
+++ b/codex-rs/app-server/src/in_process.rs
@@ -729,6 +729,8 @@ async fn start_uninitialized(args: InProcessStartArgs) -> IoResult<InProcessClie
 #[cfg(test)]
 mod tests {
     use super::*;
+    use app_test_support::ChatGptAuthFixture;
+    use app_test_support::write_chatgpt_auth;
     use codex_app_server_protocol::ClientInfo;
     use codex_app_server_protocol::ConfigRequirementsReadResponse;
     use codex_app_server_protocol::ExternalAgentConfigImportCompletedNotification;
@@ -739,10 +741,36 @@ mod tests {
     use codex_app_server_protocol::TurnCompletedNotification;
     use codex_app_server_protocol::TurnItemsView;
     use codex_app_server_protocol::TurnStatus;
+    use codex_config::types::AuthCredentialsStoreMode;
     use codex_core::config::ConfigBuilder;
     use pretty_assertions::assert_eq;
     use std::path::Path;
+    use std::sync::Arc;
+    use std::time::Duration;
     use tempfile::TempDir;
+    use tokio::sync::Notify;
+    use tokio::time::timeout;
+    use wiremock::Mock;
+    use wiremock::Request;
+    use wiremock::Respond;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::header;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+
+    #[derive(Clone)]
+    struct DelayedInstalledPluginsResponse {
+        request_received: Arc<Notify>,
+    }
+
+    impl Respond for DelayedInstalledPluginsResponse {
+        fn respond(&self, _request: &Request) -> ResponseTemplate {
+            self.request_received.notify_one();
+            ResponseTemplate::new(/*status*/ 200)
+                .set_delay(Duration::from_secs(/*secs*/ 60))
+                .set_body_string(r#"{"plugins":[],"pagination":{"next_page_token":null}}"#)
+        }
+    }
 
     async fn build_test_config(codex_home: &Path) -> Config {
         match ConfigBuilder::default()
@@ -766,6 +794,15 @@ mod tests {
     ) -> InProcessClientHandle {
         let codex_home = TempDir::new().expect("temp dir");
         let config = Arc::new(build_test_config(codex_home.path()).await);
+        start_test_client_with_config(codex_home, config, session_source, channel_capacity).await
+    }
+
+    async fn start_test_client_with_config(
+        codex_home: TempDir,
+        config: Arc<Config>,
+        session_source: SessionSource,
+        channel_capacity: usize,
+    ) -> InProcessClientHandle {
         let state_db = codex_rollout::state_db::try_init(config.as_ref())
             .await
             .expect("state db should initialize for in-process test");
@@ -850,6 +887,61 @@ mod tests {
                 .await
                 .expect("in-process runtime should shutdown cleanly");
         }
+    }
+
+    #[tokio::test]
+    async fn in_process_shutdown_does_not_wait_for_remote_plugin_refresh() {
+        let codex_home = TempDir::new().expect("temp dir");
+        let server = wiremock::MockServer::start().await;
+        std::fs::write(
+            codex_home.path().join("config.toml"),
+            "[features]\nplugins = true\n",
+        )
+        .expect("config should be written");
+        write_chatgpt_auth(
+            codex_home.path(),
+            ChatGptAuthFixture::new("chatgpt-token")
+                .account_id("account-123")
+                .chatgpt_account_id("account-123"),
+            AuthCredentialsStoreMode::File,
+        )
+        .expect("auth should be written");
+
+        let request_received = Arc::new(Notify::new());
+        Mock::given(method("GET"))
+            .and(path("/backend-api/ps/plugins/installed"))
+            .and(header("authorization", "Bearer chatgpt-token"))
+            .and(header("chatgpt-account-id", "account-123"))
+            .respond_with(DelayedInstalledPluginsResponse {
+                request_received: Arc::clone(&request_received),
+            })
+            .mount(&server)
+            .await;
+
+        let mut config = Config::load_default_with_cli_overrides_for_codex_home(
+            codex_home.path().to_path_buf(),
+            Vec::new(),
+        )
+        .await
+        .expect("plugin config should load");
+        config.chatgpt_base_url = format!("{}/backend-api/", server.uri());
+        let config = Arc::new(config);
+        assert!(config.plugins_config_input().plugins_enabled);
+        let client = start_test_client_with_config(
+            codex_home,
+            config,
+            SessionSource::Cli,
+            DEFAULT_IN_PROCESS_CHANNEL_CAPACITY,
+        )
+        .await;
+        timeout(Duration::from_secs(/*secs*/ 5), request_received.notified())
+            .await
+            .expect("remote installed-plugin refresh should start");
+
+        timeout(Duration::from_secs(/*secs*/ 2), client.shutdown())
+            .await
+            .expect("shutdown should not wait for remote plugin refresh")
+            .expect("in-process runtime should shutdown cleanly");
     }
 
     #[tokio::test]

--- a/codex-rs/app-server/src/mcp_refresh.rs
+++ b/codex-rs/app-server/src/mcp_refresh.rs
@@ -155,7 +155,7 @@ mod tests {
 
     #[tokio::test]
     async fn retained_thread_manager_does_not_retain_app_server_sender() -> anyhow::Result<()> {
-        let (outgoing_tx, mut outgoing_rx) = mpsc::channel(4);
+        let (outgoing_tx, mut outgoing_rx) = mpsc::channel(/*buffer*/ 4);
         let outgoing = Arc::new(OutgoingMessageSender::new(
             outgoing_tx,
             AnalyticsEventsClient::disabled(),
@@ -171,12 +171,12 @@ mod tests {
         drop(outgoing);
 
         assert!(matches!(
-            timeout(Duration::from_millis(100), outgoing_rx.recv()).await,
+            timeout(Duration::from_millis(/*millis*/ 100), outgoing_rx.recv()).await,
             Ok(None)
         ));
 
         detached_refresh_thread_manager
-            .shutdown_all_threads_bounded(Duration::from_secs(10))
+            .shutdown_all_threads_bounded(Duration::from_secs(/*secs*/ 10))
             .await;
         Ok(())
     }

--- a/codex-rs/app-server/src/mcp_refresh.rs
+++ b/codex-rs/app-server/src/mcp_refresh.rs
@@ -97,9 +97,13 @@ async fn queue_refresh(
 mod tests {
     use super::*;
     use crate::extensions::ThreadExtensionDependencies;
+    use crate::extensions::app_server_extension_event_sink;
     use crate::extensions::guardian_agent_spawner;
     use crate::extensions::thread_extensions;
+    use crate::outgoing_message::OutgoingMessageSender;
+    use crate::thread_state::ThreadStateManager;
     use async_trait::async_trait;
+    use codex_analytics::AnalyticsEventsClient;
     use codex_arg0::Arg0DispatchPaths;
     use codex_config::CloudConfigBundleLoader;
     use codex_config::LoaderOverrides;
@@ -112,6 +116,7 @@ mod tests {
     use codex_core::init_state_db;
     use codex_core::thread_store_from_config;
     use codex_exec_server::EnvironmentManager;
+    use codex_extension_api::ExtensionEventSink;
     use codex_extension_api::NoopExtensionEventSink;
     use codex_login::AuthManager;
     use codex_login::CodexAuth;
@@ -120,7 +125,10 @@ mod tests {
     use pretty_assertions::assert_eq;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
+    use std::time::Duration;
     use tempfile::TempDir;
+    use tokio::sync::mpsc;
+    use tokio::time::timeout;
 
     #[tokio::test]
     async fn strict_refresh_reports_thread_planning_failures() -> anyhow::Result<()> {
@@ -145,7 +153,46 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn retained_thread_manager_does_not_retain_app_server_sender() -> anyhow::Result<()> {
+        let (outgoing_tx, mut outgoing_rx) = mpsc::channel(4);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            outgoing_tx,
+            AnalyticsEventsClient::disabled(),
+        ));
+        let event_sink =
+            app_server_extension_event_sink(Arc::clone(&outgoing), ThreadStateManager::new());
+        let (_temp_dir, thread_manager, _config_manager, _loader) =
+            refresh_test_state_with_event_sink(event_sink).await?;
+
+        // Plugin refresh tasks can outlive MessageProcessor while retaining ThreadManager.
+        let detached_refresh_thread_manager = Arc::clone(&thread_manager);
+        drop(thread_manager);
+        drop(outgoing);
+
+        assert!(matches!(
+            timeout(Duration::from_millis(100), outgoing_rx.recv()).await,
+            Ok(None)
+        ));
+
+        detached_refresh_thread_manager
+            .shutdown_all_threads_bounded(Duration::from_secs(10))
+            .await;
+        Ok(())
+    }
+
     async fn refresh_test_state() -> anyhow::Result<(
+        TempDir,
+        Arc<ThreadManager>,
+        ConfigManager,
+        Arc<CountingThreadConfigLoader>,
+    )> {
+        refresh_test_state_with_event_sink(Arc::new(NoopExtensionEventSink)).await
+    }
+
+    async fn refresh_test_state_with_event_sink(
+        event_sink: Arc<dyn ExtensionEventSink>,
+    ) -> anyhow::Result<(
         TempDir,
         Arc<ThreadManager>,
         ConfigManager,
@@ -195,7 +242,7 @@ mod tests {
                 thread_extensions(
                     guardian_agent_spawner(thread_manager.clone()),
                     ThreadExtensionDependencies {
-                        event_sink: Arc::new(NoopExtensionEventSink),
+                        event_sink,
                         auth_manager: auth_manager.clone(),
                         state_db: Some(state_db.clone()),
                         analytics_events_client: codex_analytics::AnalyticsEventsClient::disabled(),

--- a/codex-rs/app-server/src/mcp_refresh.rs
+++ b/codex-rs/app-server/src/mcp_refresh.rs
@@ -97,13 +97,9 @@ async fn queue_refresh(
 mod tests {
     use super::*;
     use crate::extensions::ThreadExtensionDependencies;
-    use crate::extensions::app_server_extension_event_sink;
     use crate::extensions::guardian_agent_spawner;
     use crate::extensions::thread_extensions;
-    use crate::outgoing_message::OutgoingMessageSender;
-    use crate::thread_state::ThreadStateManager;
     use async_trait::async_trait;
-    use codex_analytics::AnalyticsEventsClient;
     use codex_arg0::Arg0DispatchPaths;
     use codex_config::CloudConfigBundleLoader;
     use codex_config::LoaderOverrides;
@@ -116,7 +112,6 @@ mod tests {
     use codex_core::init_state_db;
     use codex_core::thread_store_from_config;
     use codex_exec_server::EnvironmentManager;
-    use codex_extension_api::ExtensionEventSink;
     use codex_extension_api::NoopExtensionEventSink;
     use codex_login::AuthManager;
     use codex_login::CodexAuth;
@@ -125,10 +120,7 @@ mod tests {
     use pretty_assertions::assert_eq;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering;
-    use std::time::Duration;
     use tempfile::TempDir;
-    use tokio::sync::mpsc;
-    use tokio::time::timeout;
 
     #[tokio::test]
     async fn strict_refresh_reports_thread_planning_failures() -> anyhow::Result<()> {
@@ -153,46 +145,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn retained_thread_manager_does_not_retain_app_server_sender() -> anyhow::Result<()> {
-        let (outgoing_tx, mut outgoing_rx) = mpsc::channel(/*buffer*/ 4);
-        let outgoing = Arc::new(OutgoingMessageSender::new(
-            outgoing_tx,
-            AnalyticsEventsClient::disabled(),
-        ));
-        let event_sink =
-            app_server_extension_event_sink(Arc::clone(&outgoing), ThreadStateManager::new());
-        let (_temp_dir, thread_manager, _config_manager, _loader) =
-            refresh_test_state_with_event_sink(event_sink).await?;
-
-        // Plugin refresh tasks can outlive MessageProcessor while retaining ThreadManager.
-        let detached_refresh_thread_manager = Arc::clone(&thread_manager);
-        drop(thread_manager);
-        drop(outgoing);
-
-        assert!(matches!(
-            timeout(Duration::from_millis(/*millis*/ 100), outgoing_rx.recv()).await,
-            Ok(None)
-        ));
-
-        detached_refresh_thread_manager
-            .shutdown_all_threads_bounded(Duration::from_secs(/*secs*/ 10))
-            .await;
-        Ok(())
-    }
-
     async fn refresh_test_state() -> anyhow::Result<(
-        TempDir,
-        Arc<ThreadManager>,
-        ConfigManager,
-        Arc<CountingThreadConfigLoader>,
-    )> {
-        refresh_test_state_with_event_sink(Arc::new(NoopExtensionEventSink)).await
-    }
-
-    async fn refresh_test_state_with_event_sink(
-        event_sink: Arc<dyn ExtensionEventSink>,
-    ) -> anyhow::Result<(
         TempDir,
         Arc<ThreadManager>,
         ConfigManager,
@@ -242,7 +195,7 @@ mod tests {
                 thread_extensions(
                     guardian_agent_spawner(thread_manager.clone()),
                     ThreadExtensionDependencies {
-                        event_sink,
+                        event_sink: Arc::new(NoopExtensionEventSink),
                         auth_manager: auth_manager.clone(),
                         state_db: Some(state_db.clone()),
                         analytics_events_client: codex_analytics::AnalyticsEventsClient::disabled(),


### PR DESCRIPTION
## Why

During TUI shutdown, the in-process app server waits for its outgoing router to close. Detached plugin refresh work retains the extension registry, whose event sink held a strong reference to the router's sender. If shutdown overlapped a remote plugin request, that reference kept the router and Codex process alive until the request completed.

In one traced reproduction, Ctrl-C remained blocked for about 2.7s and the process exited once the plugin request finished. Shutdowns with no refresh in flight are unaffected.

## What Changed

`AppServerExtensionEventSink` now holds a weak reference to `OutgoingMessageSender`. Listener-routed events are unchanged, and fallback notifications are still delivered while the transport is alive. After transport shutdown, late fallback notifications are dropped because no client remains to receive them.

## Testing

Added coverage that:

- verifies the event sink does not retain the outgoing sender
- verifies fallback notifications are delivered while the sender is alive
- holds an installed-plugin response open and verifies in-process shutdown completes without waiting for it
