### PR TITLE
[codex] Preserve build-script dependencies in rules_rs annotations

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -94,6 +94,7 @@ single_version_override(
     module_name = "rules_rs",
     patch_strip = 1,
     patches = [
+        "//patches:rules_rs_build_script_deps_annotation.patch",
         "//patches:rules_rs_windows_gnullvm_exec.patch",
         "//patches:rules_rs_windows_exec_linker.patch",
     ],
@@ -295,6 +296,11 @@ bazel_dep(name = "openssl", version = "3.5.4.bcr.0")
 inject_repo(crate, "xz")
 
 crate.annotation(
+    # Build scripts compile in Bazel's exec configuration, so target-specific
+    # optional build deps are otherwise dropped for the musl release platforms.
+    build_script_deps = [
+        "@crates//:openssl-src-300.5.5+3.5.5",
+    ],
     build_script_data = [
         "@openssl//:gen_dir",
     ],

--- a/patches/BUILD.bazel
+++ b/patches/BUILD.bazel
@@ -14,6 +14,7 @@ exports_files([
     "rules_rust_windows_msvc_direct_link_args.patch",
     "rules_rust_windows_gnullvm_build_script.patch",
     "rules_cc_rusty_v8_custom_libcxx.patch",
+    "rules_rs_build_script_deps_annotation.patch",
     "rules_rs_windows_gnullvm_exec.patch",
     "rules_rs_windows_exec_linker.patch",
     "rusty_v8_prebuilt_out_dir.patch",

--- a/patches/rules_rs_build_script_deps_annotation.patch
+++ b/patches/rules_rs_build_script_deps_annotation.patch
@@ -1,0 +1,60 @@
+# What: expose the existing unconditional build-script dependency input through
+# the `rules_rs` crate annotation API.
+# Scope: annotation plumbing only; generated dependency resolution is unchanged.
+
+diff --git a/rs/extensions.bzl b/rs/extensions.bzl
+--- a/rs/extensions.bzl
++++ b/rs/extensions.bzl
+@@ -737,7 +737,7 @@ def _generate_hub_and_spokes(
+             additive_build_file = annotation.additive_build_file,
+             additive_build_file_content = annotation.additive_build_file_content,
+             gen_build_script = annotation.gen_build_script,
+-            build_script_deps = [],
++            build_script_deps = annotation.build_script_deps,
+             build_script_deps_select = _select(feature_resolutions.build_deps),
+             build_script_data = annotation.build_script_data,
+             build_script_data_select = annotation.build_script_data_select,
+@@ -1417,9 +1417,9 @@ _annotation = tag_class(
+         "build_script_data_select": attr.string_list_dict(
+             doc = "A list of labels to add to a crate's `cargo_build_script::data` attribute. Keys should be the platform triplet. Value should be a list of labels.",
+         ),
+-        # "build_script_deps": _relative_label_list(
+-        #     doc = "A list of labels to add to a crate's `cargo_build_script::deps` attribute.",
+-        # ),
++        "build_script_deps": _relative_label_list(
++            doc = "A list of labels to add to a crate's `cargo_build_script::deps` attribute.",
++        ),
+         "build_script_env": attr.string_dict(
+             doc = "Additional environment variables to set on a crate's `cargo_build_script::env` attribute.",
+         ),
+diff --git a/rs/private/annotations.bzl b/rs/private/annotations.bzl
+--- a/rs/private/annotations.bzl
++++ b/rs/private/annotations.bzl
+@@ -5,6 +5,7 @@ def _crate_annotation(
+         gen_build_script = "auto",
+         build_script_data = [],
+         build_script_data_select = {},
++        build_script_deps = [],
+         build_script_env = {},
+         build_script_env_select = {},
+         build_script_tools = [],
+@@ -28,6 +29,7 @@ def _crate_annotation(
+         gen_build_script = gen_build_script,
+         build_script_data = build_script_data,
+         build_script_data_select = build_script_data_select,
++        build_script_deps = build_script_deps,
+         build_script_env = build_script_env,
+         build_script_env_select = build_script_env_select,
+         build_script_tools = build_script_tools,
+diff --git a/rs/private/repository_utils.bzl b/rs/private/repository_utils.bzl
+--- a/rs/private/repository_utils.bzl
++++ b/rs/private/repository_utils.bzl
+@@ -216,7 +216,7 @@ common_attrs = {
+     "additive_build_file": attr.label(),
+     "additive_build_file_content": attr.string(),
+     "gen_build_script": attr.string(),
+-    "build_script_deps": attr.label_list(default = []),
++    "build_script_deps": attr.string_list(default = []),
+     "build_script_deps_select": attr.string_list_dict(),
+     "build_script_data": attr.label_list(default = []),
+     "build_script_data_select": attr.string_list_dict(),


### PR DESCRIPTION
## Why

Bazel compiles Cargo build scripts in the exec configuration. For `openssl-sys`, that means the target-specific optional `openssl-src` dependency can disappear when producing musl release binaries, even though the build script still needs the vendored source crate.

## What changed

Patch `rules_rs` to expose its existing unconditional `build_script_deps` input through `crate.annotation`, then annotate `openssl-sys` with the pinned `openssl-src` target. Target-derived build dependencies continue to use the existing selected dependency path.

## Validation

- `just bazel-lock-check`

Stack: 2 of 6. Follows #27321.