### PR TITLE
[codex] Link compiler builtins into ARM64 musl V8

### DIFF
--- a/third_party/v8/BUILD.bazel
+++ b/third_party/v8/BUILD.bazel
@@ -93,7 +93,7 @@ alias(
         "@rules_rs//rs/experimental/platforms/config:aarch64-pc-windows-gnullvm": ":v8_149_2_0_aarch64_pc_windows_gnullvm",
         "@rules_rs//rs/experimental/platforms/config:aarch64-pc-windows-msvc": ":v8_149_2_0_aarch64_pc_windows_msvc",
         "@rules_rs//rs/experimental/platforms/config:aarch64-unknown-linux-gnu": ":v8_149_2_0_aarch64_unknown_linux_gnu_bazel",
-        ":platform_aarch64_unknown_linux_musl": ":v8_149_2_0_aarch64_unknown_linux_musl_release_base",
+        ":platform_aarch64_unknown_linux_musl": ":v8_149_2_0_aarch64_unknown_linux_musl_release",
         "@rules_rs//rs/experimental/platforms/config:x86_64-apple-darwin": ":v8_149_2_0_x86_64_apple_darwin_bazel",
         "@rules_rs//rs/experimental/platforms/config:x86_64-pc-windows-gnullvm": ":v8_149_2_0_x86_64_pc_windows_gnullvm",
         "@rules_rs//rs/experimental/platforms/config:x86_64-pc-windows-msvc": ":v8_149_2_0_x86_64_pc_windows_msvc",


### PR DESCRIPTION
## Why

The source-built ARM64 musl V8 archive references compiler runtime intrinsics. The target selector currently returns the unmerged base archive, leaving those symbols unresolved when the final release binary links.

## What changed

Point the ARM64 musl target selection at the existing release archive that merges `clang_rt.builtins` with the V8 static library. Other platforms and V8 targets are unchanged.

## Validation

- `bazel query //third_party/v8:rusty_v8_archive_for_target`

The complete ARM64 musl link is exercised by #27326.

Stack: 5 of 6. Depends on #27324.