### PR TITLE
[codex] add PathUri filesystem adapter coverage

### DIFF
--- a/codex-rs/exec-server/tests/file_system/shared.rs
+++ b/codex-rs/exec-server/tests/file_system/shared.rs
@@ -1,0 +1,435 @@
+use anyhow::Context;
+use anyhow::Result;
+use codex_exec_server::CopyOptions;
+use codex_exec_server::CreateDirectoryOptions;
+use codex_exec_server::ReadDirectoryEntry;
+use codex_exec_server::RemoveOptions;
+use codex_protocol::models::AdditionalPermissionProfile;
+use codex_protocol::models::FileSystemPermissions;
+use codex_protocol::models::PermissionProfile;
+use codex_sandboxing::policy_transforms::effective_file_system_sandbox_policy;
+use codex_sandboxing::policy_transforms::effective_network_sandbox_policy;
+use pretty_assertions::assert_eq;
+use std::path::Path;
+use tempfile::TempDir;
+use test_case::test_case;
+
+use super::support::absolute_path;
+use super::support::create_file_system_context;
+use super::support::read_only_sandbox;
+use super::support::workspace_write_sandbox;
+
+#[test]
+fn sandbox_context_from_profile_preserves_workspace_write_read_only_subpaths() -> Result<()> {
+    let tmp = TempDir::new()?;
+    let writable_dir = tmp.path().join("writable");
+    let git_dir = writable_dir.join(".git");
+    std::fs::create_dir_all(&git_dir)?;
+
+    let sandbox = workspace_write_sandbox(writable_dir.clone());
+    let policy = sandbox.permissions.file_system_sandbox_policy();
+    let cwd = absolute_path(writable_dir.clone());
+    let writable_roots = policy.get_writable_roots_with_cwd(cwd.as_path());
+    let writable_dir = absolute_path(std::fs::canonicalize(writable_dir)?);
+    let git_dir = absolute_path(std::fs::canonicalize(git_dir)?);
+    let Some(writable_root) = writable_roots
+        .iter()
+        .find(|writable_root| writable_root.root == writable_dir)
+    else {
+        panic!("writable root should be preserved");
+    };
+
+    assert!(writable_root.read_only_subpaths.contains(&git_dir));
+
+    Ok(())
+}
+
+#[test_case(false ; "local")]
+#[test_case(true ; "remote")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn file_system_get_metadata_returns_expected_fields(use_remote: bool) -> Result<()> {
+    let context = create_file_system_context(use_remote).await?;
+    let file_system = context.file_system;
+
+    let tmp = TempDir::new()?;
+    let file_path = tmp.path().join("note.txt");
+    std::fs::write(&file_path, "hello")?;
+
+    let metadata = file_system
+        .get_metadata(&absolute_path(&file_path), /*sandbox*/ None)
+        .await
+        .with_context(|| format!("mode={use_remote}"))?;
+    assert_eq!(metadata.is_directory, false);
+    assert_eq!(metadata.is_file, true);
+    assert_eq!(metadata.is_symlink, false);
+    assert!(metadata.modified_at_ms > 0);
+
+    Ok(())
+}
+
+#[test_case(false ; "local")]
+#[test_case(true ; "remote")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn file_system_methods_cover_surface_area(use_remote: bool) -> Result<()> {
+    let context = create_file_system_context(use_remote).await?;
+    let file_system = context.file_system;
+
+    let tmp = TempDir::new()?;
+    let source_dir = tmp.path().join("source");
+    let nested_dir = source_dir.join("nested");
+    let source_file = source_dir.join("root.txt");
+    let nested_file = nested_dir.join("note.txt");
+    let copied_dir = tmp.path().join("copied");
+    let copied_file = tmp.path().join("copy.txt");
+
+    file_system
+        .create_directory(
+            &absolute_path(&nested_dir),
+            CreateDirectoryOptions { recursive: true },
+            /*sandbox*/ None,
+        )
+        .await
+        .with_context(|| format!("mode={use_remote}"))?;
+
+    file_system
+        .write_file(
+            &absolute_path(&nested_file),
+            b"hello from trait".to_vec(),
+            /*sandbox*/ None,
+        )
+        .await
+        .with_context(|| format!("mode={use_remote}"))?;
+    file_system
+        .write_file(
+            &absolute_path(&source_file),
+            b"hello from source root".to_vec(),
+            /*sandbox*/ None,
+        )
+        .await
+        .with_context(|| format!("mode={use_remote}"))?;
+
+    let joined_nested = file_system
+        .join(&absolute_path(&source_dir), Path::new("nested/note.txt"))
+        .await
+        .with_context(|| format!("mode={use_remote}"))?;
+    assert_eq!(
+        joined_nested,
+        absolute_path(source_dir.join("nested").join("note.txt"))
+    );
+    let joined_parent = file_system
+        .parent(&joined_nested)
+        .await
+        .with_context(|| format!("mode={use_remote}"))?;
+    assert_eq!(
+        joined_parent,
+        Some(absolute_path(source_dir.join("nested")))
+    );
+    let joined_parent_traversal = file_system
+        .join(&absolute_path(&source_dir), Path::new("../outside"))
+        .await
+        .with_context(|| format!("mode={use_remote}"))?;
+    assert_eq!(
+        joined_parent_traversal,
+        absolute_path(source_dir.join("../outside"))
+    );
+    let nested_file_contents = file_system
+        .read_file(&absolute_path(&nested_file), /*sandbox*/ None)
+        .await
+        .with_context(|| format!("mode={use_remote}"))?;
+    assert_eq!(nested_file_contents, b"hello from trait");
+
+    let nested_file_text = file_system
+        .read_file_text(&absolute_path(&nested_file), /*sandbox*/ None)
+        .await
+        .with_context(|| format!("mode={use_remote}"))?;
+    assert_eq!(nested_file_text, "hello from trait");
+
+    file_system
+        .copy(
+            &absolute_path(&nested_file),
+            &absolute_path(&copied_file),
+            CopyOptions { recursive: false },
+            /*sandbox*/ None,
+        )
+        .await
+        .with_context(|| format!("mode={use_remote}"))?;
+    assert_eq!(std::fs::read_to_string(copied_file)?, "hello from trait");
+
+    file_system
+        .copy(
+            &absolute_path(&source_dir),
+            &absolute_path(&copied_dir),
+            CopyOptions { recursive: true },
+            /*sandbox*/ None,
+        )
+        .await
+        .with_context(|| format!("mode={use_remote}"))?;
+    assert_eq!(
+        std::fs::read_to_string(copied_dir.join("nested").join("note.txt"))?,
+        "hello from trait"
+    );
+
+    let mut entries = file_system
+        .read_directory(&absolute_path(&source_dir), /*sandbox*/ None)
+        .await
+        .with_context(|| format!("mode={use_remote}"))?;
+    entries.sort_by(|left, right| left.file_name.cmp(&right.file_name));
+    assert_eq!(
+        entries,
+        vec![
+            ReadDirectoryEntry {
+                file_name: "nested".to_string(),
+                is_directory: true,
+                is_file: false,
+            },
+            ReadDirectoryEntry {
+                file_name: "root.txt".to_string(),
+                is_directory: false,
+                is_file: true,
+            },
+        ]
+    );
+
+    file_system
+        .remove(
+            &absolute_path(&copied_dir),
+            RemoveOptions {
+                recursive: true,
+                force: true,
+            },
+            /*sandbox*/ None,
+        )
+        .await
+        .with_context(|| format!("mode={use_remote}"))?;
+    assert!(!copied_dir.exists());
+
+    Ok(())
+}
+
+#[test_case(false ; "local")]
+#[test_case(true ; "remote")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn file_system_write_file_reports_missing_parent(use_remote: bool) -> Result<()> {
+    let context = create_file_system_context(use_remote).await?;
+    let file_system = context.file_system;
+
+    let tmp = TempDir::new()?;
+    let missing_parent_path = tmp.path().join("missing").join("note.txt");
+
+    let error = match file_system
+        .write_file(
+            &absolute_path(&missing_parent_path),
+            b"hello from trait".to_vec(),
+            /*sandbox*/ None,
+        )
+        .await
+    {
+        Ok(()) => anyhow::bail!("write should fail when parent directory is absent"),
+        Err(error) => error,
+    };
+    assert_eq!(
+        error.kind(),
+        std::io::ErrorKind::NotFound,
+        "mode={use_remote}"
+    );
+    assert!(!missing_parent_path.exists(), "mode={use_remote}");
+
+    Ok(())
+}
+
+#[test_case(false ; "local")]
+#[test_case(true ; "remote")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn file_system_copy_rejects_directory_without_recursive(use_remote: bool) -> Result<()> {
+    let context = create_file_system_context(use_remote).await?;
+    let file_system = context.file_system;
+
+    let tmp = TempDir::new()?;
+    let source_dir = tmp.path().join("source");
+    std::fs::create_dir_all(&source_dir)?;
+
+    let error = file_system
+        .copy(
+            &absolute_path(&source_dir),
+            &absolute_path(tmp.path().join("dest")),
+            CopyOptions { recursive: false },
+            /*sandbox*/ None,
+        )
+        .await;
+    let error = match error {
+        Ok(()) => panic!("copy should fail"),
+        Err(error) => error,
+    };
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    assert_eq!(
+        error.to_string(),
+        "fs/copy requires recursive: true when sourcePath is a directory"
+    );
+
+    Ok(())
+}
+
+#[test_case(false ; "local")]
+#[test_case(true ; "remote")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn file_system_sandboxed_read_allows_readable_root(use_remote: bool) -> Result<()> {
+    let context = create_file_system_context(use_remote).await?;
+    let file_system = context.file_system;
+
+    let tmp = TempDir::new()?;
+    let allowed_dir = tmp.path().join("allowed");
+    let file_path = allowed_dir.join("note.txt");
+    std::fs::create_dir_all(&allowed_dir)?;
+    std::fs::write(&file_path, "sandboxed hello")?;
+    let sandbox = read_only_sandbox(allowed_dir);
+
+    let contents = file_system
+        .read_file(&absolute_path(&file_path), Some(&sandbox))
+        .await
+        .with_context(|| format!("mode={use_remote}"))?;
+    assert_eq!(contents, b"sandboxed hello");
+
+    Ok(())
+}
+
+pub(crate) async fn assert_canonicalize_resolves_directory_alias(
+    use_remote: bool,
+    create_directory_alias: impl FnOnce(&Path, &Path) -> Result<()>,
+) -> Result<()> {
+    let context = create_file_system_context(use_remote).await?;
+    let file_system = context.file_system;
+
+    let tmp = TempDir::new()?;
+    let source_dir = tmp.path().join("source");
+    let nested_dir = source_dir.join("nested");
+    let file_path = nested_dir.join("note.txt");
+    let alias_dir = tmp.path().join("source-alias");
+    std::fs::create_dir_all(&nested_dir)?;
+    std::fs::write(&file_path, "canonical hello")?;
+    create_directory_alias(&source_dir, &alias_dir)?;
+
+    let requested_path = absolute_path(alias_dir.join("nested").join("note.txt"));
+    let expected_path = absolute_path(std::fs::canonicalize(&file_path)?);
+    assert_ne!(requested_path, expected_path);
+
+    let canonical_path = file_system
+        .canonicalize(&requested_path, /*sandbox*/ None)
+        .await
+        .with_context(|| format!("mode={use_remote}"))?;
+    assert_eq!(canonical_path, expected_path);
+
+    Ok(())
+}
+
+pub(crate) async fn assert_sandboxed_canonicalize_resolves_directory_alias(
+    use_remote: bool,
+    create_directory_alias: impl FnOnce(&Path, &Path) -> Result<()>,
+) -> Result<()> {
+    let context = create_file_system_context(use_remote).await?;
+    let file_system = context.file_system;
+
+    let tmp = TempDir::new()?;
+    let source_dir = tmp.path().join("source");
+    let nested_dir = source_dir.join("nested");
+    let file_path = nested_dir.join("note.txt");
+    let alias_dir = tmp.path().join("source-alias");
+    std::fs::create_dir_all(&nested_dir)?;
+    std::fs::write(&file_path, "sandboxed canonical hello")?;
+    create_directory_alias(&source_dir, &alias_dir)?;
+    let sandbox = read_only_sandbox(tmp.path().to_path_buf());
+
+    let requested_path = absolute_path(alias_dir.join("nested").join("note.txt"));
+    let expected_path = absolute_path(std::fs::canonicalize(&file_path)?);
+    assert_ne!(requested_path, expected_path);
+
+    let canonical_path = file_system
+        .canonicalize(&requested_path, Some(&sandbox))
+        .await
+        .with_context(|| format!("mode={use_remote}"))?;
+    assert_eq!(canonical_path, expected_path);
+
+    Ok(())
+}
+
+#[test_case(false ; "local")]
+#[test_case(true ; "remote")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn file_system_sandboxed_write_allows_additional_write_root(use_remote: bool) -> Result<()> {
+    let context = create_file_system_context(use_remote).await?;
+    let file_system = context.file_system;
+
+    let tmp = TempDir::new()?;
+    let readable_dir = tmp.path().join("readable");
+    let writable_dir = tmp.path().join("writable");
+    let file_path = writable_dir.join("note.txt");
+    std::fs::create_dir_all(&readable_dir)?;
+    std::fs::create_dir_all(&writable_dir)?;
+
+    let mut sandbox = read_only_sandbox(readable_dir);
+    let additional_permissions = AdditionalPermissionProfile {
+        network: None,
+        file_system: Some(FileSystemPermissions::from_read_write_roots(
+            /*read*/ None,
+            Some(vec![absolute_path(writable_dir)]),
+        )),
+    };
+    let file_system_policy = effective_file_system_sandbox_policy(
+        &sandbox.permissions.file_system_sandbox_policy(),
+        Some(&additional_permissions),
+    );
+    let network_policy = effective_network_sandbox_policy(
+        sandbox.permissions.network_sandbox_policy(),
+        Some(&additional_permissions),
+    );
+    sandbox.permissions = PermissionProfile::from_runtime_permissions_with_enforcement(
+        sandbox.permissions.enforcement(),
+        &file_system_policy,
+        network_policy,
+    );
+
+    file_system
+        .write_file(
+            &absolute_path(&file_path),
+            b"created".to_vec(),
+            Some(&sandbox),
+        )
+        .await
+        .with_context(|| format!("write file through additional root mode={use_remote}"))?;
+    assert_eq!(std::fs::read(&file_path)?, b"created");
+
+    Ok(())
+}
+
+#[test_case(false ; "local")]
+#[test_case(true ; "remote")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn file_system_copy_rejects_copying_directory_into_descendant(
+    use_remote: bool,
+) -> Result<()> {
+    let context = create_file_system_context(use_remote).await?;
+    let file_system = context.file_system;
+
+    let tmp = TempDir::new()?;
+    let source_dir = tmp.path().join("source");
+    std::fs::create_dir_all(source_dir.join("nested"))?;
+
+    let error = file_system
+        .copy(
+            &absolute_path(&source_dir),
+            &absolute_path(source_dir.join("nested").join("copy")),
+            CopyOptions { recursive: true },
+            /*sandbox*/ None,
+        )
+        .await;
+    let error = match error {
+        Ok(()) => panic!("copy should fail"),
+        Err(error) => error,
+    };
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    assert_eq!(
+        error.to_string(),
+        "fs/copy cannot copy a directory to itself or one of its descendants"
+    );
+
+    Ok(())
+}

