### PR TITLE
TUI updates to handle local ia2 sessions

### DIFF
--- a/codex-rs/app-server-protocol/schema/json/ServerNotification.json
+++ b/codex-rs/app-server-protocol/schema/json/ServerNotification.json
@@ -3435,7 +3435,8 @@
           "type": "string"
         },
         "sessionId": {
-          "description": "Session id shared by threads that belong to the same session tree.",
+          "default": "",
+          "description": "Session id shared by threads that belong to the same session tree.\n\nOlder app-server implementations omitted this field. Treat the missing value as an empty session id so newer clients can still attach; callers that need a stable identifier can fall back to `id`.",
           "type": "string"
         },
         "source": {
@@ -3486,7 +3487,6 @@
         "id",
         "modelProvider",
         "preview",
-        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -15947,7 +15947,8 @@
             "type": "string"
           },
           "sessionId": {
-            "description": "Session id shared by threads that belong to the same session tree.",
+            "default": "",
+            "description": "Session id shared by threads that belong to the same session tree.\n\nOlder app-server implementations omitted this field. Treat the missing value as an empty session id so newer clients can still attach; callers that need a stable identifier can fall back to `id`.",
             "type": "string"
           },
           "source": {
@@ -15998,7 +15999,6 @@
           "id",
           "modelProvider",
           "preview",
-          "sessionId",
           "source",
           "status",
           "turns",

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
@@ -13764,7 +13764,8 @@
           "type": "string"
         },
         "sessionId": {
-          "description": "Session id shared by threads that belong to the same session tree.",
+          "default": "",
+          "description": "Session id shared by threads that belong to the same session tree.\n\nOlder app-server implementations omitted this field. Treat the missing value as an empty session id so newer clients can still attach; callers that need a stable identifier can fall back to `id`.",
           "type": "string"
         },
         "source": {
@@ -13815,7 +13816,6 @@
         "id",
         "modelProvider",
         "preview",
-        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadForkResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadForkResponse.json
@@ -1056,7 +1056,8 @@
           "type": "string"
         },
         "sessionId": {
-          "description": "Session id shared by threads that belong to the same session tree.",
+          "default": "",
+          "description": "Session id shared by threads that belong to the same session tree.\n\nOlder app-server implementations omitted this field. Treat the missing value as an empty session id so newer clients can still attach; callers that need a stable identifier can fall back to `id`.",
           "type": "string"
         },
         "source": {
@@ -1107,7 +1108,6 @@
         "id",
         "modelProvider",
         "preview",
-        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadListResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadListResponse.json
@@ -871,7 +871,8 @@
           "type": "string"
         },
         "sessionId": {
-          "description": "Session id shared by threads that belong to the same session tree.",
+          "default": "",
+          "description": "Session id shared by threads that belong to the same session tree.\n\nOlder app-server implementations omitted this field. Treat the missing value as an empty session id so newer clients can still attach; callers that need a stable identifier can fall back to `id`.",
           "type": "string"
         },
         "source": {
@@ -922,7 +923,6 @@
         "id",
         "modelProvider",
         "preview",
-        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadMetadataUpdateResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadMetadataUpdateResponse.json
@@ -871,7 +871,8 @@
           "type": "string"
         },
         "sessionId": {
-          "description": "Session id shared by threads that belong to the same session tree.",
+          "default": "",
+          "description": "Session id shared by threads that belong to the same session tree.\n\nOlder app-server implementations omitted this field. Treat the missing value as an empty session id so newer clients can still attach; callers that need a stable identifier can fall back to `id`.",
           "type": "string"
         },
         "source": {
@@ -922,7 +923,6 @@
         "id",
         "modelProvider",
         "preview",
-        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadReadResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadReadResponse.json
@@ -871,7 +871,8 @@
           "type": "string"
         },
         "sessionId": {
-          "description": "Session id shared by threads that belong to the same session tree.",
+          "default": "",
+          "description": "Session id shared by threads that belong to the same session tree.\n\nOlder app-server implementations omitted this field. Treat the missing value as an empty session id so newer clients can still attach; callers that need a stable identifier can fall back to `id`.",
           "type": "string"
         },
         "source": {
@@ -922,7 +923,6 @@
         "id",
         "modelProvider",
         "preview",
-        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadResumeResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadResumeResponse.json
@@ -1056,7 +1056,8 @@
           "type": "string"
         },
         "sessionId": {
-          "description": "Session id shared by threads that belong to the same session tree.",
+          "default": "",
+          "description": "Session id shared by threads that belong to the same session tree.\n\nOlder app-server implementations omitted this field. Treat the missing value as an empty session id so newer clients can still attach; callers that need a stable identifier can fall back to `id`.",
           "type": "string"
         },
         "source": {
@@ -1107,7 +1108,6 @@
         "id",
         "modelProvider",
         "preview",
-        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadRollbackResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadRollbackResponse.json
@@ -871,7 +871,8 @@
           "type": "string"
         },
         "sessionId": {
-          "description": "Session id shared by threads that belong to the same session tree.",
+          "default": "",
+          "description": "Session id shared by threads that belong to the same session tree.\n\nOlder app-server implementations omitted this field. Treat the missing value as an empty session id so newer clients can still attach; callers that need a stable identifier can fall back to `id`.",
           "type": "string"
         },
         "source": {
@@ -922,7 +923,6 @@
         "id",
         "modelProvider",
         "preview",
-        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadStartResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadStartResponse.json
@@ -1056,7 +1056,8 @@
           "type": "string"
         },
         "sessionId": {
-          "description": "Session id shared by threads that belong to the same session tree.",
+          "default": "",
+          "description": "Session id shared by threads that belong to the same session tree.\n\nOlder app-server implementations omitted this field. Treat the missing value as an empty session id so newer clients can still attach; callers that need a stable identifier can fall back to `id`.",
           "type": "string"
         },
         "source": {
@@ -1107,7 +1108,6 @@
         "id",
         "modelProvider",
         "preview",
-        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadStartedNotification.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadStartedNotification.json
@@ -871,7 +871,8 @@
           "type": "string"
         },
         "sessionId": {
-          "description": "Session id shared by threads that belong to the same session tree.",
+          "default": "",
+          "description": "Session id shared by threads that belong to the same session tree.\n\nOlder app-server implementations omitted this field. Treat the missing value as an empty session id so newer clients can still attach; callers that need a stable identifier can fall back to `id`.",
           "type": "string"
         },
         "source": {
@@ -922,7 +923,6 @@
         "id",
         "modelProvider",
         "preview",
-        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadUnarchiveResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadUnarchiveResponse.json
@@ -871,7 +871,8 @@
           "type": "string"
         },
         "sessionId": {
-          "description": "Session id shared by threads that belong to the same session tree.",
+          "default": "",
+          "description": "Session id shared by threads that belong to the same session tree.\n\nOlder app-server implementations omitted this field. Treat the missing value as an empty session id so newer clients can still attach; callers that need a stable identifier can fall back to `id`.",
           "type": "string"
         },
         "source": {
@@ -922,7 +923,6 @@
         "id",
         "modelProvider",
         "preview",
-        "sessionId",
         "source",
         "status",
         "turns",

--- a/codex-rs/app-server-protocol/schema/typescript/v2/Thread.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/Thread.ts
@@ -11,6 +11,10 @@ import type { Turn } from "./Turn";
 export type Thread = { id: string,
 /**
  * Session id shared by threads that belong to the same session tree.
+ *
+ * Older app-server implementations omitted this field. Treat the missing
+ * value as an empty session id so newer clients can still attach; callers
+ * that need a stable identifier can fall back to `id`.
  */
 sessionId: string,
 /**

--- a/codex-rs/app-server-protocol/src/protocol/v2/tests.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2/tests.rs
@@ -160,6 +160,34 @@ fn thread_resume_params_accept_turns_page_bootstrap() {
 }
 
 #[test]
+fn thread_accepts_legacy_payload_without_session_id() {
+    let thread = serde_json::from_value::<Thread>(json!({
+        "id": "thr_legacy",
+        "forkedFromId": null,
+        "parentThreadId": null,
+        "preview": "legacy thread",
+        "ephemeral": false,
+        "modelProvider": "custom",
+        "createdAt": 1,
+        "updatedAt": 2,
+        "status": { "type": "idle" },
+        "path": null,
+        "cwd": "/tmp",
+        "cliVersion": "legacy",
+        "source": "appServer",
+        "threadSource": null,
+        "agentNickname": null,
+        "agentRole": null,
+        "gitInfo": null,
+        "name": null,
+        "turns": []
+    }))
+    .expect("legacy thread should deserialize");
+
+    assert_eq!(thread.session_id, "");
+}
+
+#[test]
 fn thread_resume_response_round_trips_initial_turns_page() {
     let response = ThreadResumeResponse {
         thread: Thread {

--- a/codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2/thread_data.rs
@@ -135,6 +135,11 @@ pub struct GitInfo {
 pub struct Thread {
     pub id: String,
     /// Session id shared by threads that belong to the same session tree.
+    ///
+    /// Older app-server implementations omitted this field. Treat the missing
+    /// value as an empty session id so newer clients can still attach; callers
+    /// that need a stable identifier can fall back to `id`.
+    #[serde(default)]
     pub session_id: String,
     /// Source thread id when this thread was created by forking another thread.
     pub forked_from_id: Option<String>,

--- a/codex-rs/app-server/src/request_processors/turn_processor.rs
+++ b/codex-rs/app-server/src/request_processors/turn_processor.rs
@@ -1245,61 +1245,43 @@ impl TurnRequestProcessor {
         params: TurnInterruptParams,
     ) -> Result<Option<TurnInterruptResponse>, JSONRPCErrorError> {
         let TurnInterruptParams { thread_id, turn_id } = params;
-        let is_startup_interrupt = turn_id.is_empty();
-
         let (thread_uuid, thread) = self.load_thread(&thread_id).await?;
 
-        // Record turn interrupts so we can reply when TurnAborted arrives. Startup
-        // interrupts do not have a turn and are acknowledged after submission.
-        if !is_startup_interrupt {
-            let thread_state = self.thread_state_manager.thread_state(thread_uuid).await;
-            let is_running = matches!(thread.agent_status().await, AgentStatus::Running);
-            {
-                let mut thread_state = thread_state.lock().await;
-                if let Some(active_turn) = thread_state.active_turn_snapshot() {
-                    if active_turn.id != turn_id {
-                        return Err(invalid_request(format!(
-                            "expected active turn id {turn_id} but found {}",
-                            active_turn.id
-                        )));
-                    }
-                } else if thread_state.last_terminal_turn_id.as_deref() == Some(turn_id.as_str())
-                    || !is_running
-                {
-                    return Err(invalid_request("no active turn to interrupt"));
+        let thread_state = self.thread_state_manager.thread_state(thread_uuid).await;
+        let is_running = matches!(thread.agent_status().await, AgentStatus::Running);
+        {
+            let mut thread_state = thread_state.lock().await;
+            if let Some(active_turn) = thread_state.active_turn_snapshot() {
+                if active_turn.id != turn_id {
+                    return Err(invalid_request(format!(
+                        "expected active turn id {turn_id} but found {}",
+                        active_turn.id
+                    )));
                 }
-                thread_state.pending_interrupts.push(request_id.clone());
+            } else if thread_state.last_terminal_turn_id.as_deref() == Some(turn_id.as_str())
+                || !is_running
+            {
+                return Err(invalid_request("no active turn to interrupt"));
             }
-
-            self.outgoing
-                .record_request_turn_id(request_id, &turn_id)
-                .await;
+            thread_state.pending_interrupts.push(request_id.clone());
         }
 
-        // Submit the interrupt. Turn interrupts respond upon TurnAborted; startup
-        // interrupts respond here because startup cancellation has no turn event.
+        self.outgoing
+            .record_request_turn_id(request_id, &turn_id)
+            .await;
+
         match self
             .submit_core_op(request_id, thread.as_ref(), Op::Interrupt)
             .await
         {
-            Ok(_) if is_startup_interrupt => Ok(Some(TurnInterruptResponse {})),
             Ok(_) => Ok(None),
             Err(err) => {
-                if !is_startup_interrupt {
-                    let thread_state = self.thread_state_manager.thread_state(thread_uuid).await;
-                    let mut thread_state = thread_state.lock().await;
-                    thread_state
-                        .pending_interrupts
-                        .retain(|pending_request_id| pending_request_id != request_id);
-                }
-                let interrupt_target = if is_startup_interrupt {
-                    "startup"
-                } else {
-                    "turn"
-                };
-                Err(internal_error(format!(
-                    "failed to interrupt {interrupt_target}: {err}"
-                )))
+                let thread_state = self.thread_state_manager.thread_state(thread_uuid).await;
+                let mut thread_state = thread_state.lock().await;
+                thread_state
+                    .pending_interrupts
+                    .retain(|pending_request_id| pending_request_id != request_id);
+                Err(internal_error(format!("failed to interrupt turn: {err}")))
             }
         }
     }

--- a/codex-rs/tui/src/app/agent_status_feed.rs
+++ b/codex-rs/tui/src/app/agent_status_feed.rs
@@ -133,6 +133,9 @@ impl AgentStatusThreadPreview {
 }
 
 fn activity_summary(item: &ThreadItem) -> Option<String> {
+    if !crate::thread_item_visibility::is_user_visible_thread_item(item) {
+        return None;
+    }
     let summary = match item {
         ThreadItem::AgentMessage { text, .. } | ThreadItem::Plan { text, .. } => text,
         ThreadItem::Reasoning { summary, .. } => summary.last()?,

--- a/codex-rs/tui/src/app/resize_reflow.rs
+++ b/codex-rs/tui/src/app/resize_reflow.rs
@@ -232,6 +232,12 @@ impl App {
         }
     }
 
+    pub(super) fn discard_superseded_initial_history_replay_lines(&mut self) {
+        if let Some(buffer) = &mut self.initial_history_replay_buffer {
+            buffer.retained_lines.clear();
+        }
+    }
+
     fn schedule_resize_reflow(&mut self, target_width: Option<u16>) -> bool {
         debug_assert!(self.terminal_resize_reflow_enabled());
         self.transcript_reflow.schedule_debounced(target_width)
@@ -447,6 +453,10 @@ impl App {
         // Drop any queued pre-resize/pre-consolidation inserts before rebuilding from cells.
         tui.clear_pending_history_lines();
         self.clear_terminal_for_resize_replay(tui)?;
+        // This source-backed rebuild already includes every finalized transcript cell. Retained
+        // startup replay lines were rendered before stream consolidation and can otherwise be
+        // appended afterward, hiding the final assistant message behind a stale user-message tail.
+        self.discard_superseded_initial_history_replay_lines();
 
         self.deferred_history_lines.clear();
         if !reflowed_lines.is_empty() {

--- a/codex-rs/tui/src/app/side.rs
+++ b/codex-rs/tui/src/app/side.rs
@@ -395,12 +395,10 @@ impl App {
         app_server: &mut AppServerSession,
         thread_id: ThreadId,
     ) -> std::result::Result<(), String> {
-        let interrupt_result =
-            if let Some(turn_id) = self.active_turn_id_for_thread(thread_id).await {
-                app_server.turn_interrupt(thread_id, turn_id).await
-            } else {
-                app_server.startup_interrupt(thread_id).await
-            };
+        let Some(turn_id) = self.active_turn_id_for_thread(thread_id).await else {
+            return Ok(());
+        };
+        let interrupt_result = app_server.turn_interrupt(thread_id, turn_id).await;
         interrupt_result.map_err(|err| {
             format!("Failed to close side conversation {thread_id}; it is still open: {err}")
         })

--- a/codex-rs/tui/src/app/tests.rs
+++ b/codex-rs/tui/src/app/tests.rs
@@ -3720,6 +3720,9 @@ async fn discard_side_thread_keeps_local_state_when_server_close_fails() -> Resu
         app.active_thread_id = Some(side_thread_id);
         app.side_threads
             .insert(side_thread_id, SideThreadState::new(parent_thread_id));
+        let channel = ThreadEventChannel::new(/*capacity*/ 1);
+        channel.store.lock().await.active_turn_id = Some("missing-turn".to_string());
+        app.thread_event_channels.insert(side_thread_id, channel);
         app.agent_navigation.upsert(
             side_thread_id,
             Some("Side".to_string()),
@@ -4319,6 +4322,30 @@ async fn initial_replay_buffer_keeps_recent_rows_when_row_cap_present() {
             "line 4".to_string(),
         ]
     );
+}
+
+#[tokio::test]
+async fn transcript_reflow_discards_superseded_initial_replay_rows() {
+    let (mut app, _rx, _op_rx) = make_test_app_with_channels().await;
+    enable_terminal_resize_reflow(&mut app);
+    app.config.terminal_resize_reflow.max_rows = TerminalResizeReflowMaxRows::Limit(3);
+
+    app.begin_initial_history_replay_buffer();
+    App::buffer_initial_history_replay_display_lines(
+        app.initial_history_replay_buffer
+            .as_mut()
+            .expect("initial replay buffer active"),
+        vec![Line::from("stale user-message tail").into()],
+        /*max_rows*/ 3,
+    );
+
+    app.discard_superseded_initial_history_replay_lines();
+
+    let buffer = app
+        .initial_history_replay_buffer
+        .as_ref()
+        .expect("later replay events should still be buffered");
+    assert!(buffer.retained_lines.is_empty());
 }
 
 #[tokio::test]
