### PR TITLE
Normalize context compaction before API requests

### DIFF
--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -53,7 +53,41 @@ impl Default for Prompt {
 
 impl Prompt {
     pub(crate) fn get_formatted_input(&self) -> Vec<ResponseItem> {
-        self.input.clone()
+        self.input
+            .iter()
+            .cloned()
+            .filter_map(model_api_safe_response_item)
+            .collect()
+    }
+}
+
+pub(crate) fn model_api_safe_response_item(item: ResponseItem) -> Option<ResponseItem> {
+    match item {
+        ResponseItem::ContextCompaction {
+            encrypted_content: Some(encrypted_content),
+        } => Some(ResponseItem::Compaction { encrypted_content }),
+        ResponseItem::ContextCompaction {
+            encrypted_content: None,
+        } => {
+            // Empty context-compaction items are UI lifecycle markers. The app-server UI path
+            // receives those as TurnItem::ContextCompaction; model/API history only preserves the
+            // encrypted compaction payload supported by the Responses API.
+            None
+        }
+        item @ (ResponseItem::Message { .. }
+        | ResponseItem::Reasoning { .. }
+        | ResponseItem::LocalShellCall { .. }
+        | ResponseItem::FunctionCall { .. }
+        | ResponseItem::ToolSearchCall { .. }
+        | ResponseItem::FunctionCallOutput { .. }
+        | ResponseItem::CustomToolCall { .. }
+        | ResponseItem::CustomToolCallOutput { .. }
+        | ResponseItem::ToolSearchOutput { .. }
+        | ResponseItem::WebSearchCall { .. }
+        | ResponseItem::ImageGenerationCall { .. }
+        | ResponseItem::Compaction { .. }
+        | ResponseItem::CompactionTrigger
+        | ResponseItem::Other) => Some(item),
     }
 }
 

--- a/codex-rs/core/src/client_common_tests.rs
+++ b/codex-rs/core/src/client_common_tests.rs
@@ -141,6 +141,37 @@ fn omits_text_when_not_set() {
 }
 
 #[test]
+fn formatted_input_normalizes_context_compaction_for_responses_api() {
+    let prompt = Prompt {
+        input: vec![
+            ResponseItem::ContextCompaction {
+                encrypted_content: Some("encrypted".to_string()),
+            },
+            ResponseItem::ContextCompaction {
+                encrypted_content: None,
+            },
+            ResponseItem::Other,
+        ],
+        ..Default::default()
+    };
+
+    let formatted_input = prompt.get_formatted_input();
+    let formatted_input_json = serde_json::to_string(&formatted_input).expect("json");
+
+    assert_eq!(
+        formatted_input,
+        vec![
+            ResponseItem::Compaction {
+                encrypted_content: "encrypted".to_string(),
+            },
+            ResponseItem::Other,
+        ]
+    );
+    assert!(formatted_input_json.contains(r#""type":"compaction""#));
+    assert!(!formatted_input_json.contains("context_compaction"));
+}
+
+#[test]
 fn serializes_flex_service_tier_when_set() {
     let req = ResponsesApiRequest {
         model: "gpt-5.4".to_string(),

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::Prompt;
 use crate::client::CompactConversationRequestSettings;
+use crate::client_common::model_api_safe_response_item;
 use crate::compact::CompactionAnalyticsAttempt;
 use crate::compact::InitialContextInjection;
 use crate::compact::compaction_status_from_result;
@@ -317,7 +318,11 @@ pub(crate) async fn process_compacted_history(
         Vec::new()
     };
 
-    compacted_history.retain(should_keep_compacted_history_item);
+    compacted_history = compacted_history
+        .into_iter()
+        .filter(should_keep_compacted_history_item)
+        .filter_map(model_api_safe_response_item)
+        .collect();
     insert_initial_context_before_last_real_user_or_summary(compacted_history, initial_context)
 }
 

--- a/codex-rs/core/src/compact_tests.rs
+++ b/codex-rs/core/src/compact_tests.rs
@@ -408,6 +408,27 @@ async fn process_compacted_history_drops_legacy_warnings() {
 }
 
 #[tokio::test]
+async fn process_compacted_history_normalizes_context_compaction_items() {
+    let compacted_history = vec![
+        ResponseItem::ContextCompaction {
+            encrypted_content: Some("encrypted".to_string()),
+        },
+        ResponseItem::ContextCompaction {
+            encrypted_content: None,
+        },
+    ];
+    let (refreshed, mut expected) = process_compacted_history_with_test_session(
+        compacted_history,
+        /*previous_turn_settings*/ None,
+    )
+    .await;
+    expected.push(ResponseItem::Compaction {
+        encrypted_content: "encrypted".to_string(),
+    });
+    assert_eq!(refreshed, expected);
+}
+
+#[tokio::test]
 async fn process_compacted_history_inserts_context_before_last_real_user_message_only() {
     let compacted_history = vec![
         ResponseItem::Message {


### PR DESCRIPTION
## Summary

Fixes #27269.

Remote compaction can yield `ResponseItem::ContextCompaction`, but the Responses API rejects `context_compaction` in request input. This change centralizes model/API-bound normalization so encrypted `ContextCompaction` payloads are sent as the API-supported `compaction` item, and empty context-compaction markers are omitted from model history.

The app-server/UI lifecycle path remains unchanged: UI compaction markers still flow through `TurnItem::ContextCompaction` and v2 `ThreadItem::ContextCompaction`.

## Root Cause

Remote compaction post-processing preserved `ResponseItem::ContextCompaction` in replacement history. A later model request could replay that history into `/responses`, producing the API wire enum error:

`Invalid value: context_compaction`

## What Changed

- Added one helper, `model_api_safe_response_item`, for API-safe `ResponseItem` normalization.
- Reused that helper from `Prompt::get_formatted_input()` and remote compaction replacement-history processing.
- Converted encrypted `context_compaction` items to `compaction` before model/API use.
- Dropped empty `context_compaction` items from model/API-bound history because they are UI lifecycle markers; the UI path uses `TurnItem::ContextCompaction`.
- Added regression coverage for Rust enum normalization and serialized wire shape.

## Validation

- `just fmt`
- `just test -p codex-core formatted_input_normalizes_context_compaction_for_responses_api process_compacted_history_normalizes_context_compaction_items`
  - 2 tests passed
  - recipe bench-smoke tail completed
- Broad `just test -p codex-core` was attempted. The new compaction tests passed, but the full run failed in unrelated sandbox/environment categories:
  - PATH alias creation denied in sandbox
  - missing `target/debug/test_stdio_server` for MCP stdio tests
  - `sandbox-exec: sandbox_apply: Operation not permitted`
  - timing/interrupt/unified exec tests sensitive to this managed sandbox
- `just fix -p codex-core`

## Adversarial Review

- Responses API wire enum: `Prompt::get_formatted_input()` now normalizes API-bound input, and the regression test asserts serialized JSON contains `"type":"compaction"` and not `context_compaction`.
- UI behavior: `TurnItem::ContextCompaction` remains unchanged, so app-server v2 clients still receive the canonical UI compaction item.
- Empty marker rationale: `ContextCompaction { encrypted_content: None }` carries no model-visible encrypted compaction payload. It is a UI lifecycle marker, so omitting it from model/API history avoids sending an unsupported enum without losing model history.
- Resume/replay/version skew: persisted or replayed `context_compaction` response items are normalized at the model request boundary, and new remote replacement histories are cleaned before persistence.
- Future item kinds: the normalization helper enumerates all current passthrough `ResponseItem` variants instead of using a wildcard arm, so new variants require an explicit review decision.