--- a/codex-rs/exec-server/tests/file_system/support.rs
+++ b/codex-rs/exec-server/tests/file_system/support.rs
@@ -1,0 +1,92 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Result;
+use codex_exec_server::Environment;
+use codex_exec_server::ExecServerRuntimePaths;
+use codex_exec_server::ExecutorFileSystem;
+use codex_exec_server::FileSystemSandboxContext;
+use codex_exec_server::LocalFileSystem;
+use codex_protocol::models::PermissionProfile;
+use codex_protocol::permissions::FileSystemAccessMode;
+use codex_protocol::permissions::FileSystemPath;
+use codex_protocol::permissions::FileSystemSandboxEntry;
+use codex_protocol::permissions::FileSystemSandboxPolicy;
+use codex_protocol::permissions::NetworkSandboxPolicy;
+use codex_utils_absolute_path::AbsolutePathBuf;
+
+use crate::common::exec_server::ExecServerHarness;
+use crate::common::exec_server::TestCodexHelperPaths;
+use crate::common::exec_server::exec_server;
+use crate::common::exec_server::test_codex_helper_paths;
+
+pub(crate) struct FileSystemContext {
+    pub(crate) file_system: Arc<dyn ExecutorFileSystem>,
+    _helper_paths: Option<TestCodexHelperPaths>,
+    _server: Option<ExecServerHarness>,
+}
+
+pub(crate) async fn create_file_system_context(use_remote: bool) -> Result<FileSystemContext> {
+    if use_remote {
+        let server = exec_server().await?;
+        let environment = Environment::create_for_tests(Some(server.websocket_url().to_string()))?;
+        Ok(FileSystemContext {
+            file_system: environment.get_filesystem(),
+            _helper_paths: None,
+            _server: Some(server),
+        })
+    } else {
+        let helper_paths = test_codex_helper_paths()?;
+        let runtime_paths = ExecServerRuntimePaths::new(
+            helper_paths.codex_exe.clone(),
+            helper_paths.codex_linux_sandbox_exe.clone(),
+        )?;
+        Ok(FileSystemContext {
+            file_system: Arc::new(LocalFileSystem::with_runtime_paths(runtime_paths)),
+            _helper_paths: Some(helper_paths),
+            _server: None,
+        })
+    }
+}
+
+pub(crate) fn absolute_path(path: impl AsRef<Path>) -> AbsolutePathBuf {
+    let path = path.as_ref().to_path_buf();
+    assert!(
+        path.is_absolute(),
+        "path must be absolute: {}",
+        path.display()
+    );
+    match AbsolutePathBuf::try_from(path) {
+        Ok(path) => path,
+        Err(err) => panic!("path should be absolute: {err}"),
+    }
+}
+
+pub(crate) fn read_only_sandbox(readable_root: std::path::PathBuf) -> FileSystemSandboxContext {
+    let readable_root = absolute_path(readable_root);
+    sandbox_context(vec![FileSystemSandboxEntry {
+        path: FileSystemPath::Path {
+            path: readable_root,
+        },
+        access: FileSystemAccessMode::Read,
+    }])
+}
+
+pub(crate) fn workspace_write_sandbox(
+    writable_root: std::path::PathBuf,
+) -> FileSystemSandboxContext {
+    let writable_root = absolute_path(writable_root);
+    sandbox_context(vec![FileSystemSandboxEntry {
+        path: FileSystemPath::Path {
+            path: writable_root,
+        },
+        access: FileSystemAccessMode::Write,
+    }])
+}
+
+fn sandbox_context(entries: Vec<FileSystemSandboxEntry>) -> FileSystemSandboxContext {
+    FileSystemSandboxContext::from_permission_profile(PermissionProfile::from_runtime_permissions(
+        &FileSystemSandboxPolicy::restricted(entries),
+        NetworkSandboxPolicy::Restricted,
+    ))
+}

