### PR TITLE
[codex] Build all release targets with Bazel transitions

### DIFF
--- a/bazel/platforms/BUILD.bazel
+++ b/bazel/platforms/BUILD.bazel
@@ -1,1 +1,45 @@
-# Release platform rules live in this package.
+# Only release platforms that need constraints beyond the matching @llvm
+# platform are declared here. Linux adds LLVM's non-PIE constraint, and Windows
+# adds rules_rs's gnullvm ABI constraint. macOS uses @llvm//platforms directly;
+# see release_binaries.bzl.
+platform(
+    name = "linux_arm64_musl",
+    constraint_values = [
+        "@llvm//constraints/libc:musl",
+        "@llvm//constraints/pie:off",
+        "@platforms//cpu:aarch64",
+        "@platforms//os:linux",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+platform(
+    name = "linux_amd64_musl",
+    constraint_values = [
+        "@llvm//constraints/libc:musl",
+        "@llvm//constraints/pie:off",
+        "@platforms//cpu:x86_64",
+        "@platforms//os:linux",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+platform(
+    name = "windows_amd64",
+    constraint_values = [
+        "@platforms//cpu:x86_64",
+        "@platforms//os:windows",
+        "@rules_rs//rs/experimental/platforms/constraints:windows_gnullvm",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+platform(
+    name = "windows_arm64",
+    constraint_values = [
+        "@platforms//cpu:aarch64",
+        "@platforms//os:windows",
+        "@rules_rs//rs/experimental/platforms/constraints:windows_gnullvm",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/platforms/release_binaries.bzl
+++ b/bazel/platforms/release_binaries.bzl
@@ -1,27 +1,101 @@
 """Rules for building release binaries across supported target platforms."""
 
-load("@rules_platform//platform_data:defs.bzl", "platform_data")
+_PLATFORMS = {
+    "linux_arm64_musl": struct(
+        platform = "//bazel/platforms:linux_arm64_musl",
+        v8_target_cpu = "arm64",
+    ),
+    "linux_amd64_musl": struct(
+        platform = "//bazel/platforms:linux_amd64_musl",
+        v8_target_cpu = "x64",
+    ),
+    "macos_amd64": struct(
+        platform = "@llvm//platforms:macos_amd64",
+        v8_target_cpu = "x64",
+    ),
+    "macos_arm64": struct(
+        platform = "@llvm//platforms:macos_arm64",
+        v8_target_cpu = "arm64",
+    ),
+    "windows_amd64": struct(
+        platform = "//bazel/platforms:windows_amd64",
+        v8_target_cpu = "x64",
+    ),
+    "windows_arm64": struct(
+        platform = "//bazel/platforms:windows_arm64",
+        v8_target_cpu = "arm64",
+    ),
+}
 
-PLATFORMS = [
-    "linux_arm64_musl",
-    "linux_amd64_musl",
-    "macos_amd64",
-    "macos_arm64",
-    "windows_amd64",
-    "windows_arm64",
-]
+def _release_binary_transition_impl(_settings, attr):
+    return {
+        "//command_line_option:platforms": str(attr.platform),
+        "@v8//bazel/config:v8_target_cpu": attr.v8_target_cpu,
+    }
 
-def multiplatform_binaries(name, platforms = PLATFORMS):
-    for platform in platforms:
-        platform_data(
-            name = name + "_" + platform,
-            platform = "@llvm//platforms:" + platform,
+_release_binary_transition = transition(
+    implementation = _release_binary_transition_impl,
+    inputs = [],
+    outputs = [
+        "//command_line_option:platforms",
+        "@v8//bazel/config:v8_target_cpu",
+    ],
+)
+
+def _release_binary_impl(ctx):
+    target = ctx.attr.target[0][DefaultInfo]
+    original_executable = target.files_to_run.executable
+    if original_executable == None:
+        fail("{} does not provide an executable".format(ctx.attr.target[0].label))
+
+    executable = ctx.actions.declare_file(ctx.attr.name)
+    ctx.actions.symlink(
+        output = executable,
+        target_file = original_executable,
+        is_executable = True,
+    )
+
+    return [
+        DefaultInfo(
+            executable = executable,
+            files = depset(
+                direct = [executable],
+                transitive = [target.files],
+            ),
+            runfiles = target.default_runfiles.merge(ctx.runfiles([executable])),
+        ),
+    ]
+
+_release_binary = rule(
+    implementation = _release_binary_impl,
+    attrs = {
+        "platform": attr.label(mandatory = True),
+        "target": attr.label(
+            allow_files = False,
+            cfg = _release_binary_transition,
+            executable = True,
+            mandatory = True,
+        ),
+        "v8_target_cpu": attr.string(mandatory = True),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+    executable = True,
+)
+
+def multiplatform_binaries(name, platforms = _PLATFORMS):
+    for platform_name, config in platforms.items():
+        _release_binary(
+            name = name + "_" + platform_name,
+            platform = config.platform,
             target = name,
             tags = ["manual"],
+            v8_target_cpu = config.v8_target_cpu,
         )
 
     native.filegroup(
         name = "release_binaries",
-        srcs = [name + "_" + platform for platform in platforms],
+        srcs = [name + "_" + platform for platform in platforms.keys()],
         tags = ["manual"],
     )


### PR DESCRIPTION
## Why

`just build-for-release` must configure six target binaries from one aggregate target while remote execution is enabled. The previous `platform_data` wrapper only changed the target platform; source-built V8 also needs a matching `v8_target_cpu`, and the release Linux and Windows targets require constraints not present on the corresponding upstream LLVM platforms.

## What changed

Replace the wrapper with a transition-based executable rule that sets both `//command_line_option:platforms` and V8’s target CPU for each binary. Add local Linux musl platforms with non-PIE constraints and Windows platforms with the `windows_gnullvm` ABI constraint. The macOS targets continue to use the upstream LLVM platforms directly.

The aggregate target still exposes the six named release artifacts through `//codex-rs/cli:release_binaries`.

## Validation

- `just build-for-release`

Stack: 6 of 6. Depends on #27325.