### PR TITLE
Add feature-gated session segmentation

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/thread_history.rs
+++ b/codex-rs/app-server-protocol/src/protocol/thread_history.rs
@@ -233,7 +233,9 @@ impl ThreadHistoryBuilder {
             RolloutItem::EventMsg(event) => self.handle_event(event),
             RolloutItem::Compacted(payload) => self.handle_compacted(payload),
             RolloutItem::ResponseItem(item) => self.handle_response_item(item),
-            RolloutItem::TurnContext(_) | RolloutItem::SessionMeta(_) => {}
+            RolloutItem::RolloutReference(_)
+            | RolloutItem::TurnContext(_)
+            | RolloutItem::SessionMeta(_) => {}
         }
     }
 

--- a/codex-rs/app-server/src/request_processors.rs
+++ b/codex-rs/app-server/src/request_processors.rs
@@ -298,6 +298,7 @@ use codex_core::exec::ExecCapturePolicy;
 use codex_core::exec::ExecExpiration;
 use codex_core::exec::ExecParams;
 use codex_core::exec_env::create_env;
+use codex_core::materialize_rollout_items_for_replay;
 use codex_core::path_utils;
 #[cfg(test)]
 use codex_core::read_head_for_summary;
@@ -563,4 +564,11 @@ pub(crate) fn build_api_turns_from_rollout_items(items: &[RolloutItem]) -> Vec<T
         }
     }
     builder.finish()
+}
+
+async fn materialize_rollout_items_for_app_server(
+    codex_home: &Path,
+    rollout_items: &[RolloutItem],
+) -> Vec<RolloutItem> {
+    materialize_rollout_items_for_replay(codex_home, rollout_items).await
 }

--- a/codex-rs/app-server/src/request_processors/thread_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor.rs
@@ -2142,7 +2142,12 @@ impl ThreadRequestProcessor {
                 let (mut thread, history) =
                     thread_from_stored_thread(stored_thread, fallback_provider, &self.config.cwd);
                 if include_turns && let Some(history) = history {
-                    thread.turns = build_api_turns_from_rollout_items(&history.items);
+                    let history_items = materialize_rollout_items_for_app_server(
+                        self.config.codex_home.as_path(),
+                        &history.items,
+                    )
+                    .await;
+                    thread.turns = build_api_turns_from_rollout_items(&history_items);
                 }
                 Ok(Some(thread))
             }
@@ -2208,7 +2213,12 @@ impl ThreadRequestProcessor {
                 .load_history(/*include_archived*/ true)
                 .await
                 .map_err(|err| thread_read_history_load_error(thread_id, err))?;
-            thread.turns = build_api_turns_from_rollout_items(&history.items);
+            let history_items = materialize_rollout_items_for_app_server(
+                self.config.codex_home.as_path(),
+                &history.items,
+            )
+            .await;
+            thread.turns = build_api_turns_from_rollout_items(&history_items);
         }
 
         Ok(())
@@ -2287,7 +2297,11 @@ impl ThreadRequestProcessor {
                         "thread store did not return history for thread {thread_id}"
                     ))
                 })?;
-                return Ok(history.items);
+                return Ok(materialize_rollout_items_for_app_server(
+                    self.config.codex_home.as_path(),
+                    &history.items,
+                )
+                .await);
             }
             Err(ThreadStoreError::InvalidRequest { message })
                 if message == format!("no rollout found for thread id {thread_id}") => {}
@@ -2318,11 +2332,16 @@ impl ThreadRequestProcessor {
             ));
         }
 
-        thread
+        let history_items = thread
             .load_history(/*include_archived*/ true)
             .await
             .map(|history| history.items)