--- a/codex-rs/exec-server/tests/file_system_unix.rs
+++ b/codex-rs/exec-server/tests/file_system_unix.rs
@@ -2,6 +2,11 @@
 
 mod common;
 
+#[path = "file_system/shared.rs"]
+mod shared;
+#[path = "file_system/support.rs"]
+mod support;
+
 use std::os::unix::fs::MetadataExt;
 #[cfg(target_os = "linux")]
 use std::os::unix::fs::PermissionsExt;
@@ -9,133 +14,25 @@ use std::os::unix::fs::symlink;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::Arc;
 
 use anyhow::Context;
 use anyhow::Result;
 use codex_exec_server::CopyOptions;
 use codex_exec_server::CreateDirectoryOptions;
+#[cfg(target_os = "linux")]
 use codex_exec_server::Environment;
-use codex_exec_server::ExecServerRuntimePaths;
-use codex_exec_server::ExecutorFileSystem;
-use codex_exec_server::FileSystemSandboxContext;
-use codex_exec_server::LocalFileSystem;
-use codex_exec_server::ReadDirectoryEntry;
 use codex_exec_server::RemoveOptions;
-use codex_protocol::models::AdditionalPermissionProfile;
-use codex_protocol::models::FileSystemPermissions;
-use codex_protocol::models::PermissionProfile;
-use codex_protocol::permissions::FileSystemAccessMode;
-use codex_protocol::permissions::FileSystemPath;
-use codex_protocol::permissions::FileSystemSandboxEntry;
-use codex_protocol::permissions::FileSystemSandboxPolicy;
-use codex_protocol::permissions::NetworkSandboxPolicy;
-use codex_sandboxing::policy_transforms::effective_file_system_sandbox_policy;
-use codex_sandboxing::policy_transforms::effective_network_sandbox_policy;
-use codex_utils_absolute_path::AbsolutePathBuf;
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
 use test_case::test_case;
 
