### PR TITLE
[codex] Align Bazel opt mode with Cargo release

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -94,10 +94,6 @@ common:ci --verbose_failures
 common:ci --build_metadata=REPO_URL=https://github.com/openai/codex.git
 common:ci --build_metadata=ROLE=CI
 common:ci --build_metadata=VISIBILITY=PUBLIC
-# rules_rust derives debug level from Bazel toolchain/compilation-mode settings,
-# not Cargo profiles. Keep CI Rust actions explicit and lean.
-common:ci --@rules_rust//rust/settings:extra_rustc_flag=-Cdebuginfo=0
-common:ci --@rules_rust//rust/settings:extra_exec_rustc_flag=-Cdebuginfo=0
 
 # Disable disk cache in CI since we have a remote one and aren't using persistent workers.
 common:ci --disk_cache=
@@ -110,14 +106,9 @@ common:ci-bazel --build_metadata=TAG_workflow=bazel
 # snapshot on the Windows runner.
 common:ci-bazel --test_env=CODEX_BAZEL_TEST_SKIP_FILTERS=suite::code_mode::
 
-# Shared settings for local and CI release binary builds. `fastbuild` avoids
-# optimizer and debug-info work while disabling Rust debug assertions still
-# compiles the release-only code paths.
-# TODO: Align this with Cargo's release profile, including optimized codegen,
-# ThinLTO, line-table debug info, and a single codegen unit.
-build:release-binaries --compilation_mode=fastbuild
-build:release-binaries --@rules_rust//rust/settings:extra_rustc_flag=-Cdebug-assertions=no
-build:release-binaries --@rules_rust//rust/settings:extra_exec_rustc_flag=-Cdebug-assertions=no
+# Our pinned rules_rust patch maps `opt` mode to Cargo's release profile, so
+# local and CI release binary builds only need to select the compilation mode.
+build:release-binaries --compilation_mode=opt
 
 # Shared config for Bazel-backed Rust linting.
 build:clippy --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -108,6 +108,7 @@ rules_rust = use_extension("@rules_rs//rs/experimental:rules_rust.bzl", "rules_r
 # `libssp_nonshared`, so strip the forwarded stack-protector flags there.
 rules_rust.patch(
     patches = [
+        "//patches:rules_rust_cargo_opt_profile.patch",
         "//patches:rules_rust_windows_gnullvm_build_script.patch",
         "//patches:rules_rust_windows_exec_msvc_build_script_env.patch",
         "//patches:rules_rust_windows_bootstrap_process_wrapper_linker.patch",

--- a/patches/BUILD.bazel
+++ b/patches/BUILD.bazel
@@ -9,6 +9,7 @@ exports_files([
     "llvm_windows_symlink_extract.patch",
     "rules_rust_windows_bootstrap_process_wrapper_linker.patch",
     "rules_rust_windows_build_script_runner_paths.patch",
+    "rules_rust_cargo_opt_profile.patch",
     "rules_rust_windows_exec_bin_target.patch",
     "rules_rust_windows_exec_std.patch",
     "rules_rust_windows_process_wrapper_skip_temp_outputs.patch",

--- a/patches/rules_rust_cargo_opt_profile.patch
+++ b/patches/rules_rust_cargo_opt_profile.patch
@@ -1,0 +1,73 @@
+# What: align rules_rust's default `opt` compilation mode with Cargo's release
+# profile, including Cargo's build-override defaults for exec-side tools.
+# Why: release binaries should have the same optimization, LTO, codegen-unit,
+# debug-info, and stripping behavior whether they are built by Cargo or Bazel.
+
+diff --git a/rust/private/lto.bzl b/rust/private/lto.bzl
+--- a/rust/private/lto.bzl
++++ b/rust/private/lto.bzl
+@@ -45 +45,9 @@ rust_lto_flag = rule(
+ )
++
++def _effective_lto_mode(ctx, toolchain):
++    mode = toolchain.lto.mode
++    if mode == "unspecified" and not is_exec_configuration(ctx) and ctx.var["COMPILATION_MODE"] == "opt":
++        # Match Cargo's release profile while preserving explicit command-line
++        # overrides of the rules_rust LTO build setting.
++        return "thin"
++    return mode
+@@ -63 +71 @@ def _determine_lto_object_format(ctx, toolchain, crate_info):
+-    mode = toolchain.lto.mode
++    mode = _effective_lto_mode(ctx, toolchain)
+@@ -97 +105 @@ def construct_lto_arguments(ctx, toolchain, crate_info):
+-    mode = toolchain.lto.mode
++    mode = _effective_lto_mode(ctx, toolchain)
+diff --git a/rust/private/rustc.bzl b/rust/private/rustc.bzl
+--- a/rust/private/rustc.bzl
++++ b/rust/private/rustc.bzl
+@@ -198 +198,9 @@ def get_compilation_mode_opts(ctx, toolchain):
+         fail("Unrecognized compilation mode {} for toolchain.".format(comp_mode))
++
++    if comp_mode == "opt" and is_exec_configuration(ctx):
++        # Cargo's release profile keeps build scripts and proc macros cheap.
++        return struct(
++            debug_info = "0",
++            opt_level = "0",
++            strip_level = "none",
++        )
+@@ -1145 +1154,3 @@ def construct_arguments(
+     rustc_flags.add(compilation_mode.strip_level, format = "--codegen=strip=%s")
++    if ctx.var["COMPILATION_MODE"] == "opt" and not is_exec_configuration(ctx):
++        rustc_flags.add("-Csplit-debuginfo=off")
+@@ -1186 +1196 @@ def construct_arguments(
+-    _add_codegen_units_flags(toolchain, emit, rustc_flags)
++    _add_codegen_units_flags(ctx, toolchain, emit, rustc_flags)
+@@ -1941 +1951 @@ def _add_lto_flags(ctx, toolchain, args, crate):
+-def _add_codegen_units_flags(toolchain, emit, args):
++def _add_codegen_units_flags(ctx, toolchain, emit, args):
+@@ -1946,2 +1956,3 @@ def _add_codegen_units_flags(toolchain, emit, args):
+     Args:
++        ctx (ctx): The current rule's context.
+         toolchain (rust_toolchain): The current target's `rust_toolchain`.
+@@ -1958 +1969,5 @@ def _add_codegen_units_flags(toolchain, emit, args):
+-    if not is_codegen_units_enabled(toolchain):
++    if is_codegen_units_enabled(toolchain):
++        args.add("-Ccodegen-units={}".format(toolchain._codegen_units))
++        return
++
++    if ctx.var["COMPILATION_MODE"] != "opt":
+@@ -1961 +1976,4 @@ def _add_codegen_units_flags(toolchain, emit, args):
+-    args.add("-Ccodegen-units={}".format(toolchain._codegen_units))
++    # Match Cargo's release and build-override defaults while preserving an
++    # explicit rules_rust codegen_units build setting above.
++    codegen_units = 256 if is_exec_configuration(ctx) else 1
++    args.add("-Ccodegen-units={}".format(codegen_units))
+diff --git a/rust/toolchain.bzl b/rust/toolchain.bzl
+--- a/rust/toolchain.bzl
++++ b/rust/toolchain.bzl
+@@ -692 +692 @@ rust_toolchain = rule(
+-                "opt": "0",
++                "opt": "line-tables-only",
+@@ -863 +863 @@ rust_toolchain = rule(
+-                "opt": "debuginfo",
++                "opt": "none",


### PR DESCRIPTION
## Why

Bazel release binaries should use the same optimization and debug behavior as Cargo's release profile. Keeping those semantics attached to Bazel's standard `opt` mode avoids a second release-only flag list that can drift.

## What changed

Patch the pinned `rules_rust` dependency so target-side `opt` builds use Cargo-compatible optimization, ThinLTO, debug info, stripping, split debug info, and codegen-unit defaults. Exec-side build scripts and proc macros retain Cargo's cheaper build-override defaults, while explicit upstream LTO and codegen-unit settings still take precedence.

Update the shared `release-binaries` config to select only `opt`.

## Validation

- Ran `just build-for-release` under RBE and produced all six release outputs.
- Used Bazel action queries to verify target flags, exec-side flags, and explicit override precedence.
- Ran `just bazel-lock-check`.

Stack: 8 of 8. Depends on #27456.