-            .map_err(|err| thread_turns_list_history_load_error(thread_id, err))
+            .map_err(|err| thread_turns_list_history_load_error(thread_id, err))?;
+        Ok(materialize_rollout_items_for_app_server(
+            self.config.codex_home.as_path(),
+            &history_items,
+        )
+        .await)
     }
 
     pub(crate) fn thread_created_receiver(&self) -> broadcast::Receiver<ThreadId> {
@@ -2538,6 +2557,15 @@ impl ThreadRequestProcessor {
         };
 
         let response_history = thread_history.clone();
+        let response_history_items = if include_turns || initial_turns_page.is_some() {
+            materialize_rollout_items_for_app_server(
+                self.config.codex_home.as_path(),
+                &response_history.get_rollout_items(),
+            )
+            .await
+        } else {
+            Vec::new()
+        };
 
         match self
             .thread_manager
@@ -2636,7 +2664,7 @@ impl ThreadRequestProcessor {
                 let token_usage_thread = include_turns.then(|| thread.clone());
                 let mut initial_turns_page = if let Some(params) = initial_turns_page.as_ref() {
                     match build_thread_resume_initial_turns_page(
-                        &response_history.get_rollout_items(),
+                        &response_history_items,
                         thread.status.clone(),
                         /*has_live_running_thread*/ false,
                         /*active_turn*/ None,
@@ -2680,7 +2708,7 @@ impl ThreadRequestProcessor {
                 // rebuilding history only to attribute a replayed usage update.
                 if let Some(token_usage_thread) = token_usage_thread {
                     let token_usage_turn_id = latest_token_usage_turn_id_from_rollout_items(
-                        &response_history.get_rollout_items(),
+                        &response_history_items,
                         token_usage_thread.turns.as_slice(),
                     );
                     // The client needs restored usage before it starts another turn.
@@ -2846,6 +2874,11 @@ impl ThreadRequestProcessor {
                         "thread {existing_thread_id} did not include persisted history"
                     ))
                 })?;
+            let history_items = materialize_rollout_items_for_app_server(
+                self.config.codex_home.as_path(),
+                &history_items,
+            )
+            .await;
 
             let thread_state = self
                 .thread_state_manager
@@ -2866,11 +2899,13 @@ impl ThreadRequestProcessor {
 
             let mut summary_source_thread = source_thread;
             summary_source_thread.history = None;
-            let mut thread_summary = self.stored_thread_to_api_thread(
-                summary_source_thread,
-                config_snapshot.model_provider_id.as_str(),
-                /*include_turns*/ false,
-            );
+            let mut thread_summary = self
+                .stored_thread_to_api_thread(
+                    summary_source_thread,
+                    config_snapshot.model_provider_id.as_str(),
+                    /*include_turns*/ false,
+                )
+                .await;
             thread_summary.session_id = existing_thread.session_configured().session_id.to_string();
             let instruction_sources = existing_thread.instruction_sources().await;
 
@@ -3004,7 +3039,7 @@ impl ThreadRequestProcessor {
         }))
     }
 
-    fn stored_thread_to_api_thread(
+    async fn stored_thread_to_api_thread(
         &self,
         stored_thread: StoredThread,
         fallback_provider: &str,
@@ -3013,9 +3048,14 @@ impl ThreadRequestProcessor {
         let (mut thread, history) =
             thread_from_stored_thread(stored_thread, fallback_provider, &self.config.cwd);
         if include_turns && let Some(history) = history {
+            let history_items = materialize_rollout_items_for_app_server(
+                self.config.codex_home.as_path(),
+                &history.items,
+            )
+            .await;
             populate_thread_turns_from_history(
                 &mut thread,
-                &history.items,
+                &history_items,
                 /*active_turn*/ None,
             );
         }
@@ -3126,6 +3166,11 @@ impl ThreadRequestProcessor {
         thread.path = Some(rollout_path.to_path_buf());
         if include_turns {
             let history_items = thread_history.get_rollout_items();
+            let history_items = materialize_rollout_items_for_app_server(
+                self.config.codex_home.as_path(),
+                &history_items,
+            )
+            .await;
             populate_thread_turns_from_history(
                 &mut thread,
                 &history_items,
@@ -3202,6 +3247,11 @@ impl ThreadRequestProcessor {
                     "thread {source_thread_id} did not include persisted history"
                 ))
             })?;
+        let materialized_history_items = materialize_rollout_items_for_app_server(
+            self.config.codex_home.as_path(),
+            &history_items,
+        )
+        .await;
         let history_cwd = Some(source_thread.cwd.clone());
 
         // Persist Windows sandbox mode.
@@ -3326,6 +3376,7 @@ impl ThreadRequestProcessor {
                 fallback_model_provider.as_str(),
                 include_turns,
             )
+            .await
         } else {
             let config_snapshot = forked_thread.config_snapshot().await;
             let mut thread = build_thread_from_snapshot(
@@ -3334,12 +3385,11 @@ impl ThreadRequestProcessor {
                 &config_snapshot,
                 /*path*/ None,
             );
-            thread.preview = preview_from_rollout_items(&history_items);
             thread.forked_from_id = Some(source_thread_id.to_string());
             if include_turns {
                 populate_thread_turns_from_history(
                     &mut thread,
-                    &history_items,
+                    &materialized_history_items,
                     /*active_turn*/ None,
                 );
             }
@@ -3348,6 +3398,7 @@ impl ThreadRequestProcessor {
         if let Some(name) = source_thread_name {
             set_thread_name_from_title(&mut thread, name);
         }
+        thread.preview = preview_from_rollout_items(&materialized_history_items);
         thread.session_id = session_configured.session_id.to_string();
         thread.thread_source = forked_thread
             .config_snapshot()
@@ -3396,7 +3447,7 @@ impl ThreadRequestProcessor {
         // instead of rebuilding history only to attribute a historical update.
         if let Some(token_usage_thread) = token_usage_thread {
             let token_usage_turn_id = latest_token_usage_turn_id_from_rollout_items(
-                &history_items,
+                &materialized_history_items,
                 token_usage_thread.turns.as_slice(),
             );
             // Mirror the resume contract for forks: the new thread is usable as soon

--- a/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
@@ -1036,6 +1036,7 @@ mod thread_processor_behavior_tests {
 
         let session_meta = SessionMeta {
             id: conversation_id,
+            segment_id: None,
             forked_from_id: Some(forked_from_id),
             timestamp: timestamp.clone(),
             model_provider: Some("test-provider".to_string()),

--- a/codex-rs/app-server/tests/common/rollout.rs
+++ b/codex-rs/app-server/tests/common/rollout.rs
@@ -179,6 +179,7 @@ fn create_fake_rollout_with_source_and_parent_thread_id(
     // Build JSONL lines
     let meta = SessionMeta {
         id: conversation_id,
+        segment_id: None,
         forked_from_id: None,
         parent_thread_id,
         timestamp: meta_rfc3339.to_string(),
@@ -265,6 +266,7 @@ pub fn create_fake_rollout_with_text_elements(
     // Build JSONL lines
     let meta = SessionMeta {
         id: conversation_id,
+        segment_id: None,
         forked_from_id: None,
         parent_thread_id: None,
         timestamp: meta_rfc3339.to_string(),

--- a/codex-rs/app-server/tests/suite/v2/thread_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_list.rs
@@ -1891,6 +1891,71 @@ async fn thread_list_archived_filter() -> Result<()> {
 }
 
 #[tokio::test]
+async fn thread_list_keeps_rotated_live_thread_in_recent_results() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    create_minimal_config(codex_home.path())?;
+
+    let thread_id = create_fake_rollout(
+        codex_home.path(),
+        "2025-03-01T10-00-00",
+        "2025-03-01T10:00:00Z",
+        "Active after rotation",
+        Some("mock_provider"),
+        /*git_info*/ None,
+    )?;
+    let live_rollout_path = rollout_path(codex_home.path(), "2025-03-01T10-00-00", &thread_id);
+    let legacy_rotated_path = codex_home.path().join(ARCHIVED_SESSIONS_SUBDIR).join(
+        live_rollout_path
+            .file_name()
+            .expect("live rollout should have a file name"),
+    );
+    fs::create_dir_all(
+        legacy_rotated_path
+            .parent()
+            .expect("legacy rotated rollout should have a parent"),
+    )?;
+    fs::copy(live_rollout_path.as_path(), legacy_rotated_path.as_path())?;
+
+    let mut mcp = init_mcp(codex_home.path()).await?;
+    let state_db =
+        codex_state::StateRuntime::init(codex_home.path().to_path_buf(), "mock_provider".into())
+            .await?;
+    let thread_id = ThreadId::from_string(&thread_id)?;
+    let mut metadata = state_db
+        .get_thread(thread_id)
+        .await?
+        .expect("thread should be backfilled into sqlite");
+    metadata.rollout_path = legacy_rotated_path;
+    metadata.archived_at = Some(Utc::now());
+    state_db.upsert_thread(&metadata).await?;
+
+    let ThreadListResponse { data, .. } = list_threads(
+        &mut mcp,
+        /*cursor*/ None,
+        Some(10),
+        Some(vec!["mock_provider".to_string()]),
+        /*source_kinds*/ None,
+        /*archived*/ None,
+    )
+    .await?;
+    assert_eq!(data.len(), 1);
+    assert_eq!(data[0].id, thread_id.to_string());
+
+    let ThreadListResponse { data, .. } = list_threads(
+        &mut mcp,
+        /*cursor*/ None,
+        Some(10),
+        Some(vec!["mock_provider".to_string()]),
+        /*source_kinds*/ None,
+        Some(true),
+    )
+    .await?;
+    assert!(data.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn thread_list_invalid_cursor_returns_error() -> Result<()> {
     let codex_home = TempDir::new()?;
     create_minimal_config(codex_home.path())?;

--- a/codex-rs/app-server/tests/suite/v2/thread_read.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_read.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use app_test_support::TestAppServer;
+use app_test_support::create_fake_rollout;
 use app_test_support::create_fake_rollout_with_text_elements;
 use app_test_support::create_mock_responses_server_repeating_assistant;
 use app_test_support::rollout_path;
@@ -51,6 +52,7 @@ use codex_protocol::models::BaseInstructions;
 use codex_protocol::protocol::AgentMessageEvent;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::RolloutItem;
+use codex_protocol::protocol::RolloutReferenceItem;
 use codex_protocol::protocol::SessionSource as ProtocolSessionSource;
 use codex_protocol::protocol::ThreadMemoryMode;
 use codex_protocol::protocol::UserMessageEvent;
@@ -500,6 +502,131 @@ async fn thread_read_loaded_include_turns_reads_store_history_without_rollout_pa
     let ThreadReadResponse { thread, .. } = serde_json::from_value(result)?;
 
     assert_eq!(turn_user_texts(&thread.turns), vec!["history from store"]);
+
+    client.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_read_unloaded_include_turns_materializes_rollout_reference() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    let referenced_thread_id = create_fake_rollout(
+        codex_home.path(),
+        "2025-01-05T12-00-00",
+        "2025-01-05T12:00:00Z",
+        "history before segment rotation",
+        Some("mock_provider"),
+        /*git_info*/ None,
+    )?;
+    let referenced_rollout_path = rollout_path(
+        codex_home.path(),
+        "2025-01-05T12-00-00",
+        &referenced_thread_id,
+    );
+
+    let thread_id = codex_protocol::ThreadId::from_string("00000000-0000-4000-8000-000000000125")?;
+    let store_id = Uuid::new_v4().to_string();
+    create_config_toml_with_thread_store(codex_home.path(), &store_id)?;
+    let store = InMemoryThreadStore::for_id(store_id.clone());
+    let _in_memory_store = InMemoryThreadStoreId { store_id };
+    store
+        .create_thread(CreateThreadParams {
+            thread_id,
+            extra_config: None,
+            forked_from_id: None,
+            parent_thread_id: None,
+            source: ProtocolSessionSource::Cli,
+            thread_source: None,
+            base_instructions: BaseInstructions::default(),
+            dynamic_tools: Vec::new(),
+            multi_agent_version: None,
+            metadata: ThreadPersistenceMetadata {
+                cwd: None,
+                model_provider: "test-provider".to_string(),
+                memory_mode: ThreadMemoryMode::Disabled,
+            },
+        })
+        .await?;
+    store
+        .append_items(AppendThreadItemsParams {
+            thread_id,
+            items: vec![
+                RolloutItem::RolloutReference(RolloutReferenceItem {
+                    rollout_path: referenced_rollout_path,
+                    thread_id: Some(codex_protocol::ThreadId::from_string(
+                        &referenced_thread_id,
+                    )?),
+                    rollout_timestamp: None,
+                    segment_id: None,
+                    max_depth: 2,
+                    nth_user_message: None,
+                    filter_fork_history: false,
+                    developer_message_filter_texts: None,
+                }),
+                RolloutItem::EventMsg(EventMsg::UserMessage(UserMessageEvent {
+                    message: "history after segment rotation".to_string(),
+                    ..Default::default()
+                })),
+            ],
+        })
+        .await?;
+
+    let loader_overrides = LoaderOverrides::without_managed_config_for_tests();
+    let config = ConfigBuilder::default()
+        .codex_home(codex_home.path().to_path_buf())
+        .fallback_cwd(Some(codex_home.path().to_path_buf()))
+        .loader_overrides(loader_overrides.clone())
+        .build()
+        .await?;
+    let client = in_process::start(InProcessStartArgs {
+        arg0_paths: Arg0DispatchPaths::default(),
+        config: Arc::new(config),
+        cli_overrides: Vec::new(),
+        loader_overrides,
+        strict_config: false,
+        cloud_config_bundle: CloudConfigBundleLoader::default(),
+        thread_config_loader: Arc::new(codex_config::NoopThreadConfigLoader),
+        feedback: CodexFeedback::new(),
+        log_db: None,
+        state_db: None,
+        environment_manager: Arc::new(EnvironmentManager::default_for_tests()),
+        config_warnings: Vec::new(),
+        session_source: SessionSource::Cli.into(),
+        enable_codex_api_key_env: false,
+        initialize: InitializeParams {
+            client_info: ClientInfo {
+                name: "codex-app-server-tests".to_string(),
+                title: None,
+                version: "0.1.0".to_string(),
+            },
+            capabilities: Some(InitializeCapabilities {
+                experimental_api: true,
+                ..Default::default()
+            }),
+        },
+        channel_capacity: in_process::DEFAULT_IN_PROCESS_CHANNEL_CAPACITY,
+    })
+    .await?;
+
+    let result = client
+        .request(ClientRequest::ThreadRead {
+            request_id: RequestId::Integer(1),
+            params: ThreadReadParams {
+                thread_id: thread_id.to_string(),
+                include_turns: true,
+            },
+        })
+        .await?
+        .expect("thread/read should succeed");
+    let ThreadReadResponse { thread, .. } = serde_json::from_value(result)?;
+
+    assert_eq!(
+        turn_user_texts(&thread.turns),
+        vec![
+            "history before segment rotation",
+            "history after segment rotation",
+        ]
+    );
 
     client.shutdown().await?;
     Ok(())

--- a/codex-rs/app-server/tests/suite/v2/thread_resume.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_resume.rs
@@ -53,18 +53,22 @@ use codex_app_server_protocol::UserInput;
 use codex_config::types::AuthCredentialsStoreMode;
 use codex_core::ARCHIVED_SESSIONS_SUBDIR;
 use codex_login::REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR;
+use codex_protocol::SegmentId;
 use codex_protocol::ThreadId;
 use codex_protocol::config_types::Personality;
 use codex_protocol::mcp::CallToolResult;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::AgentMessageEvent;
+use codex_protocol::protocol::ContextCompactedEvent;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::ImageGenerationEndEvent;
 use codex_protocol::protocol::McpInvocation;
 use codex_protocol::protocol::McpToolCallEndEvent;
 use codex_protocol::protocol::MultiAgentVersion;
 use codex_protocol::protocol::RolloutItem;
+use codex_protocol::protocol::RolloutLine;
+use codex_protocol::protocol::RolloutReferenceItem;
 use codex_protocol::protocol::SessionMeta;
 use codex_protocol::protocol::SessionMetaLine;
 use codex_protocol::protocol::SessionSource as RolloutSessionSource;
@@ -74,6 +78,7 @@ use codex_protocol::protocol::TokenUsageInfo;
 use codex_protocol::protocol::TurnAbortReason;
 use codex_protocol::protocol::TurnAbortedEvent;
 use codex_protocol::protocol::TurnStartedEvent;
+use codex_protocol::protocol::UserMessageEvent;
 use codex_protocol::user_input::ByteRange;
 use codex_protocol::user_input::TextElement;
 use codex_rollout::append_rollout_item_to_path;
@@ -112,6 +117,50 @@ const CODEX_5_2_INSTRUCTIONS_TEMPLATE_DEFAULT: &str = "You are Codex, a coding a
 
 fn normalized_existing_path(path: impl AsRef<Path>) -> Result<PathBuf> {
     Ok(AbsolutePathBuf::from_absolute_path(path.as_ref().canonicalize()?)?.into_path_buf())
+}
+
+fn session_meta_rollout_item(
+    thread_id: ThreadId,
+    segment_id: Option<SegmentId>,
+    timestamp: &str,
+) -> RolloutItem {
+    RolloutItem::SessionMeta(SessionMetaLine {
+        meta: SessionMeta {
+            id: thread_id,
+            segment_id,
+            timestamp: timestamp.to_string(),
+            cwd: PathBuf::from("/"),
+            originator: "codex".to_string(),
+            cli_version: "0.0.0".to_string(),
+            source: RolloutSessionSource::Cli,
+            model_provider: Some("mock_provider".to_string()),
+            ..SessionMeta::default()
+        },
+        git: None,
+    })
+}
+
+fn user_message_item(text: &str) -> RolloutItem {
+    RolloutItem::EventMsg(EventMsg::UserMessage(UserMessageEvent {
+        message: text.to_string(),
+        images: None,
+        local_images: Vec::new(),
+        text_elements: Vec::new(),
+        ..Default::default()
+    }))
+}
+
+fn write_rollout_items(path: &Path, timestamp: &str, items: &[RolloutItem]) -> Result<()> {
+    let mut jsonl = String::new();
+    for item in items {
+        jsonl.push_str(&serde_json::to_string(&RolloutLine {
+            timestamp: timestamp.to_string(),
+            item: item.clone(),
+        })?);
+        jsonl.push('\n');
+    }
+    std::fs::write(path, jsonl)?;
+    Ok(())
 }
 
 async fn wait_for_responses_request_count(
@@ -822,6 +871,108 @@ fn append_resume_redaction_history(
         &rollout_file_path,
         format!("{persisted_rollout}{appended_rollout}\n"),
     )?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn thread_resume_materializes_rollout_references_when_session_segmentation_is_disabled()
+-> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), &server.uri())?;
+
+    let thread_id = ThreadId::new();
+    let thread_id_str = thread_id.to_string();
+    let old_ts = "2025-01-05T12-00-00";
+    let current_ts = "2025-01-05T12-05-00";
+    let old_rfc3339 = "2025-01-05T12:00:00Z";
+    let current_rfc3339 = "2025-01-05T12:05:00Z";
+    let active_old_path = rollout_path(codex_home.path(), old_ts, &thread_id_str);
+    let archived_old_path = codex_home
+        .path()
+        .join("archived_sessions")
+        .join(active_old_path.file_name().expect("old rollout file name"));
+    std::fs::create_dir_all(archived_old_path.parent().expect("archived rollout parent"))?;
+    let current_path = rollout_path(codex_home.path(), current_ts, &thread_id_str);
+    std::fs::create_dir_all(current_path.parent().expect("current rollout parent"))?;
+
+    let old_items = vec![
+        session_meta_rollout_item(thread_id, Some(SegmentId::new()), old_rfc3339),
+        user_message_item("before compaction"),
+    ];
+    write_rollout_items(archived_old_path.as_path(), old_rfc3339, &old_items)?;
+
+    let current_items = vec![
+        session_meta_rollout_item(thread_id, Some(SegmentId::new()), current_rfc3339),
+        RolloutItem::RolloutReference(RolloutReferenceItem {
+            rollout_path: active_old_path,
+            thread_id: Some(thread_id),
+            rollout_timestamp: Some(old_ts.to_string()),
+            segment_id: None,
+            max_depth: 2,
+            nth_user_message: None,
+            filter_fork_history: false,
+            developer_message_filter_texts: None,
+        }),
+        RolloutItem::EventMsg(EventMsg::ContextCompacted(ContextCompactedEvent {})),
+        user_message_item("after compaction"),
+    ];
+    write_rollout_items(current_path.as_path(), current_rfc3339, &current_items)?;
+
+    let mut mcp = TestAppServer::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let resume_id = mcp
+        .send_thread_resume_request(ThreadResumeParams {
+            thread_id: thread_id_str,
+            ..Default::default()
+        })
+        .await?;
+    let resume_resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(resume_id)),
+    )
+    .await??;
+    let ThreadResumeResponse { thread, .. } = to_response::<ThreadResumeResponse>(resume_resp)?;
+
+    let user_messages: Vec<&str> = thread
+        .turns
+        .iter()
+        .flat_map(|turn| turn.items.iter())
+        .filter_map(|item| match item {
+            ThreadItem::UserMessage { content, .. } => {
+                content.iter().find_map(|input| match input {
+                    UserInput::Text { text, .. } => Some(text.as_str()),
+                    UserInput::Image { .. }
+                    | UserInput::LocalImage { .. }
+                    | UserInput::Skill { .. }
+                    | UserInput::Mention { .. } => None,
+                })
+            }
+            ThreadItem::AgentMessage { .. }
+            | ThreadItem::Reasoning { .. }
+            | ThreadItem::CommandExecution { .. }
+            | ThreadItem::FileChange { .. }
+            | ThreadItem::McpToolCall { .. }
+            | ThreadItem::WebSearch { .. }
+            | ThreadItem::ImageView { .. }
+            | ThreadItem::ImageGeneration { .. }
+            | ThreadItem::EnteredReviewMode { .. }
+            | ThreadItem::ExitedReviewMode { .. }
+            | ThreadItem::ContextCompaction { .. }
+            | ThreadItem::HookPrompt { .. }
+            | ThreadItem::CollabAgentToolCall { .. }
+            | ThreadItem::SubAgentActivity { .. }
+            | ThreadItem::DynamicToolCall { .. }
+            | ThreadItem::Plan { .. } => None,
+        })
+        .collect();
+    assert_eq!(user_messages, vec!["before compaction", "after compaction"]);
+    assert!(thread.turns.iter().any(|turn| {
+        turn.items
+            .iter()
+            .any(|item| matches!(item, ThreadItem::ContextCompaction { .. }))
+    }));
     Ok(())
 }
 
@@ -1873,6 +2024,7 @@ stream_max_retries = 0
     std::fs::create_dir_all(rollout_dir)?;
     let session_meta = SessionMeta {
         id: conversation_id,
+        segment_id: None,
         forked_from_id: None,
         parent_thread_id: None,
         timestamp: "2025-01-05T12:00:00Z".to_string(),

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -584,6 +584,9 @@
             "search_tool": {
               "type": "boolean"
             },
+            "session_segmentation": {
+              "type": "boolean"
+            },
             "shell_snapshot": {
               "type": "boolean"
             },
@@ -4708,6 +4711,9 @@
           "type": "boolean"
         },
         "search_tool": {
+          "type": "boolean"
+        },
+        "session_segmentation": {
           "type": "boolean"
         },
         "shell_snapshot": {

--- a/codex-rs/core/src/agent/control.rs
+++ b/codex-rs/core/src/agent/control.rs
@@ -19,7 +19,6 @@ use codex_protocol::ThreadId;
 use codex_protocol::error::CodexErr;
 use codex_protocol::error::Result as CodexResult;
 use codex_protocol::models::ContentItem;
-use codex_protocol::models::MessagePhase;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::InitialHistory;
 use codex_protocol::protocol::InterAgentCommunication;

--- a/codex-rs/core/src/agent/control/spawn.rs
+++ b/codex-rs/core/src/agent/control/spawn.rs
@@ -1,5 +1,9 @@
 use super::residency::is_v2_resident_session_source;
 use super::*;
+use codex_features::Feature;
+use codex_protocol::protocol::DEFAULT_ROLLOUT_REFERENCE_DEPTH;
+use codex_protocol::protocol::RolloutReferenceItem;
+use std::path::PathBuf;
 
 const AGENT_NAMES: &str = include_str!("../agent_names.txt");
 
@@ -30,37 +34,43 @@ pub(super) fn agent_nickname_candidates(config: &Config, role_name: Option<&str>
         .collect()
 }
 
-fn keep_forked_rollout_item(item: &RolloutItem, preserve_reference_context_item: bool) -> bool {
-    match item {
-        RolloutItem::ResponseItem(ResponseItem::Message { role, phase, .. }) => match role.as_str()
-        {
-            "system" | "developer" | "user" => true,
-            "assistant" => *phase == Some(MessagePhase::FinalAnswer),
-            _ => false,
-        },
-        RolloutItem::ResponseItem(
-            ResponseItem::AgentMessage { .. }
-            | ResponseItem::Reasoning { .. }
-            | ResponseItem::LocalShellCall { .. }
-            | ResponseItem::FunctionCall { .. }
-            | ResponseItem::ToolSearchCall { .. }
-            | ResponseItem::FunctionCallOutput { .. }
-            | ResponseItem::CustomToolCall { .. }
-            | ResponseItem::CustomToolCallOutput { .. }
-            | ResponseItem::ToolSearchOutput { .. }
-            | ResponseItem::WebSearchCall { .. }
-            | ResponseItem::ImageGenerationCall { .. }
-            | ResponseItem::Compaction { .. }
-            | ResponseItem::CompactionTrigger
-            | ResponseItem::ContextCompaction { .. }
-            | ResponseItem::Other,
-        ) => false,
-        // Full-history forks preserve the cached prompt prefix and can keep diffing
-        // from the parent's durable baseline. Truncated forks drop part of that prompt,
-        // so they must rebuild context on their first child turn.
-        RolloutItem::TurnContext(_) => preserve_reference_context_item,
-        RolloutItem::Compacted(_) | RolloutItem::EventMsg(_) | RolloutItem::SessionMeta(_) => true,
-    }
+fn full_history_rollout_reference_items(
+    rollout_path: PathBuf,
+    source_items: &[RolloutItem],
+) -> Vec<RolloutItem> {
+    let source_meta = source_items.iter().find_map(|item| match item {
+        RolloutItem::SessionMeta(meta) => Some(meta),
+        RolloutItem::Compacted(_)
+        | RolloutItem::EventMsg(_)
+        | RolloutItem::RolloutReference(_)
+        | RolloutItem::ResponseItem(_)
+        | RolloutItem::TurnContext(_) => None,
+    });
+
+    source_items
+        .iter()
+        .find_map(|item| match item {
+            RolloutItem::SessionMeta(meta) => Some(RolloutItem::SessionMeta(meta.clone())),
+            RolloutItem::Compacted(_)
+            | RolloutItem::EventMsg(_)
+            | RolloutItem::RolloutReference(_)
+            | RolloutItem::ResponseItem(_)
+            | RolloutItem::TurnContext(_) => None,
+        })
+        .into_iter()
+        .chain(std::iter::once(RolloutItem::RolloutReference(
+            RolloutReferenceItem {
+                rollout_path,
+                thread_id: source_meta.map(|meta| meta.meta.id),
+                rollout_timestamp: None,
+                segment_id: source_meta.and_then(|meta| meta.meta.segment_id),
+                max_depth: DEFAULT_ROLLOUT_REFERENCE_DEPTH,
+                nth_user_message: Some(usize::MAX),
+                filter_fork_history: true,
+                developer_message_filter_texts: None,
+            },
+        )))
+        .collect()
 }
 
 fn is_multi_agent_v2_usage_hint_message(item: &ResponseItem, usage_hint_texts: &[String]) -> bool {
@@ -416,21 +426,31 @@ impl AgentControl {
             parent_thread.flush_rollout().await?;
         }
 
-        let parent_history = state
+        let parent_stored_thread = state
             .read_stored_thread(ReadThreadParams {
                 thread_id: parent_thread_id,
                 include_archived: true,
                 include_history: true,
             })
-            .await?
-            .history
-            .ok_or_else(|| {
-                CodexErr::Fatal(format!(
-                    "parent thread history unavailable for fork: {parent_thread_id}"
-                ))
-            })?;
+            .await?;
+        let parent_rollout_path = parent_stored_thread.rollout_path.clone();
+        let parent_history = parent_stored_thread.history.ok_or_else(|| {
+            CodexErr::Fatal(format!(
+                "parent thread history unavailable for fork: {parent_thread_id}"
+            ))
+        })?;
 
-        let mut forked_rollout_items = parent_history.items;
+        let mut forked_rollout_items = if matches!(fork_mode, SpawnAgentForkMode::FullHistory) {
+            if config.features.enabled(Feature::SessionSegmentation)
+                && let Some(rollout_path) = parent_rollout_path
+            {
+                full_history_rollout_reference_items(rollout_path, &parent_history.items)
+            } else {
+                parent_history.items
+            }
+        } else {
+            parent_history.items
+        };
         if let SpawnAgentForkMode::LastNTurns(last_n_turns) = fork_mode {
             forked_rollout_items =
                 truncate_rollout_to_last_n_fork_turns(&forked_rollout_items, *last_n_turns);
@@ -467,16 +487,24 @@ impl AgentControl {
                 Vec::new()
             };
         let preserve_reference_context_item = matches!(fork_mode, SpawnAgentForkMode::FullHistory);
+        for item in &mut forked_rollout_items {
+            if let RolloutItem::RolloutReference(reference) = item {
+                reference.developer_message_filter_texts =
+                    Some(multi_agent_v2_usage_hint_texts_to_filter.clone());
+            }
+        }
         forked_rollout_items.retain(|item| {
-            keep_forked_rollout_item(item, preserve_reference_context_item)
-                && !matches!(
-                    item,
-                    RolloutItem::ResponseItem(response_item)
-                        if is_multi_agent_v2_usage_hint_message(
-                            response_item,
-                            &multi_agent_v2_usage_hint_texts_to_filter,
-                        )
-                )
+            crate::thread_rollout_truncation::keep_forked_rollout_item(
+                item,
+                preserve_reference_context_item,
+            ) && !matches!(
+                item,
+                RolloutItem::ResponseItem(response_item)
+                    if is_multi_agent_v2_usage_hint_message(
+                        response_item,
+                        &multi_agent_v2_usage_hint_texts_to_filter,
+                    )
+            )
         });
         for item in &mut forked_rollout_items {
             if let RolloutItem::Compacted(compacted) = item

--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -9,6 +9,7 @@ use crate::config::ConfigBuilder;
 use crate::context::ContextualUserFragment;
 use crate::context::SubagentNotification;
 use crate::init_state_db;
+use crate::rollout::RolloutRecorder;
 use assert_matches::assert_matches;
 use codex_features::Feature;
 use codex_login::CodexAuth;
@@ -825,6 +826,7 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
         Some("Parent subagent guidance.".to_string());
     let mut child_config = harness.config.clone();
     let _ = child_config.features.enable(Feature::MultiAgentV2);
+    let _ = child_config.features.enable(Feature::SessionSegmentation);
     child_config.multi_agent_v2.root_agent_usage_hint_text =
         Some("Child root guidance.".to_string());
     child_config.multi_agent_v2.subagent_usage_hint_text =
@@ -932,6 +934,23 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
         .await
         .expect("child thread should be registered");
     assert_ne!(child_thread_id, parent_thread_id);
+    let child_rollout_path = child_thread
+        .rollout_path()
+        .expect("child rollout path should be present");
+    let child_rollout = RolloutRecorder::get_rollout_history(&child_rollout_path)
+        .await
+        .expect("child rollout should be readable");
+    assert!(
+        child_rollout
+            .get_rollout_items()
+            .iter()
+            .any(|item| matches!(
+                item,
+                RolloutItem::RolloutReference(reference)
+                    if reference.nth_user_message.is_some()
+            )),
+        "full-history forks should store a compact RolloutReference so fork rollout files do not copy parent rollout history"
+    );
     let history = child_thread.codex.session.clone_history().await;
     let expected_history = [
         ResponseItem::Message {

--- a/codex-rs/core/src/codex_thread.rs
+++ b/codex-rs/core/src/codex_thread.rs
@@ -452,6 +452,13 @@ impl CodexThread {
         self.rollout_path.clone()
     }
 
+    pub async fn current_rollout_path(&self) -> Option<PathBuf> {
+        match self.codex.session.current_rollout_path().await {
+            Ok(Some(path)) => Some(path),
+            Ok(None) | Err(_) => self.rollout_path.clone(),
+        }
+    }
+
     pub fn session_configured(&self) -> SessionConfiguredEvent {
         self.session_configured.clone()
     }

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -114,6 +114,7 @@ pub use thread_manager::ThreadManager;
 pub use thread_manager::ThreadShutdownReport;
 pub use thread_manager::build_models_manager;
 pub use thread_manager::thread_store_from_config;
+pub use thread_rollout_truncation::materialize_rollout_items_for_replay;
 pub use web_search::web_search_action_detail;
 pub use web_search::web_search_detail;
 pub use windows_sandbox_read_grants::grant_read_root_non_elevated;

--- a/codex-rs/core/src/personality_migration_tests.rs
+++ b/codex-rs/core/src/personality_migration_tests.rs
@@ -44,6 +44,7 @@ async fn write_rollout_with_user_event(dir: &Path, thread_id: ThreadId) -> io::R
     let session_meta = SessionMetaLine {
         meta: SessionMeta {
             id: thread_id,
+            segment_id: None,
             forked_from_id: None,
             parent_thread_id: None,
             timestamp: TEST_TIMESTAMP.to_string(),

--- a/codex-rs/core/src/rollout.rs
+++ b/codex-rs/core/src/rollout.rs
@@ -21,6 +21,7 @@ pub use codex_rollout::find_thread_path_by_id_str;
 pub use codex_rollout::parse_cursor;
 pub use codex_rollout::read_head_for_summary;
 pub use codex_rollout::read_session_meta_line;
+pub use codex_rollout::resolve_rollout_reference_rollout_path;
 pub use codex_rollout::rollout_date_parts;
 
 impl codex_rollout::RolloutConfigView for Config {

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -36,6 +36,7 @@ use crate::realtime_conversation::RealtimeConversationManager;
 use crate::session_prefix::format_subagent_notification_message;
 use crate::skills::SkillRenderSideEffects;
 use crate::skills_load_input_from_config;
+use crate::thread_rollout_truncation::materialize_rollout_items_for_replay;
 use crate::turn_metadata::TurnMetadataState;
 use crate::turn_timing::now_unix_timestamp_ms;
 use async_channel::Receiver;
@@ -101,6 +102,7 @@ use codex_protocol::openai_models::ModelPreset;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_protocol::protocol::AdditionalContextEntry;
+use codex_protocol::protocol::DEFAULT_ROLLOUT_REFERENCE_DEPTH;
 use codex_protocol::protocol::FileChange;
 use codex_protocol::protocol::HasLegacyEvent;
 use codex_protocol::protocol::InterAgentCommunication;
@@ -140,6 +142,7 @@ use codex_thread_store::LiveThreadInitGuard;
 use codex_thread_store::LocalThreadStore;
 use codex_thread_store::ReadThreadParams;
 use codex_thread_store::ResumeThreadParams;
+use codex_thread_store::RotateThreadSegmentParams;
 use codex_thread_store::ThreadPersistenceMetadata;
 use codex_thread_store::ThreadStore;
 use codex_utils_output_truncation::TruncationPolicy;
@@ -1215,7 +1218,27 @@ impl Session {
                 .session_source
                 .is_non_root_agent()
         };
-        let has_prior_user_turns = initial_history_has_prior_user_turns(&conversation_history);
+        let codex_home = {
+            let state = self.state.lock().await;
+            state.session_configuration.codex_home().clone()
+        };
+        let replay_rollout_items = if conversation_history
+            .scan_rollout_items(|item| matches!(item, RolloutItem::RolloutReference(_)))
+        {
+            Some(
+                materialize_rollout_items_for_replay(
+                    codex_home.as_path(),
+                    &conversation_history.get_rollout_items(),
+                )
+                .await,
+            )
+        } else {
+            None
+        };
+        let has_prior_user_turns = replay_rollout_items.as_ref().map_or_else(
+            || initial_history_has_prior_user_turns(&conversation_history),
+            |items| initial_history_has_prior_user_turns(&InitialHistory::Forked(items.clone())),
+        );
         {
             let mut state = self.state.lock().await;
             state.set_next_turn_is_first(!has_prior_user_turns);
@@ -1229,7 +1252,7 @@ impl Session {
             }
             InitialHistory::Resumed(resumed_history) => {
                 let turn_context = self.new_default_turn().await;
-                let rollout_items = resumed_history.history;
+                let rollout_items = replay_rollout_items.unwrap_or(resumed_history.history);
                 let previous_turn_settings = self
                     .apply_rollout_reconstruction(&turn_context, &rollout_items)
                     .await;
@@ -1269,12 +1292,14 @@ impl Session {
             }
             InitialHistory::Forked(rollout_items) => {
                 let turn_context = self.new_default_turn().await;
-                self.apply_rollout_reconstruction(&turn_context, &rollout_items)
+                let replay_rollout_items =
+                    replay_rollout_items.unwrap_or_else(|| rollout_items.clone());
+                self.apply_rollout_reconstruction(&turn_context, &replay_rollout_items)
                     .await;
 
                 // Seed usage info from the recorded rollout so UIs can show token counts
                 // immediately on resume/fork.
-                if let Some(info) = Self::last_token_info_from_rollout(&rollout_items) {
+                if let Some(info) = Self::last_token_info_from_rollout(&replay_rollout_items) {
                     let mut state = self.state.lock().await;
                     state.set_token_info(Some(info));
                 }
@@ -2677,17 +2702,69 @@ impl Session {
             state.start_next_auto_compact_window();
         }
 
-        self.persist_rollout_items(&[RolloutItem::Compacted(compacted_item)])
-            .await;
+        let mut rollout_items = vec![RolloutItem::Compacted(compacted_item)];
         if let Some(turn_context_item) = reference_context_item {
-            self.persist_rollout_items(&[RolloutItem::TurnContext(turn_context_item)])
-                .await;
+            rollout_items.push(RolloutItem::TurnContext(turn_context_item));
+        }
+        if !self
+            .rotate_rollout_segment_after_compaction(rollout_items.clone())
+            .await
+        {
+            self.persist_rollout_items(&rollout_items).await;
         }
         {
             let mut state = self.state.lock().await;
             state.queue_pending_session_start_source(codex_hooks::SessionStartSource::Compact);
         }
         self.services.model_client.advance_window_generation();
+    }
+
+    async fn rotate_rollout_segment_after_compaction(
+        &self,
+        initial_items: Vec<RolloutItem>,
+    ) -> bool {
+        if !self.features.enabled(Feature::SessionSegmentation) {
+            return false;
+        }
+        let Some(live_thread) = self.live_thread() else {
+            return false;
+        };
+        let params = {
+            let state = self.state.lock().await;
+            let session_configuration = &state.session_configuration;
+            RotateThreadSegmentParams {
+                source: session_configuration.session_source.clone(),
+                base_instructions: BaseInstructions {
+                    text: session_configuration.base_instructions.clone(),
+                },
+                dynamic_tools: session_configuration.dynamic_tools.clone(),
+                metadata: ThreadPersistenceMetadata {
+                    cwd: Some(session_configuration.cwd().to_path_buf()),
+                    model_provider: session_configuration
+                        .original_config_do_not_use
+                        .model_provider_id
+                        .clone(),
+                    memory_mode: if session_configuration
+                        .original_config_do_not_use
+                        .memories
+                        .generate_memories
+                    {
+                        ThreadMemoryMode::Enabled
+                    } else {
+                        ThreadMemoryMode::Disabled
+                    },
+                },
+                initial_items,
+                previous_segment_reference_depth: DEFAULT_ROLLOUT_REFERENCE_DEPTH,
+            }
+        };
+        match live_thread.rotate_local_segment(params).await {
+            Ok(rotated) => rotated,
+            Err(err) => {
+                warn!("failed to rotate rollout segment after compaction: {err:#}");
+                false
+            }
+        }
     }
 
     async fn persist_rollout_response_items(&self, items: &[ResponseItem]) {

--- a/codex-rs/core/src/session/rollout_reconstruction.rs
+++ b/codex-rs/core/src/session/rollout_reconstruction.rs
@@ -207,7 +207,9 @@ impl Session {
                         active_segment.get_or_insert_with(ActiveReplaySegment::default);
                     active_segment.counts_as_user_turn |= is_user_turn_boundary(response_item);
                 }
-                RolloutItem::EventMsg(_) | RolloutItem::SessionMeta(_) => {}
+                RolloutItem::EventMsg(_)
+                | RolloutItem::RolloutReference(_)
+                | RolloutItem::SessionMeta(_) => {}
             }
 
             if base_replacement_history.is_some()
@@ -275,6 +277,7 @@ impl Session {
                     history.drop_last_n_user_turns(rollback.num_turns);
                 }
                 RolloutItem::EventMsg(_)
+                | RolloutItem::RolloutReference(_)
                 | RolloutItem::TurnContext(_)
                 | RolloutItem::SessionMeta(_) => {}
             }

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -3560,6 +3560,158 @@ async fn attach_thread_persistence(session: &mut Session) -> PathBuf {
         .expect("thread should have rollout path")
 }
 
+#[tokio::test]
+async fn replace_compacted_history_rolls_over_local_segment_at_stable_path() {
+    let (mut sess, tc, _) = make_session_and_context_with_rx().await;
+    let sess = Arc::get_mut(&mut sess).expect("session should not have additional references");
+    sess.features
+        .enable(Feature::SessionSegmentation)
+        .expect("enable session segmentation");
+    let old_rollout_path = attach_thread_persistence(sess).await;
+    sess.persist_rollout_items(&[
+        RolloutItem::ResponseItem(user_message("before compaction")),
+        RolloutItem::ResponseItem(assistant_message("before compaction answer")),
+    ])
+    .await;
+    sess.flush_rollout()
+        .await
+        .expect("pre-compaction rollout should flush");
+    let (old_items, _, _) = RolloutRecorder::load_rollout_items(old_rollout_path.as_path())
+        .await
+        .expect("load pre-compaction rollout segment");
+    let old_segment_id = old_items.iter().find_map(|item| match item {
+        RolloutItem::SessionMeta(meta) => meta.meta.segment_id,
+        RolloutItem::RolloutReference(_)
+        | RolloutItem::ResponseItem(_)
+        | RolloutItem::Compacted(_)
+        | RolloutItem::TurnContext(_)
+        | RolloutItem::EventMsg(_) => None,
+    });
+    let old_segment_id = old_segment_id.expect("pre-compaction rollout should have segment id");
+    let replacement_history = vec![user_message("compacted summary")];
+
+    sess.replace_compacted_history(
+        replacement_history.clone(),
+        Some(tc.to_turn_context_item()),
+        CompactedItem {
+            message: "compacted summary".to_string(),
+            replacement_history: Some(replacement_history.clone()),
+        },
+    )
+    .await;
+
+    let new_rollout_path = sess
+        .current_rollout_path()
+        .await
+        .expect("load current rollout path")
+        .expect("rollout path after compaction");
+    assert_eq!(new_rollout_path, old_rollout_path);
+    let config = sess.get_config().await;
+    let rotated_old_rollout_path = config
+        .codex_home
+        .join(codex_rollout::ROTATED_ROLLOUT_SEGMENTS_SUBDIR)
+        .join(sess.thread_id.to_string())
+        .join(old_segment_id.to_string())
+        .join(
+            old_rollout_path
+                .file_name()
+                .expect("old rollout path should have a file name"),
+        );
+    assert!(old_rollout_path.exists());
+    assert!(rotated_old_rollout_path.exists());
+    let old_rollout_timestamp = old_rollout_path
+        .file_name()
+        .and_then(|file_name| file_name.to_str())
+        .and_then(|file_name| file_name.strip_prefix("rollout-"))
+        .and_then(|file_name| file_name.strip_suffix(&format!("-{}.jsonl", sess.thread_id)))
+        .expect("old rollout timestamp");
+    let (new_items, new_thread_id, _) =
+        RolloutRecorder::load_rollout_items(new_rollout_path.as_path())
+            .await
+            .expect("load new rollout segment");
+    assert_eq!(new_thread_id, Some(sess.thread_id));
+    assert!(new_items.iter().any(|item| {
+        matches!(
+            item,
+            RolloutItem::RolloutReference(reference)
+                if reference.rollout_path.as_path() == rotated_old_rollout_path.as_path()
+                    && reference.thread_id == Some(sess.thread_id)
+                    && reference.rollout_timestamp.as_deref() == Some(old_rollout_timestamp)
+        )
+    }));
+    assert!(new_items.iter().any(|item| {
+        matches!(
+            item,
+            RolloutItem::Compacted(CompactedItem {
+                replacement_history: Some(history),
+                ..
+            }) if *history == replacement_history
+        )
+    }));
+
+    let replay_items = crate::thread_rollout_truncation::materialize_rollout_items_for_replay(
+        config.codex_home.as_path(),
+        &new_items,
+    )
+    .await;
+    let reconstructed = sess
+        .reconstruct_history_from_rollout(tc.as_ref(), &replay_items)
+        .await;
+    assert_eq!(reconstructed.history, replacement_history);
+}
+
+#[tokio::test]
+async fn replace_compacted_history_does_not_segment_when_feature_is_disabled() {
+    let (mut sess, tc, _) = make_session_and_context_with_rx().await;
+    let sess = Arc::get_mut(&mut sess).expect("session should not have additional references");
+    assert!(!sess.features.enabled(Feature::SessionSegmentation));
+    let rollout_path = attach_thread_persistence(sess).await;
+    sess.persist_rollout_items(&[
+        RolloutItem::ResponseItem(user_message("before compaction")),
+        RolloutItem::ResponseItem(assistant_message("before compaction answer")),
+    ])
+    .await;
+    sess.flush_rollout()
+        .await
+        .expect("pre-compaction rollout should flush");
+
+    let replacement_history = vec![user_message("compacted summary")];
+    sess.replace_compacted_history(
+        replacement_history.clone(),
+        Some(tc.to_turn_context_item()),
+        CompactedItem {
+            message: "compacted summary".to_string(),
+            replacement_history: Some(replacement_history),
+        },
+    )
+    .await;
+    sess.flush_rollout()
+        .await
+        .expect("post-compaction rollout should flush");
+
+    assert_eq!(
+        sess.current_rollout_path()
+            .await
+            .expect("load current rollout path"),
+        Some(rollout_path.clone())
+    );
+    let (items, _, _) = RolloutRecorder::load_rollout_items(rollout_path.as_path())
+        .await
+        .expect("load rollout after compaction");
+    assert!(
+        !items
+            .iter()
+            .any(|item| matches!(item, RolloutItem::RolloutReference(_)))
+    );
+    let config = sess.get_config().await;
+    assert!(
+        !config
+            .codex_home
+            .join(codex_rollout::ROTATED_ROLLOUT_SEGMENTS_SUBDIR)
+            .exists()
+    );
+}
+
 fn text_block(s: &str) -> serde_json::Value {
     json!({
         "type": "text",

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -37,6 +37,7 @@ use codex_protocol::config_types::CollaborationModeMask;
 use codex_protocol::error::CodexErr;
 use codex_protocol::error::Result as CodexResult;
 use codex_protocol::openai_models::ModelPreset;
+use codex_protocol::protocol::DEFAULT_ROLLOUT_REFERENCE_DEPTH;
 use codex_protocol::protocol::Event;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::InitialHistory;
@@ -44,6 +45,7 @@ use codex_protocol::protocol::MultiAgentVersion;
 use codex_protocol::protocol::Op;
 use codex_protocol::protocol::ResumedHistory;
 use codex_protocol::protocol::RolloutItem;
+use codex_protocol::protocol::RolloutReferenceItem;
 use codex_protocol::protocol::SessionConfiguredEvent;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SubAgentSource;
@@ -924,7 +926,28 @@ impl ThreadManager {
             .await;
         let interrupted_marker =
             InterruptedTurnHistoryMarker::from_config_and_version(&config, multi_agent_version);
+        let snapshot_state = snapshot_turn_state(&history);
+        let source_rollout_path = match &history {
+            InitialHistory::Resumed(resumed) => resumed.rollout_path.clone(),
+            InitialHistory::New | InitialHistory::Cleared | InitialHistory::Forked(_) => None,
+        };
+        let source_items = history.get_rollout_items();
+        let reference_history = config
+            .features
+            .enabled(Feature::SessionSegmentation)
+            .then_some(source_rollout_path)
+            .flatten()
+            .and_then(|rollout_path| {
+                rollout_reference_history_for_snapshot(
+                    snapshot,
+                    rollout_path,
+                    &source_items,
+                    &snapshot_state,
+                    interrupted_marker,
+                )
+            });
         let history = fork_history_from_snapshot(snapshot, history, interrupted_marker);
+        let history = reference_history.unwrap_or(history);
         let environments = default_thread_environment_selections(
             self.state.environment_manager.as_ref(),
             &config.cwd,
@@ -1602,6 +1625,75 @@ fn fork_history_from_snapshot(
             }
         }
     }
+}
+
+fn rollout_reference_history_for_snapshot(
+    snapshot: ForkSnapshot,
+    rollout_path: PathBuf,
+    source_items: &[RolloutItem],
+    snapshot_state: &SnapshotTurnState,
+    interrupted_marker: InterruptedTurnHistoryMarker,
+) -> Option<InitialHistory> {
+    let nth_user_message = match snapshot {
+        ForkSnapshot::TruncateBeforeNthUserMessage(nth_user_message) => {
+            let user_positions = truncation::user_message_positions_in_rollout(source_items);
+            if snapshot_state.ends_mid_turn && nth_user_message >= user_positions.len() {
+                return None;
+            }
+            nth_user_message
+        }
+        ForkSnapshot::Interrupted => usize::MAX,
+    };
+
+    let source_meta = source_items.iter().find_map(|item| match item {
+        RolloutItem::SessionMeta(meta) => Some(meta),
+        RolloutItem::Compacted(_)
+        | RolloutItem::EventMsg(_)
+        | RolloutItem::RolloutReference(_)
+        | RolloutItem::ResponseItem(_)
+        | RolloutItem::TurnContext(_) => None,
+    });
+
+    let mut history: Vec<RolloutItem> = source_items
+        .iter()
+        .find_map(|item| match item {
+            RolloutItem::SessionMeta(meta) => Some(RolloutItem::SessionMeta(meta.clone())),
+            RolloutItem::Compacted(_)
+            | RolloutItem::EventMsg(_)
+            | RolloutItem::RolloutReference(_)
+            | RolloutItem::ResponseItem(_)
+            | RolloutItem::TurnContext(_) => None,
+        })
+        .into_iter()
+        .chain(std::iter::once(RolloutItem::RolloutReference(
+            RolloutReferenceItem {
+                rollout_path,
+                thread_id: source_meta.map(|meta| meta.meta.id),
+                rollout_timestamp: None,
+                segment_id: source_meta.and_then(|meta| meta.meta.segment_id),
+                max_depth: DEFAULT_ROLLOUT_REFERENCE_DEPTH,
+                nth_user_message: Some(nth_user_message),
+                filter_fork_history: false,
+                developer_message_filter_texts: None,
+            },
+        )))
+        .collect();
+
+    if snapshot == ForkSnapshot::Interrupted && snapshot_state.ends_mid_turn {
+        if let Some(marker) = interrupted_turn_history_marker(interrupted_marker) {
+            history.push(RolloutItem::ResponseItem(marker));
+        }
+        history.push(RolloutItem::EventMsg(EventMsg::TurnAborted(
+            TurnAbortedEvent {
+                turn_id: snapshot_state.active_turn_id.clone(),
+                reason: TurnAbortReason::Interrupted,
+                completed_at: None,
+                duration_ms: None,
+            },
+        )));
+    }
+
+    Some(InitialHistory::Forked(history))
 }
 
 /// Append the same persisted interrupt boundary used by the live interrupt path

--- a/codex-rs/core/src/thread_manager_tests.rs
+++ b/codex-rs/core/src/thread_manager_tests.rs
@@ -7,6 +7,7 @@ use crate::session::session::SessionSettingsUpdate;
 use crate::session::tests::make_session_and_context;
 use crate::tasks::InterruptedTurnHistoryMarker;
 use crate::tasks::interrupted_turn_history_marker;
+use crate::thread_rollout_truncation::materialize_rollout_items_for_replay;
 use codex_extension_api::empty_extension_registry;
 use codex_models_manager::manager::RefreshStrategy;
 use codex_protocol::models::ContentItem;
@@ -1453,8 +1454,17 @@ async fn interrupted_fork_snapshot_uses_persisted_mid_turn_history_without_live_
     let reforked_history = RolloutRecorder::get_rollout_history(&reforked_path)
         .await
         .expect("read re-forked rollout history");
-    let reforked_rollout_items: Vec<_> = reforked_history
-        .get_rollout_items()
+    let reforked_raw_items = reforked_history.get_rollout_items();
+    assert!(
+        !reforked_raw_items
+            .iter()
+            .any(|item| matches!(item, RolloutItem::RolloutReference(_))),
+        "forks should copy history while session segmentation is disabled"
+    );
+    let materialized_reforked_items =
+        materialize_rollout_items_for_replay(config.codex_home.as_path(), &reforked_raw_items)
+            .await;
+    let reforked_rollout_items: Vec<_> = materialized_reforked_items
         .into_iter()
         .filter(|item| !matches!(item, RolloutItem::SessionMeta(_)))
         .collect();

--- a/codex-rs/core/src/thread_rollout_truncation.rs
+++ b/codex-rs/core/src/thread_rollout_truncation.rs
@@ -5,12 +5,18 @@
 
 use crate::context_manager::is_user_turn_boundary;
 use crate::event_mapping;
+use crate::rollout::RolloutRecorder;
+use crate::rollout::resolve_rollout_reference_rollout_path;
 use codex_protocol::items::TurnItem;
+use codex_protocol::models::ContentItem;
+use codex_protocol::models::MessagePhase;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::InitialHistory;
 use codex_protocol::protocol::InterAgentCommunication;
 use codex_protocol::protocol::RolloutItem;
+use std::path::Path;
+use tracing::warn;
 
 pub(crate) fn initial_history_has_prior_user_turns(conversation_history: &InitialHistory) -> bool {
     conversation_history.scan_rollout_items(rollout_item_is_user_turn_boundary)
@@ -150,6 +156,211 @@ pub(crate) fn truncate_rollout_to_last_n_fork_turns(
         return Vec::new();
     };
     items[keep_idx..].to_vec()
+}
+
+pub async fn materialize_rollout_items_for_replay(
+    codex_home: &Path,
+    rollout_items: &[RolloutItem],
+) -> Vec<RolloutItem> {
+    const MAX_REFERENCE_DEPTH: usize = 8;
+
+    enum Work {
+        Items {
+            rollout_items: Vec<RolloutItem>,
+            reference_depth: usize,
+            rollout_reference_depth: usize,
+        },
+        Item {
+            item: Box<RolloutItem>,
+            reference_depth: usize,
+            rollout_reference_depth: usize,
+        },
+        TruncateSuffix {
+            start: usize,
+            nth_user_message: usize,
+        },
+    }
+
+    let mut materialized = Vec::new();
+    let mut work = vec![Work::Items {
+        rollout_items: rollout_items.to_vec(),
+        reference_depth: 0,
+        rollout_reference_depth: 0,
+    }];
+    while let Some(next) = work.pop() {
+        match next {
+            Work::Items {
+                rollout_items,
+                reference_depth,
+                rollout_reference_depth,
+            } => {
+                if reference_depth >= MAX_REFERENCE_DEPTH {
+                    warn!("rollout reference materialization reached max depth");
+                    materialized.extend(rollout_items);
+                    continue;
+                }
+                for item in rollout_items.into_iter().rev() {
+                    work.push(Work::Item {
+                        item: Box::new(item),
+                        reference_depth,
+                        rollout_reference_depth,
+                    });
+                }
+            }
+            Work::Item {
+                item,
+                reference_depth,
+                rollout_reference_depth,
+            } => {
+                let reference = match *item {
+                    RolloutItem::RolloutReference(reference) => reference,
+                    item => {
+                        materialized.push(item);
+                        continue;
+                    }
+                };
+                let has_prefix_truncation = reference.nth_user_message.is_some();
+                if !has_prefix_truncation && rollout_reference_depth >= reference.max_depth {
+                    warn!("rollout reference materialization reached max depth");
+                    continue;
+                }
+                let resolved_path =
+                    match resolve_rollout_reference_rollout_path(codex_home, &reference).await {
+                        Ok(path) => path,
+                        Err(err) => {
+                            warn!(
+                                "failed to resolve rollout reference {}: {err}",
+                                reference.rollout_path.display()
+                            );
+                            reference.rollout_path.clone()
+                        }
+                    };
+                match RolloutRecorder::load_rollout_items(&resolved_path).await {
+                    Ok((mut reference_items, _, _)) => {
+                        if reference.filter_fork_history {
+                            reference_items.retain(|item| keep_forked_rollout_item(item, true));
+                        }
+                        if let Some(filter_texts) =
+                            reference.developer_message_filter_texts.as_deref()
+                        {
+                            apply_developer_message_filter(&mut reference_items, filter_texts);
+                        }
+                        let next_rollout_reference_depth = if has_prefix_truncation {
+                            rollout_reference_depth
+                        } else {
+                            rollout_reference_depth + 1
+                        };
+                        if let Some(nth_user_message) = reference.nth_user_message {
+                            work.push(Work::TruncateSuffix {
+                                start: materialized.len(),
+                                nth_user_message,
+                            });
+                        }
+                        work.push(Work::Items {
+                            rollout_items: reference_items,
+                            reference_depth: reference_depth + 1,
+                            rollout_reference_depth: next_rollout_reference_depth,
+                        });
+                    }
+                    Err(err) => {
+                        warn!(
+                            "failed to load rollout reference {}: {err}",
+                            resolved_path.display()
+                        );
+                    }
+                }
+            }
+            Work::TruncateSuffix {
+                start,
+                nth_user_message,
+            } => {
+                let suffix = truncate_rollout_before_nth_user_message_from_start(
+                    &materialized[start..],
+                    nth_user_message,
+                );
+                materialized.truncate(start);
+                materialized.extend(suffix);
+            }
+        }
+    }
+    materialized
+}
+
+pub(crate) fn keep_forked_rollout_item(
+    item: &RolloutItem,
+    preserve_reference_context_item: bool,
+) -> bool {
+    match item {
+        RolloutItem::ResponseItem(ResponseItem::Message { role, phase, .. }) => {
+            match role.as_str() {
+                "system" | "developer" | "user" => true,
+                "assistant" => *phase == Some(MessagePhase::FinalAnswer),
+                _ => false,
+            }
+        }
+        RolloutItem::ResponseItem(
+            ResponseItem::AgentMessage { .. }
+            | ResponseItem::Reasoning { .. }
+            | ResponseItem::LocalShellCall { .. }
+            | ResponseItem::FunctionCall { .. }
+            | ResponseItem::ToolSearchCall { .. }
+            | ResponseItem::FunctionCallOutput { .. }
+            | ResponseItem::CustomToolCall { .. }
+            | ResponseItem::CustomToolCallOutput { .. }
+            | ResponseItem::ToolSearchOutput { .. }
+            | ResponseItem::WebSearchCall { .. }
+            | ResponseItem::ImageGenerationCall { .. }
+            | ResponseItem::Compaction { .. }
+            | ResponseItem::CompactionTrigger
+            | ResponseItem::ContextCompaction { .. }
+            | ResponseItem::Other,
+        ) => false,
+        RolloutItem::TurnContext(_) => preserve_reference_context_item,
+        RolloutItem::Compacted(_) | RolloutItem::EventMsg(_) | RolloutItem::SessionMeta(_) => true,
+        RolloutItem::RolloutReference(_) => true,
+    }
+}
+
+fn apply_developer_message_filter(rollout_items: &mut Vec<RolloutItem>, filter_texts: &[String]) {
+    rollout_items.retain(|item| {
+        !matches!(
+            item,
+            RolloutItem::ResponseItem(response_item)
+                if matches_filtered_developer_message(response_item, filter_texts)
+        )
+    });
+    for item in rollout_items {
+        match item {
+            RolloutItem::Compacted(compacted) => {
+                if let Some(replacement_history) = compacted.replacement_history.as_mut() {
+                    replacement_history.retain(|response_item| {
+                        !matches_filtered_developer_message(response_item, filter_texts)
+                    });
+                }
+            }
+            RolloutItem::RolloutReference(reference) => {
+                reference.developer_message_filter_texts = Some(filter_texts.to_vec());
+            }
+            RolloutItem::SessionMeta(_)
+            | RolloutItem::ResponseItem(_)
+            | RolloutItem::TurnContext(_)
+            | RolloutItem::EventMsg(_) => {}
+        }
+    }
+}
+
+fn matches_filtered_developer_message(item: &ResponseItem, filter_texts: &[String]) -> bool {
+    let ResponseItem::Message { role, content, .. } = item else {
+        return false;
+    };
+    if role != "developer" {
+        return false;
+    }
+    let [ContentItem::InputText { text }] = content.as_slice() else {
+        return false;
+    };
+
+    filter_texts.iter().any(|filter_text| filter_text == text)
 }
 
 fn is_real_user_message_boundary(item: &ResponseItem) -> bool {

--- a/codex-rs/core/src/thread_rollout_truncation_tests.rs
+++ b/codex-rs/core/src/thread_rollout_truncation_tests.rs
@@ -1,11 +1,19 @@
 use super::*;
 use crate::session::tests::make_session_and_context;
 use codex_protocol::AgentPath;
+use codex_protocol::SegmentId;
+use codex_protocol::ThreadId;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::ReasoningItemReasoningSummary;
+use codex_protocol::protocol::DEFAULT_ROLLOUT_REFERENCE_DEPTH;
 use codex_protocol::protocol::InterAgentCommunication;
+use codex_protocol::protocol::RolloutLine;
+use codex_protocol::protocol::RolloutReferenceItem;
+use codex_protocol::protocol::SessionMeta;
+use codex_protocol::protocol::SessionMetaLine;
 use codex_protocol::protocol::ThreadRolledBackEvent;
 use pretty_assertions::assert_eq;
+use std::path::PathBuf;
 
 fn user_msg(text: &str) -> ResponseItem {
     ResponseItem::Message {
@@ -49,6 +57,34 @@ fn inter_agent_msg(text: &str, trigger_turn: bool) -> ResponseItem {
         trigger_turn,
     );
     communication.to_response_input_item().into()
+}
+
+async fn write_rollout(path: &std::path::Path, items: &[RolloutItem]) {
+    let mut jsonl = String::new();
+    for item in items {
+        let line = RolloutLine {
+            timestamp: "2026-04-30T00:00:00.000Z".to_string(),
+            item: item.clone(),
+        };
+        jsonl.push_str(&serde_json::to_string(&line).expect("serialize rollout line"));
+        jsonl.push('\n');
+    }
+    tokio::fs::write(path, jsonl).await.expect("write rollout");
+}
+
+fn session_meta_item(thread_id: ThreadId, segment_id: SegmentId) -> RolloutItem {
+    RolloutItem::SessionMeta(SessionMetaLine {
+        meta: SessionMeta {
+            id: thread_id,
+            segment_id: Some(segment_id),
+            timestamp: "2026-04-30T00:00:00.000Z".to_string(),
+            cwd: PathBuf::from("/tmp"),
+            originator: "test".to_string(),
+            cli_version: "0.0.0".to_string(),
+            ..SessionMeta::default()
+        },
+        git: None,
+    })
 }
 
 #[test]
@@ -116,6 +152,298 @@ fn truncation_max_keeps_full_rollout() {
     assert_eq!(
         serde_json::to_value(&truncated).unwrap(),
         serde_json::to_value(&rollout).unwrap()
+    );
+}
+
+#[test]
+fn legacy_fork_reference_decodes_as_rollout_reference() {
+    let item: RolloutItem = serde_json::from_value(serde_json::json!({
+        "type": "fork_reference",
+        "payload": {
+            "rollout_path": "/tmp/legacy.jsonl",
+            "nth_user_message": 3
+        }
+    }))
+    .expect("deserialize legacy fork reference");
+
+    let RolloutItem::RolloutReference(reference) = item else {
+        panic!("legacy fork reference should decode as rollout reference");
+    };
+    assert_eq!(reference.rollout_path, PathBuf::from("/tmp/legacy.jsonl"));
+    assert_eq!(reference.max_depth, DEFAULT_ROLLOUT_REFERENCE_DEPTH);
+    assert_eq!(reference.nth_user_message, Some(3));
+
+    let value = serde_json::to_value(RolloutItem::RolloutReference(reference))
+        .expect("serialize rollout reference");
+    assert_eq!(value["type"], "rollout_reference");
+}
+
+#[tokio::test]
+async fn materializes_prefix_truncated_rollout_reference_before_replay() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let source_path = temp
+        .path()
+        .join("rollout-2026-04-30T00-00-00-00000000-0000-0000-0000-000000000001.jsonl");
+    let source_items = vec![
+        RolloutItem::ResponseItem(user_msg("u1")),
+        RolloutItem::ResponseItem(assistant_msg("a1")),
+        RolloutItem::ResponseItem(user_msg("u2")),
+        RolloutItem::ResponseItem(assistant_msg("a2")),
+    ];
+    write_rollout(&source_path, &source_items).await;
+
+    let compact_reference = vec![
+        RolloutItem::RolloutReference(RolloutReferenceItem {
+            rollout_path: source_path.clone(),
+            thread_id: None,
+            rollout_timestamp: None,
+            segment_id: None,
+            max_depth: DEFAULT_ROLLOUT_REFERENCE_DEPTH,
+            nth_user_message: Some(1),
+            filter_fork_history: false,
+            developer_message_filter_texts: None,
+        }),
+        RolloutItem::ResponseItem(user_msg("child request")),
+    ];
+
+    let materialized = materialize_rollout_items_for_replay(temp.path(), &compact_reference).await;
+
+    let expected = vec![
+        RolloutItem::ResponseItem(user_msg("u1")),
+        RolloutItem::ResponseItem(assistant_msg("a1")),
+        RolloutItem::ResponseItem(user_msg("child request")),
+    ];
+    assert_eq!(
+        serde_json::to_value(&materialized).unwrap(),
+        serde_json::to_value(&expected).unwrap()
+    );
+}
+
+#[tokio::test]
+async fn materializes_prefix_truncated_rollout_reference_by_segment_id_after_source_rollover() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let thread_id = ThreadId::new();
+    let old_segment_id = SegmentId::new();
+    let new_segment_id = SegmentId::new();
+
+    let old_active_path = temp
+        .path()
+        .join("sessions/2026/04/30")
+        .join(format!("rollout-2026-04-30T00-00-00-{thread_id}.jsonl"));
+    let old_archived_path = temp
+        .path()
+        .join("archived_sessions/2026/04/30")
+        .join(format!("rollout-2026-04-30T00-00-00-{thread_id}.jsonl"));
+    let new_active_path = temp
+        .path()
+        .join("sessions/2026/05/01")
+        .join(format!("rollout-2026-05-01T00-00-00-{thread_id}.jsonl"));
+
+    tokio::fs::create_dir_all(old_archived_path.parent().expect("archived parent"))
+        .await
+        .expect("create archived parent");
+    tokio::fs::create_dir_all(new_active_path.parent().expect("active parent"))
+        .await
+        .expect("create active parent");
+
+    write_rollout(
+        &old_archived_path,
+        &[
+            session_meta_item(thread_id, old_segment_id),
+            RolloutItem::ResponseItem(user_msg("old segment request")),
+            RolloutItem::ResponseItem(assistant_msg("old segment answer")),
+        ],
+    )
+    .await;
+    write_rollout(
+        &new_active_path,
+        &[
+            session_meta_item(thread_id, new_segment_id),
+            RolloutItem::ResponseItem(user_msg("new segment request")),
+            RolloutItem::ResponseItem(assistant_msg("new segment answer")),
+        ],
+    )
+    .await;
+
+    let compact_reference = vec![
+        RolloutItem::RolloutReference(RolloutReferenceItem {
+            rollout_path: old_active_path,
+            thread_id: Some(thread_id),
+            rollout_timestamp: None,
+            segment_id: Some(old_segment_id),
+            max_depth: DEFAULT_ROLLOUT_REFERENCE_DEPTH,
+            nth_user_message: Some(usize::MAX),
+            filter_fork_history: false,
+            developer_message_filter_texts: None,
+        }),
+        RolloutItem::ResponseItem(user_msg("child request")),
+    ];
+
+    let materialized = materialize_rollout_items_for_replay(temp.path(), &compact_reference).await;
+    let text = serde_json::to_string(&materialized).expect("serialize materialized rollout");
+
+    assert!(text.contains("old segment request"));
+    assert!(!text.contains("new segment request"));
+    assert!(text.contains("child request"));
+}
+
+#[tokio::test]
+async fn materializes_prefix_truncated_reference_before_bounded_rollout_references() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let thread_id = ThreadId::new();
+    let old_segment_id = SegmentId::new();
+    let current_segment_id = SegmentId::new();
+
+    let old_path = temp.path().join("old.jsonl");
+    let current_path = temp.path().join("current.jsonl");
+
+    write_rollout(
+        &old_path,
+        &[
+            session_meta_item(thread_id, old_segment_id),
+            RolloutItem::ResponseItem(user_msg("u1")),
+            RolloutItem::ResponseItem(assistant_msg("a1")),
+        ],
+    )
+    .await;
+    write_rollout(
+        &current_path,
+        &[
+            session_meta_item(thread_id, current_segment_id),
+            RolloutItem::RolloutReference(RolloutReferenceItem {
+                rollout_path: old_path,
+                thread_id: None,
+                rollout_timestamp: None,
+                segment_id: None,
+                max_depth: 2,
+                nth_user_message: None,
+                filter_fork_history: false,
+                developer_message_filter_texts: None,
+            }),
+            RolloutItem::ResponseItem(user_msg("u2")),
+            RolloutItem::ResponseItem(assistant_msg("a2")),
+            RolloutItem::ResponseItem(user_msg("u3")),
+        ],
+    )
+    .await;
+
+    let reference_items = vec![
+        RolloutItem::RolloutReference(RolloutReferenceItem {
+            rollout_path: current_path,
+            thread_id: Some(thread_id),
+            rollout_timestamp: None,
+            segment_id: Some(current_segment_id),
+            max_depth: DEFAULT_ROLLOUT_REFERENCE_DEPTH,
+            nth_user_message: Some(2),
+            filter_fork_history: false,
+            developer_message_filter_texts: None,
+        }),
+        RolloutItem::ResponseItem(user_msg("child request")),
+    ];
+
+    let materialized = materialize_rollout_items_for_replay(temp.path(), &reference_items).await;
+    let text = serde_json::to_string(&materialized).expect("serialize materialized rollout");
+
+    assert!(text.contains("u1"));
+    assert!(text.contains("u2"));
+    assert!(!text.contains("u3"));
+    assert!(text.contains("child request"));
+}
+
+#[tokio::test]
+async fn materializes_rollout_reference_with_bounded_depth() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let thread_id = ThreadId::new();
+    let oldest_segment_id = SegmentId::new();
+    let old_segment_id = SegmentId::new();
+    let middle_segment_id = SegmentId::new();
+
+    let oldest_path = temp.path().join("oldest.jsonl");
+    let old_path = temp.path().join("old.jsonl");
+    let middle_path = temp.path().join("middle.jsonl");
+    let current_path = temp.path().join("current.jsonl");
+
+    write_rollout(
+        &oldest_path,
+        &[
+            session_meta_item(thread_id, oldest_segment_id),
+            RolloutItem::ResponseItem(user_msg("oldest segment request")),
+        ],
+    )
+    .await;
+    write_rollout(
+        &old_path,
+        &[
+            session_meta_item(thread_id, old_segment_id),
+            RolloutItem::RolloutReference(RolloutReferenceItem {
+                rollout_path: oldest_path,
+                thread_id: None,
+                rollout_timestamp: None,
+                segment_id: None,
+                max_depth: 2,
+                nth_user_message: None,
+                filter_fork_history: false,
+                developer_message_filter_texts: None,
+            }),
+            RolloutItem::ResponseItem(user_msg("old segment request")),
+        ],
+    )
+    .await;
+    write_rollout(
+        &middle_path,
+        &[
+            session_meta_item(thread_id, middle_segment_id),
+            RolloutItem::RolloutReference(RolloutReferenceItem {
+                rollout_path: old_path,
+                thread_id: None,
+                rollout_timestamp: None,
+                segment_id: None,
+                max_depth: 2,
+                nth_user_message: None,
+                filter_fork_history: false,
+                developer_message_filter_texts: None,
+            }),
+            RolloutItem::ResponseItem(user_msg("middle segment request")),
+        ],
+    )
+    .await;
+
+    let current_items = vec![
+        RolloutItem::RolloutReference(RolloutReferenceItem {
+            rollout_path: middle_path,
+            thread_id: None,
+            rollout_timestamp: None,
+            segment_id: None,
+            max_depth: 2,
+            nth_user_message: None,
+            filter_fork_history: false,
+            developer_message_filter_texts: None,
+        }),
+        RolloutItem::ResponseItem(user_msg("current segment request")),
+    ];
+    write_rollout(&current_path, &current_items).await;
+    let materialized = materialize_rollout_items_for_replay(temp.path(), &current_items).await;
+    let text = serde_json::to_string(&materialized).expect("serialize materialized rollout");
+
+    assert!(!text.contains("oldest segment request"));
+    assert!(text.contains("old segment request"));
+    assert!(text.contains("middle segment request"));
+    assert!(text.contains("current segment request"));
+
+    let fork_items = vec![RolloutItem::RolloutReference(RolloutReferenceItem {
+        rollout_path: current_path,
+        thread_id: None,
+        rollout_timestamp: None,
+        segment_id: None,
+        max_depth: DEFAULT_ROLLOUT_REFERENCE_DEPTH,
+        nth_user_message: Some(usize::MAX),
+        filter_fork_history: false,
+        developer_message_filter_texts: None,
+    })];
+    let fork_materialized = materialize_rollout_items_for_replay(temp.path(), &fork_items).await;
+    assert_eq!(
+        serde_json::to_value(&fork_materialized).unwrap(),
+        serde_json::to_value(&materialized).unwrap()
     );
 }
 

--- a/codex-rs/core/tests/suite/compact.rs
+++ b/codex-rs/core/tests/suite/compact.rs
@@ -4,6 +4,7 @@ use anyhow::anyhow;
 use codex_core::compact::SUMMARIZATION_PROMPT;
 use codex_core::compact::SUMMARY_PREFIX;
 use codex_core::config::Config;
+use codex_core::materialize_rollout_items_for_replay;
 use codex_features::Feature;
 use codex_login::CodexAuth;
 use codex_model_provider_info::ModelProviderInfo;
@@ -496,7 +497,6 @@ async fn summarize_context_three_requests_and_instructions() {
     });
     let test = builder.build(&server).await.unwrap();
     let codex = test.codex.clone();
-    let rollout_path = test.session_configured.rollout_path.expect("rollout path");
 
     // 1) Normal user input – should hit server once.
     codex
@@ -631,6 +631,7 @@ async fn summarize_context_three_requests_and_instructions() {
     );
 
     // Shut down Codex to flush rollout entries before inspecting the file.
+    let rollout_path = codex.current_rollout_path().await.expect("rollout path");
     codex.submit(Op::Shutdown).await.unwrap();
     wait_for_event(&codex, |ev| matches!(ev, EventMsg::ShutdownComplete)).await;
 
@@ -642,8 +643,7 @@ async fn summarize_context_three_requests_and_instructions() {
             rollout_path.display()
         )
     });
-    let mut regular_turn_context_count = 0usize;
-    let mut saw_compacted_summary = false;
+    let mut rollout_items = Vec::new();
     for line in text.lines() {
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -652,7 +652,15 @@ async fn summarize_context_three_requests_and_instructions() {
         let Ok(entry): Result<RolloutLine, _> = serde_json::from_str(trimmed) else {
             continue;
         };
-        match entry.item {
+        rollout_items.push(entry.item);
+    }
+    let rollout_items =
+        materialize_rollout_items_for_replay(test.config.codex_home.as_path(), &rollout_items)
+            .await;
+    let mut regular_turn_context_count = 0usize;
+    let mut saw_compacted_summary = false;
+    for item in rollout_items {
+        match item {
             RolloutItem::TurnContext(_) => {
                 regular_turn_context_count += 1;
             }
@@ -2467,7 +2475,6 @@ async fn auto_compact_persists_rollout_entries() {
     });
     let test = builder.build(&server).await.unwrap();
     let codex = test.codex.clone();
-    let session_configured = test.session_configured;
 
     codex
         .submit(Op::UserInput {
@@ -2514,10 +2521,10 @@ async fn auto_compact_persists_rollout_entries() {
         .unwrap();
     wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
 
+    let rollout_path = codex.current_rollout_path().await.expect("rollout path");
     codex.submit(Op::Shutdown).await.unwrap();
     wait_for_event(&codex, |ev| matches!(ev, EventMsg::ShutdownComplete)).await;
 
-    let rollout_path = session_configured.rollout_path.expect("rollout path");
     let text = std::fs::read_to_string(&rollout_path).unwrap_or_else(|e| {
         panic!(
             "failed to read rollout file {}: {e}",
@@ -2525,7 +2532,7 @@ async fn auto_compact_persists_rollout_entries() {
         )
     });
 
-    let mut turn_context_count = 0usize;
+    let mut rollout_items = Vec::new();
     for line in text.lines() {
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -2534,7 +2541,15 @@ async fn auto_compact_persists_rollout_entries() {
         let Ok(entry): Result<RolloutLine, _> = serde_json::from_str(trimmed) else {
             continue;
         };
-        match entry.item {
+        rollout_items.push(entry.item);
+    }
+    let rollout_items =
+        materialize_rollout_items_for_replay(test.config.codex_home.as_path(), &rollout_items)
+            .await;
+
+    let mut turn_context_count = 0usize;
+    for item in rollout_items {
+        match item {
             RolloutItem::TurnContext(_) => {
                 turn_context_count += 1;
             }

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -2445,11 +2445,6 @@ async fn remote_compact_and_resume_refresh_stale_developer_instructions() -> Res
         test_codex().with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing());
     let initial = start_builder.build(&server).await?;
     let home = initial.home.clone();
-    let rollout_path = initial
-        .session_configured
-        .rollout_path
-        .clone()
-        .expect("rollout path");
 
     let responses_mock = responses::mount_sse_sequence(
         &server,
@@ -2506,6 +2501,12 @@ async fn remote_compact_and_resume_refresh_stale_developer_instructions() -> Res
 
     initial.codex.submit(Op::Compact).await?;
     wait_for_event(&initial.codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    let rollout_path = initial
+        .codex
+        .current_rollout_path()
+        .await
+        .expect("rollout path");
 
     initial
         .codex
@@ -3125,11 +3126,6 @@ async fn snapshot_request_shape_remote_compact_resume_restates_realtime_end() ->
     let mut builder = remote_realtime_test_codex_builder(&realtime_server);
     let initial = builder.build(&server).await?;
     let home = initial.home.clone();
-    let rollout_path = initial
-        .session_configured
-        .rollout_path
-        .clone()
-        .expect("rollout path");
 
     let responses_mock = responses::mount_sse_sequence(
         &server,
@@ -3176,6 +3172,12 @@ async fn snapshot_request_shape_remote_compact_resume_restates_realtime_end() ->
 
     initial.codex.submit(Op::Compact).await?;
     wait_for_event(&initial.codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    let rollout_path = initial
+        .codex
+        .current_rollout_path()
+        .await
+        .expect("rollout path");
 
     initial.codex.submit(Op::Shutdown).await?;
     wait_for_event(&initial.codex, |ev| {

--- a/codex-rs/core/tests/suite/compact_resume_fork.rs
+++ b/codex-rs/core/tests/suite/compact_resume_fork.rs
@@ -145,7 +145,7 @@ async fn compact_resume_and_fork_preserve_model_history_view() {
     user_turn(&base, "hello world").await;
     compact_conversation(&base).await;
     user_turn(&base, "AFTER_COMPACT").await;
-    let base_path = fetch_conversation_path(&base);
+    let base_path = fetch_conversation_path(&base).await;
     assert!(
         base_path.exists(),
         "compact+resume test expects base path {base_path:?} to exist",
@@ -154,7 +154,7 @@ async fn compact_resume_and_fork_preserve_model_history_view() {
     shutdown_conversation(&base).await;
     let resumed = resume_conversation(&manager, &config, base_path).await;
     user_turn(&resumed, "AFTER_RESUME").await;
-    let resumed_path = fetch_conversation_path(&resumed);
+    let resumed_path = fetch_conversation_path(&resumed).await;
     assert!(
         resumed_path.exists(),
         "compact+resume test expects resumed path {resumed_path:?} to exist",
@@ -301,7 +301,7 @@ async fn compact_resume_after_second_compaction_preserves_history() -> Result<()
     user_turn(&base, "hello world").await;
     compact_conversation(&base).await;
     user_turn(&base, "AFTER_COMPACT").await;
-    let base_path = fetch_conversation_path(&base);
+    let base_path = fetch_conversation_path(&base).await;
     assert!(
         base_path.exists(),
         "second compact test expects base path {base_path:?} to exist",
@@ -310,7 +310,7 @@ async fn compact_resume_after_second_compaction_preserves_history() -> Result<()
     shutdown_conversation(&base).await;
     let resumed = resume_conversation(&manager, &config, base_path).await;
     user_turn(&resumed, "AFTER_RESUME").await;
-    let resumed_path = fetch_conversation_path(&resumed);
+    let resumed_path = fetch_conversation_path(&resumed).await;
     assert!(
         resumed_path.exists(),
         "second compact test expects resumed path {resumed_path:?} to exist",
@@ -321,7 +321,7 @@ async fn compact_resume_after_second_compaction_preserves_history() -> Result<()
 
     compact_conversation(&forked).await;
     user_turn(&forked, "AFTER_COMPACT_2").await;
-    let forked_path = fetch_conversation_path(&forked);
+    let forked_path = fetch_conversation_path(&forked).await;
     assert!(
         forked_path.exists(),
         "second compact test expects forked path {forked_path:?} to exist",
@@ -808,8 +808,11 @@ async fn compact_conversation(conversation: &Arc<CodexThread>) {
     wait_for_event(conversation, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
 }
 
-fn fetch_conversation_path(conversation: &Arc<CodexThread>) -> std::path::PathBuf {
-    conversation.rollout_path().expect("rollout path")
+async fn fetch_conversation_path(conversation: &Arc<CodexThread>) -> std::path::PathBuf {
+    conversation
+        .current_rollout_path()
+        .await
+        .expect("rollout path")
 }
 
 async fn shutdown_conversation(conversation: &Arc<CodexThread>) {

--- a/codex-rs/core/tests/suite/fork_thread.rs
+++ b/codex-rs/core/tests/suite/fork_thread.rs
@@ -1,6 +1,8 @@
 use codex_core::ForkSnapshot;
 use codex_core::NewThread;
+use codex_core::materialize_rollout_items_for_replay;
 use codex_core::parse_turn_item;
+use codex_features::Feature;
 use codex_protocol::items::TurnItem;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::InitialHistory;
@@ -40,7 +42,12 @@ async fn fork_thread_twice_drops_to_first_message() {
         .mount(&server)
         .await;
 
-    let mut builder = test_codex();
+    let mut builder = test_codex().with_config(|config| {
+        config
+            .features
+            .enable(Feature::SessionSegmentation)
+            .expect("enable session segmentation");
+    });
     let test = builder.build(&server).await.expect("create conversation");
     let codex = test.codex.clone();
     let thread_manager = test.thread_manager.clone();
@@ -111,13 +118,27 @@ async fn fork_thread_twice_drops_to_first_message() {
     let fork1_path = codex_fork1.rollout_path().expect("rollout path");
 
     // GetHistory on fork1 flushed; the file is ready.
-    let fork1_items = read_rollout_items(&fork1_path);
+    let fork1_raw_items = read_rollout_items(&fork1_path);
+    assert!(
+        fork1_raw_items.iter().any(|item| matches!(
+            item,
+            RolloutItem::RolloutReference(reference)
+                if reference.nth_user_message.is_some()
+        )),
+        "forked rollout should keep a compact RolloutReference instead of copying parent history"
+    );
+    let fork1_items =
+        materialize_rollout_items_for_replay(test.config.codex_home.as_path(), &fork1_raw_items)
+            .await;
+    let fork1_items = without_session_meta(fork1_items);
     pretty_assertions::assert_eq!(
         serde_json::to_value(&fork1_items).unwrap(),
         serde_json::to_value(&expected_after_first).unwrap()
     );
 
-    // Fork again with n=0 → drops the (new) last user message, leaving only the first.
+    // Fork again with n=0. The first fork's raw rollout only contains a
+    // RolloutReference, but truncation still applies to the materialized history
+    // referenced by that item.
     let NewThread {
         thread: codex_fork2,
         ..
@@ -134,14 +155,25 @@ async fn fork_thread_twice_drops_to_first_message() {
 
     let fork2_path = codex_fork2.rollout_path().expect("rollout path");
     // GetHistory on fork2 flushed; the file is ready.
-    let fork1_items = read_rollout_items(&fork1_path);
     let fork1_user_inputs = find_user_input_positions(&fork1_items);
-    let cut_last_on_fork1 = fork1_user_inputs
-        .get(fork1_user_inputs.len().saturating_sub(1))
+    let cut2 = fork1_user_inputs
+        .first()
         .copied()
-        .unwrap_or(0);
-    let expected_after_second: Vec<RolloutItem> = fork1_items[..cut_last_on_fork1].to_vec();
-    let fork2_items = read_rollout_items(&fork2_path);
+        .unwrap_or(fork1_items.len());
+    let expected_after_second = fork1_items[..cut2].to_vec();
+    let fork2_raw_items = read_rollout_items(&fork2_path);
+    assert!(
+        fork2_raw_items.iter().any(|item| matches!(
+            item,
+            RolloutItem::RolloutReference(reference)
+                if reference.nth_user_message.is_some()
+        )),
+        "re-forked rollout should keep a compact RolloutReference instead of copying parent history"
+    );
+    let fork2_items =
+        materialize_rollout_items_for_replay(test.config.codex_home.as_path(), &fork2_raw_items)
+            .await;
+    let fork2_items = without_session_meta(fork2_items);
     pretty_assertions::assert_eq!(
         serde_json::to_value(&fork2_items).unwrap(),
         serde_json::to_value(&expected_after_second).unwrap()
@@ -245,4 +277,11 @@ fn read_rollout_items(path: &std::path::Path) -> Vec<RolloutItem> {
         }
     }
     items
+}
+
+fn without_session_meta(items: Vec<RolloutItem>) -> Vec<RolloutItem> {
+    items
+        .into_iter()
+        .filter(|item| !matches!(item, RolloutItem::SessionMeta(_)))
+        .collect()
 }

--- a/codex-rs/core/tests/suite/personality_migration.rs
+++ b/codex-rs/core/tests/suite/personality_migration.rs
@@ -60,6 +60,7 @@ async fn write_rollout_with_user_event(dir: &Path, thread_id: ThreadId) -> io::R
     let session_meta = SessionMetaLine {
         meta: SessionMeta {
             id: thread_id,
+            segment_id: None,
             forked_from_id: None,
             parent_thread_id: None,
             timestamp: TEST_TIMESTAMP.to_string(),
@@ -110,6 +111,7 @@ async fn write_rollout_with_meta_only(dir: &Path, thread_id: ThreadId) -> io::Re
     let session_meta = SessionMetaLine {
         meta: SessionMeta {
             id: thread_id,
+            segment_id: None,
             forked_from_id: None,
             parent_thread_id: None,
             timestamp: TEST_TIMESTAMP.to_string(),

--- a/codex-rs/core/tests/suite/sqlite_state.rs
+++ b/codex-rs/core/tests/suite/sqlite_state.rs
@@ -217,6 +217,7 @@ async fn backfill_scans_existing_rollouts() -> Result<()> {
             let session_meta_line = SessionMetaLine {
                 meta: SessionMeta {
                     id: thread_id,
+                    segment_id: None,
                     forked_from_id: None,
                     parent_thread_id: None,
                     timestamp: "2026-01-27T12:00:00Z".to_string(),

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -125,6 +125,8 @@ pub enum Feature {
     MemoryTool,
     /// Compress cold local thread-store rollout files.
     LocalThreadStoreCompression,
+    /// Split long-lived sessions into rollout segments connected by references.
+    SessionSegmentation,
     /// Enable the Chronicle sidecar for passive screen-context memories.
     Chronicle,
     /// Append additional AGENTS.md guidance to user instructions.
@@ -858,6 +860,16 @@ pub const FEATURES: &[FeatureSpec] = &[
         id: Feature::LocalThreadStoreCompression,
         key: "local_thread_store_compression",
         stage: Stage::UnderDevelopment,
+        default_enabled: false,
+    },
+    FeatureSpec {
+        id: Feature::SessionSegmentation,
+        key: "session_segmentation",
+        stage: Stage::Experimental {
+            name: "Session segmentation",
+            menu_description: "Split long-lived sessions into linked rollout segments after compaction.",
+            announcement: "",
+        },
         default_enabled: false,
     },
     FeatureSpec {

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -342,6 +342,23 @@ fn telepathy_is_legacy_alias_for_chronicle() {
 }
 
 #[test]
+fn session_segmentation_is_experimental_and_disabled_by_default() {
+    assert_eq!(
+        Feature::SessionSegmentation.stage(),
+        Stage::Experimental {
+            name: "Session segmentation",
+            menu_description: "Split long-lived sessions into linked rollout segments after compaction.",
+            announcement: "",
+        }
+    );
+    assert!(!Feature::SessionSegmentation.default_enabled());
+    assert_eq!(
+        feature_for_key("session_segmentation"),
+        Some(Feature::SessionSegmentation)
+    );
+}
+
+#[test]
 fn collab_is_legacy_alias_for_multi_agent() {
     assert_eq!(feature_for_key("multi_agent"), Some(Feature::Collab));
     assert_eq!(feature_for_key("collab"), Some(Feature::Collab));

--- a/codex-rs/protocol/src/lib.rs
+++ b/codex-rs/protocol/src/lib.rs
@@ -6,6 +6,7 @@ mod thread_id;
 mod tool_name;
 pub use agent_path::AgentPath;
 pub use session_id::SessionId;
+pub use thread_id::SegmentId;
 pub use thread_id::ThreadId;
 pub use tool_name::ToolName;
 pub mod approvals;

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 use strum_macros::EnumIter;
 
 use crate::AgentPath;
+use crate::SegmentId;
 use crate::SessionId;
 use crate::ThreadId;
 use crate::approvals::ElicitationRequestEvent;
@@ -2782,6 +2783,7 @@ fn multi_agent_version_from_items(
         items.iter().rev().find_map(|item| match item {
             RolloutItem::TurnContext(turn_context) => turn_context.multi_agent_version,
             RolloutItem::SessionMeta(_)
+            | RolloutItem::RolloutReference(_)
             | RolloutItem::ResponseItem(_)
             | RolloutItem::Compacted(_)
             | RolloutItem::EventMsg(_) => None,
@@ -2806,6 +2808,8 @@ pub enum MultiAgentVersion {
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, TS)]
 pub struct SessionMeta {
     pub id: ThreadId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub segment_id: Option<SegmentId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub forked_from_id: Option<ThreadId>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2845,6 +2849,7 @@ impl Default for SessionMeta {
     fn default() -> Self {
         SessionMeta {
             id: ThreadId::default(),
+            segment_id: None,
             forked_from_id: None,
             parent_thread_id: None,
             timestamp: String::new(),
@@ -2873,10 +2878,41 @@ pub struct SessionMetaLine {
     pub git: Option<GitInfo>,
 }
 
+pub const DEFAULT_ROLLOUT_REFERENCE_DEPTH: usize = 2;
+
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, TS)]
+pub struct RolloutReferenceItem {
+    pub rollout_path: PathBuf,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_id: Option<ThreadId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rollout_timestamp: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub segment_id: Option<SegmentId>,
+    #[serde(default = "default_rollout_reference_depth")]
+    pub max_depth: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub nth_user_message: Option<usize>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub filter_fork_history: bool,
+    #[serde(
+        default,
+        alias = "compacted_replacement_history_filter_texts",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub developer_message_filter_texts: Option<Vec<String>>,
+}
+
+fn default_rollout_reference_depth() -> usize {
+    DEFAULT_ROLLOUT_REFERENCE_DEPTH
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, TS)]
 #[serde(tag = "type", content = "payload", rename_all = "snake_case")]
 pub enum RolloutItem {
     SessionMeta(SessionMetaLine),
+    #[serde(alias = "fork_reference")]
+    RolloutReference(RolloutReferenceItem),
     ResponseItem(ResponseItem),
     Compacted(CompactedItem),
     TurnContext(TurnContextItem),

--- a/codex-rs/protocol/src/thread_id.rs
+++ b/codex-rs/protocol/src/thread_id.rs
@@ -14,6 +14,12 @@ pub struct ThreadId {
     pub(crate) uuid: Uuid,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, TS, Hash)]
+#[ts(type = "string")]
+pub struct SegmentId {
+    uuid: Uuid,
+}
+
 impl ThreadId {
     pub fn new() -> Self {
         Self {
@@ -50,13 +56,61 @@ impl From<ThreadId> for String {
     }
 }
 
+impl SegmentId {
+    pub fn new() -> Self {
+        Self {
+            uuid: Uuid::now_v7(),
+        }
+    }
+
+    pub fn from_string(s: &str) -> Result<Self, uuid::Error> {
+        Ok(Self {
+            uuid: Uuid::parse_str(s)?,
+        })
+    }
+}
+
+impl TryFrom<&str> for SegmentId {
+    type Error = uuid::Error;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::from_string(value)
+    }
+}
+
+impl TryFrom<String> for SegmentId {
+    type Error = uuid::Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::from_string(value.as_str())
+    }
+}
+
+impl From<SegmentId> for String {
+    fn from(value: SegmentId) -> Self {
+        value.to_string()
+    }
+}
+
 impl Default for ThreadId {
     fn default() -> Self {
         Self::new()
     }
 }
 
+impl Default for SegmentId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Display for ThreadId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self.uuid, f)
+    }
+}
+
+impl Display for SegmentId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         Display::fmt(&self.uuid, f)
     }
@@ -71,7 +125,27 @@ impl Serialize for ThreadId {
     }
 }
 
+impl Serialize for SegmentId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(&self.uuid)
+    }
+}
+
 impl<'de> Deserialize<'de> for ThreadId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        let uuid = Uuid::parse_str(&value).map_err(serde::de::Error::custom)?;
+        Ok(Self { uuid })
+    }
+}
+
+impl<'de> Deserialize<'de> for SegmentId {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -92,12 +166,28 @@ impl JsonSchema for ThreadId {
     }
 }
 
+impl JsonSchema for SegmentId {
+    fn schema_name() -> String {
+        "SegmentId".to_string()
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        <String>::json_schema(generator)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     #[test]
     fn test_thread_id_default_is_not_zeroes() {
         let id = ThreadId::default();
+        assert_ne!(id.uuid, Uuid::nil());
+    }
+
+    #[test]
+    fn test_segment_id_default_is_not_zeroes() {
+        let id = SegmentId::default();
         assert_ne!(id.uuid, Uuid::nil());
     }
 }

--- a/codex-rs/rollout/src/compression_tests.rs
+++ b/codex-rs/rollout/src/compression_tests.rs
@@ -458,6 +458,7 @@ fn write_rollout(path: &std::path::Path, thread_id: ThreadId, message: &str) -> 
     let session_meta_line = SessionMetaLine {
         meta: SessionMeta {
             id: thread_id,
+            segment_id: None,
             forked_from_id: None,
             parent_thread_id: None,
             timestamp: "2025-01-03T12:00:00Z".to_string(),

--- a/codex-rs/rollout/src/lib.rs
+++ b/codex-rs/rollout/src/lib.rs
@@ -23,6 +23,7 @@ pub(crate) use codex_protocol::protocol;
 
 pub const SESSIONS_SUBDIR: &str = "sessions";
 pub const ARCHIVED_SESSIONS_SUBDIR: &str = "archived_sessions";
+pub const ROTATED_ROLLOUT_SEGMENTS_SUBDIR: &str = "rotated_rollout_segments";
 pub static INTERACTIVE_SESSION_SOURCES: LazyLock<Vec<SessionSource>> = LazyLock::new(|| {
     vec![
         SessionSource::Cli,
@@ -41,6 +42,7 @@ pub use compression::spawn_rollout_compression_worker;
 pub use config::Config;
 pub use config::RolloutConfig;
 pub use config::RolloutConfigView;
+pub use list::ArchivedThreadRolloutDisposition;
 pub use list::Cursor;
 pub use list::SortDirection;
 pub use list::ThreadItem;
@@ -48,7 +50,9 @@ pub use list::ThreadListConfig;
 pub use list::ThreadListLayout;
 pub use list::ThreadSortKey;
 pub use list::ThreadsPage;
+pub use list::classify_archived_thread_rollout;
 pub use list::find_archived_thread_path_by_id_str;
+pub use list::find_rollout_path_by_segment_id;
 pub use list::find_thread_path_by_id_str;
 #[deprecated(note = "use find_thread_path_by_id_str")]
 pub use list::find_thread_path_by_id_str as find_conversation_path_by_id_str;
@@ -58,6 +62,7 @@ pub use list::parse_cursor;
 pub use list::read_head_for_summary;
 pub use list::read_session_meta_line;
 pub use list::read_thread_item_from_rollout;
+pub use list::resolve_rollout_reference_rollout_path;
 pub use list::rollout_date_parts;
 pub use metadata::builder_from_items;
 pub use policy::is_persisted_rollout_item;

--- a/codex-rs/rollout/src/list.rs
+++ b/codex-rs/rollout/src/list.rs
@@ -17,12 +17,15 @@ use time::macros::format_description;
 use uuid::Uuid;
 
 use super::ARCHIVED_SESSIONS_SUBDIR;
+use super::ROTATED_ROLLOUT_SEGMENTS_SUBDIR;
 use super::SESSIONS_SUBDIR;
 use super::compression;
 use crate::protocol::EventMsg;
 use crate::state_db;
 use codex_file_search as file_search;
+use codex_protocol::SegmentId;
 use codex_protocol::ThreadId;
+use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::RolloutLine;
 use codex_protocol::protocol::SessionMetaLine;
@@ -90,6 +93,7 @@ pub type ConversationsPage = ThreadsPage;
 #[derive(Default)]
 struct HeadTailSummary {
     saw_session_meta: bool,
+    saw_compacted_user_message: bool,
     thread_id: Option<ThreadId>,
     first_user_message: Option<String>,
     preview: Option<String>,
@@ -136,6 +140,12 @@ pub struct ThreadListConfig<'a> {
     pub cwd_filters: Option<&'a [PathBuf]>,
     pub default_provider: &'a str,
     pub layout: ThreadListLayout,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArchivedThreadRolloutDisposition {
+    CanonicalArchivedThread,
+    LegacyRotatedSegment { live_rollout_path: Option<PathBuf> },
 }
 
 /// Pagination cursor identifying the timestamp of the last item in a page.
@@ -771,8 +781,10 @@ async fn build_thread_item(
     {
         return None;
     }
-    // Apply filters: must have session meta and a discoverable preview.
-    if summary.saw_session_meta && summary.preview.is_some() {
+    // Apply filters: must have session meta and either a discoverable preview or compacted user
+    // history.
+    if summary.saw_session_meta && (summary.preview.is_some() || summary.saw_compacted_user_message)
+    {
         let HeadTailSummary {
             thread_id,
             first_user_message,
@@ -944,6 +956,19 @@ pub(crate) fn parse_timestamp_uuid_from_filename(name: &str) -> Option<(OffsetDa
         format_description!("[year]-[month]-[day]T[hour]-[minute]-[second]");
     let ts = PrimitiveDateTime::parse(ts_str, format).ok()?.assume_utc();
     Some((ts, uuid))
+}
+
+fn parse_timestamp_string_uuid_from_filename(name: &str) -> Option<(&str, Uuid)> {
+    // Expected: rollout-YYYY-MM-DDThh-mm-ss-<uuid>.jsonl
+    let core = name.strip_prefix("rollout-")?.strip_suffix(".jsonl")?;
+    core.match_indices('-')
+        .rev()
+        .find_map(|(index, _)| {
+            Uuid::parse_str(&core[index + 1..])
+                .ok()
+                .map(|uuid| (index, uuid))
+        })
+        .map(|(index, uuid)| (&core[..index], uuid))
 }
 
 struct ThreadCandidate {
@@ -1121,6 +1146,9 @@ async fn read_head_summary(path: &Path, head_limit: usize) -> io::Result<HeadTai
                     summary.saw_session_meta = true;
                 }
             }
+            RolloutItem::RolloutReference(_) => {
+                // Not included in summaries; skip.
+            }
             RolloutItem::ResponseItem(_) => {
                 summary.created_at = summary
                     .created_at
@@ -1130,8 +1158,14 @@ async fn read_head_summary(path: &Path, head_limit: usize) -> io::Result<HeadTai
             RolloutItem::TurnContext(_) => {
                 // Not included in `head`; skip.
             }
-            RolloutItem::Compacted(_) => {
-                // Not included in `head`; skip.
+            RolloutItem::Compacted(compacted) => {
+                if compacted
+                    .replacement_history
+                    .as_deref()
+                    .is_some_and(|history| history.iter().any(ResponseItem::is_user_message))
+                {
+                    summary.saw_compacted_user_message = true;
+                }
             }
             RolloutItem::EventMsg(ev) => {
                 if let Some(preview) = event_msg_preview(&ev) {
@@ -1184,7 +1218,8 @@ pub async fn read_head_for_summary(path: &Path) -> io::Result<Vec<serde_json::Va
                         head.push(value);
                     }
                 }
-                RolloutItem::Compacted(_)
+                RolloutItem::RolloutReference(_)
+                | RolloutItem::Compacted(_)
                 | RolloutItem::TurnContext(_)
                 | RolloutItem::EventMsg(_) => {}
             }
@@ -1260,6 +1295,38 @@ fn truncate_to_millis(dt: OffsetDateTime) -> Option<OffsetDateTime> {
 }
 
 async fn find_thread_path_by_id_str_in_subdir(
+    codex_home: &Path,
+    subdir: &str,
+    id_str: &str,
+    state_db_ctx: Option<&codex_state::StateRuntime>,
+) -> io::Result<Option<PathBuf>> {
+    let found =
+        find_thread_path_by_id_str_in_subdir_unvalidated(codex_home, subdir, id_str, state_db_ctx)
+            .await?;
+    if subdir != ARCHIVED_SESSIONS_SUBDIR {
+        return Ok(found);
+    }
+    let Some(found_path) = found else {
+        return Ok(None);
+    };
+    match classify_archived_thread_rollout(codex_home, found_path.as_path(), state_db_ctx).await? {
+        ArchivedThreadRolloutDisposition::CanonicalArchivedThread => Ok(Some(found_path)),
+        ArchivedThreadRolloutDisposition::LegacyRotatedSegment { live_rollout_path } => {
+            if let Some(live_rollout_path) = live_rollout_path {
+                state_db::read_repair_rollout_path(
+                    state_db_ctx,
+                    ThreadId::from_string(id_str).ok(),
+                    Some(false),
+                    live_rollout_path.as_path(),
+                )
+                .await;
+            }
+            Ok(None)
+        }
+    }
+}
+
+async fn find_thread_path_by_id_str_in_subdir_unvalidated(
     codex_home: &Path,
     subdir: &str,
     id_str: &str,
@@ -1458,6 +1525,234 @@ pub async fn find_archived_thread_path_by_id_str(
 ) -> io::Result<Option<PathBuf>> {
     find_thread_path_by_id_str_in_subdir(codex_home, ARCHIVED_SESSIONS_SUBDIR, id_str, state_db_ctx)
         .await
+}
+
+pub async fn find_rollout_path_by_segment_id(
+    codex_home: &Path,
+    thread_id: ThreadId,
+    segment_id: SegmentId,
+) -> io::Result<Option<PathBuf>> {
+    if let Some(path) = find_rollout_path_by_segment_id_in_subdir(
+        codex_home,
+        SESSIONS_SUBDIR,
+        thread_id,
+        segment_id,
+    )
+    .await?
+    {
+        return Ok(Some(path));
+    }
+    if let Some(path) = find_rollout_path_by_segment_id_in_subdir(
+        codex_home,
+        ROTATED_ROLLOUT_SEGMENTS_SUBDIR,
+        thread_id,
+        segment_id,
+    )
+    .await?
+    {
+        return Ok(Some(path));
+    }
+    find_rollout_path_by_segment_id_in_subdir(
+        codex_home,
+        ARCHIVED_SESSIONS_SUBDIR,
+        thread_id,
+        segment_id,
+    )
+    .await
+}
+
+pub async fn classify_archived_thread_rollout(
+    codex_home: &Path,
+    rollout_path: &Path,
+    state_db_ctx: Option<&codex_state::StateRuntime>,
+) -> io::Result<ArchivedThreadRolloutDisposition> {
+    let archived_root = codex_home.join(ARCHIVED_SESSIONS_SUBDIR);
+    let Ok(relative_path) = rollout_path.strip_prefix(archived_root.as_path()) else {
+        return Ok(ArchivedThreadRolloutDisposition::CanonicalArchivedThread);
+    };
+    if relative_path.components().count() != 1 {
+        return Ok(ArchivedThreadRolloutDisposition::CanonicalArchivedThread);
+    }
+
+    let live_rollout_path =
+        find_live_rollout_path_for_archived_candidate(codex_home, rollout_path, state_db_ctx)
+            .await?;
+    if live_rollout_path.is_some() {
+        return Ok(ArchivedThreadRolloutDisposition::LegacyRotatedSegment { live_rollout_path });
+    }
+    Ok(ArchivedThreadRolloutDisposition::CanonicalArchivedThread)
+}
+
+async fn find_live_rollout_path_for_archived_candidate(
+    codex_home: &Path,
+    rollout_path: &Path,
+    state_db_ctx: Option<&codex_state::StateRuntime>,
+) -> io::Result<Option<PathBuf>> {
+    let meta_line = match read_session_meta_line(rollout_path).await {
+        Ok(meta_line) => meta_line,
+        Err(_) => return Ok(None),
+    };
+    let thread_id = meta_line.meta.id.to_string();
+    find_thread_path_by_id_str_in_subdir_unvalidated(
+        codex_home,
+        SESSIONS_SUBDIR,
+        thread_id.as_str(),
+        state_db_ctx,
+    )
+    .await
+}
+
+async fn find_rollout_path_by_segment_id_in_subdir(
+    codex_home: &Path,
+    subdir: &str,
+    thread_id: ThreadId,
+    segment_id: SegmentId,
+) -> io::Result<Option<PathBuf>> {
+    let root = codex_home.join(subdir);
+    if !tokio::fs::try_exists(&root).await.unwrap_or(false) {
+        return Ok(None);
+    }
+
+    let target_thread_id = thread_id.to_string();
+    let mut stack = vec![root];
+    let mut scanned_files = 0usize;
+    while let Some(dir) = stack.pop() {
+        let mut read_dir = match tokio::fs::read_dir(&dir).await {
+            Ok(read_dir) => read_dir,
+            Err(err) => {
+                tracing::warn!("failed to read rollout directory {}: {err}", dir.display());
+                continue;
+            }
+        };
+        while let Some(entry) = read_dir.next_entry().await? {
+            let path = entry.path();
+            let file_type = entry.file_type().await?;
+            if file_type.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if !file_type.is_file() {
+                continue;
+            }
+            let Some(file_name) = path.file_name().and_then(|file_name| file_name.to_str()) else {
+                continue;
+            };
+            if !file_name.starts_with("rollout-") || !file_name.ends_with(".jsonl") {
+                continue;
+            }
+            let Some((_, uuid)) = parse_timestamp_uuid_from_filename(file_name) else {
+                continue;
+            };
+            if uuid.to_string() != target_thread_id {
+                continue;
+            }
+            scanned_files = scanned_files.saturating_add(1);
+            if scanned_files > MAX_SCAN_FILES {
+                return Ok(None);
+            }
+            let Ok(meta_line) = read_session_meta_line(&path).await else {
+                continue;
+            };
+            if meta_line.meta.id == thread_id && meta_line.meta.segment_id == Some(segment_id) {
+                return Ok(Some(path));
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+pub async fn resolve_rollout_reference_rollout_path(
+    codex_home: &Path,
+    reference: &codex_protocol::protocol::RolloutReferenceItem,
+) -> io::Result<PathBuf> {
+    // A compacted live thread can keep the same rollout path and timestamp while moving the
+    // referenced predecessor into archive storage, so segment identity must win before fallback
+    // lookup by mutable live-path metadata.
+    if let (Some(thread_id), Some(segment_id)) = (reference.thread_id, reference.segment_id)
+        && let Some(path) =
+            find_rollout_path_by_segment_id(codex_home, thread_id, segment_id).await?
+    {
+        return Ok(path);
+    }
+
+    let rollout_path = reference.rollout_path.as_path();
+    if tokio::fs::try_exists(rollout_path).await.unwrap_or(false) {
+        return Ok(rollout_path.to_path_buf());
+    }
+
+    if let (Some(thread_id), Some(rollout_timestamp)) =
+        (reference.thread_id, reference.rollout_timestamp.as_deref())
+    {
+        let file_name = format!("rollout-{rollout_timestamp}-{thread_id}.jsonl");
+        if let Some(active_path) =
+            rollout_path_for_timestamp_file(codex_home, rollout_timestamp, &file_name)
+            && tokio::fs::try_exists(active_path.as_path())
+                .await
+                .unwrap_or(false)
+        {
+            return Ok(active_path);
+        }
+        let archived_path = codex_home.join(ARCHIVED_SESSIONS_SUBDIR).join(&file_name);
+        if tokio::fs::try_exists(archived_path.as_path())
+            .await
+            .unwrap_or(false)
+        {
+            return Ok(archived_path);
+        }
+    }
+
+    let Some(file_name) = rollout_path
+        .file_name()
+        .and_then(|file_name| file_name.to_str())
+    else {
+        return Ok(rollout_path.to_path_buf());
+    };
+    let Some((rollout_timestamp, uuid)) = parse_timestamp_string_uuid_from_filename(file_name)
+    else {
+        return Ok(rollout_path.to_path_buf());
+    };
+    let archived_path = codex_home.join(ARCHIVED_SESSIONS_SUBDIR).join(file_name);
+    if tokio::fs::try_exists(archived_path.as_path())
+        .await
+        .unwrap_or(false)
+    {
+        return Ok(archived_path);
+    }
+    if let Some(active_path) =
+        rollout_path_for_timestamp_file(codex_home, rollout_timestamp, file_name)
+        && tokio::fs::try_exists(active_path.as_path())
+            .await
+            .unwrap_or(false)
+    {
+        return Ok(active_path);
+    }
+    let id = uuid.to_string();
+    if let Some(path) = find_thread_path_by_id_str(codex_home, id.as_str(), None).await? {
+        return Ok(path);
+    }
+    if let Some(path) = find_archived_thread_path_by_id_str(codex_home, id.as_str(), None).await? {
+        return Ok(path);
+    }
+    Ok(rollout_path.to_path_buf())
+}
+
+fn rollout_path_for_timestamp_file(
+    codex_home: &Path,
+    rollout_timestamp: &str,
+    file_name: &str,
+) -> Option<PathBuf> {
+    let year = rollout_timestamp.get(0..4)?;
+    let month = rollout_timestamp.get(5..7)?;
+    let day = rollout_timestamp.get(8..10)?;
+    Some(
+        codex_home
+            .join(SESSIONS_SUBDIR)
+            .join(year)
+            .join(month)
+            .join(day)
+            .join(file_name),
+    )
 }
 
 /// Extract the `YYYY/MM/DD` directory components from a rollout filename.

--- a/codex-rs/rollout/src/metadata.rs
+++ b/codex-rs/rollout/src/metadata.rs
@@ -67,7 +67,8 @@ pub fn builder_from_items(
 ) -> Option<ThreadMetadataBuilder> {
     if let Some(session_meta) = items.iter().find_map(|item| match item {
         RolloutItem::SessionMeta(meta_line) => Some(meta_line),
-        RolloutItem::ResponseItem(_)
+        RolloutItem::RolloutReference(_)
+        | RolloutItem::ResponseItem(_)
         | RolloutItem::Compacted(_)
         | RolloutItem::TurnContext(_)
         | RolloutItem::EventMsg(_) => None,
@@ -119,7 +120,8 @@ pub async fn extract_metadata_from_rollout(
         metadata,
         memory_mode: items.iter().rev().find_map(|item| match item {
             RolloutItem::SessionMeta(meta_line) => meta_line.meta.memory_mode.clone(),
-            RolloutItem::ResponseItem(_)
+            RolloutItem::RolloutReference(_)
+            | RolloutItem::ResponseItem(_)
             | RolloutItem::Compacted(_)
             | RolloutItem::TurnContext(_)
             | RolloutItem::EventMsg(_) => None,
@@ -215,11 +217,26 @@ pub(crate) async fn backfill_sessions_with_lease(
         }
         match collect_rollout_paths(&root).await {
             Ok(paths) => {
-                rollout_paths.extend(paths.into_iter().map(|path| BackfillRolloutPath {
-                    watermark: backfill_watermark_for_path(codex_home, &path),
-                    path,
-                    archived,
-                }));
+                for path in paths {
+                    if archived
+                        && matches!(
+                            crate::list::classify_archived_thread_rollout(
+                                codex_home,
+                                path.as_path(),
+                                Some(runtime),
+                            )
+                            .await,
+                            Ok(crate::list::ArchivedThreadRolloutDisposition::LegacyRotatedSegment { .. })
+                        )
+                    {
+                        continue;
+                    }
+                    rollout_paths.push(BackfillRolloutPath {
+                        watermark: backfill_watermark_for_path(codex_home, &path),
+                        path,
+                        archived,
+                    });
+                }
             }
             Err(err) => {
                 warn!(

--- a/codex-rs/rollout/src/metadata_tests.rs
+++ b/codex-rs/rollout/src/metadata_tests.rs
@@ -34,6 +34,7 @@ async fn extract_metadata_from_rollout_uses_session_meta() {
 
     let session_meta = SessionMeta {
         id,
+        segment_id: None,
         forked_from_id: None,
         parent_thread_id: None,
         timestamp: "2026-01-27T12:34:56Z".to_string(),
@@ -88,6 +89,7 @@ async fn extract_metadata_from_rollout_returns_latest_memory_mode() {
 
     let session_meta = SessionMeta {
         id,
+        segment_id: None,
         forked_from_id: None,
         parent_thread_id: None,
         timestamp: "2026-01-27T12:34:56Z".to_string(),
@@ -289,6 +291,46 @@ async fn backfill_sessions_preserves_existing_git_branch_and_fills_missing_git_f
 }
 
 #[tokio::test]
+async fn backfill_ignores_legacy_rotated_segment_when_live_rollout_exists() {
+    let dir = tempdir().expect("tempdir");
+    let codex_home = dir.path().to_path_buf();
+    let thread_uuid = Uuid::new_v4();
+    let live_rollout_path = write_rollout_in_sessions(
+        codex_home.as_path(),
+        "2026-01-27T12-34-56",
+        "2026-01-27T12:34:56Z",
+        thread_uuid,
+        /*git*/ None,
+    );
+    let legacy_rotated_path = codex_home
+        .join(ARCHIVED_SESSIONS_SUBDIR)
+        .join(live_rollout_path.file_name().expect("rollout file name"));
+    std::fs::create_dir_all(
+        legacy_rotated_path
+            .parent()
+            .expect("legacy rotated rollout parent"),
+    )
+    .expect("create legacy rotated rollout parent");
+    std::fs::copy(live_rollout_path.as_path(), legacy_rotated_path.as_path())
+        .expect("copy legacy rotated rollout");
+
+    let runtime = codex_state::StateRuntime::init(codex_home.clone(), "test-provider".to_string())
+        .await
+        .expect("initialize runtime");
+
+    backfill_sessions(runtime.as_ref(), codex_home.as_path(), "test-provider").await;
+
+    let thread_id = ThreadId::from_string(&thread_uuid.to_string()).expect("thread id");
+    let metadata = runtime
+        .get_thread(thread_id)
+        .await
+        .expect("get thread")
+        .expect("thread metadata");
+    assert_eq!(metadata.rollout_path, live_rollout_path);
+    assert_eq!(metadata.archived_at, None);
+}
+
+#[tokio::test]
 async fn backfill_sessions_normalizes_cwd_before_upsert() {
     let dir = tempdir().expect("tempdir");
     let codex_home = dir.path().to_path_buf();
@@ -351,6 +393,7 @@ fn write_rollout_in_sessions_with_cwd(
     let path = sessions_dir.join(format!("rollout-{filename_ts}-{thread_uuid}.jsonl"));
     let session_meta = SessionMeta {
         id,
+        segment_id: None,
         forked_from_id: None,
         parent_thread_id: None,
         timestamp: event_ts.to_string(),

--- a/codex-rs/rollout/src/policy.rs
+++ b/codex-rs/rollout/src/policy.rs
@@ -8,9 +8,10 @@ pub fn is_persisted_rollout_item(item: &RolloutItem) -> bool {
         RolloutItem::ResponseItem(item) => should_persist_response_item(item),
         RolloutItem::EventMsg(ev) => should_persist_event_msg(ev),
         // Persist Codex executive markers so we can analyze flows (e.g., compaction, API turns).
-        RolloutItem::Compacted(_) | RolloutItem::TurnContext(_) | RolloutItem::SessionMeta(_) => {
-            true
-        }
+        RolloutItem::Compacted(_)
+        | RolloutItem::RolloutReference(_)
+        | RolloutItem::TurnContext(_)
+        | RolloutItem::SessionMeta(_) => true,
     }
 }
 

--- a/codex-rs/rollout/src/recorder.rs
+++ b/codex-rs/rollout/src/recorder.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use chrono::SecondsFormat;
+use codex_protocol::SegmentId;
 use codex_protocol::ThreadId;
 use codex_protocol::dynamic_tools::DynamicToolSpec;
 use codex_protocol::models::BaseInstructions;
@@ -31,6 +32,7 @@ use tracing::warn;
 use super::ARCHIVED_SESSIONS_SUBDIR;
 use super::SESSIONS_SUBDIR;
 use super::compression;
+use super::list::ArchivedThreadRolloutDisposition;
 use super::list::Cursor;
 use super::list::SortDirection;
 use super::list::ThreadItem;
@@ -89,6 +91,18 @@ pub enum RolloutRecorderParams {
         base_instructions: BaseInstructions,
         dynamic_tools: Vec<DynamicToolSpec>,
         multi_agent_version: Option<MultiAgentVersion>,
+    },
+    CreateAtPath {
+        path: PathBuf,
+        conversation_id: ThreadId,
+        forked_from_id: Option<ThreadId>,
+        parent_thread_id: Option<ThreadId>,
+        source: SessionSource,
+        thread_source: Option<ThreadSource>,
+        base_instructions: BaseInstructions,
+        dynamic_tools: Vec<DynamicToolSpec>,
+        multi_agent_version: Option<MultiAgentVersion>,
+        session_timestamp: Option<String>,
     },
     Resume {
         path: PathBuf,
@@ -489,6 +503,20 @@ impl RolloutRecorder {
         )
         .await;
         if let Some(db_page) = db_page {
+            if archived {
+                repair_legacy_rotated_archived_rows(
+                    codex_home,
+                    state_db_ctx.as_deref(),
+                    &db_page.items,
+                )
+                .await?;
+                let page = page_from_filesystem_scan(fs_page, sort_direction, page_size, sort_key);
+                return Ok(fill_missing_thread_item_metadata_from_state_db(
+                    state_db_ctx.as_deref(),
+                    page,
+                )
+                .await);
+            }
             if search_term.is_some() && (!db_page.items.is_empty() || cursor.is_some()) {
                 for item in &db_page.items {
                     state_db::reconcile_rollout(
@@ -682,41 +710,50 @@ impl RolloutRecorder {
             } => {
                 let log_file_info = precompute_log_file_info(config, conversation_id)?;
                 let path = log_file_info.path.clone();
-                let session_id = log_file_info.conversation_id;
-                let started_at = log_file_info.timestamp;
-
-                let timestamp_format: &[FormatItem] = format_description!(
-                    "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:3]Z"
-                );
-                let timestamp = started_at
-                    .to_offset(time::UtcOffset::UTC)
-                    .format(timestamp_format)
-                    .map_err(|e| IoError::other(format!("failed to format timestamp: {e}")))?;
-
-                let session_meta = SessionMeta {
-                    id: session_id,
+                let session_meta = create_session_meta(
+                    config,
+                    &log_file_info,
                     forked_from_id,
                     parent_thread_id,
-                    timestamp,
-                    cwd: config.cwd().to_path_buf(),
-                    originator: originator().value,
-                    cli_version: env!("CARGO_PKG_VERSION").to_string(),
-                    agent_nickname: source.get_nickname(),
-                    agent_role: source.get_agent_role(),
-                    agent_path: source.get_agent_path().map(Into::into),
                     source,
                     thread_source,
-                    model_provider: Some(config.model_provider_id().to_string()),
-                    base_instructions: Some(base_instructions),
-                    dynamic_tools: if dynamic_tools.is_empty() {
-                        None
-                    } else {
-                        Some(dynamic_tools)
-                    },
-                    memory_mode: (!config.generate_memories()).then_some("disabled".to_string()),
+                    base_instructions,
+                    dynamic_tools,
                     multi_agent_version,
-                };
+                    /*timestamp_override*/ None,
+                )?;
 
+                (None, Some(log_file_info), path, Some(session_meta))
+            }
+            RolloutRecorderParams::CreateAtPath {
+                path,
+                conversation_id,
+                forked_from_id,
+                parent_thread_id,
+                source,
+                thread_source,
+                base_instructions,
+                dynamic_tools,
+                multi_agent_version,
+                session_timestamp,
+            } => {
+                let log_file_info = LogFileInfo {
+                    path: path.clone(),
+                    conversation_id,
+                    timestamp: OffsetDateTime::now_utc(),
+                };
+                let session_meta = create_session_meta(
+                    config,
+                    &log_file_info,
+                    forked_from_id,
+                    parent_thread_id,
+                    source,
+                    thread_source,
+                    base_instructions,
+                    dynamic_tools,
+                    multi_agent_version,
+                    session_timestamp,
+                )?;
                 (None, Some(log_file_info), path, Some(session_meta))
             }
             RolloutRecorderParams::Resume { path } => {
@@ -879,6 +916,9 @@ impl RolloutRecorder {
                     }
                     RolloutItem::ResponseItem(item) => {
                         items.push(RolloutItem::ResponseItem(item));
+                    }
+                    RolloutItem::RolloutReference(item) => {
+                        items.push(RolloutItem::RolloutReference(item));
                     }
                     RolloutItem::Compacted(item) => {
                         items.push(RolloutItem::Compacted(item));
@@ -1193,20 +1233,64 @@ async fn list_threads_from_files_desc_unfiltered(
 ) -> std::io::Result<ThreadsPage> {
     if archived {
         let root = codex_home.join(ARCHIVED_SESSIONS_SUBDIR);
-        get_threads_in_root(
-            root,
-            page_size,
-            cursor,
-            sort_key,
-            ThreadListConfig {
-                allowed_sources,
-                model_providers,
-                cwd_filters,
-                default_provider,
-                layout: ThreadListLayout::Flat,
-            },
-        )
-        .await
+        let mut canonical_items = Vec::with_capacity(page_size);
+        let mut num_scanned_files = 0usize;
+        let mut reached_scan_cap = false;
+        let mut page_cursor = cursor.cloned();
+
+        loop {
+            let page = get_threads_in_root(
+                root.clone(),
+                page_size,
+                page_cursor.as_ref(),
+                sort_key,
+                ThreadListConfig {
+                    allowed_sources,
+                    model_providers,
+                    cwd_filters,
+                    default_provider,
+                    layout: ThreadListLayout::Flat,
+                },
+            )
+            .await?;
+            num_scanned_files = num_scanned_files.saturating_add(page.num_scanned_files);
+            reached_scan_cap |= page.reached_scan_cap;
+            for item in page.items {
+                if matches!(
+                    super::list::classify_archived_thread_rollout(
+                        codex_home,
+                        item.path.as_path(),
+                        /*state_db_ctx*/ None,
+                    )
+                    .await?,
+                    ArchivedThreadRolloutDisposition::CanonicalArchivedThread
+                ) {
+                    canonical_items.push(item);
+                    if canonical_items.len() == page_size {
+                        break;
+                    }
+                }
+            }
+            page_cursor = page.next_cursor;
+            if canonical_items.len() == page_size || page_cursor.is_none() || reached_scan_cap {
+                break;
+            }
+        }
+
+        let more_matches_available = page_cursor.is_some() || reached_scan_cap;
+        let next_cursor = if more_matches_available {
+            canonical_items
+                .last()
+                .and_then(|item| cursor_from_thread_item(item, sort_key))
+        } else {
+            None
+        };
+        Ok(ThreadsPage {
+            items: canonical_items,
+            next_cursor,
+            num_scanned_files,
+            reached_scan_cap,
+        })
     } else {
         get_threads(
             codex_home,
@@ -1299,6 +1383,35 @@ async fn list_threads_from_files_asc(
     })
 }
 
+async fn repair_legacy_rotated_archived_rows(
+    codex_home: &Path,
+    state_db_ctx: Option<&StateRuntime>,
+    items: &[codex_state::ThreadMetadata],
+) -> std::io::Result<()> {
+    for item in items {
+        let ArchivedThreadRolloutDisposition::LegacyRotatedSegment { live_rollout_path } =
+            super::list::classify_archived_thread_rollout(
+                codex_home,
+                item.rollout_path.as_path(),
+                state_db_ctx,
+            )
+            .await?
+        else {
+            continue;
+        };
+        if let Some(live_rollout_path) = live_rollout_path {
+            state_db::read_repair_rollout_path(
+                state_db_ctx,
+                Some(item.id),
+                Some(false),
+                live_rollout_path.as_path(),
+            )
+            .await;
+        }
+    }
+    Ok(())
+}
+
 async fn filter_thread_items_by_search_term(
     codex_home: &Path,
     items: &mut Vec<ThreadItem>,
@@ -1364,28 +1477,43 @@ fn precompute_log_file_info(
     // Resolve ~/.codex/sessions/YYYY/MM/DD path.
     let timestamp = OffsetDateTime::now_local()
         .map_err(|e| IoError::other(format!("failed to get local time: {e}")))?;
-    let mut dir = config.codex_home().to_path_buf();
-    dir.push(SESSIONS_SUBDIR);
-    dir.push(timestamp.year().to_string());
-    dir.push(format!("{:02}", u8::from(timestamp.month())));
-    dir.push(format!("{:02}", timestamp.day()));
 
     // Custom format for YYYY-MM-DDThh-mm-ss. Use `-` instead of `:` for
     // compatibility with filesystems that do not allow colons in filenames.
     let format: &[FormatItem] =
         format_description!("[year]-[month]-[day]T[hour]-[minute]-[second]");
-    let date_str = timestamp
-        .format(format)
-        .map_err(|e| IoError::other(format!("failed to format timestamp: {e}")))?;
-
-    let filename = format!("rollout-{date_str}-{conversation_id}.jsonl");
-
-    let path = dir.join(filename);
+    let mut selected_timestamp = timestamp;
+    let mut path = None;
+    for offset_seconds in 0..60 {
+        let candidate_timestamp = timestamp
+            .checked_add(time::Duration::seconds(offset_seconds))
+            .ok_or_else(|| IoError::other("failed to compute rollout timestamp"))?;
+        let mut dir = config.codex_home().to_path_buf();
+        dir.push(SESSIONS_SUBDIR);
+        dir.push(candidate_timestamp.year().to_string());
+        dir.push(format!("{:02}", u8::from(candidate_timestamp.month())));
+        dir.push(format!("{:02}", candidate_timestamp.day()));
+        let date_str = candidate_timestamp
+            .format(format)
+            .map_err(|e| IoError::other(format!("failed to format timestamp: {e}")))?;
+        let filename = format!("rollout-{date_str}-{conversation_id}.jsonl");
+        let candidate_path = dir.join(filename);
+        if !candidate_path.exists() {
+            selected_timestamp = candidate_timestamp;
+            path = Some(candidate_path);
+            break;
+        }
+    }
+    let path = path.ok_or_else(|| {
+        IoError::other(format!(
+            "failed to find an unused rollout path for thread {conversation_id}"
+        ))
+    })?;
 
     Ok(LogFileInfo {
         path,
         conversation_id,
-        timestamp,
+        timestamp: selected_timestamp,
     })
 }
 
@@ -1402,6 +1530,55 @@ fn open_log_file(path: &Path) -> std::io::Result<File> {
         .append(true)
         .create(true)
         .open(path)
+}
+
+fn create_session_meta(
+    config: &impl RolloutConfigView,
+    log_file_info: &LogFileInfo,
+    forked_from_id: Option<ThreadId>,
+    parent_thread_id: Option<ThreadId>,
+    source: SessionSource,
+    thread_source: Option<ThreadSource>,
+    base_instructions: BaseInstructions,
+    dynamic_tools: Vec<DynamicToolSpec>,
+    multi_agent_version: Option<MultiAgentVersion>,
+    timestamp_override: Option<String>,
+) -> std::io::Result<SessionMeta> {
+    let timestamp_format: &[FormatItem] =
+        format_description!("[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:3]Z");
+    let timestamp = match timestamp_override {
+        Some(timestamp) => timestamp,
+        None => log_file_info
+            .timestamp
+            .to_offset(time::UtcOffset::UTC)
+            .format(timestamp_format)
+            .map_err(|e| IoError::other(format!("failed to format timestamp: {e}")))?,
+    };
+
+    Ok(SessionMeta {
+        id: log_file_info.conversation_id,
+        segment_id: Some(SegmentId::new()),
+        forked_from_id,
+        parent_thread_id,
+        timestamp,
+        cwd: config.cwd().to_path_buf(),
+        originator: originator().value,
+        cli_version: env!("CARGO_PKG_VERSION").to_string(),
+        agent_nickname: source.get_nickname(),
+        agent_role: source.get_agent_role(),
+        agent_path: source.get_agent_path().map(Into::into),
+        source,
+        thread_source,
+        model_provider: Some(config.model_provider_id().to_string()),
+        base_instructions: Some(base_instructions),
+        dynamic_tools: if dynamic_tools.is_empty() {
+            None
+        } else {
+            Some(dynamic_tools)
+        },
+        memory_mode: (!config.generate_memories()).then_some("disabled".to_string()),
+        multi_agent_version,
+    })
 }
 
 /// Mutable state owned by the background rollout writer.
@@ -1774,6 +1951,7 @@ async fn resume_candidate_matches_cwd(
         && let Some(latest_turn_context_cwd) = items.iter().rev().find_map(|item| match item {
             RolloutItem::TurnContext(turn_context) => Some(turn_context.cwd.as_path()),
             RolloutItem::SessionMeta(_)
+            | RolloutItem::RolloutReference(_)
             | RolloutItem::ResponseItem(_)
             | RolloutItem::Compacted(_)
             | RolloutItem::EventMsg(_) => None,

--- a/codex-rs/rollout/src/recorder_tests.rs
+++ b/codex-rs/rollout/src/recorder_tests.rs
@@ -84,6 +84,7 @@ async fn state_db_init_backfills_before_returning() -> anyhow::Result<()> {
     let session_meta_line = SessionMetaLine {
         meta: SessionMeta {
             id: thread_id,
+            segment_id: None,
             forked_from_id: None,
             parent_thread_id: None,
             timestamp: "2026-01-27T12:34:56Z".to_string(),
@@ -424,6 +425,19 @@ async fn recorder_materializes_on_flush_with_pending_items() -> std::io::Result<
     assert!(
         text.contains("\"type\":\"session_meta\""),
         "expected session metadata in rollout"
+    );
+    let (items, _, _) = RolloutRecorder::load_rollout_items(&rollout_path).await?;
+    let segment_id = items.iter().find_map(|item| match item {
+        RolloutItem::SessionMeta(meta) => meta.meta.segment_id,
+        RolloutItem::RolloutReference(_)
+        | RolloutItem::ResponseItem(_)
+        | RolloutItem::Compacted(_)
+        | RolloutItem::TurnContext(_)
+        | RolloutItem::EventMsg(_) => None,
+    });
+    assert!(
+        segment_id.is_some(),
+        "new rollout metadata should include a segment_id for durable references"
     );
     let buffered_idx = text
         .find("buffered-event")

--- a/codex-rs/rollout/src/search.rs
+++ b/codex-rs/rollout/src/search.rs
@@ -273,6 +273,7 @@ fn conversation_text_from_item(item: &RolloutItem) -> Option<String> {
             }
         }
         RolloutItem::SessionMeta(_)
+        | RolloutItem::RolloutReference(_)
         | RolloutItem::TurnContext(_)
         | RolloutItem::EventMsg(_)
         | RolloutItem::ResponseItem(_)

--- a/codex-rs/rollout/src/session_index_tests.rs
+++ b/codex-rs/rollout/src/session_index_tests.rs
@@ -26,6 +26,7 @@ fn write_rollout_with_metadata(path: &Path, thread_id: ThreadId) -> std::io::Res
         item: RolloutItem::SessionMeta(SessionMetaLine {
             meta: SessionMeta {
                 id: thread_id,
+                segment_id: None,
                 forked_from_id: None,
                 parent_thread_id: None,
                 timestamp,

--- a/codex-rs/rollout/src/state_db_tests.rs
+++ b/codex-rs/rollout/src/state_db_tests.rs
@@ -143,6 +143,7 @@ fn write_rollout_with_user_message(
             item: RolloutItem::SessionMeta(SessionMetaLine {
                 meta: SessionMeta {
                     id: thread_id,
+                    segment_id: None,
                     forked_from_id: None,
                     parent_thread_id: None,
                     timestamp: "2026-06-01T14:26:25Z".to_string(),

--- a/codex-rs/rollout/src/tests.rs
+++ b/codex-rs/rollout/src/tests.rs
@@ -28,12 +28,14 @@ use crate::list::get_threads;
 use crate::list::read_head_for_summary;
 use crate::rollout_date_parts;
 use anyhow::Result;
+use codex_protocol::SegmentId;
 use codex_protocol::ThreadId;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::RolloutLine;
+use codex_protocol::protocol::RolloutReferenceItem;
 use codex_protocol::protocol::SessionMeta;
 use codex_protocol::protocol::SessionMetaLine;
 use codex_protocol::protocol::SessionSource;
@@ -238,6 +240,199 @@ fn rollout_date_parts_extracts_directory_components() {
         parts,
         Some(("2025".to_string(), "03".to_string(), "01".to_string()))
     );
+}
+
+#[tokio::test]
+async fn rollout_reference_resolves_archived_file_by_stable_thread_and_timestamp() {
+    let temp = TempDir::new().expect("tempdir");
+    let home = temp.path();
+    let uuid = Uuid::new_v4();
+    let thread_id = ThreadId::from_string(&uuid.to_string()).expect("thread id");
+    let ts = "2025-01-03T13-00-00";
+    let active_path = home.join(format!("sessions/2025/01/03/rollout-{ts}-{uuid}.jsonl"));
+    let archived_path = home.join(format!("archived_sessions/rollout-{ts}-{uuid}.jsonl"));
+    fs::create_dir_all(archived_path.parent().expect("archived parent")).unwrap();
+    fs::write(&archived_path, "").unwrap();
+
+    let resolved = crate::resolve_rollout_reference_rollout_path(
+        home,
+        &RolloutReferenceItem {
+            rollout_path: active_path,
+            thread_id: Some(thread_id),
+            rollout_timestamp: Some(ts.to_string()),
+            segment_id: None,
+            max_depth: 2,
+            nth_user_message: None,
+            filter_fork_history: false,
+            developer_message_filter_texts: None,
+        },
+    )
+    .await
+    .expect("resolve rollout reference");
+
+    assert_eq!(resolved, archived_path);
+}
+
+#[tokio::test]
+async fn rollout_reference_prefers_segment_id_over_live_path_with_same_thread_timestamp() {
+    let temp = TempDir::new().expect("tempdir");
+    let home = temp.path();
+    let uuid = Uuid::new_v4();
+    let thread_id = ThreadId::from_string(&uuid.to_string()).expect("thread id");
+    let referenced_segment_id = SegmentId::new();
+    let live_segment_id = SegmentId::new();
+    let ts = "2025-01-03T13-00-00";
+    let file_name = format!("rollout-{ts}-{uuid}.jsonl");
+    let active_path = home.join(format!("sessions/2025/01/03/{file_name}"));
+    let archived_path = home
+        .join("archived_sessions")
+        .join(thread_id.to_string())
+        .join(referenced_segment_id.to_string())
+        .join(file_name);
+    write_session_meta(active_path.as_path(), thread_id, live_segment_id, ts);
+    write_session_meta(
+        archived_path.as_path(),
+        thread_id,
+        referenced_segment_id,
+        ts,
+    );
+
+    let resolved = crate::resolve_rollout_reference_rollout_path(
+        home,
+        &RolloutReferenceItem {
+            rollout_path: active_path,
+            thread_id: Some(thread_id),
+            rollout_timestamp: Some(ts.to_string()),
+            segment_id: Some(referenced_segment_id),
+            max_depth: 2,
+            nth_user_message: None,
+            filter_fork_history: false,
+            developer_message_filter_texts: None,
+        },
+    )
+    .await
+    .expect("resolve rollout reference");
+
+    assert_eq!(resolved, archived_path);
+}
+
+#[tokio::test]
+async fn rollout_reference_prefers_existing_prior_segment_path_without_segment_id() {
+    let temp = TempDir::new().expect("tempdir");
+    let home = temp.path();
+    let uuid = Uuid::new_v4();
+    let thread_id = ThreadId::from_string(&uuid.to_string()).expect("thread id");
+    let live_segment_id = SegmentId::new();
+    let ts = "2025-01-03T13-00-00";
+    let file_name = format!("rollout-{ts}-{uuid}.jsonl");
+    let active_path = home.join(format!("sessions/2025/01/03/{file_name}"));
+    let legacy_rotated_path = home.join("archived_sessions").join(file_name);
+    write_session_meta(active_path.as_path(), thread_id, live_segment_id, ts);
+    write_session_meta(
+        legacy_rotated_path.as_path(),
+        thread_id,
+        SegmentId::new(),
+        ts,
+    );
+
+    let resolved = crate::resolve_rollout_reference_rollout_path(
+        home,
+        &RolloutReferenceItem {
+            rollout_path: legacy_rotated_path.clone(),
+            thread_id: Some(thread_id),
+            rollout_timestamp: Some(ts.to_string()),
+            segment_id: None,
+            max_depth: 2,
+            nth_user_message: None,
+            filter_fork_history: false,
+            developer_message_filter_texts: None,
+        },
+    )
+    .await
+    .expect("resolve rollout reference");
+
+    assert_eq!(resolved, legacy_rotated_path);
+}
+
+#[tokio::test]
+async fn rollout_reference_resolves_rotated_segment_file_by_segment_id() {
+    let temp = TempDir::new().expect("tempdir");
+    let home = temp.path();
+    let uuid = Uuid::new_v4();
+    let thread_id = ThreadId::from_string(&uuid.to_string()).expect("thread id");
+    let referenced_segment_id = SegmentId::new();
+    let live_segment_id = SegmentId::new();
+    let ts = "2025-01-03T13-00-00";
+    let file_name = format!("rollout-{ts}-{uuid}.jsonl");
+    let active_path = home.join(format!("sessions/2025/01/03/{file_name}"));
+    let rotated_segment_path = home
+        .join(crate::ROTATED_ROLLOUT_SEGMENTS_SUBDIR)
+        .join(thread_id.to_string())
+        .join(referenced_segment_id.to_string())
+        .join(file_name);
+    write_session_meta(active_path.as_path(), thread_id, live_segment_id, ts);
+    write_session_meta(
+        rotated_segment_path.as_path(),
+        thread_id,
+        referenced_segment_id,
+        ts,
+    );
+
+    let resolved = crate::resolve_rollout_reference_rollout_path(
+        home,
+        &RolloutReferenceItem {
+            rollout_path: active_path,
+            thread_id: Some(thread_id),
+            rollout_timestamp: Some(ts.to_string()),
+            segment_id: Some(referenced_segment_id),
+            max_depth: 2,
+            nth_user_message: None,
+            filter_fork_history: false,
+            developer_message_filter_texts: None,
+        },
+    )
+    .await
+    .expect("resolve rollout reference");
+
+    assert_eq!(resolved, rotated_segment_path);
+}
+
+fn write_session_meta(path: &Path, thread_id: ThreadId, segment_id: SegmentId, timestamp: &str) {
+    fs::create_dir_all(path.parent().expect("rollout parent")).expect("create rollout parent");
+    let line = RolloutLine {
+        timestamp: timestamp.to_string(),
+        item: RolloutItem::SessionMeta(SessionMetaLine {
+            meta: SessionMeta {
+                id: thread_id,
+                segment_id: Some(segment_id),
+                forked_from_id: None,
+                parent_thread_id: None,
+                timestamp: timestamp.to_string(),
+                cwd: ".".into(),
+                originator: "test_originator".into(),
+                cli_version: "test_version".into(),
+                source: SessionSource::VSCode,
+                thread_source: None,
+                agent_path: None,
+                agent_nickname: None,
+                agent_role: None,
+                model_provider: Some("test-provider".into()),
+                base_instructions: None,
+                dynamic_tools: None,
+                memory_mode: None,
+                multi_agent_version: None,
+            },
+            git: None,
+        }),
+    };
+    fs::write(
+        path,
+        format!(
+            "{}\n",
+            serde_json::to_string(&line).expect("serialize meta")
+        ),
+    )
+    .expect("write rollout");
 }
 
 async fn assert_state_db_rollout_path(
@@ -933,6 +1128,57 @@ async fn test_list_threads_scans_past_head_for_user_event() {
 }
 
 #[tokio::test]
+async fn test_list_threads_includes_compacted_replacement_history_with_user_message() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path();
+
+    let uuid = Uuid::from_u128(102);
+    let thread_id = thread_id_from_uuid(uuid);
+    let ts = "2025-05-03T10-30-00";
+    let path = home
+        .join("sessions/2025/05/03")
+        .join(format!("rollout-{ts}-{uuid}.jsonl"));
+    write_session_meta(path.as_path(), thread_id, SegmentId::new(), ts);
+    let mut file = fs::OpenOptions::new().append(true).open(path).unwrap();
+    let compacted = serde_json::json!({
+        "timestamp": ts,
+        "type": "compacted",
+        "payload": {
+            "message": "summary",
+            "replacement_history": [{
+                "type": "message",
+                "role": "user",
+                "content": [{
+                    "type": "input_text",
+                    "text": "Hello from compacted history",
+                }],
+            }],
+        },
+    });
+    writeln!(file, "{compacted}").unwrap();
+
+    let provider_filter = provider_vec(&[TEST_PROVIDER]);
+    let page = get_threads(
+        home,
+        /*page_size*/ 10,
+        /*cursor*/ None,
+        ThreadSortKey::CreatedAt,
+        INTERACTIVE_SESSION_SOURCES.as_slice(),
+        Some(provider_filter.as_slice()),
+        /*cwd_filters*/ None,
+        TEST_PROVIDER,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(page.items.len(), 1);
+    let item = &page.items[0];
+    assert_eq!(item.thread_id, Some(thread_id));
+    assert_eq!(item.preview, None);
+    assert_eq!(item.first_user_message, None);
+}
+
+#[tokio::test]
 async fn test_list_threads_uses_goal_objective_as_preview() {
     let temp = TempDir::new().unwrap();
     let home = temp.path();
@@ -1259,6 +1505,7 @@ async fn test_updated_at_uses_file_mtime() -> Result<()> {
         item: RolloutItem::SessionMeta(SessionMetaLine {
             meta: SessionMeta {
                 id: conversation_id,
+                segment_id: None,
                 forked_from_id: None,
                 parent_thread_id: None,
                 timestamp: ts.to_string(),

--- a/codex-rs/state/src/extract.rs
+++ b/codex-rs/state/src/extract.rs
@@ -22,7 +22,7 @@ pub fn apply_rollout_item(
         RolloutItem::TurnContext(turn_ctx) => apply_turn_context(metadata, turn_ctx),
         RolloutItem::EventMsg(event) => apply_event_msg(metadata, event),
         RolloutItem::ResponseItem(item) => apply_response_item(metadata, item),
-        RolloutItem::Compacted(_) => {}
+        RolloutItem::Compacted(_) | RolloutItem::RolloutReference(_) => {}
     }
     if metadata.model_provider.is_empty() {
         metadata.model_provider = default_provider.to_string();
@@ -36,9 +36,10 @@ pub fn rollout_item_affects_thread_metadata(item: &RolloutItem) -> bool {
         RolloutItem::EventMsg(
             EventMsg::TokenCount(_) | EventMsg::UserMessage(_) | EventMsg::ThreadGoalUpdated(_),
         ) => true,
-        RolloutItem::EventMsg(_) | RolloutItem::ResponseItem(_) | RolloutItem::Compacted(_) => {
-            false
-        }
+        RolloutItem::EventMsg(_)
+        | RolloutItem::RolloutReference(_)
+        | RolloutItem::ResponseItem(_)
+        | RolloutItem::Compacted(_) => false,
     }
 }
 
@@ -319,6 +320,7 @@ mod tests {
             &RolloutItem::SessionMeta(SessionMetaLine {
                 meta: SessionMeta {
                     id: thread_id,
+                    segment_id: None,
                     forked_from_id: Some(
                         ThreadId::from_string(&Uuid::now_v7().to_string()).expect("thread id"),
                     ),
@@ -484,6 +486,7 @@ mod tests {
             &RolloutItem::SessionMeta(SessionMetaLine {
                 meta: SessionMeta {
                     id: thread_id,
+                    segment_id: None,
                     forked_from_id: None,
                     parent_thread_id: None,
                     timestamp: "2026-02-26T00:00:00.000Z".to_string(),

--- a/codex-rs/state/src/runtime/threads.rs
+++ b/codex-rs/state/src/runtime/threads.rs
@@ -952,7 +952,8 @@ SELECT
 pub(super) fn extract_memory_mode(items: &[RolloutItem]) -> Option<String> {
     items.iter().rev().find_map(|item| match item {
         RolloutItem::SessionMeta(meta_line) => meta_line.meta.memory_mode.clone(),
-        RolloutItem::ResponseItem(_)
+        RolloutItem::RolloutReference(_)
+        | RolloutItem::ResponseItem(_)
         | RolloutItem::Compacted(_)
         | RolloutItem::TurnContext(_)
         | RolloutItem::EventMsg(_) => None,
@@ -1319,6 +1320,7 @@ mod tests {
         let items = vec![RolloutItem::SessionMeta(SessionMetaLine {
             meta: SessionMeta {
                 id: thread_id,
+                segment_id: None,
                 forked_from_id: None,
                 parent_thread_id: None,
                 timestamp: metadata.created_at.to_rfc3339(),
@@ -1380,6 +1382,7 @@ mod tests {
         let items = vec![RolloutItem::SessionMeta(SessionMetaLine {
             meta: SessionMeta {
                 id: thread_id,
+                segment_id: None,
                 forked_from_id: None,
                 parent_thread_id: None,
                 timestamp: created_at,

--- a/codex-rs/thread-manager-sample/src/main.rs
+++ b/codex-rs/thread-manager-sample/src/main.rs
@@ -227,6 +227,7 @@ fn new_config(model: Option<String>, arg0_paths: Arg0DispatchPaths) -> anyhow::R
         agent_job_max_runtime_seconds: None,
         agent_interrupt_message_enabled: false,
         agent_max_depth: 1,
+        watchdog_interval_s: 60,
         agent_roles: BTreeMap::new(),
         memories: MemoriesConfig::default(),
         sqlite_home: codex_home.to_path_buf(),

--- a/codex-rs/thread-store/src/in_memory.rs
+++ b/codex-rs/thread-store/src/in_memory.rs
@@ -170,6 +170,7 @@ impl ThreadStore for InMemoryThreadStore {
         state.calls.create_thread += 1;
         let session_meta = SessionMeta {
             id: params.thread_id,
+            segment_id: None,
             forked_from_id: params.forked_from_id,
             parent_thread_id: params.parent_thread_id,
             cwd: params.metadata.cwd.clone().unwrap_or_default(),

--- a/codex-rs/thread-store/src/lib.rs
+++ b/codex-rs/thread-store/src/lib.rs
@@ -35,6 +35,7 @@ pub use types::LoadThreadHistoryParams;
 pub use types::ReadThreadByRolloutPathParams;
 pub use types::ReadThreadParams;
 pub use types::ResumeThreadParams;
+pub use types::RotateThreadSegmentParams;
 pub use types::SearchThreadsParams;
 pub use types::SortDirection;
 pub use types::StoredThread;

--- a/codex-rs/thread-store/src/live_thread.rs
+++ b/codex-rs/thread-store/src/live_thread.rs
@@ -14,6 +14,7 @@ use crate::LoadThreadHistoryParams;
 use crate::LocalThreadStore;
 use crate::ReadThreadParams;
 use crate::ResumeThreadParams;
+use crate::RotateThreadSegmentParams;
 use crate::StoredThread;
 use crate::StoredThreadHistory;
 use crate::ThreadMetadataPatch;
@@ -159,6 +160,23 @@ impl LiveThread {
                 .mark_pending_update_applied(&update);
         }
         Ok(())
+    }
+
+    pub async fn rotate_local_segment(
+        &self,
+        params: RotateThreadSegmentParams,
+    ) -> ThreadStoreResult<bool> {
+        let Some(local_store) = self
+            .thread_store
+            .as_any()
+            .downcast_ref::<LocalThreadStore>()
+        else {
+            return Ok(false);
+        };
+        local_store
+            .rotate_thread_segment(self.thread_id, params)
+            .await?;
+        Ok(true)
     }
 
     pub async fn persist(&self) -> ThreadStoreResult<()> {

--- a/codex-rs/thread-store/src/local/live_writer.rs
+++ b/codex-rs/thread-store/src/local/live_writer.rs
@@ -1,10 +1,16 @@
+use std::path::Path;
 use std::path::PathBuf;
 
+use codex_protocol::SegmentId;
 use codex_protocol::ThreadId;
+use codex_protocol::protocol::RolloutItem;
+use codex_protocol::protocol::RolloutReferenceItem;
 use codex_protocol::protocol::ThreadMemoryMode;
 use codex_rollout::RolloutConfig;
 use codex_rollout::RolloutRecorder;
 use codex_rollout::RolloutRecorderParams;
+use codex_rollout::read_session_meta_line;
+use tokio::fs;
 use tracing::warn;
 
 use super::LocalThreadStore;
@@ -13,6 +19,7 @@ use crate::AppendThreadItemsParams;
 use crate::CreateThreadParams;
 use crate::ReadThreadParams;
 use crate::ResumeThreadParams;
+use crate::RotateThreadSegmentParams;
 use crate::ThreadStoreError;
 use crate::ThreadStoreResult;
 
@@ -151,6 +158,209 @@ pub(super) async fn rollout_path(
         .to_path_buf())
 }
 
+pub(super) async fn rotate_thread_segment(
+    store: &LocalThreadStore,
+    thread_id: ThreadId,
+    params: RotateThreadSegmentParams,
+) -> ThreadStoreResult<()> {
+    let old_recorder = store.live_recorder(thread_id).await?;
+    old_recorder.flush().await.map_err(thread_store_io_error)?;
+    let old_rollout_path = old_recorder.rollout_path().to_path_buf();
+    let old_meta = read_session_meta_line(old_rollout_path.as_path())
+        .await
+        .map_err(|err| ThreadStoreError::Internal {
+            message: format!(
+                "failed to read current rollout metadata from {}: {err}",
+                old_rollout_path.display()
+            ),
+        })?;
+    if old_meta.meta.id != thread_id {
+        return Err(ThreadStoreError::Internal {
+            message: format!(
+                "live rollout {} belongs to thread {} instead of {thread_id}",
+                old_rollout_path.display(),
+                old_meta.meta.id
+            ),
+        });
+    }
+
+    let cwd = params
+        .metadata
+        .cwd
+        .clone()
+        .ok_or_else(|| ThreadStoreError::InvalidRequest {
+            message: "local thread store requires a cwd".to_string(),
+        })?;
+    let config = RolloutConfig {
+        codex_home: store.config.codex_home.clone(),
+        sqlite_home: store.config.sqlite_home.clone(),
+        cwd,
+        model_provider_id: params.metadata.model_provider.clone(),
+        generate_memories: matches!(params.metadata.memory_mode, ThreadMemoryMode::Enabled),
+    };
+    if let Err(err) = old_recorder.shutdown().await {
+        warn!(
+            "failed to close previous rollout segment {} for thread {thread_id}: {err}",
+            old_rollout_path.display()
+        );
+    }
+
+    let current_path = store
+        .live_recorders
+        .lock()
+        .await
+        .get(&thread_id)
+        .ok_or(ThreadStoreError::ThreadNotFound { thread_id })?
+        .rollout_path()
+        .to_path_buf();
+    if current_path != old_rollout_path {
+        return Err(ThreadStoreError::Conflict {
+            message: format!("live writer for thread {thread_id} changed during segment rotation"),
+        });
+    }
+
+    let rotated_segment_path = rotated_segment_path(
+        store.config.codex_home.as_path(),
+        thread_id,
+        old_meta.meta.segment_id,
+        old_rollout_path.as_path(),
+    )?;
+    fs::create_dir_all(rotated_segment_path.parent().ok_or_else(|| {
+        ThreadStoreError::Internal {
+            message: format!(
+                "rotated rollout segment path {} does not have a parent",
+                rotated_segment_path.display()
+            ),
+        }
+    })?)
+    .await
+    .map_err(thread_store_io_error)?;
+    fs::copy(old_rollout_path.as_path(), rotated_segment_path.as_path())
+        .await
+        .map_err(|err| ThreadStoreError::Internal {
+            message: format!(
+                "failed to copy previous rollout segment {} to {}: {err}",
+                old_rollout_path.display(),
+                rotated_segment_path.display()
+            ),
+        })?;
+
+    let mut initial_items = Vec::with_capacity(params.initial_items.len() + 1);
+    initial_items.push(RolloutItem::RolloutReference(RolloutReferenceItem {
+        rollout_path: rotated_segment_path.clone(),
+        thread_id: Some(thread_id),
+        rollout_timestamp: rollout_timestamp_from_path(old_rollout_path.as_path()),
+        segment_id: old_meta.meta.segment_id,
+        max_depth: params.previous_segment_reference_depth,
+        nth_user_message: None,
+        filter_fork_history: false,
+        developer_message_filter_texts: None,
+    }));
+    initial_items.extend(params.initial_items);
+
+    let staged_rollout_path = staged_rollout_path(old_rollout_path.as_path())?;
+    let staged_recorder = match RolloutRecorder::new(
+        &config,
+        RolloutRecorderParams::CreateAtPath {
+            path: staged_rollout_path.clone(),
+            conversation_id: thread_id,
+            forked_from_id: old_meta.meta.forked_from_id,
+            parent_thread_id: old_meta.meta.parent_thread_id,
+            source: params.source,
+            thread_source: old_meta.meta.thread_source,
+            base_instructions: params.base_instructions,
+            dynamic_tools: params.dynamic_tools,
+            multi_agent_version: old_meta.meta.multi_agent_version,
+            session_timestamp: Some(old_meta.meta.timestamp.clone()),
+        },
+    )
+    .await
+    {
+        Ok(staged_recorder) => staged_recorder,
+        Err(err) => {
+            remove_rotation_artifacts(
+                staged_rollout_path.as_path(),
+                rotated_segment_path.as_path(),
+                "staged recorder initialization",
+            )
+            .await;
+            return Err(ThreadStoreError::Internal {
+                message: format!("failed to initialize rotated local thread recorder: {err}"),
+            });
+        }
+    };
+    if let Err(err) = staged_recorder
+        .record_canonical_items(initial_items.as_slice())
+        .await
+    {
+        let _ = staged_recorder.shutdown().await;
+        remove_rotation_artifacts(
+            staged_rollout_path.as_path(),
+            rotated_segment_path.as_path(),
+            "staged recorder write",
+        )
+        .await;
+        return Err(thread_store_io_error(err));
+    }
+    if let Err(err) = staged_recorder.flush().await {
+        let _ = staged_recorder.shutdown().await;
+        remove_rotation_artifacts(
+            staged_rollout_path.as_path(),
+            rotated_segment_path.as_path(),
+            "staged recorder flush",
+        )
+        .await;
+        return Err(thread_store_io_error(err));
+    }
+    if let Err(err) = staged_recorder.shutdown().await {
+        remove_rotation_artifacts(
+            staged_rollout_path.as_path(),
+            rotated_segment_path.as_path(),
+            "staged recorder shutdown",
+        )
+        .await;
+        return Err(thread_store_io_error(err));
+    }
+
+    if let Err(err) = replace_live_rollout_with_staged_segment(
+        staged_rollout_path.as_path(),
+        old_rollout_path.as_path(),
+    )
+    .await
+    {
+        remove_rotation_artifacts(
+            staged_rollout_path.as_path(),
+            rotated_segment_path.as_path(),
+            "staged recorder install",
+        )
+        .await;
+        return Err(err);
+    }
+
+    let new_recorder = RolloutRecorder::new(
+        &config,
+        RolloutRecorderParams::resume(old_rollout_path.clone()),
+    )
+    .await
+    .map_err(|err| ThreadStoreError::Internal {
+        message: format!("failed to resume rotated local thread recorder: {err}"),
+    })?;
+
+    let mut live_recorders = store.live_recorders.lock().await;
+    let current_path = live_recorders
+        .get(&thread_id)
+        .ok_or(ThreadStoreError::ThreadNotFound { thread_id })?
+        .rollout_path()
+        .to_path_buf();
+    if current_path != old_rollout_path {
+        return Err(ThreadStoreError::Conflict {
+            message: format!("live writer for thread {thread_id} changed during segment rotation"),
+        });
+    }
+    live_recorders.insert(thread_id, new_recorder);
+    Ok(())
+}
+
 async fn sync_materialized_rollout_path(
     store: &LocalThreadStore,
     thread_id: ThreadId,
@@ -198,4 +408,95 @@ fn thread_store_io_error(err: std::io::Error) -> ThreadStoreError {
     ThreadStoreError::Internal {
         message: err.to_string(),
     }
+}
+
+fn rotated_segment_path(
+    codex_home: &Path,
+    thread_id: ThreadId,
+    segment_id: Option<SegmentId>,
+    old_rollout_path: &Path,
+) -> ThreadStoreResult<PathBuf> {
+    let old_file_name = old_rollout_path
+        .file_name()
+        .ok_or_else(|| ThreadStoreError::Internal {
+            message: format!(
+                "previous rollout segment path {} does not have a file name",
+                old_rollout_path.display()
+            ),
+        })?;
+    let segment_key = segment_id
+        .map(|segment_id| segment_id.to_string())
+        .unwrap_or_else(|| "initial".to_string());
+    Ok(codex_home
+        .join(codex_rollout::ROTATED_ROLLOUT_SEGMENTS_SUBDIR)
+        .join(thread_id.to_string())
+        .join(segment_key)
+        .join(old_file_name))
+}
+
+fn staged_rollout_path(live_rollout_path: &Path) -> ThreadStoreResult<PathBuf> {
+    let file_name = live_rollout_path
+        .file_name()
+        .ok_or_else(|| ThreadStoreError::Internal {
+            message: format!(
+                "live rollout path {} does not have a file name",
+                live_rollout_path.display()
+            ),
+        })?;
+    let mut staged_file_name = file_name.to_os_string();
+    staged_file_name.push(format!(".staged-{}.tmp", SegmentId::new()));
+    Ok(live_rollout_path.with_file_name(staged_file_name))
+}
+
+async fn replace_live_rollout_with_staged_segment(
+    staged_rollout_path: &Path,
+    live_rollout_path: &Path,
+) -> ThreadStoreResult<()> {
+    match fs::rename(staged_rollout_path, live_rollout_path).await {
+        Ok(()) => Ok(()),
+        Err(rename_err) => {
+            fs::copy(staged_rollout_path, live_rollout_path)
+                .await
+                .map_err(|copy_err| ThreadStoreError::Internal {
+                    message: format!(
+                        "failed to replace live rollout {} from staged rollout {}: rename failed: {rename_err}; copy failed: {copy_err}",
+                        live_rollout_path.display(),
+                        staged_rollout_path.display()
+                    ),
+                })?;
+            fs::remove_file(staged_rollout_path)
+                .await
+                .map_err(|remove_err| ThreadStoreError::Internal {
+                    message: format!(
+                        "failed to remove staged rollout {} after copying it to {}: {remove_err}",
+                        staged_rollout_path.display(),
+                        live_rollout_path.display()
+                    ),
+                })?;
+            Ok(())
+        }
+    }
+}
+
+async fn remove_rotation_artifacts(staged_rollout_path: &Path, archived_path: &Path, stage: &str) {
+    for path in [staged_rollout_path, archived_path] {
+        if fs::try_exists(path).await.unwrap_or(false)
+            && let Err(err) = fs::remove_file(path).await
+        {
+            warn!(
+                "failed to remove rollout rotation artifact {} after {stage}: {err}",
+                path.display()
+            );
+        }
+    }
+}
+
+fn rollout_timestamp_from_path(path: &Path) -> Option<String> {
+    let file_name = path.file_name()?.to_str()?;
+    let core = file_name.strip_prefix("rollout-")?.strip_suffix(".jsonl")?;
+    core.match_indices('-').rev().find_map(|(index, _)| {
+        ThreadId::from_string(&core[index + 1..])
+            .ok()
+            .map(|_| core[..index].to_string())
+    })
 }

--- a/codex-rs/thread-store/src/local/mod.rs
+++ b/codex-rs/thread-store/src/local/mod.rs
@@ -29,6 +29,7 @@ use crate::LoadThreadHistoryParams;
 use crate::ReadThreadByRolloutPathParams;
 use crate::ReadThreadParams;
 use crate::ResumeThreadParams;
+use crate::RotateThreadSegmentParams;
 use crate::SearchThreadsParams;
 use crate::StoredThread;
 use crate::StoredThreadHistory;
@@ -123,6 +124,14 @@ impl LocalThreadStore {
     /// Return the live local rollout path for legacy local-only code paths.
     pub async fn live_rollout_path(&self, thread_id: ThreadId) -> ThreadStoreResult<PathBuf> {
         live_writer::rollout_path(self, thread_id).await
+    }
+
+    pub async fn rotate_thread_segment(
+        &self,
+        thread_id: ThreadId,
+        params: RotateThreadSegmentParams,
+    ) -> ThreadStoreResult<()> {
+        live_writer::rotate_thread_segment(self, thread_id, params).await
     }
 
     pub(super) async fn live_recorder(
@@ -429,6 +438,100 @@ mod tests {
         );
         assert_eq!(metadata.preview.as_deref(), Some("observed append"));
         assert_eq!(metadata.title, "observed append");
+    }
+
+    #[tokio::test]
+    async fn rotate_thread_segment_keeps_live_thread_out_of_archived_sessions() {
+        let home = TempDir::new().expect("temp dir");
+        let config = test_config(home.path());
+        let runtime = codex_state::StateRuntime::init(
+            config.sqlite_home.clone(),
+            config.default_model_provider_id.clone(),
+        )
+        .await
+        .expect("state db should initialize");
+        let store = Arc::new(LocalThreadStore::new(config, Some(runtime.clone())));
+        let thread_id = ThreadId::default();
+        let live_thread = LiveThread::create(store.clone(), create_thread_params(thread_id))
+            .await
+            .expect("create live thread");
+        live_thread
+            .append_items(&[user_message_item("before rotation")])
+            .await
+            .expect("append before rotation");
+        live_thread.flush().await.expect("flush before rotation");
+        let live_rollout_path = store
+            .live_rollout_path(thread_id)
+            .await
+            .expect("live rollout path");
+
+        store
+            .rotate_thread_segment(
+                thread_id,
+                RotateThreadSegmentParams {
+                    source: SessionSource::Exec,
+                    base_instructions: BaseInstructions::default(),
+                    dynamic_tools: Vec::new(),
+                    metadata: thread_metadata(),
+                    initial_items: Vec::new(),
+                    previous_segment_reference_depth: 1,
+                },
+            )
+            .await
+            .expect("rotate thread segment");
+
+        assert!(
+            tokio::fs::try_exists(live_rollout_path.as_path())
+                .await
+                .expect("live rollout path should be checkable")
+        );
+        let (items, _, _) = RolloutRecorder::load_rollout_items(live_rollout_path.as_path())
+            .await
+            .expect("load rotated rollout items");
+        let rotated_rollout_path = items
+            .iter()
+            .find_map(|item| match item {
+                RolloutItem::RolloutReference(reference) => Some(reference.rollout_path.clone()),
+                RolloutItem::SessionMeta(_)
+                | RolloutItem::ResponseItem(_)
+                | RolloutItem::Compacted(_)
+                | RolloutItem::TurnContext(_)
+                | RolloutItem::EventMsg(_) => None,
+            })
+            .expect("rotated rollout reference");
+        assert!(
+            rotated_rollout_path.starts_with(
+                home.path()
+                    .join(codex_rollout::ROTATED_ROLLOUT_SEGMENTS_SUBDIR)
+                    .join(thread_id.to_string())
+            )
+        );
+        assert!(
+            tokio::fs::try_exists(rotated_rollout_path.as_path())
+                .await
+                .expect("rotated rollout path should be checkable")
+        );
+        assert!(
+            !tokio::fs::try_exists(
+                home.path()
+                    .join(codex_rollout::ARCHIVED_SESSIONS_SUBDIR)
+                    .join(
+                        live_rollout_path
+                            .file_name()
+                            .expect("live rollout file name"),
+                    )
+                    .as_path(),
+            )
+            .await
+            .expect("legacy archived rollout path should be checkable")
+        );
+        let metadata = runtime
+            .get_thread(thread_id)
+            .await
+            .expect("sqlite metadata read")
+            .expect("sqlite metadata");
+        assert_eq!(metadata.rollout_path, live_rollout_path);
+        assert_eq!(metadata.archived_at, None);
     }
 
     #[tokio::test]

--- a/codex-rs/thread-store/src/local/read_thread.rs
+++ b/codex-rs/thread-store/src/local/read_thread.rs
@@ -4,7 +4,9 @@ use codex_protocol::models::PermissionProfile;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::SessionMetaLine;
 use codex_protocol::protocol::SessionSource;
+use codex_rollout::ArchivedThreadRolloutDisposition;
 use codex_rollout::RolloutRecorder;
+use codex_rollout::classify_archived_thread_rollout;
 use codex_rollout::find_archived_thread_path_by_id_str;
 use codex_rollout::find_thread_name_by_id;
 use codex_rollout::find_thread_path_by_id_str;
@@ -32,12 +34,12 @@ pub(super) async fn read_thread(
 ) -> ThreadStoreResult<StoredThread> {
     let thread_id = params.thread_id;
     if let Some(metadata) = read_sqlite_metadata(store, thread_id).await
-        && (params.include_archived
-            || (metadata.archived_at.is_none()
-                && !rollout_path_is_archived(
-                    store.config.codex_home.as_path(),
-                    metadata.rollout_path.as_path(),
-                )))
+        && sqlite_metadata_matches_requested_archive_state(
+            store,
+            &metadata,
+            params.include_archived,
+        )
+        .await
         && (!params.include_history
             || sqlite_rollout_path_can_load_history_for_thread(
                 store,
@@ -83,6 +85,35 @@ pub(super) async fn read_thread(
     }
     attach_history_if_requested(&mut thread, params.include_history).await?;
     Ok(thread)
+}
+
+async fn sqlite_metadata_matches_requested_archive_state(
+    store: &LocalThreadStore,
+    metadata: &ThreadMetadata,
+    include_archived: bool,
+) -> bool {
+    let rollout_path_is_archived = rollout_path_is_archived(
+        store.config.codex_home.as_path(),
+        metadata.rollout_path.as_path(),
+    );
+    if !include_archived {
+        return metadata.archived_at.is_none() && !rollout_path_is_archived;
+    }
+    if metadata.archived_at.is_none() {
+        return !rollout_path_is_archived;
+    }
+    if !rollout_path_is_archived {
+        return true;
+    }
+    matches!(
+        classify_archived_thread_rollout(
+            store.config.codex_home.as_path(),
+            metadata.rollout_path.as_path(),
+            store.state_db().await.as_deref(),
+        )
+        .await,
+        Ok(ArchivedThreadRolloutDisposition::CanonicalArchivedThread)
+    )
 }
 
 async fn sqlite_rollout_path_can_load_history_for_thread(
@@ -1065,6 +1096,59 @@ mod tests {
         let history = thread.history.expect("history should load");
         assert_eq!(history.thread_id, thread_id);
         assert_eq!(history.items.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn read_repair_prefers_live_rollout_over_legacy_rotated_segment_when_including_archived()
+    {
+        let home = TempDir::new().expect("temp dir");
+        let config = test_config(home.path());
+        let uuid = Uuid::from_u128(223);
+        let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+        let live_rollout_path =
+            write_session_file(home.path(), "2025-01-03T12-00-00", uuid).expect("session file");
+        let legacy_rotated_path =
+            write_archived_session_file(home.path(), "2025-01-03T12-00-00", uuid)
+                .expect("legacy rotated session file");
+        let runtime = codex_state::StateRuntime::init(
+            config.sqlite_home.clone(),
+            config.default_model_provider_id.clone(),
+        )
+        .await
+        .expect("state db should initialize");
+        let store = LocalThreadStore::new(config.clone(), Some(runtime.clone()));
+        let mut builder = ThreadMetadataBuilder::new(
+            thread_id,
+            legacy_rotated_path,
+            Utc::now(),
+            SessionSource::Cli,
+        );
+        builder.archived_at = Some(Utc::now());
+        let mut metadata = builder.build(config.default_model_provider_id.as_str());
+        metadata.first_user_message = Some("legacy rotated sqlite preview".to_string());
+        runtime
+            .upsert_thread(&metadata)
+            .await
+            .expect("state db upsert should succeed");
+
+        let thread = store
+            .read_thread(ReadThreadParams {
+                thread_id,
+                include_archived: true,
+                include_history: true,
+            })
+            .await
+            .expect("read active thread");
+
+        assert_eq!(thread.rollout_path, Some(live_rollout_path.clone()));
+        assert_eq!(thread.archived_at, None);
+        let repaired = runtime
+            .get_thread(thread_id)
+            .await
+            .expect("state db get thread")
+            .expect("repaired metadata");
+        assert_eq!(repaired.rollout_path, live_rollout_path);
+        assert_eq!(repaired.archived_at, None);
     }
 
     #[tokio::test]

--- a/codex-rs/thread-store/src/thread_metadata_sync.rs
+++ b/codex-rs/thread-store/src/thread_metadata_sync.rs
@@ -270,6 +270,7 @@ impl ThreadMetadataSync {
                     }
                 }
                 RolloutItem::SessionMeta(_)
+                | RolloutItem::RolloutReference(_)
                 | RolloutItem::EventMsg(_)
                 | RolloutItem::ResponseItem(_)
                 | RolloutItem::Compacted(_) => {}

--- a/codex-rs/thread-store/src/types.rs
+++ b/codex-rs/thread-store/src/types.rs
@@ -109,6 +109,23 @@ pub struct AppendThreadItemsParams {
     pub items: Vec<RolloutItem>,
 }
 
+/// Parameters for replacing a live local rollout segment without changing the thread id.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RotateThreadSegmentParams {
+    /// Runtime source for the thread.
+    pub source: SessionSource,
+    /// Base instructions persisted in the new session metadata.
+    pub base_instructions: BaseInstructions,
+    /// Dynamic tools available to the thread.
+    pub dynamic_tools: Vec<DynamicToolSpec>,
+    /// Metadata captured for the new segment.
+    pub metadata: ThreadPersistenceMetadata,
+    /// Items written immediately after the new segment metadata.
+    pub initial_items: Vec<RolloutItem>,
+    /// Maximum number of rollout-reference segments materialized through the new segment.
+    pub previous_segment_reference_depth: usize,
+}
+
 /// Parameters for loading persisted history for resume, fork, rollback, and memory jobs.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LoadThreadHistoryParams {


### PR DESCRIPTION
## Summary

- add the disabled-by-default experimental `session_segmentation` feature
- rotate rollout files after compaction and persist rollout references for forks only when the feature is enabled
- always decode and materialize existing rollout references, even when session segmentation is disabled
- keep rotated rollout segments out of archived top-level thread listings
- preserve the existing sanitized history contract for full-history subagent forks

Session segmentation bounds the active rollout file for long-lived threads without making segmented sessions dependent on the feature remaining enabled. This change adds no database migration.

## Testing

- `cargo test -p codex-features`
- `cargo test -p codex-protocol`
- `cargo test -p codex-rollout`
- `cargo test -p codex-thread-store`
- `RUST_MIN_STACK=33554432 cargo test -p codex-core --lib thread_rollout_truncation::tests`
- `RUST_MIN_STACK=33554432 cargo test -p codex-core --lib spawn_agent_can_fork_parent_thread_history_with_sanitized_items`
- `RUST_MIN_STACK=33554432 cargo test -p codex-core --lib replace_compacted_history`
- focused `codex-core` fork, compact/resume, and app-server thread read/resume/list regressions
- `cargo test -p codex-app-server-protocol`
- `just write-config-schema`
- scoped `just fix`
- `just fmt`
- `git diff --check`

`just argument-comment-lint` was blocked locally before linting by a stale Bazel server PID. A targeted Dylint invocation then reached the packaged toolchain but failed because it uses Rust 1.92 while this checkout's `sqlx` requires Rust 1.94; CI is the remaining lint validator.