-use common::exec_server::ExecServerHarness;
-use common::exec_server::TestCodexHelperPaths;
-use common::exec_server::exec_server;
 #[cfg(target_os = "linux")]
-use common::exec_server::exec_server_with_env;
-use common::exec_server::test_codex_helper_paths;
+use crate::common::exec_server::exec_server_with_env;
 
-struct FileSystemContext {
-    file_system: Arc<dyn ExecutorFileSystem>,
-    _helper_paths: Option<TestCodexHelperPaths>,
-    _server: Option<ExecServerHarness>,
-}
-
-async fn create_file_system_context(use_remote: bool) -> Result<FileSystemContext> {
-    if use_remote {
-        let server = exec_server().await?;
-        let environment = Environment::create_for_tests(Some(server.websocket_url().to_string()))?;
-        Ok(FileSystemContext {
-            file_system: environment.get_filesystem(),
-            _helper_paths: None,
-            _server: Some(server),
-        })
-    } else {
-        let helper_paths = test_codex_helper_paths()?;
-        let runtime_paths = ExecServerRuntimePaths::new(
-            helper_paths.codex_exe.clone(),
-            helper_paths.codex_linux_sandbox_exe.clone(),
-        )?;
-        Ok(FileSystemContext {
-            file_system: Arc::new(LocalFileSystem::with_runtime_paths(runtime_paths)),
-            _helper_paths: Some(helper_paths),
-            _server: None,
-        })
-    }
-}
-
-fn absolute_path(path: std::path::PathBuf) -> AbsolutePathBuf {
-    assert!(
-        path.is_absolute(),
-        "path must be absolute: {}",
-        path.display()
-    );
-    match AbsolutePathBuf::try_from(path) {
-        Ok(path) => path,
-        Err(err) => panic!("path should be absolute: {err}"),
-    }
-}
-
-fn read_only_sandbox(readable_root: std::path::PathBuf) -> FileSystemSandboxContext {
-    let readable_root = absolute_path(readable_root);
-    sandbox_context(vec![FileSystemSandboxEntry {
-        path: FileSystemPath::Path {
-            path: readable_root,
-        },
-        access: FileSystemAccessMode::Read,
-    }])
-}
-
-fn workspace_write_sandbox(writable_root: std::path::PathBuf) -> FileSystemSandboxContext {
-    let writable_root = absolute_path(writable_root);
-    sandbox_context(vec![FileSystemSandboxEntry {
-        path: FileSystemPath::Path {
-            path: writable_root,
-        },
-        access: FileSystemAccessMode::Write,
-    }])
-}
-
-fn sandbox_context(entries: Vec<FileSystemSandboxEntry>) -> FileSystemSandboxContext {
-    FileSystemSandboxContext::from_permission_profile(PermissionProfile::from_runtime_permissions(
-        &FileSystemSandboxPolicy::restricted(entries),
-        NetworkSandboxPolicy::Restricted,
-    ))
-}
-
-#[test]
-fn sandbox_context_from_profile_preserves_workspace_write_read_only_subpaths() -> Result<()> {
-    let tmp = TempDir::new()?;
-    let writable_dir = tmp.path().join("writable");
-    let git_dir = writable_dir.join(".git");
-    std::fs::create_dir_all(&git_dir)?;
-
-    let sandbox = workspace_write_sandbox(writable_dir.clone());
-    let policy = sandbox.permissions.file_system_sandbox_policy();
-    let cwd = absolute_path(writable_dir.clone());
-    let writable_roots = policy.get_writable_roots_with_cwd(cwd.as_path());
-    let writable_dir = absolute_path(std::fs::canonicalize(writable_dir)?);
-    let git_dir = absolute_path(std::fs::canonicalize(git_dir)?);
-    let Some(writable_root) = writable_roots
-        .iter()
-        .find(|writable_root| writable_root.root == writable_dir)
-    else {
-        panic!("writable root should be preserved");
-    };
-
-    assert!(writable_root.read_only_subpaths.contains(&git_dir));
-
-    Ok(())
-}
+use crate::support::absolute_path;
+use crate::support::create_file_system_context;
+use crate::support::read_only_sandbox;
+use crate::support::workspace_write_sandbox;
 
 fn assert_sandbox_denied(error: &std::io::Error) {
     match error.kind() {
@@ -188,6 +85,11 @@ fn alias_root_candidate() -> Result<Option<PathBuf>> {
     Ok(None)
 }
 
+fn create_directory_symlink(target: &Path, alias: &Path) -> Result<()> {
+    symlink(target, alias)?;
+    Ok(())
+}
+
 #[cfg(target_os = "linux")]
 fn write_fake_bwrap(bin_dir: &Path) -> Result<PathBuf> {
     std::fs::create_dir_all(bin_dir)?;
@@ -237,6 +139,26 @@ exec "${cmd[@]}"
     Ok(fake_bwrap)
 }
 
+#[test_case(false ; "local")]
+#[test_case(true ; "remote")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn file_system_canonicalize_resolves_directory_symlink(use_remote: bool) -> Result<()> {
+    shared::assert_canonicalize_resolves_directory_alias(use_remote, create_directory_symlink).await
+}
+
+#[test_case(false ; "local")]
+#[test_case(true ; "remote")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn file_system_sandboxed_canonicalize_resolves_directory_symlink(
+    use_remote: bool,
+) -> Result<()> {
+    shared::assert_sandboxed_canonicalize_resolves_directory_alias(
+        use_remote,
+        create_directory_symlink,
+    )
+    .await
+}
+
 #[cfg(target_os = "linux")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn sandboxed_file_system_helper_finds_bwrap_on_preserved_path() -> Result<()> {
