### PR TITLE
core: enable remote compaction v2 by default for OpenAI

### DIFF
--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -849,7 +849,9 @@ async fn run_auto_compact(
     phase: CompactionPhase,
 ) -> CodexResult<()> {
     if should_use_remote_compact_task(turn_context.provider.info()) {
-        if turn_context.features.enabled(Feature::RemoteCompactionV2) {
+        if turn_context.features.enabled(Feature::RemoteCompactionV2)
+            && turn_context.provider.info().supports_remote_compaction_v2()
+        {
             emit_compact_metric(
                 &sess.services.session_telemetry,
                 "remote_v2",

--- a/codex-rs/core/src/tasks/compact.rs
+++ b/codex-rs/core/src/tasks/compact.rs
@@ -33,6 +33,7 @@ impl SessionTask for CompactTask {
             if ctx
                 .features
                 .enabled(codex_features::Feature::RemoteCompactionV2)
+                && ctx.provider.info().supports_remote_compaction_v2()
             {
                 emit_compact_metric(
                     &session.services.session_telemetry,

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -36,7 +36,7 @@ use core_test_support::responses::start_websocket_server;
 use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::TestCodexBuilder;
 use core_test_support::test_codex::TestCodexHarness;
-use core_test_support::test_codex::test_codex;
+use core_test_support::test_codex::test_codex as base_test_codex;
 use core_test_support::test_path_buf;
 use core_test_support::wait_for_event;
 use core_test_support::wait_for_event_match;
@@ -158,6 +158,12 @@ fn compacted_summary_only_output(summary: &str) -> Vec<ResponseItem> {
     vec![ResponseItem::Compaction {
         encrypted_content: summary_with_prefix(summary),
     }]
+}
+
+fn test_codex() -> TestCodexBuilder {
+    base_test_codex().with_config(|config| {
+        let _ = config.features.disable(Feature::RemoteCompactionV2);
+    })
 }
 
 fn remote_realtime_test_codex_builder(
@@ -1126,7 +1132,8 @@ async fn remote_compact_filters_deferred_dynamic_tools() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = responses::start_mock_server().await;
-    let mut builder = test_codex().with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing());
+    let mut builder =
+        test_codex().with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing());
     let mut test = builder.build(&server).await?;
     let hidden_tool = "hidden_dynamic_tool";
     let visible_tool = "visible_dynamic_tool";
@@ -2594,7 +2601,8 @@ async fn remote_compact_refreshes_stale_developer_instructions_without_resume() 
     let server = wiremock::MockServer::start().await;
     let stale_developer_message = "STALE_DEVELOPER_INSTRUCTIONS_SHOULD_BE_REMOVED";
 
-    let mut builder = test_codex().with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing());
+    let mut builder =
+        test_codex().with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing());
     let test = builder.build(&server).await?;
 
     let responses_mock = responses::mount_sse_sequence(

--- a/codex-rs/core/tests/suite/compact_remote_parity.rs
+++ b/codex-rs/core/tests/suite/compact_remote_parity.rs
@@ -529,8 +529,8 @@ async fn build_harness_inner(
         if hooks {
             trust_discovered_hooks(config);
         }
-        if mode == Mode::V2 {
-            let _ = config.features.enable(Feature::RemoteCompactionV2);
+        if mode == Mode::Legacy {
+            let _ = config.features.disable(Feature::RemoteCompactionV2);
         }
     }))
     .await

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -209,7 +209,7 @@ pub enum Feature {
     RealtimeConversation,
     /// Prevent idle system sleep while a turn is actively running.
     PreventIdleSleep,
-    /// Enable remote compaction v2 over the normal Responses API.
+    /// Use remote compaction v2 for OpenAI over the normal Responses API.
     RemoteCompactionV2,
     /// Enable workspace dependency support.
     WorkspaceDependencies,
@@ -1237,8 +1237,8 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::RemoteCompactionV2,
         key: "remote_compaction_v2",
-        stage: Stage::UnderDevelopment,
-        default_enabled: false,
+        stage: Stage::Stable,
+        default_enabled: true,
     },
     FeatureSpec {
         id: Feature::WorkspaceDependencies,

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -157,15 +157,6 @@ fn request_permissions_tool_is_under_development() {
     assert_eq!(Feature::RequestPermissionsTool.default_enabled(), false);
 }
 
-#[test]
-fn remote_compaction_v2_is_under_development() {
-    assert_eq!(Feature::RemoteCompactionV2.stage(), Stage::UnderDevelopment);
-    assert_eq!(Feature::RemoteCompactionV2.default_enabled(), false);
-    assert_eq!(
-        feature_for_key("remote_compaction_v2"),
-        Some(Feature::RemoteCompactionV2)
-    );
-}
 
 #[test]
 fn terminal_resize_reflow_is_experimental_and_enabled_by_default() {

--- a/codex-rs/model-provider-info/src/lib.rs
+++ b/codex-rs/model-provider-info/src/lib.rs
@@ -397,7 +397,13 @@ impl ModelProviderInfo {
     }
 
     pub fn supports_remote_compaction(&self) -> bool {
-        self.is_openai() || is_azure_responses_provider(&self.name, self.base_url.as_deref())
+        self.is_openai()
+            || self.is_amazon_bedrock()
+            || is_azure_responses_provider(&self.name, self.base_url.as_deref())
+    }
+
+    pub fn supports_remote_compaction_v2(&self) -> bool {
+        self.is_openai()
     }
 
     pub fn has_command_auth(&self) -> bool {

--- a/codex-rs/model-provider-info/src/model_provider_info_tests.rs
+++ b/codex-rs/model-provider-info/src/model_provider_info_tests.rs
@@ -137,6 +137,15 @@ fn test_supports_remote_compaction_for_openai() {
     let provider = ModelProviderInfo::create_openai_provider(/*base_url*/ None);
 
     assert!(provider.supports_remote_compaction());
+    assert!(provider.supports_remote_compaction_v2());
+}
+
+#[test]
+fn test_supports_remote_compaction_for_amazon_bedrock() {
+    let provider = ModelProviderInfo::create_amazon_bedrock_provider(/*aws*/ None);
+
+    assert!(provider.supports_remote_compaction());
+    assert!(!provider.supports_remote_compaction_v2());
 }
 
 #[test]
@@ -171,6 +180,7 @@ fn test_supports_remote_compaction_for_azure_name() {
     };
 
     assert!(provider.supports_remote_compaction());
+    assert!(!provider.supports_remote_compaction_v2());
 }
 
 #[test]
@@ -196,6 +206,7 @@ fn test_supports_remote_compaction_for_non_openai_non_azure_provider() {
     };
 
     assert!(!provider.supports_remote_compaction());
+    assert!(!provider.supports_remote_compaction_v2());
 }
 
 #[test]


### PR DESCRIPTION
## Why

Remote compaction v2 is ready to be the default path for OpenAI sessions. Enabling it globally still needs to preserve provider-specific routing: providers that support only the existing remote compaction endpoint must not be sent through the OpenAI-only v2 Responses flow.

## What changed

- Mark `remote_compaction_v2` as stable and enable it by default.
- Add an explicit v2 capability check so automatic and manual compaction use v2 only for OpenAI providers.
- Route Amazon Bedrock through the existing remote compaction path, alongside Azure, while unsupported providers continue to compact locally.
- Keep legacy remote-compaction tests explicit by disabling v2 in their shared harness, and update parity coverage for the new default.

## Testing

- Extended provider capability coverage for OpenAI, Amazon Bedrock, Azure, and unsupported providers.
- Updated remote compaction integration and parity tests to exercise both the default v2 path and the explicitly selected legacy path.
