### PR TITLE
[codex] Round-trip model-bound turn state

### DIFF
--- a/codex-rs/codex-api/src/common.rs
+++ b/codex-rs/codex-api/src/common.rs
@@ -14,12 +14,61 @@ use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::OnceLock;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::task::Context;
 use std::task::Poll;
 use tokio::sync::mpsc;
 
 pub const WS_REQUEST_HEADER_TRACEPARENT_CLIENT_METADATA_KEY: &str = "ws_request_header_traceparent";
 pub const WS_REQUEST_HEADER_TRACESTATE_CLIENT_METADATA_KEY: &str = "ws_request_header_tracestate";
+
+/// Opaque turn-state token with a deferred WebSocket handshake fallback.
+///
+/// A handshake token is not eligible for requests until a response attempt completes without
+/// request-scoped metadata. This keeps preconnect from sending a stale connection-scoped token on
+/// the first `response.create`, while preserving compatibility with handshake-only servers.
+#[derive(Clone, Debug, Default)]
+pub struct ResponsesTurnState {
+    response_token: Arc<OnceLock<String>>,
+    websocket_handshake_token: Arc<OnceLock<String>>,
+    websocket_handshake_token_eligible: Arc<AtomicBool>,
+}
+
+impl ResponsesTurnState {
+    pub fn token_for_request(&self) -> &Arc<OnceLock<String>> {
+        if self.response_token.get().is_some()
+            || !self
+                .websocket_handshake_token_eligible
+                .load(Ordering::Acquire)
+        {
+            &self.response_token
+        } else {
+            &self.websocket_handshake_token
+        }
+    }
+
+    pub fn response_token(&self) -> &Arc<OnceLock<String>> {
+        &self.response_token
+    }
+
+    pub(crate) fn websocket_handshake_token(&self) -> &Arc<OnceLock<String>> {
+        &self.websocket_handshake_token
+    }
+
+    pub(crate) fn capture_response_token(&self, token: String) {
+        let _ = self.response_token.set(token);
+    }
+
+    pub(crate) fn finish_websocket_response_attempt(&self) {
+        if self.response_token.get().is_none() && self.websocket_handshake_token.get().is_some() {
+            self.websocket_handshake_token_eligible
+                .store(true, Ordering::Release);
+        }
+    }
+}
 
 /// Canonical input payload for the compaction endpoint.
 #[derive(Debug, Clone, Serialize)]