@@ -259,7 +181,7 @@ async fn sandboxed_file_system_helper_finds_bwrap_on_preserved_path() -> Result<
 
     file_system
         .write_file(
-            &absolute_path(file_path.clone()),
+            &absolute_path(&file_path),
             b"written through fs helper".to_vec(),
             Some(&sandbox),
         )
@@ -281,27 +203,17 @@ async fn sandboxed_file_system_helper_finds_bwrap_on_preserved_path() -> Result<
 #[test_case(false ; "local")]
 #[test_case(true ; "remote")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn file_system_get_metadata_returns_expected_fields(use_remote: bool) -> Result<()> {
+async fn file_system_get_metadata_reports_symlink_targets(use_remote: bool) -> Result<()> {
     let context = create_file_system_context(use_remote).await?;
     let file_system = context.file_system;
 
     let tmp = TempDir::new()?;
     let file_path = tmp.path().join("note.txt");
     std::fs::write(&file_path, "hello")?;
-
-    let metadata = file_system
-        .get_metadata(&absolute_path(file_path.clone()), /*sandbox*/ None)
-        .await
-        .with_context(|| format!("mode={use_remote}"))?;
-    assert_eq!(metadata.is_directory, false);
-    assert_eq!(metadata.is_file, true);
-    assert_eq!(metadata.is_symlink, false);
-    assert!(metadata.modified_at_ms > 0);
-
     let symlink_path = tmp.path().join("note-link.txt");
     symlink(&file_path, &symlink_path)?;
     let symlink_metadata = file_system
-        .get_metadata(&absolute_path(symlink_path.clone()), /*sandbox*/ None)
+        .get_metadata(&absolute_path(&symlink_path), /*sandbox*/ None)
         .await
         .with_context(|| format!("mode={use_remote}"))?;
     assert_eq!(symlink_metadata.is_directory, false);
@@ -314,287 +226,12 @@ async fn file_system_get_metadata_returns_expected_fields(use_remote: bool) -> R
     let dir_symlink_path = tmp.path().join("notes-link");
     symlink(&dir_path, &dir_symlink_path)?;
     let dir_symlink_metadata = file_system
-        .get_metadata(&absolute_path(dir_symlink_path), /*sandbox*/ None)
+        .get_metadata(&absolute_path(&dir_symlink_path), /*sandbox*/ None)
         .await
         .with_context(|| format!("mode={use_remote}"))?;
     assert_eq!(dir_symlink_metadata.is_directory, true);
     assert_eq!(dir_symlink_metadata.is_file, false);
     assert_eq!(dir_symlink_metadata.is_symlink, true);
-
-    Ok(())
-}
-
-#[test_case(false ; "local")]
-#[test_case(true ; "remote")]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn file_system_methods_cover_surface_area(use_remote: bool) -> Result<()> {
-    let context = create_file_system_context(use_remote).await?;
-    let file_system = context.file_system;
-
-    let tmp = TempDir::new()?;
-    let source_dir = tmp.path().join("source");
-    let nested_dir = source_dir.join("nested");
-    let source_file = source_dir.join("root.txt");
-    let nested_file = nested_dir.join("note.txt");
-    let copied_dir = tmp.path().join("copied");
-    let copied_file = tmp.path().join("copy.txt");
-
-    file_system
-        .create_directory(
-            &absolute_path(nested_dir.clone()),
-            CreateDirectoryOptions { recursive: true },
-            /*sandbox*/ None,
-        )
-        .await
-        .with_context(|| format!("mode={use_remote}"))?;
-
-    file_system
-        .write_file(
-            &absolute_path(nested_file.clone()),
-            b"hello from trait".to_vec(),
-            /*sandbox*/ None,
-        )
-        .await
-        .with_context(|| format!("mode={use_remote}"))?;
-    file_system
-        .write_file(
-            &absolute_path(source_file.clone()),
-            b"hello from source root".to_vec(),
-            /*sandbox*/ None,
-        )
-        .await
-        .with_context(|| format!("mode={use_remote}"))?;
-
-    let source_link = tmp.path().join("source-link");
-    symlink(&source_dir, &source_link)?;
-    let joined_nested = file_system
-        .join(
-            &absolute_path(source_link.clone()),
-            Path::new("nested/note.txt"),
-        )
-        .await
-        .with_context(|| format!("mode={use_remote}"))?;
-    assert_eq!(
-        joined_nested,
-        absolute_path(source_link.join("nested").join("note.txt"))
-    );
-    let joined_parent = file_system
-        .parent(&joined_nested)
-        .await
-        .with_context(|| format!("mode={use_remote}"))?;
-    assert_eq!(
-        joined_parent,
-        Some(absolute_path(source_link.join("nested")))
-    );
-    let joined_parent_traversal = file_system
-        .join(&absolute_path(source_dir.clone()), Path::new("../outside"))
-        .await
-        .with_context(|| format!("mode={use_remote}"))?;
-    assert_eq!(
-        joined_parent_traversal,
-        absolute_path(source_dir.join("../outside"))
-    );
-    let canonical_nested = file_system
-        .canonicalize(
-            &absolute_path(source_link.join("nested").join("note.txt")),
-            /*sandbox*/ None,
-        )
-        .await
-        .with_context(|| format!("mode={use_remote}"))?;
-    assert_eq!(
-        canonical_nested,
-        absolute_path(std::fs::canonicalize(
-            source_dir.join("nested").join("note.txt")
-        )?)
-    );
-
-    let nested_file_contents = file_system
-        .read_file(&absolute_path(nested_file.clone()), /*sandbox*/ None)
-        .await
-        .with_context(|| format!("mode={use_remote}"))?;
-    assert_eq!(nested_file_contents, b"hello from trait");
-
-    let nested_file_text = file_system
-        .read_file_text(&absolute_path(nested_file.clone()), /*sandbox*/ None)
-        .await
-        .with_context(|| format!("mode={use_remote}"))?;
-    assert_eq!(nested_file_text, "hello from trait");
-
-    file_system
-        .copy(
-            &absolute_path(nested_file),
-            &absolute_path(copied_file.clone()),
-            CopyOptions { recursive: false },
-            /*sandbox*/ None,
-        )
-        .await
-        .with_context(|| format!("mode={use_remote}"))?;
-    assert_eq!(std::fs::read_to_string(copied_file)?, "hello from trait");
-
-    file_system
-        .copy(
-            &absolute_path(source_dir.clone()),
-            &absolute_path(copied_dir.clone()),
-            CopyOptions { recursive: true },
-            /*sandbox*/ None,
-        )
-        .await
-        .with_context(|| format!("mode={use_remote}"))?;
-    assert_eq!(
-        std::fs::read_to_string(copied_dir.join("nested").join("note.txt"))?,
-        "hello from trait"
-    );
-
-    symlink(
-        source_dir.join("missing-target"),
-        source_dir.join("broken-link"),
-    )?;
-
-    let mut entries = file_system
-        .read_directory(&absolute_path(source_dir), /*sandbox*/ None)
-        .await
-        .with_context(|| format!("mode={use_remote}"))?;
-    entries.sort_by(|left, right| left.file_name.cmp(&right.file_name));
-    assert_eq!(
-        entries,
-        vec![
-            ReadDirectoryEntry {
-                file_name: "nested".to_string(),
-                is_directory: true,
-                is_file: false,
-            },
-            ReadDirectoryEntry {
-                file_name: "root.txt".to_string(),
-                is_directory: false,
-                is_file: true,
-            },
-        ]
-    );
-
-    file_system
-        .remove(
-            &absolute_path(copied_dir.clone()),
-            RemoveOptions {
-                recursive: true,
-                force: true,
-            },
-            /*sandbox*/ None,
-        )
-        .await
-        .with_context(|| format!("mode={use_remote}"))?;
-    assert!(!copied_dir.exists());
-
-    Ok(())
-}
-
-#[test_case(false ; "local")]
-#[test_case(true ; "remote")]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn file_system_write_file_reports_missing_parent(use_remote: bool) -> Result<()> {
-    let context = create_file_system_context(use_remote).await?;
-    let file_system = context.file_system;
-
-    let tmp = TempDir::new()?;
-    let missing_parent_path = tmp.path().join("missing").join("note.txt");
-
-    let error = match file_system
-        .write_file(
-            &absolute_path(missing_parent_path.clone()),
-            b"hello from trait".to_vec(),
-            /*sandbox*/ None,
-        )
-        .await
-    {
-        Ok(()) => anyhow::bail!("write should fail when parent directory is absent"),
-        Err(error) => error,
-    };
-    assert_eq!(
-        error.kind(),
-        std::io::ErrorKind::NotFound,
-        "mode={use_remote}"
-    );
-    assert!(!missing_parent_path.exists(), "mode={use_remote}");
-
-    Ok(())
-}
-
-#[test_case(false ; "local")]
-#[test_case(true ; "remote")]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn file_system_copy_rejects_directory_without_recursive(use_remote: bool) -> Result<()> {
-    let context = create_file_system_context(use_remote).await?;
-    let file_system = context.file_system;
-
-    let tmp = TempDir::new()?;
-    let source_dir = tmp.path().join("source");
-    std::fs::create_dir_all(&source_dir)?;
-
-    let error = file_system
-        .copy(
-            &absolute_path(source_dir),
-            &absolute_path(tmp.path().join("dest")),
-            CopyOptions { recursive: false },
-            /*sandbox*/ None,
-        )
-        .await;
-    let error = match error {
-        Ok(()) => panic!("copy should fail"),
-        Err(error) => error,
-    };
-    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
-    assert_eq!(
-        error.to_string(),
-        "fs/copy requires recursive: true when sourcePath is a directory"
-    );
-
-    Ok(())
-}
-
-#[test_case(false ; "local")]
-#[test_case(true ; "remote")]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn file_system_sandboxed_read_allows_readable_root(use_remote: bool) -> Result<()> {
-    let context = create_file_system_context(use_remote).await?;
-    let file_system = context.file_system;
-
-    let tmp = TempDir::new()?;
-    let allowed_dir = tmp.path().join("allowed");
-    let file_path = allowed_dir.join("note.txt");
-    std::fs::create_dir_all(&allowed_dir)?;
-    std::fs::write(&file_path, "sandboxed hello")?;
-    let sandbox = read_only_sandbox(allowed_dir);
-
-    let contents = file_system
-        .read_file(&absolute_path(file_path), Some(&sandbox))
-        .await
-        .with_context(|| format!("mode={use_remote}"))?;
-    assert_eq!(contents, b"sandboxed hello");
-
-    Ok(())
-}
-
-#[test_case(false ; "local")]
-#[test_case(true ; "remote")]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn file_system_sandboxed_canonicalize_allows_readable_root(use_remote: bool) -> Result<()> {
-    let context = create_file_system_context(use_remote).await?;
-    let file_system = context.file_system;
-
-    let tmp = TempDir::new()?;
-    let allowed_dir = tmp.path().join("allowed");
-    let file_path = allowed_dir.join("note.txt");
-    std::fs::create_dir_all(&allowed_dir)?;
-    std::fs::write(&file_path, "sandboxed hello")?;
-    let sandbox = read_only_sandbox(allowed_dir);
-
-    let canonical_path = file_system
-        .canonicalize(&absolute_path(file_path.clone()), Some(&sandbox))
-        .await
-        .with_context(|| format!("mode={use_remote}"))?;
-    assert_eq!(
-        canonical_path,
-        absolute_path(std::fs::canonicalize(file_path)?)
-    );
 
     Ok(())
 }
