### PR TITLE
[codex] Limit local image file reads

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -4131,7 +4131,9 @@ dependencies = [
  "codex-utils-cache",
  "divan",
  "image",
+ "libc",
  "mime_guess",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::io;
+use std::io::Read;
 use std::num::NonZeroUsize;
 use std::path::Path;
 
@@ -1017,6 +1018,7 @@ const IMAGE_CLOSE_TAG: &str = "</image>";
 const LOCAL_IMAGE_OPEN_TAG_PREFIX: &str = "<image name=";
 const LOCAL_IMAGE_OPEN_TAG_SUFFIX: &str = ">";
 const LOCAL_IMAGE_CLOSE_TAG: &str = IMAGE_CLOSE_TAG;
+const MAX_LOCAL_IMAGE_FILE_BYTES: u64 = 50 * 1024 * 1024;
 
 pub fn image_open_tag_text() -> String {
     IMAGE_OPEN_TAG.to_string()
@@ -1255,7 +1257,40 @@ impl From<Vec<UserInput>> for ResponseInputItem {
                     UserInput::LocalImage { path, detail, .. } => {
                         image_index += 1;
                         let detail = detail.unwrap_or(DEFAULT_IMAGE_DETAIL);
-                        match std::fs::read(&path) {
+                        let file_bytes = std::fs::metadata(&path).and_then(|metadata| {
+                            if !metadata.is_file() {
+                                return Err(io::Error::new(
+                                    io::ErrorKind::InvalidInput,
+                                    "local image path is not a regular file",
+                                ));
+                            }
+                            if metadata.len() > MAX_LOCAL_IMAGE_FILE_BYTES {
+                                return Err(io::Error::new(
+                                    io::ErrorKind::InvalidData,
+                                    format!(
+                                        "local image exceeds the {MAX_LOCAL_IMAGE_FILE_BYTES}-byte limit"
+                                    ),
+                                ));
+                            }
+
+                            let capacity = usize::try_from(metadata.len()).unwrap_or_default();
+                            let mut file_bytes = Vec::with_capacity(capacity);
+                            std::fs::File::open(&path)?
+                                .take(MAX_LOCAL_IMAGE_FILE_BYTES + 1)
+                                .read_to_end(&mut file_bytes)?;
+                            if file_bytes.len()
+                                > usize::try_from(MAX_LOCAL_IMAGE_FILE_BYTES).unwrap_or(usize::MAX)
+                            {
+                                return Err(io::Error::new(
+                                    io::ErrorKind::InvalidData,
+                                    format!(
+                                        "local image exceeds the {MAX_LOCAL_IMAGE_FILE_BYTES}-byte limit"
+                                    ),
+                                ));
+                            }
+                            Ok(file_bytes)
+                        });
+                        match file_bytes {
                             Ok(file_bytes) => local_image_content_items_with_label_number(
                                 &path,
                                 file_bytes,
@@ -2986,6 +3021,62 @@ mod tests {
             }
             other => panic!("expected message response but got {other:?}"),
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn local_image_too_large_adds_placeholder() -> Result<()> {
+        let dir = tempdir()?;
+        let oversized_path = dir.path().join("oversized.png");
+        std::fs::File::create(&oversized_path)?.set_len(MAX_LOCAL_IMAGE_FILE_BYTES + 1)?;
+
+        let item = ResponseInputItem::from(vec![UserInput::LocalImage {
+            path: oversized_path.clone(),
+            detail: None,
+        }]);
+
+        assert_eq!(
+            item,
+            ResponseInputItem::Message {
+                role: "user".to_string(),
+                content: vec![ContentItem::InputText {
+                    text: format!(
+                        "Codex could not read the local image at `{}`: local image exceeds the {MAX_LOCAL_IMAGE_FILE_BYTES}-byte limit",
+                        oversized_path.display()
+                    ),
+                }],
+                phase: None,
+            }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn local_image_non_file_adds_placeholder() -> Result<()> {
+        let dir = tempdir()?;
+        let directory_path = dir.path().join("image.png");
+        std::fs::create_dir(&directory_path)?;
+
+        let item = ResponseInputItem::from(vec![UserInput::LocalImage {
+            path: directory_path.clone(),
+            detail: None,
+        }]);
+
+        assert_eq!(
+            item,
+            ResponseInputItem::Message {
+                role: "user".to_string(),
+                content: vec![ContentItem::InputText {
+                    text: format!(
+                        "Codex could not read the local image at `{}`: local image path is not a regular file",
+                        directory_path.display()
+                    ),
+                }],
+                phase: None,
+            }
+        );
 
         Ok(())
     }

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -4,8 +4,10 @@ use std::io::Read;
 use std::num::NonZeroUsize;
 use std::path::Path;
 
+use codex_utils_image::MAX_PROMPT_IMAGE_FILE_BYTES;
 use codex_utils_image::PromptImageMode;
 use codex_utils_image::load_for_prompt_bytes;
+use codex_utils_image::validate_prompt_image_file_size;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
@@ -1018,7 +1020,6 @@ const IMAGE_CLOSE_TAG: &str = "</image>";
 const LOCAL_IMAGE_OPEN_TAG_PREFIX: &str = "<image name=";
 const LOCAL_IMAGE_OPEN_TAG_SUFFIX: &str = ">";
 const LOCAL_IMAGE_CLOSE_TAG: &str = IMAGE_CLOSE_TAG;
-const MAX_LOCAL_IMAGE_FILE_BYTES: u64 = 50 * 1024 * 1024;
 
 pub fn image_open_tag_text() -> String {
     IMAGE_OPEN_TAG.to_string()
@@ -1264,30 +1265,15 @@ impl From<Vec<UserInput>> for ResponseInputItem {
                                     "local image path is not a regular file",
                                 ));
                             }
-                            if metadata.len() > MAX_LOCAL_IMAGE_FILE_BYTES {
-                                return Err(io::Error::new(
-                                    io::ErrorKind::InvalidData,
-                                    format!(
-                                        "local image exceeds the {MAX_LOCAL_IMAGE_FILE_BYTES}-byte limit"
-                                    ),
-                                ));
-                            }
+                            validate_prompt_image_file_size(metadata.len())?;
 
                             let capacity = usize::try_from(metadata.len()).unwrap_or_default();
                             let mut file_bytes = Vec::with_capacity(capacity);
                             std::fs::File::open(&path)?
-                                .take(MAX_LOCAL_IMAGE_FILE_BYTES + 1)
+                                .take(MAX_PROMPT_IMAGE_FILE_BYTES + 1)
                                 .read_to_end(&mut file_bytes)?;
-                            if file_bytes.len()
-                                > usize::try_from(MAX_LOCAL_IMAGE_FILE_BYTES).unwrap_or(usize::MAX)
-                            {
-                                return Err(io::Error::new(
-                                    io::ErrorKind::InvalidData,
-                                    format!(
-                                        "local image exceeds the {MAX_LOCAL_IMAGE_FILE_BYTES}-byte limit"
-                                    ),
-                                ));
-                            }
+                            let file_size = u64::try_from(file_bytes.len()).unwrap_or(u64::MAX);
+                            validate_prompt_image_file_size(file_size)?;
                             Ok(file_bytes)
                         });
                         match file_bytes {
@@ -3029,7 +3015,7 @@ mod tests {
     fn local_image_too_large_adds_placeholder() -> Result<()> {
         let dir = tempdir()?;
         let oversized_path = dir.path().join("oversized.png");
-        std::fs::File::create(&oversized_path)?.set_len(MAX_LOCAL_IMAGE_FILE_BYTES + 1)?;
+        std::fs::File::create(&oversized_path)?.set_len(MAX_PROMPT_IMAGE_FILE_BYTES + 1)?;
 
         let item = ResponseInputItem::from(vec![UserInput::LocalImage {
             path: oversized_path.clone(),
@@ -3042,7 +3028,7 @@ mod tests {
                 role: "user".to_string(),
                 content: vec![ContentItem::InputText {
                     text: format!(
-                        "Codex could not read the local image at `{}`: local image exceeds the {MAX_LOCAL_IMAGE_FILE_BYTES}-byte limit",
+                        "Codex could not read the local image at `{}`: image exceeds the {MAX_PROMPT_IMAGE_FILE_BYTES}-byte limit",
                         oversized_path.display()
                     ),
                 }],

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 use std::io;
-use std::io::Read;
 use std::num::NonZeroUsize;
 use std::path::Path;
 
+#[cfg(test)]
 use codex_utils_image::MAX_PROMPT_IMAGE_FILE_BYTES;
 use codex_utils_image::PromptImageMode;
 use codex_utils_image::load_for_prompt_bytes;
-use codex_utils_image::validate_prompt_image_file_size;
+use codex_utils_image::read_prompt_image_file;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
@@ -1258,24 +1258,7 @@ impl From<Vec<UserInput>> for ResponseInputItem {
                     UserInput::LocalImage { path, detail, .. } => {
                         image_index += 1;
                         let detail = detail.unwrap_or(DEFAULT_IMAGE_DETAIL);
-                        let file_bytes = std::fs::metadata(&path).and_then(|metadata| {
-                            if !metadata.is_file() {
-                                return Err(io::Error::new(
-                                    io::ErrorKind::InvalidInput,
-                                    "local image path is not a regular file",
-                                ));
-                            }
-                            validate_prompt_image_file_size(metadata.len())?;
-
-                            let capacity = usize::try_from(metadata.len()).unwrap_or_default();
-                            let mut file_bytes = Vec::with_capacity(capacity);
-                            std::fs::File::open(&path)?
-                                .take(MAX_PROMPT_IMAGE_FILE_BYTES + 1)
-                                .read_to_end(&mut file_bytes)?;
-                            let file_size = u64::try_from(file_bytes.len()).unwrap_or(u64::MAX);
-                            validate_prompt_image_file_size(file_size)?;
-                            Ok(file_bytes)
-                        });
+                        let file_bytes = read_prompt_image_file(&path);
                         match file_bytes {
                             Ok(file_bytes) => local_image_content_items_with_label_number(
                                 &path,

--- a/codex-rs/utils/image/Cargo.toml
+++ b/codex-rs/utils/image/Cargo.toml
@@ -15,9 +15,13 @@ mime_guess = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "rt", "rt-multi-thread", "macros"] }
 
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
 [dev-dependencies]
 divan = { workspace = true }
 image = { workspace = true, features = ["jpeg", "png", "gif", "webp"] }
+tempfile = { workspace = true }
 
 [lib]
 doctest = false

--- a/codex-rs/utils/image/src/lib.rs
+++ b/codex-rs/utils/image/src/lib.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::LazyLock;
@@ -17,6 +18,8 @@ use image::codecs::webp::WebPEncoder;
 use image::imageops::FilterType;
 /// Maximum width or height used when resizing images before uploading.
 pub const MAX_DIMENSION: u32 = 2048;
+/// Maximum compressed file size accepted for an image added to a prompt.
+pub const MAX_PROMPT_IMAGE_FILE_BYTES: u64 = 50 * 1024 * 1024;
 
 pub mod error;
 
@@ -43,6 +46,17 @@ pub enum PromptImageMode {
     Original,
 }
 
+/// Validates the compressed byte size of an image before prompt processing.
+pub fn validate_prompt_image_file_size(file_size: u64) -> io::Result<()> {
+    if file_size > MAX_PROMPT_IMAGE_FILE_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("image exceeds the {MAX_PROMPT_IMAGE_FILE_BYTES}-byte limit"),
+        ));
+    }
+    Ok(())
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct ImageCacheKey {
     digest: [u8; 20],
@@ -57,6 +71,11 @@ pub fn load_for_prompt_bytes(
     file_bytes: Vec<u8>,
     mode: PromptImageMode,
 ) -> Result<EncodedImage, ImageProcessingError> {
+    let file_size = u64::try_from(file_bytes.len()).unwrap_or(u64::MAX);
+    validate_prompt_image_file_size(file_size).map_err(|source| ImageProcessingError::Read {
+        path: path.to_path_buf(),
+        source,
+    })?;
     let path_buf = path.to_path_buf();
 
     let key = ImageCacheKey {
@@ -209,6 +228,21 @@ mod tests {
             .write_to(&mut encoded, format)
             .expect("encode image to bytes");
         encoded.into_inner()
+    }
+
+    #[test]
+    fn prompt_image_file_size_limit_is_inclusive() {
+        assert!(validate_prompt_image_file_size(MAX_PROMPT_IMAGE_FILE_BYTES).is_ok());
+
+        let error = validate_prompt_image_file_size(MAX_PROMPT_IMAGE_FILE_BYTES + 1)
+            .expect_err("reject oversized image");
+        assert_eq!(
+            (error.kind(), error.to_string()),
+            (
+                io::ErrorKind::InvalidData,
+                format!("image exceeds the {MAX_PROMPT_IMAGE_FILE_BYTES}-byte limit"),
+            )
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/codex-rs/utils/image/src/lib.rs
+++ b/codex-rs/utils/image/src/lib.rs
@@ -1,7 +1,12 @@
+use std::fs::OpenOptions;
 use std::io;
+use std::io::Read;
 use std::num::NonZeroUsize;
 use std::path::Path;
 use std::sync::LazyLock;
+
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
@@ -19,6 +24,8 @@ use image::imageops::FilterType;
 /// Maximum width or height used when resizing images before uploading.
 pub const MAX_DIMENSION: u32 = 2048;
 /// Maximum compressed file size accepted for an image added to a prompt.
+///
+/// 50 MiB accommodates large source images while bounding the allocation made before decoding.
 pub const MAX_PROMPT_IMAGE_FILE_BYTES: u64 = 50 * 1024 * 1024;
 
 pub mod error;
@@ -46,8 +53,7 @@ pub enum PromptImageMode {
     Original,
 }
 
-/// Validates the compressed byte size of an image before prompt processing.
-pub fn validate_prompt_image_file_size(file_size: u64) -> io::Result<()> {
+fn validate_prompt_image_file_size(file_size: u64) -> io::Result<()> {
     if file_size > MAX_PROMPT_IMAGE_FILE_BYTES {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
@@ -55,6 +61,35 @@ pub fn validate_prompt_image_file_size(file_size: u64) -> io::Result<()> {
         ));
     }
     Ok(())
+}
+
+/// Reads a regular image file into memory, up to the prompt image size limit.
+///
+/// On Unix, the file is opened in nonblocking mode so a path resolving to a FIFO or other special
+/// file cannot block before its type is checked. Metadata and bytes are read from the same handle.
+pub fn read_prompt_image_file(path: &Path) -> io::Result<Vec<u8>> {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_NONBLOCK);
+
+    let file = options.open(path)?;
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "local image path is not a regular file",
+        ));
+    }
+    validate_prompt_image_file_size(metadata.len())?;
+
+    let capacity = usize::try_from(metadata.len()).unwrap_or_default();
+    let mut file_bytes = Vec::with_capacity(capacity);
+    file.take(MAX_PROMPT_IMAGE_FILE_BYTES + 1)
+        .read_to_end(&mut file_bytes)?;
+    let file_size = u64::try_from(file_bytes.len()).unwrap_or(u64::MAX);
+    validate_prompt_image_file_size(file_size)?;
+    Ok(file_bytes)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -217,6 +252,15 @@ fn format_to_mime(format: ImageFormat) -> String {
 mod tests {
     use std::io::Cursor;
 
+    #[cfg(unix)]
+    use std::ffi::CString;
+    #[cfg(unix)]
+    use std::os::unix::ffi::OsStrExt;
+    #[cfg(unix)]
+    use std::sync::mpsc;
+    #[cfg(unix)]
+    use std::time::Duration;
+
     use super::*;
     use image::GenericImageView;
     use image::ImageBuffer;
@@ -241,6 +285,39 @@ mod tests {
             (
                 io::ErrorKind::InvalidData,
                 format!("image exceeds the {MAX_PROMPT_IMAGE_FILE_BYTES}-byte limit"),
+            )
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prompt_image_file_read_rejects_fifo_without_blocking() {
+        let dir = tempfile::tempdir().expect("create tempdir");
+        let fifo_path = dir.path().join("image.png");
+        let c_path = CString::new(fifo_path.as_os_str().as_bytes()).expect("path without nul");
+        // SAFETY: `c_path` is NUL-terminated and remains valid for the duration of the call.
+        let result = unsafe {
+            libc::mkfifo(c_path.as_ptr(), /*mode*/ 0o600)
+        };
+        assert_eq!(result, 0);
+
+        let (sender, receiver) = mpsc::channel();
+        let read_thread = std::thread::spawn(move || {
+            sender
+                .send(read_prompt_image_file(&fifo_path))
+                .expect("send read result");
+        });
+        let read_result = receiver
+            .recv_timeout(Duration::from_secs(/*secs*/ 5))
+            .expect("FIFO read should return without blocking");
+        read_thread.join().expect("join read thread");
+
+        let error = read_result.expect_err("reject FIFO");
+        assert_eq!(
+            (error.kind(), error.to_string()),
+            (
+                io::ErrorKind::InvalidInput,
+                "local image path is not a regular file".to_string(),
             )
         );
     }


### PR DESCRIPTION
## Summary

- define a shared 50 MiB encoded-image limit in `codex-utils-image`
- move bounded local image reads into the image utility crate
- open local images nonblocking on Unix, then validate and read from the same file handle
- cap reads at 50 MiB plus one byte so files that grow after metadata validation are rejected
- cover the shared boundary, oversized files, non-file paths, and FIFOs with regression tests

## Motivation

Local image conversion previously used `std::fs::read` on a caller-provided path before validating the image. A large file could exhaust process memory, while special files could block or produce an unbounded stream.

The image decoder has a separate default 512 MiB allocation budget. That protects decoded allocations on a best-effort basis; the shared 50 MiB limit protects encoded input bytes and is enforced both before local reads and when bytes reach the common prompt-image loader.

Opening and validating one descriptor also removes the pathname race where a checked regular file could be replaced by a FIFO before the read.

## User impact

Normal local image attachments continue to work. Encoded images above 50 MiB and non-regular local paths now produce a readable attachment error instead of being processed.

## Validation

- `just fmt`
- `just test -p codex-utils-image` (8 passed)
- `just test -p codex-protocol` (230 passed)
- `just fix -p codex-utils-image -p codex-protocol`
- `just bazel-lock-update`
- `just bazel-lock-check`
