### PR TITLE
Keep MCP manager stable across refresh

### DIFF
--- a/codex-rs/codex-api/tests/clients.rs
+++ b/codex-rs/codex-api/tests/clients.rs
@@ -312,6 +312,7 @@ async fn responses_client_stream_request_preserves_exact_json_body() -> Result<(
             role: "user".into(),
             content: vec![ContentItem::InputText { text: "hi".into() }],
             phase: None,
+            metadata: None,
         }],
         tools: Vec::new(),
         tool_choice: "auto".into(),

--- a/codex-rs/codex-mcp/src/connection_manager.rs
+++ b/codex-rs/codex-mcp/src/connection_manager.rs
@@ -9,6 +9,9 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::PoisonError;
+use std::sync::RwLock;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 use std::time::Instant;
@@ -105,14 +108,20 @@ pub fn tool_is_model_visible(tool: &ToolInfo) -> bool {
 
 /// A thin wrapper around a set of running [`RmcpClient`] instances.
 pub struct McpConnectionManager {
+    /// Replaced by refresh while existing operations retain their current snapshot.
+    connections: RwLock<Arc<McpConnections>>,
+    elicitation_requests: RwLock<Arc<ElicitationRequestManager>>,
+    /// Rotated before each refresh so cancellation always reaches the active startup round.
+    startup_cancellation_token: Mutex<CancellationToken>,
+}
+
+struct McpConnections {
     clients: HashMap<String, AsyncManagedClient>,
     server_metadata: HashMap<String, McpServerMetadata>,
     required_servers: Vec<String>,
     tool_plugin_provenance: Arc<ToolPluginProvenance>,
     host_owned_codex_apps_enabled: bool,
     prefix_mcp_tool_names: bool,
-    elicitation_requests: ElicitationRequestManager,
-    startup_cancellation_token: CancellationToken,
 }
 
 impl McpConnectionManager {
@@ -125,7 +134,6 @@ impl McpConnectionManager {
         approval_policy: &Constrained<AskForApproval>,
         submit_id: String,
         tx_event: Sender<Event>,
-        startup_cancellation_token: CancellationToken,
         initial_permission_profile: PermissionProfile,
         runtime_context: McpRuntimeContext,
         codex_home: PathBuf,
@@ -137,147 +145,101 @@ impl McpConnectionManager {
         auth: Option<&CodexAuth>,
         elicitation_reviewer: Option<ElicitationReviewerHandle>,
     ) -> Self {
-        let mut required_servers = mcp_servers
-            .iter()
-            .filter(|(_, server)| server.enabled() && server.required())
-            .map(|(name, _)| name.clone())
-            .collect::<Vec<_>>();
-        required_servers.sort();
-        let mut clients = HashMap::new();
-        let mut server_metadata = HashMap::new();
-        let mut join_set = JoinSet::new();
+        let startup_cancellation_token = CancellationToken::new();
         let elicitation_requests = ElicitationRequestManager::new(
             approval_policy.value(),
             initial_permission_profile,
             elicitation_reviewer,
         );
-        let tool_plugin_provenance = Arc::new(tool_plugin_provenance);
-        let startup_submit_id = submit_id.clone();
-        let codex_apps_auth_provider = auth
-            .filter(|auth| auth.uses_codex_backend())
-            .map(codex_model_provider::auth_provider_from_auth);
-        let mcp_servers = mcp_servers.clone();
-        for (server_name, server) in mcp_servers
-            .into_iter()
-            .filter(|(_, server)| server.enabled())
-        {
-            server_metadata.insert(server_name.clone(), McpServerMetadata::from(&server));
-            let cancel_token = startup_cancellation_token.child_token();
-            let _ = emit_update(
-                startup_submit_id.as_str(),
-                &tx_event,
-                McpStartupUpdateEvent {
-                    server: server_name.clone(),
-                    status: McpStartupStatus::Starting,
-                },
-            )
-            .await;
-            let codex_apps_tools_cache_context = if server_name == CODEX_APPS_MCP_SERVER_NAME {
-                Some(CodexAppsToolsCacheContext {
-                    codex_home: codex_home.clone(),
-                    user_key: codex_apps_tools_cache_key.clone(),
-                })
-            } else {
-                None
-            };
-            let uses_env_bearer_token =
-                server
-                    .configured_config()
-                    .is_some_and(|config| match &config.transport {
-                        McpServerTransportConfig::StreamableHttp {
-                            bearer_token_env_var,
-                            ..
-                        } => bearer_token_env_var.is_some(),
-                        McpServerTransportConfig::Stdio { .. } => false,
-                    });
-            let runtime_auth_provider =
-                if server_name == CODEX_APPS_MCP_SERVER_NAME && !uses_env_bearer_token {
-                    codex_apps_auth_provider.clone()
-                } else {
-                    None
-                };
-            let async_managed_client = AsyncManagedClient::new(
-                server_name.clone(),
-                server,
-                store_mode,
-                keyring_backend_kind,
-                cancel_token.clone(),
-                tx_event.clone(),
-                elicitation_requests.clone(),
-                codex_apps_tools_cache_context,
-                Arc::clone(&tool_plugin_provenance),
-                runtime_context.clone(),
-                runtime_auth_provider,
-                client_elicitation_capability.clone(),
-            );
-            clients.insert(server_name.clone(), async_managed_client.clone());
-            let tx_event = tx_event.clone();
-            let submit_id = startup_submit_id.clone();
-            let auth_entry = auth_entries.get(&server_name).cloned();
-            join_set.spawn(async move {
-                let mut outcome = async_managed_client.client().await;
-                if cancel_token.is_cancelled() {
-                    outcome = Err(StartupOutcomeError::Cancelled);
-                }
-                let status = match &outcome {
-                    Ok(_) => McpStartupStatus::Ready,
-                    Err(StartupOutcomeError::Cancelled) => McpStartupStatus::Cancelled,
-                    Err(error) => {
-                        let error_str = mcp_init_error_display(
-                            server_name.as_str(),
-                            auth_entry.as_ref(),
-                            error,
-                        );
-                        McpStartupStatus::Failed { error: error_str }
-                    }
-                };
-
-                let _ = emit_update(
-                    submit_id.as_str(),
-                    &tx_event,
-                    McpStartupUpdateEvent {
-                        server: server_name.clone(),
-                        status,
-                    },
-                )
-                .await;
-
-                (server_name, outcome)
-            });
-        }
-        let manager = Self {
-            clients,
-            server_metadata,
-            required_servers,
-            tool_plugin_provenance,
+        let connections = start_connections(
+            mcp_servers,
+            store_mode,
+            keyring_backend_kind,
+            auth_entries,
+            submit_id,
+            tx_event,
+            runtime_context,
+            codex_home,
+            codex_apps_tools_cache_key,
             host_owned_codex_apps_enabled,
             prefix_mcp_tool_names,
-            elicitation_requests: elicitation_requests.clone(),
-            startup_cancellation_token: startup_cancellation_token.clone(),
+            client_elicitation_capability,
+            tool_plugin_provenance,
+            auth,
+            elicitation_requests.clone(),
+            startup_cancellation_token.clone(),
+        )
+        .await;
+        Self {
+            connections: RwLock::new(Arc::new(connections)),
+            elicitation_requests: RwLock::new(Arc::new(elicitation_requests)),
+            startup_cancellation_token: Mutex::new(startup_cancellation_token),
+        }
+    }
+
+    /// Replaces the MCP connections without replacing the manager that owns cancellation.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn refresh(
+        &self,
+        mcp_servers: &HashMap<String, EffectiveMcpServer>,
+        store_mode: OAuthCredentialsStoreMode,
+        keyring_backend_kind: AuthKeyringBackendKind,
+        auth_entries: HashMap<String, McpAuthStatusEntry>,
+        submit_id: String,
+        tx_event: Sender<Event>,
+        runtime_context: McpRuntimeContext,
+        codex_home: PathBuf,
+        codex_apps_tools_cache_key: CodexAppsToolsCacheKey,
+        host_owned_codex_apps_enabled: bool,
+        prefix_mcp_tool_names: bool,
+        client_elicitation_capability: ElicitationCapability,
+        tool_plugin_provenance: ToolPluginProvenance,
+        auth: Option<&CodexAuth>,
+        elicitation_reviewer: Option<ElicitationReviewerHandle>,
+    ) {
+        let startup_cancellation_token = {
+            let mut current = self
+                .startup_cancellation_token
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            current.cancel();
+            *current = CancellationToken::new();
+            current.clone()
         };
-        tokio::spawn(async move {
-            let outcomes = join_set.join_all().await;
-            let mut summary = McpStartupCompleteEvent::default();
-            for (server_name, outcome) in outcomes {
-                match outcome {
-                    Ok(_) => summary.ready.push(server_name),
-                    Err(StartupOutcomeError::Cancelled) => summary.cancelled.push(server_name),
-                    Err(StartupOutcomeError::Failed { error }) => {
-                        summary.failed.push(McpStartupFailure {
-                            server: server_name,
-                            error,
-                        })
-                    }
-                }
-            }
-            let _ = tx_event
-                .send(Event {
-                    id: startup_submit_id,
-                    msg: EventMsg::McpStartupComplete(summary),
-                })
-                .await;
-        });
-        manager
+        let elicitation_requests = self
+            .elicitation_requests()
+            .new_request_scope(elicitation_reviewer);
+        {
+            let mut current = self
+                .elicitation_requests
+                .write()
+                .unwrap_or_else(PoisonError::into_inner);
+            *current = Arc::new(elicitation_requests.clone());
+        }
+        let connections = start_connections(
+            mcp_servers,
+            store_mode,
+            keyring_backend_kind,
+            auth_entries,
+            submit_id,
+            tx_event,
+            runtime_context,
+            codex_home,
+            codex_apps_tools_cache_key,
+            host_owned_codex_apps_enabled,
+            prefix_mcp_tool_names,
+            client_elicitation_capability,
+            tool_plugin_provenance,
+            auth,
+            elicitation_requests,
+            startup_cancellation_token,
+        )
+        .await;
+        let mut current = self
+            .connections
+            .write()
+            .unwrap_or_else(PoisonError::into_inner);
+        *current = Arc::new(connections);
     }
 
     /// Waits for every required server and reports their startup failures together.
@@ -285,10 +247,12 @@ impl McpConnectionManager {
     /// Callers must make the manager reachable to request handlers before awaiting this method,
     /// because server initialization may require client elicitation.
     pub async fn validate_required_servers(&self) -> Result<()> {
+        let connections = self.connections();
         let failures = async {
             let mut failures = Vec::new();
-            for server_name in &self.required_servers {
-                let Some(async_managed_client) = self.clients.get(server_name).cloned() else {
+            for server_name in &connections.required_servers {
+                let Some(async_managed_client) = connections.clients.get(server_name).cloned()
+                else {
                     failures.push(McpStartupFailure {
                         server: server_name.clone(),
                         error: format!("required MCP server `{server_name}` was not initialized"),
@@ -309,7 +273,7 @@ impl McpConnectionManager {
         .instrument(info_span!(
             "session_init.required_mcp_wait",
             otel.name = "session_init.required_mcp_wait",
-            session_init.required_mcp_server_count = self.required_servers.len(),
+            session_init.required_mcp_server_count = connections.required_servers.len(),
         ))
         .await;
         if failures.is_empty() {
@@ -332,57 +296,74 @@ impl McpConnectionManager {
         prefix_mcp_tool_names: bool,
     ) -> Self {
         Self {
-            clients: HashMap::new(),
-            server_metadata: HashMap::new(),
-            required_servers: Vec::new(),
-            tool_plugin_provenance: Arc::new(ToolPluginProvenance::default()),
-            host_owned_codex_apps_enabled: false,
-            prefix_mcp_tool_names,
-            elicitation_requests: ElicitationRequestManager::new(
+            connections: RwLock::new(Arc::new(McpConnections {
+                clients: HashMap::new(),
+                server_metadata: HashMap::new(),
+                required_servers: Vec::new(),
+                tool_plugin_provenance: Arc::new(ToolPluginProvenance::default()),
+                host_owned_codex_apps_enabled: false,
+                prefix_mcp_tool_names,
+            })),
+            elicitation_requests: RwLock::new(Arc::new(ElicitationRequestManager::new(
                 approval_policy.value(),
                 permission_profile.clone(),
                 /*reviewer*/ None,
-            ),
-            startup_cancellation_token: CancellationToken::new(),
+            ))),
+            startup_cancellation_token: Mutex::new(CancellationToken::new()),
         }
     }
 
     pub fn has_servers(&self) -> bool {
-        !self.clients.is_empty()
+        !self.connections().clients.is_empty()
     }
 
     pub(crate) fn contains_server(&self, server_name: &str) -> bool {
-        self.clients.contains_key(server_name)
+        self.connections().clients.contains_key(server_name)
+    }
+
+    /// Cancels MCP servers that are still starting without shutting down ready clients.
+    pub fn cancel_startup(&self) {
+        self.startup_cancellation_token
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .cancel();
     }
 
     /// Stop all MCP clients owned by this manager and terminate stdio server processes.
     pub async fn shutdown(&self) {
-        self.startup_cancellation_token.cancel();
-        for client in self.clients.values() {
+        self.cancel_startup();
+        let connections = self.connections();
+        for client in connections.clients.values() {
             client.shutdown().await;
         }
     }
 
-    pub fn server_origin(&self, server_name: &str) -> Option<&str> {
-        self.server_metadata
+    pub fn server_origin(&self, server_name: &str) -> Option<String> {
+        self.connections()
+            .server_metadata
             .get(server_name)
             .and_then(|metadata| metadata.origin.as_ref())
             .map(super::server::McpServerOrigin::as_str)
+            .map(str::to_string)
     }
 
     pub fn server_pollutes_memory(&self, server_name: &str) -> bool {
-        self.server_metadata
+        self.connections()
+            .server_metadata
             .get(server_name)
             .is_none_or(|metadata| metadata.pollutes_memory)
     }
 
-    pub fn plugin_id_for_mcp_server_name(&self, server_name: &str) -> Option<&str> {
-        self.tool_plugin_provenance
+    pub fn plugin_id_for_mcp_server_name(&self, server_name: &str) -> Option<String> {
+        self.connections()
+            .tool_plugin_provenance
             .plugin_id_for_mcp_server_name(server_name)
+            .map(str::to_string)
     }
 
     pub fn is_selected_plugin_mcp_server(&self, server_name: &str) -> bool {
-        self.tool_plugin_provenance
+        self.connections()
+            .tool_plugin_provenance
             .is_selected_plugin_mcp_server(server_name)
     }
 
@@ -391,34 +372,38 @@ impl McpConnectionManager {
         server_name: &str,
         tool_name: &str,
     ) -> codex_config::AppToolApproval {
-        self.server_metadata
+        self.connections()
+            .server_metadata
             .get(server_name)
             .map(|metadata| metadata.tool_approval_mode(tool_name))
             .unwrap_or_default()
     }
 
     pub fn is_host_owned_codex_apps_server(&self, server_name: &str) -> bool {
-        self.host_owned_codex_apps_enabled && server_name == CODEX_APPS_MCP_SERVER_NAME
+        self.connections().host_owned_codex_apps_enabled
+            && server_name == CODEX_APPS_MCP_SERVER_NAME
     }
 
     pub fn set_approval_policy(&self, approval_policy: &Constrained<AskForApproval>) {
-        if let Ok(mut policy) = self.elicitation_requests.approval_policy.lock() {
+        let elicitation_requests = self.elicitation_requests();
+        if let Ok(mut policy) = elicitation_requests.approval_policy.lock() {
             *policy = approval_policy.value();
         }
     }
 
     pub fn set_permission_profile(&self, permission_profile: PermissionProfile) {
-        if let Ok(mut profile) = self.elicitation_requests.permission_profile.lock() {
+        let elicitation_requests = self.elicitation_requests();
+        if let Ok(mut profile) = elicitation_requests.permission_profile.lock() {
             *profile = permission_profile;
         }
     }
 
     pub fn elicitations_auto_deny(&self) -> bool {
-        self.elicitation_requests.auto_deny()
+        self.elicitation_requests().auto_deny()
     }
 
     pub fn set_elicitations_auto_deny(&self, auto_deny: bool) {
-        self.elicitation_requests.set_auto_deny(auto_deny);
+        self.elicitation_requests().set_auto_deny(auto_deny);
     }
 
     pub async fn resolve_elicitation(
@@ -427,13 +412,14 @@ impl McpConnectionManager {
         id: RequestId,
         response: ElicitationResponse,
     ) -> Result<()> {
-        self.elicitation_requests
+        self.elicitation_requests()
             .resolve(server_name, id, response)
             .await
     }
 
     pub async fn wait_for_server_ready(&self, server_name: &str, timeout: Duration) -> bool {
-        let Some(async_managed_client) = self.clients.get(server_name) else {
+        let connections = self.connections();
+        let Some(async_managed_client) = connections.clients.get(server_name) else {
             return false;
         };
 
@@ -444,10 +430,15 @@ impl McpConnectionManager {
     }
 
     /// Returns all tools with model-visible names normalized.
-    #[instrument(level = "trace", skip_all, fields(mcp_server_count = self.clients.len()))]
+    #[instrument(
+        level = "trace",
+        skip_all,
+        fields(mcp_server_count = self.connections().clients.len())
+    )]
     pub async fn list_all_tools(&self) -> Vec<ToolInfo> {
+        let connections = self.connections();
         let mut tools = Vec::new();
-        for (server_name, managed_client) in &self.clients {
+        for (server_name, managed_client) in &connections.clients {
             let has_cached_tool_info_snapshot = managed_client.cached_tool_info_snapshot.is_some();
             let startup_complete = managed_client
                 .startup_complete
@@ -478,10 +469,10 @@ impl McpConnectionManager {
             tools.extend(
                 server_tools
                     .into_iter()
-                    .map(|tool| self.with_server_metadata(tool)),
+                    .map(|tool| Self::with_server_metadata(&connections, tool)),
             );
         }
-        normalize_tools_for_model_with_prefix(tools, self.prefix_mcp_tool_names)
+        normalize_tools_for_model_with_prefix(tools, connections.prefix_mcp_tool_names)
     }
 
     /// Force-refresh codex apps tools by bypassing the in-process cache.
@@ -490,7 +481,8 @@ impl McpConnectionManager {
     /// latest filtered tools are returned directly to the caller. On
     /// failure, the existing cache remains unchanged.
     pub async fn hard_refresh_codex_apps_tools_cache(&self) -> Result<Vec<ToolInfo>> {
-        let managed_client = self
+        let connections = self.connections();
+        let managed_client = connections
             .clients
             .get(CODEX_APPS_MCP_SERVER_NAME)
             .ok_or_else(|| anyhow!("unknown MCP server '{CODEX_APPS_MCP_SERVER_NAME}'"))?
@@ -531,22 +523,21 @@ impl McpConnectionManager {
             .into_iter()
             .map(|mut tool| {
                 tool.tool = tool_with_model_visible_input_schema(&tool.tool);
-                self.with_server_metadata(tool)
+                Self::with_server_metadata(&connections, tool)
             });
         Ok(normalize_tools_for_model_with_prefix(
             tools,
-            self.prefix_mcp_tool_names,
+            connections.prefix_mcp_tool_names,
         ))
     }
 
     /// Returns a single map that contains all resources. Each key is the
     /// server name and the value is a vector of resources.
     pub async fn list_all_resources(&self) -> HashMap<String, Vec<Resource>> {
+        let connections = self.connections();
         let mut join_set = JoinSet::new();
 
-        let clients_snapshot = &self.clients;
-
-        for (server_name, async_managed_client) in clients_snapshot {
+        for (server_name, async_managed_client) in &connections.clients {
             let server_name = server_name.clone();
             let Ok(managed_client) = async_managed_client.client().await else {
                 continue;
@@ -607,11 +598,10 @@ impl McpConnectionManager {
     /// Returns a single map that contains all resource templates. Each key is the
     /// server name and the value is a vector of resource templates.
     pub async fn list_all_resource_templates(&self) -> HashMap<String, Vec<ResourceTemplate>> {
+        let connections = self.connections();
         let mut join_set = JoinSet::new();
 
-        let clients_snapshot = &self.clients;
-
-        for (server_name, async_managed_client) in clients_snapshot {
+        for (server_name, async_managed_client) in &connections.clients {
             let server_name_cloned = server_name.clone();
             let Ok(managed_client) = async_managed_client.client().await else {
                 continue;
@@ -681,7 +671,8 @@ impl McpConnectionManager {
         arguments: Option<serde_json::Value>,
         meta: Option<serde_json::Value>,
     ) -> Result<CallToolResult> {
-        let client = self.client_by_name(server).await?;
+        let connections = self.connections();
+        let client = Self::client_by_name(&connections, server).await?;
         if !client.tool_filter.allows(tool) {
             return Err(anyhow!(
                 "tool '{tool}' is disabled for MCP server '{server}'"
@@ -715,8 +706,8 @@ impl McpConnectionManager {
         &self,
         server: &str,
     ) -> Result<bool> {
-        Ok(self
-            .client_by_name(server)
+        let connections = self.connections();
+        Ok(Self::client_by_name(&connections, server)
             .await?
             .server_supports_sandbox_state_meta_capability)
     }
@@ -727,7 +718,8 @@ impl McpConnectionManager {
         server: &str,
         params: Option<PaginatedRequestParams>,
     ) -> Result<ListResourcesResult> {
-        let managed = self.client_by_name(server).await?;
+        let connections = self.connections();
+        let managed = Self::client_by_name(&connections, server).await?;
         let timeout = managed.tool_timeout;
 
         managed
@@ -743,7 +735,8 @@ impl McpConnectionManager {
         server: &str,
         params: Option<PaginatedRequestParams>,
     ) -> Result<ListResourceTemplatesResult> {
-        let managed = self.client_by_name(server).await?;
+        let connections = self.connections();
+        let managed = Self::client_by_name(&connections, server).await?;
         let client = managed.client.clone();
         let timeout = managed.tool_timeout;
 
@@ -759,7 +752,8 @@ impl McpConnectionManager {
         server: &str,
         params: ReadResourceRequestParams,
     ) -> Result<ReadResourceResult> {
-        let managed = self.client_by_name(server).await?;
+        let connections = self.connections();
+        let managed = Self::client_by_name(&connections, server).await?;
         let client = managed.client.clone();
         let timeout = managed.tool_timeout;
         let uri = params.uri.clone();
@@ -773,8 +767,9 @@ impl McpConnectionManager {
     /// Returns presentation metadata without waiting for uncached clients still initializing.
     /// Cached values will be used if available and the server is still starting up.
     pub(crate) async fn list_available_server_infos(&self) -> HashMap<String, McpServerInfo> {
+        let connections = self.connections();
         let mut server_infos = HashMap::new();
-        for (server_name, client) in &self.clients {
+        for (server_name, client) in &connections.clients {
             if !client.startup_complete.load(Ordering::Acquire) {
                 if let Some(server_info) = client.cached_server_info.clone() {
                     server_infos.insert(server_name.clone(), server_info);
@@ -795,8 +790,8 @@ impl McpConnectionManager {
         server_infos
     }
 
-    fn with_server_metadata(&self, mut tool: ToolInfo) -> ToolInfo {
-        let Some(metadata) = self.server_metadata.get(&tool.server_name) else {
+    fn with_server_metadata(connections: &McpConnections, mut tool: ToolInfo) -> ToolInfo {
+        let Some(metadata) = connections.server_metadata.get(&tool.server_name) else {
             tool.supports_parallel_tool_calls = false;
             tool.server_origin = None;
             return tool;
@@ -810,13 +805,32 @@ impl McpConnectionManager {
         tool
     }
 
-    async fn client_by_name(&self, name: &str) -> Result<ManagedClient> {
-        self.clients
+    async fn client_by_name(connections: &McpConnections, name: &str) -> Result<ManagedClient> {
+        connections
+            .clients
             .get(name)
             .ok_or_else(|| anyhow!("unknown MCP server '{name}'"))?
             .client()
             .await
             .context("failed to get client")
+    }
+
+    fn connections(&self) -> Arc<McpConnections> {
+        Arc::clone(
+            &self
+                .connections
+                .read()
+                .unwrap_or_else(PoisonError::into_inner),
+        )
+    }
+
+    fn elicitation_requests(&self) -> Arc<ElicitationRequestManager> {
+        Arc::clone(
+            &self
+                .elicitation_requests
+                .read()
+                .unwrap_or_else(PoisonError::into_inner),
+        )
     }
 
     #[cfg(test)]
@@ -835,9 +849,162 @@ impl McpConnectionManager {
 
 impl Drop for McpConnectionManager {
     fn drop(&mut self) {
-        self.startup_cancellation_token.cancel();
-        self.clients.clear();
+        self.startup_cancellation_token
+            .get_mut()
+            .unwrap_or_else(PoisonError::into_inner)
+            .cancel();
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn start_connections(
+    mcp_servers: &HashMap<String, EffectiveMcpServer>,
+    store_mode: OAuthCredentialsStoreMode,
+    keyring_backend_kind: AuthKeyringBackendKind,
+    auth_entries: HashMap<String, McpAuthStatusEntry>,
+    submit_id: String,
+    tx_event: Sender<Event>,
+    runtime_context: McpRuntimeContext,
+    codex_home: PathBuf,
+    codex_apps_tools_cache_key: CodexAppsToolsCacheKey,
+    host_owned_codex_apps_enabled: bool,
+    prefix_mcp_tool_names: bool,
+    client_elicitation_capability: ElicitationCapability,
+    tool_plugin_provenance: ToolPluginProvenance,
+    auth: Option<&CodexAuth>,
+    elicitation_requests: ElicitationRequestManager,
+    startup_cancellation_token: CancellationToken,
+) -> McpConnections {
+    let mut required_servers = mcp_servers
+        .iter()
+        .filter(|(_, server)| server.enabled() && server.required())
+        .map(|(name, _)| name.clone())
+        .collect::<Vec<_>>();
+    required_servers.sort();
+    let mut clients = HashMap::new();
+    let mut server_metadata = HashMap::new();
+    let mut join_set = JoinSet::new();
+    let tool_plugin_provenance = Arc::new(tool_plugin_provenance);
+    let startup_submit_id = submit_id.clone();
+    let codex_apps_auth_provider = auth
+        .filter(|auth| auth.uses_codex_backend())
+        .map(codex_model_provider::auth_provider_from_auth);
+    let mcp_servers = mcp_servers.clone();
+    for (server_name, server) in mcp_servers
+        .into_iter()
+        .filter(|(_, server)| server.enabled())
+    {
+        server_metadata.insert(server_name.clone(), McpServerMetadata::from(&server));
+        let cancel_token = startup_cancellation_token.child_token();
+        let _ = emit_update(
+            startup_submit_id.as_str(),
+            &tx_event,
+            McpStartupUpdateEvent {
+                server: server_name.clone(),
+                status: McpStartupStatus::Starting,
+            },
+        )
+        .await;
+        let codex_apps_tools_cache_context = if server_name == CODEX_APPS_MCP_SERVER_NAME {
+            Some(CodexAppsToolsCacheContext {
+                codex_home: codex_home.clone(),
+                user_key: codex_apps_tools_cache_key.clone(),
+            })
+        } else {
+            None
+        };
+        let uses_env_bearer_token = server
+            .configured_config()
+            .is_some_and(|config| match &config.transport {
+                McpServerTransportConfig::StreamableHttp {
+                    bearer_token_env_var,
+                    ..
+                } => bearer_token_env_var.is_some(),
+                McpServerTransportConfig::Stdio { .. } => false,
+            });
+        let runtime_auth_provider =
+            if server_name == CODEX_APPS_MCP_SERVER_NAME && !uses_env_bearer_token {
+                codex_apps_auth_provider.clone()
+            } else {
+                None
+            };
+        let async_managed_client = AsyncManagedClient::new(
+            server_name.clone(),
+            server,
+            store_mode,
+            keyring_backend_kind,
+            cancel_token.clone(),
+            tx_event.clone(),
+            elicitation_requests.clone(),
+            codex_apps_tools_cache_context,
+            Arc::clone(&tool_plugin_provenance),
+            runtime_context.clone(),
+            runtime_auth_provider,
+            client_elicitation_capability.clone(),
+        );
+        clients.insert(server_name.clone(), async_managed_client.clone());
+        let tx_event = tx_event.clone();
+        let submit_id = startup_submit_id.clone();
+        let auth_entry = auth_entries.get(&server_name).cloned();
+        join_set.spawn(async move {
+            let mut outcome = async_managed_client.client().await;
+            if cancel_token.is_cancelled() {
+                outcome = Err(StartupOutcomeError::Cancelled);
+            }
+            let status = match &outcome {
+                Ok(_) => McpStartupStatus::Ready,
+                Err(StartupOutcomeError::Cancelled) => McpStartupStatus::Cancelled,
+                Err(error) => {
+                    let error_str =
+                        mcp_init_error_display(server_name.as_str(), auth_entry.as_ref(), error);
+                    McpStartupStatus::Failed { error: error_str }
+                }
+            };
+
+            let _ = emit_update(
+                submit_id.as_str(),
+                &tx_event,
+                McpStartupUpdateEvent {
+                    server: server_name.clone(),
+                    status,
+                },
+            )
+            .await;
+
+            (server_name, outcome)
+        });
+    }
+    let connections = McpConnections {
+        clients,
+        server_metadata,
+        required_servers,
+        tool_plugin_provenance,
+        host_owned_codex_apps_enabled,
+        prefix_mcp_tool_names,
+    };
+    tokio::spawn(async move {
+        let outcomes = join_set.join_all().await;
+        let mut summary = McpStartupCompleteEvent::default();
+        for (server_name, outcome) in outcomes {
+            match outcome {
+                Ok(_) => summary.ready.push(server_name),
+                Err(StartupOutcomeError::Cancelled) => summary.cancelled.push(server_name),
+                Err(StartupOutcomeError::Failed { error }) => {
+                    summary.failed.push(McpStartupFailure {
+                        server: server_name,
+                        error,
+                    })
+                }
+            }
+        }
+        let _ = tx_event
+            .send(Event {
+                id: startup_submit_id,
+                msg: EventMsg::McpStartupComplete(summary),
+            })
+            .await;
+    });
+    connections
 }
 
 async fn emit_update(

--- a/codex-rs/codex-mcp/src/connection_manager.rs
+++ b/codex-rs/codex-mcp/src/connection_manager.rs
@@ -22,6 +22,7 @@ use crate::codex_apps::CodexAppsToolsCacheContext;
 use crate::codex_apps::CodexAppsToolsCacheKey;
 use crate::codex_apps::write_cached_codex_apps_tools_if_needed;
 use crate::elicitation::ElicitationRequestManager;
+use crate::elicitation::ElicitationRequestScope;
 use crate::elicitation::ElicitationReviewerHandle;
 use crate::mcp::CODEX_APPS_MCP_SERVER_NAME;
 use crate::mcp::ToolPluginProvenance;
@@ -82,6 +83,7 @@ use tracing::warn;
 const MCP_UI_META_KEY: &str = "ui";
 const MCP_UI_VISIBILITY_META_KEY: &str = "visibility";
 const MCP_UI_MODEL_VISIBILITY: &str = "model";
+const MAX_ELICITATION_REQUEST_SCOPES: usize = 16;
 
 /// Returns whether a tool may be included in model-facing tool declarations.
 ///
@@ -112,6 +114,7 @@ pub struct McpConnectionManager {
     /// Replaced by refresh while existing operations retain their current snapshot.
     connections: RwLock<Arc<McpConnections>>,
     elicitation_requests: RwLock<Arc<ElicitationRequestManager>>,
+    elicitation_request_scopes: Mutex<Vec<ElicitationRequestScope>>,
     /// Rotated before each refresh so cancellation always reaches the active startup round.
     startup_cancellation_token: Mutex<CancellationToken>,
 }
@@ -174,6 +177,7 @@ impl McpConnectionManager {
         .await;
         Self {
             connections: RwLock::new(Arc::new(connections)),
+            elicitation_request_scopes: Mutex::new(vec![elicitation_requests.request_scope()]),
             elicitation_requests: RwLock::new(Arc::new(elicitation_requests)),
             startup_cancellation_token: Mutex::new(startup_cancellation_token),
         }
@@ -211,6 +215,7 @@ impl McpConnectionManager {
         let elicitation_requests = self
             .elicitation_requests()
             .new_request_scope(elicitation_reviewer);
+        self.register_elicitation_request_scope(&elicitation_requests);
         {
             let mut current = self
                 .elicitation_requests
@@ -297,6 +302,12 @@ impl McpConnectionManager {
         permission_profile: &PermissionProfile,
         prefix_mcp_tool_names: bool,
     ) -> Self {
+        let elicitation_requests = Arc::new(ElicitationRequestManager::new(
+            approval_policy.value(),
+            permission_profile.clone(),
+            /*reviewer*/ None,
+        ));
+        let elicitation_request_scope = elicitation_requests.request_scope();
         Self {
             connections: RwLock::new(Arc::new(McpConnections {
                 resource_cache_identity: Arc::new(()),
@@ -307,11 +318,8 @@ impl McpConnectionManager {
                 host_owned_codex_apps_enabled: false,
                 prefix_mcp_tool_names,
             })),
-            elicitation_requests: RwLock::new(Arc::new(ElicitationRequestManager::new(
-                approval_policy.value(),
-                permission_profile.clone(),
-                /*reviewer*/ None,
-            ))),
+            elicitation_requests: RwLock::new(elicitation_requests),
+            elicitation_request_scopes: Mutex::new(vec![elicitation_request_scope]),
             startup_cancellation_token: Mutex::new(CancellationToken::new()),
         }
     }
@@ -419,9 +427,20 @@ impl McpConnectionManager {
         id: RequestId,
         response: ElicitationResponse,
     ) -> Result<()> {
-        self.elicitation_requests()
-            .resolve(server_name, id, response)
-            .await
+        let scopes = self
+            .elicitation_request_scopes
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone();
+        for scope in scopes {
+            if scope
+                .try_resolve(&server_name, &id, response.clone())
+                .await?
+            {
+                return Ok(());
+            }
+        }
+        Err(anyhow!("elicitation request not found"))
     }
 
     pub async fn wait_for_server_ready(&self, server_name: &str, timeout: Duration) -> bool {
@@ -838,6 +857,16 @@ impl McpConnectionManager {
                 .read()
                 .unwrap_or_else(PoisonError::into_inner),
         )
+    }
+
+    fn register_elicitation_request_scope(&self, manager: &ElicitationRequestManager) {
+        let mut scopes = self
+            .elicitation_request_scopes
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        scopes.retain(ElicitationRequestScope::is_live);
+        scopes.insert(0, manager.request_scope());
+        scopes.truncate(MAX_ELICITATION_REQUEST_SCOPES);
     }
 
     #[cfg(test)]

--- a/codex-rs/codex-mcp/src/connection_manager.rs
+++ b/codex-rs/codex-mcp/src/connection_manager.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::PoisonError;
 use std::sync::RwLock;
+use std::sync::Weak;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 use std::time::Instant;
@@ -116,6 +117,7 @@ pub struct McpConnectionManager {
 }
 
 struct McpConnections {
+    resource_cache_identity: Arc<()>,
     clients: HashMap<String, AsyncManagedClient>,
     server_metadata: HashMap<String, McpServerMetadata>,
     required_servers: Vec<String>,
@@ -297,6 +299,7 @@ impl McpConnectionManager {
     ) -> Self {
         Self {
             connections: RwLock::new(Arc::new(McpConnections {
+                resource_cache_identity: Arc::new(()),
                 clients: HashMap::new(),
                 server_metadata: HashMap::new(),
                 required_servers: Vec::new(),
@@ -319,6 +322,10 @@ impl McpConnectionManager {
 
     pub(crate) fn contains_server(&self, server_name: &str) -> bool {
         self.connections().clients.contains_key(server_name)
+    }
+
+    pub(crate) fn resource_cache_key(&self) -> Weak<()> {
+        Arc::downgrade(&self.connections().resource_cache_identity)
     }
 
     /// Cancels MCP servers that are still starting without shutting down ready clients.
@@ -975,6 +982,7 @@ async fn start_connections(
         });
     }
     let connections = McpConnections {
+        resource_cache_identity: Arc::new(()),
         clients,
         server_metadata,
         required_servers,

--- a/codex-rs/codex-mcp/src/connection_manager_tests.rs
+++ b/codex-rs/codex-mcp/src/connection_manager_tests.rs
@@ -44,6 +44,16 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use tempfile::tempdir;
 
+fn connections_mut(manager: &mut McpConnectionManager) -> &mut McpConnections {
+    Arc::get_mut(
+        manager
+            .connections
+            .get_mut()
+            .unwrap_or_else(PoisonError::into_inner),
+    )
+    .expect("test manager connection snapshot should be uniquely owned")
+}
+
 fn create_test_tool(server_name: &str, tool_name: &str) -> ToolInfo {
     ToolInfo {
         server_name: server_name.to_string(),
@@ -809,7 +819,7 @@ async fn list_all_tools_uses_cached_tool_info_snapshot_while_client_is_pending()
         &permission_profile,
         /*prefix_mcp_tool_names*/ true,
     );
-    manager.clients.insert(
+    connections_mut(&mut manager).clients.insert(
         CODEX_APPS_MCP_SERVER_NAME.to_string(),
         AsyncManagedClient {
             client: pending_client,
@@ -846,7 +856,7 @@ async fn list_available_server_infos_uses_cache_while_client_is_pending() {
         /*prefix_mcp_tool_names*/ true,
     );
     let server_info = create_test_server_info("Codex Apps");
-    manager.clients.insert(
+    connections_mut(&mut manager).clients.insert(
         CODEX_APPS_MCP_SERVER_NAME.to_string(),
         AsyncManagedClient {
             client: pending_client,
@@ -883,7 +893,7 @@ async fn list_all_tools_accepts_canonical_namespaced_tool_names() {
         &permission_profile,
         /*prefix_mcp_tool_names*/ false,
     );
-    manager.clients.insert(
+    connections_mut(&mut manager).clients.insert(
         "rmcp".to_string(),
         AsyncManagedClient {
             client: pending_client,
@@ -926,7 +936,7 @@ async fn list_all_tools_applies_legacy_mcp_prefix_by_default() {
         &permission_profile,
         /*prefix_mcp_tool_names*/ true,
     );
-    manager.clients.insert(
+    connections_mut(&mut manager).clients.insert(
         "rmcp".to_string(),
         AsyncManagedClient {
             client: pending_client,
@@ -968,7 +978,7 @@ async fn list_all_tools_blocks_while_client_is_pending_without_cached_tool_info_
         &permission_profile,
         /*prefix_mcp_tool_names*/ true,
     );
-    manager.clients.insert(
+    connections_mut(&mut manager).clients.insert(
         CODEX_APPS_MCP_SERVER_NAME.to_string(),
         AsyncManagedClient {
             client: pending_client,
@@ -983,6 +993,27 @@ async fn list_all_tools_blocks_while_client_is_pending_without_cached_tool_info_
     let timeout_result =
         tokio::time::timeout(Duration::from_millis(10), manager.list_all_tools()).await;
     assert!(timeout_result.is_err());
+}
+
+#[test]
+fn cancel_startup_cancels_manager_owned_token() {
+    let approval_policy = Constrained::allow_any(AskForApproval::OnFailure);
+    let permission_profile = Constrained::allow_any(PermissionProfile::default());
+    let manager = McpConnectionManager::new_uninitialized(
+        &approval_policy,
+        &permission_profile,
+        /*prefix_mcp_tool_names*/ true,
+    );
+
+    manager.cancel_startup();
+
+    assert!(
+        manager
+            .startup_cancellation_token
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .is_cancelled()
+    );
 }
 
 #[tokio::test]
@@ -1004,7 +1035,7 @@ async fn shutdown_cancels_pending_tool_listing() {
         &permission_profile,
         /*prefix_mcp_tool_names*/ true,
     );
-    manager.clients.insert(
+    connections_mut(&mut manager).clients.insert(
         CODEX_APPS_MCP_SERVER_NAME.to_string(),
         AsyncManagedClient {
             client: pending_client,
@@ -1039,7 +1070,7 @@ async fn list_all_tools_does_not_block_when_cached_tool_info_snapshot_is_empty()
         &permission_profile,
         /*prefix_mcp_tool_names*/ true,
     );
-    manager.clients.insert(
+    connections_mut(&mut manager).clients.insert(
         CODEX_APPS_MCP_SERVER_NAME.to_string(),
         AsyncManagedClient {
             client: pending_client,
@@ -1079,7 +1110,7 @@ async fn list_all_tools_uses_cached_tool_info_snapshot_when_client_startup_fails
         /*prefix_mcp_tool_names*/ true,
     );
     let startup_complete = Arc::new(std::sync::atomic::AtomicBool::new(true));
-    manager.clients.insert(
+    connections_mut(&mut manager).clients.insert(
         CODEX_APPS_MCP_SERVER_NAME.to_string(),
         AsyncManagedClient {
             client: failed_client,
@@ -1124,7 +1155,7 @@ async fn list_all_tools_adds_server_metadata_to_cached_tools() {
         &permission_profile,
         /*prefix_mcp_tool_names*/ true,
     );
-    manager.server_metadata.insert(
+    connections_mut(&mut manager).server_metadata.insert(
         server_name.to_string(),
         McpServerMetadata {
             pollutes_memory: true,
@@ -1136,7 +1167,7 @@ async fn list_all_tools_adds_server_metadata_to_cached_tools() {
             tool_approval_modes: HashMap::new(),
         },
     );
-    manager.clients.insert(
+    connections_mut(&mut manager).clients.insert(
         server_name.to_string(),
         AsyncManagedClient {
             client: pending_client,
@@ -1238,7 +1269,6 @@ async fn no_local_runtime_fails_local_stdio_but_keeps_local_http_server() {
         ),
     ]);
 
-    let cancel_token = CancellationToken::new();
     let manager = McpConnectionManager::new(
         &mcp_servers,
         OAuthCredentialsStoreMode::default(),
@@ -1247,7 +1277,6 @@ async fn no_local_runtime_fails_local_stdio_but_keeps_local_http_server() {
         &approval_policy,
         String::new(),
         tx_event,
-        cancel_token.clone(),
         PermissionProfile::default(),
         McpRuntimeContext::new(
             Arc::new(EnvironmentManager::without_environments()),
@@ -1268,14 +1297,15 @@ async fn no_local_runtime_fails_local_stdio_but_keeps_local_http_server() {
     )
     .await;
 
-    assert!(manager.clients.contains_key("stdio"));
-    assert!(manager.clients.contains_key("http"));
+    let connections = manager.connections();
+    assert!(connections.clients.contains_key("stdio"));
+    assert!(connections.clients.contains_key("http"));
     assert!(
         !manager
             .wait_for_server_ready("stdio", Duration::from_millis(10))
             .await
     );
-    let error = match manager
+    let error = match connections
         .clients
         .get("stdio")
         .expect("stdio client")
@@ -1289,7 +1319,7 @@ async fn no_local_runtime_fails_local_stdio_but_keeps_local_http_server() {
         startup_outcome_error_message(error),
         "local stdio MCP server `stdio` requires a local environment"
     );
-    cancel_token.cancel();
+    manager.cancel_startup();
 }
 
 #[test]

--- a/codex-rs/codex-mcp/src/connection_manager_tests.rs
+++ b/codex-rs/codex-mcp/src/connection_manager_tests.rs
@@ -319,6 +319,60 @@ async fn disabled_permissions_do_not_auto_accept_elicitation_with_requested_fiel
     );
 }
 
+#[tokio::test]
+async fn resolve_elicitation_searches_request_scopes_retained_across_refresh() {
+    let approval_policy = Constrained::allow_any(AskForApproval::OnRequest);
+    let permission_profile = Constrained::allow_any(PermissionProfile::default());
+    let manager = McpConnectionManager::new_uninitialized(
+        &approval_policy,
+        &permission_profile,
+        /*prefix_mcp_tool_names*/ true,
+    );
+    let old_scope = manager.elicitation_requests();
+    let (tx_event, rx_event) = async_channel::bounded(1);
+    let sender = old_scope.make_sender("server".to_string(), tx_event);
+    let request_id = NumberOrString::Number(1);
+    let pending_response = tokio::spawn(sender(
+        request_id.clone(),
+        CreateElicitationRequestParams::FormElicitationParams {
+            meta: None,
+            message: "Confirm?".to_string(),
+            requested_schema: rmcp::model::ElicitationSchema::builder()
+                .build()
+                .expect("schema should build"),
+        },
+    ));
+    rx_event
+        .recv()
+        .await
+        .expect("elicitation request event should be sent");
+
+    let new_scope = old_scope.new_request_scope(/*reviewer*/ None);
+    manager.register_elicitation_request_scope(&new_scope);
+    *manager
+        .elicitation_requests
+        .write()
+        .unwrap_or_else(PoisonError::into_inner) = Arc::new(new_scope);
+    let response = ElicitationResponse {
+        action: ElicitationAction::Accept,
+        content: Some(serde_json::json!({})),
+        meta: None,
+    };
+
+    manager
+        .resolve_elicitation("server".to_string(), request_id, response.clone())
+        .await
+        .expect("previous request scope should remain resolvable");
+
+    assert_eq!(
+        pending_response
+            .await
+            .expect("elicitation task should finish")
+            .expect("elicitation response should succeed"),
+        response
+    );
+}
+
 #[test]
 fn test_normalize_tools_short_non_duplicated_names() {
     let tools = vec![

--- a/codex-rs/codex-mcp/src/elicitation.rs
+++ b/codex-rs/codex-mcp/src/elicitation.rs
@@ -72,6 +72,16 @@ impl ElicitationRequestManager {
         }
     }
 
+    pub(crate) fn new_request_scope(&self, reviewer: Option<ElicitationReviewerHandle>) -> Self {
+        Self {
+            requests: Arc::new(Mutex::new(HashMap::new())),
+            approval_policy: Arc::clone(&self.approval_policy),
+            permission_profile: Arc::clone(&self.permission_profile),
+            auto_deny: Arc::clone(&self.auto_deny),
+            reviewer,
+        }
+    }
+
     pub(crate) fn auto_deny(&self) -> bool {
         self.auto_deny
             .lock()

--- a/codex-rs/codex-mcp/src/elicitation.rs
+++ b/codex-rs/codex-mcp/src/elicitation.rs
@@ -8,6 +8,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
+use std::sync::Weak;
 
 use crate::mcp::McpPermissionPromptAutoApproveContext;
 use crate::mcp::mcp_permission_prompt_is_auto_approved;
@@ -57,6 +58,11 @@ pub(crate) struct ElicitationRequestManager {
     reviewer: Option<ElicitationReviewerHandle>,
 }
 
+#[derive(Clone)]
+pub(crate) struct ElicitationRequestScope {
+    requests: Weak<Mutex<ResponderMap>>,
+}
+
 impl ElicitationRequestManager {
     pub(crate) fn new(
         approval_policy: AskForApproval,
@@ -82,6 +88,12 @@ impl ElicitationRequestManager {
         }
     }
 
+    pub(crate) fn request_scope(&self) -> ElicitationRequestScope {
+        ElicitationRequestScope {
+            requests: Arc::downgrade(&self.requests),
+        }
+    }
+
     pub(crate) fn auto_deny(&self) -> bool {
         self.auto_deny
             .lock()
@@ -93,21 +105,6 @@ impl ElicitationRequestManager {
         if let Ok(mut current) = self.auto_deny.lock() {
             *current = auto_deny;
         }
-    }
-
-    pub(crate) async fn resolve(
-        &self,
-        server_name: String,
-        id: RequestId,
-        response: ElicitationResponse,
-    ) -> Result<()> {
-        self.requests
-            .lock()
-            .await
-            .remove(&(server_name, id))
-            .ok_or_else(|| anyhow!("elicitation request not found"))?
-            .send(response)
-            .map_err(|e| anyhow!("failed to send elicitation response: {e:?}"))
     }
 
     pub(crate) fn make_sender(
@@ -238,6 +235,34 @@ impl ElicitationRequestManager {
             }
             .boxed()
         })
+    }
+}
+
+impl ElicitationRequestScope {
+    pub(crate) fn is_live(&self) -> bool {
+        self.requests.strong_count() > 0
+    }
+
+    pub(crate) async fn try_resolve(
+        &self,
+        server_name: &str,
+        id: &RequestId,
+        response: ElicitationResponse,
+    ) -> Result<bool> {
+        let Some(requests) = self.requests.upgrade() else {
+            return Ok(false);
+        };
+        let Some(responder) = requests
+            .lock()
+            .await
+            .remove(&(server_name.to_string(), id.clone()))
+        else {
+            return Ok(false);
+        };
+        responder
+            .send(response)
+            .map_err(|error| anyhow!("failed to send elicitation response: {error:?}"))?;
+        Ok(true)
     }
 }
 

--- a/codex-rs/codex-mcp/src/mcp/mod.rs
+++ b/codex-rs/codex-mcp/src/mcp/mod.rs
@@ -37,7 +37,6 @@ use rmcp::model::ElicitationCapability;
 use rmcp::model::ReadResourceRequestParams;
 use rmcp::model::ReadResourceResult;
 use serde_json::Value;
-use tokio_util::sync::CancellationToken;
 
 use crate::ResolvedMcpCatalog;
 use crate::codex_apps::codex_apps_tools_cache_key;
@@ -288,7 +287,6 @@ pub async fn read_mcp_resource(
     .await;
     let (tx_event, rx_event) = unbounded();
     drop(rx_event);
-    let cancel_token = CancellationToken::new();
     let manager = McpConnectionManager::new(
         &mcp_servers,
         config.mcp_oauth_credentials_store_mode,
@@ -297,7 +295,6 @@ pub async fn read_mcp_resource(
         &config.approval_policy,
         String::new(),
         tx_event,
-        cancel_token.clone(),
         PermissionProfile::default(),
         runtime_context,
         config.codex_home.clone(),
@@ -314,7 +311,7 @@ pub async fn read_mcp_resource(
     let result = manager
         .read_resource(server, ReadResourceRequestParams::new(uri))
         .await;
-    cancel_token.cancel();
+    manager.cancel_startup();
     result
 }
 
@@ -362,7 +359,6 @@ pub async fn collect_mcp_server_status_snapshot_with_detail(
     let (tx_event, rx_event) = unbounded();
     drop(rx_event);
 
-    let cancel_token = CancellationToken::new();
     let mcp_connection_manager = McpConnectionManager::new(
         &mcp_servers,
         config.mcp_oauth_credentials_store_mode,
@@ -371,7 +367,6 @@ pub async fn collect_mcp_server_status_snapshot_with_detail(
         &config.approval_policy,
         submit_id,
         tx_event,
-        cancel_token.clone(),
         PermissionProfile::default(),
         runtime_context,
         config.codex_home.clone(),
@@ -393,7 +388,7 @@ pub async fn collect_mcp_server_status_snapshot_with_detail(
     )
     .await;
 
-    cancel_token.cancel();
+    mcp_connection_manager.cancel_startup();
 
     snapshot
 }

--- a/codex-rs/codex-mcp/src/resource_client.rs
+++ b/codex-rs/codex-mcp/src/resource_client.rs
@@ -36,9 +36,9 @@ pub struct McpResourceClient {
     manager: Arc<ArcSwap<McpConnectionManager>>,
 }
 
-/// Opaque identity for the manager currently used by an MCP resource client.
+/// Opaque identity for the connection snapshot currently used by an MCP resource client.
 #[derive(Clone)]
-pub struct McpResourceClientCacheKey(Weak<McpConnectionManager>);
+pub struct McpResourceClientCacheKey(Weak<()>);
 
 impl PartialEq for McpResourceClientCacheKey {
     fn eq(&self, other: &Self) -> bool {
@@ -62,9 +62,9 @@ impl McpResourceClient {
         Self { manager }
     }
 
-    /// Returns an identity that changes whenever the published manager changes.
+    /// Returns an identity that changes whenever the manager's connections change.
     pub fn cache_key(&self) -> McpResourceClientCacheKey {
-        McpResourceClientCacheKey(Arc::downgrade(&self.manager.load_full()))
+        McpResourceClientCacheKey(self.manager.load_full().resource_cache_key())
     }
 
     /// Returns whether the current manager contains the named server.

--- a/codex-rs/codex-mcp/src/resource_client.rs
+++ b/codex-rs/codex-mcp/src/resource_client.rs
@@ -29,8 +29,8 @@ pub struct McpResourceReadResult {
 
 /// Session-scoped access to MCP resources through the currently installed manager.
 ///
-/// The client retains the manager's shared publication handle rather than a manager
-/// snapshot, so calls automatically use replacements installed during startup and refresh.
+/// The client retains the session's shared manager handle, so each call observes the current
+/// connection snapshot while in-flight calls may finish against the snapshot they started with.
 #[derive(Clone)]
 pub struct McpResourceClient {
     manager: Arc<ArcSwap<McpConnectionManager>>,

--- a/codex-rs/core/src/connectors.rs
+++ b/codex-rs/core/src/connectors.rs
@@ -17,7 +17,6 @@ use codex_exec_server::EnvironmentManager;
 use codex_exec_server::ExecServerRuntimePaths;
 use codex_protocol::models::PermissionProfile;
 use codex_tools::DiscoverableTool;
-use tokio_util::sync::CancellationToken;
 use tracing::instrument;
 use tracing::warn;
 
@@ -271,7 +270,6 @@ pub async fn list_accessible_connectors_from_mcp_tools_with_mcp_manager(
     let (tx_event, rx_event) = unbounded();
     drop(rx_event);
 
-    let cancel_token = CancellationToken::new();
     let mcp_connection_manager = McpConnectionManager::new(
         &mcp_servers,
         config.mcp_oauth_credentials_store_mode,
@@ -280,7 +278,6 @@ pub async fn list_accessible_connectors_from_mcp_tools_with_mcp_manager(
         &config.permissions.approval_policy,
         INITIAL_SUBMIT_ID.to_owned(),
         tx_event,
-        cancel_token.clone(),
         PermissionProfile::default(),
         // Connector discovery is threadless. Use an actually configured env if
         // one exists, but do not reintroduce the old hidden-local fallback.
@@ -348,7 +345,7 @@ pub async fn list_accessible_connectors_from_mcp_tools_with_mcp_manager(
         tools = mcp_connection_manager.list_all_tools().await;
     }
     if codex_apps_ready {
-        cancel_token.cancel();
+        mcp_connection_manager.cancel_startup();
     }
 
     let accessible_connectors = codex_connectors::filter::filter_disallowed_connectors(

--- a/codex-rs/core/src/guardian/tests.rs
+++ b/codex-rs/core/src/guardian/tests.rs
@@ -1696,6 +1696,7 @@ async fn guardian_review_request_layout_matches_model_visible_request_snapshot()
                     ),
                 }],
                 phase: None,
+                metadata: None,
             }],
         )
         .await;

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -335,8 +335,7 @@ async fn handle_approved_mcp_tool_call(
         .services
         .mcp_connection_manager
         .load_full()
-        .server_origin(&server)
-        .map(str::to_string);
+        .server_origin(&server);
 
     let start = Instant::now();
     let rewrite = rewrite_mcp_tool_arguments_for_openai_files(
@@ -1433,9 +1432,7 @@ pub(crate) async fn lookup_mcp_tool_metadata(
     tool_name: &str,
 ) -> Option<McpToolApprovalMetadata> {
     let manager = sess.services.mcp_connection_manager.load_full();
-    let plugin_id = manager
-        .plugin_id_for_mcp_server_name(server)
-        .map(str::to_string);
+    let plugin_id = manager.plugin_id_for_mcp_server_name(server);
     let tools = manager.list_all_tools().await;
     let tool_info = tools
         .into_iter()

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -46,7 +46,6 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tempfile::tempdir;
-use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 use tracing::Level;
 use tracing_subscriber::fmt::format::FmtSpan;
@@ -1265,7 +1264,6 @@ async fn install_host_owned_codex_apps_manager(session: &Session, turn_context: 
         &turn_context.approval_policy,
         turn_context.sub_id.clone(),
         session.get_tx_event(),
-        CancellationToken::new(),
         turn_context.permission_profile(),
         codex_mcp::McpRuntimeContext::new(Arc::clone(&session.services.environment_manager), {
             #[allow(deprecated)]

--- a/codex-rs/core/src/session/mcp.rs
+++ b/codex-rs/core/src/session/mcp.rs
@@ -328,41 +328,27 @@ impl Session {
                 turn_context.cwd.to_path_buf(),
             ),
         };
-        let mcp_startup_cancellation_token = {
-            let mut guard = self.services.mcp_startup_cancellation_token.lock().await;
-            guard.cancel();
-            let cancellation_token = CancellationToken::new();
-            *guard = cancellation_token.clone();
-            cancellation_token
-        };
-        let refreshed_manager = McpConnectionManager::new(
-            &mcp_servers,
-            store_mode,
-            keyring_backend_kind,
-            auth_statuses,
-            &turn_context.approval_policy,
-            turn_context.sub_id.clone(),
-            self.get_tx_event(),
-            mcp_startup_cancellation_token,
-            turn_context.permission_profile(),
-            mcp_runtime_context,
-            config.codex_home.to_path_buf(),
-            codex_apps_tools_cache_key(auth.as_ref()),
-            host_owned_codex_apps_enabled,
-            mcp_config.prefix_mcp_tool_names,
-            mcp_config.client_elicitation_capability,
-            tool_plugin_provenance,
-            auth.as_ref(),
-            elicitation_reviewer,
-        )
-        .await;
-        {
-            let current_manager = self.services.mcp_connection_manager.load_full();
-            refreshed_manager.set_elicitations_auto_deny(current_manager.elicitations_auto_deny());
-        }
         self.services
             .mcp_connection_manager
-            .store(Arc::new(refreshed_manager));
+            .load_full()
+            .refresh(
+                &mcp_servers,
+                store_mode,
+                keyring_backend_kind,
+                auth_statuses,
+                turn_context.sub_id.clone(),
+                self.get_tx_event(),
+                mcp_runtime_context,
+                config.codex_home.to_path_buf(),
+                codex_apps_tools_cache_key(auth.as_ref()),
+                host_owned_codex_apps_enabled,
+                mcp_config.prefix_mcp_tool_names,
+                mcp_config.client_elicitation_capability,
+                tool_plugin_provenance,
+                auth.as_ref(),
+                elicitation_reviewer,
+            )
+            .await;
     }
 
     pub(crate) async fn refresh_mcp_servers_if_requested(
@@ -435,21 +421,8 @@ impl Session {
         .await;
     }
 
-    #[cfg(test)]
-    pub(crate) async fn mcp_startup_cancellation_token(&self) -> CancellationToken {
-        self.services
-            .mcp_startup_cancellation_token
-            .lock()
-            .await
-            .clone()
-    }
-
-    pub(crate) async fn cancel_mcp_startup(&self) {
-        self.services
-            .mcp_startup_cancellation_token
-            .lock()
-            .await
-            .cancel();
+    pub(crate) fn cancel_mcp_startup(&self) {
+        self.services.mcp_connection_manager.load().cancel_startup();
     }
 }
 

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -3501,7 +3501,7 @@ impl Session {
         let had_active_turn = self.active_turn.lock().await.is_some();
         self.abort_all_tasks(TurnAbortReason::Interrupted).await;
         if !had_active_turn {
-            self.cancel_mcp_startup().await;
+            self.cancel_mcp_startup();
         }
     }
 

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -978,7 +978,6 @@ impl Session {
                 // changing this to use Option or OnceCell, though the current
                 // setup is straightforward enough and performs well.
                 mcp_connection_manager,
-                mcp_startup_cancellation_token: Mutex::new(CancellationToken::new()),
                 unified_exec_manager: UnifiedExecProcessManager::new(
                     config.background_terminal_max_timeout,
                 ),
@@ -1109,13 +1108,6 @@ impl Session {
             } else {
                 ElicitationCapability::default()
             };
-            let mcp_startup_cancellation_token = {
-                let mut cancel_guard = sess.services.mcp_startup_cancellation_token.lock().await;
-                cancel_guard.cancel();
-                let cancel_token = CancellationToken::new();
-                *cancel_guard = cancel_token.clone();
-                cancel_token
-            };
             let turn_environment = crate::environment_selection::resolve_environment_selections(
                 sess.services.environment_manager.as_ref(),
                 session_configuration.environment_selections(),
@@ -1147,7 +1139,6 @@ impl Session {
                 &session_configuration.approval_policy,
                 INITIAL_SUBMIT_ID.to_owned(),
                 tx_event.clone(),
-                mcp_startup_cancellation_token,
                 session_configuration.permission_profile(),
                 mcp_runtime_context,
                 config.codex_home.to_path_buf(),

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -970,13 +970,9 @@ impl Session {
             }
 
             let services = SessionServices {
-                // Initialize the MCP connection manager with an uninitialized
-                // instance. It will be replaced with one created via
-                // McpConnectionManager::new() once all its constructor args are
-                // available. This also ensures `SessionConfigured` is emitted
-                // before any MCP-related events. It is reasonable to consider
-                // changing this to use Option or OnceCell, though the current
-                // setup is straightforward enough and performs well.
+                // Publish the stable MCP manager before startup so interrupts and extension
+                // resource clients can reach the active startup round. Its connections are
+                // populated after `SessionConfigured` is emitted.
                 mcp_connection_manager,
                 unified_exec_manager: UnifiedExecProcessManager::new(
                     config.background_terminal_max_timeout,
@@ -1131,33 +1127,34 @@ impl Session {
                     session_configuration.cwd().to_path_buf(),
                 ),
             };
-            let mcp_connection_manager = McpConnectionManager::new(
-                &mcp_servers,
-                config.mcp_oauth_credentials_store_mode,
-                config.auth_keyring_backend_kind(),
-                auth_statuses,
-                &session_configuration.approval_policy,
-                INITIAL_SUBMIT_ID.to_owned(),
-                tx_event.clone(),
-                session_configuration.permission_profile(),
-                mcp_runtime_context,
-                config.codex_home.to_path_buf(),
-                codex_apps_tools_cache_key(auth),
-                host_owned_codex_apps_enabled,
-                config.prefix_mcp_tool_names(),
-                client_elicitation_capability,
-                tool_plugin_provenance,
-                auth,
-                Some(sess.mcp_elicitation_reviewer()),
-            )
-            .instrument(info_span!(
-                "session_init.mcp_manager_init",
-                otel.name = "session_init.mcp_manager_init",
-            ))
-            .await;
-            sess.services
-                .install_mcp_connection_manager(mcp_connection_manager)
-                .await?;
+            let mcp_connection_manager = sess.services.mcp_connection_manager.load_full();
+            mcp_connection_manager.set_approval_policy(&session_configuration.approval_policy);
+            mcp_connection_manager
+                .set_permission_profile(session_configuration.permission_profile());
+            mcp_connection_manager
+                .refresh(
+                    &mcp_servers,
+                    config.mcp_oauth_credentials_store_mode,
+                    config.auth_keyring_backend_kind(),
+                    auth_statuses,
+                    INITIAL_SUBMIT_ID.to_owned(),
+                    tx_event.clone(),
+                    mcp_runtime_context,
+                    config.codex_home.to_path_buf(),
+                    codex_apps_tools_cache_key(auth),
+                    host_owned_codex_apps_enabled,
+                    config.prefix_mcp_tool_names(),
+                    client_elicitation_capability,
+                    tool_plugin_provenance,
+                    auth,
+                    Some(sess.mcp_elicitation_reviewer()),
+                )
+                .instrument(info_span!(
+                    "session_init.mcp_manager_init",
+                    otel.name = "session_init.mcp_manager_init",
+                ))
+                .await;
+            mcp_connection_manager.validate_required_servers().await?;
             sess.schedule_startup_prewarm(session_configuration.base_instructions.clone())
                 .await;
             let session_start_source = match &initial_history {

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -4966,7 +4966,6 @@ pub(crate) async fn make_session_and_context() -> (Session, TurnContext) {
                 config.prefix_mcp_tool_names(),
             ),
         )),
-        mcp_startup_cancellation_token: Mutex::new(CancellationToken::new()),
         unified_exec_manager: UnifiedExecProcessManager::new(
             config.background_terminal_max_timeout,
         ),
@@ -6972,7 +6971,6 @@ where
                 config.prefix_mcp_tool_names(),
             ),
         )),
-        mcp_startup_cancellation_token: Mutex::new(CancellationToken::new()),
         unified_exec_manager: UnifiedExecProcessManager::new(
             config.background_terminal_max_timeout,
         ),
@@ -7122,8 +7120,7 @@ pub(crate) async fn make_session_and_context_with_rx() -> (
 #[tokio::test]
 async fn refresh_mcp_servers_is_deferred_until_next_turn() {
     let (session, turn_context) = make_session_and_context().await;
-    let old_token = session.mcp_startup_cancellation_token().await;
-    assert!(!old_token.is_cancelled());
+    let old_manager = session.services.mcp_connection_manager.load_full();
 
     let mcp_oauth_credentials_store_mode =
         serde_json::to_value(OAuthCredentialsStoreMode::Auto).expect("serialize store mode");
@@ -7139,29 +7136,39 @@ async fn refresh_mcp_servers_is_deferred_until_next_turn() {
         *guard = Some(refresh_config);
     }
 
-    assert!(!old_token.is_cancelled());
-    assert!(
-        session
-            .pending_mcp_server_refresh_config
-            .lock()
-            .await
-            .is_some()
+    assert_eq!(
+        (
+            Arc::ptr_eq(
+                &old_manager,
+                &session.services.mcp_connection_manager.load_full()
+            ),
+            session
+                .pending_mcp_server_refresh_config
+                .lock()
+                .await
+                .is_some(),
+        ),
+        (true, true)
     );
 
     session
         .refresh_mcp_servers_if_requested(&turn_context, /*elicitation_reviewer*/ None)
         .await;
 
-    assert!(old_token.is_cancelled());
-    assert!(
-        session
-            .pending_mcp_server_refresh_config
-            .lock()
-            .await
-            .is_none()
+    assert_eq!(
+        (
+            Arc::ptr_eq(
+                &old_manager,
+                &session.services.mcp_connection_manager.load_full()
+            ),
+            session
+                .pending_mcp_server_refresh_config
+                .lock()
+                .await
+                .is_some(),
+        ),
+        (true, false)
     );
-    let new_token = session.mcp_startup_cancellation_token().await;
-    assert!(!new_token.is_cancelled());
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/state/service.rs
+++ b/codex-rs/core/src/state/service.rs
@@ -38,12 +38,10 @@ use codex_thread_store::ThreadStore;
 use std::path::PathBuf;
 use tokio::runtime::Handle;
 use tokio::sync::Mutex;
-use tokio_util::sync::CancellationToken;
 
 pub(crate) struct SessionServices {
     /// The latest manager; callers retain an owned handle while performing MCP I/O.
     pub(crate) mcp_connection_manager: Arc<ArcSwap<McpConnectionManager>>,
-    pub(crate) mcp_startup_cancellation_token: Mutex<CancellationToken>,
     pub(crate) unified_exec_manager: UnifiedExecProcessManager,
     #[cfg_attr(not(unix), allow(dead_code))]
     pub(crate) shell_zsh_path: Option<PathBuf>,

--- a/codex-rs/core/src/state/service.rs
+++ b/codex-rs/core/src/state/service.rs
@@ -17,7 +17,6 @@ use crate::tools::handlers::ToolSearchHandlerCache;
 use crate::tools::network_approval::NetworkApprovalService;
 use crate::tools::sandboxing::ApprovalStore;
 use crate::unified_exec::UnifiedExecProcessManager;
-use anyhow::Result;
 use arc_swap::ArcSwap;
 use arc_swap::ArcSwapOption;
 use codex_analytics::AnalyticsEventsClient;
@@ -40,7 +39,7 @@ use tokio::runtime::Handle;
 use tokio::sync::Mutex;
 
 pub(crate) struct SessionServices {
-    /// The latest manager; callers retain an owned handle while performing MCP I/O.
+    /// The session's stable manager; callers retain an owned handle while performing MCP I/O.
     pub(crate) mcp_connection_manager: Arc<ArcSwap<McpConnectionManager>>,
     pub(crate) unified_exec_manager: UnifiedExecProcessManager,
     #[cfg_attr(not(unix), allow(dead_code))]
@@ -84,19 +83,4 @@ pub(crate) struct SessionServices {
     /// Shared process-level environment registry. Sessions carry an `Arc` handle so they can pass
     /// the same manager through child-thread spawn paths without reconstructing it.
     pub(crate) environment_manager: Arc<EnvironmentManager>,
-}
-
-impl SessionServices {
-    /// Installs the manager before validating required servers so startup-time elicitation can
-    /// resolve through the session's manager while validation waits.
-    pub(crate) async fn install_mcp_connection_manager(
-        &self,
-        manager: McpConnectionManager,
-    ) -> Result<()> {
-        self.mcp_connection_manager.store(Arc::new(manager));
-        self.mcp_connection_manager
-            .load_full()
-            .validate_required_servers()
-            .await
-    }
 }


### PR DESCRIPTION
## Why

MCP startup cancellation belongs with the manager that owns the clients. Replacing the entire `McpConnectionManager` during refresh creates a short interval where new startup work exists before the replacement manager is published, so an interrupt can only reach the old manager.

Keep one manager installed for the session and refresh only its connection state. The manager can then publish the new startup token before constructing clients, making the active startup round cancellable throughout refresh.

## What changed

- move startup cancellation ownership into `McpConnectionManager`
- retain the installed manager across refresh and atomically replace its connection snapshot
- publish a fresh elicitation request scope before refreshed clients can start, while sharing policy, permission, and auto-deny state
- let in-flight operations retain the connection snapshot they started with
- remove the duplicate startup token and mutex from `SessionServices`

## Validation

- `cancel_startup_cancels_manager_owned_token` verifies manager-owned cancellation
- `refresh_mcp_servers_is_deferred_until_next_turn` verifies refresh remains deferred and preserves manager identity when applied
- GitHub CI covers the Rust and Bazel test suites