### PR TITLE
[codex] Skip plugin MCP OAuth when app route is available

### DIFF
--- a/codex-rs/core/src/plugins/mod.rs
+++ b/codex-rs/core/src/plugins/mod.rs
@@ -11,6 +11,7 @@ pub(crate) use codex_plugin::PluginCapabilitySummary;
 pub(crate) use discoverable::list_tool_suggest_discoverable_plugins;
 pub(crate) use injection::build_plugin_injections;
 pub(crate) use render::render_explicit_plugin_instructions;
+pub(crate) use routing::filter_model_visible_tools_for_plugin_routes;
 
 pub(crate) use mentions::build_connector_slug_counts;
 pub(crate) use mentions::build_skill_name_counts;

--- a/codex-rs/core/src/plugins/routing.rs
+++ b/codex-rs/core/src/plugins/routing.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
 
 use codex_app_server_protocol::AuthMode;
+use codex_mcp::CODEX_APPS_MCP_SERVER_NAME;
+use codex_mcp::ToolInfo;
 
 use crate::plugins::PluginCapabilitySummary;
 
@@ -8,6 +10,16 @@ use crate::plugins::PluginCapabilitySummary;
 pub(crate) enum PluginRoute {
     Default,
     McpOnly,
+}
+
+impl PluginRoute {
+    fn allows_app_tools(self) -> bool {
+        matches!(self, Self::Default)
+    }
+
+    fn allows_mcp_tools(self) -> bool {
+        matches!(self, Self::Default | Self::McpOnly)
+    }
 }
 
 pub(crate) fn route_for_plugin(
@@ -23,6 +35,83 @@ pub(crate) fn route_for_plugin(
     }
 
     PluginRoute::Default
+}
+
+pub(crate) fn filter_model_visible_tools_for_plugin_routes(
+    tools: &[ToolInfo],
+    plugins: &[PluginCapabilitySummary],
+    auth_mode: Option<AuthMode>,
+) -> Vec<ToolInfo> {
+    let plugin_routes = plugins
+        .iter()
+        .map(|plugin| (plugin, route_for_plugin(plugin, auth_mode)))
+        .collect::<Vec<_>>();
+
+    tools
+        .iter()
+        .filter(|tool| tool_allowed_for_plugin_routes(tool, &plugin_routes))
+        .cloned()
+        .collect()
+}
+
+fn tool_allowed_for_plugin_routes(
+    tool: &ToolInfo,
+    plugin_routes: &[(&PluginCapabilitySummary, PluginRoute)],
+) -> bool {
+    if tool.server_name == CODEX_APPS_MCP_SERVER_NAME {
+        let Some(connector_id) = tool.connector_id.as_deref() else {
+            return true;
+        };
+        return connector_tool_allowed_for_plugin_routes(connector_id, plugin_routes);
+    }
+
+    mcp_tool_allowed_for_plugin_routes(tool.server_name.as_str(), plugin_routes)
+}
+
+fn connector_tool_allowed_for_plugin_routes(
+    connector_id: &str,
+    plugin_routes: &[(&PluginCapabilitySummary, PluginRoute)],
+) -> bool {
+    let mut owned_by_plugin = false;
+
+    for (plugin, route) in plugin_routes {
+        if !plugin
+            .app_connector_ids
+            .iter()
+            .any(|plugin_connector_id| plugin_connector_id.0 == connector_id)
+        {
+            continue;
+        }
+        owned_by_plugin = true;
+        if route.allows_app_tools() {
+            return true;
+        }
+    }
+
+    !owned_by_plugin
+}
+
+fn mcp_tool_allowed_for_plugin_routes(
+    server_name: &str,
+    plugin_routes: &[(&PluginCapabilitySummary, PluginRoute)],
+) -> bool {
+    let mut owned_by_plugin = false;
+
+    for (plugin, route) in plugin_routes {
+        if !plugin
+            .mcp_server_names
+            .iter()
+            .any(|plugin_server_name| plugin_server_name == server_name)
+        {
+            continue;
+        }
+        owned_by_plugin = true;
+        if route.allows_mcp_tools() {
+            return true;
+        }
+    }
+
+    !owned_by_plugin
 }
 
 fn is_dual_surface_plugin(plugin: &PluginCapabilitySummary) -> bool {

--- a/codex-rs/core/src/plugins/routing_tests.rs
+++ b/codex-rs/core/src/plugins/routing_tests.rs
@@ -1,5 +1,12 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
 use codex_app_server_protocol::AuthMode;
+use codex_mcp::CODEX_APPS_MCP_SERVER_NAME;
+use codex_mcp::ToolInfo;
 use codex_plugin::AppConnectorId;
+use rmcp::model::JsonObject;
+use rmcp::model::Tool;
 
 use super::*;
 
@@ -24,6 +31,59 @@ struct RouteCase {
     plugin: PluginCapabilitySummary,
     auth_mode: Option<AuthMode>,
     expected_plugin_route: PluginRoute,
+}
+
+struct ToolFilterCase {
+    name: &'static str,
+    tools: Vec<ToolInfo>,
+    plugins: Vec<PluginCapabilitySummary>,
+    auth_mode: Option<AuthMode>,
+    expected_callable_names: &'static [&'static str],
+}
+
+fn mcp_tool(server_name: &str, callable_name: &str) -> ToolInfo {
+    ToolInfo {
+        server_name: server_name.to_string(),
+        supports_parallel_tool_calls: false,
+        server_origin: None,
+        callable_name: callable_name.to_string(),
+        callable_namespace: format!("mcp__{server_name}"),
+        namespace_description: None,
+        tool: Tool::new(
+            callable_name.to_string(),
+            format!("Test tool: {callable_name}"),
+            Arc::new(JsonObject::default()),
+        ),
+        connector_id: None,
+        connector_name: None,
+        plugin_display_names: Vec::new(),
+    }
+}
+
+fn app_tool(connector_id: &str, callable_name: &str) -> ToolInfo {
+    ToolInfo {
+        server_name: CODEX_APPS_MCP_SERVER_NAME.to_string(),
+        supports_parallel_tool_calls: false,
+        server_origin: None,
+        callable_name: callable_name.to_string(),
+        callable_namespace: format!("mcp__codex_apps__{connector_id}"),
+        namespace_description: None,
+        tool: Tool::new(
+            callable_name.to_string(),
+            format!("Test tool: {callable_name}"),
+            Arc::new(JsonObject::default()),
+        ),
+        connector_id: Some(connector_id.to_string()),
+        connector_name: Some(connector_id.to_string()),
+        plugin_display_names: Vec::new(),
+    }
+}
+
+fn callable_names(tools: &[ToolInfo]) -> HashSet<&str> {
+    tools
+        .iter()
+        .map(|tool| tool.callable_name.as_str())
+        .collect()
 }
 
 #[test]
