### PR TITLE
[codex] Include turn ID in WebSocket client metadata

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/client_metadata.rs
+++ b/codex-rs/app-server/tests/suite/v2/client_metadata.rs
@@ -611,6 +611,10 @@ async fn turn_start_forwards_client_metadata_to_responses_websocket_request_body
     assert_eq!(metadata["fiber_run_id"].as_str(), Some("fiber-start-123"));
     assert_eq!(metadata["origin"].as_str(), Some("gaas"));
     assert_eq!(metadata["turn_id"].as_str(), Some(turn.id.as_str()));
+    assert_eq!(
+        request["client_metadata"]["turn_id"].as_str(),
+        Some(turn.id.as_str())
+    );
     assert!(metadata.get("session_id").is_some());
     assert_eq!(
         metadata["window_id"].as_str(),

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -134,6 +134,7 @@ pub const OPENAI_BETA_HEADER: &str = "OpenAI-Beta";
 pub const X_CODEX_INSTALLATION_ID_HEADER: &str = "x-codex-installation-id";
 pub const X_CODEX_TURN_STATE_HEADER: &str = "x-codex-turn-state";
 pub const X_CODEX_TURN_METADATA_HEADER: &str = "x-codex-turn-metadata";
+const TURN_ID_CLIENT_METADATA_KEY: &str = "turn_id";
 pub const X_CODEX_PARENT_THREAD_ID_HEADER: &str = "x-codex-parent-thread-id";
 pub const X_CODEX_WINDOW_ID_HEADER: &str = "x-codex-window-id";
 pub const X_OPENAI_MEMGEN_REQUEST_HEADER: &str = "x-openai-memgen-request";
@@ -645,6 +646,7 @@ impl ModelClient {
         &self,
         window_id: &str,
         turn_metadata_header: Option<&str>,
+        turn_id: Option<&str>,
         use_responses_lite: bool,
     ) -> HashMap<String, String> {
         let mut client_metadata = HashMap::new();
@@ -669,6 +671,9 @@ impl ModelClient {
                 X_CODEX_TURN_METADATA_HEADER.to_string(),
                 turn_metadata.to_string(),
             );
+        }
+        if let Some(turn_id) = turn_id {
+            client_metadata.insert(TURN_ID_CLIENT_METADATA_KEY.to_string(), turn_id.to_string());
         }
         if use_responses_lite {
             client_metadata.insert(
@@ -1369,6 +1374,7 @@ impl ModelClientSession {
         summary: ReasoningSummaryConfig,
         service_tier: Option<String>,
         turn_metadata_header: Option<&str>,
+        turn_id: Option<&str>,
         warmup: bool,
         request_trace: Option<W3cTraceContext>,
         inference_trace: &InferenceTraceContext,
@@ -1410,6 +1416,7 @@ impl ModelClientSession {
                     Some(self.client.build_ws_client_metadata(
                         window_id,
                         turn_metadata_header,
+                        turn_id,
                         model_info.use_responses_lite,
                     )),
                     request_trace.as_ref(),
@@ -1571,6 +1578,7 @@ impl ModelClientSession {
                 summary,
                 service_tier,
                 turn_metadata_header,
+                /*turn_id*/ None,
                 /*warmup*/ true,
                 current_span_w3c_trace_context(),
                 &disabled_trace,
@@ -1615,6 +1623,7 @@ impl ModelClientSession {
         summary: ReasoningSummaryConfig,
         service_tier: Option<String>,
         turn_metadata_header: Option<&str>,
+        turn_id: Option<&str>,
         inference_trace: &InferenceTraceContext,
     ) -> Result<ResponseStream> {
         let wire_api = self.client.state.provider.info().wire_api;
@@ -1632,6 +1641,7 @@ impl ModelClientSession {
                             summary,
                             service_tier.clone(),
                             turn_metadata_header,
+                            turn_id,
                             /*warmup*/ false,
                             request_trace,
                             inference_trace,

--- a/codex-rs/core/src/client_tests.rs
+++ b/codex-rs/core/src/client_tests.rs
@@ -296,6 +296,7 @@ fn build_ws_client_metadata_includes_window_lineage_and_turn_metadata() {
     let client_metadata = client.build_ws_client_metadata(
         &window_id,
         Some(r#"{"turn_id":"turn-123"}"#),
+        Some("turn-123"),
         /*use_responses_lite*/ false,
     );
     assert_eq!(
@@ -321,6 +322,7 @@ fn build_ws_client_metadata_includes_window_lineage_and_turn_metadata() {
                 X_CODEX_TURN_METADATA_HEADER.to_string(),
                 r#"{"turn_id":"turn-123"}"#.to_string(),
             ),
+            ("turn_id".to_string(), "turn-123".to_string()),
         ])
     );
 }

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -601,6 +601,7 @@ async fn drain_to_completed(
             turn_context.reasoning_summary,
             turn_context.config.service_tier.clone(),
             turn_metadata_header,
+            Some(turn_context.sub_id.as_str()),
             // Rollout tracing currently models remote compaction only; local compaction streams
             // are left untraced until the reducer has a first-class local compaction lifecycle.
             &InferenceTraceContext::disabled(),

--- a/codex-rs/core/src/compact_remote_v2.rs
+++ b/codex-rs/core/src/compact_remote_v2.rs
@@ -347,6 +347,7 @@ async fn run_remote_compaction_request_v2(
                 turn_context.reasoning_summary,
                 turn_context.config.service_tier.clone(),
                 turn_metadata_header,
+                Some(turn_context.sub_id.as_str()),
                 &InferenceTraceContext::disabled(),
             )
             .await

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -1833,6 +1833,7 @@ async fn try_run_sampling_request(
             turn_context.reasoning_summary,
             turn_context.config.service_tier.clone(),
             turn_metadata_header,
+            Some(turn_context.sub_id.as_str()),
             &inference_trace,
         )
         .instrument(trace_span!("stream_request"))

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -135,6 +135,7 @@ async fn responses_stream_includes_subagent_header_on_review() {
             summary.unwrap_or(model_info.default_reasoning_summary),
             /*service_tier*/ None,
             /*turn_metadata_header*/ None,
+            /*turn_id*/ None,
             &codex_rollout_trace::InferenceTraceContext::disabled(),
         )
         .await
@@ -269,6 +270,7 @@ async fn responses_stream_includes_subagent_header_on_other() {
             summary.unwrap_or(model_info.default_reasoning_summary),
             /*service_tier*/ None,
             /*turn_metadata_header*/ None,
+            /*turn_id*/ None,
             &codex_rollout_trace::InferenceTraceContext::disabled(),
         )
         .await
@@ -389,6 +391,7 @@ async fn responses_respects_model_info_overrides_from_config() {
             summary.unwrap_or(model_info.default_reasoning_summary),
             /*service_tier*/ None,
             /*turn_metadata_header*/ None,
+            /*turn_id*/ None,
             &codex_rollout_trace::InferenceTraceContext::disabled(),
         )
         .await

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -933,6 +933,7 @@ async fn send_provider_auth_request(server: &MockServer, auth: ModelProviderAuth
             summary.unwrap_or(ReasoningSummary::Auto),
             /*service_tier*/ None,
             /*turn_metadata_header*/ None,
+            /*turn_id*/ None,
             &codex_rollout_trace::InferenceTraceContext::disabled(),
         )
         .await
@@ -2477,6 +2478,7 @@ async fn azure_responses_request_includes_store_and_reasoning_ids() {
             summary.unwrap_or(ReasoningSummary::Auto),
             /*service_tier*/ None,
             /*turn_metadata_header*/ None,
+            /*turn_id*/ None,
             &codex_rollout_trace::InferenceTraceContext::disabled(),
         )
         .await

--- a/codex-rs/core/tests/suite/client_websockets.rs
+++ b/codex-rs/core/tests/suite/client_websockets.rs
@@ -453,6 +453,7 @@ async fn responses_websocket_request_prewarm_traces_logical_request() {
             harness.summary,
             /*service_tier*/ None,
             /*turn_metadata_header*/ None,
+            /*turn_id*/ None,
             &inference_trace,
         )
         .await
@@ -625,6 +626,7 @@ async fn responses_websocket_preconnect_is_reused_even_with_header_changes() {
             harness.summary,
             /*service_tier*/ None,
             /*turn_metadata_header*/ None,
+            /*turn_id*/ None,
             &codex_rollout_trace::InferenceTraceContext::disabled(),
         )
         .await
@@ -678,6 +680,7 @@ async fn responses_websocket_request_prewarm_is_reused_even_with_header_changes(
             harness.summary,
             /*service_tier*/ None,
             /*turn_metadata_header*/ None,
+            /*turn_id*/ None,
             &codex_rollout_trace::InferenceTraceContext::disabled(),
         )
         .await
@@ -1083,6 +1086,7 @@ async fn responses_websocket_emits_reasoning_included_event() {
             harness.summary,
             /*service_tier*/ None,
             /*turn_metadata_header*/ None,
+            /*turn_id*/ None,
             &codex_rollout_trace::InferenceTraceContext::disabled(),
         )
         .await
@@ -1158,6 +1162,7 @@ async fn responses_websocket_emits_rate_limit_events() {
             harness.summary,
             /*service_tier*/ None,
             /*turn_metadata_header*/ None,
+            /*turn_id*/ None,
             &codex_rollout_trace::InferenceTraceContext::disabled(),
         )
         .await
@@ -1813,6 +1818,7 @@ async fn responses_websocket_v2_after_error_uses_full_create_without_previous_re
             harness.summary,
             /*service_tier*/ None,
             /*turn_metadata_header*/ None,
+            /*turn_id*/ None,
             &codex_rollout_trace::InferenceTraceContext::disabled(),
         )
         .await
@@ -1902,6 +1908,7 @@ async fn responses_websocket_v2_surfaces_terminal_error_without_close_handshake(
             harness.summary,
             /*service_tier*/ None,
             /*turn_metadata_header*/ None,
+            /*turn_id*/ None,
             &codex_rollout_trace::InferenceTraceContext::disabled(),
         )
         .await
@@ -2137,6 +2144,7 @@ async fn stream_until_complete_with_model_info(
             harness.summary,
             /*service_tier*/ None,
             /*turn_metadata_header*/ None,
+            /*turn_id*/ None,
             &codex_rollout_trace::InferenceTraceContext::disabled(),
         )
         .await
@@ -2205,6 +2213,7 @@ async fn stream_until_complete_with_request_metadata(
             harness.summary,
             service_tier.map(|service_tier| service_tier.request_value().to_string()),
             turn_metadata_header,
+            /*turn_id*/ None,
             &codex_rollout_trace::InferenceTraceContext::disabled(),
         )
         .await

--- a/codex-rs/memories/write/src/runtime.rs
+++ b/codex-rs/memories/write/src/runtime.rs
@@ -254,6 +254,7 @@ impl MemoryStartupContext {
                 context.reasoning_summary,
                 context.service_tier.clone(),
                 context.turn_metadata_header.as_deref(),
+                /*turn_id*/ None,
                 &InferenceTraceContext::disabled(),
             )
             .await?;


### PR DESCRIPTION
## What changed

- Pass the canonical turn ID alongside the serialized turn metadata through the model client stream path.
- Add `turn_id` to per-turn WebSocket `client_metadata` while leaving `x-codex-turn-metadata` unchanged.
- Keep HTTP request behavior unchanged.

## Why

HTTP requests carry `x-codex-turn-metadata` as a request header. WebSocket connections cannot update handshake headers for each turn, so Codex copies the turn metadata blob into each `response.create.client_metadata` body.

Responses API applies a 2,048-character per-value limit to generic client metadata. Large Codex metadata blobs can therefore be dropped, including the embedded turn ID. Emitting the canonical turn ID as a separate small field allows the normal metadata path to preserve it without parsing the full blob in Responses API.

The scalar and blob values both come from the same structured turn context. This change does not parse the serialized JSON blob or change its existing contract.

Linear: https://linear.app/openai/issue/DF-653/validate-thinking-metadata-and-processing-parity-with-codex-cli-and

Replaces the Responses-side approach from closed PR: https://github.com/openai/openai/pull/1016377

## Validation

- `just test -p codex-core build_ws_client_metadata_includes_window_lineage_and_turn_metadata`
- `just test -p codex-app-server turn_start_forwards_client_metadata_to_responses_websocket_request_body_v2`
- `just fix -p codex-core -p codex-memories-write -p codex-app-server`
- `just fmt`
