### PR TITLE
[codex] link Windows releases with LLD

### DIFF
--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -89,6 +89,11 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Configure LLVM linker
+        uses: ./.github/actions/setup-msvc-env
+        with:
+          target: ${{ matrix.target }}
+
       - name: Cargo build (Windows binaries)
         shell: bash
         run: |


### PR DESCRIPTION
Windows x64 release builds spend about 36.5 of 48 minutes in final
LLVM code generation and MSVC linking. Use the existing target-aware MSVC
setup action to select LLD for release builds; the Windows ARM64 archive
path already exercises the action and its LLD wrapper.

In https://github.com/openai/codex/actions/runs/27242495616, macOS becomes
the critical path after roughly four minutes of Windows improvement, so
this is expected to reduce total workflow time by about four minutes.