### PR TITLE
Stop Guardian reviews when parent turns are interrupted

### DIFF
--- a/codex-rs/core/src/guardian/metrics.rs
+++ b/codex-rs/core/src/guardian/metrics.rs
@@ -7,6 +7,7 @@ use codex_analytics::GuardianReviewFailureReason;
 use codex_analytics::GuardianReviewSessionKind;
 use codex_analytics::GuardianReviewTerminalStatus;
 use codex_analytics::GuardianReviewedAction;
+use codex_otel::GUARDIAN_REVIEW_CLEANUP_COUNT_METRIC;
 use codex_otel::GUARDIAN_REVIEW_COUNT_METRIC;
 use codex_otel::GUARDIAN_REVIEW_DURATION_METRIC;
 use codex_otel::GUARDIAN_REVIEW_TOKEN_USAGE_METRIC;
@@ -17,6 +18,27 @@ use codex_protocol::protocol::GuardianAssessmentOutcome;
 use codex_protocol::protocol::GuardianRiskLevel;
 use codex_protocol::protocol::GuardianUserAuthorization;
 use codex_protocol::protocol::TokenUsage;
+
+use super::task_owner::GuardianReviewCleanupReason;
+
+pub(crate) fn emit_guardian_review_cleanup_metric(
+    session_telemetry: &SessionTelemetry,
+    reason: GuardianReviewCleanupReason,
+    fallback_emitted: bool,
+) {
+    let reason = match reason {
+        GuardianReviewCleanupReason::DrainTimeout => "drain_timeout",
+        GuardianReviewCleanupReason::MissingTerminal => "missing_terminal",
+    };
+    session_telemetry.counter(
+        GUARDIAN_REVIEW_CLEANUP_COUNT_METRIC,
+        /*inc*/ 1,
+        &[
+            ("reason", reason),
+            ("fallback_emitted", bool_tag(fallback_emitted)),
+        ],
+    );
+}
 
 pub(crate) fn emit_guardian_review_metrics(
     session_telemetry: &SessionTelemetry,
@@ -414,5 +436,39 @@ mod tests {
             histogram_sums(&snapshot, GUARDIAN_REVIEW_TTFT_DURATION_METRIC),
             BTreeMap::from([("sample".to_string(), 123)])
         );
+    }
+
+    #[test]
+    fn guardian_review_cleanup_metric_records_bounded_tags() {
+        for (reason, fallback_emitted, expected_reason) in [
+            (
+                GuardianReviewCleanupReason::DrainTimeout,
+                false,
+                "drain_timeout",
+            ),
+            (
+                GuardianReviewCleanupReason::MissingTerminal,
+                true,
+                "missing_terminal",
+            ),
+        ] {
+            let session_telemetry = test_session_telemetry();
+
+            emit_guardian_review_cleanup_metric(&session_telemetry, reason, fallback_emitted);
+
+            let snapshot = session_telemetry
+                .snapshot_metrics()
+                .expect("runtime metrics snapshot");
+            let (attrs, value) = counter_point(&snapshot, GUARDIAN_REVIEW_CLEANUP_COUNT_METRIC);
+
+            assert_eq!(value, 1);
+            assert_eq!(
+                attrs,
+                BTreeMap::from([
+                    ("fallback_emitted".to_string(), fallback_emitted.to_string()),
+                    ("reason".to_string(), expected_reason.to_string()),
+                ])
+            );
+        }
     }
 }

--- a/codex-rs/core/src/guardian/mod.rs
+++ b/codex-rs/core/src/guardian/mod.rs
@@ -30,6 +30,7 @@ pub(crate) use approval_request::GuardianMcpAnnotations;
 pub(crate) use approval_request::GuardianNetworkAccessTrigger;
 #[cfg(test)]
 pub(crate) use approval_request::guardian_approval_request_to_json;
+pub(crate) use metrics::emit_guardian_review_cleanup_metric;
 pub(crate) use review::guardian_rejection_message;
 pub(crate) use review::guardian_timeout_message;
 pub(crate) use review::is_guardian_reviewer_source;

--- a/codex-rs/core/src/guardian/mod.rs
+++ b/codex-rs/core/src/guardian/mod.rs
@@ -172,8 +172,6 @@ use prompt::render_guardian_transcript_entries;
 #[cfg(test)]
 use review::GuardianReviewOutcome;
 #[cfg(test)]
-use review::run_guardian_review_session as run_guardian_review_session_for_test;
-#[cfg(test)]
 use review_session::build_guardian_review_session_config as build_guardian_review_session_config_for_test;
 
 #[cfg(test)]

--- a/codex-rs/core/src/guardian/mod.rs
+++ b/codex-rs/core/src/guardian/mod.rs
@@ -16,6 +16,7 @@ mod metrics;
 mod prompt;
 mod review;
 mod review_session;
+mod task_owner;
 
 use std::time::Duration;
 
@@ -43,6 +44,9 @@ pub(crate) use review::routes_approval_to_guardian_with_reviewer;
 pub(crate) use review::spawn_approval_request_review;
 pub(crate) use review_session::GuardianReviewSessionManager;
 pub(crate) use review_session::prompt_cache_key_override_for_review_session;
+pub(crate) use task_owner::GuardianReviewDrain;
+pub(crate) use task_owner::GuardianReviewDrainOutcome;
+pub(crate) use task_owner::GuardianReviewTaskOwner;
 
 pub(crate) const GUARDIAN_REVIEW_TIMEOUT: Duration = Duration::from_secs(90);
 pub(crate) const GUARDIAN_REVIEWER_NAME: &str = "guardian";

--- a/codex-rs/core/src/guardian/review.rs
+++ b/codex-rs/core/src/guardian/review.rs
@@ -568,6 +568,50 @@ async fn run_guardian_review(
     }
 }
 