@@ -71,6 +131,80 @@ fn routes_plugins_by_auth_mode() {
         assert_eq!(
             route_for_plugin(&case.plugin, case.auth_mode),
             case.expected_plugin_route,
+            "{}",
+            case.name
+        );
+    }
+}
+
+#[test]
+fn filters_model_visible_tools_by_auth_route() {
+    let cases = vec![
+        ToolFilterCase {
+            name: "chatgpt dual-surface plugin exposes app and mcp tools",
+            tools: vec![
+                mcp_tool("sample-mcp", "mcp_search"),
+                app_tool("connector_sample", "app_search"),
+            ],
+            plugins: vec![plugin(&["connector_sample"], &["sample-mcp"])],
+            auth_mode: Some(AuthMode::Chatgpt),
+            expected_callable_names: &["app_search", "mcp_search"],
+        },
+        ToolFilterCase {
+            name: "api-key dual-surface plugin exposes mcp tools",
+            tools: vec![
+                mcp_tool("sample-mcp", "mcp_search"),
+                app_tool("connector_sample", "app_search"),
+            ],
+            plugins: vec![plugin(&["connector_sample"], &["sample-mcp"])],
+            auth_mode: Some(AuthMode::ApiKey),
+            expected_callable_names: &["mcp_search"],
+        },
+        ToolFilterCase {
+            name: "chatgpt dual-surface plugin with only mcp tool exposes mcp tool",
+            tools: vec![mcp_tool("sample-mcp", "mcp_search")],
+            plugins: vec![plugin(&["connector_sample"], &["sample-mcp"])],
+            auth_mode: Some(AuthMode::Chatgpt),
+            expected_callable_names: &["mcp_search"],
+        },
+        ToolFilterCase {
+            name: "single-surface and unowned tools remain visible",
+            tools: vec![
+                mcp_tool("sample-mcp", "mcp_search"),
+                app_tool("connector_sample", "app_search"),
+                mcp_tool("user-server", "user_search"),
+            ],
+            plugins: vec![plugin(&[], &["sample-mcp"])],
+            auth_mode: Some(AuthMode::Chatgpt),
+            expected_callable_names: &["mcp_search", "app_search", "user_search"],
+        },
+        ToolFilterCase {
+            name: "shared mcp server remains visible if any owner routes to mcp",
+            tools: vec![mcp_tool("shared-mcp", "shared_search")],
+            plugins: vec![
+                plugin(&["connector_sample"], &["shared-mcp"]),
+                plugin(&[], &["shared-mcp"]),
+            ],
+            auth_mode: Some(AuthMode::Chatgpt),
+            expected_callable_names: &["shared_search"],
+        },
+    ];
+
+    for case in cases {
+        let filtered = filter_model_visible_tools_for_plugin_routes(
+            &case.tools,
+            &case.plugins,
+            case.auth_mode,
+        );
+        let expected_callable_names = case
+            .expected_callable_names
+            .iter()
+            .copied()
+            .collect::<HashSet<_>>();
+
+        assert_eq!(
+            callable_names(&filtered),
+            expected_callable_names,
             "{}",
             case.name
         );

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -35,6 +35,7 @@ use crate::mentions::collect_explicit_app_ids;
 use crate::mentions::collect_explicit_plugin_mentions;
 use crate::mentions::collect_tool_mentions_from_messages;
 use crate::plugins::build_plugin_injections;
+use crate::plugins::filter_model_visible_tools_for_plugin_routes;
 use crate::responses_retry::ResponsesStreamRequest;
 use crate::responses_retry::handle_retryable_response_stream_error;
 use crate::session::PreviousTurnSettings;
@@ -1159,8 +1160,14 @@ pub(crate) async fn built_tools(
         None
     };
 
-    let mcp_tool_exposure = build_mcp_tool_exposure(
+    let route_filtered_mcp_tools = filter_model_visible_tools_for_plugin_routes(
         &all_mcp_tools,
+        loaded_plugins.capability_summaries(),
+        sess.services.auth_manager.auth_mode(),
+    );
+
+    let mcp_tool_exposure = build_mcp_tool_exposure(
+        &route_filtered_mcp_tools,
         connectors.as_deref(),
         &turn_context.config,
         search_tool_enabled(turn_context),

--- a/codex-rs/core/tests/suite/plugins.rs
+++ b/codex-rs/core/tests/suite/plugins.rs
@@ -404,6 +404,63 @@ async fn explicit_plugin_mentions_route_guidance_to_mcp_for_api_key_auth() -> Re
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicit_plugin_mentions_filter_app_tools_for_api_key_auth() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+    let server = start_mock_server().await;
+    let mock = mount_sse_once(
+        &server,
+        sse(vec![ev_response_created("resp-1"), ev_completed("resp-1")]),
+    )
+    .await;
+
+    let codex_home = Arc::new(TempDir::new()?);
+    let rmcp_test_server_bin = match stdio_server_bin() {
+        Ok(bin) => bin,
+        Err(err) => {
+            eprintln!("test_stdio_server binary not available, skipping test: {err}");
+            return Ok(());
+        }
+    };
+    write_plugin_skill_plugin(codex_home.as_ref());
+    write_plugin_mcp_plugin(codex_home.as_ref(), &rmcp_test_server_bin);
+    write_plugin_app_plugin(codex_home.as_ref());
+
+    let test_codex = build_api_key_plugin_test_codex(&server, codex_home).await?;
+    let codex = Arc::clone(&test_codex.codex);
+    wait_for_mcp_server(&codex, "sample").await?;
+
+    codex
+        .submit(Op::UserInput {
+            items: vec![codex_protocol::user_input::UserInput::Mention {
+                name: "sample".into(),
+                path: format!("plugin://{SAMPLE_PLUGIN_CONFIG_NAME}"),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: Default::default(),
+        })
+        .await?;
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    let request = mock.single_request();
+    assert!(
+        request.tool_by_name("mcp__sample", "echo").is_some(),
+        "expected plugin MCP tool to be model-visible: {:?}",
+        request.body_json()["tools"]
+    );
+    assert!(
+        request
+            .tool_by_name("mcp__codex_apps__google_calendar", "_create_event")
+            .is_none(),
+        "did not expect plugin app tool to be model-visible for API-key auth: {:?}",
+        request.body_json()["tools"]
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn explicit_plugin_mentions_track_plugin_used_analytics() -> Result<()> {
     skip_if_no_network!(Ok(()));
     let server = start_mock_server().await;


### PR DESCRIPTION
## Context

This is PR3 in the plugin auth-routing stack. PR1 handles runtime MCP server filtering, and PR2 covers the model-visible explicit-plugin behavior. This PR closes the install-time gap: installing a dual-surface plugin under ChatGPT/SIWC should not eagerly probe the plugin-owned MCP OAuth flow when the app route is available.

## PRs Goals

The goal of this stack is to add guardrails that ensure Codex includes the appropriate plugin app and MCP surfaces based on the auth type.

- [PR1](https://github.com/openai/codex/pull/27199): filter effective MCP servers by auth/app-route availability.
- [PR2](https://github.com/openai/codex/pull/27206): add explicit-plugin integration coverage for the SWIC and API-key routes.
- [PR3](https://github.com/openai/codex/pull/27217): suppress install-time MCP OAuth when a plugin app route is available.

## Summary

- Add a shared install-time helper that decides whether plugin MCP OAuth should start.
- Skip plugin MCP OAuth probing during local and remote plugin install when the plugin declares apps and the current auth/config can use the app route.
- Preserve existing plugin MCP OAuth behavior for API-key sessions, apps-disabled sessions, and MCP-only plugins.
- Add integration tests for both sides of the matrix:
  - ChatGPT/SIWC dual-surface plugin install does not hit MCP OAuth discovery.
  - API-key dual-surface plugin install still hits MCP OAuth discovery.

## Validation

```bash
git diff --check
cargo test -p codex-app-server --test all plugin_install_
```

Both pass locally.
