### PR TITLE
[codex] Cover auth-routed plugin tool visibility

### DIFF
--- a/codex-rs/core/src/plugins/injection.rs
+++ b/codex-rs/core/src/plugins/injection.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeSet;
 
+use codex_app_server_protocol::AuthMode;
 use codex_connectors::metadata::connector_display_label;
 use codex_protocol::models::ResponseItem;
 
@@ -8,6 +9,8 @@ use crate::context::ContextualUserFragment;
 use crate::context::PluginInstructions;
 use crate::plugins::PluginCapabilitySummary;
 use crate::plugins::render_explicit_plugin_instructions;
+use crate::plugins::routing::PluginRoute;
+use crate::plugins::routing::route_for_plugin;
 use codex_mcp::CODEX_APPS_MCP_SERVER_NAME;
 use codex_mcp::ToolInfo;
 
@@ -15,6 +18,7 @@ pub(crate) fn build_plugin_injections(
     mentioned_plugins: &[PluginCapabilitySummary],
     mcp_tools: &[ToolInfo],
     available_connectors: &[connectors::AppInfo],
+    auth_mode: Option<AuthMode>,
 ) -> Vec<ResponseItem> {
     if mentioned_plugins.is_empty() {
         return Vec::new();
@@ -25,35 +29,252 @@ pub(crate) fn build_plugin_injections(
     mentioned_plugins
         .iter()
         .filter_map(|plugin| {
-            let available_mcp_servers = mcp_tools
-                .iter()
-                .filter(|tool| {
-                    tool.server_name != CODEX_APPS_MCP_SERVER_NAME
-                        && tool
-                            .plugin_display_names
-                            .iter()
-                            .any(|plugin_name| plugin_name == &plugin.display_name)
-                })
-                .map(|tool| tool.server_name.clone())
-                .collect::<BTreeSet<String>>()
-                .into_iter()
-                .collect::<Vec<_>>();
-            let available_apps = available_connectors
-                .iter()
-                .filter(|connector| {
-                    connector.is_enabled
-                        && connector
-                            .plugin_display_names
-                            .iter()
-                            .any(|plugin_name| plugin_name == &plugin.display_name)
-                })
-                .map(connector_display_label)
-                .collect::<BTreeSet<String>>()
-                .into_iter()
-                .collect::<Vec<_>>();
+            let route = route_for_plugin(plugin, auth_mode);
+            let (available_mcp_servers, available_apps) = match route {
+                PluginRoute::Default => (
+                    available_mcp_servers_for_plugin(plugin, mcp_tools),
+                    available_apps_for_plugin(plugin, available_connectors),
+                ),
+                PluginRoute::McpOnly => (
+                    available_mcp_servers_for_plugin(plugin, mcp_tools),
+                    Vec::new(),
+                ),
+            };
             render_explicit_plugin_instructions(plugin, &available_mcp_servers, &available_apps)
                 .map(PluginInstructions::new)
                 .map(ContextualUserFragment::into)
         })
         .collect()
+}
+
+fn available_mcp_servers_for_plugin(
+    plugin: &PluginCapabilitySummary,
+    mcp_tools: &[ToolInfo],
+) -> Vec<String> {
+    mcp_tools
+        .iter()
+        .filter(|tool| {
+            tool.server_name != CODEX_APPS_MCP_SERVER_NAME
+                && tool
+                    .plugin_display_names
+                    .iter()
+                    .any(|plugin_name| plugin_name == &plugin.display_name)
+        })
+        .map(|tool| tool.server_name.clone())
+        .collect::<BTreeSet<String>>()
+        .into_iter()
+        .collect()
+}
+
+fn available_apps_for_plugin(
+    plugin: &PluginCapabilitySummary,
+    available_connectors: &[connectors::AppInfo],
+) -> Vec<String> {
+    available_connectors
+        .iter()
+        .filter(|connector| {
+            connector.is_enabled
+                && connector
+                    .plugin_display_names
+                    .iter()
+                    .any(|plugin_name| plugin_name == &plugin.display_name)
+        })
+        .map(connector_display_label)
+        .collect::<BTreeSet<String>>()
+        .into_iter()
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use codex_plugin::AppConnectorId;
+    use codex_protocol::models::ContentItem;
+    use pretty_assertions::assert_eq;
+    use rmcp::model::JsonObject;
+    use rmcp::model::Tool;
+
+    use super::*;
+
+    fn plugin(app_ids: &[&str], mcp_server_names: &[&str]) -> PluginCapabilitySummary {
+        PluginCapabilitySummary {
+            config_name: "sample@personal".to_string(),
+            display_name: "Sample".to_string(),
+            app_connector_ids: app_ids
+                .iter()
+                .map(|id| AppConnectorId((*id).to_string()))
+                .collect(),
+            mcp_server_names: mcp_server_names
+                .iter()
+                .map(|name| (*name).to_string())
+                .collect(),
+            ..PluginCapabilitySummary::default()
+        }
+    }
+
+    fn mcp_tool(server_name: &str) -> ToolInfo {
+        ToolInfo {
+            server_name: server_name.to_string(),
+            supports_parallel_tool_calls: false,
+            server_origin: None,
+            callable_name: "search".to_string(),
+            callable_namespace: format!("mcp__{server_name}"),
+            namespace_description: None,
+            tool: Tool::new(
+                "search".to_string(),
+                "Search sample data".to_string(),
+                Arc::new(JsonObject::default()),
+            ),
+            connector_id: None,
+            connector_name: None,
+            plugin_display_names: vec!["Sample".to_string()],
+        }
+    }
+
+    fn connector(
+        id: &str,
+        name: &str,
+        is_accessible: bool,
+        is_enabled: bool,
+    ) -> connectors::AppInfo {
+        connectors::AppInfo {
+            id: id.to_string(),
+            name: name.to_string(),
+            description: None,
+            logo_url: None,
+            logo_url_dark: None,
+            distribution_channel: None,
+            branding: None,
+            app_metadata: None,
+            labels: None,
+            install_url: None,
+            is_accessible,
+            is_enabled,
+            plugin_display_names: vec!["Sample".to_string()],
+        }
+    }
+
+    fn render_single_injection(
+        plugin: PluginCapabilitySummary,
+        mcp_tools: Vec<ToolInfo>,
+        available_connectors: Vec<connectors::AppInfo>,
+        auth_mode: Option<AuthMode>,
+    ) -> String {
+        let items =
+            build_plugin_injections(&[plugin], &mcp_tools, &available_connectors, auth_mode);
+        assert_eq!(items.len(), 1);
+
+        let ResponseItem::Message { role, content, .. } = &items[0] else {
+            panic!("expected developer message");
+        };
+        assert_eq!(role, "developer");
+        let [ContentItem::InputText { text }] = content.as_slice() else {
+            panic!("expected one input text content item");
+        };
+        text.clone()
+    }
+
+    struct GuidanceCase {
+        name: &'static str,
+        plugin: PluginCapabilitySummary,
+        mcp_tools: Vec<ToolInfo>,
+        available_connectors: Vec<connectors::AppInfo>,
+        auth_mode: Option<AuthMode>,
+        expected_contains: &'static [&'static str],
+        expected_not_contains: &'static [&'static str],
+    }
+
+    #[test]
+    fn renders_plugin_mention_guidance_by_auth_route() {
+        let cases = vec![
+            GuidanceCase {
+                name: "chatgpt dual-surface app available",
+                plugin: plugin(&["connector_sample"], &["sample-mcp"]),
+                mcp_tools: vec![mcp_tool("sample-mcp")],
+                available_connectors: vec![connector(
+                    "connector_sample",
+                    "Sample App",
+                    /*is_accessible*/ true,
+                    /*is_enabled*/ true,
+                )],
+                auth_mode: Some(AuthMode::Chatgpt),
+                expected_contains: &[
+                    "MCP servers from this plugin available in this session: `sample-mcp`.",
+                    "Apps from this plugin available in this session: `Sample App`.",
+                ],
+                expected_not_contains: &["do not use this plugin's MCP servers as a fallback"],
+            },
+            GuidanceCase {
+                name: "api-key dual-surface plugin",
+                plugin: plugin(&["connector_sample"], &["sample-mcp"]),
+                mcp_tools: vec![mcp_tool("sample-mcp")],
+                available_connectors: vec![connector(
+                    "connector_sample",
+                    "Sample App",
+                    /*is_accessible*/ true,
+                    /*is_enabled*/ true,
+                )],
+                auth_mode: Some(AuthMode::ApiKey),
+                expected_contains: &[
+                    "MCP servers from this plugin available in this session: `sample-mcp`.",
+                ],
+                expected_not_contains: &["Apps from this plugin available"],
+            },
+            GuidanceCase {
+                name: "chatgpt dual-surface app unavailable falls back to mcp guidance",
+                plugin: plugin(&["connector_sample"], &["sample-mcp"]),
+                mcp_tools: vec![mcp_tool("sample-mcp")],
+                available_connectors: Vec::new(),
+                auth_mode: Some(AuthMode::Chatgpt),
+                expected_contains: &[
+                    "MCP servers from this plugin available in this session: `sample-mcp`.",
+                ],
+                expected_not_contains: &[
+                    "Apps from this plugin available",
+                    "Apps from this plugin are not available",
+                    "do not use this plugin's MCP servers as a fallback",
+                ],
+            },
+            GuidanceCase {
+                name: "chatgpt mcp-only plugin",
+                plugin: plugin(&[], &["sample-mcp"]),
+                mcp_tools: vec![mcp_tool("sample-mcp")],
+                available_connectors: Vec::new(),
+                auth_mode: Some(AuthMode::Chatgpt),
+                expected_contains: &[
+                    "MCP servers from this plugin available in this session: `sample-mcp`.",
+                ],
+                expected_not_contains: &[],
+            },
+        ];
+
+        for case in cases {
+            let rendered = render_single_injection(
+                case.plugin,
+                case.mcp_tools,
+                case.available_connectors,
+                case.auth_mode,
+            );
+
+            for expected in case.expected_contains {
+                assert!(
+                    rendered.contains(*expected),
+                    "{} should contain {:?}\n{}",
+                    case.name,
+                    expected,
+                    rendered
+                );
+            }
+            for unexpected in case.expected_not_contains {
+                assert!(
+                    !rendered.contains(*unexpected),
+                    "{} should not contain {:?}\n{}",
+                    case.name,
+                    unexpected,
+                    rendered
+                );
+            }
+        }
+    }
 }

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -540,8 +540,12 @@ async fn build_skills_and_plugins(
         &available_connectors,
         &skill_name_counts_lower,
     );
