### PR TITLE
[codex] Defer thread session initialization

### DIFF
--- a/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
+++ b/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
@@ -130,15 +130,32 @@ pub(super) enum EnsureConversationListenerResult {
     ConnectionClosed,
 }
 
-#[expect(
-    clippy::await_holding_invalid_type,
-    reason = "listener subscription must be serialized against pending unloads"
-)]
 pub(super) async fn ensure_conversation_listener(
     listener_task_context: ListenerTaskContext,
     conversation_id: ThreadId,
     connection_id: ConnectionId,
     raw_events_enabled: bool,
+) -> Result<EnsureConversationListenerResult, JSONRPCErrorError> {
+    ensure_conversation_listener_with_baseline(
+        listener_task_context,
+        conversation_id,
+        connection_id,
+        raw_events_enabled,
+        /*thread_settings_baseline*/ None,
+    )
+    .await
+}
+
+#[expect(
+    clippy::await_holding_invalid_type,
+    reason = "listener subscription must be serialized against pending unloads"
+)]
+pub(super) async fn ensure_conversation_listener_with_baseline(
+    listener_task_context: ListenerTaskContext,
+    conversation_id: ThreadId,
+    connection_id: ConnectionId,
+    raw_events_enabled: bool,
+    thread_settings_baseline: Option<ThreadSettings>,
 ) -> Result<EnsureConversationListenerResult, JSONRPCErrorError> {
     let conversation = match listener_task_context
         .thread_manager
@@ -173,6 +190,7 @@ pub(super) async fn ensure_conversation_listener(
         conversation_id,
         conversation,
         thread_state,
+        thread_settings_baseline,
     )
     .await
     {
@@ -214,6 +232,7 @@ pub(super) async fn ensure_listener_task_running(
     conversation_id: ThreadId,
     conversation: Arc<CodexThread>,
     thread_state: Arc<Mutex<ThreadState>>,
+    thread_settings_baseline: Option<ThreadSettings>,
 ) -> Result<(), JSONRPCErrorError> {
     let (cancel_tx, mut cancel_rx) = oneshot::channel();
     let Some(mut unloading_state) = UnloadingState::new(
@@ -237,8 +256,10 @@ pub(super) async fn ensure_listener_task_running(
             &environments,
         )
         .await;
-    let thread_settings_baseline =
-        thread_settings_from_config_snapshot(&conversation.config_snapshot().await);
+    let thread_settings_baseline = match thread_settings_baseline {
+        Some(thread_settings_baseline) => thread_settings_baseline,
+        None => thread_settings_from_config_snapshot(&conversation.config_snapshot().await),
+    };
     let (mut listener_command_rx, listener_generation) = {
         let mut thread_state = thread_state.lock().await;
         if thread_state.listener_matches(&conversation) {

--- a/codex-rs/app-server/src/request_processors/thread_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor.rs
@@ -795,6 +795,7 @@ impl ThreadRequestProcessor {
             conversation_id,
             conversation,
             thread_state,
+            /*thread_settings_baseline*/ None,
         )
         .await
     }
@@ -1029,8 +1030,8 @@ impl ThreadRequestProcessor {
                     /*fallback_cwd*/ None,
                 )
                 .instrument(tracing::info_span!(
-                    "app_server.thread_start.reload_config_after_trust",
-                    otel.name = "app_server.thread_start.reload_config_after_trust",
+                    "app_server.thread_start.reload_config",
+                    otel.name = "app_server.thread_start.reload_config",
                 ))
                 .await
                 .map_err(|err| config_load_error(&err))?;
@@ -1122,11 +1123,12 @@ impl ThreadRequestProcessor {
 
         // Auto-attach a thread listener when starting a thread.
         log_listener_attach_result(
-            super::thread_lifecycle::ensure_conversation_listener(
+            super::thread_lifecycle::ensure_conversation_listener_with_baseline(
                 listener_task_context.clone(),
                 thread_id,
                 request_id.connection_id,
                 experimental_raw_events,
+                Some(thread_settings_from_config_snapshot(&config_snapshot)),
             )
             .instrument(tracing::info_span!(
                 "app_server.thread_start.attach_listener",

--- a/codex-rs/core/src/codex_thread.rs
+++ b/codex-rs/core/src/codex_thread.rs
@@ -221,6 +221,10 @@ impl CodexThread {
 
     #[doc(hidden)]
     pub async fn ensure_rollout_materialized(&self) {
+        self.codex
+            .session
+            .ensure_deferred_initialization_ready()
+            .await;
         self.codex.session.ensure_rollout_materialized().await;
     }
 

--- a/codex-rs/core/src/prompt_debug.rs
+++ b/codex-rs/core/src/prompt_debug.rs
@@ -73,7 +73,7 @@ pub(crate) async fn build_prompt_input_from_session(
     sess: &Session,
     input: Vec<UserInput>,
 ) -> CodexResult<Vec<ResponseItem>> {
-    let turn_context = sess.new_default_turn().await;
+    let turn_context = sess.new_inference_turn().await;
     sess.record_context_updates_and_set_reference_context_item(turn_context.as_ref())
         .await;
 

--- a/codex-rs/core/src/session/config_lock.rs
+++ b/codex-rs/core/src/session/config_lock.rs
@@ -16,6 +16,7 @@ use crate::config_lock::config_lockfile;
 use crate::config_lock::toml_round_trip;
 use crate::config_lock::validate_config_lock_replay;
 
+use super::Session;
 use super::SessionConfiguration;
 
 pub(crate) async fn validate_config_lock_if_configured(
@@ -67,6 +68,35 @@ pub(crate) async fn export_config_lock_if_configured(
         .with_context(|| format!("failed to write config lock to {}", path.display()))?;
 
     Ok(())
+}
+
+impl Session {
+    pub(super) async fn spawn_config_lock_export(
+        &self,
+        session_configuration: SessionConfiguration,
+    ) {
+        if session_configuration
+            .original_config_do_not_use
+            .config_lock_export_dir
+            .is_none()
+        {
+            return;
+        }
+        let conversation_id = self.thread_id;
+        let task = tokio::spawn(async move {
+            export_config_lock_if_configured(&session_configuration, conversation_id).await
+        });
+        *self.config_lock_export_task.lock().await = Some(task);
+    }
+
+    pub(super) async fn wait_for_config_lock_export(&self) -> anyhow::Result<()> {
+        let task = self.config_lock_export_task.lock().await.take();
+        if let Some(task) = task {
+            task.await
+                .context("config lock export task failed to join")??;
+        }
+        Ok(())
+    }
 }
 
 impl SessionConfiguration {

--- a/codex-rs/core/src/session/deferred_init.rs
+++ b/codex-rs/core/src/session/deferred_init.rs
@@ -89,7 +89,7 @@ impl Session {
             .await;
     }
 
-    pub(super) async fn ensure_deferred_initialization_ready(&self) {
+    pub(crate) async fn ensure_deferred_initialization_ready(&self) {
         self.deferred_initialization_ready
             .get_or_init(|| async {
                 self.ensure_model_catalog_ready().await;

--- a/codex-rs/core/src/session/deferred_init.rs
+++ b/codex-rs/core/src/session/deferred_init.rs
@@ -1,0 +1,144 @@
+use super::*;
+use crate::session::session::BaseInstructionsOrigin;
+use std::sync::atomic::Ordering;
+
+impl Session {
+    pub(crate) async fn ensure_model_catalog_ready(&self) {
+        if !self.model_catalog_refresh_enabled {
+            return;
+        }
+
+        self.model_catalog_ready
+            .get_or_init(|| async {
+                self.services
+                    .models_manager
+                    .list_models(codex_models_manager::manager::RefreshStrategy::OnlineIfUncached)
+                    .await;
+
+                let refreshed_default_model = self.initial_default_model.as_ref().map(|_| {
+                    self.services
+                        .models_manager
+                        .get_default_model_from_current_catalog(/*configured_model*/ None)
+                });
+
+                let model_changed = {
+                    let mut state = self.state.lock().await;
+                    if let (Some(initial_model), Some(refreshed_model)) =
+                        (&self.initial_default_model, refreshed_default_model)
+                        && state.session_configuration.collaboration_mode.model() == initial_model
+                        && refreshed_model != *initial_model
+                    {
+                        state
+                            .session_configuration
+                            .collaboration_mode
+                            .settings
+                            .model = refreshed_model;
+                        true
+                    } else {
+                        false
+                    }
+                };
+                if model_changed {
+                    self.send_event_raw(Event {
+                        id: INITIAL_SUBMIT_ID.to_owned(),
+                        msg: super::handlers::thread_settings_applied_event(self).await,
+                    })
+                    .await;
+                }
+                loop {
+                    let (model, personality, config) = {
+                        let state = self.state.lock().await;
+                        (
+                            state
+                                .session_configuration
+                                .collaboration_mode
+                                .model()
+                                .to_string(),
+                            state.session_configuration.personality,
+                            Self::build_effective_session_config(&state.session_configuration),
+                        )
+                    };
+                    let model_info = self
+                        .services
+                        .models_manager
+                        .get_model_info(&model, &config.to_models_manager_config())
+                        .await;
+                    let base_instructions = model_info.get_model_instructions(personality);
+                    let mut state = self.state.lock().await;
+                    if state.session_configuration.collaboration_mode.model() != model
+                        || state.session_configuration.personality != personality
+                    {
+                        continue;
+                    }
+                    state.session_configuration.service_tier = crate::session::get_service_tier(
+                        state.session_configuration.service_tier.clone(),
+                        config.features.enabled(codex_features::Feature::FastMode),
+                        &model_info,
+                    );
+                    if matches!(
+                        self.base_instructions_origin,
+                        BaseInstructionsOrigin::ModelDerived
+                    ) {
+                        state.session_configuration.base_instructions = base_instructions;
+                    }
+                    break;
+                }
+                let session_configuration = self.state.lock().await.session_configuration.clone();
+                self.spawn_config_lock_export(session_configuration).await;
+            })
+            .await;
+    }
+
+    pub(super) async fn ensure_deferred_initialization_ready(&self) {
+        self.deferred_initialization_ready
+            .get_or_init(|| async {
+                self.ensure_model_catalog_ready().await;
+                let initial_history = self.initial_history.lock().await.take();
+                if let Some(initial_history) = initial_history {
+                    self.record_initial_history(initial_history).await;
+                }
+            })
+            .await;
+    }
+
+    #[expect(
+        clippy::await_holding_invalid_type,
+        reason = "the prewarm gate must stay locked until the handle is installed"
+    )]
+    pub(crate) async fn finish_deferred_initialization(self: &Arc<Self>) {
+        self.ensure_deferred_initialization_ready().await;
+        let mut prewarm_pending = self.model_catalog_prewarm_pending.lock().await;
+        if self.shutdown_requested.load(Ordering::SeqCst) || !*prewarm_pending {
+            return;
+        }
+        *prewarm_pending = false;
+        let base_instructions = {
+            let state = self.state.lock().await;
+            state.session_configuration.base_instructions.clone()
+        };
+        self.schedule_startup_prewarm(base_instructions).await;
+        drop(prewarm_pending);
+    }
+
+    pub(super) async fn claim_model_catalog_prewarm(&self) {
+        *self.model_catalog_prewarm_pending.lock().await = false;
+    }
+
+    pub(crate) async fn shutdown_deferred_initialization(&self) -> anyhow::Result<()> {
+        self.shutdown_requested.store(true, Ordering::SeqCst);
+        *self.model_catalog_prewarm_pending.lock().await = false;
+        let deferred_initialization_task = self.deferred_initialization_task.lock().await.take();
+        let task_result = match deferred_initialization_task {
+            Some(task) => task
+                .await
+                .map_err(|err| anyhow::anyhow!("deferred initialization task failed: {err}")),
+            None => Ok(()),
+        };
+        if let Some(prewarm) = self.take_session_startup_prewarm().await {
+            prewarm.abort().await;
+        }
+        let export_result = self.wait_for_config_lock_export().await;
+        task_result?;
+        export_result
+    }
+}

--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -168,7 +168,7 @@ async fn thread_settings_update(
     }
 }
 
-async fn thread_settings_applied_event(sess: &Session) -> EventMsg {
+pub(super) async fn thread_settings_applied_event(sess: &Session) -> EventMsg {
     let snapshot = {
         let state = sess.state.lock().await;
         state.session_configuration.thread_config_snapshot()
@@ -484,7 +484,7 @@ pub async fn reload_user_config(sess: &Arc<Session>) {
 }
 
 pub async fn compact(sess: &Arc<Session>, sub_id: String) {
-    let turn_context = sess.new_default_turn_with_sub_id(sub_id).await;
+    let turn_context = sess.new_inference_turn_with_sub_id(sub_id).await;
 
     sess.spawn_task(Arc::clone(&turn_context), Vec::new(), CompactTask)
         .await;
@@ -622,8 +622,9 @@ pub async fn set_thread_memory_mode(sess: &Arc<Session>, sub_id: String, mode: T
     }
 }
 
-async fn shutdown_session_runtime(sess: &Arc<Session>) {
+async fn shutdown_session_runtime(sess: &Arc<Session>) -> Option<anyhow::Error> {
     sess.abort_all_tasks(TurnAbortReason::Interrupted).await;
+    let deferred_work_error = sess.shutdown_deferred_initialization().await.err();
     let _ = sess.conversation.shutdown().await;
     sess.services
         .unified_exec_manager
@@ -638,6 +639,7 @@ async fn shutdown_session_runtime(sess: &Arc<Session>) {
     };
     mcp_shutdown.await;
     sess.guardian_review_session.shutdown().await;
+    deferred_work_error
 }
 
 async fn emit_thread_stop_lifecycle(sess: &Session) {
@@ -652,7 +654,7 @@ async fn emit_thread_stop_lifecycle(sess: &Session) {
 }
 
 pub async fn shutdown(sess: &Arc<Session>, sub_id: String) -> bool {
-    shutdown_session_runtime(sess).await;
+    let deferred_work_error = shutdown_session_runtime(sess).await;
     info!("Shutting down Codex instance");
     let history = sess.clone_history().await;
     let turn_count = history
@@ -684,6 +686,18 @@ pub async fn shutdown(sess: &Arc<Session>, sub_id: String) -> bool {
         sess.send_event_raw(event).await;
     }
 
+    if let Some(err) = deferred_work_error {
+        warn!("failed to complete deferred session work during shutdown: {err:#}");
+        sess.send_event_raw(Event {
+            id: sub_id.clone(),
+            msg: EventMsg::Error(ErrorEvent {
+                message: format!("Failed to export config lock: {err:#}"),
+                codex_error_info: Some(CodexErrorInfo::Other),
+            }),
+        })
+        .await;
+    }
+
     let event = Event {
         id: sub_id,
         msg: EventMsg::ShutdownComplete,
@@ -704,7 +718,7 @@ pub async fn review(
     sub_id: String,
     review_request: ReviewRequest,
 ) {
-    let turn_context = sess.new_default_turn_with_sub_id(sub_id.clone()).await;
+    let turn_context = sess.new_inference_turn_with_sub_id(sub_id.clone()).await;
     sess.maybe_emit_unknown_model_warning_for_turn(turn_context.as_ref())
         .await;
     sess.refresh_mcp_servers_if_requested(&turn_context, Some(sess.mcp_elicitation_reviewer()))
@@ -879,7 +893,9 @@ pub(super) async fn submission_loop(
     // If the submission loop exits because the channel closed without an
     // explicit shutdown op, still run session teardown.
     if !shutdown_received {
-        shutdown_session_runtime(&sess).await;
+        if let Some(err) = shutdown_session_runtime(&sess).await {
+            warn!("failed to complete deferred session work during teardown: {err:#}");
+        }
         emit_thread_stop_lifecycle(sess.as_ref()).await;
     }
     debug!("Agent loop exited");

--- a/codex-rs/core/src/session/inject.rs
+++ b/codex-rs/core/src/session/inject.rs
@@ -84,7 +84,7 @@ impl Session {
         }
 
         let turn_context = self
-            .new_default_turn_with_sub_id(uuid::Uuid::new_v4().to_string())
+            .new_inference_turn_with_sub_id(uuid::Uuid::new_v4().to_string())
             .await;
         if turn_context.collaboration_mode.mode == ModeKind::Plan {
             self.clear_reserved_idle_turn(&turn_state).await;

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -196,6 +196,7 @@ use codex_protocol::error::Result as CodexResult;
 use codex_protocol::exec_output::StreamOutput;
 
 mod config_lock;
+mod deferred_init;
 mod handlers;
 mod inject;
 mod input_queue;
@@ -207,7 +208,6 @@ mod rollout_reconstruction;
 pub(crate) mod session;
 pub(crate) mod turn;
 pub(crate) mod turn_context;
-use self::config_lock::export_config_lock_if_configured;
 use self::config_lock::validate_config_lock_if_configured;
 #[cfg(test)]
 use self::handlers::submission_dispatch_span;
@@ -533,22 +533,7 @@ impl Codex {
         };
 
         let config = Arc::new(config);
-        let refresh_strategy = if session_source.is_non_root_agent() {
-            codex_models_manager::manager::RefreshStrategy::Offline
-        } else {
-            codex_models_manager::manager::RefreshStrategy::OnlineIfUncached
-        };
-        if config.model.is_none()
-            || !matches!(
-                refresh_strategy,
-                codex_models_manager::manager::RefreshStrategy::Offline
-            )
-        {
-            let _ = models_manager.list_models(refresh_strategy).await;
-        }
-        let model = models_manager
-            .get_default_model(&config.model, refresh_strategy)
-            .await;
+        let model = models_manager.get_default_model_from_current_catalog(config.model.as_deref());
 
         // Resolve base instructions for the session. Priority order:
         // 1. config.base_instructions override
@@ -590,11 +575,9 @@ impl Codex {
                 developer_instructions: None,
             },
         };
-        let service_tier = get_service_tier(
-            config.service_tier.clone(),
-            config.features.enabled(Feature::FastMode),
-            &model_info,
-        );
+        // Preserve the requested tier until the final model catalog is available. Per-turn
+        // construction filters it against the resolved model before sending a request.
+        let service_tier = config.service_tier.clone();
         let session_configuration = SessionConfiguration {
             provider: config.model_provider.clone(),
             collaboration_mode,
@@ -644,7 +627,7 @@ impl Codex {
             tx_event.clone(),
             agent_status_tx.clone(),
             conversation_history,
-            session_source_clone,
+            session_source_clone.clone(),
             skills_manager,
             plugins_manager,
             mcp_manager.clone(),
@@ -662,6 +645,21 @@ impl Codex {
             error!("Failed to create session: {e:#}");
             map_session_init_error(&e, &config.codex_home)
         })?;
+        if !session_source_clone.is_non_root_agent() {
+            let session_for_deferred_init = Arc::clone(&session);
+            let deferred_initialization_task = tokio::spawn(
+                async move {
+                    session_for_deferred_init
+                        .finish_deferred_initialization()
+                        .await;
+                }
+                .instrument(info_span!(
+                    "session_init.deferred_initialization",
+                    otel.name = "session_init.deferred_initialization",
+                )),
+            );
+            *session.deferred_initialization_task.lock().await = Some(deferred_initialization_task);
+        }
         let thread_id = session.thread_id;
 
         // This task will run until Op::Shutdown is received.

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -1313,7 +1313,7 @@ impl Session {
             turn_context.config.model_auto_compact_token_limit_scope,
             AutoCompactTokenLimitScope::BodyAfterPrefix
         ) {
-            let history = self.clone_history().await;
+            let history = self.state.lock().await.clone_history();
             let base_instructions = self.get_base_instructions().await;
             history.estimate_token_count_with_base_instructions(&base_instructions)
         } else {
@@ -2994,6 +2994,7 @@ impl Session {
     }
 
     pub(crate) async fn clone_history(&self) -> ContextManager {
+        self.ensure_deferred_initialization_ready().await;
         let state = self.state.lock().await;
         state.clone_history()
     }

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -15,7 +15,10 @@ use codex_protocol::protocol::ThreadSource;
 use codex_protocol::protocol::TurnEnvironmentSelection;
 use codex_protocol::protocol::TurnEnvironmentSelections;
 use std::sync::OnceLock;
+use std::sync::atomic::AtomicBool;
+use tokio::sync::OnceCell;
 use tokio::sync::Semaphore;
+use tokio::task::JoinHandle;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum BaseInstructionsOrigin {
@@ -42,6 +45,16 @@ pub(crate) struct Session {
     pub(super) multi_agent_version: OnceLock<MultiAgentVersion>,
     pub(super) pending_mcp_server_refresh_config: Mutex<Option<McpServerRefreshConfig>>,
     pub(crate) late_mcp_tools: LateToolRegistry,
+    pub(super) model_catalog_ready: OnceCell<()>,
+    pub(super) deferred_initialization_ready: OnceCell<()>,
+    pub(super) initial_history: Mutex<Option<InitialHistory>>,
+    pub(super) model_catalog_refresh_enabled: bool,
+    pub(super) initial_default_model: Option<String>,
+    pub(super) model_catalog_prewarm_pending: Mutex<bool>,
+    pub(super) deferred_initialization_task: Mutex<Option<JoinHandle<()>>>,
+    pub(super) config_lock_export_task: Mutex<Option<JoinHandle<anyhow::Result<()>>>>,
+    pub(super) shutdown_requested: AtomicBool,
+    pub(super) base_instructions_origin: BaseInstructionsOrigin,
     pub(crate) conversation: Arc<RealtimeConversationManager>,
     pub(crate) active_turn: Mutex<Option<ActiveTurn>>,
     pub(crate) input_queue: InputQueue,
@@ -519,6 +532,12 @@ impl Session {
         session_configuration.parent_thread_id = parent_thread_id;
         let multi_agent_version = multi_agent_version.map(OnceLock::from).unwrap_or_default();
         let initial_multi_agent_version = multi_agent_version.get().copied();
+        let model_catalog_refresh_enabled = !session_source.is_non_root_agent();
+        let initial_default_model = config
+            .model
+            .is_none()
+            .then(|| session_configuration.collaboration_mode.model().to_string());
+        let model_catalog_prewarm_pending = model_catalog_refresh_enabled;
 
         let thread_id = match &initial_history {
             InitialHistory::New | InitialHistory::Cleared | InitialHistory::Forked(_) => {
@@ -653,12 +672,7 @@ impl Session {
         ));
 
         // Join all independent futures.
-        let (
-            thread_persistence_result,
-            state_db_ctx,
-            (auth, mcp_servers),
-            plugin_skill_errors,
-        ) = tokio::join!(
+        let (thread_persistence_result, state_db_ctx, (auth, mcp_servers), plugin_skill_errors) = tokio::join!(
             thread_persistence_fut,
             state_db_fut,
             auth_and_mcp_fut,
@@ -875,7 +889,6 @@ impl Session {
                     .await;
             session_configuration.thread_name = thread_name.clone();
             validate_config_lock_if_configured(&session_configuration).await?;
-            export_config_lock_if_configured(&session_configuration, thread_id).await?;
             let state = SessionState::new(session_configuration.clone());
             let managed_network_requirements_configured = config
                 .config_layer_stack
@@ -1071,6 +1084,16 @@ impl Session {
                 multi_agent_version,
                 pending_mcp_server_refresh_config: Mutex::new(None),
                 late_mcp_tools: LateToolRegistry::default(),
+                model_catalog_ready: OnceCell::new(),
+                deferred_initialization_ready: OnceCell::new(),
+                initial_history: Mutex::new(Some(initial_history.clone())),
+                model_catalog_refresh_enabled,
+                initial_default_model,
+                model_catalog_prewarm_pending: Mutex::new(model_catalog_prewarm_pending),
+                deferred_initialization_task: Mutex::new(None),
+                config_lock_export_task: Mutex::new(None),
+                shutdown_requested: AtomicBool::new(false),
+                base_instructions_origin,
                 conversation: Arc::new(RealtimeConversationManager::new()),
                 active_turn: Mutex::new(None),
                 input_queue: InputQueue::new(),
@@ -1078,6 +1101,10 @@ impl Session {
                 services,
                 next_internal_sub_id: AtomicU64::new(0),
             });
+            if !model_catalog_refresh_enabled {
+                sess.spawn_config_lock_export(session_configuration.clone())
+                    .await;
+            }
             if let Some(network_policy_decider_session) = network_policy_decider_session {
                 let mut guard = network_policy_decider_session.write().await;
                 *guard = Arc::downgrade(&sess);
@@ -1224,8 +1251,10 @@ impl Session {
                     anyhow::bail!("required MCP servers failed to initialize: {details}");
                 }
             }
-            sess.schedule_startup_prewarm(session_configuration.base_instructions.clone())
-                .await;
+            if !model_catalog_prewarm_pending {
+                sess.schedule_startup_prewarm(session_configuration.base_instructions.clone())
+                    .await;
+            }
             let session_start_source = match &initial_history {
                 InitialHistory::Resumed(_) => codex_hooks::SessionStartSource::Resume,
                 InitialHistory::New | InitialHistory::Forked(_) => {
@@ -1234,8 +1263,6 @@ impl Session {
                 InitialHistory::Cleared => codex_hooks::SessionStartSource::Clear,
             };
 
-            // record_initial_history can emit events. We record only after the SessionConfiguredEvent is emitted.
-            Box::pin(sess.record_initial_history(initial_history)).await;
             {
                 let mut state = sess.state.lock().await;
                 state.queue_pending_session_start_source(session_start_source);

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -23,6 +23,7 @@ use codex_config::Sourced;
 use codex_config::loader::project_trust_key;
 use codex_config::types::ToolSuggestDisabledTool;
 use core_test_support::test_codex::local_selections;
+use std::sync::atomic::AtomicBool;
 
 use codex_features::Feature;
 use codex_login::CodexAuth;
@@ -4924,6 +4925,16 @@ pub(crate) async fn make_session_and_context() -> (Session, TurnContext) {
         multi_agent_version: OnceLock::from(config.multi_agent_version_from_features()),
         pending_mcp_server_refresh_config: Mutex::new(None),
         late_mcp_tools: crate::tools::registry::LateToolRegistry::default(),
+        model_catalog_ready: tokio::sync::OnceCell::new(),
+        deferred_initialization_ready: tokio::sync::OnceCell::new(),
+        initial_history: Mutex::new(None),
+        model_catalog_refresh_enabled: false,
+        initial_default_model: None,
+        model_catalog_prewarm_pending: Mutex::new(false),
+        deferred_initialization_task: Mutex::new(None),
+        config_lock_export_task: Mutex::new(None),
+        shutdown_requested: AtomicBool::new(false),
+        base_instructions_origin: BaseInstructionsOrigin::Fixed,
         conversation: Arc::new(RealtimeConversationManager::new()),
         active_turn: Mutex::new(None),
         input_queue: super::input_queue::InputQueue::new(),
@@ -6991,6 +7002,16 @@ where
         multi_agent_version: OnceLock::from(config.multi_agent_version_from_features()),
         pending_mcp_server_refresh_config: Mutex::new(None),
         late_mcp_tools: crate::tools::registry::LateToolRegistry::default(),
+        model_catalog_ready: tokio::sync::OnceCell::new(),
+        deferred_initialization_ready: tokio::sync::OnceCell::new(),
+        initial_history: Mutex::new(None),
+        model_catalog_refresh_enabled: false,
+        initial_default_model: None,
+        model_catalog_prewarm_pending: Mutex::new(false),
+        deferred_initialization_task: Mutex::new(None),
+        config_lock_export_task: Mutex::new(None),
+        shutdown_requested: AtomicBool::new(false),
+        base_instructions_origin: BaseInstructionsOrigin::Fixed,
         conversation: Arc::new(RealtimeConversationManager::new()),
         active_turn: Mutex::new(None),
         input_queue: super::input_queue::InputQueue::new(),

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -582,6 +582,8 @@ impl Session {
         sub_id: String,
         updates: SessionSettingsUpdate,
     ) -> CodexResult<Arc<TurnContext>> {
+        self.claim_model_catalog_prewarm().await;
+        self.ensure_deferred_initialization_ready().await;
         let notify_config_contributors = !self.services.extensions.config_contributors().is_empty();
         let update_result: CodexResult<_> = {
             let mut state = self.state.lock().await;
@@ -826,6 +828,17 @@ impl Session {
     pub(crate) async fn new_default_turn(&self) -> Arc<TurnContext> {
         self.new_default_turn_with_sub_id(self.next_internal_sub_id())
             .await
+    }
+
+    pub(crate) async fn new_inference_turn(&self) -> Arc<TurnContext> {
+        self.new_inference_turn_with_sub_id(self.next_internal_sub_id())
+            .await
+    }
+
+    pub(crate) async fn new_inference_turn_with_sub_id(&self, sub_id: String) -> Arc<TurnContext> {
+        self.claim_model_catalog_prewarm().await;
+        self.ensure_deferred_initialization_ready().await;
+        self.new_default_turn_with_sub_id(sub_id).await
     }
 
     pub(crate) async fn new_default_turn_with_sub_id(&self, sub_id: String) -> Arc<TurnContext> {

--- a/codex-rs/core/src/session_startup_prewarm.rs
+++ b/codex-rs/core/src/session_startup_prewarm.rs
@@ -46,6 +46,11 @@ impl SessionStartupPrewarmHandle {
         }
     }
 
+    pub(crate) async fn abort(self) {
+        self.task.abort();
+        let _ = self.task.await;
+    }
+
     async fn resolve(
         self,
         session_telemetry: &SessionTelemetry,

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -472,7 +472,7 @@ impl Session {
             *active_turn = Some(ActiveTurn::default());
         }
 
-        let turn_context = self.new_default_turn_with_sub_id(sub_id).await;
+        let turn_context = self.new_inference_turn_with_sub_id(sub_id).await;
         self.maybe_emit_unknown_model_warning_for_turn(turn_context.as_ref())
             .await;
         self.start_task(turn_context, Vec::new(), RegularTask::new())

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -919,7 +919,7 @@ impl ThreadManager {
             self.state.environment_manager.as_ref(),
             &config.cwd,
         );
-        Box::pin(self.state.spawn_thread(
+        let new_thread = Box::pin(self.state.spawn_thread(
             config,
             history,
             Arc::clone(&self.state.auth_manager),
@@ -933,7 +933,10 @@ impl ThreadManager {
             environments,
             /*user_shell_override*/ None,
         ))
-        .await
+        .await?;
+        new_thread.thread.ensure_rollout_materialized().await;
+        new_thread.thread.flush_rollout().await?;
+        Ok(new_thread)
     }
 
     pub(crate) fn agent_control(&self) -> AgentControl {

--- a/codex-rs/core/tests/common/streaming_sse.rs
+++ b/codex-rs/core/tests/common/streaming_sse.rs
@@ -1,5 +1,7 @@
 use std::collections::VecDeque;
 use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
@@ -22,6 +24,8 @@ pub struct StreamingSseServer {
     uri: String,
     requests: Arc<TokioMutex<Vec<Vec<u8>>>>,
     request_notify: Arc<Notify>,
+    model_request_count: Arc<AtomicUsize>,
+    model_request_notify: Arc<Notify>,
     shutdown: oneshot::Sender<()>,
     task: tokio::task::JoinHandle<()>,
 }
@@ -44,6 +48,15 @@ impl StreamingSseServer {
         }
     }
 
+    pub async fn wait_for_model_request_count(&self, count: usize) {
+        loop {
+            if self.model_request_count.load(Ordering::Acquire) >= count {
+                return;
+            }
+            self.model_request_notify.notified().await;
+        }
+    }
+
     pub async fn shutdown(self) {
         let _ = self.shutdown.send(());
         let _ = self.task.await;
@@ -58,6 +71,37 @@ impl StreamingSseServer {
 /// response stream finishes sending its final chunk.
 pub async fn start_streaming_sse_server(
     responses: Vec<Vec<StreamingSseChunk>>,
+) -> (StreamingSseServer, Vec<oneshot::Receiver<i64>>) {
+    let models_response = serde_json::json!({
+        "data": [],
+        "object": "list"
+    })
+    .to_string();
+    start_streaming_sse_server_inner(responses, models_response, /*models_gate*/ None).await
+}
+
+pub async fn start_streaming_sse_server_with_models_gate(
+    responses: Vec<Vec<StreamingSseChunk>>,
+    models_response: codex_protocol::openai_models::ModelsResponse,
+) -> (
+    StreamingSseServer,
+    Vec<oneshot::Receiver<i64>>,
+    oneshot::Sender<()>,
+) {
+    let (models_gate_tx, models_gate_rx) = oneshot::channel();
+    let (server, completions) = start_streaming_sse_server_inner(
+        responses,
+        serde_json::to_string(&models_response).expect("serialize models response"),
+        Some(models_gate_rx),
+    )
+    .await;
+    (server, completions, models_gate_tx)
+}
+
+async fn start_streaming_sse_server_inner(
+    responses: Vec<Vec<StreamingSseChunk>>,
+    models_response: String,
+    models_gate: Option<oneshot::Receiver<()>>,
 ) -> (StreamingSseServer, Vec<oneshot::Receiver<i64>>) {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
@@ -76,11 +120,17 @@ pub async fn start_streaming_sse_server(
     let state = Arc::new(TokioMutex::new(StreamingSseState {
         responses: VecDeque::from(responses),
         completions: VecDeque::from(completion_senders),
+        models_response,
+        models_gate,
     }));
     let requests = Arc::new(TokioMutex::new(Vec::new()));
     let request_notify = Arc::new(Notify::new());
     let requests_for_task = Arc::clone(&requests);
     let request_notify_for_task = Arc::clone(&request_notify);
+    let model_request_count = Arc::new(AtomicUsize::new(0));
+    let model_request_notify = Arc::new(Notify::new());
+    let model_request_count_for_task = Arc::clone(&model_request_count);
+    let model_request_notify_for_task = Arc::clone(&model_request_notify);
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
 
     let task = tokio::spawn(async move {
@@ -92,6 +142,8 @@ pub async fn start_streaming_sse_server(
                     let state = Arc::clone(&state);
                     let requests = Arc::clone(&requests_for_task);
                     let request_notify = Arc::clone(&request_notify_for_task);
+                    let model_request_count = Arc::clone(&model_request_count_for_task);
+                    let model_request_notify = Arc::clone(&model_request_notify_for_task);
                     tokio::spawn(async move {
                         let (request, body_prefix) = read_http_request(&mut stream).await;
                         let Some((method, path)) = parse_request_line(&request) else {
@@ -99,7 +151,7 @@ pub async fn start_streaming_sse_server(
                             return;
                         };
 
-                        if method == "GET" && path == "/v1/models" {
+                        if method == "GET" && path.starts_with("/v1/models") {
                             if read_request_body(&mut stream, &request, body_prefix)
                                 .await
                                 .is_err()
@@ -107,11 +159,15 @@ pub async fn start_streaming_sse_server(
                                 let _ = write_http_response(&mut stream, /*status*/ 400, "bad request", "text/plain").await;
                                 return;
                             }
-                            let body = serde_json::json!({
-                                "data": [],
-                                "object": "list"
-                            })
-                            .to_string();
+                            model_request_count.fetch_add(1, Ordering::Release);
+                            model_request_notify.notify_waiters();
+                            let (body, gate) = {
+                                let mut state = state.lock().await;
+                                (state.models_response.clone(), state.models_gate.take())
+                            };
+                            if let Some(gate) = gate {
+                                let _ = gate.await;
+                            }
                             let _ = write_http_response(&mut stream, /*status*/ 200, &body, "application/json").await;
                             return;
                         }
@@ -165,6 +221,8 @@ pub async fn start_streaming_sse_server(
             uri,
             requests,
             request_notify,
+            model_request_count,
+            model_request_notify,
             shutdown: shutdown_tx,
             task,
         },
@@ -175,6 +233,8 @@ pub async fn start_streaming_sse_server(
 struct StreamingSseState {
     responses: VecDeque<Vec<StreamingSseChunk>>,
     completions: VecDeque<oneshot::Sender<i64>>,
+    models_response: String,
+    models_gate: Option<oneshot::Receiver<()>>,
 }
 
 async fn take_next_stream(

--- a/codex-rs/core/tests/suite/model_runtime_selectors.rs
+++ b/codex-rs/core/tests/suite/model_runtime_selectors.rs
@@ -257,7 +257,7 @@ async fn remote_multi_agent_selector_uses_model_selected_before_first_turn() -> 
             models_mock.requests().len(),
             test.codex.multi_agent_version(),
         ),
-        (1, None)
+        (0, None)
     );
 
     submit_thread_settings(

--- a/codex-rs/core/tests/suite/models_etag_responses.rs
+++ b/codex-rs/core/tests/suite/models_etag_responses.rs
@@ -38,7 +38,7 @@ async fn refresh_models_on_models_etag_mismatch_and_avoid_duplicate_models_fetch
 
     let server = MockServer::start().await;
 
-    // 1) On spawn, Codex fetches /models and stores the ETag.
+    // 1) The first inference fetches /models and stores the ETag without blocking spawn.
     let spawn_models_mock = responses::mount_models_once_with_etag(
         &server,
         ModelsResponse { models: Vec::new() },
@@ -68,8 +68,7 @@ async fn refresh_models_on_models_etag_mismatch_and_avoid_duplicate_models_fetch
     let (sandbox_policy, permission_profile) =
         turn_permission_fields(PermissionProfile::Disabled, cwd_path.as_path());
 
-    assert_eq!(spawn_models_mock.requests().len(), 1);
-    assert_eq!(spawn_models_mock.single_request_path(), "/v1/models");
+    assert_eq!(spawn_models_mock.requests().len(), 0);
 
     // 2) If the server sends a different X-Models-Etag on /responses, Codex refreshes /models.
     let refresh_models_mock = responses::mount_models_once_with_etag(
@@ -138,6 +137,9 @@ async fn refresh_models_on_models_etag_mismatch_and_avoid_duplicate_models_fetch
         Duration::from_secs(30),
     )
     .await;
+
+    assert_eq!(spawn_models_mock.requests().len(), 1);
+    assert_eq!(spawn_models_mock.single_request_path(), "/v1/models");
 
     // Assert /models was refreshed exactly once after the X-Models-Etag mismatch.
     assert_eq!(refresh_models_mock.requests().len(), 1);

--- a/codex-rs/core/tests/suite/remote_models.rs
+++ b/codex-rs/core/tests/suite/remote_models.rs
@@ -1,6 +1,8 @@
 #![cfg(not(target_os = "windows"))]
 #![allow(clippy::expect_used)]
+use anyhow::Context;
 use anyhow::Result;
+use codex_features::Feature;
 use codex_login::CodexAuth;
 use codex_model_provider_info::ModelProviderInfo;
 use codex_model_provider_info::built_in_model_providers;
@@ -12,6 +14,7 @@ use codex_protocol::models::PermissionProfile;
 use codex_protocol::openai_models::ConfigShellToolType;
 use codex_protocol::openai_models::ModelInfo;
 use codex_protocol::openai_models::ModelPreset;
+use codex_protocol::openai_models::ModelServiceTier;
 use codex_protocol::openai_models::ModelVisibility;
 use codex_protocol::openai_models::ModelsResponse;
 use codex_protocol::openai_models::ReasoningEffort;
@@ -36,6 +39,8 @@ use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::skip_if_no_network;
 use core_test_support::skip_if_sandbox;
+use core_test_support::streaming_sse::StreamingSseChunk;
+use core_test_support::streaming_sse::start_streaming_sse_server_with_models_gate;
 use core_test_support::test_codex::TestCodex;
 use core_test_support::test_codex::local_selections;
 use core_test_support::test_codex::test_codex;
@@ -1038,7 +1043,7 @@ async fn remote_models_request_times_out_after_5s() -> Result<()> {
         ModelsResponse {
             models: vec![remote_model],
         },
-        Duration::from_secs(6),
+        Duration::from_secs(/*secs*/ 6),
     )
     .await;
 
@@ -1089,6 +1094,247 @@ async fn remote_models_request_times_out_after_5s() -> Result<()> {
         1,
         "expected a single /models request"
     );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn thread_start_does_not_wait_for_uncached_remote_models() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+    skip_if_sandbox!(Ok(()));
+
+    let remote_model_slug = "remote-cold-start-default";
+    let remote_base_instructions = "Use the delayed remote model instructions.";
+    let remote_model = ModelInfo {
+        slug: remote_model_slug.to_string(),
+        base_instructions: remote_base_instructions.to_string(),
+        service_tiers: vec![ModelServiceTier {
+            id: "flex".to_string(),
+            name: "Flex".to_string(),
+            description: "Remote-only flex tier".to_string(),
+        }],
+        ..test_remote_model(
+            remote_model_slug,
+            ModelVisibility::List,
+            /*priority*/ 0,
+        )
+    };
+    let (server, _completions, models_gate) = start_streaming_sse_server_with_models_gate(
+        vec![vec![StreamingSseChunk {
+            gate: None,
+            body: sse(vec![
+                ev_response_created("resp-1"),
+                ev_assistant_message("msg-1", "done"),
+                ev_completed("resp-1"),
+            ]),
+        }]],
+        ModelsResponse {
+            models: vec![remote_model],
+        },
+    )
+    .await;
+    let config_lock_dir = tempfile::tempdir()?;
+    let config_lock_path = config_lock_dir.path().to_path_buf();
+    let test = timeout(
+        Duration::from_secs(/*secs*/ 10),
+        test_codex()
+            .with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing())
+            .with_config(move |config| {
+                config
+                    .features
+                    .disable(Feature::EnableRequestCompression)
+                    .expect("test config should allow feature update");
+                config
+                    .features
+                    .enable(Feature::FastMode)
+                    .expect("test config should allow feature update");
+                config.model = None;
+                config.service_tier = Some("flex".to_string());
+                config.config_lock_export_dir = Some(
+                    config_lock_path
+                        .try_into()
+                        .expect("config lock path should be absolute"),
+                );
+                config.config_lock_save_fields_resolved_from_model_catalog = true;
+            })
+            .build_with_streaming_server(&server),
+    )
+    .await
+    .expect("thread startup should complete while the remote model catalog is blocked")?;
+
+    assert_eq!(test.session_configured.model, bundled_model_slug());
+    timeout(
+        Duration::from_secs(/*secs*/ 10),
+        server.wait_for_model_request_count(/*count*/ 1),
+    )
+    .await
+    .expect("background model refresh should start");
+    models_gate
+        .send(())
+        .expect("models response gate should still be held");
+    let refreshed_model = wait_for_event_match(&test.codex, |event| match event {
+        EventMsg::ThreadSettingsApplied(event) => Some(event.thread_settings.model.clone()),
+        _ => None,
+    })
+    .await;
+    assert_eq!(refreshed_model, remote_model_slug);
+    test.codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "hello after cold start".to_string(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: Default::default(),
+        })
+        .await?;
+    wait_for_event(&test.codex, |event| {
+        matches!(event, EventMsg::TurnComplete(_))
+    })
+    .await;
+
+    assert_eq!(server.requests().await.len(), 1);
+    let response_requests = server.requests().await;
+    let response_request: serde_json::Value = serde_json::from_slice(&response_requests[0])
+        .with_context(|| format!("parse response request body: {:?}", response_requests[0]))?;
+    assert_eq!(response_request["instructions"], remote_base_instructions);
+    assert_eq!(response_request["model"], remote_model_slug);
+    assert_eq!(response_request["service_tier"], "flex");
+    let config_lock_path = config_lock_dir.path().join(format!(
+        "{}.config.lock.toml",
+        test.session_configured.session_id
+    ));
+    let config_lock = timeout(Duration::from_secs(/*secs*/ 2), async {
+        loop {
+            match tokio::fs::read_to_string(&config_lock_path).await {
+                Ok(config_lock) => break Ok(config_lock),
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    sleep(Duration::from_millis(/*millis*/ 10)).await;
+                }
+                Err(err) => break Err(err),
+            }
+        }
+    })
+    .await
+    .expect("config lock export should complete")?;
+    assert!(config_lock.contains(remote_base_instructions));
+    assert!(config_lock.contains(remote_model_slug));
+    assert!(config_lock.contains("service_tier = \"flex\""));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn immediate_shutdown_waits_for_deferred_config_lock_export() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+    skip_if_sandbox!(Ok(()));
+
+    let server = MockServer::start().await;
+    let remote_model_slug = "remote-shutdown-default";
+    let remote_base_instructions = "Persist instructions resolved during graceful shutdown.";
+    let models_mock = mount_models_once_with_delay(
+        &server,
+        ModelsResponse {
+            models: vec![ModelInfo {
+                slug: remote_model_slug.to_string(),
+                base_instructions: remote_base_instructions.to_string(),
+                ..test_remote_model(
+                    remote_model_slug,
+                    ModelVisibility::List,
+                    /*priority*/ 0,
+                )
+            }],
+        },
+        Duration::from_secs(/*secs*/ 1),
+    )
+    .await;
+    let config_lock_dir = tempfile::tempdir()?;
+    let config_lock_path = config_lock_dir.path().to_path_buf();
+    let test = timeout(
+        Duration::from_millis(/*millis*/ 500),
+        test_codex()
+            .with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing())
+            .with_config(move |config| {
+                config.model = None;
+                config.config_lock_export_dir = Some(
+                    config_lock_path
+                        .try_into()
+                        .expect("config lock path should be absolute"),
+                );
+                config.config_lock_save_fields_resolved_from_model_catalog = true;
+            })
+            .build(&server),
+    )
+    .await
+    .expect("thread startup should not wait for the remote model catalog")?;
+
+    test.codex.submit(Op::Shutdown).await?;
+    wait_for_event(&test.codex, |event| {
+        matches!(event, EventMsg::ShutdownComplete)
+    })
+    .await;
+
+    assert_eq!(models_mock.requests().len(), 1);
+    let config_lock = tokio::fs::read_to_string(config_lock_dir.path().join(format!(
+        "{}.config.lock.toml",
+        test.session_configured.session_id
+    )))
+    .await?;
+    assert!(config_lock.contains(remote_model_slug));
+    assert!(config_lock.contains(remote_base_instructions));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shutdown_reports_deferred_config_lock_export_failure() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+    skip_if_sandbox!(Ok(()));
+
+    let server = MockServer::start().await;
+    let remote_model_slug = "remote-shutdown-export-error";
+    let _models_mock = mount_models_once(
+        &server,
+        ModelsResponse {
+            models: vec![test_remote_model(
+                remote_model_slug,
+                ModelVisibility::List,
+                /*priority*/ 0,
+            )],
+        },
+    )
+    .await;
+    let export_parent = tempfile::tempdir()?;
+    let export_path = export_parent.path().join("not-a-directory");
+    tokio::fs::write(&export_path, "occupied").await?;
+    let test = test_codex()
+        .with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing())
+        .with_config(move |config| {
+            config.model = None;
+            config.config_lock_export_dir = Some(
+                export_path
+                    .try_into()
+                    .expect("config lock path should be absolute"),
+            );
+        })
+        .build(&server)
+        .await?;
+
+    test.codex.submit(Op::Shutdown).await?;
+    let error_message = wait_for_event_match(&test.codex, |event| match event {
+        EventMsg::Error(error) if error.message.contains("Failed to export config lock") => {
+            Some(error.message.clone())
+        }
+        _ => None,
+    })
+    .await;
+    assert!(error_message.contains("failed to create config lock export directory"));
+    wait_for_event(&test.codex, |event| {
+        matches!(event, EventMsg::ShutdownComplete)
+    })
+    .await;
 
     Ok(())
 }

--- a/codex-rs/core/tests/suite/resume.rs
+++ b/codex-rs/core/tests/suite/resume.rs
@@ -18,6 +18,7 @@ use core_test_support::test_codex::TestCodexBuilder;
 use core_test_support::test_codex::test_codex;
 use core_test_support::wait_for_event;
 use pretty_assertions::assert_eq;
+use pretty_assertions::assert_ne;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -237,7 +238,7 @@ async fn resume_includes_initial_messages_from_reasoning_events() -> Result<()> 
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn resume_switches_models_preserves_base_instructions() -> Result<()> {
+async fn resume_switches_model_derived_base_instructions() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
@@ -342,7 +343,8 @@ async fn resume_switches_models_preserves_base_instructions() -> Result<()> {
     assert_eq!(requests.len(), 2, "expected two resumed requests");
 
     let first_resumed = &requests[0];
-    assert_eq!(first_resumed.instructions_text(), initial_instructions);
+    assert_ne!(first_resumed.instructions_text(), initial_instructions);
+    let resumed_instructions = first_resumed.instructions_text();
     let first_developer_texts = first_resumed.message_input_texts("developer");
     let first_model_switch_count = first_developer_texts
         .iter()
@@ -354,7 +356,7 @@ async fn resume_switches_models_preserves_base_instructions() -> Result<()> {
     );
 
     let second_resumed = &requests[1];
-    assert_eq!(second_resumed.instructions_text(), initial_instructions);
+    assert_eq!(second_resumed.instructions_text(), resumed_instructions);
     let second_developer_texts = second_resumed.message_input_texts("developer");
     let second_model_switch_count = second_developer_texts
         .iter()


### PR DESCRIPTION
## Summary
- resolve a thread immediately from the in-memory model catalog, then refresh remote model metadata in the background
- defer initial history recording, config-lock export, and startup prewarm until first inference or orderly shutdown
- preserve settings notifications when the deferred model refresh races listener attachment
- add deterministic startup and shutdown regression coverage

Plugin/skill and MCP initialization intentionally remain synchronous in this layer.

## Validation
- `cargo check -p codex-core -p codex-app-server --tests`
- `just test -p codex-core thread_start_does_not_wait_for_uncached_remote_models`
- `just test -p codex-core immediate_shutdown_waits_for_deferred_config_lock_export`
- `just test -p codex-core shutdown_reports_deferred_config_lock_export_failure`
- `just fix -p codex-core`
- `just fix -p codex-app-server`
- `just fmt`

Stacked on #27215.