### PR TITLE
[codex] Gate plugin MCP servers by auth route

### DIFF
--- a/codex-rs/core/src/plugins/mod.rs
+++ b/codex-rs/core/src/plugins/mod.rs
@@ -2,6 +2,7 @@ mod discoverable;
 mod injection;
 mod mentions;
 mod render;
+mod routing;
 #[cfg(test)]
 pub(crate) mod test_support;
 

--- a/codex-rs/core/src/plugins/routing.rs
+++ b/codex-rs/core/src/plugins/routing.rs
@@ -1,0 +1,34 @@
+#![allow(dead_code)]
+
+use codex_app_server_protocol::AuthMode;
+
+use crate::plugins::PluginCapabilitySummary;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum PluginRoute {
+    Default,
+    McpOnly,
+}
+
+pub(crate) fn route_for_plugin(
+    plugin: &PluginCapabilitySummary,
+    auth_mode: Option<AuthMode>,
+) -> PluginRoute {
+    if !is_dual_surface_plugin(plugin) {
+        return PluginRoute::Default;
+    }
+
+    if auth_mode == Some(AuthMode::ApiKey) {
+        return PluginRoute::McpOnly;
+    }
+
+    PluginRoute::Default
+}
+
+fn is_dual_surface_plugin(plugin: &PluginCapabilitySummary) -> bool {
+    !plugin.app_connector_ids.is_empty() && !plugin.mcp_server_names.is_empty()
+}
+
+#[cfg(test)]
+#[path = "routing_tests.rs"]
+mod tests;

--- a/codex-rs/core/src/plugins/routing_tests.rs
+++ b/codex-rs/core/src/plugins/routing_tests.rs
@@ -1,0 +1,78 @@
+use codex_app_server_protocol::AuthMode;
+use codex_plugin::AppConnectorId;
+
+use super::*;
+
+fn plugin(app_ids: &[&str], mcp_server_names: &[&str]) -> PluginCapabilitySummary {
+    PluginCapabilitySummary {
+        config_name: "sample@personal".to_string(),
+        display_name: "Sample".to_string(),
+        app_connector_ids: app_ids
+            .iter()
+            .map(|id| AppConnectorId((*id).to_string()))
+            .collect(),
+        mcp_server_names: mcp_server_names
+            .iter()
+            .map(|name| (*name).to_string())
+            .collect(),
+        ..PluginCapabilitySummary::default()
+    }
+}
+
+struct RouteCase {
+    name: &'static str,
+    plugin: PluginCapabilitySummary,
+    auth_mode: Option<AuthMode>,
+    expected_plugin_route: PluginRoute,
+}
+
+#[test]
+fn routes_plugins_by_auth_mode() {
+    let cases = vec![
+        RouteCase {
+            name: "chatgpt dual-surface plugin",
+            plugin: plugin(&["connector_sample"], &["sample-mcp"]),
+            auth_mode: Some(AuthMode::Chatgpt),
+            expected_plugin_route: PluginRoute::Default,
+        },
+        RouteCase {
+            name: "api-key dual-surface plugin",
+            plugin: plugin(&["connector_sample"], &["sample-mcp"]),
+            auth_mode: Some(AuthMode::ApiKey),
+            expected_plugin_route: PluginRoute::McpOnly,
+        },
+        RouteCase {
+            name: "unknown auth dual-surface plugin",
+            plugin: plugin(&["connector_sample"], &["sample-mcp"]),
+            auth_mode: None,
+            expected_plugin_route: PluginRoute::Default,
+        },
+        RouteCase {
+            name: "agent identity dual-surface plugin",
+            plugin: plugin(&["connector_sample"], &["sample-mcp"]),
+            auth_mode: Some(AuthMode::AgentIdentity),
+            expected_plugin_route: PluginRoute::Default,
+        },
+        RouteCase {
+            name: "chatgpt app-only plugin",
+            plugin: plugin(&["connector_sample"], &[]),
+            auth_mode: Some(AuthMode::Chatgpt),
+            expected_plugin_route: PluginRoute::Default,
+        },
+        RouteCase {
+            name: "chatgpt mcp-only plugin",
+            plugin: plugin(&[], &["sample-mcp"]),
+            auth_mode: Some(AuthMode::Chatgpt),
+            expected_plugin_route: PluginRoute::Default,
+        },
+    ];
+
+    for case in cases {
+        assert_eq!(
+            route_for_plugin(&case.plugin, case.auth_mode),
+            case.expected_plugin_route,
+            "{}",
+            case.name
+        );
+    }
+}


### PR DESCRIPTION
## Context

Some plugins have both an app definition and an MCP definition. The app path authenticates through ChatGPT/SIWC, but API-key login users do not have that connected-app auth path available. We want those users to still be able to use high-value plugins, such as Slack, GitHub, Google Drive, Notion, and Linear, through MCP/OAuth.

## PRs Goals

The goal of this stack is to add guardrails that ensure Codex includes the appropriate plugin app and MCP surfaces based on the auth type.

- [PR1](https://github.com/openai/codex/pull/27199): filter effective MCP servers by auth/app-route availability.
- [PR2](https://github.com/openai/codex/pull/27206): add explicit-plugin integration coverage for the SWIC and API-key routes.
- [PR3](https://github.com/openai/codex/pull/27217): suppress install-time MCP OAuth when a plugin app route is available.

## Summary

- Filter plugin-owned MCP servers from the effective MCP config when the Codex apps route is available and the plugin also declares app connector IDs.
- Preserve plugin MCP servers for API-key auth because the connected-app route is unavailable there.
- Preserve MCP-only plugins and user-configured MCP servers for ChatGPT/SIWC sessions.
- Keep the existing `codex_apps` behavior for Codex-backend auth, and remove it when the app route is unavailable.
- Add table-driven tests for the effective MCP server routing matrix.

## Validation

```bash
git diff --check
cargo test -p codex-mcp effective_mcp_servers_routes_plugin_surfaces_by_auth
```

Both pass locally.