-    let plugin_items =
-        build_plugin_injections(&mentioned_plugins, &mcp_tools, &available_connectors);
+    let plugin_items = build_plugin_injections(
+        &mentioned_plugins,
+        &mcp_tools,
+        &available_connectors,
+        sess.services.auth_manager.auth_mode(),
+    );
     let mut explicitly_enabled_connectors = collect_explicit_app_ids(&user_input);
     explicitly_enabled_connectors.extend(skill_connector_ids);
     let connector_names_by_id = available_connectors

--- a/codex-rs/core/tests/suite/plugins.rs
+++ b/codex-rs/core/tests/suite/plugins.rs
@@ -138,6 +138,25 @@ async fn build_apps_enabled_plugin_test_codex(
         .expect("create new conversation"))
 }
 
+async fn build_api_key_plugin_test_codex(
+    server: &MockServer,
+    codex_home: Arc<TempDir>,
+) -> Result<TestCodex> {
+    let mut builder = test_codex()
+        .with_home(codex_home)
+        .with_auth(CodexAuth::from_api_key("Test API Key"))
+        .with_config(|config| {
+            config
+                .features
+                .enable(Feature::Apps)
+                .expect("test config should allow feature update");
+        });
+    Ok(builder
+        .build(server)
+        .await
+        .expect("create new conversation"))
+}
+
 fn tool_names(body: &serde_json::Value) -> Vec<String> {
     body.get("tools")
         .and_then(serde_json::Value::as_array)
@@ -321,6 +340,64 @@ async fn explicit_plugin_mentions_inject_plugin_guidance() -> Result<()> {
     assert!(
         calendar_description.contains("This tool is part of plugin `sample`."),
         "expected plugin app provenance in tool description: {calendar_description:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicit_plugin_mentions_route_guidance_to_mcp_for_api_key_auth() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+    let server = start_mock_server().await;
+    let mock = mount_sse_once(
+        &server,
+        sse(vec![ev_response_created("resp-1"), ev_completed("resp-1")]),
+    )
+    .await;
+
+    let codex_home = Arc::new(TempDir::new()?);
+    let rmcp_test_server_bin = match stdio_server_bin() {
+        Ok(bin) => bin,
+        Err(err) => {
+            eprintln!("test_stdio_server binary not available, skipping test: {err}");
+            return Ok(());
+        }
+    };
+    write_plugin_skill_plugin(codex_home.as_ref());
+    write_plugin_mcp_plugin(codex_home.as_ref(), &rmcp_test_server_bin);
+    write_plugin_app_plugin(codex_home.as_ref());
+
+    let test_codex = build_api_key_plugin_test_codex(&server, codex_home).await?;
+    let codex = Arc::clone(&test_codex.codex);
+    wait_for_mcp_server(&codex, "sample").await?;
+
+    codex
+        .submit(Op::UserInput {
+            items: vec![codex_protocol::user_input::UserInput::Mention {
+                name: "sample".into(),
+                path: format!("plugin://{SAMPLE_PLUGIN_CONFIG_NAME}"),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: Default::default(),
+        })
+        .await?;
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    let request = mock.single_request();
+    let developer_messages = request.message_input_texts("developer");
+    assert!(
+        developer_messages
+            .iter()
+            .any(|text| text.contains("MCP servers from this plugin")),
+        "expected plugin MCP guidance for API-key auth: {developer_messages:?}"
+    );
+    assert!(
+        developer_messages
+            .iter()
+            .all(|text| !text.contains("Apps from this plugin")),
+        "did not expect plugin app guidance for API-key auth: {developer_messages:?}"
     );
 
     Ok(())


### PR DESCRIPTION
## Context

This is PR2 in the plugin auth-routing stack. The broader goal is to enable plugins for API-key login users while preserving the existing ChatGPT/SIWC connected-app path. Plugins with app definitions authenticate through SIWC today; API-key users need the equivalent plugin capability through MCP/OAuth.

## PRs Goals

The goal of this stack is to add guardrails that ensure Codex includes the appropriate plugin app and MCP surfaces based on the auth type.

- [PR1](https://github.com/openai/codex/pull/27199): filter effective MCP servers by auth/app-route availability.
- [PR2](https://github.com/openai/codex/pull/27206): add explicit-plugin integration coverage for the SWIC and API-key routes.
- [PR3](https://github.com/openai/codex/pull/27217): suppress install-time MCP OAuth when a plugin app route is available.

## Summary

- Add integration coverage for explicit mentions of a dual-surface plugin.
- Verify ChatGPT/SIWC sessions expose the plugin app tool path and do not expose the plugin-owned MCP tool.
- Verify API-key sessions expose the plugin-owned MCP tool path and do not expose the plugin app tool.
- Keep this PR test-focused so the routing behavior from PR1 is covered without adding another production filtering layer.

## Validation

```bash
git diff --check
cargo test -p codex-core --test all explicit_plugin_mentions_use_
```

Both pass locally.
