### PR TITLE
Add managed Guardian fail-open config

### DIFF
--- a/codex-rs/config/src/config_requirements.rs
+++ b/codex-rs/config/src/config_requirements.rs
@@ -149,6 +149,7 @@ pub struct ConfigRequirements {
     pub web_search_mode: ConstrainedWithSource<WebSearchMode>,
     pub allow_managed_hooks_only: Option<Sourced<bool>>,
     pub allow_appshots: Option<Sourced<bool>>,
+    pub allow_guardian_fail_open: Option<Sourced<bool>>,
     pub computer_use: Option<Sourced<ComputerUseRequirementsToml>>,
     pub feature_requirements: Option<Sourced<FeatureRequirementsToml>>,
     pub managed_hooks: Option<ConstrainedWithSource<ManagedHooksRequirementsToml>>,
@@ -189,6 +190,7 @@ impl Default for ConfigRequirements {
             ),
             allow_managed_hooks_only: None,
             allow_appshots: None,
+            allow_guardian_fail_open: None,
             computer_use: None,
             feature_requirements: None,
             managed_hooks: None,
@@ -828,6 +830,7 @@ pub struct ConfigRequirementsToml {
     pub allowed_web_search_modes: Option<Vec<WebSearchModeRequirement>>,
     pub allow_managed_hooks_only: Option<bool>,
     pub allow_appshots: Option<bool>,
+    pub allow_guardian_fail_open: Option<bool>,
     pub computer_use: Option<ComputerUseRequirementsToml>,
     pub windows: Option<WindowsRequirementsToml>,
     #[serde(rename = "features", alias = "feature_requirements")]
@@ -882,6 +885,7 @@ pub struct ConfigRequirementsWithSources {
     pub allowed_web_search_modes: Option<Sourced<Vec<WebSearchModeRequirement>>>,
     pub allow_managed_hooks_only: Option<Sourced<bool>>,
     pub allow_appshots: Option<Sourced<bool>>,
+    pub allow_guardian_fail_open: Option<Sourced<bool>>,
     pub computer_use: Option<Sourced<ComputerUseRequirementsToml>>,
     pub windows: Option<Sourced<WindowsRequirementsToml>>,
     pub feature_requirements: Option<Sourced<FeatureRequirementsToml>>,
@@ -924,6 +928,7 @@ impl ConfigRequirementsWithSources {
             allowed_web_search_modes: _,
             allow_managed_hooks_only: _,
             allow_appshots: _,
+            allow_guardian_fail_open: _,
             computer_use: _,
             windows: _,
             feature_requirements: _,
@@ -959,6 +964,7 @@ impl ConfigRequirementsWithSources {
                 allowed_web_search_modes,
                 allow_managed_hooks_only,
                 allow_appshots,
+                allow_guardian_fail_open,
                 computer_use,
                 windows,
                 feature_requirements,
@@ -992,6 +998,7 @@ impl ConfigRequirementsWithSources {
             allowed_web_search_modes,
             allow_managed_hooks_only,
             allow_appshots,
+            allow_guardian_fail_open,
             computer_use,
             windows,
             feature_requirements,
@@ -1015,6 +1022,7 @@ impl ConfigRequirementsWithSources {
             allowed_web_search_modes: allowed_web_search_modes.map(|sourced| sourced.value),
             allow_managed_hooks_only: allow_managed_hooks_only.map(|sourced| sourced.value),
             allow_appshots: allow_appshots.map(|sourced| sourced.value),
+            allow_guardian_fail_open: allow_guardian_fail_open.map(|sourced| sourced.value),
             computer_use: computer_use.map(|sourced| sourced.value),
             windows: windows.map(|sourced| sourced.value),
             feature_requirements: feature_requirements.map(|sourced| sourced.value),
@@ -1104,6 +1112,7 @@ impl ConfigRequirementsToml {
             && self.allowed_web_search_modes.is_none()
             && self.allow_managed_hooks_only.is_none()
             && self.allow_appshots.is_none()
+            && self.allow_guardian_fail_open.is_none()
             && self
                 .computer_use
                 .as_ref()
@@ -1156,6 +1165,7 @@ impl TryFrom<ConfigRequirementsWithSources> for ConfigRequirements {
             allowed_web_search_modes,
             allow_managed_hooks_only,
             allow_appshots,
+            allow_guardian_fail_open,
             computer_use,
             windows,
             feature_requirements,
@@ -1434,6 +1444,7 @@ impl TryFrom<ConfigRequirementsWithSources> for ConfigRequirements {
             web_search_mode,
             allow_managed_hooks_only,
             allow_appshots,
+            allow_guardian_fail_open,
             computer_use,
             feature_requirements,
             managed_hooks,
@@ -1525,6 +1536,7 @@ mod tests {
             allowed_web_search_modes,
             allow_managed_hooks_only,
             allow_appshots,
+            allow_guardian_fail_open,
             computer_use,
             windows,
             feature_requirements,
@@ -1554,6 +1566,8 @@ mod tests {
             allow_managed_hooks_only: allow_managed_hooks_only
                 .map(|value| Sourced::new(value, RequirementSource::Unknown)),
             allow_appshots: allow_appshots
+                .map(|value| Sourced::new(value, RequirementSource::Unknown)),
+            allow_guardian_fail_open: allow_guardian_fail_open
                 .map(|value| Sourced::new(value, RequirementSource::Unknown)),
             computer_use: computer_use.map(|value| Sourced::new(value, RequirementSource::Unknown)),
             windows: windows.map(|value| Sourced::new(value, RequirementSource::Unknown)),
@@ -1745,6 +1759,7 @@ mod tests {
             allowed_web_search_modes: Some(allowed_web_search_modes.clone()),
             allow_managed_hooks_only: Some(true),
             allow_appshots: Some(false),
+            allow_guardian_fail_open: Some(true),
             computer_use: Some(computer_use.clone()),
             windows: None,
             feature_requirements: Some(feature_requirements.clone()),
@@ -1787,6 +1802,10 @@ mod tests {
                     enforce_source.clone(),
                 )),
                 allow_appshots: Some(Sourced::new(/*value*/ false, enforce_source.clone(),)),
+                allow_guardian_fail_open: Some(Sourced::new(
+                    /*value*/ true,
+                    enforce_source.clone(),
+                )),
                 computer_use: Some(Sourced::new(computer_use, enforce_source.clone())),
                 windows: None,
                 feature_requirements: Some(Sourced::new(
@@ -1835,6 +1854,7 @@ mod tests {
                 allowed_web_search_modes: None,
                 allow_managed_hooks_only: None,
                 allow_appshots: None,
+                allow_guardian_fail_open: None,
                 computer_use: None,
                 windows: None,
                 feature_requirements: None,
@@ -1888,6 +1908,7 @@ mod tests {
                 allowed_web_search_modes: None,
                 allow_managed_hooks_only: None,
                 allow_appshots: None,
+                allow_guardian_fail_open: None,
                 computer_use: None,
                 windows: None,
                 feature_requirements: None,

--- a/codex-rs/config/src/requirements_layers/stack.rs
+++ b/codex-rs/config/src/requirements_layers/stack.rs
@@ -182,6 +182,7 @@ fn populate_merged_regular_fields_with_sources(
         allowed_web_search_modes,
         allow_managed_hooks_only,
         allow_appshots,
+        allow_guardian_fail_open,
         computer_use,
         windows,
         feature_requirements,
@@ -210,6 +211,7 @@ fn populate_merged_regular_fields_with_sources(
     set_sourced!(allowed_web_search_modes, &["allowed_web_search_modes"]);
     set_sourced!(allow_managed_hooks_only, &["allow_managed_hooks_only"]);
     set_sourced!(allow_appshots, &["allow_appshots"]);
+    set_sourced!(allow_guardian_fail_open, &["allow_guardian_fail_open"]);
     set_sourced!(computer_use, &["computer_use"]);
     set_sourced!(windows, &["windows"]);
     set_sourced!(feature_requirements, &["features", "feature_requirements"]);

--- a/codex-rs/config/src/requirements_layers/stack_tests.rs
+++ b/codex-rs/config/src/requirements_layers/stack_tests.rs
@@ -63,6 +63,7 @@ fn top_level_values_use_toml_priority() {
 allowed_approval_policies = ["on-request"]
 allowed_sandbox_modes = ["workspace-write"]
 default_permissions = ":workspace"
+allow_guardian_fail_open = true
 
 [allowed_permission_profiles]
 ":read-only" = true
@@ -76,6 +77,7 @@ default_permissions = ":workspace"
 allowed_approval_policies = ["never"]
 allowed_sandbox_modes = ["read-only"]
 default_permissions = ":read-only"
+allow_guardian_fail_open = false
 
 [allowed_permission_profiles]
 ":danger-full-access" = false
@@ -93,6 +95,7 @@ default_permissions = ":read-only"
 allowed_approval_policies = ["never"]
 allowed_sandbox_modes = ["read-only"]
 default_permissions = ":read-only"
+allow_guardian_fail_open = false
 
 [allowed_permission_profiles]
 ":danger-full-access" = false

--- a/codex-rs/core/src/config/config_loader_tests.rs
+++ b/codex-rs/core/src/config/config_loader_tests.rs
@@ -315,6 +315,33 @@ async fn top_level_allow_managed_hooks_only_in_user_config_does_not_enable_requi
 }
 
 #[tokio::test]
+async fn allow_guardian_fail_open_in_user_config_does_not_enable_requirements_policy()
+-> std::io::Result<()> {
+    let tmp = tempdir().expect("tempdir");
+    std::fs::write(
+        tmp.path().join(CONFIG_TOML_FILE),
+        "allow_guardian_fail_open = true",
+    )
+    .expect("write config");
+
+    let cwd = AbsolutePathBuf::try_from(tmp.path()).expect("cwd");
+    let layers = load_config_layers_state(
+        LOCAL_FS.as_ref(),
+        tmp.path(),
+        Some(cwd),
+        &[] as &[(String, TomlValue)],
+        LoaderOverrides::default(),
+        &codex_config::NoopThreadConfigLoader,
+    )
+    .await?;
+
+    assert_eq!(layers.requirements_toml().allow_guardian_fail_open, None);
+    assert!(layers.requirements().allow_guardian_fail_open.is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn hooks_allow_managed_hooks_only_in_user_config_does_not_enable_requirements_policy()
 -> std::io::Result<()> {
     let tmp = tempdir().expect("tempdir");

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -6628,6 +6628,39 @@ async fn load_config_uses_requirements_guardian_policy_config() -> std::io::Resu
     Ok(())
 }
 
+#[tokio::test]
+async fn load_config_uses_requirements_guardian_fail_open() -> std::io::Result<()> {
+    for (requirement, expected) in [(None, false), (Some(false), false), (Some(true), true)] {
+        let codex_home = TempDir::new()?;
+        let requirements_toml = codex_config::ConfigRequirementsToml {
+            allow_guardian_fail_open: requirement,
+            ..Default::default()
+        };
+        let mut requirements_with_sources = codex_config::ConfigRequirementsWithSources::default();
+        requirements_with_sources
+            .merge_unset_fields(RequirementSource::Unknown, requirements_toml.clone());
+        let requirements = codex_config::ConfigRequirements::try_from(requirements_with_sources)
+            .map_err(std::io::Error::other)?;
+        let config_layer_stack = ConfigLayerStack::new(Vec::new(), requirements, requirements_toml)
+            .map_err(std::io::Error::other)?;
+
+        let config = Config::load_config_with_layer_stack(
+            LOCAL_FS.as_ref(),
+            ConfigToml::default(),
+            ConfigOverrides {
+                cwd: Some(codex_home.path().to_path_buf()),
+                ..Default::default()
+            },
+            codex_home.abs(),
+            config_layer_stack,
+        )
+        .await?;
+
+        assert_eq!(config.allow_guardian_fail_open, expected);
+    }
+    Ok(())
+}
+
 #[test]
 fn config_toml_deserializes_auto_review_policy() {
     let cfg = toml::from_str::<ConfigToml>(
@@ -8357,6 +8390,7 @@ async fn test_requirements_web_search_mode_allowlist_does_not_warn_when_unset() 
         allowed_web_search_modes: Some(vec![codex_config::WebSearchModeRequirement::Cached]),
         allow_managed_hooks_only: None,
         allow_appshots: None,
+        allow_guardian_fail_open: None,
         computer_use: None,
         windows: None,
         feature_requirements: None,

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -662,6 +662,10 @@ pub struct Config {
     /// guardian developer prompt.
     pub guardian_policy_config: Option<String>,
 
+    /// Whether managed organization policy allows Guardian infrastructure
+    /// failures to approve the reviewed action.
+    pub allow_guardian_fail_open: bool,
+
     /// Whether to inject the `<permissions instructions>` developer block.
     pub include_permissions_instructions: bool,
 
@@ -2591,6 +2595,7 @@ impl Config {
             web_search_mode: mut constrained_web_search_mode,
             allow_managed_hooks_only: _,
             allow_appshots: _,
+            allow_guardian_fail_open,
             computer_use: _,
             feature_requirements,
             managed_hooks: _,
@@ -3544,6 +3549,8 @@ impl Config {
                 .or(show_raw_agent_reasoning)
                 .unwrap_or(false),
             guardian_policy_config,
+            allow_guardian_fail_open: allow_guardian_fail_open
+                .is_some_and(|sourced| sourced.value),
             model_reasoning_effort: cfg.model_reasoning_effort,
             plan_mode_reasoning_effort: cfg.plan_mode_reasoning_effort,
             model_reasoning_summary: cfg.model_reasoning_summary,

--- a/codex-rs/tui/src/debug_config.rs
+++ b/codex-rs/tui/src/debug_config.rs
@@ -196,6 +196,17 @@ fn render_debug_config_lines(
         ));
     }
 
+    if let Some(allow_guardian_fail_open) = requirements_toml.allow_guardian_fail_open {
+        requirement_lines.push(requirement_line(
+            "allow_guardian_fail_open",
+            allow_guardian_fail_open.to_string(),
+            requirements
+                .allow_guardian_fail_open
+                .as_ref()
+                .map(|sourced| &sourced.source),
+        ));
+    }
+
     if requirements_toml.guardian_policy_config.is_some() {
         requirement_lines.push(requirement_line(
             "guardian_policy_config",
@@ -712,6 +723,10 @@ mod tests {
                 /*value*/ false,
                 RequirementSource::LegacyManagedConfigTomlFromMdm,
             )),
+            allow_guardian_fail_open: Some(Sourced::new(
+                /*value*/ true,
+                RequirementSource::LegacyManagedConfigTomlFromMdm,
+            )),
             feature_requirements: Some(Sourced::new(
                 FeatureRequirementsToml {
                     entries: BTreeMap::from([("guardian_approval".to_string(), true)]),
@@ -753,6 +768,7 @@ mod tests {
             allowed_web_search_modes: Some(vec![WebSearchModeRequirement::Cached]),
             allow_managed_hooks_only: Some(true),
             allow_appshots: Some(false),
+            allow_guardian_fail_open: Some(true),
             computer_use: None,
             windows: None,
             guardian_policy_config: Some("Use the managed guardian policy.".to_string()),
@@ -819,6 +835,9 @@ mod tests {
         )));
         assert!(rendered.contains(&format!(
             "allow_appshots: false (source: {requirements_source})"
+        )));
+        assert!(rendered.contains(&format!(
+            "allow_guardian_fail_open: true (source: {requirements_source})"
         )));
         assert!(rendered.contains(&format!(
             "guardian_policy_config: configured (source: {requirements_source})"
@@ -1112,6 +1131,7 @@ approval_policy = "never"
             allowed_web_search_modes: Some(Vec::new()),
             allow_managed_hooks_only: None,
             allow_appshots: None,
+            allow_guardian_fail_open: None,
             computer_use: None,
             windows: None,
             guardian_policy_config: None,


### PR DESCRIPTION
## Summary
- add top-level managed `allow_guardian_fail_open` support to `requirements.toml`
- project unset and explicit `false` to fail-closed runtime configuration
- expose the effective managed value in debug config output

## Testing
- `just test -p codex-config` (177 passed)
- focused `codex-core` config projection coverage for `None`, `false`, and `true`
- scoped `just fix` across all touched crates
- final code-review passes: breaking changes, change size, model context, testing

## Stack
1. This PR: managed configuration
2. Runtime behavior and app-server protocol
3. Analytics and TUI presentation

Linear: https://linear.app/openai/issue/CA-544/fail-open-setting-for-guardian-allow-user-to-approve-failed-guardian