### PR TITLE
[codex] Record exec-server process lifecycle metrics

### DIFF
--- a/codex-rs/exec-server/src/local_process.rs
+++ b/codex-rs/exec-server/src/local_process.rs
@@ -3,6 +3,7 @@ use std::collections::VecDeque;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::Instant;
 
 use async_trait::async_trait;
 use codex_app_server_protocol::JSONRPCErrorError;
@@ -45,6 +46,7 @@ use crate::rpc::RpcServerOutboundMessage;
 use crate::rpc::internal_error;
 use crate::rpc::invalid_params;
 use crate::rpc::invalid_request;
+use crate::telemetry::ExecServerTelemetry;
 
 const RETAINED_OUTPUT_BYTES_PER_PROCESS: usize = 1024 * 1024;
 const NOTIFICATION_CHANNEL_CAPACITY: usize = 256;
@@ -74,6 +76,9 @@ struct RunningProcess {
     output_notify: Arc<Notify>,
     open_streams: usize,
     closed: bool,
+    started_at: Instant,
+    metrics_finished: bool,
+    termination_requested: bool,
 }
 
 enum ProcessEntry {
@@ -84,6 +89,7 @@ enum ProcessEntry {
 struct Inner {
     notifications: std::sync::RwLock<Option<RpcNotificationSender>>,
     processes: Mutex<HashMap<ProcessId, ProcessEntry>>,
+    telemetry: ExecServerTelemetry,
 }
 
 #[derive(Clone)]
@@ -103,16 +109,23 @@ impl Default for LocalProcess {
         let (outgoing_tx, mut outgoing_rx) =
             mpsc::channel::<RpcServerOutboundMessage>(NOTIFICATION_CHANNEL_CAPACITY);
         tokio::spawn(async move { while outgoing_rx.recv().await.is_some() {} });
-        Self::new(RpcNotificationSender::new(outgoing_tx))
+        Self::new(
+            RpcNotificationSender::new(outgoing_tx),
+            ExecServerTelemetry::default(),
+        )
     }
 }
 
 impl LocalProcess {
-    pub(crate) fn new(notifications: RpcNotificationSender) -> Self {
+    pub(crate) fn new(
+        notifications: RpcNotificationSender,
+        telemetry: ExecServerTelemetry,
+    ) -> Self {
         Self {
             inner: Arc::new(Inner {
                 notifications: std::sync::RwLock::new(Some(notifications)),
                 processes: Mutex::new(HashMap::new()),
+                telemetry,
             }),
         }
     }
@@ -129,6 +142,11 @@ impl LocalProcess {
                 .collect::<Vec<_>>()
         };
         for process in remaining {
+            if !process.metrics_finished {
+                self.inner
+                    .telemetry
+                    .process_finished("terminated", process.started_at.elapsed());
+            }
             process.session.terminate();
         }
     }
@@ -226,9 +244,13 @@ impl LocalProcess {
                     output_notify: Arc::clone(&output_notify),
                     open_streams: 2,
                     closed: false,
+                    started_at: Instant::now(),
+                    metrics_finished: false,
+                    termination_requested: false,
                 })),
             );
         }