@@ -5508,6 +5535,55 @@ async fn interrupt_without_active_turn_is_treated_as_handled() {
         .expect("interrupt submission should not fail");
 
         assert_eq!(handled, true);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn turn_start_response_records_active_turn_before_notifications() {
+    Box::pin(async {
+        let mut app = make_test_app().await;
+        let mut app_server = Box::pin(crate::start_embedded_app_server_for_picker(
+            app.chat_widget.config_ref(),
+        ))
+        .await
+        .expect("embedded app server");
+        let started = app_server
+            .start_thread(app.chat_widget.config_ref())
+            .await
+            .expect("thread/start should succeed");
+        let thread_id = started.session.thread_id;
+        app.enqueue_primary_thread_session(started.session, started.turns)
+            .await
+            .expect("primary thread should be registered");
+        let config = app.chat_widget.config_ref();
+        let op = AppCommand::user_turn(
+            vec![UserInput::Text {
+                text: "hello".to_string(),
+                text_elements: Vec::new(),
+            }],
+            config.cwd.to_path_buf(),
+            AskForApproval::from(config.permissions.approval_policy.value()),
+            /*active_permission_profile*/ None,
+            config
+                .model
+                .clone()
+                .unwrap_or_else(|| "gpt-5.4".to_string()),
+            /*effort*/ None,
+            /*summary*/ None,
+            /*service_tier*/ None,
+            /*final_output_json_schema*/ None,
+            /*collaboration_mode*/ None,
+            /*personality*/ None,
+        );
+
+        let handled = app
+            .try_submit_active_thread_op_via_app_server(&mut app_server, thread_id, &op)
+            .await
+            .expect("turn submission should not fail");
+
+        assert!(handled);
+        assert!(app.active_turn_id_for_thread(thread_id).await.is_some());
     })
     .await;
 }

--- a/codex-rs/tui/src/app/thread_routing.rs
+++ b/codex-rs/tui/src/app/thread_routing.rs
@@ -529,10 +529,9 @@ impl App {
                     }
                     unreachable!("interrupt retry loop should return");
                 } else {
-                    app_server
-                        .startup_interrupt(thread_id)
-                        .await
-                        .wrap_err("turn/interrupt failed in TUI")?;
+                    // The turn/start response is recorded below before this command can run. If
+                    // no active turn is known, there is nothing safe to interrupt: older remote
+                    // app servers require a real turn id and must not receive a sentinel value.
                 }
                 Ok(true)
             }
