### PR TITLE
Add dormant plugin script lifecycle state

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -559,6 +559,9 @@
             "plugin_hooks": {
               "type": "boolean"
             },
+            "plugin_script_lifecycle": {
+              "type": "boolean"
+            },
             "plugin_sharing": {
               "type": "boolean"
             },
@@ -4718,6 +4721,9 @@
           "type": "boolean"
         },
         "plugin_hooks": {
+          "type": "boolean"
+        },
+        "plugin_script_lifecycle": {
           "type": "boolean"
         },
         "plugin_sharing": {

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -70,6 +70,7 @@ pub use mention_syntax::TOOL_MENTION_SIGIL;
 pub use utils::path_utils;
 pub mod personality_migration;
 #[allow(dead_code)]
+mod plugin_script_lifecycle;
 mod plugin_script_resolver;
 pub(crate) mod plugins;
 #[doc(hidden)]

--- a/codex-rs/core/src/plugin_script_lifecycle.rs
+++ b/codex-rs/core/src/plugin_script_lifecycle.rs
@@ -1,0 +1,161 @@
+use std::sync::Arc;
+use std::sync::OnceLock;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::time::Instant;
+
+use chrono::SecondsFormat;
+use chrono::Utc;
+use codex_analytics::AnalyticsEventsClient;
+use codex_analytics::CodexPluginScriptLifecycleEvent;
+use codex_analytics::PluginScriptLifecycleStatus;
+use codex_analytics::PluginScriptSkill;
+use codex_features::Feature;
+use codex_utils_absolute_path::AbsolutePathBuf;
+use uuid::Uuid;
+
+use crate::plugin_script_resolver::resolve_plugin_script;
+use crate::session::session::Session;
+use crate::session::turn_context::TurnContext;
+use crate::shell::ShellType;
+
+/// Tracks one resolved plugin-script invocation through executor lifecycle events.
+///
+/// Resolution is dormant until an executor adapter calls these methods. The
+/// started fact is built only after successful process spawn so terminal
+/// duration measures actual process lifetime rather than attribution time.
+pub(crate) struct PluginScriptExecution {
+    analytics: AnalyticsEventsClient,
+    event: PluginScriptEvent,
+    started_at: OnceLock<Instant>,
+    terminal_emitted: AtomicBool,
+    cancelled: AtomicBool,
+    #[cfg(test)]
+    emitted: std::sync::Mutex<Vec<CodexPluginScriptLifecycleEvent>>,
+}
+
+#[derive(Clone)]
+struct PluginScriptEvent {
+    thread_id: String,
+    turn_id: String,
+    plugin_id: String,
+    execution_id: String,
+    script_path: String,
+    skill: Option<PluginScriptSkill>,
+}
+
+impl PluginScriptExecution {
+    pub(crate) fn resolve(
+        session: &Session,
+        turn: &TurnContext,
+        command: &str,
+        cwd: &AbsolutePathBuf,
+        shell_type: ShellType,
+    ) -> Option<Arc<Self>> {
+        if !turn.config.features.enabled(Feature::PluginScriptLifecycle) {
+            return None;
+        }
+
+        let resolved = resolve_plugin_script(
+            &turn.first_party_plugin_roots,
+            turn.turn_skills.snapshot.outcome(),
+            command,
+            cwd,
+            shell_type,
+        )?;
+        Some(Arc::new(Self::new(
+            session.services.analytics_events_client.clone(),
+            PluginScriptEvent {
+                thread_id: session.thread_id.to_string(),
+                turn_id: turn.sub_id.clone(),
+                plugin_id: resolved.plugin_id,
+                execution_id: Uuid::new_v4().to_string(),
+                script_path: resolved.script_path,
+                skill: resolved.skill,
+            },
+        )))
+    }
+
+    pub(crate) fn mark_started(&self) {
+        if self.started_at.set(Instant::now()).is_err() {
+            return;
+        }
+        self.emit(self.event(
+            PluginScriptLifecycleStatus::Started,
+            /*duration_ms*/ None,
+            /*exit_code*/ None,
+        ));
+    }
+
+    pub(crate) fn mark_cancelled(&self) {
+        self.cancelled.store(true, Ordering::Release);
+    }
+
+    pub(crate) fn finish(&self, exit_code: Option<i32>, failed: bool) {
+        let Some(started_at) = self.started_at.get() else {
+            return;
+        };
+        if self.terminal_emitted.swap(true, Ordering::AcqRel) {
+            return;
+        }
+
+        let status = if self.cancelled.load(Ordering::Acquire) {
+            PluginScriptLifecycleStatus::Cancelled
+        } else if !failed && exit_code == Some(0) {
+            PluginScriptLifecycleStatus::Completed
+        } else {
+            PluginScriptLifecycleStatus::Failed
+        };
+        let duration_ms = u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX);
+        self.emit(self.event(status, Some(duration_ms), exit_code));
+    }
+
+    fn new(analytics: AnalyticsEventsClient, event: PluginScriptEvent) -> Self {
+        Self {
+            analytics,
+            event,
+            started_at: OnceLock::new(),
+            terminal_emitted: AtomicBool::new(false),
+            cancelled: AtomicBool::new(false),
+            #[cfg(test)]
+            emitted: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    fn event(
+        &self,
+        status: PluginScriptLifecycleStatus,
+        duration_ms: Option<u64>,
+        exit_code: Option<i32>,
+    ) -> CodexPluginScriptLifecycleEvent {
+        CodexPluginScriptLifecycleEvent {
+            thread_id: self.event.thread_id.clone(),
+            turn_id: self.event.turn_id.clone(),
+            plugin_id: self.event.plugin_id.clone(),
+            execution_id: self.event.execution_id.clone(),
+            script_path: self.event.script_path.clone(),
+            timestamp: lifecycle_timestamp(),
+            status,
+            duration_ms,
+            exit_code,
+            skill: self.event.skill.clone(),
+        }
+    }
+
+    fn emit(&self, event: CodexPluginScriptLifecycleEvent) {
+        #[cfg(test)]
+        self.emitted
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(event.clone());
+        self.analytics.track_plugin_script_lifecycle(event);
+    }
+}
+
+fn lifecycle_timestamp() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+#[cfg(test)]
+#[path = "plugin_script_lifecycle_tests.rs"]
+mod tests;

--- a/codex-rs/core/src/plugin_script_lifecycle_tests.rs
+++ b/codex-rs/core/src/plugin_script_lifecycle_tests.rs
@@ -1,0 +1,131 @@
+use std::thread;
+use std::time::Duration;
+use std::time::Instant;
+
+use codex_analytics::AnalyticsEventsClient;
+use codex_analytics::CodexPluginScriptLifecycleEvent;
+use codex_analytics::PluginScriptLifecycleStatus;
+use pretty_assertions::assert_eq;
+
+use super::*;
+
+fn execution() -> PluginScriptExecution {
+    PluginScriptExecution::new(
+        AnalyticsEventsClient::disabled(),
+        PluginScriptEvent {
+            thread_id: "thread".to_string(),
+            turn_id: "turn".to_string(),
+            plugin_id: "plugin".to_string(),
+            execution_id: "execution".to_string(),
+            script_path: "scripts/run.py".to_string(),
+            skill: None,
+        },
+    )
+}
+
+fn emitted(execution: &PluginScriptExecution) -> Vec<CodexPluginScriptLifecycleEvent> {
+    execution
+        .emitted
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone()
+}
+
+fn statuses(execution: &PluginScriptExecution) -> Vec<&'static str> {
+    emitted(execution)
+        .into_iter()
+        .map(|event| match event.status {
+            PluginScriptLifecycleStatus::Started => "started",
+            PluginScriptLifecycleStatus::Completed => "completed",
+            PluginScriptLifecycleStatus::Failed => "failed",
+            PluginScriptLifecycleStatus::Cancelled => "cancelled",
+        })
+        .collect()
+}
+
+#[test]
+fn finish_before_start_emits_no_transition() {
+    let execution = execution();
+
+    execution.finish(Some(0), /*failed*/ false);
+
+    assert_eq!(statuses(&execution), Vec::<&str>::new());
+}
+
+#[test]
+fn start_is_idempotent() {
+    let execution = execution();
+
+    execution.mark_started();
+    execution.mark_started();
+
+    assert_eq!(statuses(&execution), vec!["started"]);
+}
+
+#[test]
+fn exit_zero_completes() {
+    let execution = execution();
+
+    execution.mark_started();
+    execution.finish(Some(0), /*failed*/ false);
+
+    assert_eq!(statuses(&execution), vec!["started", "completed"]);
+}
+
+#[test]
+fn nonzero_exit_and_executor_error_fail() {
+    for (exit_code, failed) in [(Some(9), false), (None, true)] {
+        let execution = execution();
+        execution.mark_started();
+        execution.finish(exit_code, failed);
+
+        assert_eq!(statuses(&execution), vec!["started", "failed"]);
+    }
+}
+
+#[test]
+fn cancellation_wins_over_terminal_classification() {
+    let execution = execution();
+
+    execution.mark_started();
+    execution.mark_cancelled();
+    execution.finish(Some(0), /*failed*/ false);
+
+    assert_eq!(statuses(&execution), vec!["started", "cancelled"]);
+}
+
+#[test]
+fn terminal_transition_is_idempotent() {
+    let execution = execution();
+
+    execution.mark_started();
+    execution.finish(Some(0), /*failed*/ false);
+    execution.finish(Some(9), /*failed*/ true);
+
+    assert_eq!(statuses(&execution), vec!["started", "completed"]);
+}
+
+#[test]
+fn duration_begins_at_actual_start() {
+    let execution = execution();
+    let before_pre_start_delay = Instant::now();
+
+    thread::sleep(Duration::from_millis(25));
+    execution.mark_started();
+    execution.finish(Some(0), /*failed*/ false);
+
+    let duration_ms = emitted(&execution)[1].duration_ms.expect("duration");
+    let total_elapsed_ms = before_pre_start_delay.elapsed().as_millis();
+    assert!(u128::from(duration_ms) < total_elapsed_ms);
+}
+
+#[test]
+fn start_and_terminal_facts_retain_one_execution_id() {
+    let execution = execution();
+
+    execution.mark_started();
+    execution.finish(Some(0), /*failed*/ false);
+    let events = emitted(&execution);
+
+    assert_eq!(events[0].execution_id, events[1].execution_id);
+}

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -159,6 +159,8 @@ pub enum Feature {
     ToolSuggest,
     /// Enable plugins.
     Plugins,
+    /// Emit lifecycle analytics for scripts executed from first-party plugins.
+    PluginScriptLifecycle,
     /// Removed compatibility flag for plugin-bundled lifecycle hooks.
     PluginHooks,
     /// Allow the in-app browser pane in desktop apps.
@@ -1046,6 +1048,12 @@ pub const FEATURES: &[FeatureSpec] = &[
         key: "plugins",
         stage: Stage::Stable,
         default_enabled: true,
+    },
+    FeatureSpec {
+        id: Feature::PluginScriptLifecycle,
+        key: "plugin_script_lifecycle",
+        stage: Stage::UnderDevelopment,
+        default_enabled: false,
     },
     FeatureSpec {
         id: Feature::PluginHooks,


### PR DESCRIPTION
## Why

FOO-574 needs a merge-safe core lifecycle slice before executor adapters can emit plugin-script lifecycle facts. This stacked PR keeps that state machine dormant behind a default-off feature so later adapter PRs can wire process spawn and terminal observations without mixing shell/runtime plumbing into the core boundary.

## What changed

- Add dormant `PluginScriptExecution` lifecycle state with `resolve`, `mark_started`, `mark_cancelled`, and `finish`.
- Reuse the resolver from #28012 instead of duplicating script provenance resolution.
- Build the started fact only inside `mark_started`, after a successful future process spawn, so duration starts at actual execution start.
- Register default-off `plugin_script_lifecycle` feature configuration and regenerate the mechanical config schema lines.
- Add focused core tests for pre-start finish, start/terminal idempotence, completion/failure/cancellation classification, actual-start duration, and shared execution ID.

## Stack boundary

- Responsibility: dormant plugin-script lifecycle execution state machine plus default-off feature gate.
- Boundary: lifecycle state only; no process adapter calls are included, so this remains dormant and independently merge-safe.
- Depends on: #28012 at exact head `ea2fc2fd409a84e5072bda4dd928eac8ff3b428c` at `53e5554ca435da1a9b76f1dbd8eb3771b238e011` (`dev/kyleb/plugin-script-command-resolver`).
- Deliberately deferred: shell/zsh-fork adapter wiring and unified-exec sibling adapter wiring.
- Diff size: 301 handwritten changed lines; `codex-rs/core/config.schema.json` has 6 mechanical generated changed lines.
- UI evidence: none; no user-visible UI changes.

## Validation

Restack validation (2026-06-17): `cd codex-rs && just fmt`; `cd codex-rs && just write-config-schema`; `cd codex-rs && just test -p codex-core plugin_script_lifecycle`; `cd codex-rs && just test -p codex-core plugin_script_resolver`; `cd codex-rs && just test -p codex-features` — passed.

- `cd codex-rs && just write-config-schema`
- `cd codex-rs && just test -p codex-core plugin_script_lifecycle`
- `cd codex-rs && just test -p codex-core plugin_script_resolver`
- `cd codex-rs && just test -p codex-features`
- `cd codex-rs && just argument-comment-lint`
- `cd codex-rs && just fix -p codex-core`
- `cd codex-rs && just fix -p codex-features`
- `cd codex-rs && just fmt`

## Tracking

- Claim: `linear_issue:FOO-574` / `claim-1a4aebf2007e42c1b03e896787970de3`
- Sticky worker: `kyleb-worker-0`

## Stack position
Slice 5/7 in FOO-574 merge order; direct dependency: #28012 at exact head `ea2fc2fd409a84e5072bda4dd928eac8ff3b428c`.


