### PR TITLE
[codex] Raise app-server recursion limit

### DIFF
--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 #![deny(clippy::print_stdout, clippy::print_stderr)]
 
 use codex_arg0::Arg0DispatchPaths;


### PR DESCRIPTION
## Summary

Unblock Rust release builds after tracing instrumentation increased the async future query depth beyond rustc's default limit.

Set the `codex-app-server` crate recursion limit to 256. This changes compilation only; runtime behavior is unchanged.

## Validation

- `just test -p codex-app-server`
- `cargo build --release --bin codex-app-server`