### PR TITLE
[codex] Provide ARM64 MinGW powl compatibility support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,6 +11,7 @@ single_version_override(
     patch_strip = 1,
     patches = [
         "//patches:llvm_rusty_v8_custom_libcxx.patch",
+        "//patches:llvm_windows_arm64_powl.patch",
         "//patches:llvm_windows_symlink_extract.patch",
     ],
 )

--- a/patches/BUILD.bazel
+++ b/patches/BUILD.bazel
@@ -5,6 +5,7 @@ exports_files([
     "aws-lc-sys_windows_msvc_memcmp_probe.patch",
     "bzip2_windows_stack_args.patch",
     "llvm_rusty_v8_custom_libcxx.patch",
+    "llvm_windows_arm64_powl.patch",
     "llvm_windows_symlink_extract.patch",
     "rules_rust_windows_bootstrap_process_wrapper_linker.patch",
     "rules_rust_windows_build_script_runner_paths.patch",

--- a/patches/llvm_windows_arm64_powl.patch
+++ b/patches/llvm_windows_arm64_powl.patch
@@ -1,0 +1,24 @@
+# What: provide and link MinGW's ARM64 long-double `powl` compatibility shim.
+# Why: Windows ARM64 uses 64-bit long doubles, but LLVM's Bazel source list
+# omits the upstream `powl -> pow` implementation and its default link flags
+# omit the MinGW extension archive that owns the shim.
+
+diff --git a/runtimes/mingw/crt_sources.bzl b/runtimes/mingw/crt_sources.bzl
+--- a/runtimes/mingw/crt_sources.bzl
++++ b/runtimes/mingw/crt_sources.bzl
+@@ -420,4 +420,5 @@
+ MINGWEX_ARM64_SRCS = [
++    "math/arm-common/powl.c",
+     "math/sincos.c",
+     "math/sincosf.c",
+     "math/arm-common/sincosl.c",
+diff --git a/toolchain/args/windows/BUILD.bazel b/toolchain/args/windows/BUILD.bazel
+--- a/toolchain/args/windows/BUILD.bazel
++++ b/toolchain/args/windows/BUILD.bazel
+@@ -49,5 +49,6 @@ cc_args(
++        "-lmingwex",
+         # For now, we force on ucrt.
+         # TODO(cerisier): make this either a constraint or a build setting
+         "-lucrt",
+     ],
+     data = [


### PR DESCRIPTION
## Why

Windows ARM64 uses 64-bit `long double`, but the LLVM MinGW Bazel configuration omits the upstream `powl` compatibility source and does not link the `mingwex` archive that owns it. Cross-linking the release binary therefore fails with an unresolved `powl` symbol.

## What changed

Patch the LLVM module to compile `math/arm-common/powl.c` into the ARM64 MinGW extension sources and add `-lmingwex` to the Windows toolchain defaults.

## Validation

- `just bazel-lock-check`

Stack: 3 of 6. Depends on #27322.