@@ -612,7 +249,7 @@ async fn file_system_sandboxed_write_rejects_unwritable_path(use_remote: bool) -
     let sandbox = read_only_sandbox(tmp.path().to_path_buf());
     let error = match file_system
         .write_file(
-            &absolute_path(blocked_path.clone()),
+            &absolute_path(&blocked_path),
             b"nope".to_vec(),
             Some(&sandbox),
         )
@@ -646,61 +283,12 @@ async fn file_system_sandboxed_write_allows_explicit_alias_roots(use_remote: boo
 
     file_system
         .write_file(
-            &absolute_path(file_path.clone()),
+            &absolute_path(&file_path),
             b"created".to_vec(),
             Some(&sandbox),
         )
         .await
         .with_context(|| format!("write file through alias root mode={use_remote}"))?;
-    assert_eq!(std::fs::read(&file_path)?, b"created");
-
-    Ok(())
-}
-
-#[test_case(false ; "local")]
-#[test_case(true ; "remote")]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn file_system_sandboxed_write_allows_additional_write_root(use_remote: bool) -> Result<()> {
-    let context = create_file_system_context(use_remote).await?;
-    let file_system = context.file_system;
-
-    let tmp = TempDir::new()?;
-    let readable_dir = tmp.path().join("readable");
-    let writable_dir = tmp.path().join("writable");
-    let file_path = writable_dir.join("note.txt");
-    std::fs::create_dir_all(&readable_dir)?;
-    std::fs::create_dir_all(&writable_dir)?;
-
-    let mut sandbox = read_only_sandbox(readable_dir);
-    let additional_permissions = AdditionalPermissionProfile {
-        network: None,
-        file_system: Some(FileSystemPermissions::from_read_write_roots(
-            /*read*/ None,
-            Some(vec![absolute_path(writable_dir)]),
-        )),
-    };
-    let file_system_policy = effective_file_system_sandbox_policy(
-        &sandbox.permissions.file_system_sandbox_policy(),
-        Some(&additional_permissions),
-    );
-    let network_policy = effective_network_sandbox_policy(
-        sandbox.permissions.network_sandbox_policy(),
-        Some(&additional_permissions),
-    );
-    sandbox.permissions = PermissionProfile::from_runtime_permissions_with_enforcement(
-        sandbox.permissions.enforcement(),
-        &file_system_policy,
-        network_policy,
-    );
-
-    file_system
-        .write_file(
-            &absolute_path(file_path.clone()),
-            b"created".to_vec(),
-            Some(&sandbox),
-        )
-        .await
-        .with_context(|| format!("write file through additional root mode={use_remote}"))?;
     assert_eq!(std::fs::read(&file_path)?, b"created");
 
     Ok(())
