### PR TITLE
Fix image extension PathUri conversion

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -3134,6 +3134,7 @@ dependencies = [
  "codex-tools",
  "codex-utils-absolute-path",
  "codex-utils-image",
+ "codex-utils-path-uri",
  "http 1.4.0",
  "pretty_assertions",
  "schemars 0.8.22",

--- a/codex-rs/ext/image-generation/Cargo.toml
+++ b/codex-rs/ext/image-generation/Cargo.toml
@@ -23,6 +23,7 @@ codex-protocol = { workspace = true }
 codex-tools = { workspace = true }
 codex-utils-absolute-path = { workspace = true }
 codex-utils-image = { workspace = true }
+codex-utils-path-uri = { workspace = true }
 http = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/codex-rs/ext/image-generation/src/tool.rs
+++ b/codex-rs/ext/image-generation/src/tool.rs
@@ -33,6 +33,7 @@ use codex_tools::default_namespace_description;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_image::PromptImageMode;
 use codex_utils_image::load_for_prompt_bytes;
+use codex_utils_path_uri::PathUri;
 use schemars::JsonSchema;
 use schemars::r#gen::SchemaSettings;
 use serde::Deserialize;
@@ -324,9 +325,15 @@ async fn image_url(
     path: &AbsolutePathBuf,
     environment: &ToolEnvironment,
 ) -> Result<ImageUrl, FunctionCallError> {
+    let path_uri = PathUri::from_abs_path(path).map_err(|error| {
+        FunctionCallError::RespondToModel(format!(
+            "unable to read referenced image at `{}`: {error}",
+            path.display()
+        ))
+    })?;
     let bytes = environment
         .file_system
-        .read_file(path, Some(&environment.file_system_sandbox_context))
+        .read_file(&path_uri, Some(&environment.file_system_sandbox_context))
         .await
         .map_err(|error| {
             FunctionCallError::RespondToModel(format!(


### PR DESCRIPTION
## Why

`main` stopped compiling when #27498 passed an `AbsolutePathBuf` to the `ExecutorFileSystem` API migrated to `PathUri` by #27653.

## What

Convert referenced image paths to `PathUri` before filesystem reads, declare the internal path-URI dependency, and refresh `Cargo.lock`.