### PR TITLE
[codex] revert concurrent npm publishing

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -1357,15 +1357,20 @@ jobs:
             other_tarballs+=("${tarball}")
           done
 
-          publish_tarball() {
-            local tarball="$1"
-            local filename
-            local tag
-            local platform
-            local publish_output
-            local publish_status
-            local -a publish_cmd
+          # npm returns HTTP 409 when concurrent publishes update the same
+          # packument. Every platform tarball is a version of @openai/codex,
+          # so publish all tarballs serially.
+          tarballs=(
+            "${platform_tarballs[@]}"
+            "${other_tarballs[@]}"
+            "${root_tarball}"
+          )
+          # The SDK depends on this exact root package version.
+          if [[ -f "${sdk_tarball}" ]]; then
+            tarballs+=("${sdk_tarball}")
+          fi
 
+          for tarball in "${tarballs[@]}"; do
             filename="$(basename "${tarball}")"
             tag=""
 
@@ -1380,7 +1385,7 @@ jobs:
                 ;;
               *)
                 echo "Unexpected npm tarball: ${filename}"
-                return 1
+                exit 1
                 ;;
             esac
 
@@ -1397,34 +1402,16 @@ jobs:
 
             echo "${publish_output}"
             if [[ ${publish_status} -eq 0 ]]; then
-              return 0
+              continue
             fi
 
             if grep -qiE "previously published|cannot publish over|version already exists" <<< "${publish_output}"; then
               echo "Skipping already-published package version for ${filename}"
-              return 0
+              continue
             fi
 
-            return "${publish_status}"
-          }
-
-          # Publish independent packages concurrently, but wait for all of
-          # them before publishing the root CLI wrapper.
-          independent_tarballs=(
-            "${platform_tarballs[@]}"
-            "${other_tarballs[@]}"
-          )
-
-          export prefix
-          export -f publish_tarball
-          printf '%s\0' "${independent_tarballs[@]}" |
-            xargs -0 -n1 -P0 bash -c "publish_tarball \"\$1\"" _
-
-          publish_tarball "${root_tarball}"
-          # The SDK depends on this exact root package version.
-          if [[ -f "${sdk_tarball}" ]]; then
-            publish_tarball "${sdk_tarball}"
-          fi
+            exit "${publish_status}"
+          done
 
   deploy-dev-website:
     name: Trigger developers.openai.com deploy


### PR DESCRIPTION
In https://github.com/openai/codex/actions/runs/27354608310, the
concurrency introduced by
https://github.com/openai/codex/commit/5e50e7e639c9284ceac24a5498b73a5602fb6615
caused the npm publish job to fail.

The six platform tarballs contain different versions of the same
`@openai/codex` package. Every publish updates the same packument, so
only two concurrent updates succeeded while four failed with HTTP 409.

Serializing that group would leave only the responses API proxy running
in parallel. Saving one publish does not justify the nested `xargs`
machinery needed to express those groups.

Restore the serial publish loop and document why the platform variants
must not publish concurrently. Platform packages remain ahead of the
root CLI wrapper, and the SDK remains after its exact root dependency.
