### PR TITLE
[codex] Outline remaining core ToolExecutor handlers

### DIFF
--- a/codex-rs/core/src/tools/code_mode/execute_handler.rs
+++ b/codex-rs/core/src/tools/code_mode/execute_handler.rs
@@ -105,6 +105,15 @@ impl ToolExecutor<ToolInvocation> for CodeModeExecuteHandler {
         &self,
         invocation: ToolInvocation,
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
+        self.handle_call(invocation).await
+    }
+}
+
+impl CodeModeExecuteHandler {
+    async fn handle_call(
+        &self,
+        invocation: ToolInvocation,
+    ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
             turn,

--- a/codex-rs/core/src/tools/code_mode/wait_handler.rs
+++ b/codex-rs/core/src/tools/code_mode/wait_handler.rs
@@ -58,6 +58,15 @@ impl ToolExecutor<ToolInvocation> for CodeModeWaitHandler {
         &self,
         invocation: ToolInvocation,
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
+        self.handle_call(invocation).await
+    }
+}
+
+impl CodeModeWaitHandler {
+    async fn handle_call(
+        &self,
+        invocation: ToolInvocation,
+    ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
             turn,

--- a/codex-rs/core/src/tools/handlers/dynamic.rs
+++ b/codex-rs/core/src/tools/handlers/dynamic.rs
@@ -90,6 +90,15 @@ impl ToolExecutor<ToolInvocation> for DynamicToolHandler {
         &self,
         invocation: ToolInvocation,
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
+        self.handle_call(invocation).await
+    }
+}
+
+impl DynamicToolHandler {
+    async fn handle_call(
+        &self,
+        invocation: ToolInvocation,
+    ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
             turn,

--- a/codex-rs/core/src/tools/handlers/list_available_plugins_to_install.rs
+++ b/codex-rs/core/src/tools/handlers/list_available_plugins_to_install.rs
@@ -72,6 +72,15 @@ impl ToolExecutor<ToolInvocation> for ListAvailablePluginsToInstallHandler {
         &self,
         invocation: ToolInvocation,
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
+        self.handle_call(invocation).await
+    }
+}
+
+impl ListAvailablePluginsToInstallHandler {
+    async fn handle_call(
+        &self,
+        invocation: ToolInvocation,
+    ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation { payload, .. } = invocation;
         match payload {
             ToolPayload::Function { .. } => {}

--- a/codex-rs/core/src/tools/handlers/plan.rs
+++ b/codex-rs/core/src/tools/handlers/plan.rs
@@ -59,6 +59,15 @@ impl ToolExecutor<ToolInvocation> for PlanHandler {
         &self,
         invocation: ToolInvocation,
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
+        self.handle_call(invocation).await
+    }
+}
+
+impl PlanHandler {
+    async fn handle_call(
+        &self,
+        invocation: ToolInvocation,
+    ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
             turn,

--- a/codex-rs/core/src/tools/handlers/request_permissions.rs
+++ b/codex-rs/core/src/tools/handlers/request_permissions.rs
@@ -39,6 +39,15 @@ impl ToolExecutor<ToolInvocation> for RequestPermissionsHandler {
         &self,
         invocation: ToolInvocation,
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
+        self.handle_call(invocation).await
+    }
+}
+
+impl RequestPermissionsHandler {
+    async fn handle_call(
+        &self,
+        invocation: ToolInvocation,
+    ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
             turn,

--- a/codex-rs/core/src/tools/handlers/request_user_input.rs
+++ b/codex-rs/core/src/tools/handlers/request_user_input.rs
@@ -34,6 +34,15 @@ impl ToolExecutor<ToolInvocation> for RequestUserInputHandler {
         &self,
         invocation: ToolInvocation,
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
+        self.handle_call(invocation).await
+    }
+}
+
+impl RequestUserInputHandler {
+    async fn handle_call(
+        &self,
+        invocation: ToolInvocation,
+    ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
             turn,

--- a/codex-rs/core/src/tools/handlers/shell/shell_command.rs
+++ b/codex-rs/core/src/tools/handlers/shell/shell_command.rs
@@ -145,6 +145,15 @@ impl ToolExecutor<ToolInvocation> for ShellCommandHandler {
         &self,
         invocation: ToolInvocation,
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
+        self.handle_call(invocation).await
+    }
+}
+
+impl ShellCommandHandler {
+    async fn handle_call(
+        &self,
+        invocation: ToolInvocation,
+    ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
             turn,

--- a/codex-rs/core/src/tools/handlers/test_sync.rs
+++ b/codex-rs/core/src/tools/handlers/test_sync.rs
@@ -75,6 +75,15 @@ impl ToolExecutor<ToolInvocation> for TestSyncHandler {
         &self,
         invocation: ToolInvocation,
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
+        self.handle_call(invocation).await
+    }
+}
+
+impl TestSyncHandler {
+    async fn handle_call(
+        &self,
+        invocation: ToolInvocation,
+    ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation { payload, .. } = invocation;
 
         let arguments = match payload {

--- a/codex-rs/core/src/tools/handlers/tool_search.rs
+++ b/codex-rs/core/src/tools/handlers/tool_search.rs
@@ -71,6 +71,15 @@ impl ToolExecutor<ToolInvocation> for ToolSearchHandler {
         &self,
         invocation: ToolInvocation,
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
+        self.handle_call(invocation).await
+    }
+}
+
+impl ToolSearchHandler {
+    async fn handle_call(
+        &self,
+        invocation: ToolInvocation,
+    ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation { payload, .. } = invocation;
 
         let args = match payload {

--- a/codex-rs/core/src/tools/handlers/unified_exec/write_stdin.rs
+++ b/codex-rs/core/src/tools/handlers/unified_exec/write_stdin.rs
@@ -45,6 +45,15 @@ impl ToolExecutor<ToolInvocation> for WriteStdinHandler {
         &self,
         invocation: ToolInvocation,
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
+        self.handle_call(invocation).await
+    }
+}
+
+impl WriteStdinHandler {
+    async fn handle_call(
+        &self,
+        invocation: ToolInvocation,
+    ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
             turn,


### PR DESCRIPTION
## Why

`ToolExecutor`'s `async_trait` usage is a significant contributor to slow debug builds for `codex-core` unit tests. Removing it makes those builds materially faster, but the direct trait flip is easier to review once large handler bodies are outside `ToolExecutor::handle`.

Stacked on #27301, this PR finishes the behavior-preserving core handler preparation before the trait change.

## What Changed

Outlined the existing `ToolExecutor::handle` bodies into inherent async `handle_call` methods for the remaining core handlers that still contained substantial trait-method bodies, including code mode, dynamic, plan, permission, tool search, shell, test-sync, list-install, request-user-input, and write-stdin handlers.

The trait methods still use `async_trait` and now just delegate to `self.handle_call(invocation).await`.

## Validation

No new tests; this is a behavior-preserving refactor.