@@ -724,7 +312,7 @@ async fn file_system_sandboxed_read_rejects_symlink_escape(use_remote: bool) -> 
     let requested_path = allowed_dir.join("link").join("secret.txt");
     let sandbox = read_only_sandbox(allowed_dir);
     let error = match file_system
-        .read_file(&absolute_path(requested_path.clone()), Some(&sandbox))
+        .read_file(&absolute_path(&requested_path), Some(&sandbox))
         .await
     {
         Ok(_) => anyhow::bail!("read should be blocked"),
@@ -759,11 +347,11 @@ async fn file_system_sandboxed_read_rejects_symlink_parent_dotdot_escape(
         Ok(_) => anyhow::bail!("read should fail after path normalization"),
         Err(error) => error,
     };
-    // AbsolutePathBuf normalizes `link/../secret.txt` to `allowed/secret.txt`
-    // before the request reaches the filesystem layer. Depending on whether
-    // the platform/runtime resolves that normalized path through a top-level
-    // symlink alias, the request can surface as either "missing file" or an
-    // upfront sandbox rejection.
+    // AbsolutePathBuf normalizes `link/../secret.txt` to
+    // `allowed/secret.txt` before the request reaches the filesystem layer.
+    // Depending on whether the platform/runtime resolves that normalized path
+    // through a top-level symlink alias, the request can surface as either
+    // "missing file" or an upfront sandbox rejection.
     assert_normalized_path_rejected(&error);
 
     Ok(())
@@ -787,7 +375,7 @@ async fn file_system_sandboxed_write_rejects_symlink_escape(use_remote: bool) ->
     let sandbox = workspace_write_sandbox(allowed_dir);
     let error = match file_system
         .write_file(
-            &absolute_path(requested_path.clone()),
+            &absolute_path(&requested_path),
             b"nope".to_vec(),
             Some(&sandbox),
         )
@@ -823,7 +411,7 @@ async fn file_system_sandboxed_write_preserves_existing_hard_link(use_remote: bo
     let sandbox = workspace_write_sandbox(allowed_dir);
     file_system
         .write_file(
-            &absolute_path(hard_link.clone()),
+            &absolute_path(&hard_link),
             b"updated through existing hard link\n".to_vec(),
             Some(&sandbox),
         )
@@ -867,7 +455,7 @@ async fn file_system_create_directory_rejects_symlink_escape(use_remote: bool) -
     let sandbox = workspace_write_sandbox(allowed_dir);
     let error = match file_system
         .create_directory(
-            &absolute_path(requested_path.clone()),
+            &absolute_path(&requested_path),
             CreateDirectoryOptions { recursive: false },
             Some(&sandbox),
         )
@@ -900,7 +488,7 @@ async fn file_system_read_directory_rejects_symlink_escape(use_remote: bool) -> 
     let requested_path = allowed_dir.join("link");
     let sandbox = read_only_sandbox(allowed_dir);
     let error = match file_system
-        .read_directory(&absolute_path(requested_path.clone()), Some(&sandbox))
+        .read_directory(&absolute_path(&requested_path), Some(&sandbox))
         .await
     {
         Ok(_) => anyhow::bail!("read_directory should be blocked"),
@@ -931,7 +519,7 @@ async fn file_system_copy_rejects_symlink_escape_destination(use_remote: bool) -
     let error = match file_system
         .copy(
             &absolute_path(allowed_dir.join("source.txt")),
-            &absolute_path(requested_destination.clone()),
+            &absolute_path(&requested_destination),
             CopyOptions { recursive: false },
             Some(&sandbox),
         )
@@ -966,7 +554,7 @@ async fn file_system_remove_removes_symlink_not_target(use_remote: bool) -> Resu
     let sandbox = workspace_write_sandbox(allowed_dir);
     file_system
         .remove(
-            &absolute_path(symlink_path.clone()),
+            &absolute_path(&symlink_path),
             RemoveOptions {
                 recursive: false,
                 force: false,
@@ -1004,8 +592,8 @@ async fn file_system_copy_preserves_symlink_source(use_remote: bool) -> Result<(
     let sandbox = workspace_write_sandbox(allowed_dir.clone());
     file_system
         .copy(
-            &absolute_path(source_symlink),
-            &absolute_path(copied_symlink.clone()),
+            &absolute_path(&source_symlink),
+            &absolute_path(&copied_symlink),
             CopyOptions { recursive: false },
             Some(&sandbox),
         )
@@ -1039,7 +627,7 @@ async fn file_system_remove_rejects_symlink_escape(use_remote: bool) -> Result<(
     let sandbox = workspace_write_sandbox(allowed_dir);
     let error = match file_system
         .remove(
-            &absolute_path(requested_path.clone()),
+            &absolute_path(&requested_path),
             RemoveOptions {
                 recursive: false,
                 force: false,
@@ -1078,8 +666,8 @@ async fn file_system_copy_rejects_symlink_escape_source(use_remote: bool) -> Res
     let sandbox = workspace_write_sandbox(allowed_dir);
     let error = match file_system
         .copy(
-            &absolute_path(requested_source.clone()),
-            &absolute_path(requested_destination.clone()),
+            &absolute_path(&requested_source),
+            &absolute_path(&requested_destination),
             CopyOptions { recursive: false },
             Some(&sandbox),
         )
@@ -1090,40 +678,6 @@ async fn file_system_copy_rejects_symlink_escape_source(use_remote: bool) -> Res
     };
     assert_sandbox_denied(&error);
     assert!(!requested_destination.exists());
-
-    Ok(())
-}
-
-#[test_case(false ; "local")]
-#[test_case(true ; "remote")]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn file_system_copy_rejects_copying_directory_into_descendant(
-    use_remote: bool,
-) -> Result<()> {
-    let context = create_file_system_context(use_remote).await?;
-    let file_system = context.file_system;
-
-    let tmp = TempDir::new()?;
-    let source_dir = tmp.path().join("source");
-    std::fs::create_dir_all(source_dir.join("nested"))?;
-
-    let error = file_system
-        .copy(
-            &absolute_path(source_dir.clone()),
-            &absolute_path(source_dir.join("nested").join("copy")),
-            CopyOptions { recursive: true },
-            /*sandbox*/ None,
-        )
-        .await;
-    let error = match error {
-        Ok(()) => panic!("copy should fail"),
-        Err(error) => error,
-    };
-    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
-    assert_eq!(
-        error.to_string(),
-        "fs/copy cannot copy a directory to itself or one of its descendants"
-    );
 
     Ok(())
 }
@@ -1144,8 +698,8 @@ async fn file_system_copy_preserves_symlinks_in_recursive_copy(use_remote: bool)
 
     file_system
         .copy(
-            &absolute_path(source_dir),
-            &absolute_path(copied_dir.clone()),
+            &absolute_path(&source_dir),
+            &absolute_path(&copied_dir),
             CopyOptions { recursive: true },
             /*sandbox*/ None,
         )
@@ -1190,8 +744,8 @@ async fn file_system_copy_ignores_unknown_special_files_in_recursive_copy(
 
     file_system
         .copy(
-            &absolute_path(source_dir),
-            &absolute_path(copied_dir.clone()),
+            &absolute_path(&source_dir),
+            &absolute_path(&copied_dir),
             CopyOptions { recursive: true },
             /*sandbox*/ None,
         )
@@ -1227,7 +781,7 @@ async fn file_system_copy_rejects_standalone_fifo_source(use_remote: bool) -> Re
 
     let error = file_system
         .copy(
-            &absolute_path(fifo_path),
+            &absolute_path(&fifo_path),
             &absolute_path(tmp.path().join("copied")),
             CopyOptions { recursive: false },
             /*sandbox*/ None,

--- a/codex-rs/exec-server/tests/file_system_windows.rs
+++ b/codex-rs/exec-server/tests/file_system_windows.rs
@@ -1,0 +1,51 @@
+#![cfg(windows)]
+
+mod common;
+
+#[path = "file_system/shared.rs"]
+mod shared;
+#[path = "file_system/support.rs"]
+mod support;
+
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::Result;
+use test_case::test_case;
+
+fn create_directory_junction(target: &Path, alias: &Path) -> Result<()> {
+    let output = Command::new("cmd")
+        .args(["/C", "mklink", "/J"])
+        .arg(alias)
+        .arg(target)
+        .output()?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "mklink /J failed: stdout={} stderr={}",
+            String::from_utf8_lossy(&output.stdout).trim(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(())
+}
+
+#[test_case(false ; "local")]
+#[test_case(true ; "remote")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn file_system_canonicalize_resolves_directory_junction(use_remote: bool) -> Result<()> {
+    shared::assert_canonicalize_resolves_directory_alias(use_remote, create_directory_junction)
+        .await
+}
+
+#[test_case(false ; "local")]
+#[test_case(true ; "remote")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn file_system_sandboxed_canonicalize_resolves_directory_junction(
+    use_remote: bool,
+) -> Result<()> {
+    shared::assert_sandboxed_canonicalize_resolves_directory_alias(
+        use_remote,
+        create_directory_junction,
+    )
+    .await
+}


### PR DESCRIPTION
Intent: prove the temporary `PathUri`/native adapters keep the existing native protocol behavior.

Implementation: add adapter `InvalidInput` coverage, native helper wire assertions, and Unix/Windows filesystem adapter cases including canonicalization aliases and Windows drive/UNC requests.

Validation: focused stack validation ran affected crate tests and core regression selectors.

Stacked on #27432.