### PR TITLE
[codex] Tag multi-agent spawn metrics with version

### DIFF
--- a/codex-rs/core/src/tools/handlers/multi_agents/spawn.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents/spawn.rs
@@ -204,7 +204,7 @@ async fn handle_spawn_agent(
     turn.session_telemetry.counter(
         "codex.multi_agent.spawn",
         /*inc*/ 1,
-        &[("role", role_tag)],
+        &[("role", role_tag), ("version", "v1")],
     );
 
     Ok(SpawnAgentResult {

--- a/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs
@@ -165,7 +165,7 @@ async fn handle_spawn_agent(
     turn.session_telemetry.counter(
         "codex.multi_agent.spawn",
         /*inc*/ 1,
-        &[("role", role_tag)],
+        &[("role", role_tag), ("version", "v2")],
     );
     let task_name = String::from(new_agent_path);
 


### PR DESCRIPTION
## Summary
- tag legacy multi-agent spawn metrics with `version=v1`
- tag multi-agent v2 spawn metrics with `version=v2`

## Why
`codex.multi_agent.spawn` is emitted by both runtimes, so the existing metric cannot distinguish v2 adoption from aggregate multi-agent spawning. The bounded version tag makes that breakdown directly queryable without changing the counter's success-only semantics.

## Validation
- `just fmt`
- `git diff --check`
- Tests and Clippy were intentionally left to CI.