### PR TITLE
[codex] Preserve Guardian stream-disconnect classification

### DIFF
--- a/codex-rs/core/src/guardian/review.rs
+++ b/codex-rs/core/src/guardian/review.rs
@@ -910,6 +910,7 @@ fn should_retry_guardian_review(outcome: &GuardianReviewOutcome) -> bool {
 #[cfg(test)]
 mod review_tests {
     use super::*;
+    use codex_protocol::error::CodexErr;
     use std::time::Duration;
 
     #[test]
@@ -1012,6 +1013,23 @@ mod review_tests {
         for (outcome, expected) in outcomes {
             assert_eq!(should_retry_guardian_review(&outcome), expected);
         }
+    }
+
+    #[test]
+    fn guardian_review_retries_codex_stream_disconnect_errors() {
+        let error_event = CodexErr::Stream(
+            "WebSocket protocol error: Connection reset without closing handshake".to_string(),
+            None,
+        )
+        .to_error_event(Some("Error running remote compact task".to_string()));
+        let outcome = GuardianReviewOutcome::Error(GuardianReviewError::session_with_error_info(
+            anyhow::anyhow!(error_event.message),
+            error_event
+                .codex_error_info
+                .expect("stream disconnect should preserve structured error info"),
+        ));
+
+        assert!(should_retry_guardian_review(&outcome));
     }
 
     #[tokio::test]

--- a/codex-rs/core/src/guardian/review_session.rs
+++ b/codex-rs/core/src/guardian/review_session.rs
@@ -1066,6 +1066,7 @@ async fn interrupt_and_drain_turn(codex: &Codex, expected_turn_id: &str) -> anyh
 #[cfg(test)]
 mod tests {
     use super::*;
+    use codex_protocol::error::CodexErr;
     use codex_protocol::protocol::AgentStatus;
     use codex_protocol::protocol::ErrorEvent;
     use codex_protocol::protocol::Submission;
@@ -1648,6 +1649,59 @@ mod tests {
         };
         assert_eq!(error.to_string(), "temporary failure");
         assert_eq!(error_info, Some(CodexErrorInfo::ServerOverloaded));
+        assert!(keep_review_session);
+        assert!(capture_token_usage);
+    }
+
+    #[tokio::test]
+    async fn wait_for_guardian_review_preserves_remote_compact_stream_disconnect() {
+        let (review_session, tx_event, _rx_sub) = test_review_session().await;
+        let stream_error = CodexErr::Stream(
+            "WebSocket protocol error: Connection reset without closing handshake".to_string(),
+            None,
+        );
+        tx_event
+            .send(Event {
+                id: "current-turn".to_string(),
+                msg: EventMsg::Error(
+                    stream_error
+                        .to_error_event(Some("Error running remote compact task".to_string())),
+                ),
+            })
+            .await
+            .expect("queue guardian error");
+        tx_event
+            .send(turn_complete_event(
+                "current-turn",
+                /*last_agent_message*/ None,
+                Some(42),
+            ))
+            .await
+            .expect("queue current turn completion");
+
+        let mut analytics_result = GuardianReviewAnalyticsResult::without_session();
+        let (outcome, keep_review_session, capture_token_usage) = wait_for_guardian_review(
+            &review_session,
+            "current-turn",
+            tokio::time::Instant::now() + Duration::from_secs(1),
+            /*external_cancel*/ None,
+            &mut analytics_result,
+        )
+        .await;
+
+        let GuardianReviewSessionOutcome::SessionFailed { error, error_info } = outcome else {
+            panic!("expected structured session failure");
+        };
+        assert_eq!(
+            error.to_string(),
+            "Error running remote compact task: stream disconnected before completion: WebSocket protocol error: Connection reset without closing handshake"
+        );
+        assert_eq!(
+            error_info,
+            Some(CodexErrorInfo::ResponseStreamDisconnected {
+                http_status_code: None,
+            })
+        );
         assert!(keep_review_session);
         assert!(capture_token_usage);
     }

--- a/codex-rs/protocol/src/error.rs
+++ b/codex-rs/protocol/src/error.rs
@@ -228,6 +228,9 @@ impl CodexErr {
             CodexErr::RetryLimit(_) => CodexErrorInfo::ResponseTooManyFailedAttempts {
                 http_status_code: self.http_status_code_value(),
             },
+            CodexErr::Stream(..) => CodexErrorInfo::ResponseStreamDisconnected {
+                http_status_code: self.http_status_code_value(),
+            },
             CodexErr::ConnectionFailed(_) => CodexErrorInfo::HttpConnectionFailed {
                 http_status_code: self.http_status_code_value(),
             },

--- a/codex-rs/protocol/src/error_tests.rs
+++ b/codex-rs/protocol/src/error_tests.rs
@@ -191,6 +191,27 @@ fn to_error_event_handles_response_stream_failed() {
 }
 
 #[test]
+fn to_error_event_handles_response_stream_disconnected() {
+    let err = CodexErr::Stream(
+        "WebSocket protocol error: Connection reset without closing handshake".to_string(),
+        None,
+    );
+
+    let event = err.to_error_event(Some("Error running remote compact task".to_string()));
+
+    assert_eq!(
+        event.message,
+        "Error running remote compact task: stream disconnected before completion: WebSocket protocol error: Connection reset without closing handshake"
+    );
+    assert_eq!(
+        event.codex_error_info,
+        Some(CodexErrorInfo::ResponseStreamDisconnected {
+            http_status_code: None,
+        })
+    );
+}
+
+#[test]
 fn sandbox_denied_reports_exit_code_when_no_output_available() {
     let output = ExecToolCallOutput {
         exit_code: 13,


### PR DESCRIPTION
## Problem

Remote compact websocket resets can happen while a Guardian review is running. In the failing CA-539 example, that showed up as:

> Automatic approval review failed: Error running remote compact task: stream disconnected before completion...

That is an infrastructure stream disconnect, not a Guardian policy decision.

This PR fixes the **error classification** for that failure. It does not own the broader manual-fallback behavior.

## What Was Wrong

Remote compact reports websocket disconnects as `CodexErr::Stream`.

Before this PR, `CodexErr::Stream` converted to:

`CodexErrorInfo::Other`

`Other` loses the useful information that this was a stream disconnect. Guardian only recognizes known structured transient infrastructure errors for retry/unavailable handling, so the remote compact reset could be treated like an unstructured Guardian session failure.

## What Changed

`CodexErr::Stream` now converts to:

`CodexErrorInfo::ResponseStreamDisconnected`

That keeps the websocket reset classified as a structured transient stream failure when it is surfaced through protocol error events.

The tests cover:

- protocol conversion from `CodexErr::Stream` to `ResponseStreamDisconnected`
- Guardian preserving the remote compact error message prefix plus the structured error metadata
- Guardian treating the converted stream-disconnect error as retry eligible

## What This PR Does Not Do

- It does not change Guardian policy decisions.
- It does not approve any action.
- It does not add manual approval fallback.
- It does not, by itself, complete the full CA-539 user-visible behavior where exhausted transient Guardian failures become unavailable/timed out instead of denials.

That terminal fallback behavior is handled separately by #27540. This PR is safe and useful on its own because it preserves the correct error type; #27540 then uses that structured error type for the final fallback behavior.

## Validation

- `just fmt`
- `just test -p codex-protocol to_error_event_handles_response_stream_disconnected --no-capture`
- `just test -p codex-core guardian_review_retries_codex_stream_disconnect_errors wait_for_guardian_review_preserves_remote_compact_stream_disconnect --no-capture`
- `just fix -p codex-protocol`
- `just fix -p codex-core`
