### PR TITLE
[codex] migrate ExecutorFileSystem read_directory to PathUri

### DIFF
--- a/codex-rs/app-server/src/request_processors/fs_processor.rs
+++ b/codex-rs/app-server/src/request_processors/fs_processor.rs
@@ -134,9 +134,10 @@ impl FsRequestProcessor {
         &self,
         params: FsReadDirectoryParams,
     ) -> Result<FsReadDirectoryResponse, JSONRPCErrorError> {
+        let path = PathUri::from_abs_path(&params.path).map_err(map_fs_error)?;
         let entries = self
             .file_system()?
-            .read_directory(&params.path, /*sandbox*/ None)
+            .read_directory(&path, /*sandbox*/ None)
             .await
             .map_err(map_fs_error)?;
         Ok(FsReadDirectoryResponse {

--- a/codex-rs/config/src/loader/tests.rs
+++ b/codex-rs/config/src/loader/tests.rs
@@ -62,7 +62,7 @@ impl ExecutorFileSystem for TestFileSystem {
 
     async fn read_directory(
         &self,
-        _path: &AbsolutePathBuf,
+        _path: &PathUri,
         _sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<Vec<ReadDirectoryEntry>> {
         unimplemented!("test filesystem only supports reads")

--- a/codex-rs/core-skills/src/loader.rs
+++ b/codex-rs/core-skills/src/loader.rs
@@ -571,7 +571,17 @@ async fn discover_skills_under_root(
     let mut truncated_by_dir_limit = false;
 
     while let Some((dir, depth)) = queue.pop_front() {
-        let entries = match fs.read_directory(&dir, /*sandbox*/ None).await {
+        let dir_uri = match PathUri::from_abs_path(&dir) {
+            Ok(path) => path,
+            Err(e) => {
+                tracing::warn!(
+                    "failed to convert skills dir {} to URI: {e:#}",
+                    dir.display()
+                );
+                continue;
+            }
+        };
+        let entries = match fs.read_directory(&dir_uri, /*sandbox*/ None).await {
             Ok(entries) => entries,
             Err(e) => {
                 error!("failed to read skills dir {}: {e:#}", dir.display());
@@ -608,7 +618,7 @@ async fn discover_skills_under_root(
                 if !follow_symlinks {
                     continue;
                 }
-                match fs.read_directory(&path, /*sandbox*/ None).await {
+                match fs.read_directory(&path_uri, /*sandbox*/ None).await {
                     Ok(_) => {
                         let resolved_dir = canonicalize_for_skill_identity(fs, &path).await;
                         enqueue_dir(

--- a/codex-rs/core/src/config/agent_roles.rs
+++ b/codex-rs/core/src/config/agent_roles.rs
@@ -525,7 +525,8 @@ async fn collect_agent_role_files(
     let mut files = Vec::new();
     let mut dirs = vec![dir.clone()];
     while let Some(dir) = dirs.pop() {
-        let entries = match fs.read_directory(&dir, /*sandbox*/ None).await {
+        let dir_uri = PathUri::from_abs_path(&dir)?;
+        let entries = match fs.read_directory(&dir_uri, /*sandbox*/ None).await {
             Ok(entries) => entries,
             Err(err) if err.kind() == ErrorKind::NotFound => continue,
             Err(err) => return Err(err),

--- a/codex-rs/exec-server/src/fs_helper.rs
+++ b/codex-rs/exec-server/src/fs_helper.rs
@@ -258,8 +258,10 @@ pub(crate) async fn run_direct_request(
             }))
         }
         FsHelperRequest::ReadDirectory(params) => {
+            let path =
+                codex_utils_path_uri::PathUri::from_abs_path(&params.path).map_err(map_fs_error)?;
             let entries = file_system
-                .read_directory(&params.path, /*sandbox*/ None)
+                .read_directory(&path, /*sandbox*/ None)
                 .await
                 .map_err(map_fs_error)?
                 .into_iter()

--- a/codex-rs/exec-server/src/local_file_system.rs
+++ b/codex-rs/exec-server/src/local_file_system.rs
@@ -129,7 +129,7 @@ impl ExecutorFileSystem for LocalFileSystem {
 
     async fn read_directory(
         &self,
-        path: &AbsolutePathBuf,
+        path: &PathUri,
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<Vec<ReadDirectoryEntry>> {
         let (file_system, sandbox) = self.file_system_for(sandbox)?;
@@ -215,7 +215,7 @@ impl ExecutorFileSystem for UnsandboxedFileSystem {
 
     async fn read_directory(
         &self,
-        path: &AbsolutePathBuf,
+        path: &PathUri,
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<Vec<ReadDirectoryEntry>> {
         reject_platform_sandbox_context(sandbox)?;
@@ -333,10 +333,11 @@ impl ExecutorFileSystem for DirectFileSystem {
 
     async fn read_directory(
         &self,
-        path: &AbsolutePathBuf,
+        path: &PathUri,
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<Vec<ReadDirectoryEntry>> {
         reject_sandbox_context(sandbox)?;
+        let path = path.to_abs_path()?;
         let mut entries = Vec::new();
         let mut read_dir = tokio::fs::read_dir(path.as_path()).await?;
         while let Some(entry) = read_dir.next_entry().await? {

--- a/codex-rs/exec-server/src/remote_file_system.rs
+++ b/codex-rs/exec-server/src/remote_file_system.rs
@@ -148,14 +148,15 @@ impl ExecutorFileSystem for RemoteFileSystem {
 
     async fn read_directory(
         &self,
-        path: &AbsolutePathBuf,
+        path: &PathUri,
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<Vec<ReadDirectoryEntry>> {
         trace!("remote fs read_directory");
+        let path = path.to_abs_path()?;
         let client = self.client.get().await.map_err(map_remote_error)?;
         let response = client
             .fs_read_directory(FsReadDirectoryParams {
-                path: path.clone(),
+                path,
                 sandbox: remote_sandbox_context(sandbox),
             })
             .await

--- a/codex-rs/exec-server/src/sandboxed_file_system.rs
+++ b/codex-rs/exec-server/src/sandboxed_file_system.rs
@@ -168,7 +168,7 @@ impl ExecutorFileSystem for SandboxedFileSystem {
 
     async fn read_directory(
         &self,
-        path: &AbsolutePathBuf,
+        path: &PathUri,
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<Vec<ReadDirectoryEntry>> {
         let sandbox = require_platform_sandbox(sandbox)?;
@@ -176,7 +176,7 @@ impl ExecutorFileSystem for SandboxedFileSystem {
             .run_sandboxed(
                 sandbox,
                 FsHelperRequest::ReadDirectory(FsReadDirectoryParams {
-                    path: path.clone(),
+                    path: path.to_abs_path()?,
                     sandbox: None,
                 }),
             )

--- a/codex-rs/exec-server/src/server/file_system_handler.rs
+++ b/codex-rs/exec-server/src/server/file_system_handler.rs
@@ -153,9 +153,10 @@ impl FileSystemHandler {
         &self,
         params: FsReadDirectoryParams,
     ) -> Result<FsReadDirectoryResponse, JSONRPCErrorError> {
+        let path = PathUri::from_abs_path(&params.path).map_err(map_fs_error)?;
         let entries = self
             .file_system
-            .read_directory(&params.path, params.sandbox.as_ref())
+            .read_directory(&path, params.sandbox.as_ref())
             .await
             .map_err(map_fs_error)?
             .into_iter()

--- a/codex-rs/exec-server/tests/file_system/shared.rs
+++ b/codex-rs/exec-server/tests/file_system/shared.rs
@@ -273,7 +273,7 @@ async fn file_system_read_directory_lists_entries(
     std::fs::write(source_dir.join("root.txt"), "hello")?;
 
     let mut entries = file_system
-        .read_directory(&absolute_path(&source_dir), /*sandbox*/ None)
+        .read_directory(&PathUri::from_path(&source_dir)?, /*sandbox*/ None)
         .await
         .with_context(|| format!("mode={implementation}"))?;
     entries.sort_by(|left, right| left.file_name.cmp(&right.file_name));

--- a/codex-rs/exec-server/tests/file_system_unix.rs
+++ b/codex-rs/exec-server/tests/file_system_unix.rs
@@ -513,7 +513,7 @@ async fn file_system_read_directory_rejects_symlink_escape(
     let requested_path = allowed_dir.join("link");
     let sandbox = read_only_sandbox(allowed_dir);
     let error = match file_system
-        .read_directory(&absolute_path(&requested_path), Some(&sandbox))
+        .read_directory(&PathUri::from_path(&requested_path)?, Some(&sandbox))
         .await
     {
         Ok(_) => anyhow::bail!("read_directory should be blocked"),

--- a/codex-rs/ext/skills/tests/executor_file_system_authority.rs
+++ b/codex-rs/ext/skills/tests/executor_file_system_authority.rs
@@ -111,16 +111,17 @@ impl ExecutorFileSystem for SyntheticFileSystem {
 
     async fn read_directory(
         &self,
-        path: &AbsolutePathBuf,
+        path: &PathUri,
         _sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<Vec<ReadDirectoryEntry>> {
-        if path == &self.canonical_root {
+        let path = path.to_abs_path()?;
+        if path == self.canonical_root {
             Ok(vec![ReadDirectoryEntry {
                 file_name: "skill".to_string(),
                 is_directory: true,
                 is_file: false,
             }])
-        } else if path == &self.canonical_root.join("skill") {
+        } else if path == self.canonical_root.join("skill") {
             Ok(vec![ReadDirectoryEntry {
                 file_name: "SKILL.md".to_string(),
                 is_directory: false,

--- a/codex-rs/file-system/src/lib.rs
+++ b/codex-rs/file-system/src/lib.rs
@@ -179,7 +179,7 @@ pub trait ExecutorFileSystem: Send + Sync {
 
     async fn read_directory(
         &self,
-        path: &AbsolutePathBuf,
+        path: &PathUri,
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<Vec<ReadDirectoryEntry>>;
 


### PR DESCRIPTION
Intent: move `ExecutorFileSystem` directory reads onto `PathUri` without changing wire payloads.

Implementation: change `read_directory` arguments to `PathUri`, converting at exec-server adapter boundaries.

Validation: focused stack validation ran affected crate tests and core regression selectors.

Stacked on #27429.