### PR TITLE
[codex] restore source-specific import copy

### DIFF
--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -221,7 +221,7 @@ pub(crate) enum AppEvent {
     /// Open the resume picker inside the running TUI session.
     OpenResumePicker,
 
-    /// Open the external agent migration picker inside the running TUI session.
+    /// Open the Claude Code migration picker inside the running TUI session.
     OpenExternalAgentConfigMigration,
 
     /// Resume a thread by UUID or thread name inside the running TUI session.

--- a/codex-rs/tui/src/app_server_session.rs
+++ b/codex-rs/tui/src/app_server_session.rs
@@ -139,7 +139,7 @@ use uuid::Uuid;
 const JSONRPC_INVALID_REQUEST: i64 = -32600;
 const JSONRPC_METHOD_NOT_FOUND: i64 = -32601;
 pub(crate) const EXTERNAL_AGENT_CONFIG_IMPORT_IN_PROGRESS_MESSAGE: &str =
-    "A previous agent import is still running. Wait for it to finish before importing again.";
+    "A previous Claude Code import is still running. Wait for it to finish before importing again.";
 const THREAD_SETTINGS_UPDATE_METHOD: &str = "thread/settings/update";
 
 fn bootstrap_request_error(context: &'static str, err: TypedRequestError) -> color_eyre::Report {
@@ -369,7 +369,7 @@ impl AppServerSession {
         self.client
             .request_typed(ClientRequest::ExternalAgentConfigDetect { request_id, params })
             .await
-            .wrap_err("externalAgentConfig/detect failed during agent import")
+            .wrap_err("externalAgentConfig/detect failed during Claude Code import")
     }
 
     pub(crate) async fn external_agent_config_import(
@@ -392,7 +392,7 @@ impl AppServerSession {
                 params: ExternalAgentConfigImportParams { migration_items },
             })
             .await
-            .wrap_err("externalAgentConfig/import failed during agent import");
+            .wrap_err("externalAgentConfig/import failed during Claude Code import");
         match response {
             Ok(_) => Ok(()),
             Err(err) => {

--- a/codex-rs/tui/src/external_agent_config_migration.rs
+++ b/codex-rs/tui/src/external_agent_config_migration.rs
@@ -758,7 +758,7 @@ mod tests {
             },
             ExternalAgentConfigMigrationItem {
                 item_type: ExternalAgentConfigMigrationItemType::Sessions,
-                description: "Migrate recent chat sessions".to_string(),
+                description: "Migrate recent Claude Code sessions".to_string(),
                 cwd: None,
                 details: Some(codex_app_server_protocol::MigrationDetails {
                     sessions: vec![SessionMigration {

--- a/codex-rs/tui/src/external_agent_config_migration/render.rs
+++ b/codex-rs/tui/src/external_agent_config_migration/render.rs
@@ -80,13 +80,13 @@ impl WidgetRef for &ExternalAgentConfigMigrationScreen {
             MigrationView::Summary => vec![
                 Line::from("Bring over your setup, current project, and recent chats."),
                 Line::from("Codex may add files to your current project folder."),
-                Line::from("Your existing agent setup will not be changed."),
-                Line::from("Cloud-hosted chat data cannot be imported."),
+                Line::from("Your existing Claude Code setup will not be changed."),
+                Line::from("Standard Claude Chat data cannot be imported."),
             ],
             MigrationView::Customize => vec![
-                Line::from("Choose the items to import."),
+                Line::from("Choose the Claude Code items to import."),
                 Line::from("Codex may add files to your current project folder."),
-                Line::from("Your existing agent setup will not be changed."),
+                Line::from("Your existing Claude Code setup will not be changed."),
             ],
         };
         let intro_height = intro_lines.len() as u16;
@@ -119,7 +119,7 @@ impl WidgetRef for &ExternalAgentConfigMigrationScreen {
         .areas(inner_area);
 
         let title = match self.view {
-            MigrationView::Summary => "Import from another coding agent",
+            MigrationView::Summary => "Import from Claude Code",
             MigrationView::Customize => "Choose what to import",
         };
         let heading = Line::from(vec!["> ".into(), title.bold()]);

--- a/codex-rs/tui/src/external_agent_config_migration_flow.rs
+++ b/codex-rs/tui/src/external_agent_config_migration_flow.rs
@@ -7,12 +7,11 @@ use crate::tui;
 use codex_app_server_protocol::ExternalAgentConfigDetectParams;
 
 pub(crate) const EXTERNAL_AGENT_CONFIG_MIGRATION_FINISHED_MESSAGE: &str =
-    "Agent import finished. Run /import again to check for additional items.";
+    "Claude Code import finished. Run /import again to check for additional items.";
 pub(crate) const EXTERNAL_AGENT_CONFIG_MIGRATION_NO_ITEMS_MESSAGE: &str =
-    "No supported agent setup was found to import.";
-pub(crate) const EXTERNAL_AGENT_CONFIG_MIGRATION_REMOTE_UNAVAILABLE_MESSAGE: &str =
-    "Agent import is unavailable in remote sessions. Start Codex locally and run /import.";
-pub(crate) const EXTERNAL_AGENT_CONFIG_MIGRATION_DAEMON_UNAVAILABLE_MESSAGE: &str = "Agent import is unavailable while Codex is connected to the local app-server daemon. Stop the daemon, restart Codex, and run /import.";
+    "No Claude Code setup was found to import.";
+pub(crate) const EXTERNAL_AGENT_CONFIG_MIGRATION_REMOTE_UNAVAILABLE_MESSAGE: &str = "Import from Claude Code is unavailable in remote sessions. Start Codex locally and run /import.";
+pub(crate) const EXTERNAL_AGENT_CONFIG_MIGRATION_DAEMON_UNAVAILABLE_MESSAGE: &str = "Import from Claude Code is unavailable while Codex is connected to the local app-server daemon. Stop the daemon, restart Codex, and run /import.";
 
 pub(crate) enum ExternalAgentConfigMigrationFlowOutcome {
     Started(String),
@@ -21,7 +20,7 @@ pub(crate) enum ExternalAgentConfigMigrationFlowOutcome {
 }
 
 fn external_agent_config_migration_success_message(remaining_item_count: usize) -> String {
-    let message = "Agent import started. You can keep working while it finishes. Imported setup will apply to new chats.";
+    let message = "Claude Code import started. You can keep working while it finishes. Imported setup will apply to new chats.";
     match remaining_items_handoff(remaining_item_count) {
         Some(remaining_items_handoff) => format!("{message} {remaining_items_handoff}"),
         None => message.to_string(),
@@ -71,7 +70,7 @@ pub(crate) async fn handle_external_agent_config_migration_prompt(
                 cwd = %cwd.display(),
                 "failed to detect external agent config migrations"
             );
-            return Err(format!("Could not check for agent setup: {err}"));
+            return Err(format!("Could not check for Claude Code setup: {err}"));
         }
     };
 

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -101,9 +101,7 @@ impl SlashCommand {
             SlashCommand::Diff => "show git diff (including untracked files)",
             SlashCommand::Mention => "mention a file",
             SlashCommand::Skills => "use skills to improve how Codex performs specific tasks",
-            SlashCommand::Import => {
-                "import setup, this project, and recent chats from another coding agent"
-            }
+            SlashCommand::Import => "import setup, this project, and recent chats from Claude Code",
             SlashCommand::Hooks => "view and manage lifecycle hooks",
             SlashCommand::Status => "show current session configuration and token usage",
             SlashCommand::DebugConfig => "show config layers and requirement sources for debugging",

--- a/codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_customize.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_customize.snap
@@ -4,14 +4,14 @@ expression: rendered
 ---
 
   > Choose what to import
-  Choose the items to import.
+  Choose the Claude Code items to import.
   Codex may add files to your current project folder.
-  Your existing agent setup will not be changed.
+  Your existing Claude Code setup will not be changed.
   Home
   › [x] Settings (settings.json -> config.toml)
         Import /Users/alex/.claude/settings.json into /Users/alex/.codex/conf…
     [x] Recent chat sessions
-        Import recent chat sessions
+        Import recent Claude Code sessions
         1 chat session: Investigate migration UX
 
   Current project: /workspace/project

--- a/codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_customize_action.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_customize_action.snap
@@ -4,14 +4,14 @@ expression: rendered
 ---
 
   > Choose what to import
-  Choose the items to import.
+  Choose the Claude Code items to import.
   Codex may add files to your current project folder.
-  Your existing agent setup will not be changed.
+  Your existing Claude Code setup will not be changed.
   Home
     [x] Settings (settings.json -> config.toml)
         Import /Users/alex/.claude/settings.json into /Users/alex/.codex/conf…
     [x] Recent chat sessions
-        Import recent chat sessions
+        Import recent Claude Code sessions
         1 chat session: Investigate migration UX
 
   Current project: /workspace/project

--- a/codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_customize_action_windows.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_customize_action_windows.snap
@@ -4,14 +4,14 @@ expression: rendered
 ---
 
   > Choose what to import
-  Choose the items to import.
+  Choose the Claude Code items to import.
   Codex may add files to your current project folder.
-  Your existing agent setup will not be changed.
+  Your existing Claude Code setup will not be changed.
   Home
     [x] Settings (settings.json -> config.toml)
         Import /Users/alex/.claude/settings.json into /Users/alex/.codex/conf…
     [x] Recent chat sessions
-        Import recent chat sessions
+        Import recent Claude Code sessions
         1 chat session: Investigate migration UX
 
   Current project: C:\workspace\project

--- a/codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_customize_windows.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_customize_windows.snap
@@ -4,14 +4,14 @@ expression: rendered
 ---
 
   > Choose what to import
-  Choose the items to import.
+  Choose the Claude Code items to import.
   Codex may add files to your current project folder.
-  Your existing agent setup will not be changed.
+  Your existing Claude Code setup will not be changed.
   Home
   › [x] Settings (settings.json -> config.toml)
         Import /Users/alex/.claude/settings.json into /Users/alex/.codex/conf…
     [x] Recent chat sessions
-        Import recent chat sessions
+        Import recent Claude Code sessions
         1 chat session: Investigate migration UX
 
   Current project: C:\workspace\project

--- a/codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_prompt.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_prompt.snap
@@ -3,11 +3,11 @@ source: tui/src/external_agent_config_migration.rs
 expression: rendered
 ---
 
-  > Import from another coding agent
+  > Import from Claude Code
   Bring over your setup, current project, and recent chats.
   Codex may add files to your current project folder.
-  Your existing agent setup will not be changed.
-  Cloud-hosted chat data cannot be imported.
+  Your existing Claude Code setup will not be changed.
+  Standard Claude Chat data cannot be imported.
     [x] Tools & setup
         Settings, instructions, integrations, agents, commands, and skills
     [x] Current project

--- a/codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_prompt_windows.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration__tests__external_agent_config_migration_prompt_windows.snap
@@ -3,11 +3,11 @@ source: tui/src/external_agent_config_migration.rs
 expression: rendered
 ---
 
-  > Import from another coding agent
+  > Import from Claude Code
   Bring over your setup, current project, and recent chats.
   Codex may add files to your current project folder.
-  Your existing agent setup will not be changed.
-  Cloud-hosted chat data cannot be imported.
+  Your existing Claude Code setup will not be changed.
+  Standard Claude Chat data cannot be imported.
     [x] Tools & setup
         Settings, instructions, integrations, agents, commands, and skills
     [x] Current project

--- a/codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration_flow__tests__external_agent_config_migration_messages.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__external_agent_config_migration_flow__tests__external_agent_config_migration_messages.snap
@@ -2,11 +2,11 @@
 source: tui/src/external_agent_config_migration_flow_tests.rs
 expression: messages
 ---
-Agent import started. You can keep working while it finishes. Imported setup will apply to new chats.
-Agent import started. You can keep working while it finishes. Imported setup will apply to new chats. 1 additional item remains. After it finishes, run /import again to review it.
-Agent import started. You can keep working while it finishes. Imported setup will apply to new chats. 2 additional items remain. After it finishes, run /import again to review them.
-Agent import finished. Run /import again to check for additional items.
-No supported agent setup was found to import.
-Agent import is unavailable in remote sessions. Start Codex locally and run /import.
-Agent import is unavailable while Codex is connected to the local app-server daemon. Stop the daemon, restart Codex, and run /import.
-A previous agent import is still running. Wait for it to finish before importing again.
+Claude Code import started. You can keep working while it finishes. Imported setup will apply to new chats.
+Claude Code import started. You can keep working while it finishes. Imported setup will apply to new chats. 1 additional item remains. After it finishes, run /import again to review it.
+Claude Code import started. You can keep working while it finishes. Imported setup will apply to new chats. 2 additional items remain. After it finishes, run /import again to review them.
+Claude Code import finished. Run /import again to check for additional items.
+No Claude Code setup was found to import.
+Import from Claude Code is unavailable in remote sessions. Start Codex locally and run /import.
+Import from Claude Code is unavailable while Codex is connected to the local app-server daemon. Stop the daemon, restart Codex, and run /import.
+A previous Claude Code import is still running. Wait for it to finish before importing again.


### PR DESCRIPTION
## Summary

- restore source-specific wording across the `/import` picker, lifecycle messages, diagnostics, and help text
- update the matching Unix and Windows snapshots
- leave import behavior unchanged

## Why

The import path currently supports one source, so the UI should identify that source directly instead of presenting the flow as provider-agnostic.

## Validation

- `just test -p codex-tui external_agent_config_migration` (12 passed)
- `just fix -p codex-tui`
- `just fmt`