### PR TITLE
[codex] Outline extension ToolExecutor handlers

### DIFF
--- a/codex-rs/ext/image-generation/src/tool.rs
+++ b/codex-rs/ext/image-generation/src/tool.rs
@@ -97,6 +97,12 @@ impl ToolExecutor<ToolCall> for ImageGenerationTool {
 
     /// Executes the selected image operation and returns the completed image result.
     async fn handle(&self, call: ToolCall) -> Result<Box<dyn ToolOutput>, FunctionCallError> {
+        self.handle_call(call).await
+    }
+}
+
+impl ImageGenerationTool {
+    async fn handle_call(&self, call: ToolCall) -> Result<Box<dyn ToolOutput>, FunctionCallError> {
         let args = parse_args(&call)?;
         let request = request_for_args(&args, call.conversation_history.items())?;
         call.turn_item_emitter

--- a/codex-rs/ext/memories/src/tools/ad_hoc_note.rs
+++ b/codex-rs/ext/memories/src/tools/ad_hoc_note.rs
@@ -62,6 +62,19 @@ where
         call: ToolCall,
     ) -> Result<Box<dyn codex_extension_api::ToolOutput>, codex_extension_api::FunctionCallError>
     {
+        self.handle_call(call).await
+    }
+}
+
+impl<B> AddAdHocNoteTool<B>
+where
+    B: MemoriesBackend,
+{
+    async fn handle_call(
+        &self,
+        call: ToolCall,
+    ) -> Result<Box<dyn codex_extension_api::ToolOutput>, codex_extension_api::FunctionCallError>
+    {
         let backend = self.backend.clone();
         let args: AddAdHocNoteArgs = parse_args(&call)?;
         let response = backend

--- a/codex-rs/ext/memories/src/tools/list.rs
+++ b/codex-rs/ext/memories/src/tools/list.rs
@@ -60,6 +60,19 @@ where
         call: ToolCall,
     ) -> Result<Box<dyn codex_extension_api::ToolOutput>, codex_extension_api::FunctionCallError>
     {
+        self.handle_call(call).await
+    }
+}
+
+impl<B> ListTool<B>
+where
+    B: MemoriesBackend,
+{
+    async fn handle_call(
+        &self,
+        call: ToolCall,
+    ) -> Result<Box<dyn codex_extension_api::ToolOutput>, codex_extension_api::FunctionCallError>
+    {
         let backend = self.backend.clone();
         let args: ListArgs = parse_args(&call)?;
         let scope = scope_from_optional_path(args.path.as_deref(), "root");

--- a/codex-rs/ext/memories/src/tools/read.rs
+++ b/codex-rs/ext/memories/src/tools/read.rs
@@ -59,6 +59,19 @@ where
         call: ToolCall,
     ) -> Result<Box<dyn codex_extension_api::ToolOutput>, codex_extension_api::FunctionCallError>
     {
+        self.handle_call(call).await
+    }
+}
+
+impl<B> ReadTool<B>
+where
+    B: MemoriesBackend,
+{
+    async fn handle_call(
+        &self,
+        call: ToolCall,
+    ) -> Result<Box<dyn codex_extension_api::ToolOutput>, codex_extension_api::FunctionCallError>
+    {
         let backend = self.backend.clone();
         let args: ReadArgs = parse_args(&call)?;
         let path = args.path;

--- a/codex-rs/ext/memories/src/tools/search.rs
+++ b/codex-rs/ext/memories/src/tools/search.rs
@@ -68,6 +68,19 @@ where
         call: ToolCall,
     ) -> Result<Box<dyn codex_extension_api::ToolOutput>, codex_extension_api::FunctionCallError>
     {
+        self.handle_call(call).await
+    }
+}
+
+impl<B> SearchTool<B>
+where
+    B: MemoriesBackend,
+{
+    async fn handle_call(
+        &self,
+        call: ToolCall,
+    ) -> Result<Box<dyn codex_extension_api::ToolOutput>, codex_extension_api::FunctionCallError>
+    {
         let backend = self.backend.clone();
         let args: SearchArgs = parse_args(&call)?;
         let scope = scope_from_optional_path(args.path.as_deref(), "all");

--- a/codex-rs/ext/web-search/src/tool.rs
+++ b/codex-rs/ext/web-search/src/tool.rs
@@ -75,6 +75,12 @@ impl ToolExecutor<ToolCall> for WebSearchTool {
     }
 
     async fn handle(&self, call: ToolCall) -> Result<Box<dyn ToolOutput>, FunctionCallError> {
+        self.handle_call(call).await
+    }
+}
+
+impl WebSearchTool {
+    async fn handle_call(&self, call: ToolCall) -> Result<Box<dyn ToolOutput>, FunctionCallError> {
         let commands = parse_commands(&call)?;
         let command_action = command_action(&commands);
         let provider = self


### PR DESCRIPTION
## Why

`ToolExecutor`'s `async_trait` usage is a significant contributor to slow debug builds for `codex-core` unit tests. Removing it makes those builds materially faster, but the direct trait flip is easier to review once large handler bodies are outside `ToolExecutor::handle`.

Stacked on #27302, this PR finishes the behavior-preserving handler preparation in extension crates before the trait change.

## What Changed

Outlined the existing `ToolExecutor::handle` bodies into inherent async `handle_call` methods for image generation, memories, and web search extension tools.

The trait methods still use `async_trait` and now just delegate to `self.handle_call(call).await`.

## Validation

No new tests; this is a behavior-preserving refactor.