### PR TITLE
[codex] Outline MCP ToolExecutor handlers

### DIFF
--- a/codex-rs/core/src/tools/handlers/apply_patch.rs
+++ b/codex-rs/core/src/tools/handlers/apply_patch.rs
@@ -319,6 +319,15 @@ impl ToolExecutor<ToolInvocation> for ApplyPatchHandler {
         &self,
         invocation: ToolInvocation,
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
+        self.handle_call(invocation).await
+    }
+}
+
+impl ApplyPatchHandler {
+    async fn handle_call(
+        &self,
+        invocation: ToolInvocation,
+    ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
             turn,

--- a/codex-rs/core/src/tools/handlers/mcp.rs
+++ b/codex-rs/core/src/tools/handlers/mcp.rs
@@ -117,6 +117,15 @@ impl ToolExecutor<ToolInvocation> for McpHandler {
         &self,
         invocation: ToolInvocation,
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
+        self.handle_call(invocation).await
+    }
+}
+
+impl McpHandler {
+    async fn handle_call(
+        &self,
+        invocation: ToolInvocation,
+    ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
             turn,

--- a/codex-rs/core/src/tools/handlers/mcp_resource/list_mcp_resource_templates.rs
+++ b/codex-rs/core/src/tools/handlers/mcp_resource/list_mcp_resource_templates.rs
@@ -40,11 +40,20 @@ impl ToolExecutor<ToolInvocation> for ListMcpResourceTemplatesHandler {
         true
     }
 
+    async fn handle(
+        &self,
+        invocation: ToolInvocation,
+    ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
+        self.handle_call(invocation).await
+    }
+}
+
+impl ListMcpResourceTemplatesHandler {
     #[expect(
         clippy::await_holding_invalid_type,
         reason = "MCP resource template listing reads through the session-owned manager guard"
     )]
-    async fn handle(
+    async fn handle_call(
         &self,
         invocation: ToolInvocation,
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {

--- a/codex-rs/core/src/tools/handlers/mcp_resource/list_mcp_resources.rs
+++ b/codex-rs/core/src/tools/handlers/mcp_resource/list_mcp_resources.rs
@@ -40,11 +40,20 @@ impl ToolExecutor<ToolInvocation> for ListMcpResourcesHandler {
         true
     }
 
+    async fn handle(
+        &self,
+        invocation: ToolInvocation,
+    ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
+        self.handle_call(invocation).await
+    }
+}
+
+impl ListMcpResourcesHandler {
     #[expect(
         clippy::await_holding_invalid_type,
         reason = "MCP resource listing reads through the session-owned manager guard"
     )]
-    async fn handle(
+    async fn handle_call(
         &self,
         invocation: ToolInvocation,
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {

--- a/codex-rs/core/src/tools/handlers/mcp_resource/read_mcp_resource.rs
+++ b/codex-rs/core/src/tools/handlers/mcp_resource/read_mcp_resource.rs
@@ -44,6 +44,15 @@ impl ToolExecutor<ToolInvocation> for ReadMcpResourceHandler {
         &self,
         invocation: ToolInvocation,
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
+        self.handle_call(invocation).await
+    }
+}
+
+impl ReadMcpResourceHandler {
+    async fn handle_call(
+        &self,
+        invocation: ToolInvocation,
+    ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
             turn,

--- a/codex-rs/core/src/tools/handlers/request_plugin_install.rs
+++ b/codex-rs/core/src/tools/handlers/request_plugin_install.rs
@@ -66,6 +66,15 @@ impl ToolExecutor<ToolInvocation> for RequestPluginInstallHandler {
         &self,
         invocation: ToolInvocation,
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
+        self.handle_call(invocation).await
+    }
+}
+
+impl RequestPluginInstallHandler {
+    async fn handle_call(
+        &self,
+        invocation: ToolInvocation,
+    ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             payload,
             session,

--- a/codex-rs/core/src/tools/handlers/unified_exec/exec_command.rs
+++ b/codex-rs/core/src/tools/handlers/unified_exec/exec_command.rs
@@ -96,6 +96,15 @@ impl ToolExecutor<ToolInvocation> for ExecCommandHandler {
         &self,
         invocation: ToolInvocation,
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
+        self.handle_call(invocation).await
+    }
+}
+
+impl ExecCommandHandler {
+    async fn handle_call(
+        &self,
+        invocation: ToolInvocation,
+    ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
             turn,

--- a/codex-rs/core/src/tools/handlers/view_image.rs
+++ b/codex-rs/core/src/tools/handlers/view_image.rs
@@ -82,6 +82,15 @@ impl ToolExecutor<ToolInvocation> for ViewImageHandler {
         &self,
         invocation: ToolInvocation,
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
+        self.handle_call(invocation).await
+    }
+}
+
+impl ViewImageHandler {
+    async fn handle_call(
+        &self,
+        invocation: ToolInvocation,
+    ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         if !invocation
             .turn
             .model_info


### PR DESCRIPTION
## Why

`ToolExecutor`'s `async_trait` usage is a significant contributor to slow debug builds for `codex-core` unit tests. Removing it makes those builds materially faster, but the direct trait flip is easier to review once large handler bodies are outside `ToolExecutor::handle`.

Stacked on #27299, this PR continues that behavior-preserving preparation for MCP handlers.

## What Changed

Outlined the existing `ToolExecutor::handle` bodies into inherent async `handle_call` methods for `McpHandler`, `ListMcpResourcesHandler`, `ListMcpResourceTemplatesHandler`, and `ReadMcpResourceHandler`.

The trait methods still use `async_trait` and now just delegate to `self.handle_call(invocation).await`.

## Validation

No new tests; this is a behavior-preserving refactor.