+        self.inner.telemetry.process_started();
 
         tokio::spawn(stream_output(
             process_id.clone(),
@@ -389,12 +411,13 @@ impl LocalProcess {
     ) -> Result<TerminateResponse, JSONRPCErrorError> {
         let _process_id = params.process_id.clone();
         let running = {
-            let process_map = self.inner.processes.lock().await;
-            match process_map.get(&params.process_id) {
+            let mut process_map = self.inner.processes.lock().await;
+            match process_map.get_mut(&params.process_id) {
                 Some(ProcessEntry::Running(process)) => {
                     if process.exit_code.is_some() {
                         return Ok(TerminateResponse { running: false });
                     }
+                    process.termination_requested = true;
                     process.session.terminate();
                     true
                 }
@@ -601,7 +624,7 @@ async fn watch_exit(
     output_notify: Arc<Notify>,
 ) {
     let exit_code = exit_rx.await.unwrap_or(-1);
-    let notification = {
+    let (notification, process_duration, termination_requested) = {
         let mut processes = inner.processes.lock().await;
         if let Some(ProcessEntry::Running(process)) = processes.get_mut(&process_id) {
             let seq = process.next_seq;
@@ -611,15 +634,32 @@ async fn watch_exit(
             process
                 .events
                 .publish(ExecProcessEvent::Exited { seq, exit_code });
-            Some(ExecExitedNotification {
-                process_id: process_id.clone(),
-                seq,
-                exit_code,
-            })
+            process.metrics_finished = true;
+            (
+                Some(ExecExitedNotification {
+                    process_id: process_id.clone(),
+                    seq,
+                    exit_code,
+                }),
+                Some(process.started_at.elapsed()),
+                process.termination_requested,
+            )
         } else {
-            None
+            (None, None, false)
         }
     };
+    if let Some(process_duration) = process_duration {
+        inner.telemetry.process_finished(
+            if termination_requested {
+                "terminated"
+            } else if exit_code == 0 {
+                "success"
+            } else {
+                "error"
+            },
+            process_duration,
+        );
+    }
     output_notify.notify_waiters();
     if let Some(notification) = notification
         && let Some(notifications) = notification_sender(&inner)
@@ -890,6 +930,9 @@ mod tests {
                 output_notify: Arc::clone(&output_notify),
                 open_streams: 2,
                 closed: false,
+                started_at: Instant::now(),
+                metrics_finished: false,
+                termination_requested: false,
             })),
         );
         assert!(previous.is_none());

--- a/codex-rs/exec-server/src/server/handler/tests.rs
+++ b/codex-rs/exec-server/src/server/handler/tests.rs
@@ -77,7 +77,7 @@ fn test_runtime_paths() -> ExecServerRuntimePaths {
 
 async fn initialized_handler() -> Arc<ExecServerHandler> {
     let (outgoing_tx, _outgoing_rx) = mpsc::channel(16);
-    let registry = SessionRegistry::new();
+    let registry = SessionRegistry::new(crate::ExecServerTelemetry::default());
     let handler = Arc::new(ExecServerHandler::new(
         registry,
         RpcNotificationSender::new(outgoing_tx),
@@ -155,7 +155,7 @@ async fn terminate_reports_false_after_process_exit() {
 #[tokio::test]
 async fn long_poll_read_fails_after_session_resume() {
     let (first_tx, _first_rx) = mpsc::channel(16);
-    let registry = SessionRegistry::new();
+    let registry = SessionRegistry::new(crate::ExecServerTelemetry::default());
     let first_handler = Arc::new(ExecServerHandler::new(
         Arc::clone(&registry),
         RpcNotificationSender::new(first_tx),
@@ -228,7 +228,7 @@ async fn long_poll_read_fails_after_session_resume() {
 #[tokio::test]
 async fn active_session_resume_is_rejected() {
     let (first_tx, _first_rx) = mpsc::channel(16);
-    let registry = SessionRegistry::new();
+    let registry = SessionRegistry::new(crate::ExecServerTelemetry::default());
     let first_handler = Arc::new(ExecServerHandler::new(
         Arc::clone(&registry),
         RpcNotificationSender::new(first_tx),
@@ -272,7 +272,7 @@ async fn active_session_resume_is_rejected() {
 async fn output_and_exit_are_retained_after_notification_receiver_closes() {
     let (outgoing_tx, outgoing_rx) = mpsc::channel(16);
     let handler = Arc::new(ExecServerHandler::new(
-        SessionRegistry::new(),
+        SessionRegistry::new(crate::ExecServerTelemetry::default()),
         RpcNotificationSender::new(outgoing_tx),
         test_runtime_paths(),
     ));

--- a/codex-rs/exec-server/src/server/process_handler.rs
+++ b/codex-rs/exec-server/src/server/process_handler.rs
@@ -10,6 +10,7 @@ use crate::protocol::TerminateResponse;
 use crate::protocol::WriteParams;
 use crate::protocol::WriteResponse;
 use crate::rpc::RpcNotificationSender;
+use crate::telemetry::ExecServerTelemetry;
 
 #[derive(Clone)]
 pub(crate) struct ProcessHandler {
@@ -17,9 +18,12 @@ pub(crate) struct ProcessHandler {
 }
 
 impl ProcessHandler {
-    pub(crate) fn new(notifications: RpcNotificationSender) -> Self {
+    pub(crate) fn new(
+        notifications: RpcNotificationSender,
+        telemetry: ExecServerTelemetry,
+    ) -> Self {
         Self {
-            process: LocalProcess::new(notifications),
+            process: LocalProcess::new(notifications, telemetry),
         }
     }
 

--- a/codex-rs/exec-server/src/server/processor.rs
+++ b/codex-rs/exec-server/src/server/processor.rs
@@ -34,7 +34,7 @@ impl ConnectionProcessor {
         telemetry: ExecServerTelemetry,
     ) -> Self {
         Self {
-            session_registry: SessionRegistry::new(),
+            session_registry: SessionRegistry::new(telemetry.clone()),
             runtime_paths,
             telemetry,
         }
@@ -401,7 +401,7 @@ mod tests {
 
     #[tokio::test]
     async fn transport_disconnect_detaches_session_during_in_flight_read() {
-        let registry = SessionRegistry::new();
+        let registry = SessionRegistry::new(crate::ExecServerTelemetry::default());
         let (mut first_writer, mut first_lines, first_task) =
             spawn_test_connection(Arc::clone(&registry), "first");
 

--- a/codex-rs/exec-server/src/server/session_registry.rs
+++ b/codex-rs/exec-server/src/server/session_registry.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 use crate::rpc::RpcNotificationSender;
 use crate::rpc::invalid_request;
 use crate::server::process_handler::ProcessHandler;
+use crate::telemetry::ExecServerTelemetry;
 
 #[cfg(test)]
 const DETACHED_SESSION_TTL: Duration = Duration::from_millis(200);
@@ -18,6 +19,7 @@ const DETACHED_SESSION_TTL: Duration = Duration::from_secs(10);
 
 pub(crate) struct SessionRegistry {
     sessions: Mutex<HashMap<String, Arc<SessionEntry>>>,
+    telemetry: ExecServerTelemetry,
 }
 
 struct SessionEntry {
@@ -49,9 +51,10 @@ pub(crate) struct SessionHandle {
 }
 
 impl SessionRegistry {
-    pub(crate) fn new() -> Arc<Self> {
+    pub(crate) fn new(telemetry: ExecServerTelemetry) -> Arc<Self> {
         Arc::new(Self {
             sessions: Mutex::new(HashMap::new()),
+            telemetry,
         })
     }
 
@@ -94,7 +97,7 @@ impl SessionRegistry {
                 let session_id = Uuid::new_v4().to_string();
                 let entry = Arc::new(SessionEntry::new(
                     session_id.clone(),
-                    ProcessHandler::new(notifications),
+                    ProcessHandler::new(notifications, self.telemetry.clone()),
                     connection_id,
                 ));
                 sessions.insert(session_id, Arc::clone(&entry));
@@ -140,6 +143,7 @@ impl Default for SessionRegistry {
     fn default() -> Self {
         Self {
             sessions: Mutex::new(HashMap::new()),
+            telemetry: ExecServerTelemetry::default(),
         }
     }
 }

--- a/codex-rs/exec-server/src/telemetry.rs
+++ b/codex-rs/exec-server/src/telemetry.rs
@@ -14,6 +14,13 @@ const REQUESTS_TOTAL_METRIC: &str = "exec_server_requests_total";
 const REQUESTS_TOTAL_DESCRIPTION: &str = "Total number of exec-server requests.";
 const REQUEST_DURATION_METRIC: &str = "exec_server_request_duration_seconds";
 const REQUEST_DURATION_DESCRIPTION: &str = "Duration of exec-server requests in seconds.";
+const PROCESSES_ACTIVE_METRIC: &str = "exec_server_processes_active";
+const PROCESSES_ACTIVE_DESCRIPTION: &str = "Number of active exec-server processes.";
+const PROCESSES_FINISHED_TOTAL_METRIC: &str = "exec_server_processes_finished_total";
+const PROCESSES_FINISHED_TOTAL_DESCRIPTION: &str =
+    "Total number of finished exec-server processes.";
+const PROCESS_DURATION_METRIC: &str = "exec_server_process_duration_seconds";
+const PROCESS_DURATION_DESCRIPTION: &str = "Duration of exec-server processes in seconds.";
 
 pub fn runtime_span() -> tracing::Span {
     tracing::info_span!("codex.exec_server", otel.kind = "internal")
@@ -46,6 +53,7 @@ struct ExecServerTelemetryInner {
     relay_connections: AtomicI64,
     stdio_connections: AtomicI64,
     websocket_connections: AtomicI64,
+    active_processes: AtomicI64,
 }
 
 pub(crate) struct ConnectionMetricGuard {
@@ -62,6 +70,7 @@ impl ExecServerTelemetry {
                     relay_connections: AtomicI64::new(0),
                     stdio_connections: AtomicI64::new(0),
                     websocket_connections: AtomicI64::new(0),
+                    active_processes: AtomicI64::new(0),
                 })
             }),
         }
@@ -111,6 +120,41 @@ impl ExecServerTelemetry {
                 REQUEST_DURATION_DESCRIPTION,
                 duration,
                 &tags,
+            );
+        });
+    }
+
+    pub(crate) fn process_started(&self) {
+        self.with_inner(|inner| {
+            let active = inner.active_processes.fetch_add(1, Ordering::AcqRel) + 1;
+            inner.gauge(
+                PROCESSES_ACTIVE_METRIC,
+                PROCESSES_ACTIVE_DESCRIPTION,
+                active,
+                &[],
+            );
+        });
+    }
+
+    pub(crate) fn process_finished(&self, result: &'static str, duration: Duration) {
+        self.with_inner(|inner| {
+            let active = inner.active_processes.fetch_sub(1, Ordering::AcqRel) - 1;
+            inner.gauge(
+                PROCESSES_ACTIVE_METRIC,
+                PROCESSES_ACTIVE_DESCRIPTION,
+                active,
+                &[],
+            );
+            inner.counter(
+                PROCESSES_FINISHED_TOTAL_METRIC,
+                PROCESSES_FINISHED_TOTAL_DESCRIPTION,
+                &[("result", result)],
+            );
+            inner.duration(
+                PROCESS_DURATION_METRIC,
+                PROCESS_DURATION_DESCRIPTION,
+                duration,
+                &[("result", result)],
             );
         });
     }

--- a/codex-rs/exec-server/src/telemetry_tests.rs
+++ b/codex-rs/exec-server/src/telemetry_tests.rs
@@ -86,6 +86,47 @@ fn emits_request_metrics() {
     );
 }
 
+#[test]
+fn emits_process_metrics() {
+    let (telemetry, metrics, exporter) = test_telemetry();
+
+    telemetry.process_started();
+    telemetry.process_finished("terminated", Duration::from_millis(34));
+    metrics.shutdown().expect("shutdown metrics");
+
+    let metrics = latest_metrics(&exporter);
+    assert_eq!(
+        metric_points(&metrics, PROCESSES_ACTIVE_METRIC),
+        vec![(0.0, BTreeMap::new())]
+    );
+    assert_eq!(
+        metric_points(&metrics, PROCESSES_FINISHED_TOTAL_METRIC),
+        vec![(
+            1.0,
+            BTreeMap::from([("result".to_string(), "terminated".to_string())]),
+        )]
+    );
+    assert_eq!(histogram_count(&metrics, PROCESS_DURATION_METRIC), 1);
+    assert_metric_metadata(
+        &metrics,
+        PROCESSES_ACTIVE_METRIC,
+        PROCESSES_ACTIVE_DESCRIPTION,
+        "",
+    );
+    assert_metric_metadata(
+        &metrics,
+        PROCESSES_FINISHED_TOTAL_METRIC,
+        PROCESSES_FINISHED_TOTAL_DESCRIPTION,
+        "",
+    );
+    assert_metric_metadata(
+        &metrics,
+        PROCESS_DURATION_METRIC,
+        PROCESS_DURATION_DESCRIPTION,
+        "s",
+    );
+}
+
 fn test_telemetry() -> (
     ExecServerTelemetry,
     codex_otel::MetricsClient,


### PR DESCRIPTION
## Summary
- Record active, finished, and duration metrics for process lifecycles, including explicit termination, exactly once.

## Stack
- Previous: #27468
- Next: #27470

## Validation
- `just test -p codex-exec-server --lib` (114 passed)
