### PR TITLE
feat: add Bedrock API key as a managed auth mode

### DIFF
--- a/codex-rs/app-server-protocol/schema/json/ServerNotification.json
+++ b/codex-rs/app-server-protocol/schema/json/ServerNotification.json
@@ -532,6 +532,13 @@
             "personalAccessToken"
           ],
           "type": "string"
+        },
+        {
+          "description": "Amazon Bedrock bearer token managed by Codex.",
+          "enum": [
+            "bedrockApiKey"
+          ],
+          "type": "string"
         }
       ]
     },

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -6728,6 +6728,13 @@
               "personalAccessToken"
             ],
             "type": "string"
+          },
+          {
+            "description": "Amazon Bedrock bearer token managed by Codex.",
+            "enum": [
+              "bedrockApiKey"
+            ],
+            "type": "string"
           }
         ]
       },

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
@@ -1006,6 +1006,13 @@
             "personalAccessToken"
           ],
           "type": "string"
+        },
+        {
+          "description": "Amazon Bedrock bearer token managed by Codex.",
+          "enum": [
+            "bedrockApiKey"
+          ],
+          "type": "string"
         }
       ]
     },

--- a/codex-rs/app-server-protocol/schema/json/v2/AccountUpdatedNotification.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/AccountUpdatedNotification.json
@@ -38,6 +38,13 @@
             "personalAccessToken"
           ],
           "type": "string"
+        },
+        {
+          "description": "Amazon Bedrock bearer token managed by Codex.",
+          "enum": [
+            "bedrockApiKey"
+          ],
+          "type": "string"
         }
       ]
     },

--- a/codex-rs/app-server-protocol/schema/typescript/AuthMode.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/AuthMode.ts
@@ -5,4 +5,4 @@
 /**
  * Authentication mode for OpenAI-backed providers.
  */
-export type AuthMode = "apikey" | "chatgpt" | "chatgptAuthTokens" | "agentIdentity" | "personalAccessToken";
+export type AuthMode = "apikey" | "chatgpt" | "chatgptAuthTokens" | "agentIdentity" | "personalAccessToken" | "bedrockApiKey";

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -41,6 +41,11 @@ pub enum AuthMode {
     #[ts(rename = "personalAccessToken")]
     #[strum(serialize = "personalAccessToken")]
     PersonalAccessToken,
+    /// Amazon Bedrock bearer token managed by Codex.
+    #[serde(rename = "bedrockApiKey")]
+    #[ts(rename = "bedrockApiKey")]
+    #[strum(serialize = "bedrockApiKey")]
+    BedrockApiKey,
 }
 
 impl AuthMode {
@@ -48,7 +53,7 @@ impl AuthMode {
     pub fn has_chatgpt_account(self) -> bool {
         match self {
             Self::Chatgpt | Self::ChatgptAuthTokens | Self::PersonalAccessToken => true,
-            Self::ApiKey | Self::AgentIdentity => false,
+            Self::ApiKey | Self::AgentIdentity | Self::BedrockApiKey => false,
         }
     }
 }

--- a/codex-rs/app-server-transport/src/transport/remote_control/tests.rs
+++ b/codex-rs/app-server-transport/src/transport/remote_control/tests.rs
@@ -116,6 +116,7 @@ fn remote_control_auth_dot_json(account_id: Option<&str>) -> AuthDotJson {
         last_refresh: Some(chrono::Utc::now()),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     }
 }
 

--- a/codex-rs/app-server-transport/src/transport/remote_control/websocket.rs
+++ b/codex-rs/app-server-transport/src/transport/remote_control/websocket.rs
@@ -1842,6 +1842,7 @@ mod tests {
             last_refresh: Some(Utc::now()),
             agent_identity: None,
             personal_access_token: None,
+            bedrock_api_key: None,
         }
     }
 

--- a/codex-rs/app-server/src/request_processors/account_processor.rs
+++ b/codex-rs/app-server/src/request_processors/account_processor.rs
@@ -778,7 +778,9 @@ impl AccountRequestProcessor {
                     let auth_mode = auth.api_auth_mode();
                     let (reported_auth_method, token_opt) = if matches!(
                         auth,
-                        CodexAuth::AgentIdentity(_) | CodexAuth::PersonalAccessToken(_)
+                        CodexAuth::AgentIdentity(_)
+                            | CodexAuth::PersonalAccessToken(_)
+                            | CodexAuth::BedrockApiKey(_)
                     ) || include_token
                         && permanent_refresh_failure
                     {

--- a/codex-rs/app-server/src/request_processors/account_processor.rs
+++ b/codex-rs/app-server/src/request_processors/account_processor.rs
@@ -778,9 +778,7 @@ impl AccountRequestProcessor {
                     let auth_mode = auth.api_auth_mode();
                     let (reported_auth_method, token_opt) = if matches!(
                         auth,
-                        CodexAuth::AgentIdentity(_)
-                            | CodexAuth::PersonalAccessToken(_)
-                            | CodexAuth::BedrockApiKey(_)
+                        CodexAuth::AgentIdentity(_) | CodexAuth::PersonalAccessToken(_)
                     ) || include_token
                         && permanent_refresh_failure
                     {

--- a/codex-rs/app-server/tests/common/auth_fixtures.rs
+++ b/codex-rs/app-server/tests/common/auth_fixtures.rs
@@ -165,6 +165,7 @@ pub fn write_chatgpt_auth(
         last_refresh,
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
 
     save_auth(codex_home, &auth, cli_auth_credentials_store_mode).context("write auth.json")

--- a/codex-rs/app-server/tests/suite/v2/app_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/app_list.rs
@@ -119,6 +119,7 @@ async fn list_apps_returns_empty_with_api_key_auth() -> Result<()> {
             last_refresh: None,
             agent_identity: None,
             personal_access_token: None,
+            bedrock_api_key: None,
         },
         AuthCredentialsStoreMode::File,
     )?;

--- a/codex-rs/cli/src/doctor.rs
+++ b/codex-rs/cli/src/doctor.rs
@@ -1324,6 +1324,7 @@ fn stored_auth_mode(auth: &codex_login::AuthDotJson) -> &'static str {
         codex_app_server_protocol::AuthMode::ChatgptAuthTokens => "chatgpt_auth_tokens",
         codex_app_server_protocol::AuthMode::AgentIdentity => "agent_identity",
         codex_app_server_protocol::AuthMode::PersonalAccessToken => "personal_access_token",
+        codex_app_server_protocol::AuthMode::BedrockApiKey => "bedrock_api_key",
     }
 }
 
@@ -1331,10 +1332,12 @@ fn stored_auth_mode_value(auth: &AuthDotJson) -> codex_app_server_protocol::Auth
     if let Some(mode) = auth.auth_mode {
         return mode;
     }
-    if auth.openai_api_key.is_some() {
-        codex_app_server_protocol::AuthMode::ApiKey
-    } else if auth.personal_access_token.is_some() {
+    if auth.personal_access_token.is_some() {
         codex_app_server_protocol::AuthMode::PersonalAccessToken
+    } else if auth.bedrock_api_key.is_some() {
+        codex_app_server_protocol::AuthMode::BedrockApiKey
+    } else if auth.openai_api_key.is_some() {
+        codex_app_server_protocol::AuthMode::ApiKey
     } else {
         codex_app_server_protocol::AuthMode::Chatgpt
     }
@@ -1405,6 +1408,11 @@ fn stored_auth_issues(
                 .is_none_or(|token| token.trim().is_empty())
             {
                 issues.push("personal access token auth is missing a personal access token");
+            }
+        }
+        codex_app_server_protocol::AuthMode::BedrockApiKey => {
+            if auth.bedrock_api_key.is_none() {
+                issues.push("Bedrock API key auth is missing a Bedrock API key");
             }
         }
     }
@@ -2437,6 +2445,7 @@ fn auth_mode_name(auth: &CodexAuth) -> &'static str {
         codex_app_server_protocol::AuthMode::ChatgptAuthTokens => "chatgpt_auth_tokens",
         codex_app_server_protocol::AuthMode::AgentIdentity => "agent_identity",
         codex_app_server_protocol::AuthMode::PersonalAccessToken => "personal_access_token",
+        codex_app_server_protocol::AuthMode::BedrockApiKey => "bedrock_api_key",
     }
 }
 
