### PR TITLE
Surface Guardian fail-open outcomes

### DIFF
--- a/codex-rs/analytics/src/analytics_client_tests.rs
+++ b/codex-rs/analytics/src/analytics_client_tests.rs
@@ -892,6 +892,7 @@ fn sample_guardian_review_completed(
     review_id: &str,
     target_item_id: Option<&str>,
     status: GuardianApprovalReviewStatus,
+    decision_source: codex_app_server_protocol::AutoReviewDecisionSource,
 ) -> ServerNotification {
     ServerNotification::ItemGuardianApprovalReviewCompleted(
         ItemGuardianApprovalReviewCompletedNotification {
@@ -901,7 +902,7 @@ fn sample_guardian_review_completed(
             completed_at_ms: 1_042,
             review_id: review_id.to_string(),
             target_item_id: target_item_id.map(str::to_string),
-            decision_source: codex_app_server_protocol::AutoReviewDecisionSource::Agent,
+            decision_source,
             review: GuardianApprovalReview {
                 status,
                 risk_level: None,
@@ -2340,6 +2341,7 @@ async fn guardian_completed_notification_publishes_review_event_with_thread_meta
                 "guardian-review-1",
                 Some("item-1"),
                 GuardianApprovalReviewStatus::Denied,
+                codex_app_server_protocol::AutoReviewDecisionSource::Agent,
             ))),
             &mut events,
         )
@@ -2356,6 +2358,37 @@ async fn guardian_completed_notification_publishes_review_event_with_thread_meta
     assert_eq!(payload["event_params"]["started_at_ms"], 1_000);
     assert_eq!(payload["event_params"]["completed_at_ms"], 1_042);
     assert_eq!(payload["event_params"]["duration_ms"], 42);
+}
+
+#[tokio::test]
+async fn guardian_failed_open_denormalizes_onto_tool_item_events() {
+    let mut reducer = AnalyticsReducer::default();
+    let mut events = Vec::new();
+
+    ingest_review_prerequisites(&mut reducer, &mut events).await;
+    reducer
+        .ingest(
+            AnalyticsFact::Notification(Box::new(sample_guardian_review_completed(
+                "guardian-review-failed-open",
+                Some("item-1"),
+                GuardianApprovalReviewStatus::Approved,
+                codex_app_server_protocol::AutoReviewDecisionSource::OrganizationPolicy,
+            ))),
+            &mut events,
+        )
+        .await;
+
+    let review_payload = serde_json::to_value(&events[0]).expect("serialize review event");
+    assert_eq!(review_payload["event_params"]["status"], "failed_open");
+    events.clear();
+
+    ingest_completed_command_execution_item(&mut reducer, &mut events, "thread-1", "item-1").await;
+
+    let item_payload = serde_json::to_value(&events[0]).expect("serialize tool item event");
+    assert_eq!(
+        item_payload["event_params"]["final_approval_outcome"],
+        "guardian_failed_open"
+    );
 }
 
 #[tokio::test]

--- a/codex-rs/analytics/src/reducer.rs
+++ b/codex-rs/analytics/src/reducer.rs
@@ -86,6 +86,7 @@ use crate::now_unix_seconds;
 use crate::option_i64_to_u64;
 use crate::serialize_enum_as_string;
 use crate::usize_to_u64;
+use codex_app_server_protocol::AutoReviewDecisionSource;
 use codex_app_server_protocol::ClientRequest;
 use codex_app_server_protocol::ClientResponse;
 use codex_app_server_protocol::CodexErrorInfo;