@@ -313,5 +362,32 @@ impl Stream for ResponseStream {
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.rx_event.poll_recv(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn responses_turn_state_defers_handshake_fallback_and_prefers_response_metadata() {
+        let state = ResponsesTurnState::default();
+        let _ = state
+            .websocket_handshake_token()
+            .set("handshake".to_string());
+
+        assert_eq!(state.token_for_request().get(), None);
+
+        state.finish_websocket_response_attempt();
+        assert_eq!(
+            state.token_for_request().get().map(String::as_str),
+            Some("handshake")
+        );
+
+        state.capture_response_token("response".to_string());
+        assert_eq!(
+            state.token_for_request().get().map(String::as_str),
+            Some("response")
+        );
     }
 }

--- a/codex-rs/codex-api/src/endpoint/compact.rs
+++ b/codex-rs/codex-api/src/endpoint/compact.rs
@@ -3,6 +3,7 @@ use crate::common::CompactionInput;
 use crate::endpoint::session::EndpointSession;
 use crate::error::ApiError;
 use crate::provider::Provider;
+use crate::sse::responses::capture_turn_state;
 use codex_client::HttpTransport;
 use codex_client::RequestTelemetry;
 use codex_protocol::models::ResponseItem;
@@ -11,6 +12,7 @@ use http::Method;
 use serde::Deserialize;
 use serde_json::to_value;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 pub struct CompactClient<T: HttpTransport> {
@@ -40,6 +42,22 @@ impl<T: HttpTransport> CompactClient<T> {
         extra_headers: HeaderMap,
         request_timeout: Duration,
     ) -> Result<Vec<ResponseItem>, ApiError> {
+        self.compact_with_turn_state(
+            body,
+            extra_headers,
+            request_timeout,
+            /*turn_state*/ None,
+        )
+        .await
+    }
+
+    pub async fn compact_with_turn_state(
+        &self,
+        body: serde_json::Value,
+        extra_headers: HeaderMap,
+        request_timeout: Duration,
+        turn_state: Option<Arc<OnceLock<String>>>,
+    ) -> Result<Vec<ResponseItem>, ApiError> {
         let resp = self
             .session
             .execute_with(
@@ -52,6 +70,9 @@ impl<T: HttpTransport> CompactClient<T> {
                 },
             )
             .await?;
+        if let Some(turn_state) = turn_state.as_deref() {
+            capture_turn_state(&resp.headers, turn_state);
+        }
         let parsed: CompactHistoryResponse =
             serde_json::from_slice(&resp.body).map_err(|e| ApiError::Stream(e.to_string()))?;
         Ok(parsed.output)
@@ -63,9 +84,26 @@ impl<T: HttpTransport> CompactClient<T> {
         extra_headers: HeaderMap,
         request_timeout: Duration,
     ) -> Result<Vec<ResponseItem>, ApiError> {
+        self.compact_input_with_turn_state(
+            input,
+            extra_headers,
+            request_timeout,
+            /*turn_state*/ None,
+        )
+        .await
+    }
+
+    pub async fn compact_input_with_turn_state(
+        &self,
+        input: &CompactionInput<'_>,
+        extra_headers: HeaderMap,
+        request_timeout: Duration,
+        turn_state: Option<Arc<OnceLock<String>>>,
+    ) -> Result<Vec<ResponseItem>, ApiError> {
         let body = to_value(input)
             .map_err(|e| ApiError::Stream(format!("failed to encode compaction input: {e}")))?;
-        self.compact(body, extra_headers, request_timeout).await
+        self.compact_with_turn_state(body, extra_headers, request_timeout, turn_state)
+            .await
     }
 }
 

--- a/codex-rs/codex-api/src/endpoint/responses_websocket.rs
+++ b/codex-rs/codex-api/src/endpoint/responses_websocket.rs
@@ -1,6 +1,7 @@
 use crate::auth::SharedAuthProvider;
 use crate::common::ResponseEvent;
 use crate::common::ResponseStream;
+use crate::common::ResponsesTurnState;
 use crate::common::ResponsesWsRequest;
 use crate::error::ApiError;
 use crate::provider::Provider;
@@ -216,6 +217,16 @@ impl ResponsesWebsocketConnection {
         request: ResponsesWsRequest,
         connection_reused: bool,
     ) -> Result<ResponseStream, ApiError> {
+        self.stream_request_with_turn_state(request, connection_reused, /*turn_state*/ None)
+            .await
+    }
+
+    pub async fn stream_request_with_turn_state(
+        &self,
+        request: ResponsesWsRequest,
+        connection_reused: bool,
+        turn_state: Option<ResponsesTurnState>,
+    ) -> Result<ResponseStream, ApiError> {
         let (tx_event, rx_event) =
             mpsc::channel::<std::result::Result<ResponseEvent, ApiError>>(1600);
         let stream = Arc::clone(&self.stream);
@@ -264,9 +275,13 @@ impl ResponsesWebsocketConnection {
                         idle_timeout,
                         telemetry,
                         connection_reused,
+                        turn_state.as_ref(),
                     )
                     .await
                 };
+                if let Some(turn_state) = turn_state.as_ref() {
+                    turn_state.finish_websocket_response_attempt();
+                }
 
                 if let Err(err) = result {
                     // A terminal stream error should reach the caller immediately. Waiting for a
@@ -338,6 +353,37 @@ impl ResponsesWebsocketClient {
         turn_state: Option<Arc<OnceLock<String>>>,
         telemetry: Option<Arc<dyn WebsocketTelemetry>>,
     ) -> Result<ResponsesWebsocketConnection, ApiError> {
+        self.connect_with_handshake_sink(extra_headers, default_headers, turn_state, telemetry)
+            .await
+    }
+
+    #[instrument(
+        name = "responses_websocket.connect",
+        level = "info",
+        skip_all,
+        fields(transport = "responses_websocket", api.path = "responses")
+    )]
+    pub async fn connect_with_turn_state(
+        &self,
+        extra_headers: HeaderMap,
+        default_headers: HeaderMap,
+        turn_state: Option<ResponsesTurnState>,
+        telemetry: Option<Arc<dyn WebsocketTelemetry>>,
+    ) -> Result<ResponsesWebsocketConnection, ApiError> {
+        let handshake_sink = turn_state
+            .as_ref()
+            .map(|state| Arc::clone(state.websocket_handshake_token()));
+        self.connect_with_handshake_sink(extra_headers, default_headers, handshake_sink, telemetry)
+            .await
+    }
+
+    async fn connect_with_handshake_sink(
+        &self,
+        extra_headers: HeaderMap,
+        default_headers: HeaderMap,
+        handshake_sink: Option<Arc<OnceLock<String>>>,
+        telemetry: Option<Arc<dyn WebsocketTelemetry>>,
+    ) -> Result<ResponsesWebsocketConnection, ApiError> {
         let ws_url = self
             .provider
             .websocket_url_for_path("responses")
@@ -348,7 +394,7 @@ impl ResponsesWebsocketClient {
         self.auth.add_auth_headers(&mut headers);
 
         let (stream, _status, server_reasoning_included, models_etag, server_model) =
-            connect_websocket(ws_url, headers, turn_state.clone()).await?;
+            connect_websocket(ws_url, headers, handshake_sink).await?;
         Ok(ResponsesWebsocketConnection::new(
             stream,
             self.provider.stream_idle_timeout,
@@ -631,6 +677,7 @@ async fn run_websocket_response_stream(
     idle_timeout: Duration,
     telemetry: Option<Arc<dyn WebsocketTelemetry>>,
     connection_reused: bool,
+    turn_state: Option<&ResponsesTurnState>,
 ) -> Result<(), ApiError> {
     let mut last_server_model: Option<String> = None;
     send_websocket_request(
@@ -682,6 +729,11 @@ async fn run_websocket_response_stream(
                         continue;
                     }
                 };
+                if let Some(response_turn_state) = event.turn_state()
+                    && let Some(turn_state) = turn_state
+                {
+                    turn_state.capture_response_token(response_turn_state);
+                }
                 let model_verifications = event.model_verifications();
                 let turn_moderation_metadata = event.turn_moderation_metadata();
                 if event.kind() == "codex.rate_limits" {
@@ -721,6 +773,11 @@ async fn run_websocket_response_stream(
                 match process_responses_event(event) {
                     Ok(Some(event)) => {
                         let is_completed = matches!(event, ResponseEvent::Completed { .. });
+                        if is_completed && let Some(turn_state) = turn_state {
+                            // Make a handshake-only fallback visible before the consumer can
+                            // start the next request after observing response.completed.
+                            turn_state.finish_websocket_response_attempt();
+                        }
                         let _ = tx_event.send(Ok(event)).await;
                         if is_completed {
                             break;

--- a/codex-rs/codex-api/src/lib.rs
+++ b/codex-rs/codex-api/src/lib.rs
@@ -35,6 +35,7 @@ pub use crate::common::ResponseCreateWsRequest;
 pub use crate::common::ResponseEvent;
 pub use crate::common::ResponseStream;
 pub use crate::common::ResponsesApiRequest;
+pub use crate::common::ResponsesTurnState;
 pub use crate::common::ResponsesWsRequest;
 pub use crate::common::TextControls;
 pub use crate::common::WS_REQUEST_HEADER_TRACEPARENT_CLIENT_METADATA_KEY;

--- a/codex-rs/codex-api/src/sse/responses.rs
+++ b/codex-rs/codex-api/src/sse/responses.rs
@@ -23,6 +23,7 @@ use tracing::debug;
 use tracing::trace;
 
 const X_REASONING_INCLUDED_HEADER: &str = "x-reasoning-included";
+const X_CODEX_TURN_STATE_HEADER: &str = "x-codex-turn-state";
 const OPENAI_MODEL_HEADER: &str = "openai-model";
 const REQUEST_ID_HEADER: &str = "x-request-id";
 const TRUSTED_ACCESS_FOR_CYBER_VERIFICATION: &str = "trusted_access_for_cyber";
@@ -53,13 +54,8 @@ pub fn spawn_response_stream(
         .get(REQUEST_ID_HEADER)
         .and_then(|value| value.to_str().ok())
         .map(str::to_string);
-    if let Some(turn_state) = turn_state.as_ref()
-        && let Some(header_value) = stream_response
-            .headers
-            .get("x-codex-turn-state")
-            .and_then(|v| v.to_str().ok())
-    {
-        let _ = turn_state.set(header_value.to_string());
+    if let Some(turn_state) = turn_state.as_deref() {
+        capture_turn_state(&stream_response.headers, turn_state);
     }
     let (tx_event, rx_event) = mpsc::channel::<Result<ResponseEvent, ApiError>>(1600);
     tokio::spawn(async move {
@@ -83,6 +79,15 @@ pub fn spawn_response_stream(
     ResponseStream {
         rx_event,
         upstream_request_id,
+    }
+}
+
+pub(crate) fn capture_turn_state(headers: &http::HeaderMap, turn_state: &OnceLock<String>) {
+    if let Some(header_value) = headers
+        .get(X_CODEX_TURN_STATE_HEADER)
+        .and_then(|value| value.to_str().ok())
+    {
+        let _ = turn_state.set(header_value.to_string());
     }
 }
 
@@ -184,6 +189,16 @@ impl ResponsesStreamEvent {
         }
     }
 
+    pub(crate) fn turn_state(&self) -> Option<String> {
+        if self.kind() != "codex.response.metadata" {
+            return None;
+        }
+
+        self.headers
+            .as_ref()
+            .and_then(header_turn_state_value_from_json)
+    }
+
     pub(crate) fn model_verifications(&self) -> Option<Vec<ModelVerification>> {
         if self.kind() != "response.metadata" {
             return None;
@@ -213,6 +228,17 @@ fn header_openai_model_value_from_json(value: &Value) -> Option<String> {
     headers.iter().find_map(|(name, value)| {
         if name.eq_ignore_ascii_case("openai-model") || name.eq_ignore_ascii_case("x-openai-model")
         {
+            json_value_as_string(value)
+        } else {
+            None
+        }
+    })
+}
+
+fn header_turn_state_value_from_json(value: &Value) -> Option<String> {
+    let headers = value.as_object()?;
+    headers.iter().find_map(|(name, value)| {
+        if name.eq_ignore_ascii_case(X_CODEX_TURN_STATE_HEADER) {
             json_value_as_string(value)
         } else {
             None

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -50,6 +50,7 @@ use codex_api::ResponseCreateWsRequest;
 use codex_api::ResponsesApiRequest;
 use codex_api::ResponsesClient as ApiResponsesClient;
 use codex_api::ResponsesOptions as ApiResponsesOptions;
+use codex_api::ResponsesTurnState as ApiResponsesTurnState;
 use codex_api::ResponsesWebsocketClient as ApiWebSocketResponsesClient;
 use codex_api::ResponsesWebsocketConnection as ApiWebSocketConnection;
 use codex_api::ResponsesWsRequest;
@@ -237,17 +238,27 @@ pub struct ModelClient {
 pub struct ModelClientSession {
     client: ModelClient,
     websocket_session: WebsocketSession,
-    /// Turn state for sticky routing.
-    ///
-    /// This is an `OnceLock` that stores the turn state value received from the server
-    /// on turn start via the `x-codex-turn-state` response header. Once set, this value
-    /// should be sent back to the server in the `x-codex-turn-state` request header for
-    /// all subsequent requests within the same turn to maintain sticky routing.
-    ///
-    /// This is a contract between the client and server: we receive it at turn start,
-    /// keep sending it unchanged between turn requests (e.g., for retries, incremental
-    /// appends, or continuation requests), and must not send it between different turns.
-    turn_state: Arc<OnceLock<String>>,
+    turn_state: Option<ModelTurnState>,
+}
+
+/// Opaque sticky-routing state bound to the requested model that produced it.
+///
+/// A model change replaces this entire value, so a late response for the previous model cannot
+/// populate the new model's state. The API state keeps request-scoped metadata authoritative and
+/// defers any handshake fallback until a response attempt completes without metadata.
+#[derive(Clone)]
+struct ModelTurnState {
+    requested_model: String,
+    token: ApiResponsesTurnState,
+}
+
+impl ModelTurnState {
+    fn new(requested_model: &str) -> Self {
+        Self {
+            requested_model: requested_model.to_string(),
+            token: ApiResponsesTurnState::default(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -374,7 +385,7 @@ impl ModelClient {
         ModelClientSession {
             client: self.clone(),
             websocket_session: self.take_cached_websocket_session(),
-            turn_state: Arc::new(OnceLock::new()),
+            turn_state: None,
         }
     }
 
@@ -428,10 +439,11 @@ impl ModelClient {
     /// The model selection and telemetry context are passed explicitly to keep `ModelClient`
     /// session-scoped.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) async fn compact_conversation_history(
+    async fn compact_conversation_history(
         &self,
         prompt: &Prompt,
         model_info: &ModelInfo,
+        turn_state: ModelTurnState,
         settings: CompactConversationRequestSettings,
         session_telemetry: &SessionTelemetry,
         compaction_trace: &CompactionTraceContext,
@@ -491,7 +503,7 @@ impl ModelClient {
         }
         extra_headers.extend(build_responses_headers(
             self.state.beta_features_header.as_deref(),
-            /*turn_state*/ None,
+            Some(turn_state.token.token_for_request()),
         ));
         extra_headers.extend(self.build_responses_compatibility_headers(responses_metadata));
         extra_headers.extend(build_session_headers(
@@ -511,7 +523,12 @@ impl ModelClient {
                 .with_telemetry(Some(request_telemetry));
         let trace_attempt = compaction_trace.start_attempt(&payload);
         let result = client
-            .compact_input(&payload, extra_headers, compact_request_timeout)
+            .compact_input_with_turn_state(
+                &payload,
+                extra_headers,
+                compact_request_timeout,
+                Some(Arc::clone(turn_state.token.response_token())),
+            )
             .await
             .map_err(map_api_error);
         trace_attempt.record_result(result.as_deref());
@@ -635,9 +652,22 @@ impl ModelClient {
     fn build_ws_client_metadata(
         &self,
         responses_metadata: &CodexResponsesMetadata,
+        turn_state: &ModelTurnState,
         use_responses_lite: bool,
     ) -> HashMap<String, String> {
         let mut client_metadata = responses_metadata.client_metadata();
+        // WebSocket headers are fixed at upgrade time, so request-scoped turn state travels in
+        // response.create client metadata. An empty value explicitly starts fresh state when a
+        // connection is reused across turns or requested models.
+        client_metadata.insert(
+            X_CODEX_TURN_STATE_HEADER.to_string(),
+            turn_state
+                .token
+                .token_for_request()
+                .get()
+                .cloned()
+                .unwrap_or_default(),
+        );
         if use_responses_lite {
             client_metadata.insert(
                 WS_REQUEST_HEADER_RESPONSES_LITE_CLIENT_METADATA_KEY.to_string(),
@@ -798,12 +828,15 @@ impl ModelClient {
         api_provider: codex_api::Provider,
         api_auth: SharedAuthProvider,
         responses_metadata: &CodexResponsesMetadata,
-        turn_state: Option<Arc<OnceLock<String>>>,
+        turn_state: Option<&ModelTurnState>,
         auth_context: AuthRequestTelemetryContext,
         request_route_telemetry: RequestRouteTelemetry,
     ) -> std::result::Result<ApiWebSocketConnection, ApiError> {
         let headers = self
-            .build_websocket_headers(responses_metadata, turn_state.as_ref())
+            .build_websocket_headers(
+                responses_metadata,
+                turn_state.map(|state| state.token.token_for_request()),
+            )
             .await;
         let websocket_telemetry = ModelClientSession::build_websocket_telemetry(
             session_telemetry,
@@ -815,10 +848,10 @@ impl ModelClient {
         let start = Instant::now();
         let result = match tokio::time::timeout(
             websocket_connect_timeout,
-            ApiWebSocketResponsesClient::new(api_provider, api_auth).connect(
+            ApiWebSocketResponsesClient::new(api_provider, api_auth).connect_with_turn_state(
                 headers,
                 codex_login::default_client::default_headers(),
-                turn_state,
+                turn_state.map(|state| state.token.clone()),
                 Some(websocket_telemetry),
             ),
         )
@@ -922,6 +955,41 @@ impl Drop for ModelClientSession {
 }
 
 impl ModelClientSession {
+    pub(crate) async fn compact_conversation_history(
+        &mut self,
+        prompt: &Prompt,
+        model_info: &ModelInfo,
+        settings: CompactConversationRequestSettings,
+        session_telemetry: &SessionTelemetry,
+        compaction_trace: &CompactionTraceContext,
+        responses_metadata: &CodexResponsesMetadata,
+    ) -> Result<Vec<ResponseItem>> {
+        let turn_state = self.turn_state_for_model(&model_info.slug);
+        self.client
+            .compact_conversation_history(
+                prompt,
+                model_info,
+                turn_state,
+                settings,
+                session_telemetry,
+                compaction_trace,
+                responses_metadata,
+            )
+            .await
+    }
+
+    fn turn_state_for_model(&mut self, requested_model: &str) -> ModelTurnState {
+        if let Some(state) = self.turn_state.as_ref()
+            && state.requested_model == requested_model
+        {
+            return state.clone();
+        }
+
+        let state = ModelTurnState::new(requested_model);
+        self.turn_state = Some(state.clone());
+        state
+    }
+
     fn reset_websocket_session(&mut self) {
         self.websocket_session.connection = None;
         self.websocket_session.last_request = None;
@@ -939,6 +1007,7 @@ impl ModelClientSession {
     async fn build_responses_options(
         &self,
         responses_metadata: &CodexResponsesMetadata,
+        turn_state: &ApiResponsesTurnState,
         compression: Compression,
         use_responses_lite: bool,
     ) -> ApiResponsesOptions {
@@ -949,7 +1018,7 @@ impl ModelClientSession {
             extra_headers: {
                 let mut headers = build_responses_headers(
                     self.client.state.beta_features_header.as_deref(),
-                    Some(&self.turn_state),
+                    Some(turn_state.token_for_request()),
                 );
                 headers.extend(
                     self.client
@@ -962,7 +1031,7 @@ impl ModelClientSession {
                 headers
             },
             compression,
-            turn_state: Some(Arc::clone(&self.turn_state)),
+            turn_state: Some(Arc::clone(turn_state.response_token())),
         }
     }
 
@@ -1054,6 +1123,7 @@ impl ModelClientSession {
     pub async fn preconnect_websocket(
         &mut self,
         session_telemetry: &SessionTelemetry,
+        model_info: &ModelInfo,
         responses_metadata: &CodexResponsesMetadata,
     ) -> std::result::Result<(), ApiError> {
         if !self.client.responses_websocket_enabled() {
@@ -1073,6 +1143,7 @@ impl ModelClientSession {
             client_setup.api_auth.as_ref(),
             PendingUnauthorizedRetry::default(),
         );
+        let turn_state = self.turn_state_for_model(&model_info.slug);
         let connection = self
             .client
             .connect_websocket(
@@ -1080,7 +1151,7 @@ impl ModelClientSession {
                 client_setup.api_provider,
                 client_setup.api_auth,
                 responses_metadata,
-                Some(Arc::clone(&self.turn_state)),
+                Some(&turn_state),
                 auth_context,
                 RequestRouteTelemetry::for_endpoint(RESPONSES_ENDPOINT),
             )
@@ -1112,7 +1183,7 @@ impl ModelClientSession {
             api_provider,
             api_auth,
             responses_metadata,
-            options,
+            turn_state,
             auth_context,
             request_route_telemetry,
         } = params;
@@ -1125,10 +1196,6 @@ impl ModelClientSession {
             self.websocket_session.last_request = None;
             self.websocket_session.last_response_rx = None;
             self.websocket_session.last_response_from_untraced_warmup = false;
-            let turn_state = options
-                .turn_state
-                .clone()
-                .unwrap_or_else(|| Arc::clone(&self.turn_state));
             let new_conn = match self
                 .client
                 .connect_websocket(
@@ -1195,7 +1262,7 @@ impl ModelClientSession {
         )
     )]
     async fn stream_responses_api(
-        &self,
+        &mut self,
         prompt: &Prompt,
         model_info: &ModelInfo,
         session_telemetry: &SessionTelemetry,
@@ -1205,6 +1272,7 @@ impl ModelClientSession {
         responses_metadata: &CodexResponsesMetadata,
         inference_trace: &InferenceTraceContext,
     ) -> Result<ResponseStream> {
+        let turn_state = self.turn_state_for_model(&model_info.slug);
         let auth_manager = self.client.state.provider.auth_manager();
         let mut auth_recovery = auth_manager
             .as_ref()
@@ -1228,6 +1296,7 @@ impl ModelClientSession {
             let mut options = self
                 .build_responses_options(
                     responses_metadata,
+                    &turn_state.token,
                     compression,
                     model_info.use_responses_lite,
                 )
@@ -1325,6 +1394,7 @@ impl ModelClientSession {
         request_trace: Option<W3cTraceContext>,
         inference_trace: &InferenceTraceContext,
     ) -> Result<WebsocketStreamOutcome> {
+        let turn_state = self.turn_state_for_model(&model_info.slug);
         let auth_manager = self.client.state.provider.auth_manager();
 
         let mut auth_recovery = auth_manager
@@ -1338,15 +1408,6 @@ impl ModelClientSession {
                 client_setup.api_auth.as_ref(),
                 pending_retry,
             );
-            let compression = self.responses_request_compression(client_setup.auth.as_ref());
-
-            let options = self
-                .build_responses_options(
-                    responses_metadata,
-                    compression,
-                    model_info.use_responses_lite,
-                )
-                .await;
             let request = self.client.build_responses_request(
                 &client_setup.api_provider,
                 prompt,
@@ -1360,6 +1421,7 @@ impl ModelClientSession {
                 client_metadata: response_create_client_metadata(
                     Some(self.client.build_ws_client_metadata(
                         responses_metadata,
+                        &turn_state,
                         model_info.use_responses_lite,
                     )),
                     request_trace.as_ref(),
@@ -1376,7 +1438,7 @@ impl ModelClientSession {
                     api_provider: client_setup.api_provider,
                     api_auth: client_setup.api_auth,
                     responses_metadata,
-                    options: &options,
+                    turn_state: &turn_state,
                     auth_context: request_auth_context,
                     request_route_telemetry: RequestRouteTelemetry::for_endpoint(
                         RESPONSES_ENDPOINT,
@@ -1433,7 +1495,11 @@ impl ModelClientSession {
                     ))
                 })?;
             let stream_result = websocket_connection
-                .stream_request(ws_request, self.websocket_session.connection_reused())
+                .stream_request_with_turn_state(
+                    ws_request,
+                    self.websocket_session.connection_reused(),
+                    Some(turn_state.token.clone()),
+                )
                 .await
                 .map_err(|err| {
                     let response_debug_context =
@@ -1912,7 +1978,7 @@ struct WebsocketConnectParams<'a> {
     api_provider: codex_api::Provider,
     api_auth: SharedAuthProvider,
     responses_metadata: &'a CodexResponsesMetadata,
-    options: &'a ApiResponsesOptions,
+    turn_state: &'a ModelTurnState,
     auth_context: AuthRequestTelemetryContext,
     request_route_telemetry: RequestRouteTelemetry,
 }

--- a/codex-rs/core/src/client_tests.rs
+++ b/codex-rs/core/src/client_tests.rs
@@ -5,6 +5,7 @@ use super::UnauthorizedRecoveryExecution;
 use super::X_CODEX_INSTALLATION_ID_HEADER;
 use super::X_CODEX_PARENT_THREAD_ID_HEADER;
 use super::X_CODEX_TURN_METADATA_HEADER;
+use super::X_CODEX_TURN_STATE_HEADER;
 use super::X_CODEX_WINDOW_ID_HEADER;
 use super::X_OPENAI_SUBAGENT_HEADER;
 use crate::AttestationContext;
@@ -311,8 +312,12 @@ fn build_ws_client_metadata_includes_window_lineage_and_turn_metadata() {
         Some(parent_thread_id),
         TestCodexResponsesRequestKind::Turn,
     );
-    let client_metadata =
-        client.build_ws_client_metadata(&responses_metadata, /*use_responses_lite*/ false);
+    let turn_state = super::ModelTurnState::new("gpt-test");
+    let client_metadata = client.build_ws_client_metadata(
+        &responses_metadata,
+        &turn_state,
+        /*use_responses_lite*/ false,
+    );
     let parent_thread_id = parent_thread_id.to_string();
     let turn_metadata: serde_json::Value = serde_json::from_str(
         client_metadata
@@ -351,6 +356,12 @@ fn build_ws_client_metadata_includes_window_lineage_and_turn_metadata() {
             .get(X_OPENAI_SUBAGENT_HEADER)
             .map(String::as_str),
         Some("collab_spawn")
+    );
+    assert_eq!(
+        client_metadata
+            .get(X_CODEX_TURN_STATE_HEADER)
+            .map(String::as_str),
+        Some("")
     );
 }
 

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::Prompt;
 use crate::client::CompactConversationRequestSettings;
+use crate::client::ModelClientSession;
 use crate::compact::CompactionAnalyticsAttempt;
 use crate::compact::CompactionAnalyticsDetails;
 use crate::compact::InitialContextInjection;
@@ -43,6 +44,7 @@ const CONTEXT_WINDOW_TRUNCATED_OUTPUT_MESSAGE: &str =
 pub(crate) async fn run_inline_remote_auto_compact_task(
     sess: Arc<Session>,
     turn_context: Arc<TurnContext>,
+    client_session: &mut ModelClientSession,
     initial_context_injection: InitialContextInjection,
     reason: CompactionReason,
     phase: CompactionPhase,
@@ -50,6 +52,7 @@ pub(crate) async fn run_inline_remote_auto_compact_task(
     run_remote_compact_task_inner(
         &sess,
         &turn_context,
+        client_session,
         initial_context_injection,
         CompactionTrigger::Auto,
         reason,
@@ -72,9 +75,11 @@ pub(crate) async fn run_remote_compact_task(
     });
     sess.send_event(&turn_context, start_event).await;
 
+    let mut client_session = sess.services.model_client.new_session();
     run_remote_compact_task_inner(
         &sess,
         &turn_context,
+        &mut client_session,
         InitialContextInjection::DoNotInject,
         CompactionTrigger::Manual,
         CompactionReason::UserRequested,
@@ -87,6 +92,7 @@ pub(crate) async fn run_remote_compact_task(
 async fn run_remote_compact_task_inner(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
+    client_session: &mut ModelClientSession,
     initial_context_injection: InitialContextInjection,
     trigger: CompactionTrigger,
     reason: CompactionReason,
@@ -130,6 +136,7 @@ async fn run_remote_compact_task_inner(
     let result = run_remote_compact_task_inner_impl(
         sess,
         turn_context,
+        client_session,
         initial_context_injection,
         compaction_metadata,
         &mut analytics_details,
@@ -163,6 +170,7 @@ async fn run_remote_compact_task_inner(
 async fn run_remote_compact_task_inner_impl(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
+    client_session: &mut ModelClientSession,
     initial_context_injection: InitialContextInjection,
     compaction_metadata: CompactionTurnMetadata,
     analytics_details: &mut CompactionAnalyticsDetails,
@@ -231,9 +239,7 @@ async fn run_remote_compact_task_inner_impl(
         window_id,
         CodexResponsesRequestKind::Compaction(compaction_metadata),
     );
-    let mut new_history = sess
-        .services
-        .model_client
+    let mut new_history = client_session
         .compact_conversation_history(
             &prompt,
             &turn_context.model_info,

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -922,6 +922,7 @@ async fn run_auto_compact(
         run_inline_remote_auto_compact_task(
             Arc::clone(sess),
             Arc::clone(turn_context),
+            client_session,
             initial_context_injection,
             reason,
             phase,

--- a/codex-rs/core/tests/suite/client_websockets.rs
+++ b/codex-rs/core/tests/suite/client_websockets.rs
@@ -65,6 +65,7 @@ const OPENAI_BETA_HEADER: &str = "OpenAI-Beta";
 const USER_AGENT_HEADER: &str = "user-agent";
 const WS_V2_BETA_HEADER_VALUE: &str = "responses_websockets=2026-02-06";
 const X_CLIENT_REQUEST_ID_HEADER: &str = "x-client-request-id";
+const X_CODEX_TURN_STATE_HEADER: &str = "x-codex-turn-state";
 const WS_REQUEST_HEADER_RESPONSES_LITE_CLIENT_METADATA_KEY: &str =
     "ws_request_header_x_openai_internal_codex_responses_lite";
 const TEST_INSTALLATION_ID: &str = "11111111-1111-4111-8111-111111111111";
@@ -315,7 +316,11 @@ async fn responses_websocket_preconnect_does_not_replace_turn_trace_payload() {
     let mut client_session = harness.client.new_session();
     let responses_metadata = websocket_connection_metadata(&harness);
     client_session
-        .preconnect_websocket(&harness.session_telemetry, &responses_metadata)
+        .preconnect_websocket(
+            &harness.session_telemetry,
+            &harness.model_info,
+            &responses_metadata,
+        )
         .await
         .expect("websocket preconnect failed");
     let prompt = prompt_with_input(vec![message_item("hello")]);
@@ -352,7 +357,11 @@ async fn responses_websocket_preconnect_reuses_connection() {
     let mut client_session = harness.client.new_session();
     let responses_metadata = websocket_connection_metadata(&harness);
     client_session
-        .preconnect_websocket(&harness.session_telemetry, &responses_metadata)
+        .preconnect_websocket(
+            &harness.session_telemetry,
+            &harness.model_info,
+            &responses_metadata,
+        )
         .await
         .expect("websocket preconnect failed");
     let prompt = prompt_with_input(vec![message_item("hello")]);
@@ -696,6 +705,139 @@ async fn responses_websocket_sends_responses_lite_metadata_per_request() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn responses_websocket_turn_state_is_bound_to_requested_model() {
+    skip_if_no_network!();
+
+    let server = start_websocket_server(vec![vec![
+        vec![
+            json!({
+                "type": "codex.response.metadata",
+                "headers": {(X_CODEX_TURN_STATE_HEADER): "state-a"},
+            }),
+            ev_response_created("resp-a-1"),
+            ev_completed("resp-a-1"),
+        ],
+        vec![ev_response_created("resp-a-2"), ev_completed("resp-a-2")],
+        vec![
+            json!({
+                "type": "codex.response.metadata",
+                "headers": {(X_CODEX_TURN_STATE_HEADER): "state-b"},
+            }),
+            ev_response_created("resp-b-1"),
+            ev_completed("resp-b-1"),
+        ],
+        vec![ev_response_created("resp-b-2"), ev_completed("resp-b-2")],
+    ]])
+    .await;
+
+    let harness = websocket_harness(&server).await;
+    let model_a = harness.model_info.clone();
+    let mut model_b = harness.model_info.clone();
+    model_b.slug = "gpt-5.3-codex-other".to_string();
+    let mut session = harness.client.new_session();
+
+    for (model_info, response_id) in [
+        (&model_a, "resp-a-1"),
+        (&model_a, "resp-a-2"),
+        (&model_b, "resp-b-1"),
+        (&model_b, "resp-b-2"),
+    ] {
+        stream_until_complete_with_model_info(
+            &mut session,
+            &harness,
+            &prompt_with_input(vec![message_item(response_id)]),
+            model_info,
+            response_id,
+        )
+        .await;
+    }
+
+    let requests = server.single_connection();
+    assert_eq!(requests.len(), 4);
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| {
+                let body = request.body_json();
+                json!({
+                    "model": body["model"],
+                    "turn_state": body["client_metadata"][X_CODEX_TURN_STATE_HEADER],
+                })
+            })
+            .collect::<Vec<_>>(),
+        vec![
+            json!({"model": model_a.slug.as_str(), "turn_state": ""}),
+            json!({"model": model_a.slug.as_str(), "turn_state": "state-a"}),
+            json!({"model": model_b.slug.as_str(), "turn_state": ""}),
+            json!({"model": model_b.slug.as_str(), "turn_state": "state-b"}),
+        ]
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn responses_websocket_preconnect_defers_handshake_turn_state_fallback() {
+    skip_if_no_network!();
+
+    let server = start_websocket_server_with_headers(vec![WebSocketConnectionConfig {
+        requests: vec![
+            vec![
+                json!({
+                    "type": "codex.response.metadata",
+                    "headers": {(X_CODEX_TURN_STATE_HEADER): "response-state"},
+                }),
+                ev_response_created("resp-1"),
+                ev_completed("resp-1"),
+            ],
+            vec![ev_response_created("resp-2"), ev_completed("resp-2")],
+        ],
+        response_headers: vec![(
+            X_CODEX_TURN_STATE_HEADER.to_string(),
+            "stale-handshake-state".to_string(),
+        )],
+        accept_delay: None,
+        close_after_requests: true,
+    }])
+    .await;
+
+    let harness = websocket_harness(&server).await;
+    let mut session = harness.client.new_session();
+    let responses_metadata = websocket_connection_metadata(&harness);
+    session
+        .preconnect_websocket(
+            &harness.session_telemetry,
+            &harness.model_info,
+            &responses_metadata,
+        )
+        .await
+        .expect("websocket preconnect");
+
+    for response_id in ["resp-1", "resp-2"] {
+        stream_until_complete(
+            &mut session,
+            &harness,
+            &prompt_with_input(vec![message_item(response_id)]),
+        )
+        .await;
+    }
+
+    let requests = server.single_connection();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| {
+                request.body_json()["client_metadata"][X_CODEX_TURN_STATE_HEADER].clone()
+            })
+            .collect::<Vec<_>>(),
+        vec![json!(""), json!("response-state")]
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn responses_websocket_preconnect_is_reused_even_with_header_changes() {
     skip_if_no_network!();
 
@@ -709,7 +851,11 @@ async fn responses_websocket_preconnect_is_reused_even_with_header_changes() {
     let mut client_session = harness.client.new_session();
     let preconnect_metadata = websocket_connection_metadata(&harness);
     client_session
-        .preconnect_websocket(&harness.session_telemetry, &preconnect_metadata)
+        .preconnect_websocket(
+            &harness.session_telemetry,
+            &harness.model_info,
+            &preconnect_metadata,
+        )
         .await
         .expect("websocket preconnect failed");
     let prompt = prompt_with_input(vec![message_item("hello")]);
@@ -880,7 +1026,11 @@ async fn responses_websocket_preconnect_runs_when_only_v2_feature_enabled() {
     let mut client_session = harness.client.new_session();
     let responses_metadata = websocket_connection_metadata(&harness);
     client_session
-        .preconnect_websocket(&harness.session_telemetry, &responses_metadata)
+        .preconnect_websocket(
+            &harness.session_telemetry,
+            &harness.model_info,
+            &responses_metadata,
+        )
         .await
         .expect("websocket preconnect failed");
 
@@ -1477,9 +1627,22 @@ async fn responses_websocket_connection_limit_error_reconnects_and_completes() {
         }
     });
 
-    let server = start_websocket_server(vec![
-        vec![vec![websocket_connection_limit_error]],
-        vec![vec![ev_response_created("resp-1"), ev_completed("resp-1")]],
+    let server = start_websocket_server_with_headers(vec![
+        WebSocketConnectionConfig {
+            requests: vec![vec![websocket_connection_limit_error]],
+            response_headers: vec![(
+                X_CODEX_TURN_STATE_HEADER.to_string(),
+                "handshake-state".to_string(),
+            )],
+            accept_delay: None,
+            close_after_requests: true,
+        },
+        WebSocketConnectionConfig {
+            requests: vec![vec![ev_response_created("resp-1"), ev_completed("resp-1")]],
+            response_headers: Vec::new(),
+            accept_delay: None,
+            close_after_requests: true,
+        },
     ])
     .await;
     let mut builder = test_codex().with_config(|config| {
@@ -1495,10 +1658,20 @@ async fn responses_websocket_connection_limit_error_reconnects_and_completes() {
         .await
         .expect("submission should reconnect after websocket connection limit error");
 
-    let total_websocket_requests: usize = server.connections().iter().map(Vec::len).sum();
+    let connections = server.connections();
+    let total_websocket_requests: usize = connections.iter().map(Vec::len).sum();
     assert_eq!(total_websocket_requests, 2);
-    let handshake_user_agents: Vec<_> = server
-        .handshakes()
+    assert_eq!(
+        connections[0][0].body_json()["client_metadata"][X_CODEX_TURN_STATE_HEADER],
+        ""
+    );
+    assert_eq!(
+        connections[1][0].body_json()["client_metadata"][X_CODEX_TURN_STATE_HEADER],
+        "handshake-state"
+    );
+
+    let handshakes = server.handshakes();
+    let handshake_user_agents: Vec<_> = handshakes
         .iter()
         .map(|handshake| handshake.header(USER_AGENT_HEADER))
         .collect();
@@ -1508,6 +1681,11 @@ async fn responses_websocket_connection_limit_error_reconnects_and_completes() {
             Some(codex_login::default_client::get_codex_user_agent()),
             Some(codex_login::default_client::get_codex_user_agent()),
         ]
+    );
+    assert_eq!(handshakes[0].header(X_CODEX_TURN_STATE_HEADER), None);
+    assert_eq!(
+        handshakes[1].header(X_CODEX_TURN_STATE_HEADER).as_deref(),
+        Some("handshake-state")
     );
 
     server.shutdown().await;

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -131,6 +131,7 @@ fn canonical_json(value: &Value) -> Value {
 
 const PRETURN_CONTEXT_DIFF_CWD: &str = "/tmp/PRETURN_CONTEXT_DIFF_CWD";
 const DUMMY_FUNCTION_NAME: &str = "test_tool";
+const TURN_STATE_HEADER: &str = "x-codex-turn-state";
 const REMOTE_COMPACT_TURN_COMPLETE_TIMEOUT: Duration = Duration::from_secs(30);
 
 fn summary_with_prefix(summary: &str) -> String {
@@ -3339,6 +3340,108 @@ async fn snapshot_request_shape_remote_pre_turn_compaction_including_incoming_us
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_pre_turn_compact_turn_state_rotates_on_model_switch() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let previous_model = "gpt-5.4";
+    let next_model = "gpt-5.3-codex";
+    let harness = TestCodexHarness::with_builder(
+        test_codex()
+            .with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing())
+            .with_model(previous_model)
+            .with_config(|config| {
+                config.model_auto_compact_token_limit = Some(200);
+            }),
+    )
+    .await?;
+    let codex = harness.test().codex.clone();
+
+    let responses_mock = responses::mount_response_sequence(
+        harness.server(),
+        vec![
+            responses::sse_response(responses::sse(vec![
+                responses::ev_assistant_message("m1", "BEFORE_SWITCH_REPLY"),
+                responses::ev_completed_with_tokens("r1", /*total_tokens*/ 500),
+            ])),
+            responses::sse_response(responses::sse(vec![
+                responses::ev_function_call("call-after-switch", DUMMY_FUNCTION_NAME, "{}"),
+                responses::ev_completed_with_tokens("r2", /*total_tokens*/ 80),
+            ]))
+            .insert_header(TURN_STATE_HEADER, "current-model-state"),
+            responses::sse_response(responses::sse(vec![
+                responses::ev_assistant_message("m2", "AFTER_SWITCH_REPLY"),
+                responses::ev_completed_with_tokens("r3", /*total_tokens*/ 80),
+            ])),
+        ],
+    )
+    .await;
+    let compact_mock = responses::mount_compact_response_once(
+        harness.server(),
+        ResponseTemplate::new(200)
+            .insert_header("content-type", "application/json")
+            .insert_header(TURN_STATE_HEADER, "previous-model-state")
+            .set_body_json(json!({
+                "output": compacted_summary_only_output("MODEL_SWITCH_COMPACT_SUMMARY"),
+            })),
+    )
+    .await;
+
+    codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "BEFORE_SWITCH_USER".to_string(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: Default::default(),
+        })
+        .await?;
+    wait_for_turn_complete(&codex).await;
+
+    core_test_support::submit_thread_settings(
+        &codex,
+        codex_protocol::protocol::ThreadSettingsOverrides {
+            model: Some(next_model.to_string()),
+            ..Default::default()
+        },
+    )
+    .await?;
+    codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "AFTER_SWITCH_USER".to_string(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: Default::default(),
+        })
+        .await?;
+    wait_for_turn_complete(&codex).await;
+
+    let compact_request = compact_mock.single_request();
+    assert_eq!(compact_request.body_json()["model"], previous_model);
+    assert_eq!(compact_request.header(TURN_STATE_HEADER), None);
+
+    let requests = responses_mock.requests();
+    assert_eq!(requests.len(), 3);
+    assert_eq!(requests[0].body_json()["model"], previous_model);
+    assert_eq!(requests[0].header(TURN_STATE_HEADER), None);
+    assert_eq!(requests[1].body_json()["model"], next_model);
+    assert_eq!(requests[1].header(TURN_STATE_HEADER), None);
+    assert_eq!(requests[2].body_json()["model"], next_model);
+    assert_eq!(
+        requests[2].header(TURN_STATE_HEADER).as_deref(),
+        Some("current-model-state")
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn snapshot_request_shape_remote_pre_turn_compaction_strips_incoming_model_switch()
 -> Result<()> {
     skip_if_no_network!(Ok(()));
@@ -3584,6 +3687,76 @@ async fn snapshot_request_shape_remote_pre_turn_compaction_context_window_exceed
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_pre_turn_compact_turn_state_is_replayed_to_sampling() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let harness = TestCodexHarness::with_builder(
+        test_codex()
+            .with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing())
+            .with_config(|config| {
+                config.model_auto_compact_token_limit = Some(200);
+            }),
+    )
+    .await?;
+    let codex = harness.test().codex.clone();
+
+    let responses_mock = responses::mount_response_sequence(
+        harness.server(),
+        vec![
+            responses::sse_response(responses::sse(vec![
+                responses::ev_assistant_message("m1", "BEFORE_COMPACT_REPLY"),
+                responses::ev_completed_with_tokens("r1", /*total_tokens*/ 500),
+            ])),
+            responses::sse_response(responses::sse(vec![
+                responses::ev_assistant_message("m2", "AFTER_COMPACT_REPLY"),
+                responses::ev_completed_with_tokens("r2", /*total_tokens*/ 80),
+            ])),
+        ],
+    )
+    .await;
+    let compact_mock = responses::mount_compact_response_once(
+        harness.server(),
+        ResponseTemplate::new(200)
+            .insert_header("content-type", "application/json")
+            .insert_header(TURN_STATE_HEADER, "compact-state")
+            .set_body_json(json!({
+                "output": compacted_summary_only_output("PRE_TURN_COMPACT_SUMMARY"),
+            })),
+    )
+    .await;
+
+    for text in ["BEFORE_COMPACT_USER", "AFTER_COMPACT_USER"] {
+        codex
+            .submit(Op::UserInput {
+                items: vec![UserInput::Text {
+                    text: text.to_string(),
+                    text_elements: Vec::new(),
+                }],
+                final_output_json_schema: None,
+                responsesapi_client_metadata: None,
+                additional_context: Default::default(),
+                thread_settings: Default::default(),
+            })
+            .await?;
+        wait_for_turn_complete(&codex).await;
+    }
+
+    assert_eq!(
+        compact_mock.single_request().header(TURN_STATE_HEADER),
+        None
+    );
+    let requests = responses_mock.requests();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0].header(TURN_STATE_HEADER), None);
+    assert_eq!(
+        requests[1].header(TURN_STATE_HEADER).as_deref(),
+        Some("compact-state")
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn snapshot_request_shape_remote_mid_turn_continuation_compaction() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
@@ -3597,17 +3770,18 @@ async fn snapshot_request_shape_remote_mid_turn_continuation_compaction() -> Res
     .await?;
     let codex = harness.test().codex.clone();
 
-    let responses_mock = responses::mount_sse_sequence(
+    let responses_mock = responses::mount_response_sequence(
         harness.server(),
         vec![
-            responses::sse(vec![
+            responses::sse_response(responses::sse(vec![
                 responses::ev_function_call("call-remote-mid-turn", DUMMY_FUNCTION_NAME, "{}"),
                 responses::ev_completed_with_tokens("r1", /*total_tokens*/ 500),
-            ]),
-            responses::sse(vec![
+            ]))
+            .insert_header(TURN_STATE_HEADER, "sampling-state"),
+            responses::sse_response(responses::sse(vec![
                 responses::ev_assistant_message("m2", "REMOTE_MID_TURN_FINAL_REPLY"),
                 responses::ev_completed_with_tokens("r2", /*total_tokens*/ 80),
-            ]),
+            ])),
         ],
     )
     .await;
@@ -3641,6 +3815,14 @@ async fn snapshot_request_shape_remote_mid_turn_continuation_compaction() -> Res
     );
 
     let compact_request = compact_mock.single_request();
+    assert_eq!(
+        compact_request.header(TURN_STATE_HEADER).as_deref(),
+        Some("sampling-state")
+    );
+    assert_eq!(
+        requests[1].header(TURN_STATE_HEADER).as_deref(),
+        Some("sampling-state")
+    );
     insta::assert_snapshot!(
         "remote_mid_turn_compaction_shapes",
         format_labeled_requests_snapshot(

--- a/codex-rs/core/tests/suite/turn_state.rs
+++ b/codex-rs/core/tests/suite/turn_state.rs
@@ -16,6 +16,7 @@ use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::test_codex;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
+use serde_json::json;
 
 const TURN_STATE_HEADER: &str = "x-codex-turn-state";
 
@@ -91,56 +92,66 @@ async fn responses_turn_state_persists_within_turn_and_resets_after() -> Result<
 async fn websocket_turn_state_persists_within_turn_and_resets_after() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
-    let call_id = "ws-shell-turn-state";
-    // First connection delivers turn_state; second (same turn) must send it; third (new turn) must not.
-    let server = start_websocket_server_with_headers(vec![
-        WebSocketConnectionConfig {
-            requests: vec![vec![
+    let first_call_id = "ws-shell-turn-state-1";
+    let second_call_id = "ws-shell-turn-state-2";
+    let server = start_websocket_server_with_headers(vec![WebSocketConnectionConfig {
+        requests: vec![
+            vec![
+                json!({
+                    "type": "codex.response.metadata",
+                    "headers": {(TURN_STATE_HEADER): "ts-1"},
+                }),
                 ev_response_created("resp-1"),
                 ev_reasoning_item("rsn-1", &["thinking"], &[]),
-                ev_shell_command_call(call_id, "echo websocket"),
+                ev_shell_command_call(first_call_id, "echo websocket one"),
                 ev_completed("resp-1"),
-            ]],
-            response_headers: vec![(TURN_STATE_HEADER.to_string(), "ts-1".to_string())],
-            accept_delay: None,
-            close_after_requests: true,
-        },
-        WebSocketConnectionConfig {
-            requests: vec![vec![
+            ],
+            vec![
                 ev_response_created("resp-2"),
                 ev_assistant_message("msg-1", "done"),
                 ev_completed("resp-2"),
-            ]],
-            response_headers: Vec::new(),
-            accept_delay: None,
-            close_after_requests: true,
-        },
-        WebSocketConnectionConfig {
-            requests: vec![vec![
+            ],
+            vec![
+                json!({
+                    "type": "codex.response.metadata",
+                    "headers": {(TURN_STATE_HEADER): "ts-2"},
+                }),
                 ev_response_created("resp-3"),
-                ev_assistant_message("msg-2", "done"),
+                ev_reasoning_item("rsn-2", &["thinking"], &[]),
+                ev_shell_command_call(second_call_id, "echo websocket two"),
                 ev_completed("resp-3"),
-            ]],
-            response_headers: Vec::new(),
-            accept_delay: None,
-            close_after_requests: true,
-        },
-    ])
+            ],
+            vec![
+                ev_response_created("resp-4"),
+                ev_assistant_message("msg-2", "done"),
+                ev_completed("resp-4"),
+            ],
+        ],
+        // The request-scoped metadata token must win over any connection-scoped handshake token.
+        response_headers: vec![(
+            TURN_STATE_HEADER.to_string(),
+            "stale-handshake-state".to_string(),
+        )],
+        accept_delay: None,
+        close_after_requests: false,
+    }])
     .await;
 
     let mut builder = test_codex();
     let test = builder.build_with_websocket_server(&server).await?;
     test.submit_turn("run the echo command").await?;
-    test.submit_turn("second turn").await?;
+    test.submit_turn("run another echo command").await?;
 
-    let handshakes = server.handshakes();
-    assert_eq!(handshakes.len(), 3);
-    assert_eq!(handshakes[0].header(TURN_STATE_HEADER), None);
+    assert_eq!(server.handshakes().len(), 1);
+    let requests = server.single_connection();
+    assert_eq!(requests.len(), 4);
     assert_eq!(
-        handshakes[1].header(TURN_STATE_HEADER),
-        Some("ts-1".to_string())
+        requests
+            .iter()
+            .map(|request| request.body_json()["client_metadata"][TURN_STATE_HEADER].clone())
+            .collect::<Vec<_>>(),
+        vec![json!(""), json!("ts-1"), json!(""), json!("ts-2")]
     );
-    assert_eq!(handshakes[2].header(TURN_STATE_HEADER), None);
 
     server.shutdown().await;
     Ok(())


### PR DESCRIPTION
## What

- bind the opaque `x-codex-turn-state` token to the requested model slug
- round-trip request-scoped turn state through HTTP, WebSocket `response.create.client_metadata`, and compact responses
- explicitly reset WebSocket turn state for a new turn/model while preserving handshake-only servers as a deferred fallback
- reuse the same model-bound client session across inline compaction

Companion to backend PR: https://github.com/openai/openai/pull/1018026

## Why

WebSocket upgrade headers are connection-scoped, so a reused connection cannot carry the correct per-request turn state. Compact responses also previously dropped the response header. A single unqualified `OnceLock` could retain state from an older requested model during pre-turn compaction.

The client now treats response metadata as authoritative, uses a handshake token only after a response attempt produces no metadata, and replaces the state when the requested slug changes.

## Validation

- `cargo check -p codex-core`
- focused `codex-core` routing/WS/compact suite: 8 passed
- `just test -p codex-api`: 123 passed
- `just fix -p codex-api`
- `cargo fmt --all`
