### PR TITLE
[codex] Verify cross-platform release builds in CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -110,6 +110,15 @@ common:ci-bazel --build_metadata=TAG_workflow=bazel
 # snapshot on the Windows runner.
 common:ci-bazel --test_env=CODEX_BAZEL_TEST_SKIP_FILTERS=suite::code_mode::
 
+# Shared settings for local and CI release binary builds. `fastbuild` avoids
+# optimizer and debug-info work while disabling Rust debug assertions still
+# compiles the release-only code paths.
+# TODO: Align this with Cargo's release profile, including optimized codegen,
+# ThinLTO, line-table debug info, and a single codegen unit.
+build:release-binaries --compilation_mode=fastbuild
+build:release-binaries --@rules_rust//rust/settings:extra_rustc_flag=-Cdebug-assertions=no
+build:release-binaries --@rules_rust//rust/settings:extra_exec_rustc_flag=-Cdebug-assertions=no
+
 # Shared config for Bazel-backed Rust linting.
 build:clippy --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 build:clippy --output_groups=+clippy_checks

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -552,3 +552,69 @@ jobs:
         with:
           path: ${{ steps.prepare_bazel.outputs.repository-cache-path }}
           key: ${{ steps.prepare_bazel.outputs.repository-cache-key }}
+
+  cross-release-build:
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    name: Verify cross-platform release build under RBE
+    environment:
+      name: bazel
+      deployment: false
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Prepare Bazel CI
+        id: prepare_bazel
+        uses: ./.github/actions/prepare-bazel-ci
+        with:
+          target: x86_64-unknown-linux-gnu
+          cache-scope: bazel-${{ github.job }}
+
+      - name: Bazel build cross-platform release binaries
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        shell: bash
+        run: |
+          # The release bundle transition cross-compiles every supported
+          # platform from Linux RBE. Fork PRs do not receive the BuildBuddy
+          # credential, and compiling the full matrix locally is too costly.
+          if [[ -z "${BUILDBUDDY_API_KEY}" ]]; then
+            echo "BuildBuddy API key unavailable; skipping the RBE cross-release build."
+            exit 0
+          fi
+
+          # Keep this in sync with `just build-for-release` by selecting the
+          # shared release-binaries config.
+          ./.github/scripts/run-bazel-ci.sh \
+            --print-failed-action-summary \
+            -- \
+            build \
+            --config=release-binaries \
+            --build_metadata=COMMIT_SHA=${GITHUB_SHA} \
+            --build_metadata=TAG_job=cross-release-build \
+            --build_metadata=TAG_rust_debug_assertions=off \
+            -- \
+            //codex-rs/cli:release_binaries
+
+      - name: Upload Bazel execution logs
+        if: always() && !cancelled()
+        continue-on-error: true
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: bazel-execution-logs-cross-release-build
+          path: ${{ runner.temp }}/bazel-execution-logs
+          if-no-files-found: ignore
+
+      # Save the job-scoped Bazel repository cache after cache misses. Keep the
+      # upload non-fatal so cache service issues never fail the job itself.
+      - name: Save bazel repository cache
+        if: always() && !cancelled() && steps.prepare_bazel.outputs.repository-cache-hit != 'true'
+        continue-on-error: true
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ${{ steps.prepare_bazel.outputs.repository-cache-path }}
+          key: ${{ steps.prepare_bazel.outputs.repository-cache-key }}

--- a/justfile
+++ b/justfile
@@ -133,8 +133,9 @@ bazel-clippy:
 bazel-argument-comment-lint:
     bazel build --config=argument-comment-lint -- $({{ justfile_directory() }}/tools/argument-comment-lint/list-bazel-targets.sh)
 
+# Keep this in sync with CI by selecting the shared release-binaries config.
 build-for-release:
-    bazel build //codex-rs/cli:release_binaries
+    bazel build --config=release-binaries //codex-rs/cli:release_binaries
 
 # Run the MCP server
 mcp-server-run *args:


### PR DESCRIPTION
## Why

The release bundle depends on Bazel transitions and cross-toolchain behavior that the existing host release checks do not exercise. CI should catch regressions across all six release targets under the same configuration used by local release builds.

## What changed

Add a standalone Linux `cross-release-build` job that runs in parallel with the existing Bazel jobs and builds `//codex-rs/cli:release_binaries`. Both the workflow and `just build-for-release` use the shared `release-binaries` Bazel config so their invocation settings stay synchronized. Fork PRs without the remote-build credential skip the aggregate build.

## Validation

- Ran `just build-for-release` under RBE and produced all six release outputs.

Stack: 7 of 8. Depends on #27326.