+async fn run_guardian_review_in_task(
+    session: Arc<Session>,
+    turn: Arc<TurnContext>,
+    review_id: String,
+    request: GuardianApprovalRequest,
+    retry_reason: Option<String>,
+    approval_request_source: GuardianApprovalRequestSource,
+    owner_cancel: CancellationToken,
+) -> ReviewDecision {
+    let Some(review_activity) = turn.guardian_reviews.begin() else {
+        return ReviewDecision::Abort;
+    };
+    let cancel_activity = review_activity.clone();
+    let request_cancel = owner_cancel.clone();
+    let runtime_handle = session.services.runtime_handle.clone();
+    let review = run_guardian_review(
+        session,
+        Arc::clone(&turn),
+        review_id,
+        request,
+        retry_reason,
+        approval_request_source,
+        Some(review_activity.cancellation_token()),
+    );
+    let Some(review) = turn.guardian_reviews.spawn(&runtime_handle, async move {
+        tokio::pin!(review);
+        tokio::select! {
+            biased;
+            _ = request_cancel.cancelled() => {
+                cancel_activity.cancel();
+                review.await
+            }
+            decision = &mut review => decision,
+        }
+    }) else {
+        return ReviewDecision::Abort;
+    };
+    match review.await {
+        Ok(decision) => decision,
+        Err(err) if err.is_cancelled() || owner_cancel.is_cancelled() => ReviewDecision::Abort,
+        Err(_) => ReviewDecision::Denied,
+    }
+}
+
 /// Public entrypoint for approval requests that should be reviewed by guardian.
 pub(crate) async fn review_approval_request(
     session: &Arc<Session>,
@@ -576,17 +620,15 @@ pub(crate) async fn review_approval_request(
     request: GuardianApprovalRequest,
     retry_reason: Option<String>,
 ) -> ReviewDecision {
-    // Box the delegated review future so callers do not inline the entire
-    // guardian session state machine into their own async stack.
-    Box::pin(run_guardian_review(
+    run_guardian_review_in_task(
         Arc::clone(session),
         Arc::clone(turn),
         review_id,
         request,
         retry_reason,
         GuardianApprovalRequestSource::MainTurn,
-        /*external_cancel*/ None,
-    ))
+        turn.guardian_reviews.cancellation_token(),
+    )
     .await
 }
 
@@ -599,14 +641,14 @@ pub(crate) async fn review_approval_request_with_cancel(
     approval_request_source: GuardianApprovalRequestSource,
     cancel_token: CancellationToken,
 ) -> ReviewDecision {
-    run_guardian_review(
+    run_guardian_review_in_task(
         Arc::clone(session),
         Arc::clone(turn),
         review_id,
         request,
         retry_reason,
         approval_request_source,
-        Some(cancel_token),
+        cancel_token,
     )
     .await
 }

--- a/codex-rs/core/src/guardian/review.rs
+++ b/codex-rs/core/src/guardian/review.rs
@@ -18,6 +18,7 @@ use codex_protocol::protocol::SubAgentSource;
 use codex_protocol::protocol::TurnAbortReason;
 use codex_protocol::protocol::WarningEvent;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 
@@ -40,9 +41,11 @@ use super::approval_request::guardian_reviewed_action;
 use super::metrics::emit_guardian_review_metrics;
 use super::prompt::guardian_output_schema;
 use super::prompt::parse_guardian_assessment;
+use super::review_session::GuardianReviewSessionGeneration;
 use super::review_session::GuardianReviewSessionOutcome;
 use super::review_session::GuardianReviewSessionParams;
 use super::review_session::build_guardian_review_session_config;
+use super::task_owner::GuardianReviewActivity;
 
 const GUARDIAN_REJECTION_INSTRUCTIONS: &str = concat!(
     "The agent must not attempt to achieve the same outcome via workaround, ",
@@ -57,6 +60,8 @@ const GUARDIAN_TIMEOUT_INSTRUCTIONS: &str = concat!(
     "Do not assume the action is unsafe based on the timeout alone. ",
     "You may retry once, or ask the user for guidance or explicit approval.",
 );
+
+const GUARDIAN_REVIEW_CANCEL_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub(crate) fn new_guardian_review_id() -> String {
     uuid::Uuid::new_v4().to_string()
@@ -91,6 +96,12 @@ pub(crate) fn guardian_timeout_message() -> String {
 pub(super) enum GuardianReviewOutcome {
     Completed(GuardianAssessment),
     Error(GuardianReviewError),
+}
+
+#[derive(Clone)]
+pub(super) struct GuardianReviewRunContext {
+    pub(super) activity: GuardianReviewActivity,
+    pub(super) generation: GuardianReviewSessionGeneration,
 }
 
 #[derive(Debug)]
@@ -258,10 +269,11 @@ async fn run_guardian_review(
     request: GuardianApprovalRequest,
     retry_reason: Option<String>,
     approval_request_source: GuardianApprovalRequestSource,
-    external_cancel: Option<CancellationToken>,
+    review_context: GuardianReviewRunContext,
 ) -> ReviewDecision {
     let target_item_id = guardian_request_target_item_id(&request).map(str::to_string);
     let assessment_turn_id = guardian_request_turn_id(&request, &turn.sub_id).to_string();
+    let cancellation_token = review_context.activity.cancellation_token();
     let action_summary = guardian_assessment_action(&request);
     let reviewed_action = guardian_reviewed_action(&request);
     let review_tracking = GuardianReviewTrackContext::new(
@@ -293,10 +305,7 @@ async fn run_guardian_review(
         )
         .await;
 
-    if external_cancel
-        .as_ref()
-        .is_some_and(CancellationToken::is_cancelled)
-    {
+    if cancellation_token.is_cancelled() {
         let completed_at_ms = now_unix_timestamp_ms();
         track_guardian_review(
             session.as_ref(),
@@ -335,15 +344,42 @@ async fn run_guardian_review(
 
     let schema = guardian_output_schema();
     let terminal_action = action_summary.clone();
-    let (outcome, analytics_result) = Box::pin(run_guardian_review_session(
+    let reset_generation = review_context.generation.clone();
+    let mut session_review = Box::pin(run_guardian_review_session(
         session.clone(),
         turn.clone(),
+        review_context.clone(),
         request,
         retry_reason.clone(),
         schema,
-        external_cancel,
-    ))
-    .await;
+        Some(cancellation_token.clone()),
+    ));
+    let (outcome, analytics_result) = tokio::select! {
+        biased;
+        _ = cancellation_token.cancelled() => {
+            if review_context.activity.is_committed() {
+                session_review.await
+            } else {
+                let analytics_result = match tokio::time::timeout(
+                    GUARDIAN_REVIEW_CANCEL_DRAIN_TIMEOUT,
+                    &mut session_review,
+                )
+                .await
+                {
+                    Ok((_, analytics_result)) => analytics_result,
+                    Err(_) => {
+                        session.guardian_review_session.shutdown_generation_in_background(
+                            reset_generation,
+                            &session.services.runtime_handle,
+                        );
+                        GuardianReviewAnalyticsResult::without_session()
+                    }
+                };
+                (GuardianReviewOutcome::Error(GuardianReviewError::Cancelled), analytics_result)
+            }
+        }
+        result = &mut session_review => result,
+    };
 
     let completed_at_ms = now_unix_timestamp_ms();
     let (assessment, count_denial_for_circuit_breaker) = match outcome {
@@ -554,7 +590,6 @@ async fn run_guardian_review(
             }),
         )
         .await;
-
     if count_denial_for_circuit_breaker {
         record_guardian_denial(&session, &turn, &assessment_turn_id).await;
     } else {
@@ -583,6 +618,7 @@ async fn run_guardian_review_in_task(
     let cancel_activity = review_activity.clone();
     let request_cancel = owner_cancel.clone();
     let runtime_handle = session.services.runtime_handle.clone();
+    let review_generation = session.guardian_review_session.generation();
     let review = run_guardian_review(
         session,
         Arc::clone(&turn),
@@ -590,7 +626,10 @@ async fn run_guardian_review_in_task(
         request,
         retry_reason,
         approval_request_source,
-        Some(review_activity.cancellation_token()),
+        GuardianReviewRunContext {
+            activity: review_activity.clone(),
+            generation: review_generation,
+        },
     );
     let Some(review) = turn.guardian_reviews.spawn(&runtime_handle, async move {
         tokio::pin!(review);
@@ -702,6 +741,7 @@ pub(crate) fn spawn_approval_request_review(
 pub(super) async fn run_guardian_review_session(
     session: Arc<Session>,
     turn: Arc<TurnContext>,
+    review_context: GuardianReviewRunContext,
     request: GuardianApprovalRequest,
     retry_reason: Option<String>,
     schema: serde_json::Value,
@@ -780,10 +820,10 @@ pub(super) async fn run_guardian_review_session(
         }
     };
 
-    let (session_outcome, session_analytics_result) = Box::pin(
-        session
-            .guardian_review_session
-            .run_review(GuardianReviewSessionParams {
+    let (session_outcome, session_analytics_result) =
+        Box::pin(session.guardian_review_session.run_review(
+            review_context.generation,
+            GuardianReviewSessionParams {
                 parent_session: Arc::clone(&session),
                 parent_turn: turn.clone(),
                 spawn_config: guardian_config,
@@ -795,9 +835,15 @@ pub(super) async fn run_guardian_review_session(
                 reasoning_summary: turn.reasoning_summary,
                 personality: turn.personality,
                 external_cancel,
-            }),
-    )
-    .await;
+                review_activity: review_context.activity.clone(),
+            },
+        ))
+        .await;
+    let session_outcome = match session_outcome {
+        GuardianReviewSessionOutcome::Aborted => GuardianReviewSessionOutcome::Aborted,
+        outcome if review_context.activity.try_commit() => outcome,
+        _ => GuardianReviewSessionOutcome::Aborted,
+    };
 
     match session_outcome {
         GuardianReviewSessionOutcome::Completed(Ok(last_agent_message)) => match last_agent_message

--- a/codex-rs/core/src/guardian/review.rs
+++ b/codex-rs/core/src/guardian/review.rs
@@ -286,24 +286,28 @@ async fn run_guardian_review(
         GUARDIAN_REVIEW_TIMEOUT.as_millis() as u64,
     );
     let started_at_ms = review_tracking.started_at_ms.try_into().unwrap_or_default();
+    let started_event = GuardianAssessmentEvent {
+        id: review_id.clone(),
+        target_item_id: target_item_id.clone(),
+        turn_id: assessment_turn_id.clone(),
+        started_at_ms,
+        completed_at_ms: None,
+        status: GuardianAssessmentStatus::InProgress,
+        risk_level: None,
+        user_authorization: None,
+        rationale: None,
+        decision_source: None,
+        action: action_summary.clone(),
+    };
+    let abort_fallback = GuardianAssessmentEvent {
+        status: GuardianAssessmentStatus::Aborted,
+        decision_source: Some(GuardianAssessmentDecisionSource::Agent),
+        ..started_event.clone()
+    };
     session
-        .send_event(
-            turn.as_ref(),
-            EventMsg::GuardianAssessment(GuardianAssessmentEvent {
-                id: review_id.clone(),
-                target_item_id: target_item_id.clone(),
-                turn_id: assessment_turn_id.clone(),
-                started_at_ms,
-                completed_at_ms: None,
-                status: GuardianAssessmentStatus::InProgress,
-                risk_level: None,
-                user_authorization: None,
-                rationale: None,
-                decision_source: None,
-                action: action_summary.clone(),
-            }),
-        )
+        .send_event(turn.as_ref(), EventMsg::GuardianAssessment(started_event))
         .await;
+    review_context.activity.mark_started(abort_fallback);
 
     if cancellation_token.is_cancelled() {
         let completed_at_ms = now_unix_timestamp_ms();
@@ -338,6 +342,7 @@ async fn run_guardian_review(
                 }),
             )
             .await;
+        review_context.activity.mark_terminal();
         record_guardian_non_denial(&session, &assessment_turn_id).await;
         return ReviewDecision::Abort;
     }
@@ -457,6 +462,7 @@ async fn run_guardian_review(
                         }),
                     )
                     .await;
+                review_context.activity.mark_terminal();
                 record_guardian_non_denial(&session, &assessment_turn_id).await;
                 return ReviewDecision::TimedOut;
             }
@@ -492,6 +498,7 @@ async fn run_guardian_review(
                         }),
                     )
                     .await;
+                review_context.activity.mark_terminal();
                 record_guardian_non_denial(&session, &assessment_turn_id).await;
                 return ReviewDecision::Abort;
             }
@@ -590,6 +597,8 @@ async fn run_guardian_review(
             }),
         )
         .await;
+    review_context.activity.mark_terminal();
+
     if count_denial_for_circuit_breaker {
         record_guardian_denial(&session, &turn, &assessment_turn_id).await;
     } else {
@@ -631,17 +640,20 @@ async fn run_guardian_review_in_task(
             generation: review_generation,
         },
     );
-    let Some(review) = turn.guardian_reviews.spawn(&runtime_handle, async move {
-        tokio::pin!(review);
-        tokio::select! {
-            biased;
-            _ = request_cancel.cancelled() => {
-                cancel_activity.cancel();
-                review.await
+    let Some(review) = turn
+        .guardian_reviews
+        .spawn(&runtime_handle, &review_activity, async move {
+            tokio::pin!(review);
+            tokio::select! {
+                biased;
+                _ = request_cancel.cancelled() => {
+                    cancel_activity.cancel();
+                    review.await
+                }
+                decision = &mut review => decision,
             }
-            decision = &mut review => decision,
-        }
-    }) else {
+        })
+    else {
         return ReviewDecision::Abort;
     };
     match review.await {

--- a/codex-rs/core/src/guardian/review_session.rs
+++ b/codex-rs/core/src/guardian/review_session.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::anyhow;
+use arc_swap::ArcSwap;
 use codex_analytics::GuardianReviewAnalyticsResult;
 use codex_analytics::GuardianReviewSessionKind;
 use codex_protocol::ThreadId;
@@ -54,6 +55,7 @@ use super::prompt::GuardianTranscriptCursor;
 use super::prompt::build_guardian_prompt_items_with_parent_turn;
 use super::prompt::guardian_policy_prompt;
 use super::prompt::guardian_policy_prompt_with_config;
+use super::task_owner::GuardianReviewActivity;
 
 const GUARDIAN_INTERRUPT_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 #[derive(Debug)]
@@ -77,15 +79,20 @@ pub(crate) struct GuardianReviewSessionParams {
     pub(crate) reasoning_summary: ReasoningSummaryConfig,
     pub(crate) personality: Option<Personality>,
     pub(crate) external_cancel: Option<CancellationToken>,
+    pub(crate) review_activity: GuardianReviewActivity,
 }
 
 #[derive(Default)]
 pub(crate) struct GuardianReviewSessionManager {
-    state: Arc<Mutex<GuardianReviewSessionState>>,
+    state: ArcSwap<Mutex<GuardianReviewSessionState>>,
 }
+
+#[derive(Clone)]
+pub(crate) struct GuardianReviewSessionGeneration(Arc<Mutex<GuardianReviewSessionState>>);
 
 #[derive(Default)]
 struct GuardianReviewSessionState {
+    closed: bool,
     trunk: Option<Arc<GuardianReviewSession>>,
     ephemeral_reviews: Vec<Arc<GuardianReviewSession>>,
 }
@@ -276,8 +283,31 @@ impl Drop for EphemeralReviewCleanup {
 }
 
 impl GuardianReviewSessionManager {
+    fn state(&self) -> Arc<Mutex<GuardianReviewSessionState>> {
+        self.state.load_full()
+    }
+
+    pub(crate) fn generation(&self) -> GuardianReviewSessionGeneration {
+        GuardianReviewSessionGeneration(self.state())
+    }
+
+    async fn take_review_sessions(
+        state: &Mutex<GuardianReviewSessionState>,
+    ) -> (
+        Option<Arc<GuardianReviewSession>>,
+        Vec<Arc<GuardianReviewSession>>,
+    ) {
+        let mut state = state.lock().await;
+        state.closed = true;
+        (
+            state.trunk.take(),
+            std::mem::take(&mut state.ephemeral_reviews),
+        )
+    }
+
     pub(crate) async fn trunk_rollout_path(&self) -> Option<PathBuf> {
-        let trunk = self.state.lock().await.trunk.clone()?;
+        let state = self.state();
+        let trunk = state.lock().await.trunk.clone()?;
         trunk.codex.session.ensure_rollout_materialized().await;
         match trunk.codex.session.current_rollout_path().await {
             Ok(path) => path,
@@ -289,13 +319,10 @@ impl GuardianReviewSessionManager {
     }
 
     pub(crate) async fn shutdown(&self) {
-        let (review_session, ephemeral_reviews) = {
-            let mut state = self.state.lock().await;
-            (
-                state.trunk.take(),
-                std::mem::take(&mut state.ephemeral_reviews),
-            )
-        };
+        let state = self
+            .state
+            .swap(Arc::new(Mutex::new(GuardianReviewSessionState::default())));
+        let (review_session, ephemeral_reviews) = Self::take_review_sessions(&state).await;
         if let Some(review_session) = review_session {
             review_session.shutdown().await;
         }
@@ -304,14 +331,53 @@ impl GuardianReviewSessionManager {
         }
     }
 
+    pub(crate) fn shutdown_in_background(&self, runtime_handle: &tokio::runtime::Handle) {
+        self.shutdown_generation_in_background(self.generation(), runtime_handle);
+    }
+
+    pub(crate) fn shutdown_generation_in_background(
+        &self,
+        generation: GuardianReviewSessionGeneration,
+        runtime_handle: &tokio::runtime::Handle,
+    ) {
+        let previous = self.state.compare_and_swap(
+            &generation.0,
+            Arc::new(Mutex::new(GuardianReviewSessionState::default())),
+        );
+        let did_swap = Arc::ptr_eq(&*previous, &generation.0);
+        drop(previous);
+        if !did_swap {
+            return;
+        }
+        let state = generation.0;
+        drop(runtime_handle.spawn(async move {
+            let (review_session, ephemeral_reviews) =
+                GuardianReviewSessionManager::take_review_sessions(&state).await;
+            if let Some(review_session) = review_session {
+                review_session.shutdown().await;
+            }
+            for review_session in ephemeral_reviews {
+                review_session.shutdown().await;
+            }
+        }));
+    }
+
     #[expect(
         clippy::await_holding_invalid_type,
         reason = "review session selection and trunk spawning must stay serialized"
     )]
     pub(super) async fn run_review(
         &self,
+        generation: GuardianReviewSessionGeneration,
         params: GuardianReviewSessionParams,
     ) -> (GuardianReviewSessionOutcome, GuardianReviewAnalyticsResult) {
+        if params.review_activity.cancellation_token().is_cancelled() {
+            return (
+                GuardianReviewSessionOutcome::Aborted,
+                GuardianReviewAnalyticsResult::without_session(),
+            );
+        }
+        let state = generation.0;
         let deadline = tokio::time::Instant::now() + GUARDIAN_REVIEW_TIMEOUT;
         let next_reuse_key = GuardianReviewSessionReuseKey::from_spawn_config(&params.spawn_config);
         let mut stale_trunk_to_shutdown = None;
@@ -319,11 +385,17 @@ impl GuardianReviewSessionManager {
         let trunk_candidate = match run_before_review_deadline(
             deadline,
             params.external_cancel.as_ref(),
-            self.state.lock(),
+            state.lock(),
         )
         .await
         {
             Ok(mut state) => {
+                if state.closed {
+                    return (
+                        GuardianReviewSessionOutcome::Aborted,
+                        GuardianReviewAnalyticsResult::without_session(),
+                    );
+                }
                 if let Some(trunk) = state.trunk.as_ref()
                     && trunk.reuse_key != next_reuse_key
                     && trunk.review_lock.try_acquire().is_ok()
@@ -382,6 +454,7 @@ impl GuardianReviewSessionManager {
 
         if trunk.reuse_key != next_reuse_key {
             return Box::pin(self.run_ephemeral_review(
+                Arc::clone(&state),
                 params,
                 next_reuse_key,
                 deadline,
@@ -394,6 +467,7 @@ impl GuardianReviewSessionManager {
             Ok(trunk_guard) => trunk_guard,
             Err(_) => {
                 return Box::pin(self.run_ephemeral_review(
+                    Arc::clone(&state),
                     params,
                     next_reuse_key,
                     deadline,
@@ -423,7 +497,7 @@ impl GuardianReviewSessionManager {
         if keep_review_session {
             (outcome, analytics_result)
         } else {
-            if let Some(review_session) = self.remove_trunk_if_current(&trunk).await {
+            if let Some(review_session) = Self::remove_trunk_if_current(&state, &trunk).await {
                 review_session.shutdown_in_background();
             }
             (outcome, analytics_result)
@@ -435,7 +509,8 @@ impl GuardianReviewSessionManager {
         let reuse_key = GuardianReviewSessionReuseKey::from_spawn_config(
             codex.session.get_config().await.as_ref(),
         );
-        self.state.lock().await.trunk = Some(Arc::new(GuardianReviewSession {
+        let state = self.state();
+        state.lock().await.trunk = Some(Arc::new(GuardianReviewSession {
             reuse_key,
             codex,
             cancel_token: CancellationToken::new(),
@@ -453,7 +528,8 @@ impl GuardianReviewSessionManager {
         let reuse_key = GuardianReviewSessionReuseKey::from_spawn_config(
             codex.session.get_config().await.as_ref(),
         );
-        self.state
+        let state = self.state();
+        state
             .lock()
             .await
             .ephemeral_reviews
@@ -472,7 +548,8 @@ impl GuardianReviewSessionManager {
 
     #[cfg(test)]
     pub(crate) async fn committed_fork_rollout_items_for_test(&self) -> Option<Vec<RolloutItem>> {
-        let trunk = self.state.lock().await.trunk.clone()?;
+        let manager_state = self.state();
+        let trunk = manager_state.lock().await.trunk.clone()?;
         let state = trunk.state.lock().await;
         let snapshot = state.last_committed_fork_snapshot.as_ref()?;
         match &snapshot.initial_history {
@@ -483,8 +560,8 @@ impl GuardianReviewSessionManager {
 
     #[cfg(test)]
     pub(crate) async fn send_trunk_event_raw_for_test(&self, event: Event) {
-        let trunk = self
-            .state
+        let state = self.state();
+        let trunk = state
             .lock()
             .await
             .trunk
@@ -494,10 +571,10 @@ impl GuardianReviewSessionManager {
     }
 
     async fn remove_trunk_if_current(
-        &self,
+        state: &Mutex<GuardianReviewSessionState>,
         trunk: &Arc<GuardianReviewSession>,
     ) -> Option<Arc<GuardianReviewSession>> {
-        let mut state = self.state.lock().await;
+        let mut state = state.lock().await;
         if state
             .trunk
             .as_ref()
@@ -509,19 +586,23 @@ impl GuardianReviewSessionManager {
         }
     }
 
-    async fn register_active_ephemeral(&self, review_session: Arc<GuardianReviewSession>) {
-        self.state
-            .lock()
-            .await
-            .ephemeral_reviews
-            .push(review_session);
+    async fn register_active_ephemeral(
+        state: &Mutex<GuardianReviewSessionState>,
+        review_session: Arc<GuardianReviewSession>,
+    ) -> bool {
+        let mut state = state.lock().await;
+        if state.closed {
+            return false;
+        }
+        state.ephemeral_reviews.push(review_session);
+        true
     }
 
     async fn take_active_ephemeral(
-        &self,
+        state: &Mutex<GuardianReviewSessionState>,
         review_session: &Arc<GuardianReviewSession>,
     ) -> Option<Arc<GuardianReviewSession>> {
-        let mut state = self.state.lock().await;
+        let mut state = state.lock().await;
         let ephemeral_review_index = state
             .ephemeral_reviews
             .iter()
@@ -531,6 +612,7 @@ impl GuardianReviewSessionManager {
 
     async fn run_ephemeral_review(
         &self,
+        state: Arc<Mutex<GuardianReviewSessionState>>,
         params: GuardianReviewSessionParams,
         reuse_key: GuardianReviewSessionReuseKey,
         deadline: tokio::time::Instant,
@@ -562,10 +644,15 @@ impl GuardianReviewSessionManager {
             }
             Err(outcome) => return (outcome, GuardianReviewAnalyticsResult::without_session()),
         };
-        self.register_active_ephemeral(Arc::clone(&review_session))
-            .await;
+        if !Self::register_active_ephemeral(&state, Arc::clone(&review_session)).await {
+            review_session.shutdown_in_background();
+            return (
+                GuardianReviewSessionOutcome::Aborted,
+                GuardianReviewAnalyticsResult::without_session(),
+            );
+        }
         let mut cleanup =
-            EphemeralReviewCleanup::new(Arc::clone(&self.state), Arc::clone(&review_session));
+            EphemeralReviewCleanup::new(Arc::clone(&state), Arc::clone(&review_session));
 
         let (outcome, _, analytics_result) = Box::pin(run_review_on_session(
             review_session.as_ref(),
@@ -574,7 +661,7 @@ impl GuardianReviewSessionManager {
             deadline,
         ))
         .await;
-        if let Some(review_session) = self.take_active_ephemeral(&review_session).await {
+        if let Some(review_session) = Self::take_active_ephemeral(&state, &review_session).await {
             cleanup.disarm();
             review_session.shutdown_in_background();
         }
@@ -773,7 +860,7 @@ async fn run_review_on_session(
     };
     analytics_result.reviewed_action_truncated = reviewed_action_truncated;
 
-    let outcome = wait_for_guardian_review(
+    let (mut outcome, mut keep_review_session, should_commit_review) = wait_for_guardian_review(
         review_session,
         child_turn_id.as_str(),
         deadline,
@@ -781,10 +868,15 @@ async fn run_review_on_session(
         &mut analytics_result,
     )
     .await;
-    if matches!(outcome.0, GuardianReviewSessionOutcome::Completed(_)) {
-        if outcome.2
-            && let Some(total_token_usage) = review_session.codex.session.total_token_usage().await
-        {
+    if should_commit_review
+        && matches!(outcome, GuardianReviewSessionOutcome::Completed(_))
+        && !params.review_activity.try_commit()
+    {
+        outcome = GuardianReviewSessionOutcome::Aborted;
+        keep_review_session = false;
+    }
+    if should_commit_review && matches!(outcome, GuardianReviewSessionOutcome::Completed(_)) {
+        if let Some(total_token_usage) = review_session.codex.session.total_token_usage().await {
             analytics_result.token_usage = Some(token_usage_delta(
                 &token_usage_at_review_start,
                 &total_token_usage,
@@ -794,7 +886,7 @@ async fn run_review_on_session(
         state.prior_review_count = state.prior_review_count.saturating_add(1);
         state.last_reviewed_transcript_cursor = Some(transcript_cursor);
     }
-    (outcome.0, outcome.1, analytics_result)
+    (outcome, keep_review_session, analytics_result)
 }
 
 async fn append_guardian_followup_reminder(review_session: &GuardianReviewSession) {
@@ -845,13 +937,12 @@ async fn wait_for_guardian_review(
                     std::future::pending::<()>().await;
                 }
             } => {
-                let keep_review_session = interrupt_and_drain_turn(
+                let _ = interrupt_and_drain_turn(
                     &review_session.codex,
                     expected_turn_id,
                 )
-                .await
-                .is_ok();
-                return (GuardianReviewSessionOutcome::Aborted, keep_review_session, false);
+                .await;
+                return (GuardianReviewSessionOutcome::Aborted, false, false);
             }
             event = review_session.codex.next_event() => {
                 match event {
@@ -880,7 +971,7 @@ async fn wait_for_guardian_review(
                             last_error_message = Some(error.message);
                         }
                         EventMsg::TurnAborted(_) => {
-                            return (GuardianReviewSessionOutcome::Aborted, true, false);
+                            return (GuardianReviewSessionOutcome::Aborted, false, false);
                         }
                         _ => {}
                     },
@@ -1129,9 +1220,14 @@ mod tests {
         )
         .expect("guardian config");
 
+        let parent_turn = Arc::new(turn);
+        let review_activity = parent_turn
+            .guardian_reviews
+            .begin()
+            .expect("guardian review activity");
         GuardianReviewSessionParams {
             parent_session: Arc::new(session),
-            parent_turn: Arc::new(turn),
+            parent_turn,
             spawn_config,
             request: GuardianApprovalRequest::Shell {
                 id: "shell-1".to_string(),
@@ -1148,6 +1244,7 @@ mod tests {
             reasoning_summary,
             personality,
             external_cancel: None,
+            review_activity,
         }
     }
 
@@ -1181,6 +1278,52 @@ mod tests {
             cached_reuse_key,
             GuardianReviewSessionReuseKey::from_spawn_config(&cached_spawn_config)
         );
+    }
+
+    #[tokio::test]
+    async fn forced_shutdown_replaces_manager_state_without_waiting() {
+        let manager = GuardianReviewSessionManager::default();
+        let old_generation = manager.generation();
+        let old_state = Arc::clone(&old_generation.0);
+        let old_state_guard = old_state.lock().await;
+
+        manager.shutdown_generation_in_background(
+            old_generation.clone(),
+            &tokio::runtime::Handle::current(),
+        );
+
+        let new_state = manager.state();
+        assert!(!Arc::ptr_eq(&old_state, &new_state));
+        manager
+            .shutdown_generation_in_background(old_generation, &tokio::runtime::Handle::current());
+        assert!(Arc::ptr_eq(&new_state, &manager.state()));
+        drop(old_state_guard);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if old_state.lock().await.closed {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("retired manager state should close");
+        assert!(!new_state.lock().await.closed);
+    }
+
+    #[tokio::test]
+    async fn cancelled_review_does_not_enter_manager_generation() {
+        let manager = GuardianReviewSessionManager::default();
+        let params = test_review_params().await;
+        assert!(params.review_activity.cancel());
+
+        let (outcome, _) = manager.run_review(manager.generation(), params).await;
+
+        assert!(matches!(outcome, GuardianReviewSessionOutcome::Aborted));
+        let state = manager.state();
+        let state = state.lock().await;
+        assert!(state.trunk.is_none());
+        assert!(state.ephemeral_reviews.is_empty());
     }
 
     #[tokio::test]
@@ -1474,6 +1617,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_review_on_session_does_not_commit_cancelled_activity() {
+        let (review_session, tx_event, rx_sub) = test_review_session().await;
+        let mut params = test_review_params().await;
+        params.review_activity = params
+            .parent_turn
+            .guardian_reviews
+            .begin()
+            .expect("guardian review activity");
+        let review_activity = params.review_activity.clone();
+
+        let review = tokio::spawn(async move {
+            let outcome = run_review_on_session(
+                &review_session,
+                &params,
+                GuardianReviewSessionKind::TrunkReused,
+                tokio::time::Instant::now() + Duration::from_secs(1),
+            )
+            .await;
+            let state = review_session.state.lock().await;
+            (
+                outcome,
+                state.prior_review_count,
+                state.last_reviewed_transcript_cursor,
+            )
+        });
+        let submission = rx_sub.recv().await.expect("guardian submission");
+        assert!(review_activity.cancel());
+        tx_event
+            .send(turn_complete_event(
+                submission.id.as_str(),
+                Some("completed after cancellation"),
+                Some(42),
+            ))
+            .await
+            .expect("queue submitted turn completion");
+
+        let ((outcome, keep_review_session, _), prior_review_count, transcript_cursor) =
+            review.await.expect("review task should complete");
+        assert!(matches!(outcome, GuardianReviewSessionOutcome::Aborted));
+        assert!(!keep_review_session);
+        assert_eq!(prior_review_count, 0);
+        assert!(transcript_cursor.is_none());
+    }
+
+    #[tokio::test]
     async fn wait_for_guardian_review_ignores_prior_turn_completion() {
         let (review_session, tx_event, _rx_sub) = test_review_session().await;
         tx_event
@@ -1644,7 +1832,7 @@ mod tests {
             .await
             .expect("interrupt response task should complete");
         assert!(matches!(outcome, GuardianReviewSessionOutcome::Aborted));
-        assert!(keep_review_session);
+        assert!(!keep_review_session);
         assert!(!capture_token_usage);
     }
 

--- a/codex-rs/core/src/guardian/task_owner.rs
+++ b/codex-rs/core/src/guardian/task_owner.rs
@@ -1,0 +1,143 @@
+use std::future::Future;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use tokio::runtime::Handle;
+use tokio::task::AbortHandle;
+use tokio::task::JoinHandle;
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+use tracing::warn;
+
+const GUARDIAN_REVIEW_DRAIN_TIMEOUT: Duration = Duration::from_secs(6);
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum GuardianReviewDrainOutcome {
+    Drained,
+    Forced,
+}
+
+#[derive(Debug)]
+struct TrackedGuardianReview {
+    abort_handle: AbortHandle,
+}
+
+#[derive(Debug, Default)]
+struct GuardianReviewTaskOwnerState {
+    closed_at: Option<Instant>,
+    reviews: Vec<TrackedGuardianReview>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct GuardianReviewTaskOwner {
+    cancellation_token: CancellationToken,
+    tasks: TaskTracker,
+    state: Mutex<GuardianReviewTaskOwnerState>,
+}
+
+impl GuardianReviewTaskOwner {
+    fn lock_state(&self) -> std::sync::MutexGuard<'_, GuardianReviewTaskOwnerState> {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    pub(crate) fn cancellation_token(&self) -> CancellationToken {
+        self.cancellation_token.child_token()
+    }
+
+    pub(crate) fn begin(self: &Arc<Self>) -> Option<GuardianReviewActivity> {
+        if self.lock_state().closed_at.is_some() {
+            return None;
+        }
+        Some(GuardianReviewActivity {
+            cancellation_token: self.cancellation_token.child_token(),
+        })
+    }
+
+    pub(crate) fn spawn<F>(
+        self: &Arc<Self>,
+        runtime_handle: &Handle,
+        future: F,
+    ) -> Option<JoinHandle<F::Output>>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let state = self.lock_state();
+        if state.closed_at.is_some() {
+            return None;
+        }
+        let task = self.tasks.spawn_on(future, runtime_handle);
+        let mut state = state;
+        state.reviews.push(TrackedGuardianReview {
+            abort_handle: task.abort_handle(),
+        });
+        drop(state);
+        Some(task)
+    }
+
+    pub(crate) fn close(self: &Arc<Self>) -> GuardianReviewDrain {
+        let closed_at = {
+            let mut state = self.lock_state();
+            *state.closed_at.get_or_insert_with(|| {
+                self.cancellation_token.cancel();
+                self.tasks.close();
+                Instant::now()
+            })
+        };
+        GuardianReviewDrain {
+            owner: Arc::clone(self),
+            deadline: closed_at + GUARDIAN_REVIEW_DRAIN_TIMEOUT,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct GuardianReviewActivity {
+    cancellation_token: CancellationToken,
+}
+
+impl GuardianReviewActivity {
+    pub(crate) fn cancellation_token(&self) -> CancellationToken {
+        self.cancellation_token.clone()
+    }
+
+    pub(crate) fn cancel(&self) {
+        self.cancellation_token.cancel();
+    }
+}
+
+#[must_use = "Guardian reviews must be drained after the parent turn is cancelled"]
+pub(crate) struct GuardianReviewDrain {
+    owner: Arc<GuardianReviewTaskOwner>,
+    deadline: Instant,
+}
+
+impl GuardianReviewDrain {
+    pub(crate) async fn drain(self) -> GuardianReviewDrainOutcome {
+        let timed_out = tokio::time::timeout_at(self.deadline, self.owner.tasks.wait())
+            .await
+            .is_err();
+        let reviews = {
+            let mut state = self.owner.lock_state();
+            std::mem::take(&mut state.reviews)
+        };
+        if timed_out {
+            for review in &reviews {
+                review.abort_handle.abort();
+            }
+            self.owner.tasks.wait().await;
+            warn!("timed out waiting for Guardian reviews to stop");
+            GuardianReviewDrainOutcome::Forced
+        } else {
+            GuardianReviewDrainOutcome::Drained
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "task_owner_tests.rs"]
+mod tests;

--- a/codex-rs/core/src/guardian/task_owner.rs
+++ b/codex-rs/core/src/guardian/task_owner.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
+use codex_protocol::protocol::GuardianAssessmentEvent;
 use tokio::runtime::Handle;
 use tokio::task::AbortHandle;
 use tokio::task::JoinHandle;
@@ -18,12 +19,41 @@ const GUARDIAN_REVIEW_DRAIN_TIMEOUT: Duration = Duration::from_secs(6);
 #[derive(Debug, PartialEq)]
 pub(crate) enum GuardianReviewDrainOutcome {
     Drained,
-    Forced,
+    Forced(Vec<GuardianAssessmentEvent>),
 }
 
 #[derive(Debug)]
 struct TrackedGuardianReview {
     abort_handle: AbortHandle,
+    lifecycle: GuardianReviewLifecycle,
+}
+
+#[derive(Clone, Debug, Default)]
+struct GuardianReviewLifecycle {
+    fallback: Arc<Mutex<Option<GuardianAssessmentEvent>>>,
+}
+
+impl GuardianReviewLifecycle {
+    fn mark_started(&self, fallback: GuardianAssessmentEvent) {
+        *self
+            .fallback
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(fallback);
+    }
+
+    fn mark_terminal(&self) {
+        self.fallback
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+    }
+
+    fn take_fallback(&self) -> Option<GuardianAssessmentEvent> {
+        self.fallback
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+    }
 }
 
 #[derive(Debug, Default)]
@@ -58,12 +88,14 @@ impl GuardianReviewTaskOwner {
             owner: Arc::clone(self),
             cancellation_token: self.cancellation_token.child_token(),
             committed: Arc::new(AtomicBool::new(false)),
+            lifecycle: GuardianReviewLifecycle::default(),
         })
     }
 
     pub(crate) fn spawn<F>(
         self: &Arc<Self>,
         runtime_handle: &Handle,
+        activity: &GuardianReviewActivity,
         future: F,
     ) -> Option<JoinHandle<F::Output>>
     where
@@ -78,6 +110,7 @@ impl GuardianReviewTaskOwner {
         let mut state = state;
         state.reviews.push(TrackedGuardianReview {
             abort_handle: task.abort_handle(),
+            lifecycle: activity.lifecycle.clone(),
         });
         drop(state);
         Some(task)
@@ -104,11 +137,20 @@ pub(crate) struct GuardianReviewActivity {
     owner: Arc<GuardianReviewTaskOwner>,
     cancellation_token: CancellationToken,
     committed: Arc<AtomicBool>,
+    lifecycle: GuardianReviewLifecycle,
 }
 
 impl GuardianReviewActivity {
     pub(crate) fn cancellation_token(&self) -> CancellationToken {
         self.cancellation_token.clone()
+    }
+
+    pub(crate) fn mark_started(&self, fallback: GuardianAssessmentEvent) {
+        self.lifecycle.mark_started(fallback);
+    }
+
+    pub(crate) fn mark_terminal(&self) {
+        self.lifecycle.mark_terminal();
     }
 
     pub(crate) fn cancel(&self) -> bool {
@@ -164,7 +206,13 @@ impl GuardianReviewDrain {
             }
             self.owner.tasks.wait().await;
             warn!("timed out waiting for Guardian reviews to stop");
-            GuardianReviewDrainOutcome::Forced
+        }
+        let forced_aborts: Vec<_> = reviews
+            .into_iter()
+            .filter_map(|review| review.lifecycle.take_fallback())
+            .collect();
+        if timed_out || !forced_aborts.is_empty() {
+            GuardianReviewDrainOutcome::Forced(forced_aborts)
         } else {
             GuardianReviewDrainOutcome::Drained
         }

--- a/codex-rs/core/src/guardian/task_owner.rs
+++ b/codex-rs/core/src/guardian/task_owner.rs
@@ -19,7 +19,16 @@ const GUARDIAN_REVIEW_DRAIN_TIMEOUT: Duration = Duration::from_secs(6);
 #[derive(Debug, PartialEq)]
 pub(crate) enum GuardianReviewDrainOutcome {
     Drained,
-    Forced(Vec<GuardianAssessmentEvent>),
+    Forced {
+        events: Vec<GuardianAssessmentEvent>,
+        reason: GuardianReviewCleanupReason,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum GuardianReviewCleanupReason {
+    DrainTimeout,
+    MissingTerminal,
 }
 
 #[derive(Debug)]
@@ -211,8 +220,16 @@ impl GuardianReviewDrain {
             .into_iter()
             .filter_map(|review| review.lifecycle.take_fallback())
             .collect();
-        if timed_out || !forced_aborts.is_empty() {
-            GuardianReviewDrainOutcome::Forced(forced_aborts)
+        if timed_out {
+            GuardianReviewDrainOutcome::Forced {
+                events: forced_aborts,
+                reason: GuardianReviewCleanupReason::DrainTimeout,
+            }
+        } else if !forced_aborts.is_empty() {
+            GuardianReviewDrainOutcome::Forced {
+                events: forced_aborts,
+                reason: GuardianReviewCleanupReason::MissingTerminal,
+            }
         } else {
             GuardianReviewDrainOutcome::Drained
         }

--- a/codex-rs/core/src/guardian/task_owner.rs
+++ b/codex-rs/core/src/guardian/task_owner.rs
@@ -1,6 +1,8 @@
 use std::future::Future;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use tokio::runtime::Handle;
@@ -53,7 +55,9 @@ impl GuardianReviewTaskOwner {
             return None;
         }
         Some(GuardianReviewActivity {
+            owner: Arc::clone(self),
             cancellation_token: self.cancellation_token.child_token(),
+            committed: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -97,7 +101,9 @@ impl GuardianReviewTaskOwner {
 
 #[derive(Clone)]
 pub(crate) struct GuardianReviewActivity {
+    owner: Arc<GuardianReviewTaskOwner>,
     cancellation_token: CancellationToken,
+    committed: Arc<AtomicBool>,
 }
 
 impl GuardianReviewActivity {
@@ -105,8 +111,35 @@ impl GuardianReviewActivity {
         self.cancellation_token.clone()
     }
 
-    pub(crate) fn cancel(&self) {
+    pub(crate) fn cancel(&self) -> bool {
+        if self.committed.load(Ordering::Acquire) {
+            return false;
+        }
+        let _state = self.owner.lock_state();
+        if self.committed.load(Ordering::Acquire) {
+            return false;
+        }
         self.cancellation_token.cancel();
+        true
+    }
+
+    pub(crate) fn is_committed(&self) -> bool {
+        self.committed.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn try_commit(&self) -> bool {
+        if self.committed.load(Ordering::Acquire) {
+            return true;
+        }
+        let state = self.owner.lock_state();
+        if self.committed.load(Ordering::Acquire) {
+            return true;
+        }
+        let can_commit = state.closed_at.is_none() && !self.cancellation_token.is_cancelled();
+        if can_commit {
+            self.committed.store(true, Ordering::Release);
+        }
+        can_commit
     }
 }
 

--- a/codex-rs/core/src/guardian/task_owner_tests.rs
+++ b/codex-rs/core/src/guardian/task_owner_tests.rs
@@ -1,0 +1,49 @@
+use pretty_assertions::assert_eq;
+use std::sync::Arc;
+use tokio::sync::oneshot;
+use tokio::time::Instant;
+
+use super::GuardianReviewDrainOutcome;
+use super::GuardianReviewTaskOwner;
+
+#[tokio::test]
+async fn dropping_review_handle_leaves_cleanup_to_owner() {
+    let owner = Arc::new(GuardianReviewTaskOwner::default());
+    let cancellation_token = owner.cancellation_token();
+    let (completed_tx, completed_rx) = oneshot::channel();
+    let task = owner
+        .spawn(&tokio::runtime::Handle::current(), async move {
+            cancellation_token.cancelled().await;
+            let _ = completed_tx.send(());
+        })
+        .expect("review task should start");
+
+    drop(task);
+
+    assert_eq!(
+        owner.close().drain().await,
+        GuardianReviewDrainOutcome::Drained
+    );
+    assert_eq!(completed_rx.await, Ok(()));
+}
+
+#[tokio::test]
+async fn forced_drain_aborts_review_task() {
+    let owner = Arc::new(GuardianReviewTaskOwner::default());
+    let (drop_tx, mut drop_rx) = oneshot::channel::<()>();
+    let task = owner
+        .spawn(&tokio::runtime::Handle::current(), async move {
+            let _drop_tx = drop_tx;
+            std::future::pending::<()>().await;
+        })
+        .expect("review task should start");
+    drop(task);
+
+    let mut drain = owner.close();
+    drain.deadline = Instant::now();
+    assert_eq!(drain.drain().await, GuardianReviewDrainOutcome::Forced);
+    assert_eq!(
+        drop_rx.try_recv(),
+        Err(oneshot::error::TryRecvError::Closed)
+    );
+}

--- a/codex-rs/core/src/guardian/task_owner_tests.rs
+++ b/codex-rs/core/src/guardian/task_owner_tests.rs
@@ -1,3 +1,6 @@
+use codex_protocol::protocol::GuardianAssessmentAction;
+use codex_protocol::protocol::GuardianAssessmentEvent;
+use codex_protocol::protocol::GuardianAssessmentStatus;
 use pretty_assertions::assert_eq;
 use std::sync::Arc;
 use tokio::sync::oneshot;
@@ -6,13 +9,36 @@ use tokio::time::Instant;
 use super::GuardianReviewDrainOutcome;
 use super::GuardianReviewTaskOwner;
 
+fn forced_abort_event() -> GuardianAssessmentEvent {
+    GuardianAssessmentEvent {
+        id: "review-1".to_string(),
+        target_item_id: Some("item-1".to_string()),
+        turn_id: "turn-1".to_string(),
+        started_at_ms: 1,
+        completed_at_ms: None,
+        status: GuardianAssessmentStatus::Aborted,
+        risk_level: None,
+        user_authorization: None,
+        rationale: None,
+        decision_source: None,
+        action: GuardianAssessmentAction::McpToolCall {
+            server: "test-server".to_string(),
+            tool_name: "test-tool".to_string(),
+            connector_id: None,
+            connector_name: None,
+            tool_title: None,
+        },
+    }
+}
+
 #[tokio::test]
 async fn dropping_review_handle_leaves_cleanup_to_owner() {
     let owner = Arc::new(GuardianReviewTaskOwner::default());
+    let activity = owner.begin().expect("review should start");
     let cancellation_token = owner.cancellation_token();
     let (completed_tx, completed_rx) = oneshot::channel();
     let task = owner
-        .spawn(&tokio::runtime::Handle::current(), async move {
+        .spawn(&tokio::runtime::Handle::current(), &activity, async move {
             cancellation_token.cancelled().await;
             let _ = completed_tx.send(());
         })
@@ -30,9 +56,12 @@ async fn dropping_review_handle_leaves_cleanup_to_owner() {
 #[tokio::test]
 async fn forced_drain_aborts_review_task() {
     let owner = Arc::new(GuardianReviewTaskOwner::default());
+    let activity = owner.begin().expect("review should start");
+    let forced_abort = forced_abort_event();
+    activity.mark_started(forced_abort.clone());
     let (drop_tx, mut drop_rx) = oneshot::channel::<()>();
     let task = owner
-        .spawn(&tokio::runtime::Handle::current(), async move {
+        .spawn(&tokio::runtime::Handle::current(), &activity, async move {
             let _drop_tx = drop_tx;
             std::future::pending::<()>().await;
         })
@@ -41,10 +70,71 @@ async fn forced_drain_aborts_review_task() {
 
     let mut drain = owner.close();
     drain.deadline = Instant::now();
-    assert_eq!(drain.drain().await, GuardianReviewDrainOutcome::Forced);
+    assert_eq!(
+        drain.drain().await,
+        GuardianReviewDrainOutcome::Forced(vec![forced_abort])
+    );
     assert_eq!(
         drop_rx.try_recv(),
         Err(oneshot::error::TryRecvError::Closed)
+    );
+}
+
+#[tokio::test]
+async fn panicked_review_returns_fallback_after_draining() {
+    let owner = Arc::new(GuardianReviewTaskOwner::default());
+    let activity = owner.begin().expect("review should start");
+    let forced_abort = forced_abort_event();
+    activity.mark_started(forced_abort.clone());
+    let task = owner
+        .spawn(&tokio::runtime::Handle::current(), &activity, async move {
+            panic!("guardian review panicked");
+        })
+        .expect("review task should start");
+    drop(task);
+
+    assert_eq!(
+        owner.close().drain().await,
+        GuardianReviewDrainOutcome::Forced(vec![forced_abort])
+    );
+}
+
+#[tokio::test]
+async fn fallback_requires_started_nonterminal_review() {
+    let owner = Arc::new(GuardianReviewTaskOwner::default());
+    let activity = owner.begin().expect("review should start");
+    let task = owner
+        .spawn(
+            &tokio::runtime::Handle::current(),
+            &activity,
+            std::future::pending::<()>(),
+        )
+        .expect("review task should start");
+    drop(task);
+    let mut drain = owner.close();
+    drain.deadline = Instant::now();
+    assert_eq!(
+        drain.drain().await,
+        GuardianReviewDrainOutcome::Forced(Vec::new())
+    );
+
+    let owner = Arc::new(GuardianReviewTaskOwner::default());
+    let activity = owner.begin().expect("review should start");
+    activity.mark_started(forced_abort_event());
+    activity.mark_terminal();
+    let task = owner
+        .spawn(
+            &tokio::runtime::Handle::current(),
+            &activity,
+            std::future::pending::<()>(),
+        )
+        .expect("review task should start");
+    drop(task);
+    let mut drain = owner.close();
+    drain.deadline = Instant::now();
+    assert_eq!(
+        drain.drain().await,
+        GuardianReviewDrainOutcome::Forced(Vec::new())
     );
 }
 

--- a/codex-rs/core/src/guardian/task_owner_tests.rs
+++ b/codex-rs/core/src/guardian/task_owner_tests.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use tokio::sync::oneshot;
 use tokio::time::Instant;
 
+use super::GuardianReviewCleanupReason;
 use super::GuardianReviewDrainOutcome;
 use super::GuardianReviewTaskOwner;
 
@@ -72,7 +73,10 @@ async fn forced_drain_aborts_review_task() {
     drain.deadline = Instant::now();
     assert_eq!(
         drain.drain().await,
-        GuardianReviewDrainOutcome::Forced(vec![forced_abort])
+        GuardianReviewDrainOutcome::Forced {
+            events: vec![forced_abort],
+            reason: GuardianReviewCleanupReason::DrainTimeout,
+        }
     );
     assert_eq!(
         drop_rx.try_recv(),
@@ -95,7 +99,10 @@ async fn panicked_review_returns_fallback_after_draining() {
 
     assert_eq!(
         owner.close().drain().await,
-        GuardianReviewDrainOutcome::Forced(vec![forced_abort])
+        GuardianReviewDrainOutcome::Forced {
+            events: vec![forced_abort],
+            reason: GuardianReviewCleanupReason::MissingTerminal,
+        }
     );
 }
 
@@ -115,7 +122,10 @@ async fn fallback_requires_started_nonterminal_review() {
     drain.deadline = Instant::now();
     assert_eq!(
         drain.drain().await,
-        GuardianReviewDrainOutcome::Forced(Vec::new())
+        GuardianReviewDrainOutcome::Forced {
+            events: Vec::new(),
+            reason: GuardianReviewCleanupReason::DrainTimeout,
+        }
     );
 
     let owner = Arc::new(GuardianReviewTaskOwner::default());
@@ -134,7 +144,10 @@ async fn fallback_requires_started_nonterminal_review() {
     drain.deadline = Instant::now();
     assert_eq!(
         drain.drain().await,
-        GuardianReviewDrainOutcome::Forced(Vec::new())
+        GuardianReviewDrainOutcome::Forced {
+            events: Vec::new(),
+            reason: GuardianReviewCleanupReason::DrainTimeout,
+        }
     );
 }
 

--- a/codex-rs/core/src/guardian/task_owner_tests.rs
+++ b/codex-rs/core/src/guardian/task_owner_tests.rs
@@ -47,3 +47,25 @@ async fn forced_drain_aborts_review_task() {
         Err(oneshot::error::TryRecvError::Closed)
     );
 }
+
+#[test]
+fn commit_is_linearized_against_cancellation() {
+    let committed_owner = Arc::new(GuardianReviewTaskOwner::default());
+    let committed = committed_owner.begin().expect("review should start");
+    assert!(committed.try_commit());
+    let _drain = committed_owner.close();
+    assert!(committed.try_commit());
+
+    let interrupted_owner = Arc::new(GuardianReviewTaskOwner::default());
+    let interrupted = interrupted_owner
+        .begin()
+        .expect("review should start before interruption");
+    let _drain = interrupted_owner.close();
+    assert!(!interrupted.try_commit());
+    assert!(interrupted_owner.begin().is_none());
+
+    let cancelled_owner = Arc::new(GuardianReviewTaskOwner::default());
+    let cancelled = cancelled_owner.begin().expect("review should start");
+    assert!(cancelled.cancel());
+    assert!(!cancelled.try_commit());
+}

--- a/codex-rs/core/src/guardian/tests.rs
+++ b/codex-rs/core/src/guardian/tests.rs
@@ -79,6 +79,37 @@ fn fixed_guardian_parent_session_id() -> ThreadId {
         .expect("fixed parent session id should be a valid UUID")
 }
 
+async fn run_guardian_review_session_for_test(
+    session: Arc<Session>,
+    turn: Arc<TurnContext>,
+    request: GuardianApprovalRequest,
+    retry_reason: Option<String>,
+    schema: serde_json::Value,
+    external_cancel: Option<CancellationToken>,
+) -> (
+    GuardianReviewOutcome,
+    codex_analytics::GuardianReviewAnalyticsResult,
+) {
+    let review_activity = turn
+        .guardian_reviews
+        .begin()
+        .expect("guardian review activity");
+    let review_generation = session.guardian_review_session.generation();
+    super::review::run_guardian_review_session(
+        session,
+        turn,
+        super::review::GuardianReviewRunContext {
+            activity: review_activity,
+            generation: review_generation,
+        },
+        request,
+        retry_reason,
+        schema,
+        external_cancel,
+    )
+    .await
+}
+
 #[test]
 fn guardian_rejection_circuit_breaker_interrupts_after_three_consecutive_denials() {
     let mut circuit_breaker = GuardianRejectionCircuitBreaker::default();

--- a/codex-rs/core/src/session/review.rs
+++ b/codex-rs/core/src/session/review.rs
@@ -109,6 +109,7 @@ pub(super) async fn spawn_review_thread(
 
     let review_turn_context = TurnContext {
         sub_id: review_turn_id.clone(),
+        guardian_reviews: Arc::new(crate::guardian::GuardianReviewTaskOwner::default()),
         trace_id: current_span_trace_id(),
         realtime_active: parent_turn_context.realtime_active,
         config: per_turn_config,

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -20,6 +20,8 @@ use codex_sandboxing::policy_transforms::effective_network_sandbox_policy;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 
+use crate::guardian::GuardianReviewTaskOwner;
+
 #[derive(Clone, Debug)]
 pub(crate) struct TurnSkillsContext {
     pub(crate) outcome: Arc<SkillLoadOutcome>,
@@ -56,6 +58,7 @@ impl TurnEnvironment {
 #[derive(Debug)]
 pub struct TurnContext {
     pub(crate) sub_id: String,
+    pub(crate) guardian_reviews: Arc<GuardianReviewTaskOwner>,
     pub(crate) trace_id: Option<String>,
     pub(crate) realtime_active: bool,
     pub config: Arc<Config>,
@@ -224,6 +227,7 @@ impl TurnContext {
 
         Self {
             sub_id: self.sub_id.clone(),
+            guardian_reviews: Arc::clone(&self.guardian_reviews),
             trace_id: self.trace_id.clone(),
             realtime_active: self.realtime_active,
             config: Arc::new(config),
@@ -526,6 +530,7 @@ impl Session {
         extension_data.insert(HostLoadedSkills::new(Arc::clone(&skills_outcome)));
         TurnContext {
             sub_id,
+            guardian_reviews: Arc::new(GuardianReviewTaskOwner::default()),
             trace_id: current_span_trace_id(),
             realtime_active: false,
             config: per_turn_config.clone(),

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -550,11 +550,22 @@ impl Session {
         true
     }
 
-    async fn drain_guardian_reviews(&self, drain: crate::guardian::GuardianReviewDrain) {
-        if drain.drain().await == crate::guardian::GuardianReviewDrainOutcome::Forced {
-            self.guardian_review_session
-                .shutdown_in_background(&self.services.runtime_handle);
+    async fn drain_guardian_reviews(
+        &self,
+        turn_context: &TurnContext,
+        drain: crate::guardian::GuardianReviewDrain,
+    ) {
+        let crate::guardian::GuardianReviewDrainOutcome::Forced(events) = drain.drain().await
+        else {
+            return;
+        };
+        for mut event in events {
+            event.completed_at_ms = Some(crate::turn_timing::now_unix_timestamp_ms());
+            self.send_event(turn_context, EventMsg::GuardianAssessment(event))
+                .await;
         }
+        self.guardian_review_session
+            .shutdown_in_background(&self.services.runtime_handle);
     }
 
     pub async fn on_task_finished(
@@ -577,7 +588,7 @@ impl Session {
         let Some(turn_state) = turn_state else {
             return;
         };
-        self.drain_guardian_reviews(turn_context.guardian_reviews.close())
+        self.drain_guardian_reviews(turn_context.as_ref(), turn_context.guardian_reviews.close())
             .await;
         let pending_input = self
             .input_queue
@@ -797,7 +808,8 @@ impl Session {
         let task_already_cancelled = task.cancellation_token.is_cancelled();
         task.cancellation_token.cancel();
         if task_already_cancelled {
-            self.drain_guardian_reviews(guardian_drain).await;
+            self.drain_guardian_reviews(task.turn_context.as_ref(), guardian_drain)
+                .await;
             return;
         }
 
@@ -824,7 +836,8 @@ impl Session {
         session_task
             .abort(session_ctx, Arc::clone(&task.turn_context))
             .await;
-        self.drain_guardian_reviews(guardian_drain).await;
+        self.drain_guardian_reviews(task.turn_context.as_ref(), guardian_drain)
+            .await;
 
         if reason == TurnAbortReason::Interrupted
             && let Some(marker) = interrupted_turn_history_marker(

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -550,6 +550,12 @@ impl Session {
         true
     }
 
+    async fn drain_guardian_reviews(&self, drain: crate::guardian::GuardianReviewDrain) {
+        if drain.drain().await == crate::guardian::GuardianReviewDrainOutcome::Forced {
+            self.guardian_review_session.shutdown().await;
+        }
+    }
+
     pub async fn on_task_finished(
         self: &Arc<Self>,
         turn_context: Arc<TurnContext>,
@@ -570,6 +576,8 @@ impl Session {
         let Some(turn_state) = turn_state else {
             return;
         };
+        self.drain_guardian_reviews(turn_context.guardian_reviews.close())
+            .await;
         let pending_input = self
             .input_queue
             .take_pending_input_for_turn_state(turn_state.as_ref())
@@ -784,12 +792,15 @@ impl Session {
 
     async fn handle_task_abort(self: &Arc<Self>, task: RunningTask, reason: TurnAbortReason) {
         let sub_id = task.turn_context.sub_id.clone();
-        if task.cancellation_token.is_cancelled() {
+        let guardian_drain = task.turn_context.guardian_reviews.close();
+        let task_already_cancelled = task.cancellation_token.is_cancelled();
+        task.cancellation_token.cancel();
+        if task_already_cancelled {
+            self.drain_guardian_reviews(guardian_drain).await;
             return;
         }
 
         trace!(task_kind = ?task.kind, sub_id, "aborting running task");
-        task.cancellation_token.cancel();
         task.turn_context
             .turn_metadata_state
             .cancel_git_enrichment_task();
@@ -812,6 +823,7 @@ impl Session {
         session_task
             .abort(session_ctx, Arc::clone(&task.turn_context))
             .await;
+        self.drain_guardian_reviews(guardian_drain).await;
 
         if reason == TurnAbortReason::Interrupted
             && let Some(marker) = interrupted_turn_history_marker(

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -555,15 +555,22 @@ impl Session {
         turn_context: &TurnContext,
         drain: crate::guardian::GuardianReviewDrain,
     ) {
-        let crate::guardian::GuardianReviewDrainOutcome::Forced(events) = drain.drain().await
+        let crate::guardian::GuardianReviewDrainOutcome::Forced { events, reason } =
+            drain.drain().await
         else {
             return;
         };
+        let fallback_emitted = !events.is_empty();
         for mut event in events {
             event.completed_at_ms = Some(crate::turn_timing::now_unix_timestamp_ms());
             self.send_event(turn_context, EventMsg::GuardianAssessment(event))
                 .await;
         }
+        crate::guardian::emit_guardian_review_cleanup_metric(
+            &self.services.session_telemetry,
+            reason,
+            fallback_emitted,
+        );
         self.guardian_review_session
             .shutdown_in_background(&self.services.runtime_handle);
     }

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -552,7 +552,8 @@ impl Session {
 
     async fn drain_guardian_reviews(&self, drain: crate::guardian::GuardianReviewDrain) {
         if drain.drain().await == crate::guardian::GuardianReviewDrainOutcome::Forced {
-            self.guardian_review_session.shutdown().await;
+            self.guardian_review_session
+                .shutdown_in_background(&self.services.runtime_handle);
         }
     }
 

--- a/codex-rs/core/tests/suite/guardian_review.rs
+++ b/codex-rs/core/tests/suite/guardian_review.rs
@@ -6,6 +6,7 @@ use codex_core::sandboxing::SandboxPermissions;
 use codex_protocol::config_types::ApprovalsReviewer;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
+use codex_protocol::protocol::GuardianAssessmentStatus;
 use codex_protocol::protocol::Op;
 use codex_protocol::protocol::SandboxPolicy;
 use codex_protocol::user_input::UserInput;
@@ -14,8 +15,10 @@ use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_function_call;
 use core_test_support::responses::ev_response_created;
+use core_test_support::responses::mount_response_sequence;
 use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
+use core_test_support::responses::sse_response;
 use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
 use core_test_support::skip_if_sandbox;
@@ -29,6 +32,144 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::time::Duration;
 use tempfile::TempDir;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn interrupting_parent_turn_shuts_down_active_guardian_review() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+    skip_if_sandbox!(Ok(()));
+
+    let server = start_mock_server().await;
+    let approval_policy = AskForApproval::OnRequest;
+    let sandbox_policy = SandboxPolicy::WorkspaceWrite {
+        writable_roots: vec![],
+        network_access: false,
+        exclude_tmpdir_env_var: true,
+        exclude_slash_tmp: true,
+    };
+    let sandbox_policy_for_config = sandbox_policy.clone();
+    let mut builder = test_codex().with_config(move |config| {
+        config.permissions.approval_policy = Constrained::allow_any(approval_policy);
+        config
+            .set_legacy_sandbox_policy(sandbox_policy_for_config)
+            .expect("set sandbox policy");
+    });
+    let test = builder.build(&server).await?;
+
+    let output_file = test.cwd.path().join("guardian-review-after-interrupt.txt");
+    let command = format!("printf guardian-approved > {}", output_file.display());
+    let tool_args = json!({
+        "cmd": command,
+        "yield_time_ms": 1_000_u64,
+        "sandbox_permissions": SandboxPermissions::RequireEscalated,
+        "justification": "Exercise Guardian cancellation.",
+    });
+    let parent_response = sse_response(sse(vec![
+        ev_response_created("resp-parent-tool"),
+        ev_function_call(
+            "exec-call",
+            "exec_command",
+            &serde_json::to_string(&tool_args)?,
+        ),
+        ev_completed("resp-parent-tool"),
+    ]));
+    let guardian_response = sse_response(sse(vec![
+        ev_response_created("resp-guardian-delayed"),
+        ev_assistant_message(
+            "msg-guardian-delayed",
+            &json!({
+                "risk_level": "low",
+                "user_authorization": "high",
+                "outcome": "allow",
+                "rationale": "The command writes a marker file in the workspace.",
+            })
+            .to_string(),
+        ),
+        ev_completed("resp-guardian-delayed"),
+    ]))
+    .set_delay(Duration::from_secs(1));
+    let responses =
+        mount_response_sequence(&server, vec![parent_response, guardian_response]).await;
+
+    test.codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "run a command that requires Guardian review".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: codex_protocol::protocol::ThreadSettingsOverrides {
+                environments: Some(local_selections(test.config.cwd.clone())),
+                approval_policy: Some(approval_policy),
+                approvals_reviewer: Some(ApprovalsReviewer::AutoReview),
+                sandbox_policy: Some(sandbox_policy),
+                ..Default::default()
+            },
+        })
+        .await?;
+    let guardian_started = wait_for_event(&test.codex, |event| {
+        matches!(event, EventMsg::GuardianAssessment(_))
+    })
+    .await;
+    let EventMsg::GuardianAssessment(guardian_started) = guardian_started else {
+        unreachable!("wait predicate only accepts guardian assessments");
+    };
+    assert_eq!(
+        guardian_started.status,
+        GuardianAssessmentStatus::InProgress
+    );
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while responses.requests().len() < 2 {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("guardian review request should be in flight before interrupt");
+
+    test.codex.submit(Op::Interrupt).await?;
+    let statuses = tokio::time::timeout(Duration::from_secs(5), async {
+        let mut statuses = vec![guardian_started.status];
+        loop {
+            match test.codex.next_event().await?.msg {
+                EventMsg::GuardianAssessment(event) => statuses.push(event.status),
+                EventMsg::TurnAborted(_) => return Ok::<_, anyhow::Error>(statuses),
+                _ => {}
+            }
+        }
+    })
+    .await??;
+    assert_eq!(
+        statuses,
+        vec![
+            GuardianAssessmentStatus::InProgress,
+            GuardianAssessmentStatus::Aborted,
+        ]
+    );
+
+    match tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            let event = test.codex.next_event().await?;
+            if let EventMsg::GuardianAssessment(assessment) = event.msg {
+                return Ok::<_, anyhow::Error>(assessment);
+            }
+        }
+    })
+    .await
+    {
+        Err(_) => {}
+        Ok(Ok(assessment)) => {
+            panic!("received late Guardian assessment after parent abort: {assessment:?}")
+        }
+        Ok(Err(err)) => return Err(err),
+    }
+    assert!(
+        !output_file.exists(),
+        "Guardian-approved command ran after parent abort"
+    );
+
+    Ok(())
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn guardian_review_session_does_not_inherit_legacy_notify() -> Result<()> {

--- a/codex-rs/otel/src/metrics/names.rs
+++ b/codex-rs/otel/src/metrics/names.rs
@@ -29,6 +29,7 @@ pub const TURN_MEMORY_METRIC: &str = "codex.turn.memory";
 pub const TURN_TOOL_CALL_METRIC: &str = "codex.turn.tool.call";
 pub const TURN_TOKEN_USAGE_METRIC: &str = "codex.turn.token_usage";
 pub const GUARDIAN_REVIEW_COUNT_METRIC: &str = "codex.guardian.review";
+pub const GUARDIAN_REVIEW_CLEANUP_COUNT_METRIC: &str = "codex.guardian.review.cleanup";
 pub const GUARDIAN_REVIEW_DURATION_METRIC: &str = "codex.guardian.review.duration_ms";
 pub const GUARDIAN_REVIEW_TTFT_DURATION_METRIC: &str = "codex.guardian.review.ttft.duration_ms";
 pub const GUARDIAN_REVIEW_TOKEN_USAGE_METRIC: &str = "codex.guardian.review.token_usage";


### PR DESCRIPTION
## Why

Interrupting a parent turn did not own the lifecycle of an in-flight Guardian review. A review could outlive the parent, leave an `InProgress` assessment without a terminal event, or return a delayed approval after interruption. Manager-wide cleanup alone also risks stale timeout cleanup tearing down a newer reusable Guardian generation.

Fixes CA-419.

## What changed

- own Guardian review tasks per parent `TurnContext`, cancelling and draining them before parent terminal lifecycle events
- replace reusable Guardian session state by generation and fence cleanup and transcript commits against cancellation
- track started, nonterminal assessments and synthesize exactly one `Aborted` event after a panic or forced drain
- strengthen the interruption integration test to prove a delayed `Allow` response cannot execute the reviewed command after the parent stops

## Commit structure

1. [`core: own Guardian reviews by parent turn`](https://github.com/openai/codex/commit/a2d506d9fbb871426a8a08247f7e740c554ea67c)
2. [`core: fence Guardian session cleanup by generation`](https://github.com/openai/codex/commit/3440a4aa4c7784e99e03e6fc1eab70d6532b3f6c)
3. [`core: close Guardian assessment lifecycle on abort`](https://github.com/openai/codex/commit/8db4dd0685d7a82da17cd6d076b32128cdef5f89)

## Review map

The easiest way to review this is by invariant rather than reading the full diff front to back.

### 1. Per-turn ownership and shutdown ordering

Start with [`GuardianReviewTaskOwner`](https://github.com/openai/codex/blob/8db4dd0685d7a82da17cd6d076b32128cdef5f89/codex-rs/core/src/guardian/task_owner.rs#L65-L219), then follow review creation through [`run_guardian_review_in_task`](https://github.com/openai/codex/blob/8db4dd0685d7a82da17cd6d076b32128cdef5f89/codex-rs/core/src/guardian/review.rs#L615-L664).

Critical checks:

- `begin()` and `spawn()` refuse work after the owner closes
- the abort handle is registered while the owner-state lock is held
- `close()` cancels the task group and prevents later registration
- [`handle_task_abort`](https://github.com/openai/codex/blob/8db4dd0685d7a82da17cd6d076b32128cdef5f89/codex-rs/core/src/tasks/mod.rs#L805-L840) drains Guardian work before the parent emits `TurnAborted`
- normal completion also drains Guardian work before `TurnComplete`

### 2. Cancellation versus commit

The key linearization boundary is [`GuardianReviewActivity::cancel` / `try_commit`](https://github.com/openai/codex/blob/8db4dd0685d7a82da17cd6d076b32128cdef5f89/codex-rs/core/src/guardian/task_owner.rs#L156-L185). Both synchronize with owner closure through the same state lock.

There should be only two valid outcomes:

1. cancellation wins, so `try_commit()` fails and the review cannot approve or mutate reusable transcript state;
2. commit wins, so cancellation waits for the already-completed result and the owner still drains it before the parent terminal event.

Verify that reusable state is updated only after the second commit fence in [`run_review_on_session`](https://github.com/openai/codex/blob/8db4dd0685d7a82da17cd6d076b32128cdef5f89/codex-rs/core/src/guardian/review_session.rs#L863-L889).

### 3. Generation-safe reusable-session cleanup

Review [`shutdown_generation_in_background`](https://github.com/openai/codex/blob/8db4dd0685d7a82da17cd6d076b32128cdef5f89/codex-rs/core/src/guardian/review_session.rs#L338-L363) and the closed-generation checks in [`run_review`](https://github.com/openai/codex/blob/8db4dd0685d7a82da17cd6d076b32128cdef5f89/codex-rs/core/src/guardian/review_session.rs#L369-L440).

The important race is: review A times out, review B starts on a replacement generation, then A cleanup runs. The compare-and-swap must make A cleanup a no-op against B. Also check the post-spawn closed-state guard for [ephemeral reviews](https://github.com/openai/codex/blob/8db4dd0685d7a82da17cd6d076b32128cdef5f89/codex-rs/core/src/guardian/review_session.rs#L589-L668).

### 4. Exactly one terminal assessment

The fallback is armed only after `InProgress` is emitted in [`run_guardian_review`](https://github.com/openai/codex/blob/8db4dd0685d7a82da17cd6d076b32128cdef5f89/codex-rs/core/src/guardian/review.rs#L289-L310). Every normal terminal path immediately calls `mark_terminal()`. Fallbacks are collected only after tasks have stopped in [`GuardianReviewDrain::drain`](https://github.com/openai/codex/blob/8db4dd0685d7a82da17cd6d076b32128cdef5f89/codex-rs/core/src/guardian/task_owner.rs#L194-L219).

Expected behavior:

- no fallback when `InProgress` was never visible
- no duplicate after a normal terminal assessment
- one `Aborted` fallback after a panic or forced abort of a started review

### Critical tests

- [owner cleanup, forced drain, panic fallback, duplicate suppression, and commit ordering](https://github.com/openai/codex/blob/8db4dd0685d7a82da17cd6d076b32128cdef5f89/codex-rs/core/src/guardian/task_owner_tests.rs#L34-L161)
- [stale generation cleanup and cancelled-generation admission](https://github.com/openai/codex/blob/8db4dd0685d7a82da17cd6d076b32128cdef5f89/codex-rs/core/src/guardian/review_session.rs#L1283-L1327)
- [cancelled completion cannot commit reusable transcript state](https://github.com/openai/codex/blob/8db4dd0685d7a82da17cd6d076b32128cdef5f89/codex-rs/core/src/guardian/review_session.rs#L1619-L1662)
- [end-to-end delayed `Allow` response cannot execute after interruption](https://github.com/openai/codex/blob/8db4dd0685d7a82da17cd6d076b32128cdef5f89/codex-rs/core/tests/suite/guardian_review.rs#L37-L171)

For the integration test, all three assertions are important: the statuses before `TurnAborted` are exactly `[InProgress, Aborted]`, no later assessment arrives, and the reviewed marker-file command never executes.

The main timing boundary to scrutinize is the 5-second inner cancellation drain versus the 6-second owner drain. Also verify that every terminal path disarms its fallback and that no reusable-session mutation occurs before `try_commit()` succeeds.

## Test plan

- `just test -p codex-core task_owner`
- `just test -p codex-core review_session`
- `just test -p codex-core interrupting_parent_turn_shuts_down_active_guardian_review` outside the sandbox
- `just test -p codex-core guardian`