@@ -2566,7 +2575,10 @@ fn provider_auth_reachability_mode_from_auth(
         return ProviderAuthReachabilityMode::Chatgpt;
     }
     match stored_auth.map(stored_auth_mode_value) {
-        Some(codex_app_server_protocol::AuthMode::ApiKey) => ProviderAuthReachabilityMode::ApiKey,
+        Some(
+            codex_app_server_protocol::AuthMode::ApiKey
+            | codex_app_server_protocol::AuthMode::BedrockApiKey,
+        ) => ProviderAuthReachabilityMode::ApiKey,
         Some(
             codex_app_server_protocol::AuthMode::Chatgpt
             | codex_app_server_protocol::AuthMode::ChatgptAuthTokens
@@ -3471,6 +3483,7 @@ mod tests {
             last_refresh: None,
             agent_identity: None,
             personal_access_token: None,
+            bedrock_api_key: None,
         };
 
         assert_eq!(
@@ -3489,6 +3502,7 @@ mod tests {
             last_refresh: None,
             agent_identity: None,
             personal_access_token: None,
+            bedrock_api_key: None,
         };
 
         assert_eq!(
@@ -3509,6 +3523,7 @@ mod tests {
             last_refresh: None,
             agent_identity: None,
             personal_access_token: Some("at-test".to_string()),
+            bedrock_api_key: None,
         };
 
         assert_eq!(stored_auth_mode(&auth), "personal_access_token");
@@ -3531,6 +3546,7 @@ mod tests {
             last_refresh: None,
             agent_identity: None,
             personal_access_token: None,
+            bedrock_api_key: None,
         };
 
         assert_eq!(

--- a/codex-rs/cli/src/login.rs
+++ b/codex-rs/cli/src/login.rs
@@ -395,6 +395,10 @@ pub async fn run_login_status(cli_config_overrides: CliConfigOverrides) -> ! {
                 eprintln!("Logged in using personal access token");
                 std::process::exit(0);
             }
+            AuthMode::BedrockApiKey => {
+                eprintln!("Logged in using Amazon Bedrock API key");
+                std::process::exit(0);
+            }
         },
         Ok(None) => {
             eprintln!("Not logged in");

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -1985,7 +1985,7 @@ impl AuthRequestTelemetryContext {
         let auth_telemetry = auth_header_telemetry(api_auth);
         Self {
             auth_mode: auth_mode.map(|mode| match mode {
-                AuthMode::ApiKey => "ApiKey",
+                AuthMode::ApiKey | AuthMode::BedrockApiKey => "ApiKey",
                 AuthMode::Chatgpt
                 | AuthMode::ChatgptAuthTokens
                 | AuthMode::AgentIdentity

--- a/codex-rs/login/src/auth/auth_tests.rs
+++ b/codex-rs/login/src/auth/auth_tests.rs
@@ -166,6 +166,7 @@ async fn login_with_access_token_writes_only_personal_access_token() {
             last_refresh: None,
             agent_identity: None,
             personal_access_token: Some("at-login-test".to_string()),
+            bedrock_api_key: None,
         }
     );
     assert_eq!(auth.resolved_mode(), AuthMode::PersonalAccessToken);
@@ -325,6 +326,7 @@ async fn pro_account_with_no_api_key_uses_chatgpt_auth() {
             last_refresh: Some(last_refresh),
             agent_identity: None,
             personal_access_token: None,
+            bedrock_api_key: None,
         },
         auth_dot_json
     );
@@ -367,6 +369,7 @@ fn logout_removes_auth_file() -> Result<(), std::io::Error> {
         last_refresh: None,
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     super::save_auth(dir.path(), &auth_dot_json, AuthCredentialsStoreMode::File)?;
     let auth_file = get_auth_file(dir.path());
@@ -1112,6 +1115,7 @@ async fn enforce_login_restrictions_logs_out_for_agent_identity_workspace_mismat
             last_refresh: None,
             agent_identity: Some(agent_identity),
             personal_access_token: None,
+            bedrock_api_key: None,
         },
         AuthCredentialsStoreMode::File,
     )

--- a/codex-rs/login/src/auth/bedrock_api_key.rs
+++ b/codex-rs/login/src/auth/bedrock_api_key.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 
 use super::manager::AuthManager;
 use super::storage::AuthDotJson;
-use super::storage::create_auth_storage;
+use codex_app_server_protocol::AuthMode;
 
 /// Managed Amazon Bedrock API key persisted in `auth.json`.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
@@ -30,13 +30,19 @@ impl BedrockApiKeyAuthRecord {
     }
 }
 
-impl AuthDotJson {
-    pub(super) fn has_primary_auth(&self) -> bool {
-        self.auth_mode.is_some()
-            || self.openai_api_key.is_some()
-            || self.tokens.is_some()
-            || self.agent_identity.is_some()
-            || self.personal_access_token.is_some()
+/// Runtime authentication state for Amazon Bedrock bearer-token auth.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BedrockApiKeyAuth {
+    record: BedrockApiKeyAuthRecord,
+}
+
+impl BedrockApiKeyAuth {
+    pub fn load(record: BedrockApiKeyAuthRecord) -> Self {
+        Self { record }
+    }
+
+    pub fn api_key(&self) -> &str {
+        self.record.api_key()
     }
 }
 
@@ -52,44 +58,44 @@ impl AuthManager {
         self.bedrock_api_key_cached().is_some()
     }
 
-    pub fn save_bedrock_api_key(&self, record: BedrockApiKeyAuthRecord) -> io::Result<()> {
-        let storage = create_auth_storage(
-            self.codex_home_for_auth_storage(),
-            self.auth_credentials_store_mode(),
-        );
-        let mut auth = storage.load()?.unwrap_or_else(empty_auth_dot_json);
-        auth.bedrock_api_key = Some(record);
-        storage.save(&auth)
+    pub async fn save_bedrock_api_key(&self, record: BedrockApiKeyAuthRecord) -> io::Result<()> {
+        let storage = self.auth_storage();
+        storage.save(&bedrock_auth_dot_json(record))?;
+        self.reload().await;
+        Ok(())
     }
 
-    pub fn clear_bedrock_api_key(&self) -> io::Result<bool> {
-        let storage = create_auth_storage(
-            self.codex_home_for_auth_storage(),
-            self.auth_credentials_store_mode(),
-        );
-        let Some(mut auth) = storage.load()? else {
+    pub async fn clear_bedrock_api_key(&self) -> io::Result<bool> {
+        let storage = self.auth_storage();
+        let Some(auth) = storage.load()? else {
             return Ok(false);
         };
-        if auth.bedrock_api_key.take().is_none() {
+        if auth.resolved_mode() != AuthMode::BedrockApiKey {
             return Ok(false);
         }
-        if !auth.has_primary_auth() {
-            storage.delete()?;
-        } else {
-            storage.save(&auth)?;
-        }
-        Ok(true)
+        let removed = storage.delete()?;
+        self.reload().await;
+        Ok(removed)
+    }
+}
+
+pub(super) fn bedrock_auth_dot_json(record: BedrockApiKeyAuthRecord) -> AuthDotJson {
+    AuthDotJson {
+        auth_mode: Some(AuthMode::BedrockApiKey),
+        openai_api_key: None,
+        tokens: None,
+        last_refresh: None,
+        agent_identity: None,
+        personal_access_token: None,
+        bedrock_api_key: Some(record),
     }
 }
 
 fn load_auth_dot_json(manager: &AuthManager) -> io::Result<Option<AuthDotJson>> {
-    create_auth_storage(
-        manager.codex_home_for_auth_storage(),
-        manager.auth_credentials_store_mode(),
-    )
-    .load()
+    manager.auth_storage().load()
 }
 
+#[cfg(test)]
 fn empty_auth_dot_json() -> AuthDotJson {
     AuthDotJson {
         auth_mode: None,

--- a/codex-rs/login/src/auth/bedrock_api_key.rs
+++ b/codex-rs/login/src/auth/bedrock_api_key.rs
@@ -1,0 +1,107 @@
+use std::io;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use super::manager::AuthManager;
+use super::storage::AuthDotJson;
+use super::storage::create_auth_storage;
+
+/// Managed Amazon Bedrock API key persisted in `auth.json`.
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
+pub struct BedrockApiKeyAuthRecord {
+    api_key: String,
+}
+
+impl BedrockApiKeyAuthRecord {
+    pub fn try_new(api_key: impl Into<String>) -> io::Result<Self> {
+        let api_key = api_key.into().trim().to_string();
+        if api_key.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Bedrock API key must not be empty",
+            ));
+        }
+        Ok(Self { api_key })
+    }
+
+    pub fn api_key(&self) -> &str {
+        &self.api_key
+    }
+}
+
+impl AuthDotJson {
+    pub(super) fn has_primary_auth(&self) -> bool {
+        self.auth_mode.is_some()
+            || self.openai_api_key.is_some()
+            || self.tokens.is_some()
+            || self.agent_identity.is_some()
+            || self.personal_access_token.is_some()
+    }
+}
+
+impl AuthManager {
+    pub fn bedrock_api_key_cached(&self) -> Option<BedrockApiKeyAuthRecord> {
+        load_auth_dot_json(self)
+            .ok()
+            .flatten()
+            .and_then(|auth| auth.bedrock_api_key)
+    }
+
+    pub fn has_bedrock_api_key(&self) -> bool {
+        self.bedrock_api_key_cached().is_some()
+    }
+
+    pub fn save_bedrock_api_key(&self, record: BedrockApiKeyAuthRecord) -> io::Result<()> {
+        let storage = create_auth_storage(
+            self.codex_home_for_auth_storage(),
+            self.auth_credentials_store_mode(),
+        );
+        let mut auth = storage.load()?.unwrap_or_else(empty_auth_dot_json);
+        auth.bedrock_api_key = Some(record);
+        storage.save(&auth)
+    }
+
+    pub fn clear_bedrock_api_key(&self) -> io::Result<bool> {
+        let storage = create_auth_storage(
+            self.codex_home_for_auth_storage(),
+            self.auth_credentials_store_mode(),
+        );
+        let Some(mut auth) = storage.load()? else {
+            return Ok(false);
+        };
+        if auth.bedrock_api_key.take().is_none() {
+            return Ok(false);
+        }
+        if !auth.has_primary_auth() {
+            storage.delete()?;
+        } else {
+            storage.save(&auth)?;
+        }
+        Ok(true)
+    }
+}
+
+fn load_auth_dot_json(manager: &AuthManager) -> io::Result<Option<AuthDotJson>> {
+    create_auth_storage(
+        manager.codex_home_for_auth_storage(),
+        manager.auth_credentials_store_mode(),
+    )
+    .load()
+}
+
+fn empty_auth_dot_json() -> AuthDotJson {
+    AuthDotJson {
+        auth_mode: None,
+        openai_api_key: None,
+        tokens: None,
+        last_refresh: None,
+        agent_identity: None,
+        personal_access_token: None,
+        bedrock_api_key: None,
+    }
+}
+
+#[cfg(test)]
+#[path = "bedrock_api_key_tests.rs"]
+mod tests;

--- a/codex-rs/login/src/auth/bedrock_api_key.rs
+++ b/codex-rs/login/src/auth/bedrock_api_key.rs
@@ -9,11 +9,11 @@ use codex_app_server_protocol::AuthMode;
 
 /// Managed Amazon Bedrock API key persisted in `auth.json`.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct BedrockApiKeyAuthRecord {
+pub struct BedrockApiKeyAuth {
     api_key: String,
 }
 
-impl BedrockApiKeyAuthRecord {
+impl BedrockApiKeyAuth {
     pub fn try_new(api_key: impl Into<String>) -> io::Result<Self> {
         let api_key = api_key.into().trim().to_string();
         if api_key.is_empty() {
@@ -30,37 +30,10 @@ impl BedrockApiKeyAuthRecord {
     }
 }
 
-/// Runtime authentication state for Amazon Bedrock bearer-token auth.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct BedrockApiKeyAuth {
-    record: BedrockApiKeyAuthRecord,
-}
-
-impl BedrockApiKeyAuth {
-    pub fn load(record: BedrockApiKeyAuthRecord) -> Self {
-        Self { record }
-    }
-
-    pub fn api_key(&self) -> &str {
-        self.record.api_key()
-    }
-}
-
 impl AuthManager {
-    pub fn bedrock_api_key_cached(&self) -> Option<BedrockApiKeyAuthRecord> {
-        load_auth_dot_json(self)
-            .ok()
-            .flatten()
-            .and_then(|auth| auth.bedrock_api_key)
-    }
-
-    pub fn has_bedrock_api_key(&self) -> bool {
-        self.bedrock_api_key_cached().is_some()
-    }
-
-    pub async fn save_bedrock_api_key(&self, record: BedrockApiKeyAuthRecord) -> io::Result<()> {
+    pub async fn save_bedrock_api_key(&self, auth: BedrockApiKeyAuth) -> io::Result<()> {
         let storage = self.auth_storage();
-        storage.save(&bedrock_auth_dot_json(record))?;
+        storage.save(&bedrock_auth_dot_json(auth))?;
         self.reload().await;
         Ok(())
     }
@@ -79,7 +52,7 @@ impl AuthManager {
     }
 }
 
-pub(super) fn bedrock_auth_dot_json(record: BedrockApiKeyAuthRecord) -> AuthDotJson {
+pub(super) fn bedrock_auth_dot_json(auth: BedrockApiKeyAuth) -> AuthDotJson {
     AuthDotJson {
         auth_mode: Some(AuthMode::BedrockApiKey),
         openai_api_key: None,
@@ -87,24 +60,7 @@ pub(super) fn bedrock_auth_dot_json(record: BedrockApiKeyAuthRecord) -> AuthDotJ
         last_refresh: None,
         agent_identity: None,
         personal_access_token: None,
-        bedrock_api_key: Some(record),
-    }
-}
-
-fn load_auth_dot_json(manager: &AuthManager) -> io::Result<Option<AuthDotJson>> {
-    manager.auth_storage().load()
-}
-
-#[cfg(test)]
-fn empty_auth_dot_json() -> AuthDotJson {
-    AuthDotJson {
-        auth_mode: None,
-        openai_api_key: None,
-        tokens: None,
-        last_refresh: None,
-        agent_identity: None,
-        personal_access_token: None,
-        bedrock_api_key: None,
+        bedrock_api_key: Some(auth),
     }
 }
 

--- a/codex-rs/login/src/auth/bedrock_api_key.rs
+++ b/codex-rs/login/src/auth/bedrock_api_key.rs
@@ -1,67 +1,40 @@
-use std::io;
+use std::path::Path;
 
+use codex_config::types::AuthCredentialsStoreMode;
 use serde::Deserialize;
 use serde::Serialize;
 
-use super::manager::AuthManager;
+use super::manager::save_auth;
 use super::storage::AuthDotJson;
 use codex_app_server_protocol::AuthMode;
 
 /// Managed Amazon Bedrock API key persisted in `auth.json`.
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct BedrockApiKeyAuth {
-    api_key: String,
+    pub api_key: String,
+    pub region: String,
 }
 
-impl BedrockApiKeyAuth {
-    pub fn try_new(api_key: impl Into<String>) -> io::Result<Self> {
-        let api_key = api_key.into().trim().to_string();
-        if api_key.is_empty() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "Bedrock API key must not be empty",
-            ));
-        }
-        Ok(Self { api_key })
-    }
-
-    pub fn api_key(&self) -> &str {
-        &self.api_key
-    }
-}
-
-impl AuthManager {
-    pub async fn save_bedrock_api_key(&self, auth: BedrockApiKeyAuth) -> io::Result<()> {
-        let storage = self.auth_storage();
-        storage.save(&bedrock_auth_dot_json(auth))?;
-        self.reload().await;
-        Ok(())
-    }
-
-    pub async fn clear_bedrock_api_key(&self) -> io::Result<bool> {
-        let storage = self.auth_storage();
-        let Some(auth) = storage.load()? else {
-            return Ok(false);
-        };
-        if auth.resolved_mode() != AuthMode::BedrockApiKey {
-            return Ok(false);
-        }
-        let removed = storage.delete()?;
-        self.reload().await;
-        Ok(removed)
-    }
-}
-
-pub(super) fn bedrock_auth_dot_json(auth: BedrockApiKeyAuth) -> AuthDotJson {
-    AuthDotJson {
+/// Writes an `auth.json` that contains only the Amazon Bedrock API key auth.
+pub fn login_with_bedrock_api_key(
+    codex_home: &Path,
+    api_key: &str,
+    region: &str,
+    auth_credentials_store_mode: AuthCredentialsStoreMode,
+) -> std::io::Result<()> {
+    let auth_dot_json = AuthDotJson {
         auth_mode: Some(AuthMode::BedrockApiKey),
         openai_api_key: None,
         tokens: None,
         last_refresh: None,
         agent_identity: None,
         personal_access_token: None,
-        bedrock_api_key: Some(auth),
-    }
+        bedrock_api_key: Some(BedrockApiKeyAuth {
+            api_key: api_key.to_string(),
+            region: region.to_string(),
+        }),
+    };
+    save_auth(codex_home, &auth_dot_json, auth_credentials_store_mode)
 }
 
 #[cfg(test)]

--- a/codex-rs/login/src/auth/bedrock_api_key_tests.rs
+++ b/codex-rs/login/src/auth/bedrock_api_key_tests.rs
@@ -4,6 +4,7 @@ use pretty_assertions::assert_eq;
 use tempfile::tempdir;
 
 use super::*;
+use crate::auth::CodexAuth;
 use crate::auth::storage::AuthStorageBackend;
 use crate::auth::storage::FileAuthStorage;
 use crate::auth::storage::get_auth_file;
@@ -32,7 +33,7 @@ fn bedrock_record() -> BedrockApiKeyAuthRecord {
 }
 
 #[tokio::test]
-async fn save_bedrock_api_key_preserves_openai_auth() -> anyhow::Result<()> {
+async fn save_bedrock_api_key_replaces_openai_auth() -> anyhow::Result<()> {
     let codex_home = tempdir()?;
     let storage = FileAuthStorage::new(codex_home.path().to_path_buf());
     storage.save(&api_key_auth())?;
@@ -44,15 +45,25 @@ async fn save_bedrock_api_key_preserves_openai_auth() -> anyhow::Result<()> {
     )
     .await;
 
-    auth_manager.save_bedrock_api_key(bedrock_record())?;
+    auth_manager.save_bedrock_api_key(bedrock_record()).await?;
 
     let loaded = storage.load()?.expect("auth should be stored");
+    let expected = bedrock_auth_dot_json(BedrockApiKeyAuthRecord::try_new("bedrock-api-key-test")?);
+    assert_eq!(loaded, expected);
+    assert_eq!(auth_manager.auth_mode(), Some(AuthMode::BedrockApiKey));
     assert_eq!(
-        loaded,
-        AuthDotJson {
-            bedrock_api_key: Some(BedrockApiKeyAuthRecord::try_new("bedrock-api-key-test")?),
-            ..api_key_auth()
-        }
+        auth_manager
+            .auth_cached()
+            .and_then(|auth| match auth {
+                CodexAuth::BedrockApiKey(auth) => Some(auth.api_key().to_string()),
+                CodexAuth::ApiKey(_)
+                | CodexAuth::Chatgpt(_)
+                | CodexAuth::ChatgptAuthTokens(_)
+                | CodexAuth::AgentIdentity(_)
+                | CodexAuth::PersonalAccessToken(_) => None,
+            })
+            .as_deref(),
+        Some("bedrock-api-key-test")
     );
     assert_eq!(
         auth_manager
@@ -66,13 +77,10 @@ async fn save_bedrock_api_key_preserves_openai_auth() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn clear_bedrock_api_key_preserves_openai_auth() -> anyhow::Result<()> {
+async fn clear_bedrock_api_key_removes_bedrock_auth() -> anyhow::Result<()> {
     let codex_home = tempdir()?;
     let storage = FileAuthStorage::new(codex_home.path().to_path_buf());
-    storage.save(&AuthDotJson {
-        bedrock_api_key: Some(bedrock_record()),
-        ..api_key_auth()
-    })?;
+    storage.save(&bedrock_auth_dot_json(bedrock_record()))?;
     let auth_manager = AuthManager::new(
         codex_home.path().to_path_buf(),
         /*enable_codex_api_key_env*/ false,
@@ -81,9 +89,10 @@ async fn clear_bedrock_api_key_preserves_openai_auth() -> anyhow::Result<()> {
     )
     .await;
 
-    assert!(auth_manager.clear_bedrock_api_key()?);
+    assert!(auth_manager.clear_bedrock_api_key().await?);
 
-    assert_eq!(storage.load()?, Some(api_key_auth()));
+    assert_eq!(storage.load()?, None);
+    assert_eq!(auth_manager.auth_cached(), None);
     assert!(!auth_manager.has_bedrock_api_key());
     Ok(())
 }
@@ -101,14 +110,14 @@ async fn clear_bedrock_api_key_without_entry_is_noop() -> anyhow::Result<()> {
     )
     .await;
 
-    assert!(!auth_manager.clear_bedrock_api_key()?);
+    assert!(!auth_manager.clear_bedrock_api_key().await?);
 
     assert_eq!(storage.load()?, Some(api_key_auth()));
     Ok(())
 }
 
 #[tokio::test]
-async fn bedrock_only_auth_storage_does_not_create_primary_auth() -> anyhow::Result<()> {
+async fn bedrock_only_auth_storage_creates_primary_auth() -> anyhow::Result<()> {
     let codex_home = tempdir()?;
     let storage = FileAuthStorage::new(codex_home.path().to_path_buf());
     storage.save(&bedrock_only_auth())?;
@@ -121,7 +130,21 @@ async fn bedrock_only_auth_storage_does_not_create_primary_auth() -> anyhow::Res
     )
     .await;
 
-    assert_eq!(auth_manager.auth_cached(), None);
+    assert_eq!(auth_manager.auth_mode(), Some(AuthMode::BedrockApiKey));
+    assert_eq!(
+        auth_manager
+            .auth_cached()
+            .and_then(|auth| match auth {
+                CodexAuth::BedrockApiKey(auth) => Some(auth.api_key().to_string()),
+                CodexAuth::ApiKey(_)
+                | CodexAuth::Chatgpt(_)
+                | CodexAuth::ChatgptAuthTokens(_)
+                | CodexAuth::AgentIdentity(_)
+                | CodexAuth::PersonalAccessToken(_) => None,
+            })
+            .as_deref(),
+        Some("bedrock-api-key-test")
+    );
     assert!(auth_manager.has_bedrock_api_key());
     Ok(())
 }
@@ -139,9 +162,25 @@ async fn clear_bedrock_only_auth_storage_removes_auth_file() -> anyhow::Result<(
     )
     .await;
 
-    assert!(auth_manager.clear_bedrock_api_key()?);
+    assert!(auth_manager.clear_bedrock_api_key().await?);
 
     assert!(!get_auth_file(codex_home.path()).exists());
     assert_eq!(storage.load()?, None);
+    Ok(())
+}
+
+#[tokio::test]
+async fn login_with_api_key_clears_bedrock_api_key() -> anyhow::Result<()> {
+    let codex_home = tempdir()?;
+    let storage = FileAuthStorage::new(codex_home.path().to_path_buf());
+    storage.save(&bedrock_auth_dot_json(bedrock_record()))?;
+
+    crate::auth::login_with_api_key(
+        codex_home.path(),
+        "sk-test-key",
+        AuthCredentialsStoreMode::File,
+    )?;
+
+    assert_eq!(storage.load()?, Some(api_key_auth()));
     Ok(())
 }

--- a/codex-rs/login/src/auth/bedrock_api_key_tests.rs
+++ b/codex-rs/login/src/auth/bedrock_api_key_tests.rs
@@ -22,14 +22,20 @@ fn api_key_auth() -> AuthDotJson {
 }
 
 fn bedrock_only_auth() -> AuthDotJson {
-    let mut auth = empty_auth_dot_json();
-    auth.bedrock_api_key = Some(bedrock_record());
-    auth
+    AuthDotJson {
+        auth_mode: None,
+        openai_api_key: None,
+        tokens: None,
+        last_refresh: None,
+        agent_identity: None,
+        personal_access_token: None,
+        bedrock_api_key: Some(bedrock_auth()),
+    }
 }
 
-fn bedrock_record() -> BedrockApiKeyAuthRecord {
-    BedrockApiKeyAuthRecord::try_new(" bedrock-api-key-test ")
-        .expect("record should normalize non-empty key")
+fn bedrock_auth() -> BedrockApiKeyAuth {
+    BedrockApiKeyAuth::try_new(" bedrock-api-key-test ")
+        .expect("auth should normalize non-empty key")
 }
 
 #[tokio::test]
@@ -45,10 +51,10 @@ async fn save_bedrock_api_key_replaces_openai_auth() -> anyhow::Result<()> {
     )
     .await;
 
-    auth_manager.save_bedrock_api_key(bedrock_record()).await?;
+    auth_manager.save_bedrock_api_key(bedrock_auth()).await?;
 
     let loaded = storage.load()?.expect("auth should be stored");
-    let expected = bedrock_auth_dot_json(BedrockApiKeyAuthRecord::try_new("bedrock-api-key-test")?);
+    let expected = bedrock_auth_dot_json(BedrockApiKeyAuth::try_new("bedrock-api-key-test")?);
     assert_eq!(loaded, expected);
     assert_eq!(auth_manager.auth_mode(), Some(AuthMode::BedrockApiKey));
     assert_eq!(
@@ -65,14 +71,6 @@ async fn save_bedrock_api_key_replaces_openai_auth() -> anyhow::Result<()> {
             .as_deref(),
         Some("bedrock-api-key-test")
     );
-    assert_eq!(
-        auth_manager
-            .bedrock_api_key_cached()
-            .as_ref()
-            .map(BedrockApiKeyAuthRecord::api_key),
-        Some("bedrock-api-key-test")
-    );
-    assert!(auth_manager.has_bedrock_api_key());
     Ok(())
 }
 
@@ -80,7 +78,7 @@ async fn save_bedrock_api_key_replaces_openai_auth() -> anyhow::Result<()> {
 async fn clear_bedrock_api_key_removes_bedrock_auth() -> anyhow::Result<()> {
     let codex_home = tempdir()?;
     let storage = FileAuthStorage::new(codex_home.path().to_path_buf());
-    storage.save(&bedrock_auth_dot_json(bedrock_record()))?;
+    storage.save(&bedrock_auth_dot_json(bedrock_auth()))?;
     let auth_manager = AuthManager::new(
         codex_home.path().to_path_buf(),
         /*enable_codex_api_key_env*/ false,
@@ -93,7 +91,6 @@ async fn clear_bedrock_api_key_removes_bedrock_auth() -> anyhow::Result<()> {
 
     assert_eq!(storage.load()?, None);
     assert_eq!(auth_manager.auth_cached(), None);
-    assert!(!auth_manager.has_bedrock_api_key());
     Ok(())
 }
 
@@ -145,7 +142,6 @@ async fn bedrock_only_auth_storage_creates_primary_auth() -> anyhow::Result<()> 
             .as_deref(),
         Some("bedrock-api-key-test")
     );
-    assert!(auth_manager.has_bedrock_api_key());
     Ok(())
 }
 
@@ -173,7 +169,7 @@ async fn clear_bedrock_only_auth_storage_removes_auth_file() -> anyhow::Result<(
 async fn login_with_api_key_clears_bedrock_api_key() -> anyhow::Result<()> {
     let codex_home = tempdir()?;
     let storage = FileAuthStorage::new(codex_home.path().to_path_buf());
-    storage.save(&bedrock_auth_dot_json(bedrock_record()))?;
+    storage.save(&bedrock_auth_dot_json(bedrock_auth()))?;
 
     crate::auth::login_with_api_key(
         codex_home.path(),

--- a/codex-rs/login/src/auth/bedrock_api_key_tests.rs
+++ b/codex-rs/login/src/auth/bedrock_api_key_tests.rs
@@ -4,10 +4,10 @@ use pretty_assertions::assert_eq;
 use tempfile::tempdir;
 
 use super::*;
+use crate::auth::AuthManager;
 use crate::auth::CodexAuth;
 use crate::auth::storage::AuthStorageBackend;
 use crate::auth::storage::FileAuthStorage;
-use crate::auth::storage::get_auth_file;
 
 fn api_key_auth() -> AuthDotJson {
     AuthDotJson {
@@ -34,15 +34,24 @@ fn bedrock_only_auth() -> AuthDotJson {
 }
 
 fn bedrock_auth() -> BedrockApiKeyAuth {
-    BedrockApiKeyAuth::try_new(" bedrock-api-key-test ")
-        .expect("auth should normalize non-empty key")
+    BedrockApiKeyAuth {
+        api_key: "bedrock-api-key-test".to_string(),
+        region: "us-east-1".to_string(),
+    }
 }
 
 #[tokio::test]
-async fn save_bedrock_api_key_replaces_openai_auth() -> anyhow::Result<()> {
+async fn login_with_bedrock_api_key_replaces_openai_auth() -> anyhow::Result<()> {
     let codex_home = tempdir()?;
     let storage = FileAuthStorage::new(codex_home.path().to_path_buf());
     storage.save(&api_key_auth())?;
+    login_with_bedrock_api_key(
+        codex_home.path(),
+        "bedrock-api-key-test",
+        "us-east-1",
+        AuthCredentialsStoreMode::File,
+    )?;
+
     let auth_manager = AuthManager::new(
         codex_home.path().to_path_buf(),
         /*enable_codex_api_key_env*/ false,
@@ -51,34 +60,42 @@ async fn save_bedrock_api_key_replaces_openai_auth() -> anyhow::Result<()> {
     )
     .await;
 
-    auth_manager.save_bedrock_api_key(bedrock_auth()).await?;
-
     let loaded = storage.load()?.expect("auth should be stored");
-    let expected = bedrock_auth_dot_json(BedrockApiKeyAuth::try_new("bedrock-api-key-test")?);
+    let expected = AuthDotJson {
+        auth_mode: Some(AuthMode::BedrockApiKey),
+        openai_api_key: None,
+        tokens: None,
+        last_refresh: None,
+        agent_identity: None,
+        personal_access_token: None,
+        bedrock_api_key: Some(bedrock_auth()),
+    };
     assert_eq!(loaded, expected);
     assert_eq!(auth_manager.auth_mode(), Some(AuthMode::BedrockApiKey));
     assert_eq!(
-        auth_manager
-            .auth_cached()
-            .and_then(|auth| match auth {
-                CodexAuth::BedrockApiKey(auth) => Some(auth.api_key().to_string()),
-                CodexAuth::ApiKey(_)
-                | CodexAuth::Chatgpt(_)
-                | CodexAuth::ChatgptAuthTokens(_)
-                | CodexAuth::AgentIdentity(_)
-                | CodexAuth::PersonalAccessToken(_) => None,
-            })
-            .as_deref(),
-        Some("bedrock-api-key-test")
+        auth_manager.auth_cached().and_then(|auth| match auth {
+            CodexAuth::BedrockApiKey(auth) => Some(auth),
+            CodexAuth::ApiKey(_)
+            | CodexAuth::Chatgpt(_)
+            | CodexAuth::ChatgptAuthTokens(_)
+            | CodexAuth::AgentIdentity(_)
+            | CodexAuth::PersonalAccessToken(_) => None,
+        }),
+        Some(bedrock_auth())
     );
     Ok(())
 }
 
 #[tokio::test]
-async fn clear_bedrock_api_key_removes_bedrock_auth() -> anyhow::Result<()> {
+async fn logout_removes_bedrock_auth() -> anyhow::Result<()> {
     let codex_home = tempdir()?;
     let storage = FileAuthStorage::new(codex_home.path().to_path_buf());
-    storage.save(&bedrock_auth_dot_json(bedrock_auth()))?;
+    login_with_bedrock_api_key(
+        codex_home.path(),
+        "bedrock-api-key-test",
+        "us-east-1",
+        AuthCredentialsStoreMode::File,
+    )?;
     let auth_manager = AuthManager::new(
         codex_home.path().to_path_buf(),
         /*enable_codex_api_key_env*/ false,
@@ -87,29 +104,10 @@ async fn clear_bedrock_api_key_removes_bedrock_auth() -> anyhow::Result<()> {
     )
     .await;
 
-    assert!(auth_manager.clear_bedrock_api_key().await?);
+    assert!(auth_manager.logout().await?);
 
     assert_eq!(storage.load()?, None);
     assert_eq!(auth_manager.auth_cached(), None);
-    Ok(())
-}
-
-#[tokio::test]
-async fn clear_bedrock_api_key_without_entry_is_noop() -> anyhow::Result<()> {
-    let codex_home = tempdir()?;
-    let storage = FileAuthStorage::new(codex_home.path().to_path_buf());
-    storage.save(&api_key_auth())?;
-    let auth_manager = AuthManager::new(
-        codex_home.path().to_path_buf(),
-        /*enable_codex_api_key_env*/ false,
-        AuthCredentialsStoreMode::File,
-        /*chatgpt_base_url*/ None,
-    )
-    .await;
-
-    assert!(!auth_manager.clear_bedrock_api_key().await?);
-
-    assert_eq!(storage.load()?, Some(api_key_auth()));
     Ok(())
 }
 
@@ -129,39 +127,16 @@ async fn bedrock_only_auth_storage_creates_primary_auth() -> anyhow::Result<()> 
 
     assert_eq!(auth_manager.auth_mode(), Some(AuthMode::BedrockApiKey));
     assert_eq!(
-        auth_manager
-            .auth_cached()
-            .and_then(|auth| match auth {
-                CodexAuth::BedrockApiKey(auth) => Some(auth.api_key().to_string()),
-                CodexAuth::ApiKey(_)
-                | CodexAuth::Chatgpt(_)
-                | CodexAuth::ChatgptAuthTokens(_)
-                | CodexAuth::AgentIdentity(_)
-                | CodexAuth::PersonalAccessToken(_) => None,
-            })
-            .as_deref(),
-        Some("bedrock-api-key-test")
+        auth_manager.auth_cached().and_then(|auth| match auth {
+            CodexAuth::BedrockApiKey(auth) => Some(auth),
+            CodexAuth::ApiKey(_)
+            | CodexAuth::Chatgpt(_)
+            | CodexAuth::ChatgptAuthTokens(_)
+            | CodexAuth::AgentIdentity(_)
+            | CodexAuth::PersonalAccessToken(_) => None,
+        }),
+        Some(bedrock_auth())
     );
-    Ok(())
-}
-
-#[tokio::test]
-async fn clear_bedrock_only_auth_storage_removes_auth_file() -> anyhow::Result<()> {
-    let codex_home = tempdir()?;
-    let storage = FileAuthStorage::new(codex_home.path().to_path_buf());
-    storage.save(&bedrock_only_auth())?;
-    let auth_manager = AuthManager::new(
-        codex_home.path().to_path_buf(),
-        /*enable_codex_api_key_env*/ false,
-        AuthCredentialsStoreMode::File,
-        /*chatgpt_base_url*/ None,
-    )
-    .await;
-
-    assert!(auth_manager.clear_bedrock_api_key().await?);
-
-    assert!(!get_auth_file(codex_home.path()).exists());
-    assert_eq!(storage.load()?, None);
     Ok(())
 }
 
@@ -169,7 +144,12 @@ async fn clear_bedrock_only_auth_storage_removes_auth_file() -> anyhow::Result<(
 async fn login_with_api_key_clears_bedrock_api_key() -> anyhow::Result<()> {
     let codex_home = tempdir()?;
     let storage = FileAuthStorage::new(codex_home.path().to_path_buf());
-    storage.save(&bedrock_auth_dot_json(bedrock_auth()))?;
+    login_with_bedrock_api_key(
+        codex_home.path(),
+        "bedrock-api-key-test",
+        "us-east-1",
+        AuthCredentialsStoreMode::File,
+    )?;
 
     crate::auth::login_with_api_key(
         codex_home.path(),

--- a/codex-rs/login/src/auth/bedrock_api_key_tests.rs
+++ b/codex-rs/login/src/auth/bedrock_api_key_tests.rs
@@ -1,0 +1,147 @@
+use codex_app_server_protocol::AuthMode;
+use codex_config::types::AuthCredentialsStoreMode;
+use pretty_assertions::assert_eq;
+use tempfile::tempdir;
+
+use super::*;
+use crate::auth::storage::AuthStorageBackend;
+use crate::auth::storage::FileAuthStorage;
+use crate::auth::storage::get_auth_file;
+
+fn api_key_auth() -> AuthDotJson {
+    AuthDotJson {
+        auth_mode: Some(AuthMode::ApiKey),
+        openai_api_key: Some("sk-test-key".to_string()),
+        tokens: None,
+        last_refresh: None,
+        agent_identity: None,
+        personal_access_token: None,
+        bedrock_api_key: None,
+    }
+}
+
+fn bedrock_only_auth() -> AuthDotJson {
+    let mut auth = empty_auth_dot_json();
+    auth.bedrock_api_key = Some(bedrock_record());
+    auth
+}
+
+fn bedrock_record() -> BedrockApiKeyAuthRecord {
+    BedrockApiKeyAuthRecord::try_new(" bedrock-api-key-test ")
+        .expect("record should normalize non-empty key")
+}
+
+#[tokio::test]
+async fn save_bedrock_api_key_preserves_openai_auth() -> anyhow::Result<()> {
+    let codex_home = tempdir()?;
+    let storage = FileAuthStorage::new(codex_home.path().to_path_buf());
+    storage.save(&api_key_auth())?;
+    let auth_manager = AuthManager::new(
+        codex_home.path().to_path_buf(),
+        /*enable_codex_api_key_env*/ false,
+        AuthCredentialsStoreMode::File,
+        /*chatgpt_base_url*/ None,
+    )
+    .await;
+
+    auth_manager.save_bedrock_api_key(bedrock_record())?;
+
+    let loaded = storage.load()?.expect("auth should be stored");
+    assert_eq!(
+        loaded,
+        AuthDotJson {
+            bedrock_api_key: Some(BedrockApiKeyAuthRecord::try_new("bedrock-api-key-test")?),
+            ..api_key_auth()
+        }
+    );
+    assert_eq!(
+        auth_manager
+            .bedrock_api_key_cached()
+            .as_ref()
+            .map(BedrockApiKeyAuthRecord::api_key),
+        Some("bedrock-api-key-test")
+    );
+    assert!(auth_manager.has_bedrock_api_key());
+    Ok(())
+}
+
+#[tokio::test]
+async fn clear_bedrock_api_key_preserves_openai_auth() -> anyhow::Result<()> {
+    let codex_home = tempdir()?;
+    let storage = FileAuthStorage::new(codex_home.path().to_path_buf());
+    storage.save(&AuthDotJson {
+        bedrock_api_key: Some(bedrock_record()),
+        ..api_key_auth()
+    })?;
+    let auth_manager = AuthManager::new(
+        codex_home.path().to_path_buf(),
+        /*enable_codex_api_key_env*/ false,
+        AuthCredentialsStoreMode::File,
+        /*chatgpt_base_url*/ None,
+    )
+    .await;
+
+    assert!(auth_manager.clear_bedrock_api_key()?);
+
+    assert_eq!(storage.load()?, Some(api_key_auth()));
+    assert!(!auth_manager.has_bedrock_api_key());
+    Ok(())
+}
+
+#[tokio::test]
+async fn clear_bedrock_api_key_without_entry_is_noop() -> anyhow::Result<()> {
+    let codex_home = tempdir()?;
+    let storage = FileAuthStorage::new(codex_home.path().to_path_buf());
+    storage.save(&api_key_auth())?;
+    let auth_manager = AuthManager::new(
+        codex_home.path().to_path_buf(),
+        /*enable_codex_api_key_env*/ false,
+        AuthCredentialsStoreMode::File,
+        /*chatgpt_base_url*/ None,
+    )
+    .await;
+
+    assert!(!auth_manager.clear_bedrock_api_key()?);
+
+    assert_eq!(storage.load()?, Some(api_key_auth()));
+    Ok(())
+}
+
+#[tokio::test]
+async fn bedrock_only_auth_storage_does_not_create_primary_auth() -> anyhow::Result<()> {
+    let codex_home = tempdir()?;
+    let storage = FileAuthStorage::new(codex_home.path().to_path_buf());
+    storage.save(&bedrock_only_auth())?;
+
+    let auth_manager = AuthManager::new(
+        codex_home.path().to_path_buf(),
+        /*enable_codex_api_key_env*/ false,
+        AuthCredentialsStoreMode::File,
+        /*chatgpt_base_url*/ None,
+    )
+    .await;
+
+    assert_eq!(auth_manager.auth_cached(), None);
+    assert!(auth_manager.has_bedrock_api_key());
+    Ok(())
+}
+
+#[tokio::test]
+async fn clear_bedrock_only_auth_storage_removes_auth_file() -> anyhow::Result<()> {
+    let codex_home = tempdir()?;
+    let storage = FileAuthStorage::new(codex_home.path().to_path_buf());
+    storage.save(&bedrock_only_auth())?;
+    let auth_manager = AuthManager::new(
+        codex_home.path().to_path_buf(),
+        /*enable_codex_api_key_env*/ false,
+        AuthCredentialsStoreMode::File,
+        /*chatgpt_base_url*/ None,
+    )
+    .await;
+
+    assert!(auth_manager.clear_bedrock_api_key()?);
+
+    assert!(!get_auth_file(codex_home.path()).exists());
+    assert_eq!(storage.load()?, None);
+    Ok(())
+}

--- a/codex-rs/login/src/auth/manager.rs
+++ b/codex-rs/login/src/auth/manager.rs
@@ -29,6 +29,7 @@ use super::access_token::classify_codex_access_token;
 use super::external_bearer::BearerTokenRefresher;
 use super::revoke::revoke_auth_tokens;
 pub use crate::auth::agent_identity::AgentIdentityAuth;
+pub use crate::auth::bedrock_api_key::BedrockApiKeyAuth;
 pub use crate::auth::personal_access_token::PersonalAccessTokenAuth;
 pub use crate::auth::storage::AgentIdentityAuthRecord;
 pub use crate::auth::storage::AuthDotJson;
@@ -57,12 +58,14 @@ pub enum CodexAuth {
     ChatgptAuthTokens(ChatgptAuthTokens),
     AgentIdentity(AgentIdentityAuth),
     PersonalAccessToken(PersonalAccessTokenAuth),
+    BedrockApiKey(BedrockApiKeyAuth),
 }
 
 impl PartialEq for CodexAuth {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::PersonalAccessToken(a), Self::PersonalAccessToken(b)) => a == b,
+            (Self::BedrockApiKey(a), Self::BedrockApiKey(b)) => a == b,
             _ => self.api_auth_mode() == other.api_auth_mode(),
         }
     }
@@ -235,6 +238,14 @@ impl CodexAuth {
             };
             return Self::from_personal_access_token(personal_access_token).await;
         }
+        if auth_mode == ApiAuthMode::BedrockApiKey {
+            let Some(record) = auth_dot_json.bedrock_api_key else {
+                return Err(std::io::Error::other(
+                    "Bedrock API key auth is missing a Bedrock API key.",
+                ));
+            };
+            return Ok(Self::BedrockApiKey(BedrockApiKeyAuth::load(record)));
+        }
 
         let storage_mode = auth_dot_json.storage_mode(auth_credentials_store_mode);
         let state = ChatgptAuthState {
@@ -255,6 +266,7 @@ impl CodexAuth {
             ApiAuthMode::PersonalAccessToken => {
                 unreachable!("personal access token mode is handled above")
             }
+            ApiAuthMode::BedrockApiKey => unreachable!("bedrock api key mode is handled above"),
         }
     }
 
@@ -296,6 +308,7 @@ impl CodexAuth {
             Self::Chatgpt(_) | Self::ChatgptAuthTokens(_) => AuthMode::Chatgpt,
             Self::AgentIdentity(_) => AuthMode::AgentIdentity,
             Self::PersonalAccessToken(_) => AuthMode::PersonalAccessToken,
+            Self::BedrockApiKey(_) => AuthMode::BedrockApiKey,
         }
     }
 
@@ -306,6 +319,7 @@ impl CodexAuth {
             Self::ChatgptAuthTokens(_) => ApiAuthMode::ChatgptAuthTokens,
             Self::AgentIdentity(_) => ApiAuthMode::AgentIdentity,
             Self::PersonalAccessToken(_) => ApiAuthMode::PersonalAccessToken,
+            Self::BedrockApiKey(_) => ApiAuthMode::BedrockApiKey,
         }
     }
 
@@ -346,7 +360,8 @@ impl CodexAuth {
             Self::Chatgpt(_)
             | Self::ChatgptAuthTokens(_)
             | Self::AgentIdentity(_)
-            | Self::PersonalAccessToken(_) => None,
+            | Self::PersonalAccessToken(_)
+            | Self::BedrockApiKey(_) => None,
         }
     }
 
@@ -375,6 +390,9 @@ impl CodexAuth {
                 "agent identity auth does not expose a bearer token",
             )),
             Self::PersonalAccessToken(auth) => Ok(auth.access_token().to_string()),
+            Self::BedrockApiKey(_) => Err(std::io::Error::other(
+                "Bedrock API key auth does not expose a Codex bearer token",
+            )),
         }
     }
 
@@ -447,7 +465,10 @@ impl CodexAuth {
         let state = match self {
             Self::Chatgpt(auth) => &auth.state,
             Self::ChatgptAuthTokens(auth) => &auth.state,
-            Self::ApiKey(_) | Self::AgentIdentity(_) | Self::PersonalAccessToken(_) => return None,
+            Self::ApiKey(_)
+            | Self::AgentIdentity(_)
+            | Self::PersonalAccessToken(_)
+            | Self::BedrockApiKey(_) => return None,
         };
         #[expect(clippy::unwrap_used)]
         state.auth_dot_json.lock().unwrap().clone()
@@ -702,7 +723,8 @@ pub async fn enforce_login_restrictions(config: &AuthConfig) -> std::io::Result<
 
     if let Some(required_method) = config.forced_login_method {
         let method_violation = match (required_method, auth.auth_mode()) {
-            (ForcedLoginMethod::Api, AuthMode::ApiKey) => None,
+            (ForcedLoginMethod::Api, AuthMode::ApiKey)
+            | (ForcedLoginMethod::Api, AuthMode::BedrockApiKey) => None,
             (ForcedLoginMethod::Chatgpt, AuthMode::Chatgpt)
             | (ForcedLoginMethod::Chatgpt, AuthMode::ChatgptAuthTokens)
             | (ForcedLoginMethod::Chatgpt, AuthMode::AgentIdentity)
@@ -714,7 +736,8 @@ pub async fn enforce_login_restrictions(config: &AuthConfig) -> std::io::Result<
                 "API key login is required, but ChatGPT is currently being used. Logging out."
                     .to_string(),
             ),
-            (ForcedLoginMethod::Chatgpt, AuthMode::ApiKey) => Some(
+            (ForcedLoginMethod::Chatgpt, AuthMode::ApiKey)
+            | (ForcedLoginMethod::Chatgpt, AuthMode::BedrockApiKey) => Some(
                 "ChatGPT login is required, but an API key is currently being used. Logging out."
                     .to_string(),
             ),
@@ -731,7 +754,9 @@ pub async fn enforce_login_restrictions(config: &AuthConfig) -> std::io::Result<
 
     if let Some(expected_account_ids) = config.forced_chatgpt_workspace_id.as_deref() {
         let chatgpt_account_id = match &auth {
-            CodexAuth::ApiKey(_) | CodexAuth::PersonalAccessToken(_) => return Ok(()),
+            CodexAuth::ApiKey(_)
+            | CodexAuth::PersonalAccessToken(_)
+            | CodexAuth::BedrockApiKey(_) => return Ok(()),
             CodexAuth::AgentIdentity(_) => auth.get_account_id(),
             CodexAuth::Chatgpt(_) | CodexAuth::ChatgptAuthTokens(_) => {
                 let token_data = match auth.get_token_data() {
@@ -822,9 +847,6 @@ async fn load_auth(
         AuthCredentialsStoreMode::Ephemeral,
     );
     if let Some(auth_dot_json) = ephemeral_storage.load()? {
-        if !auth_dot_json.has_primary_auth() {
-            return Ok(None);
-        }
         let auth = CodexAuth::from_auth_dot_json(
             codex_home,
             auth_dot_json,
@@ -861,9 +883,6 @@ async fn load_auth(
         Some(auth) => auth,
         None => return Ok(None),
     };
-    if !auth_dot_json.has_primary_auth() {
-        return Ok(None);
-    }
 
     let auth = CodexAuth::from_auth_dot_json(
         codex_home,
@@ -1070,12 +1089,15 @@ impl AuthDotJson {
         Self::from_external_tokens(&external)
     }
 
-    fn resolved_mode(&self) -> ApiAuthMode {
+    pub(super) fn resolved_mode(&self) -> ApiAuthMode {
         if let Some(mode) = self.auth_mode {
             return mode;
         }
         if self.personal_access_token.is_some() {
             return ApiAuthMode::PersonalAccessToken;
+        }
+        if self.bedrock_api_key.is_some() {
+            return ApiAuthMode::BedrockApiKey;
         }
         if self.openai_api_key.is_some() {
             return ApiAuthMode::ApiKey;
@@ -1509,12 +1531,8 @@ impl AuthManager {
         self.inner.read().ok().and_then(|c| c.auth.clone())
     }
 
-    pub(super) fn codex_home_for_auth_storage(&self) -> PathBuf {
-        self.codex_home.clone()
-    }
-
-    pub(super) fn auth_credentials_store_mode(&self) -> AuthCredentialsStoreMode {
-        self.auth_credentials_store_mode
+    pub(super) fn auth_storage(&self) -> Arc<dyn AuthStorageBackend> {
+        create_auth_storage(self.codex_home.clone(), self.auth_credentials_store_mode)
     }
 
     /// Subscribes to cached auth changes that can affect request recovery.
@@ -1609,6 +1627,7 @@ impl AuthManager {
                     _ => false,
                 },
                 (ApiAuthMode::PersonalAccessToken, ApiAuthMode::PersonalAccessToken) => a == b,
+                (ApiAuthMode::BedrockApiKey, ApiAuthMode::BedrockApiKey) => a == b,
                 _ => false,
             },
             _ => false,
@@ -1800,10 +1819,11 @@ impl AuthManager {
             ))
         })?;
         let auth_before_reload = self.auth_cached();
-        if auth_before_reload
-            .as_ref()
-            .is_some_and(|auth| auth.is_api_key_auth() || auth.is_personal_access_token_auth())
-        {
+        if auth_before_reload.as_ref().is_some_and(|auth| {
+            auth.is_api_key_auth()
+                || auth.is_personal_access_token_auth()
+                || matches!(auth, CodexAuth::BedrockApiKey(_))
+        }) {
             return Ok(());
         }
         let expected_account_id = auth_before_reload
@@ -1870,7 +1890,8 @@ impl AuthManager {
             }
             CodexAuth::ApiKey(_)
             | CodexAuth::AgentIdentity(_)
-            | CodexAuth::PersonalAccessToken(_) => Ok(()),
+            | CodexAuth::PersonalAccessToken(_)
+            | CodexAuth::BedrockApiKey(_) => Ok(()),
         };
         if let Err(RefreshTokenError::Permanent(error)) = &result {
             self.record_permanent_refresh_failure_if_unchanged(&attempted_auth, error);

--- a/codex-rs/login/src/auth/manager.rs
+++ b/codex-rs/login/src/auth/manager.rs
@@ -239,12 +239,12 @@ impl CodexAuth {
             return Self::from_personal_access_token(personal_access_token).await;
         }
         if auth_mode == ApiAuthMode::BedrockApiKey {
-            let Some(record) = auth_dot_json.bedrock_api_key else {
+            let Some(auth) = auth_dot_json.bedrock_api_key else {
                 return Err(std::io::Error::other(
                     "Bedrock API key auth is missing a Bedrock API key.",
                 ));
             };
-            return Ok(Self::BedrockApiKey(BedrockApiKeyAuth::load(record)));
+            return Ok(Self::BedrockApiKey(auth));
         }
 
         let storage_mode = auth_dot_json.storage_mode(auth_credentials_store_mode);
@@ -1819,11 +1819,10 @@ impl AuthManager {
             ))
         })?;
         let auth_before_reload = self.auth_cached();
-        if auth_before_reload.as_ref().is_some_and(|auth| {
-            auth.is_api_key_auth()
-                || auth.is_personal_access_token_auth()
-                || matches!(auth, CodexAuth::BedrockApiKey(_))
-        }) {
+        if auth_before_reload
+            .as_ref()
+            .is_some_and(|auth| auth.is_api_key_auth() || auth.is_personal_access_token_auth())
+        {
             return Ok(());
         }
         let expected_account_id = auth_before_reload

--- a/codex-rs/login/src/auth/manager.rs
+++ b/codex-rs/login/src/auth/manager.rs
@@ -1531,10 +1531,6 @@ impl AuthManager {
         self.inner.read().ok().and_then(|c| c.auth.clone())
     }
 
-    pub(super) fn auth_storage(&self) -> Arc<dyn AuthStorageBackend> {
-        create_auth_storage(self.codex_home.clone(), self.auth_credentials_store_mode)
-    }
-
     /// Subscribes to cached auth changes that can affect request recovery.
     pub fn auth_change_receiver(&self) -> watch::Receiver<u64> {
         self.auth_change_tx.subscribe()

--- a/codex-rs/login/src/auth/manager.rs
+++ b/codex-rs/login/src/auth/manager.rs
@@ -472,6 +472,7 @@ impl CodexAuth {
             last_refresh: Some(Utc::now()),
             agent_identity: None,
             personal_access_token: None,
+            bedrock_api_key: None,
         };
 
         let client = create_client();
@@ -589,6 +590,7 @@ pub fn login_with_api_key(
         last_refresh: None,
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     save_auth(codex_home, &auth_dot_json, auth_credentials_store_mode)
 }
@@ -612,6 +614,7 @@ pub async fn login_with_access_token(
                 last_refresh: None,
                 agent_identity: None,
                 personal_access_token: Some(access_token.to_string()),
+                bedrock_api_key: None,
             }
         }
         CodexAccessToken::AgentIdentityJwt(jwt) => {
@@ -627,6 +630,7 @@ pub async fn login_with_access_token(
                 last_refresh: None,
                 agent_identity: Some(jwt.to_string()),
                 personal_access_token: None,
+                bedrock_api_key: None,
             }
         }
     };
@@ -818,6 +822,9 @@ async fn load_auth(
         AuthCredentialsStoreMode::Ephemeral,
     );
     if let Some(auth_dot_json) = ephemeral_storage.load()? {
+        if !auth_dot_json.has_primary_auth() {
+            return Ok(None);
+        }
         let auth = CodexAuth::from_auth_dot_json(
             codex_home,
             auth_dot_json,
@@ -854,6 +861,9 @@ async fn load_auth(
         Some(auth) => auth,
         None => return Ok(None),
     };
+    if !auth_dot_json.has_primary_auth() {
+        return Ok(None);
+    }
 
     let auth = CodexAuth::from_auth_dot_json(
         codex_home,
@@ -1043,6 +1053,7 @@ impl AuthDotJson {
             last_refresh: Some(Utc::now()),
             agent_identity: None,
             personal_access_token: None,
+            bedrock_api_key: None,
         })
     }
 
@@ -1496,6 +1507,14 @@ impl AuthManager {
     /// Current cached auth (clone) without attempting a refresh.
     pub fn auth_cached(&self) -> Option<CodexAuth> {
         self.inner.read().ok().and_then(|c| c.auth.clone())
+    }
+
+    pub(super) fn codex_home_for_auth_storage(&self) -> PathBuf {
+        self.codex_home.clone()
+    }
+
+    pub(super) fn auth_credentials_store_mode(&self) -> AuthCredentialsStoreMode {
+        self.auth_credentials_store_mode
     }
 
     /// Subscribes to cached auth changes that can affect request recovery.

--- a/codex-rs/login/src/auth/mod.rs
+++ b/codex-rs/login/src/auth/mod.rs
@@ -1,5 +1,6 @@
 mod access_token;
 mod agent_identity;
+mod bedrock_api_key;
 pub mod default_client;
 pub mod error;
 mod personal_access_token;
@@ -10,6 +11,7 @@ mod external_bearer;
 mod manager;
 mod revoke;
 
+pub use bedrock_api_key::BedrockApiKeyAuthRecord;
 pub use error::RefreshTokenFailedError;
 pub use error::RefreshTokenFailedReason;
 pub use manager::*;

--- a/codex-rs/login/src/auth/mod.rs
+++ b/codex-rs/login/src/auth/mod.rs
@@ -12,7 +12,6 @@ mod manager;
 mod revoke;
 
 pub use bedrock_api_key::BedrockApiKeyAuth;
-pub use bedrock_api_key::BedrockApiKeyAuthRecord;
 pub use error::RefreshTokenFailedError;
 pub use error::RefreshTokenFailedReason;
 pub use manager::*;

--- a/codex-rs/login/src/auth/mod.rs
+++ b/codex-rs/login/src/auth/mod.rs
@@ -12,6 +12,7 @@ mod manager;
 mod revoke;
 
 pub use bedrock_api_key::BedrockApiKeyAuth;
+pub use bedrock_api_key::login_with_bedrock_api_key;
 pub use error::RefreshTokenFailedError;
 pub use error::RefreshTokenFailedReason;
 pub use manager::*;

--- a/codex-rs/login/src/auth/mod.rs
+++ b/codex-rs/login/src/auth/mod.rs
@@ -11,6 +11,7 @@ mod external_bearer;
 mod manager;
 mod revoke;
 
+pub use bedrock_api_key::BedrockApiKeyAuth;
 pub use bedrock_api_key::BedrockApiKeyAuthRecord;
 pub use error::RefreshTokenFailedError;
 pub use error::RefreshTokenFailedReason;

--- a/codex-rs/login/src/auth/storage.rs
+++ b/codex-rs/login/src/auth/storage.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use tracing::warn;
 
-use super::BedrockApiKeyAuthRecord;
+use super::BedrockApiKeyAuth;
 use crate::token_data::TokenData;
 use codex_agent_identity::AgentIdentityJwtClaims;
 use codex_agent_identity::decode_agent_identity_jwt;
@@ -51,7 +51,7 @@ pub struct AuthDotJson {
     pub personal_access_token: Option<String>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub bedrock_api_key: Option<BedrockApiKeyAuthRecord>,
+    pub bedrock_api_key: Option<BedrockApiKeyAuth>,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]

--- a/codex-rs/login/src/auth/storage.rs
+++ b/codex-rs/login/src/auth/storage.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use tracing::warn;
 
+use super::BedrockApiKeyAuthRecord;
 use crate::token_data::TokenData;
 use codex_agent_identity::AgentIdentityJwtClaims;
 use codex_agent_identity::decode_agent_identity_jwt;
@@ -48,6 +49,9 @@ pub struct AuthDotJson {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub personal_access_token: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bedrock_api_key: Option<BedrockApiKeyAuthRecord>,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]

--- a/codex-rs/login/src/auth/storage_tests.rs
+++ b/codex-rs/login/src/auth/storage_tests.rs
@@ -20,6 +20,7 @@ async fn file_storage_load_returns_auth_dot_json() -> anyhow::Result<()> {
         last_refresh: Some(Utc::now()),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
 
     storage
@@ -42,6 +43,7 @@ async fn file_storage_save_persists_auth_dot_json() -> anyhow::Result<()> {
         last_refresh: Some(Utc::now()),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
 
     let file = get_auth_file(codex_home.path());
@@ -76,6 +78,7 @@ async fn file_storage_round_trips_agent_identity_auth() -> anyhow::Result<()> {
         last_refresh: None,
         agent_identity: Some(agent_identity),
         personal_access_token: None,
+        bedrock_api_key: None,
     };
 
     storage.save(&auth_dot_json)?;
@@ -96,6 +99,7 @@ async fn file_storage_round_trips_personal_access_token_auth() -> anyhow::Result
         last_refresh: None,
         agent_identity: None,
         personal_access_token: Some("at-example".to_string()),
+        bedrock_api_key: None,
     };
 
     storage.save(&auth_dot_json)?;
@@ -146,6 +150,7 @@ fn file_storage_delete_removes_auth_file() -> anyhow::Result<()> {
         last_refresh: None,
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     let storage = create_auth_storage(dir.path().to_path_buf(), AuthCredentialsStoreMode::File);
     storage.save(&auth_dot_json)?;
@@ -171,6 +176,7 @@ fn ephemeral_storage_save_load_delete_is_in_memory_only() -> anyhow::Result<()> 
         last_refresh: Some(Utc::now()),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
 
     storage.save(&auth_dot_json)?;
@@ -271,6 +277,7 @@ fn auth_with_prefix(prefix: &str) -> AuthDotJson {
         last_refresh: None,
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     }
 }
 
@@ -297,6 +304,7 @@ fn keyring_auth_storage_load_returns_deserialized_auth() -> anyhow::Result<()> {
         last_refresh: None,
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     seed_keyring_with_auth(
         &mock_keyring,
@@ -341,6 +349,7 @@ fn keyring_auth_storage_save_persists_and_removes_fallback_file() -> anyhow::Res
         last_refresh: Some(Utc::now()),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
 
     storage.save(&auth)?;

--- a/codex-rs/login/src/lib.rs
+++ b/codex-rs/login/src/lib.rs
@@ -40,6 +40,7 @@ pub use auth::enforce_login_restrictions;
 pub use auth::load_auth_dot_json;
 pub use auth::login_with_access_token;
 pub use auth::login_with_api_key;
+pub use auth::login_with_bedrock_api_key;
 pub use auth::logout;
 pub use auth::logout_with_revoke;
 pub use auth::read_codex_access_token_from_env;

--- a/codex-rs/login/src/server.rs
+++ b/codex-rs/login/src/server.rs
@@ -823,6 +823,7 @@ pub(crate) async fn persist_tokens_async(
             last_refresh: Some(Utc::now()),
             agent_identity: None,
             personal_access_token: None,
+            bedrock_api_key: None,
         };
         save_auth(&codex_home, &auth, auth_credentials_store_mode)?;
         Ok::<_, io::Error>((previous_auth, auth))
@@ -1327,6 +1328,7 @@ mod tests {
             last_refresh: None,
             agent_identity: None,
             personal_access_token: None,
+            bedrock_api_key: None,
         }
     }
 

--- a/codex-rs/login/tests/suite/auth_refresh.rs
+++ b/codex-rs/login/tests/suite/auth_refresh.rs
@@ -56,6 +56,7 @@ async fn refresh_token_succeeds_updates_storage() -> Result<()> {
         last_refresh: Some(initial_last_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     ctx.write_auth(&initial_auth).await?;
 
@@ -121,6 +122,7 @@ async fn refresh_token_refreshes_when_auth_is_unchanged() -> Result<()> {
         last_refresh: Some(initial_last_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     ctx.write_auth(&initial_auth).await?;
 
@@ -187,6 +189,7 @@ async fn auth_refreshes_when_access_token_is_near_expiry() -> Result<()> {
         last_refresh: Some(initial_last_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     ctx.write_auth(&initial_auth).await?;
 
@@ -238,6 +241,7 @@ async fn auth_skips_access_token_outside_refresh_window() -> Result<()> {
         last_refresh: Some(initial_last_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     ctx.write_auth(&initial_auth).await?;
 
@@ -275,6 +279,7 @@ async fn refresh_token_skips_refresh_when_auth_changed() -> Result<()> {
         last_refresh: Some(initial_last_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     ctx.write_auth(&initial_auth).await?;
 
@@ -286,6 +291,7 @@ async fn refresh_token_skips_refresh_when_auth_changed() -> Result<()> {
         last_refresh: Some(initial_last_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     save_auth(
         ctx.codex_home.path(),
@@ -342,6 +348,7 @@ async fn refresh_token_errors_on_account_mismatch() -> Result<()> {
         last_refresh: Some(initial_last_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     ctx.write_auth(&initial_auth).await?;
 
@@ -354,6 +361,7 @@ async fn refresh_token_errors_on_account_mismatch() -> Result<()> {
         last_refresh: Some(initial_last_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     save_auth(
         ctx.codex_home.path(),
@@ -414,6 +422,7 @@ async fn returns_fresh_tokens_as_is() -> Result<()> {
         last_refresh: Some(stale_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     ctx.write_auth(&initial_auth).await?;
 
@@ -463,6 +472,7 @@ async fn refreshes_token_when_access_token_is_expired() -> Result<()> {
         last_refresh: Some(fresh_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     ctx.write_auth(&initial_auth).await?;
 
@@ -514,6 +524,7 @@ async fn auth_reloads_disk_auth_when_cached_auth_is_stale() -> Result<()> {
         last_refresh: Some(stale_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     ctx.write_auth(&initial_auth).await?;
 
@@ -526,6 +537,7 @@ async fn auth_reloads_disk_auth_when_cached_auth_is_stale() -> Result<()> {
         last_refresh: Some(fresh_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     save_auth(
         ctx.codex_home.path(),
@@ -579,6 +591,7 @@ async fn auth_reloads_disk_auth_without_calling_expired_refresh_token() -> Resul
         last_refresh: Some(stale_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     ctx.write_auth(&initial_auth).await?;
 
@@ -591,6 +604,7 @@ async fn auth_reloads_disk_auth_without_calling_expired_refresh_token() -> Resul
         last_refresh: Some(fresh_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     save_auth(
         ctx.codex_home.path(),
@@ -642,6 +656,7 @@ async fn refresh_token_returns_permanent_error_for_expired_refresh_token() -> Re
         last_refresh: Some(initial_last_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     ctx.write_auth(&initial_auth).await?;
 
@@ -696,6 +711,7 @@ async fn refresh_token_does_not_retry_after_permanent_failure() -> Result<()> {
         last_refresh: Some(initial_last_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     ctx.write_auth(&initial_auth).await?;
 
@@ -764,6 +780,7 @@ async fn refresh_token_does_not_retry_after_bad_request_reused_failure() -> Resu
         last_refresh: Some(initial_last_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     ctx.write_auth(&initial_auth).await?;
 
@@ -832,6 +849,7 @@ async fn refresh_token_reloads_changed_auth_after_permanent_failure() -> Result<
         last_refresh: Some(initial_last_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     ctx.write_auth(&initial_auth).await?;
 
@@ -855,6 +873,7 @@ async fn refresh_token_reloads_changed_auth_after_permanent_failure() -> Result<
         last_refresh: Some(fresh_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     save_auth(
         ctx.codex_home.path(),
@@ -915,6 +934,7 @@ async fn refresh_token_returns_transient_error_on_server_failure() -> Result<()>
         last_refresh: Some(initial_last_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     ctx.write_auth(&initial_auth).await?;
 
@@ -969,6 +989,7 @@ async fn unauthorized_recovery_reloads_then_refreshes_tokens() -> Result<()> {
         last_refresh: Some(initial_last_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     ctx.write_auth(&initial_auth).await?;
 
@@ -980,6 +1001,7 @@ async fn unauthorized_recovery_reloads_then_refreshes_tokens() -> Result<()> {
         last_refresh: Some(initial_last_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     save_auth(
         ctx.codex_home.path(),
@@ -1065,6 +1087,7 @@ async fn unauthorized_recovery_errors_on_account_mismatch() -> Result<()> {
         last_refresh: Some(initial_last_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     ctx.write_auth(&initial_auth).await?;
 
@@ -1077,6 +1100,7 @@ async fn unauthorized_recovery_errors_on_account_mismatch() -> Result<()> {
         last_refresh: Some(initial_last_refresh),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     save_auth(
         ctx.codex_home.path(),
@@ -1136,6 +1160,7 @@ async fn unauthorized_recovery_requires_chatgpt_auth() -> Result<()> {
         last_refresh: None,
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     ctx.write_auth(&auth).await?;
 

--- a/codex-rs/login/tests/suite/logout.rs
+++ b/codex-rs/login/tests/suite/logout.rs
@@ -196,6 +196,7 @@ fn chatgpt_auth_with_refresh_token(refresh_token: &str) -> AuthDotJson {
         last_refresh: None,
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     }
 }
 

--- a/codex-rs/model-provider/src/auth.rs
+++ b/codex-rs/model-provider/src/auth.rs
@@ -152,10 +152,10 @@ mod tests {
     #[test]
     fn openai_provider_rejects_bedrock_api_key_auth() {
         let provider = ModelProviderInfo::create_openai_provider(/*base_url*/ None);
-        let auth = CodexAuth::BedrockApiKey(
-            BedrockApiKeyAuth::try_new("bedrock-api-key-test")
-                .expect("Bedrock API key should be valid"),
-        );
+        let auth = CodexAuth::BedrockApiKey(BedrockApiKeyAuth {
+            api_key: "bedrock-api-key-test".to_string(),
+            region: "us-east-1".to_string(),
+        });
 
         match resolve_provider_auth(Some(&auth), &provider) {
             Err(CodexErr::UnsupportedOperation(message)) => {

--- a/codex-rs/model-provider/src/auth.rs
+++ b/codex-rs/model-provider/src/auth.rs
@@ -8,10 +8,14 @@ use codex_api::SharedAuthProvider;
 use codex_login::AuthManager;
 use codex_login::CodexAuth;
 use codex_model_provider_info::ModelProviderInfo;
+use codex_protocol::error::CodexErr;
 use http::HeaderMap;
 use http::HeaderValue;
 
 use crate::bearer_auth_provider::BearerAuthProvider;
+
+const BEDROCK_API_KEY_UNSUPPORTED_MESSAGE: &str =
+    "Bedrock API key auth is only supported by the Amazon Bedrock model provider";
 
 #[derive(Clone, Debug)]
 struct AgentIdentityAuthProvider {
@@ -79,6 +83,12 @@ pub(crate) fn resolve_provider_auth(
     auth: Option<&CodexAuth>,
     provider: &ModelProviderInfo,
 ) -> codex_protocol::error::Result<SharedAuthProvider> {
+    if matches!(auth, Some(CodexAuth::BedrockApiKey(_))) {
+        return Err(CodexErr::UnsupportedOperation(
+            BEDROCK_API_KEY_UNSUPPORTED_MESSAGE.to_string(),
+        ));
+    }
+
     if let Some(auth) = bearer_auth_for_provider(provider)? {
         return Ok(Arc::new(auth));
     }
@@ -109,6 +119,7 @@ pub fn auth_provider_from_auth(auth: &CodexAuth) -> SharedAuthProvider {
         CodexAuth::AgentIdentity(auth) => {
             Arc::new(AgentIdentityAuthProvider { auth: auth.clone() })
         }
+        CodexAuth::BedrockApiKey(_) => unreachable!("{BEDROCK_API_KEY_UNSUPPORTED_MESSAGE}"),
         CodexAuth::ApiKey(_)
         | CodexAuth::Chatgpt(_)
         | CodexAuth::ChatgptAuthTokens(_)
@@ -122,8 +133,11 @@ pub fn auth_provider_from_auth(auth: &CodexAuth) -> SharedAuthProvider {
 
 #[cfg(test)]
 mod tests {
+    use codex_login::auth::BedrockApiKeyAuth;
+    use codex_login::auth::BedrockApiKeyAuthRecord;
     use codex_model_provider_info::WireApi;
     use codex_model_provider_info::create_oss_provider_with_base_url;
+    use pretty_assertions::assert_eq;
 
     use super::*;
 
@@ -134,5 +148,22 @@ mod tests {
         let auth = resolve_provider_auth(/*auth*/ None, &provider).expect("auth should resolve");
 
         assert!(auth.to_auth_headers().is_empty());
+    }
+
+    #[test]
+    fn openai_provider_rejects_bedrock_api_key_auth() {
+        let provider = ModelProviderInfo::create_openai_provider(/*base_url*/ None);
+        let auth = CodexAuth::BedrockApiKey(BedrockApiKeyAuth::load(
+            BedrockApiKeyAuthRecord::try_new("bedrock-api-key-test")
+                .expect("Bedrock API key should be valid"),
+        ));
+
+        match resolve_provider_auth(Some(&auth), &provider) {
+            Err(CodexErr::UnsupportedOperation(message)) => {
+                assert_eq!(message, BEDROCK_API_KEY_UNSUPPORTED_MESSAGE);
+            }
+            Err(err) => panic!("unexpected auth error: {err:?}"),
+            Ok(_) => panic!("Bedrock API key auth should be rejected"),
+        }
     }
 }

--- a/codex-rs/model-provider/src/auth.rs
+++ b/codex-rs/model-provider/src/auth.rs
@@ -134,7 +134,6 @@ pub fn auth_provider_from_auth(auth: &CodexAuth) -> SharedAuthProvider {
 #[cfg(test)]
 mod tests {
     use codex_login::auth::BedrockApiKeyAuth;
-    use codex_login::auth::BedrockApiKeyAuthRecord;
     use codex_model_provider_info::WireApi;
     use codex_model_provider_info::create_oss_provider_with_base_url;
     use pretty_assertions::assert_eq;
@@ -153,10 +152,10 @@ mod tests {
     #[test]
     fn openai_provider_rejects_bedrock_api_key_auth() {
         let provider = ModelProviderInfo::create_openai_provider(/*base_url*/ None);
-        let auth = CodexAuth::BedrockApiKey(BedrockApiKeyAuth::load(
-            BedrockApiKeyAuthRecord::try_new("bedrock-api-key-test")
+        let auth = CodexAuth::BedrockApiKey(
+            BedrockApiKeyAuth::try_new("bedrock-api-key-test")
                 .expect("Bedrock API key should be valid"),
-        ));
+        );
 
         match resolve_provider_auth(Some(&auth), &provider) {
             Err(CodexErr::UnsupportedOperation(message)) => {

--- a/codex-rs/model-provider/src/provider.rs
+++ b/codex-rs/model-provider/src/provider.rs
@@ -298,7 +298,6 @@ mod tests {
     use std::num::NonZeroU64;
 
     use codex_login::auth::BedrockApiKeyAuth;
-    use codex_login::auth::BedrockApiKeyAuthRecord;
     use codex_model_provider_info::ModelProviderAwsAuthInfo;
     use codex_model_provider_info::WireApi;
     use codex_models_manager::manager::RefreshStrategy;
@@ -387,10 +386,10 @@ mod tests {
     }
 
     fn bedrock_api_key_auth() -> CodexAuth {
-        CodexAuth::BedrockApiKey(BedrockApiKeyAuth::load(
-            BedrockApiKeyAuthRecord::try_new("bedrock-api-key-test")
+        CodexAuth::BedrockApiKey(
+            BedrockApiKeyAuth::try_new("bedrock-api-key-test")
                 .expect("Bedrock API key should be valid"),
-        ))
+        )
     }
 
     #[test]

--- a/codex-rs/model-provider/src/provider.rs
+++ b/codex-rs/model-provider/src/provider.rs
@@ -386,10 +386,10 @@ mod tests {
     }
 
     fn bedrock_api_key_auth() -> CodexAuth {
-        CodexAuth::BedrockApiKey(
-            BedrockApiKeyAuth::try_new("bedrock-api-key-test")
-                .expect("Bedrock API key should be valid"),
-        )
+        CodexAuth::BedrockApiKey(BedrockApiKeyAuth {
+            api_key: "bedrock-api-key-test".to_string(),
+            region: "us-east-1".to_string(),
+        })
     }
 
     #[test]

--- a/codex-rs/model-provider/src/provider.rs
+++ b/codex-rs/model-provider/src/provider.rs
@@ -51,6 +51,7 @@ pub struct ProviderAccountState {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderAccountError {
     MissingChatgptAccountDetails,
+    UnsupportedBedrockApiKeyAuth,
 }
 
 impl fmt::Display for ProviderAccountError {
@@ -60,6 +61,12 @@ impl fmt::Display for ProviderAccountError {
                 write!(
                     f,
                     "email and plan type are required for chatgpt authentication"
+                )
+            }
+            Self::UnsupportedBedrockApiKeyAuth => {
+                write!(
+                    f,
+                    "Bedrock API key auth is only supported by the Amazon Bedrock model provider"
                 )
             }
         }
@@ -232,6 +239,9 @@ impl ModelProvider for ConfiguredModelProvider {
                 })
                 .map(|auth| match &auth {
                     CodexAuth::ApiKey(_) => Ok(ProviderAccount::ApiKey),
+                    CodexAuth::BedrockApiKey(_) => {
+                        Err(ProviderAccountError::UnsupportedBedrockApiKeyAuth)
+                    }
                     CodexAuth::Chatgpt(_)
                     | CodexAuth::ChatgptAuthTokens(_)
                     | CodexAuth::AgentIdentity(_)
@@ -287,6 +297,8 @@ impl ModelProvider for ConfiguredModelProvider {
 mod tests {
     use std::num::NonZeroU64;
 
+    use codex_login::auth::BedrockApiKeyAuth;
+    use codex_login::auth::BedrockApiKeyAuthRecord;
     use codex_model_provider_info::ModelProviderAwsAuthInfo;
     use codex_model_provider_info::WireApi;
     use codex_models_manager::manager::RefreshStrategy;
@@ -372,6 +384,13 @@ mod tests {
             "experimental_supported_tools": [],
         }))
         .expect("valid model")
+    }
+
+    fn bedrock_api_key_auth() -> CodexAuth {
+        CodexAuth::BedrockApiKey(BedrockApiKeyAuth::load(
+            BedrockApiKeyAuthRecord::try_new("bedrock-api-key-test")
+                .expect("Bedrock API key should be valid"),
+        ))
     }
 
     #[test]
@@ -488,6 +507,19 @@ mod tests {
         assert_eq!(
             provider.account_state(),
             Err(ProviderAccountError::MissingChatgptAccountDetails)
+        );
+    }
+
+    #[test]
+    fn openai_provider_rejects_bedrock_api_key_account_state() {
+        let provider = create_model_provider(
+            ModelProviderInfo::create_openai_provider(/*base_url*/ None),
+            Some(AuthManager::from_auth_for_testing(bedrock_api_key_auth())),
+        );
+
+        assert_eq!(
+            provider.account_state(),
+            Err(ProviderAccountError::UnsupportedBedrockApiKeyAuth)
         );
     }
 

--- a/codex-rs/models-manager/src/manager_tests.rs
+++ b/codex-rs/models-manager/src/manager_tests.rs
@@ -212,6 +212,7 @@ c2ln",
         last_refresh: Some(Utc::now()),
         agent_identity: None,
         personal_access_token: None,
+        bedrock_api_key: None,
     };
     std::fs::create_dir_all(codex_home).expect("codex home should be created");
     std::fs::write(

--- a/codex-rs/otel/src/lib.rs
+++ b/codex-rs/otel/src/lib.rs
@@ -54,7 +54,8 @@ pub enum TelemetryAuthMode {
 impl From<codex_app_server_protocol::AuthMode> for TelemetryAuthMode {
     fn from(mode: codex_app_server_protocol::AuthMode) -> Self {
         match mode {
-            codex_app_server_protocol::AuthMode::ApiKey => Self::ApiKey,
+            codex_app_server_protocol::AuthMode::ApiKey
+            | codex_app_server_protocol::AuthMode::BedrockApiKey => Self::ApiKey,
             codex_app_server_protocol::AuthMode::Chatgpt
             | codex_app_server_protocol::AuthMode::ChatgptAuthTokens
             | codex_app_server_protocol::AuthMode::AgentIdentity

--- a/codex-rs/tui/src/app_server_session.rs
+++ b/codex-rs/tui/src/app_server_session.rs
@@ -1169,6 +1169,7 @@ pub(crate) fn status_account_display_from_auth_mode(
             email: None,
             plan: plan_type.map(plan_type_display_name),
         }),
+        Some(AuthMode::BedrockApiKey) => None,
         None => None,
     }
 }

--- a/codex-rs/tui/src/local_chatgpt_auth.rs
+++ b/codex-rs/tui/src/local_chatgpt_auth.rs
@@ -110,6 +110,7 @@ mod tests {
             last_refresh: Some(Utc::now()),
             agent_identity: None,
             personal_access_token: None,
+            bedrock_api_key: None,
         };
         save_auth(codex_home, &auth, AuthCredentialsStoreMode::File)
             .expect("chatgpt auth should save");
@@ -158,6 +159,7 @@ mod tests {
                 last_refresh: None,
                 agent_identity: None,
                 personal_access_token: None,
+                bedrock_api_key: None,
             },
             AuthCredentialsStoreMode::File,
         )


### PR DESCRIPTION
## Why

Codex needs to manage Amazon Bedrock API key credentials through the existing auth lifecycle instead of introducing a separate auth manager or provider-specific credential file. Treating Bedrock API key login as a primary auth mode gives it the same persistence, keyring, reload, and logout behavior as the existing OpenAI API key and ChatGPT modes.

The credential is valid only for the `amazon-bedrock` model provider. OpenAI-compatible providers must reject this auth mode rather than treating the Bedrock key as an OpenAI bearer token.

## What changed

- Added `bedrockApiKey` as an app-server `AuthMode` and `CodexAuth::BedrockApiKey` as a primary `AuthManager` mode.
- Added `BedrockApiKeyAuth`, containing the API key and AWS region, to the existing `AuthDotJson` payload stored in `$CODEX_HOME/auth.json` or the configured keyring backend.
- Added `login_with_bedrock_api_key(...)`, parallel to `login_with_api_key(...)`, which replaces the current stored login with Bedrock credentials.
- Reused generic auth reload and logout behavior instead of adding a Bedrock-specific auth manager or logout path.
- Updated login restrictions, status reporting, diagnostics, telemetry classification, generated app-server schemas, and auth fixtures for the new mode.
- Added explicit errors when Bedrock API key auth is selected with an OpenAI-compatible model provider.

This PR establishes managed storage and auth-mode behavior. Routing the managed key and region into Amazon Bedrock requests will be in follow-up PRs.
