### PR TITLE
[codex] retry remote environment registration

### DIFF
--- a/codex-rs/exec-server/src/remote.rs
+++ b/codex-rs/exec-server/src/remote.rs
@@ -1,10 +1,16 @@
 use std::time::Duration;
+use std::time::Instant;
 
 use codex_api::SharedAuthProvider;
+use codex_client::backoff;
 use reqwest::StatusCode;
+use reqwest::header::RETRY_AFTER;
 use serde::Deserialize;
 use tokio::time::sleep;
+use tokio::time::timeout;
 use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::client::uri_mode;
 use tracing::warn;
 
 use codex_utils_rustls_provider::ensure_rustls_crypto_provider;
@@ -15,6 +21,11 @@ use crate::relay::run_multiplexed_environment;
 use crate::server::ConnectionProcessor;
 
 const ERROR_BODY_PREVIEW_BYTES: usize = 4096;
+const ENVIRONMENT_REGISTRY_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const RENDEZVOUS_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const INITIAL_RECONNECT_BACKOFF: Duration = Duration::from_secs(1);
+const MAX_RECONNECT_BACKOFF: Duration = Duration::from_secs(30);
+const STABLE_CONNECTION_DURATION: Duration = Duration::from_secs(30);
 
 #[derive(Clone)]
 struct EnvironmentRegistryClient {
@@ -40,6 +51,7 @@ impl EnvironmentRegistryClient {
             auth_provider,
             http: reqwest::Client::builder()
                 .redirect(reqwest::redirect::Policy::none())
+                .timeout(ENVIRONMENT_REGISTRY_REQUEST_TIMEOUT)
                 .build()?,
         })
     }
