### PR TITLE
[codex] Expand hosted web search citation guidance

### DIFF
--- a/codex-rs/ext/web-search/web_run_description.md
+++ b/codex-rs/ext/web-search/web_run_description.md
@@ -70,11 +70,10 @@ Formatting of citations:
 - Do not put citations on a line by themselves or collect all citations at the
   end of the response.
 
-If you browse the internet, cite statements supported by web sources. Ensure
-that every factual statement that may have changed since your knowledge cutoff
-has a citation. Each cited source must directly support the associated claim.
-Prefer primary and authoritative sources, and use sources from different domains
-when the response benefits from multiple perspectives.
+If you browse the internet, cite statements supported by web sources. Each cited
+source must directly support the associated claim. Prefer primary and
+authoritative sources, and use sources from different domains when the response
+benefits from multiple perspectives.
 
 ---
 

--- a/codex-rs/ext/web-search/web_run_description.md
+++ b/codex-rs/ext/web-search/web_run_description.md
@@ -48,6 +48,36 @@ Below is a list of scenarios where browsing the internet MUST be used. PAY CLOSE
 
 ---
 
+## Citations
+
+Results from `web.run` include internal reference IDs such as `turn2search5`. Use
+those reference IDs only in calls to `web.run`; do not expose them in the final
+response.
+
+Cite sources in the final response using Markdown links:
+
+- Cite a single source as `[descriptive source title](https://example.com/page)`.
+- Cite multiple sources with separate Markdown links, for example
+  `[first source](https://example.com/one), [second source](https://example.com/two)`.
+- Link directly to the page that supports the claim. Do not link to search result
+  pages or use bare URLs.
+
+Formatting of citations:
+
+- Place each citation as near as possible to the claim it supports, normally at
+  the end of the sentence or paragraph and after punctuation.
+- Do not place citations inside code fences.
+- Do not put citations on a line by themselves or collect all citations at the
+  end of the response.
+
+If you browse the internet, cite statements supported by web sources. Ensure
+that every factual statement that may have changed since your knowledge cutoff
+has a citation. Each cited source must directly support the associated claim.
+Prefer primary and authoritative sources, and use sources from different domains
+when the response benefits from multiple perspectives.
+
+---
+
 ## Special cases
 If these conflict with any other instructions, these should take precedence.
 
@@ -74,7 +104,3 @@ Responses may not excessively quote or draw on a specific source. There are seve
   - You must avoid providing full articles, long verbatim passages, or extensive direct quotes due to copyright concerns.
   - If the user asked for a verbatim quote, the response should provide a short compliant excerpt and then answer with paraphrases and summaries.
   - Again, this limit does not apply to reddit content, as long as it's appropriately indicated that those are direct quotes and you link to the source.
-
----
-
-Cite your sources by using markdown links to the sites you used in your response. Do NOT use citations in the `turnX` style.


### PR DESCRIPTION
## Summary

- Expand the hosted web search prompt with explicit Markdown-link citation guidance.
- Keep internal `turnX` reference IDs out of final responses and place citations next to supported claims.

## Context

https://openai.slack.com/archives/C0AU83S0ZQU/p1781133381448499?thread_ts=1780352049.512299&cid=C0AU83S0ZQU

## Test plan

- Confirmed `codex-rs/ext/web-search/web_run_description.md` exactly matches the supplied target prompt.
- `UV_CACHE_DIR=/tmp/codex-uv-cache PATH=/tmp/codex-just/bin:/home/dev-user/.rustup/toolchains/1.95.0-x86_64-unknown-linux-gnu/bin:$PATH python3 scripts/format.py --check`
- `git diff --check`
