### PR TITLE
[codex] Continue unfinished tasks after image generation

### DIFF
--- a/codex-rs/ext/image-generation/imagegen_description.md
+++ b/codex-rs/ext/image-generation/imagegen_description.md
@@ -13,5 +13,5 @@ Guidelines:
 - Never provide both `referenced_image_paths` and `num_last_images_to_include`.
 - If neither mechanism can include every target image, ask the user to attach the missing images again.
 - Directly generate the image without reconfirmation or clarification unless required images must be attached again.
-- After each image generation, do not mention anything related to download. Do not summarize the image. Do not ask followup question. Do not say ANYTHING after you generate an image.
+- After image generation, do not add download instructions or an unsolicited summary of the image. If image generation fully completes the user's request, do not add any text afterward. If the active user request still has unfinished deliverables or requires an approval step, continue with those deliverables or request the required approval.
 - Always use this tool for image editing unless the user explicitly requests otherwise. Do not use the `python` tool for image editing unless specifically instructed.

--- a/codex-rs/ext/image-generation/src/tests.rs
+++ b/codex-rs/ext/image-generation/src/tests.rs
@@ -38,6 +38,30 @@ fn uses_reserved_image_gen_namespace() {
 }
 
 #[test]
+fn description_allows_continuing_unfinished_requests() {
+    let ToolSpec::Namespace(spec) = imagegen_tool_spec() else {
+        panic!("imagegen should advertise a namespace tool");
+    };
+    let ResponsesApiNamespaceTool::Function(function) = &spec.tools[0];
+
+    assert!(
+        function
+            .description
+            .contains("If image generation fully completes the user's request")
+    );
+    assert!(
+        function
+            .description
+            .contains("If the active user request still has unfinished deliverables")
+    );
+    assert!(
+        !function
+            .description
+            .contains("Do not say ANYTHING after you generate an image")
+    );
+}
+
+#[test]
 fn omitted_references_generate_with_fixed_defaults() {
     assert_eq!(
         request_for_args(


### PR DESCRIPTION
## Summary

- keep image-only responses free of redundant download instructions and unsolicited summaries
- allow the model to continue when image generation is only one part of an unfinished request
- add a regression test for the model-facing image-generation tool description

## Why

The previous instruction said not to say anything after generating an image. In a multi-part design task, the model applied that rule literally and returned a blank final even though a requested build plan and required approval step were still outstanding.

This change scopes the silence rule to requests that are fully completed by image generation and explicitly tells the model to continue unfinished deliverables or request required approval.

Feedback report: https://app.notion.com/p/openai/2026-06-11-00-11-02-912089-PDT-37c8e50b62b0812fb16bf1b62399ce2a

## Validation

- `cargo test -p codex-image-generation-extension`
- `cargo fmt --all -- --check`
