### PR TITLE
[codex] Move release platform rules into bazel package

### DIFF
--- a/bazel/platforms/BUILD.bazel
+++ b/bazel/platforms/BUILD.bazel
@@ -1,0 +1,1 @@
+# Release platform rules live in this package.

--- a/bazel/platforms/release_binaries.bzl
+++ b/bazel/platforms/release_binaries.bzl
@@ -1,0 +1,27 @@
+"""Rules for building release binaries across supported target platforms."""
+
+load("@rules_platform//platform_data:defs.bzl", "platform_data")
+
+PLATFORMS = [
+    "linux_arm64_musl",
+    "linux_amd64_musl",
+    "macos_amd64",
+    "macos_arm64",
+    "windows_amd64",
+    "windows_arm64",
+]
+
+def multiplatform_binaries(name, platforms = PLATFORMS):
+    for platform in platforms:
+        platform_data(
+            name = name + "_" + platform,
+            platform = "@llvm//platforms:" + platform,
+            target = name,
+            tags = ["manual"],
+        )
+
+    native.filegroup(
+        name = "release_binaries",
+        srcs = [name + "_" + platform for platform in platforms],
+        tags = ["manual"],
+    )

--- a/codex-rs/cli/BUILD.bazel
+++ b/codex-rs/cli/BUILD.bazel
@@ -1,4 +1,5 @@
-load("//:defs.bzl", "MACOS_WEBRTC_RUSTC_LINK_FLAGS", "codex_rust_crate", "multiplatform_binaries")
+load("//:defs.bzl", "MACOS_WEBRTC_RUSTC_LINK_FLAGS", "codex_rust_crate")
+load("//bazel/platforms:release_binaries.bzl", "multiplatform_binaries")
 
 codex_rust_crate(
     name = "cli",

--- a/defs.bzl
+++ b/defs.bzl
@@ -1,17 +1,7 @@
 load("@crates//:data.bzl", "DEP_DATA")
 load("@crates//:defs.bzl", "all_crate_deps")
-load("@rules_platform//platform_data:defs.bzl", "platform_data")
 load("@rules_rust//cargo/private:cargo_build_script_wrapper.bzl", "cargo_build_script")
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_proc_macro", "rust_test")
-
-PLATFORMS = [
-    "linux_arm64_musl",
-    "linux_amd64_musl",
-    "macos_amd64",
-    "macos_arm64",
-    "windows_amd64",
-    "windows_arm64",
-]
 
 # Match Cargo's Windows linker behavior so Bazel-built binaries and tests use
 # the same stack reserve on both Windows ABIs and resolve UCRT imports on MSVC.
@@ -52,21 +42,6 @@ MACOS_WEBRTC_RUSTC_LINK_FLAGS = select({
     ],
     "//conditions:default": [],
 })
-
-def multiplatform_binaries(name, platforms = PLATFORMS):
-    for platform in platforms:
-        platform_data(
-            name = name + "_" + platform,
-            platform = "@llvm//platforms:" + platform,
-            target = name,
-            tags = ["manual"],
-        )
-
-    native.filegroup(
-        name = "release_binaries",
-        srcs = [name + "_" + platform for platform in platforms],
-        tags = ["manual"],
-    )
 
 def _workspace_root_test_impl(ctx):
     is_windows = ctx.target_platform_has_constraint(ctx.attr._windows_constraint[platform_common.ConstraintValueInfo])


### PR DESCRIPTION
## Intent

Keep release-specific Bazel helpers out of the shared Rust crate definitions and colocate them with Bazel platform configuration.

## Implementation

Moves `multiplatform_binaries` and its platform list from `defs.bzl` into `bazel/platforms/release_binaries.bzl` and updates the CLI load site. Behavior is unchanged.

## Validation

- `bazel query //codex-rs/cli:release_binaries`

Stack: 1 of 6.