@@ -47,8 +59,8 @@ impl EnvironmentRegistryClient {
     async fn register_environment(
         &self,
         environment_id: &str,
-    ) -> Result<EnvironmentRegistryRegistrationResponse, ExecServerError> {
-        let response = self
+    ) -> Result<EnvironmentRegistryRegistrationResponse, EnvironmentRegistrationError> {
+        let response = match self
             .http
             .post(endpoint_url(
                 &self.base_url,
@@ -56,28 +68,110 @@ impl EnvironmentRegistryClient {
             ))
             .headers(self.auth_provider.to_auth_headers())
             .send()
-            .await?;
-        self.parse_json_response(response).await
+            .await
+        {
+            Ok(response) => response,
+            Err(error) if error.is_builder() => {
+                return Err(EnvironmentRegistrationError::Permanent {
+                    source: error.into(),
+                });
+            }
+            Err(error) => {
+                return Err(EnvironmentRegistrationError::Retryable {
+                    source: error.into(),
+                    retry_after: None,
+                });
+            }
+        };
+        self.parse_registration_response(response).await
     }
 
-    async fn parse_json_response<R>(
+    async fn parse_registration_response(
         &self,
         response: reqwest::Response,
-    ) -> Result<R, ExecServerError>
-    where
-        R: for<'de> Deserialize<'de>,
-    {
+    ) -> Result<EnvironmentRegistryRegistrationResponse, EnvironmentRegistrationError> {
         if response.status().is_success() {
-            return response.json::<R>().await.map_err(ExecServerError::from);
+            let body = response.bytes().await.map_err(|error| {
+                EnvironmentRegistrationError::Retryable {
+                    source: error.into(),
+                    retry_after: None,
+                }
+            })?;
+            let response = serde_json::from_slice(&body).map_err(|error| {
+                EnvironmentRegistrationError::Permanent {
+                    source: error.into(),
+                }
+            })?;
+            return validate_registration_response(response)
+                .map_err(|source| EnvironmentRegistrationError::Permanent { source });
         }
 
         let status = response.status();
-        let body = response.text().await.unwrap_or_default();
+        let retry_after = response
+            .headers()
+            .get(RETRY_AFTER)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.parse::<u64>().ok())
+            .map(Duration::from_secs);
+        let body =
+            response
+                .bytes()
+                .await
+                .map_err(|error| EnvironmentRegistrationError::Retryable {
+                    source: error.into(),
+                    retry_after,
+                })?;
+        let body = String::from_utf8_lossy(&body);
         if matches!(status, StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN) {
-            return Err(environment_registry_auth_error(status, &body));
+            return Err(EnvironmentRegistrationError::Permanent {
+                source: environment_registry_auth_error(status, body.as_ref()),
+            });
         }
 
-        Err(environment_registry_http_error(status, &body))
+        let source = environment_registry_http_error(status, body.as_ref());
+        let ExecServerError::EnvironmentRegistryHttp { code, .. } = &source else {
+            unreachable!("environment registry HTTP errors use the HTTP error variant");
+        };
+        if is_retryable_registration_status(status, code.as_deref()) {
+            Err(EnvironmentRegistrationError::Retryable {
+                source,
+                retry_after,
+            })
+        } else {
+            Err(EnvironmentRegistrationError::Permanent { source })
+        }
+    }
+}
+
+#[derive(Debug)]
+enum EnvironmentRegistrationError {
+    Retryable {
+        source: ExecServerError,
+        retry_after: Option<Duration>,
+    },
+    Permanent {
+        source: ExecServerError,
+    },
+}
+
+#[derive(Default)]
+struct ReconnectBackoff {
+    attempt: u64,
+}
+
+impl ReconnectBackoff {
+    fn reset(&mut self) {
+        self.attempt = 0;
+    }
+
+    fn next_delay(&mut self, retry_after: Option<Duration>) -> Duration {
+        self.attempt = self.attempt.saturating_add(1);
+        let jittered_backoff = backoff(INITIAL_RECONNECT_BACKOFF, self.attempt);
+        retry_after
+            .map_or(jittered_backoff, |retry_after| {
+                retry_after.max(jittered_backoff)
+            })
+            .min(MAX_RECONNECT_BACKOFF)
     }
 }
 
@@ -85,6 +179,28 @@ impl EnvironmentRegistryClient {
 struct EnvironmentRegistryRegistrationResponse {
     environment_id: String,
     url: String,
+}
+
+fn validate_registration_response(
+    response: EnvironmentRegistryRegistrationResponse,
+) -> Result<EnvironmentRegistryRegistrationResponse, ExecServerError> {
+    if response.environment_id.trim().is_empty() {
+        return Err(ExecServerError::Protocol(
+            "environment registry returned an empty environment id".to_string(),
+        ));
+    }
+    let valid_websocket_url = response
+        .url
+        .as_str()
+        .into_client_request()
+        .and_then(|request| uri_mode(request.uri()).map(|_| ()))
+        .is_ok();
+    if !valid_websocket_url {
+        return Err(ExecServerError::Protocol(
+            "environment registry returned an invalid rendezvous websocket URL".to_string(),
+        ));
+    }
+    Ok(response)
 }
 
 /// Configuration for registering an exec-server for remote use.
@@ -133,28 +249,62 @@ pub async fn run_remote_environment(
     let client =
         EnvironmentRegistryClient::new(config.base_url.clone(), config.auth_provider.clone())?;
     let processor = ConnectionProcessor::new(runtime_paths);
-    let mut backoff = Duration::from_secs(1);
+    let mut reconnect_backoff = ReconnectBackoff::default();
 
     loop {
-        let response = client.register_environment(&config.environment_id).await?;
-        eprintln!(
-            "codex exec-server remote environment registered with environment_id {}",
-            response.environment_id
-        );
+        let retry_after = match client.register_environment(&config.environment_id).await {
+            Ok(response) => {
+                eprintln!(
+                    "codex exec-server remote environment registered with environment_id {}",
+                    response.environment_id
+                );
 
-        match connect_async(response.url.as_str()).await {
-            Ok((websocket, _)) => {
-                backoff = Duration::from_secs(1);
-                run_multiplexed_environment(websocket, processor.clone()).await;
+                match timeout(
+                    RENDEZVOUS_CONNECT_TIMEOUT,
+                    connect_async(response.url.as_str()),
+                )
+                .await
+                {
+                    Ok(Ok((websocket, _))) => {
+                        let connected_at = Instant::now();
+                        run_multiplexed_environment(websocket, processor.clone()).await;
+                        if connected_at.elapsed() >= STABLE_CONNECTION_DURATION {
+                            reconnect_backoff.reset();
+                        }
+                    }
+                    Ok(Err(error)) => {
+                        warn!("failed to connect remote exec-server websocket: {error}");
+                    }
+                    Err(_) => warn!(
+                        "timed out connecting remote exec-server websocket after {:?}",
+                        RENDEZVOUS_CONNECT_TIMEOUT
+                    ),
+                }
+                None
             }
-            Err(err) => {
-                warn!("failed to connect remote exec-server websocket: {err}");
+            Err(EnvironmentRegistrationError::Retryable {
+                source,
+                retry_after,
+            }) => {
+                warn!(error = %source, "failed to register remote exec-server environment");
+                retry_after
             }
-        }
+            Err(EnvironmentRegistrationError::Permanent { source }) => {
+                return Err(source);
+            }
+        };
 
-        sleep(backoff).await;
-        backoff = (backoff * 2).min(Duration::from_secs(30));
+        sleep(reconnect_backoff.next_delay(retry_after)).await;
     }
+}
+
+fn is_retryable_registration_status(status: StatusCode, code: Option<&str>) -> bool {
+    status.is_server_error()
+        || matches!(
+            status,
+            StatusCode::REQUEST_TIMEOUT | StatusCode::TOO_MANY_REQUESTS
+        )
+        || (status == StatusCode::CONFLICT && code == Some("route_unavailable"))
 }
 
 fn normalize_environment_id(environment_id: String) -> Result<String, ExecServerError> {
@@ -249,6 +399,8 @@ mod tests {
     use http::HeaderMap;
     use http::HeaderValue;
     use pretty_assertions::assert_eq;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
     use wiremock::Mock;
     use wiremock::MockServer;
     use wiremock::ResponseTemplate;
@@ -340,12 +492,234 @@ mod tests {
             .await
             .expect_err("redirect response should not be followed");
 
-        assert!(matches!(
-            error,
-            ExecServerError::EnvironmentRegistryHttp {
-                status: StatusCode::FOUND,
-                ..
-            }
+        match error {
+            EnvironmentRegistrationError::Permanent {
+                source:
+                    ExecServerError::EnvironmentRegistryHttp {
+                        status: StatusCode::FOUND,
+                        ..
+                    },
+            } => {}
+            other => panic!("expected permanent redirect error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn register_environment_classifies_server_errors_as_retryable() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/cloud/environment/environment-requested/register"))
+            .respond_with(
+                ResponseTemplate::new(StatusCode::SERVICE_UNAVAILABLE)
+                    .insert_header("retry-after", "7"),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let client = EnvironmentRegistryClient::new(server.uri(), static_registry_auth_provider())
+            .expect("client");
+
+        let error = client
+            .register_environment("environment-requested")
+            .await
+            .expect_err("server error should be retryable");
+
+        match error {
+            EnvironmentRegistrationError::Retryable {
+                source:
+                    ExecServerError::EnvironmentRegistryHttp {
+                        status: StatusCode::SERVICE_UNAVAILABLE,
+                        ..
+                    },
+                retry_after: Some(retry_after),
+            } => assert_eq!(retry_after, Duration::from_secs(7)),
+            other => panic!("expected retryable server error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn register_environment_treats_malformed_success_as_permanent() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/cloud/environment/environment-requested/register"))
+            .respond_with(ResponseTemplate::new(StatusCode::OK).set_body_string("not json"))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let client = EnvironmentRegistryClient::new(server.uri(), static_registry_auth_provider())
+            .expect("client");
+
+        let error = client
+            .register_environment("environment-requested")
+            .await
+            .expect_err("malformed success should fail permanently");
+
+        match error {
+            EnvironmentRegistrationError::Permanent {
+                source: ExecServerError::Json(_),
+            } => {}
+            other => panic!("expected permanent decode error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn register_environment_retries_truncated_success_body() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let address = listener.local_addr().expect("listener should have address");
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("listener should accept");
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: 512\r\nconnection: close\r\n\r\n{\"environment_id\":\"env-1\"",
+                )
+                .await
+                .expect("partial response should write");
+        });
+        let client = EnvironmentRegistryClient::new(
+            format!("http://{address}"),
+            static_registry_auth_provider(),
+        )
+        .expect("client");
+
+        let error = client
+            .register_environment("environment-requested")
+            .await
+            .expect_err("truncated success body should be retryable");
+
+        match error {
+            EnvironmentRegistrationError::Retryable {
+                source: ExecServerError::EnvironmentRegistryRequest(_),
+                retry_after: None,
+            } => {}
+            other => panic!("expected retryable body error, got {other:?}"),
+        }
+        server.await.expect("server task should finish");
+    }
+
+    #[tokio::test]
+    async fn register_environment_retries_truncated_error_body() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let address = listener.local_addr().expect("listener should have address");
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("listener should accept");
+            stream
+                .write_all(
+                    b"HTTP/1.1 409 Conflict\r\ncontent-type: application/json\r\ncontent-length: 512\r\nretry-after: 7\r\nconnection: close\r\n\r\n{\"error\":{\"code\":\"route_unavailable\"",
+                )
+                .await
+                .expect("partial response should write");
+        });
+        let client = EnvironmentRegistryClient::new(
+            format!("http://{address}"),
+            static_registry_auth_provider(),
+        )
+        .expect("client");
+
+        let error = client
+            .register_environment("environment-requested")
+            .await
+            .expect_err("truncated error body should be retryable");
+
+        match error {
+            EnvironmentRegistrationError::Retryable {
+                source: ExecServerError::EnvironmentRegistryRequest(_),
+                retry_after: Some(retry_after),
+            } => assert_eq!(retry_after, Duration::from_secs(7)),
+            other => panic!("expected retryable body error, got {other:?}"),
+        }
+        server.await.expect("server task should finish");
+    }
+
+    #[tokio::test]
+    async fn register_environment_rejects_url_that_websocket_client_cannot_parse() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/cloud/environment/environment-requested/register"))
+            .respond_with(
+                ResponseTemplate::new(StatusCode::OK).set_body_json(serde_json::json!({
+                    "environment_id": "env-1",
+                    "url": "ws://rendezvous.test/environment with space",
+                })),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        let client = EnvironmentRegistryClient::new(server.uri(), static_registry_auth_provider())
+            .expect("client");
+
+        let error = client
+            .register_environment("environment-requested")
+            .await
+            .expect_err("invalid websocket URL should fail permanently");
+
+        match error {
+            EnvironmentRegistrationError::Permanent {
+                source: ExecServerError::Protocol(message),
+            } => assert_eq!(
+                message,
+                "environment registry returned an invalid rendezvous websocket URL"
+            ),
+            other => panic!("expected permanent URL error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reconnect_backoff_owns_one_advancing_sequence() {
+        let mut reconnect_backoff = ReconnectBackoff::default();
+
+        let first_delay = reconnect_backoff.next_delay(/*retry_after*/ None);
+        assert!(first_delay >= Duration::from_millis(900));
+        assert!(first_delay <= Duration::from_millis(1_100));
+        let second_delay = reconnect_backoff.next_delay(/*retry_after*/ None);
+        assert!(second_delay >= Duration::from_millis(1_800));
+        assert!(second_delay <= Duration::from_millis(2_200));
+
+        reconnect_backoff.reset();
+        assert_eq!(
+            reconnect_backoff.next_delay(Some(Duration::from_secs(10))),
+            Duration::from_secs(10)
+        );
+        assert_eq!(
+            reconnect_backoff.next_delay(Some(Duration::from_secs(60))),
+            MAX_RECONNECT_BACKOFF
+        );
+        reconnect_backoff.reset();
+        let reset_delay = reconnect_backoff.next_delay(/*retry_after*/ None);
+        assert!(reset_delay >= Duration::from_millis(900));
+        assert!(reset_delay <= Duration::from_millis(1_100));
+    }
+
+    #[test]
+    fn registration_retryability_distinguishes_transient_and_permanent_statuses() {
+        for status in [
+            StatusCode::REQUEST_TIMEOUT,
+            StatusCode::TOO_MANY_REQUESTS,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            StatusCode::SERVICE_UNAVAILABLE,
+        ] {
+            assert!(is_retryable_registration_status(status, /*code*/ None));
+        }
+        assert!(is_retryable_registration_status(
+            StatusCode::CONFLICT,
+            Some("route_unavailable")
+        ));
+
+        for status in [StatusCode::BAD_REQUEST, StatusCode::NOT_FOUND] {
+            assert!(!is_retryable_registration_status(
+                status, /*code*/ None
+            ));
+        }
+        assert!(!is_retryable_registration_status(
+            StatusCode::CONFLICT,
+            Some("permanent_conflict")
+        ));
+        assert!(!is_retryable_registration_status(
+            StatusCode::UNAUTHORIZED,
+            /*code*/ None
         ));
     }
 


### PR DESCRIPTION
## Summary

- retry transient Environment Registry Service registration failures
- honor `Retry-After` as a bounded floor and add deterministic per-environment jitter
- bound ERS HTTP requests and rendezvous WebSocket connection attempts
- retain elevated backoff after brief connections and reset it after a stable connection
- disable redirects so registration credentials are never forwarded to another origin

## Why

Remote environment exec-servers exited when ERS or rendezvous was temporarily unavailable. This made topology changes and pod draining unsafe because a transient `409 route_unavailable`, `429`, or server error required an external process restart.

## Impact

Remote environments now re-register until transient failures recover. Authentication errors and other permanent client errors still fail immediately. Reconnect attempts are bounded and spread across environments to avoid synchronized retry spikes.

## Validation

- `just test -p codex-exec-server register_environment`
- `just test -p codex-exec-server retry_after_is_a_bounded_floor_on_jittered_backoff`
- `just fix -p codex-exec-server`
- `just fmt`
- `git diff --check`