@@ -626,7 +625,7 @@ impl App {
                             .as_ref()
                             .map(|profile| &profile.permission_profile),
                     );
-                    app_server
+                    let response = app_server
                         .turn_start(
                             thread_id,
                             items.to_vec(),
@@ -644,6 +643,10 @@ impl App {
                             final_output_json_schema.clone(),
                         )
                         .await?;
+                    if let Some(channel) = self.thread_event_channels.get(&thread_id) {
+                        let mut store = channel.store.lock().await;
+                        store.active_turn_id = Some(response.turn.id);
+                    }
                 }
                 Ok(true)
             }

--- a/codex-rs/tui/src/app_server_session.rs
+++ b/codex-rs/tui/src/app_server_session.rs
@@ -788,13 +788,6 @@ impl AppServerSession {
         Ok(())
     }
 
-    pub(crate) async fn startup_interrupt(
-        &mut self,
-        thread_id: ThreadId,
-    ) -> std::result::Result<(), TypedRequestError> {
-        self.turn_interrupt(thread_id, String::new()).await
-    }
-
     pub(crate) async fn turn_steer(
         &mut self,
         thread_id: ThreadId,

--- a/codex-rs/tui/src/chatwidget/protocol.rs
+++ b/codex-rs/tui/src/chatwidget/protocol.rs
@@ -304,6 +304,9 @@ impl ChatWidget {
         notification: ItemStartedNotification,
         from_replay: bool,
     ) {
+        if self.update_status_for_thread_item(&notification.item) {
+            return;
+        }
         match notification.item {
             item @ ThreadItem::CommandExecution { .. } => self.on_command_execution_started(item),
             ThreadItem::FileChange { id: _, changes, .. } => {

--- a/codex-rs/tui/src/chatwidget/replay.rs
+++ b/codex-rs/tui/src/chatwidget/replay.rs
@@ -69,6 +69,9 @@ impl ChatWidget {
         turn_id: String,
         render_source: ThreadItemRenderSource,
     ) {
+        if self.update_status_for_thread_item(&item) {
+            return;
+        }
         let from_replay = render_source.is_replay();
         let replay_kind = render_source.replay_kind();
         match item {
@@ -197,5 +200,26 @@ impl ChatWidget {
         if matches!(replay_kind, Some(ReplayKind::ThreadSnapshot)) && turn_id.is_empty() {
             self.request_redraw();
         }
+    }
+
+    /// Applies status-only semantics for internal app-server items. Returns true when the item is
+    /// internal and should not be rendered. A clock wait leaves the app-server turn open so future
+    /// wakeups continue streaming, but the status should describe that dormant state rather than
+    /// looking like an indefinitely busy turn.
+    pub(super) fn update_status_for_thread_item(&mut self, item: &ThreadItem) -> bool {
+        if crate::thread_item_visibility::is_internal_clock_wait_thread_item(item) {
+            if self.bottom_pane.is_task_running() {
+                self.set_status_header(String::from("Sleeping"));
+                self.request_redraw();
+            }
+            return true;
+        }
+
+        if self.bottom_pane.is_task_running()
+            && self.status_state.current_status.header == "Sleeping"
+        {
+            self.set_status_header(String::from("Working"));
+        }
+        false
     }
 }

--- a/codex-rs/tui/src/chatwidget/tests/app_server.rs
+++ b/codex-rs/tui/src/chatwidget/tests/app_server.rs
@@ -61,6 +61,79 @@ fn configured_thread_session(thread_id: ThreadId) -> crate::session_state::Threa
 }
 
 #[tokio::test]
+async fn internal_clock_wait_command_is_not_rendered() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
+    chat.on_task_started();
+    let _ = drain_insert_history(&mut rx);
+    let cwd = chat.config.cwd.clone();
+    let command_item = |status| AppServerThreadItem::CommandExecution {
+        id: "clock-wait-1".to_string(),
+        command: "[cot] {\"seconds\":7200}".to_string(),
+        cwd: cwd.clone(),
+        process_id: None,
+        source: ExecCommandSource::Agent,
+        status,
+        command_actions: Vec::new(),
+        aggregated_output: Some(
+            "Channel: analysis\nRecipient: clock.wait\nStream channel: agent".to_string(),
+        ),
+        exit_code: Some(0),
+        duration_ms: None,
+    };
+
+    chat.handle_server_notification(
+        ServerNotification::ItemStarted(ItemStartedNotification {
+            thread_id: "thread-1".to_string(),
+            turn_id: "turn-1".to_string(),
+            started_at_ms: 0,
+            item: command_item(AppServerCommandExecutionStatus::InProgress),
+        }),
+        /*replay_kind*/ None,
+    );
+    chat.handle_server_notification(
+        ServerNotification::ItemCompleted(ItemCompletedNotification {
+            thread_id: "thread-1".to_string(),
+            turn_id: "turn-1".to_string(),
+            completed_at_ms: 0,
+            item: command_item(AppServerCommandExecutionStatus::Completed),
+        }),
+        /*replay_kind*/ None,
+    );
+
+    assert!(drain_insert_history(&mut rx).is_empty());
+    assert_eq!(
+        chat.bottom_pane
+            .status_widget()
+            .expect("status indicator")
+            .header(),
+        "Sleeping"
+    );
+
+    chat.handle_server_notification(
+        ServerNotification::ItemCompleted(ItemCompletedNotification {
+            thread_id: "thread-1".to_string(),
+            turn_id: "turn-1".to_string(),
+            completed_at_ms: 0,
+            item: AppServerThreadItem::AgentMessage {
+                id: "agent-1".to_string(),
+                text: "Awake again".to_string(),
+                phase: None,
+                memory_citation: None,
+            },
+        }),
+        /*replay_kind*/ None,
+    );
+
+    assert_eq!(
+        chat.bottom_pane
+            .status_widget()
+            .expect("status indicator")
+            .header(),
+        "Working"
+    );
+}
+
+#[tokio::test]
 async fn invalid_url_elicitation_is_declined() {
     let (mut chat, _app_event_tx, mut rx, _op_rx) = make_chatwidget_manual_with_sender().await;
     let visible_thread_id = ThreadId::new();

--- a/codex-rs/tui/src/chatwidget/tests/history_replay.rs
+++ b/codex-rs/tui/src/chatwidget/tests/history_replay.rs
@@ -1089,6 +1089,47 @@ async fn replayed_in_progress_turn_marks_task_running() {
 }
 
 #[tokio::test]
+async fn replayed_in_progress_turn_waiting_on_clock_is_sleeping() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    let cwd = chat.config.cwd.clone();
+
+    chat.replay_thread_turns(
+        vec![AppServerTurn {
+            id: "turn-1".to_string(),
+            items_view: codex_app_server_protocol::TurnItemsView::Full,
+            items: vec![AppServerThreadItem::CommandExecution {
+                id: "clock-wait-1".to_string(),
+                command: "[cot] {\"seconds\":300}".to_string(),
+                cwd,
+                process_id: None,
+                source: ExecCommandSource::Agent,
+                status: AppServerCommandExecutionStatus::Completed,
+                command_actions: Vec::new(),
+                aggregated_output: Some(
+                    "Channel: analysis\nRecipient: clock.wait\nStream channel: agent".to_string(),
+                ),
+                exit_code: Some(0),
+                duration_ms: None,
+            }],
+            status: AppServerTurnStatus::InProgress,
+            error: None,
+            started_at: None,
+            completed_at: None,
+            duration_ms: None,
+        }],
+        ReplayKind::ResumeInitialMessages,
+    );
+
+    assert!(drain_insert_history(&mut rx).is_empty());
+    assert!(chat.bottom_pane.is_task_running());
+    let status = chat
+        .bottom_pane
+        .status_widget()
+        .expect("status indicator should be visible");
+    assert_eq!(status.header(), "Sleeping");
+}
+
+#[tokio::test]
 async fn replayed_stream_error_does_not_set_retry_status_or_status_indicator() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
     chat.set_status_header("Idle".to_string());

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -193,6 +193,7 @@ mod terminal_title;
 mod terminal_visualization_instructions;
 mod text_formatting;
 mod theme_picker;
+mod thread_item_visibility;
 mod thread_transcript;
 mod token_usage;
 mod tooltips;
@@ -1022,15 +1023,22 @@ pub async fn run_main(
         .chatgpt_base_url
         .clone()
         .unwrap_or_else(|| "https://chatgpt.com/backend-api/".to_string());
-    let cloud_config_bundle = cloud_config_bundle_loader_for_storage(
-        codex_home.to_path_buf(),
-        /*enable_codex_api_key_env*/ false,
-        bootstrap_config_toml
-            .cli_auth_credentials_store
-            .unwrap_or_default(),
-        chatgpt_base_url,
-    )
-    .await;
+    let cloud_config_bundle = if app_server_target.uses_remote_workspace() {
+        // Remote app servers own authentication and managed policy. Loading a
+        // local cloud bundle here can fail before the TUI connects, and would
+        // incorrectly project local workspace policy onto the remote thread.
+        CloudConfigBundleLoader::default()
+    } else {
+        cloud_config_bundle_loader_for_storage(
+            codex_home.to_path_buf(),
+            /*enable_codex_api_key_env*/ false,
+            bootstrap_config_toml
+                .cli_auth_credentials_store
+                .unwrap_or_default(),
+            chatgpt_base_url,
+        )
+        .await
+    };
 
     let cwd_override = if app_server_target.uses_remote_workspace() {
         None

--- a/codex-rs/tui/src/thread_item_visibility.rs
+++ b/codex-rs/tui/src/thread_item_visibility.rs
@@ -1,0 +1,72 @@
+use codex_app_server_protocol::ThreadItem;
+
+/// Returns false for protocol items that are retained for session bookkeeping but are not part of
+/// the user-visible conversation. The app-server protocol does not currently carry a general
+/// visibility flag, so require both the internal command marker and its recipient metadata before
+/// suppressing an item.
+pub(crate) fn is_user_visible_thread_item(item: &ThreadItem) -> bool {
+    !is_internal_clock_wait_thread_item(item)
+}
+
+pub(crate) fn is_internal_clock_wait_thread_item(item: &ThreadItem) -> bool {
+    let ThreadItem::CommandExecution {
+        command,
+        aggregated_output,
+        ..
+    } = item
+    else {
+        return false;
+    };
+
+    let is_cot_command = command == "[cot]" || command.starts_with("[cot] ");
+    let is_clock_wait = aggregated_output
+        .as_deref()
+        .is_some_and(|output| output.lines().any(|line| line == "Recipient: clock.wait"));
+
+    is_cot_command && is_clock_wait
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codex_app_server_protocol::CommandExecutionSource;
+    use codex_app_server_protocol::CommandExecutionStatus;
+    use codex_utils_absolute_path::AbsolutePathBuf;
+
+    fn command_item(command: &str, output: Option<&str>) -> ThreadItem {
+        ThreadItem::CommandExecution {
+            id: "item-1".to_string(),
+            command: command.to_string(),
+            cwd: AbsolutePathBuf::from_absolute_path("/tmp").expect("absolute path"),
+            process_id: None,
+            status: CommandExecutionStatus::Completed,
+            command_actions: Vec::new(),
+            aggregated_output: output.map(str::to_string),
+            exit_code: Some(0),
+            duration_ms: None,
+            source: CommandExecutionSource::Agent,
+        }
+    }
+
+    #[test]
+    fn hides_internal_clock_wait_command() {
+        let item = command_item(
+            "[cot] {\"seconds\":7200}",
+            Some("Channel: analysis\nRecipient: clock.wait\nStream channel: agent"),
+        );
+
+        assert!(!is_user_visible_thread_item(&item));
+    }
+
+    #[test]
+    fn does_not_hide_user_commands_that_only_resemble_internal_items() {
+        assert!(is_user_visible_thread_item(&command_item(
+            "[cot] hello",
+            None
+        )));
+        assert!(is_user_visible_thread_item(&command_item(
+            "echo hello",
+            Some("Recipient: clock.wait"),
+        )));
+    }
+}

--- a/codex-rs/tui/src/thread_transcript.rs
+++ b/codex-rs/tui/src/thread_transcript.rs
@@ -121,6 +121,9 @@ pub(crate) fn thread_to_transcript_cells(
 }
 
 fn fallback_transcript_cell(item: &ThreadItem) -> Option<PlainHistoryCell> {
+    if !crate::thread_item_visibility::is_user_visible_thread_item(item) {
+        return None;
+    }
     let lines = match item {
         ThreadItem::HookPrompt { fragments, .. } => fragments
             .iter()


### PR DESCRIPTION
TUI updates to locally start, resume, prompt, read, and interrupt the local ia2 backend, and hide/swallow/gracefully handle ia2 items.  IA2 local support is limited to just the basics of control as an alternative to a remote connection (i.e. no attempts to make slash commands work, etc.)