@@ -1312,7 +1313,9 @@ impl AnalyticsReducer {
         notification: codex_app_server_protocol::ItemGuardianApprovalReviewCompletedNotification,
         out: &mut Vec<TrackEventRequest>,
     ) {
-        let Some((status, resolution)) = guardian_review_result(notification.review.status) else {
+        let Some((status, resolution)) =
+            guardian_review_result(notification.review.status, notification.decision_source)
+        else {
             return;
         };
         let (subject_kind, subject_name, trigger) =
@@ -2108,19 +2111,23 @@ fn effective_permissions_review_result(
 
 fn guardian_review_result(
     status: GuardianApprovalReviewStatus,
+    decision_source: AutoReviewDecisionSource,
 ) -> Option<(ReviewStatus, ReviewResolution)> {
-    match status {
-        GuardianApprovalReviewStatus::InProgress => None,
-        GuardianApprovalReviewStatus::Approved => {
+    match (status, decision_source) {
+        (GuardianApprovalReviewStatus::InProgress, _) => None,
+        (GuardianApprovalReviewStatus::Approved, AutoReviewDecisionSource::OrganizationPolicy) => {
+            Some((ReviewStatus::FailedOpen, ReviewResolution::None))
+        }
+        (GuardianApprovalReviewStatus::Approved, AutoReviewDecisionSource::Agent) => {
             Some((ReviewStatus::Approved, ReviewResolution::None))
         }
-        GuardianApprovalReviewStatus::Denied => {
+        (GuardianApprovalReviewStatus::Denied, _) => {
             Some((ReviewStatus::Denied, ReviewResolution::None))
         }
-        GuardianApprovalReviewStatus::TimedOut => {
+        (GuardianApprovalReviewStatus::TimedOut, _) => {
             Some((ReviewStatus::TimedOut, ReviewResolution::None))
         }
-        GuardianApprovalReviewStatus::Aborted => {
+        (GuardianApprovalReviewStatus::Aborted, _) => {
             Some((ReviewStatus::Aborted, ReviewResolution::None))
         }
     }
@@ -2222,6 +2229,9 @@ fn final_approval_outcome(
     match (reviewer, status, resolution) {
         (Reviewer::Guardian, ReviewStatus::Approved, _) => FinalApprovalOutcome::GuardianApproved,
         (Reviewer::Guardian, ReviewStatus::Denied, _) => FinalApprovalOutcome::GuardianDenied,
+        (Reviewer::Guardian, ReviewStatus::FailedOpen, _) => {
+            FinalApprovalOutcome::GuardianFailedOpen
+        }
         (Reviewer::Guardian, _, _) => FinalApprovalOutcome::GuardianAborted,
         (Reviewer::User, ReviewStatus::Approved, ReviewResolution::SessionApproval) => {
             FinalApprovalOutcome::UserApprovedForSession
@@ -2694,10 +2704,26 @@ mod tests {
 
     #[test]
     fn guardian_review_result_maps_terminal_statuses() {
-        assert!(guardian_review_result(GuardianApprovalReviewStatus::InProgress).is_none());
+        assert!(
+            guardian_review_result(
+                GuardianApprovalReviewStatus::InProgress,
+                AutoReviewDecisionSource::Agent,
+            )
+            .is_none()
+        );
         assert!(matches!(
-            guardian_review_result(GuardianApprovalReviewStatus::TimedOut),
+            guardian_review_result(
+                GuardianApprovalReviewStatus::TimedOut,
+                AutoReviewDecisionSource::Agent,
+            ),
             Some((ReviewStatus::TimedOut, ReviewResolution::None))
+        ));
+        assert!(matches!(
+            guardian_review_result(
+                GuardianApprovalReviewStatus::Approved,
+                AutoReviewDecisionSource::OrganizationPolicy,
+            ),
+            Some((ReviewStatus::FailedOpen, ReviewResolution::None))
         ));
     }
 }

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__guardian_failed_open_exec_renders_policy_approval.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__guardian_failed_open_exec_renders_policy_approval.snap
@@ -1,0 +1,24 @@
+---
+source: tui/src/chatwidget/tests/guardian.rs
+expression: normalize_snapshot_paths(term.backend().vt100().screen().contents())
+---
+
+
+⚠ Automatic approval review failed: request timed out. Organization policy
+  allowed the request to proceed.
+
+! Review failed, but organization policy allowed this action: curl -sS
+  https://example.com
+
+! Review failed, but organization policy allowed this action: apply_patch
+  touching 2 files
+
+! Review failed, but organization policy allowed this action: MCP
+  create_pull_request on github
+
+• Working (0s • esc to interrupt)
+
+
+› Ask Codex to do anything
+
+  gpt-5.5 default · /tmp/project

--- a/codex-rs/tui/src/chatwidget/tests/guardian.rs
+++ b/codex-rs/tui/src/chatwidget/tests/guardian.rs
@@ -317,6 +317,113 @@ async fn guardian_timed_out_exec_renders_warning_and_timed_out_request() {
 }
 
 #[tokio::test]
+async fn guardian_failed_open_exec_renders_policy_approval() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    chat.show_welcome_banner = false;
+    let action = GuardianAssessmentAction::Command {
+        source: GuardianCommandSource::Shell,
+        command: "curl -sS https://example.com".to_string(),
+        cwd: test_path_buf("/tmp").abs(),
+    };
+    let rationale = "Automatic approval review failed: request timed out. Organization policy allowed the request to proceed.";
+
+    chat.on_guardian_assessment(GuardianAssessmentEvent {
+        id: "guardian-1".into(),
+        target_item_id: Some("guardian-target-1".into()),
+        turn_id: "turn-1".into(),
+        started_at_ms: 0,
+        completed_at_ms: None,
+        status: GuardianAssessmentStatus::InProgress,
+        risk_level: None,
+        user_authorization: None,
+        rationale: None,
+        decision_source: None,
+        action: action,
+    });
+    chat.on_warning(rationale);
+    chat.handle_server_notification(
+        ServerNotification::ItemGuardianApprovalReviewCompleted(
+            ItemGuardianApprovalReviewCompletedNotification {
+                thread_id: "thread-1".to_string(),
+                turn_id: "turn-1".to_string(),
+                started_at_ms: 0,
+                completed_at_ms: 1,
+                review_id: "guardian-1".to_string(),
+                target_item_id: Some("guardian-target-1".to_string()),
+                decision_source: AppServerGuardianApprovalReviewDecisionSource::OrganizationPolicy,
+                review: GuardianApprovalReview {
+                    status: GuardianApprovalReviewStatus::Approved,
+                    risk_level: None,
+                    user_authorization: None,
+                    rationale: Some(rationale.to_string()),
+                },
+                action: AppServerGuardianApprovalReviewAction::Command {
+                    source: AppServerGuardianCommandSource::Shell,
+                    command: "curl -sS https://example.com".to_string(),
+                    cwd: test_path_buf("/tmp").abs(),
+                },
+            },
+        ),
+        /*replay_kind*/ None,
+    );
+    let actions = [
+        GuardianAssessmentAction::ApplyPatch {
+            cwd: test_path_buf("/tmp").abs(),
+            files: vec![
+                test_path_buf("/tmp/src/lib.rs").abs(),
+                test_path_buf("/tmp/src/main.rs").abs(),
+            ],
+        },
+        GuardianAssessmentAction::McpToolCall {
+            server: "github".into(),
+            tool_name: "create_pull_request".into(),
+            connector_id: None,
+            connector_name: None,
+            tool_title: None,
+        },
+    ];
+    for (index, action) in actions.into_iter().enumerate() {
+        chat.on_guardian_assessment(GuardianAssessmentEvent {
+            id: format!("guardian-{}", index + 2),
+            target_item_id: Some(format!("guardian-target-{}", index + 2)),
+            turn_id: "turn-1".into(),
+            started_at_ms: 0,
+            completed_at_ms: Some(index as i64 + 2),
+            status: GuardianAssessmentStatus::Approved,
+            risk_level: None,
+            user_authorization: None,
+            rationale: Some(rationale.into()),
+            decision_source: Some(GuardianAssessmentDecisionSource::OrganizationPolicy),
+            action,
+        });
+    }
+
+    let width: u16 = 140;
+    let ui_height: u16 = chat.desired_height(width);
+    let vt_height: u16 = 20;
+    let viewport = Rect::new(0, vt_height - ui_height - 1, width, ui_height);
+
+    let backend = VT100Backend::new(width, vt_height);
+    let mut term = crate::custom_terminal::Terminal::with_options(backend).expect("terminal");
+    term.set_viewport_area(viewport);
+
+    for lines in drain_insert_history(&mut rx) {
+        crate::insert_history::insert_history_lines(&mut term, lines)
+            .expect("Failed to insert history lines in test");
+    }
+
+    term.draw(|f| {
+        chat.render(f.area(), f.buffer_mut());
+    })
+    .expect("draw Guardian fail-open history");
+
+    assert_chatwidget_snapshot!(
+        "guardian_failed_open_exec_renders_policy_approval",
+        normalize_snapshot_paths(term.backend().vt100().screen().contents())
+    );
+}
+
+#[tokio::test]
 async fn app_server_guardian_review_started_sets_review_status() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
     let action = AppServerGuardianApprovalReviewAction::Command {

--- a/codex-rs/tui/src/chatwidget/tool_requests.rs
+++ b/codex-rs/tui/src/chatwidget/tool_requests.rs
@@ -148,6 +148,23 @@ impl ChatWidget {
             self.set_status_header(String::from("Working"));
         }
 
+        if ev.status == GuardianAssessmentStatus::Approved
+            && ev.decision_source == Some(GuardianAssessmentDecisionSource::OrganizationPolicy)
+        {
+            let summary = if let Some(summary) = guardian_action_summary(&ev.action) {
+                summary
+            } else {
+                serde_json::to_string(&ev.action)
+                    .unwrap_or_else(|_| "<unrenderable guardian action>".to_string())
+            };
+
+            self.add_boxed_history(history_cell::new_guardian_failed_open_action_request(
+                summary,
+            ));
+            self.request_redraw();
+            return;
+        }
+
         if ev.status == GuardianAssessmentStatus::Approved {
             let cell = if let Some(command) = guardian_command(&ev.action) {
                 history_cell::new_approval_decision_cell(

--- a/codex-rs/tui/src/history_cell/approvals.rs
+++ b/codex-rs/tui/src/history_cell/approvals.rs
@@ -352,6 +352,16 @@ pub fn new_guardian_timed_out_action_request(summary: String) -> Box<dyn History
     Box::new(PrefixedWrappedHistoryCell::new(line, "✗ ".red(), "  "))
 }
 
+pub fn new_guardian_failed_open_action_request(summary: String) -> Box<dyn HistoryCell> {
+    let line = Line::from(vec![
+        "Review ".into(),
+        "failed".bold(),
+        ", but organization policy allowed this action: ".into(),
+        Span::from(summary).dim(),
+    ]);
+    Box::new(PrefixedWrappedHistoryCell::new(line, "! ".magenta(), "  "))
+}
+
 /// Cyan history cell line showing the current review status.
 pub(crate) fn new_review_status_line(message: String) -> PlainHistoryCell {
     PlainHistoryCell {


### PR DESCRIPTION
## Summary
- render failed-open Guardian approvals as organization-policy decisions in the TUI
- preserve the decision source in analytics reduction
- add warning styling and snapshot coverage for command, patch, and MCP review presentation
- drive command presentation through the app-server notification boundary

## Testing
- focused failed-open TUI snapshot passed
- analytics reducer coverage passed in `just test -p codex-analytics` (72 passed)
- full `codex-tui` run: 2,824 passed; two unchanged app-config tests failed and five unrelated timing-sensitive tests timed out in this environment
- scoped `just fix` across all touched crates
- final code-review passes: breaking changes, change size, model context, testing

## Stack
- Depends on #27346, which depends on #27345

Linear: https://linear.app/openai/issue/CA-544/fail-open-setting-for-guardian-allow-user-to-approve-failed-guardian