### PR TITLE
[codex] Prewarm guardian review trunks

### DIFF
--- a/codex-rs/core/src/guardian/mod.rs
+++ b/codex-rs/core/src/guardian/mod.rs
@@ -33,6 +33,7 @@ pub(crate) use review::guardian_rejection_message;
 pub(crate) use review::guardian_timeout_message;
 pub(crate) use review::is_guardian_reviewer_source;
 pub(crate) use review::new_guardian_review_id;
+pub(crate) use review::prewarm_guardian_review_session;
 #[cfg(test)]
 pub(crate) use review::record_guardian_denial_for_test;
 pub(crate) use review::review_approval_request;

--- a/codex-rs/core/src/guardian/review.rs
+++ b/codex-rs/core/src/guardian/review.rs
@@ -786,8 +786,8 @@ async fn run_guardian_review_session_before_deadline(
     external_cancel: Option<CancellationToken>,
     deadline: Instant,
 ) -> (GuardianReviewOutcome, GuardianReviewAnalyticsResult) {
-    let setup = match guardian_review_session_setup(&session, &turn).await {
-        Ok(setup) => setup,
+    let review_session_setup = match guardian_review_session_setup(&session, &turn).await {
+        Ok(review_session_setup) => review_session_setup,
         Err(err) => {
             return (
                 GuardianReviewOutcome::Error(GuardianReviewError::prompt_build(err)),
@@ -802,12 +802,12 @@ async fn run_guardian_review_session_before_deadline(
             .run_review(GuardianReviewSessionParams {
                 parent_session: Arc::clone(&session),
                 parent_turn: turn.clone(),
-                spawn_config: setup.spawn_config,
+                spawn_config: review_session_setup.spawn_config,
                 request,
                 retry_reason,
                 schema,
-                model: setup.model,
-                reasoning_effort: setup.reasoning_effort,
+                model: review_session_setup.model,
+                reasoning_effort: review_session_setup.reasoning_effort,
                 reasoning_summary: turn.reasoning_summary,
                 personality: turn.personality,
                 external_cancel,

--- a/codex-rs/core/src/guardian/review.rs
+++ b/codex-rs/core/src/guardian/review.rs
@@ -23,7 +23,9 @@ use tokio::sync::oneshot;
 use tokio::time::Instant;
 use tokio::time::sleep_until;
 use tokio_util::sync::CancellationToken;
+use tracing::warn;
 
+use crate::config::Config;
 use crate::session::session::Session;
 use crate::session::turn_context::TurnContext;
 use crate::turn_timing::now_unix_timestamp_ms;
@@ -46,6 +48,7 @@ use super::prompt::guardian_output_schema;
 use super::prompt::parse_guardian_assessment;
 use super::review_session::GuardianReviewSessionOutcome;
 use super::review_session::GuardianReviewSessionParams;
+use super::review_session::GuardianReviewSessionPrewarmParams;
 use super::review_session::build_guardian_review_session_config;
 
 const GUARDIAN_REJECTION_INSTRUCTIONS: &str = concat!(
@@ -665,40 +668,19 @@ pub(crate) fn spawn_approval_request_review(
     rx
 }
 
-/// Runs the guardian in a locked-down reusable review session.
-///
-/// The guardian itself should not mutate state or trigger further approvals, so
-/// it is pinned to a read-only sandbox with `approval_policy = never` and
-/// nonessential agent features disabled. When the cached trunk session is idle,
-/// later approvals append onto that same guardian conversation to preserve a
-/// stable prompt-cache key. If the trunk is already busy, the review runs in an
-/// ephemeral fork from the last committed trunk rollout so parallel approvals
-/// do not block each other or mutate the cached thread. The trunk is recreated
-/// when the effective review-session config changes, and any future compaction
-/// must continue to preserve the guardian policy as exact top-level developer
-/// context. It may still reuse the parent's managed-network allowlist for
-/// read-only checks, but it intentionally runs without inherited exec-policy
-/// rules.
-async fn run_guardian_review_session_before_deadline(
-    session: Arc<Session>,
-    turn: Arc<TurnContext>,
-    request: GuardianApprovalRequest,
-    retry_reason: Option<String>,
-    schema: serde_json::Value,
-    external_cancel: Option<CancellationToken>,
-    deadline: Instant,
-) -> (GuardianReviewOutcome, GuardianReviewAnalyticsResult) {
+struct GuardianReviewSessionSetup {
+    spawn_config: Config,
+    model: String,
+    reasoning_effort: Option<codex_protocol::openai_models::ReasoningEffort>,
+}
+
+async fn guardian_review_session_setup(
+    session: &Arc<Session>,
+    turn: &Arc<TurnContext>,
+) -> anyhow::Result<GuardianReviewSessionSetup> {
     let network_proxy = session.services.network_proxy.load_full();
     let live_network_config = match network_proxy.as_ref() {
-        Some(network_proxy) => match network_proxy.proxy().current_cfg().await {
-            Ok(config) => Some(config),
-            Err(err) => {
-                return (
-                    GuardianReviewOutcome::Error(GuardianReviewError::prompt_build(err)),
-                    GuardianReviewAnalyticsResult::without_session(),
-                );
-            }
-        },
+        Some(network_proxy) => Some(network_proxy.proxy().current_cfg().await?),
         None => None,
     };
     let available_models = session
@@ -745,14 +727,67 @@ async fn run_guardian_review_session_before_deadline(
             reasoning_effort,
         )
     };
-    let guardian_config = build_guardian_review_session_config(
+    let spawn_config = build_guardian_review_session_config(
         turn.config.as_ref(),
-        live_network_config.clone(),
+        live_network_config,
         guardian_model.as_str(),
         guardian_reasoning_effort.clone(),
-    );
-    let guardian_config = match guardian_config {
-        Ok(config) => config,
+    )?;
+
+    Ok(GuardianReviewSessionSetup {
+        spawn_config,
+        model: guardian_model,
+        reasoning_effort: guardian_reasoning_effort,
+    })
+}
+
+pub(crate) async fn prewarm_guardian_review_session(session: Arc<Session>, turn: Arc<TurnContext>) {
+    if !routes_approval_to_guardian(turn.as_ref()) {
+        return;
+    }
+
+    let setup = match guardian_review_session_setup(&session, &turn).await {
+        Ok(setup) => setup,
+        Err(err) => {
+            warn!("guardian trunk prewarm setup failed: {err:#}");
+            return;
+        }
+    };
+    session
+        .guardian_review_session
+        .prewarm_trunk(GuardianReviewSessionPrewarmParams {
+            parent_session: Arc::clone(&session),
+            parent_turn: turn,
+            spawn_config: setup.spawn_config,
+        })
+        .await;
+}
+
+/// Runs the guardian in a locked-down reusable review session.
+///
+/// The guardian itself should not mutate state or trigger further approvals, so
+/// it is pinned to a read-only sandbox with `approval_policy = never` and
+/// nonessential agent features disabled. When the cached trunk session is idle,
+/// later approvals append onto that same guardian conversation to preserve a
+/// stable prompt-cache key. If the trunk is already busy, the review runs in an
+/// ephemeral fork from the last committed trunk rollout so parallel approvals
+/// do not block each other or mutate the cached thread. The trunk is recreated
+/// when the effective review-session config changes, and any future compaction
+/// must continue to preserve the guardian policy as exact top-level developer
+/// context. It may still reuse the parent's managed-network allowlist for
+/// read-only checks, but it intentionally runs without inherited exec-policy
+/// rules.
+async fn run_guardian_review_session_before_deadline(
+    session: Arc<Session>,
+    turn: Arc<TurnContext>,
+    request: GuardianApprovalRequest,
+    retry_reason: Option<String>,
+    schema: serde_json::Value,
+    external_cancel: Option<CancellationToken>,
+    deadline: Instant,
+) -> (GuardianReviewOutcome, GuardianReviewAnalyticsResult) {
+    let setup = match guardian_review_session_setup(&session, &turn).await {
+        Ok(setup) => setup,
         Err(err) => {
             return (
                 GuardianReviewOutcome::Error(GuardianReviewError::prompt_build(err)),
@@ -767,12 +802,12 @@ async fn run_guardian_review_session_before_deadline(
             .run_review(GuardianReviewSessionParams {
                 parent_session: Arc::clone(&session),
                 parent_turn: turn.clone(),
-                spawn_config: guardian_config,
+                spawn_config: setup.spawn_config,
                 request,
                 retry_reason,
                 schema,
-                model: guardian_model,
-                reasoning_effort: guardian_reasoning_effort,
+                model: setup.model,
+                reasoning_effort: setup.reasoning_effort,
                 reasoning_summary: turn.reasoning_summary,
                 personality: turn.personality,
                 external_cancel,

--- a/codex-rs/core/src/guardian/review_session.rs
+++ b/codex-rs/core/src/guardian/review_session.rs
@@ -28,6 +28,7 @@ use codex_protocol::protocol::SubAgentSource;
 use codex_protocol::protocol::TokenUsage;
 use serde_json::Value;
 use tokio::sync::Mutex;
+use tokio::sync::OwnedSemaphorePermit;
 use tokio::sync::Semaphore;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
@@ -114,7 +115,7 @@ struct GuardianReviewSession {
     codex: Codex,
     cancel_token: CancellationToken,
     reuse_key: GuardianReviewSessionReuseKey,
-    review_lock: Semaphore,
+    review_lock: Arc<Semaphore>,
     state: Mutex<GuardianReviewState>,
 }
 
@@ -149,6 +150,11 @@ struct GuardianReviewForkSnapshot {
     initial_history: InitialHistory,
     prior_review_count: usize,
     last_reviewed_transcript_cursor: Option<GuardianTranscriptCursor>,
+}
+
+struct ReservedGuardianReviewSession {
+    review_session: Arc<GuardianReviewSession>,
+    review_guard: OwnedSemaphorePermit,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -233,6 +239,17 @@ impl GuardianReviewSession {
         drop(tokio::spawn(async move {
             review_session.shutdown().await;
         }));
+    }
+
+    fn shutdown_reserved_in_background(self: Arc<Self>, review_guard: OwnedSemaphorePermit) {
+        drop(tokio::spawn(async move {
+            let _review_guard = review_guard;
+            self.shutdown().await;
+        }));
+    }
+
+    fn try_acquire_review_lock(&self) -> Option<OwnedSemaphorePermit> {
+        Arc::clone(&self.review_lock).try_acquire_owned().ok()
     }
 
     async fn fork_snapshot(&self) -> Option<GuardianReviewForkSnapshot> {
@@ -355,11 +372,20 @@ impl GuardianReviewSessionManager {
                 if trunk.reuse_key == reuse_key {
                     should_schedule_prewarm = false;
                 }
-                if should_schedule_prewarm && trunk.review_lock.try_acquire().is_ok() {
-                    stale_trunk_to_shutdown = state.trunk.take();
-                } else if should_schedule_prewarm {
-                    info!("guardian trunk prewarm skipped because a stale trunk is currently busy");
-                    should_schedule_prewarm = false;
+                if should_schedule_prewarm {
+                    if let Some(review_guard) = trunk.try_acquire_review_lock() {
+                        stale_trunk_to_shutdown = state.trunk.take().map(|review_session| {
+                            ReservedGuardianReviewSession {
+                                review_session,
+                                review_guard,
+                            }
+                        });
+                    } else {
+                        info!(
+                            "guardian trunk prewarm skipped because a stale trunk is currently busy"
+                        );
+                        should_schedule_prewarm = false;
+                    }
                 }
             }
 
@@ -376,8 +402,10 @@ impl GuardianReviewSessionManager {
             info!("cancelling stale guardian trunk prewarm before scheduling a replacement");
             prewarm.cancel_token.cancel();
         }
-        if let Some(review_session) = stale_trunk_to_shutdown {
-            review_session.shutdown_in_background();
+        if let Some(reserved_review_session) = stale_trunk_to_shutdown {
+            reserved_review_session
+                .review_session
+                .shutdown_reserved_in_background(reserved_review_session.review_guard);
         }
         if !should_schedule_prewarm {
             return;
@@ -427,9 +455,14 @@ impl GuardianReviewSessionManager {
                     state.prewarm = None;
                     if let Some(trunk) = state.trunk.as_ref()
                         && trunk.reuse_key != reuse_key
-                        && trunk.review_lock.try_acquire().is_ok()
+                        && let Some(review_guard) = trunk.try_acquire_review_lock()
                     {
-                        stale_trunk_to_shutdown = state.trunk.take();
+                        stale_trunk_to_shutdown = state.trunk.take().map(|review_session| {
+                            ReservedGuardianReviewSession {
+                                review_session,
+                                review_guard,
+                            }
+                        });
                     }
                     if state.trunk.is_none() {
                         state.trunk = spawned_session_to_shutdown.take();
@@ -443,8 +476,10 @@ impl GuardianReviewSessionManager {
             if installed {
                 info!("guardian trunk prewarm installed");
             }
-            if let Some(review_session) = stale_trunk_to_shutdown {
-                review_session.shutdown_in_background();
+            if let Some(reserved_review_session) = stale_trunk_to_shutdown {
+                reserved_review_session
+                    .review_session
+                    .shutdown_reserved_in_background(reserved_review_session.review_guard);
             }
             if let Some(review_session) = spawned_session_to_shutdown {
                 review_session.shutdown().await;
@@ -492,9 +527,16 @@ impl GuardianReviewSessionManager {
                 }
                 if let Some(trunk) = state.trunk.as_ref()
                     && trunk.reuse_key != next_reuse_key
-                    && trunk.review_lock.try_acquire().is_ok()
+                    && let Some(review_guard) = trunk.try_acquire_review_lock()
                 {
-                    stale_trunk_to_shutdown = state.trunk.take();
+                    stale_trunk_to_shutdown =
+                        state
+                            .trunk
+                            .take()
+                            .map(|review_session| ReservedGuardianReviewSession {
+                                review_session,
+                                review_guard,
+                            });
                 }
 
                 let pending_prewarm_completion = if state.trunk.is_none() {
@@ -556,8 +598,10 @@ impl GuardianReviewSessionManager {
             }
         };
 
-        if let Some(review_session) = stale_trunk_to_shutdown {
-            review_session.shutdown_in_background();
+        if let Some(reserved_review_session) = stale_trunk_to_shutdown {
+            reserved_review_session
+                .review_session
+                .shutdown_reserved_in_background(reserved_review_session.review_guard);
         }
 
         let Some(trunk) = trunk_candidate else {
@@ -579,9 +623,9 @@ impl GuardianReviewSessionManager {
             .await;
         }
 
-        let trunk_guard = match trunk.review_lock.try_acquire() {
-            Ok(trunk_guard) => trunk_guard,
-            Err(_) => {
+        let trunk_guard = match trunk.try_acquire_review_lock() {
+            Some(trunk_guard) => trunk_guard,
+            None => {
                 return Box::pin(self.run_ephemeral_review(
                     params,
                     next_reuse_key,
@@ -629,7 +673,7 @@ impl GuardianReviewSessionManager {
             reuse_key,
             codex,
             cancel_token: CancellationToken::new(),
-            review_lock: Semaphore::new(/*permits*/ 1),
+            review_lock: Arc::new(Semaphore::new(/*permits*/ 1)),
             state: Mutex::new(GuardianReviewState {
                 prior_review_count: 0,
                 last_reviewed_transcript_cursor: None,
@@ -652,7 +696,7 @@ impl GuardianReviewSessionManager {
                 reuse_key,
                 codex,
                 cancel_token: CancellationToken::new(),
-                review_lock: Semaphore::new(/*permits*/ 1),
+                review_lock: Arc::new(Semaphore::new(/*permits*/ 1)),
                 state: Mutex::new(GuardianReviewState {
                     prior_review_count: 0,
                     last_reviewed_transcript_cursor: None,
@@ -808,7 +852,7 @@ async fn spawn_guardian_review_session(
         codex,
         cancel_token,
         reuse_key,
-        review_lock: Semaphore::new(/*permits*/ 1),
+        review_lock: Arc::new(Semaphore::new(/*permits*/ 1)),
         state: Mutex::new(GuardianReviewState {
             prior_review_count,
             last_reviewed_transcript_cursor: initial_transcript_cursor,
@@ -1285,7 +1329,7 @@ mod tests {
                 },
                 cancel_token: CancellationToken::new(),
                 reuse_key,
-                review_lock: Semaphore::new(/*permits*/ 1),
+                review_lock: Arc::new(Semaphore::new(/*permits*/ 1)),
                 state: Mutex::new(GuardianReviewState {
                     prior_review_count: 0,
                     last_reviewed_transcript_cursor: None,
@@ -1559,6 +1603,58 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_review_cancels_stale_pending_prewarm_before_reusing_matching_trunk() {
+        let params = test_review_params().await;
+        let reuse_key = GuardianReviewSessionReuseKey::from_spawn_config(
+            &params.spawn_config,
+            params.parent_session.user_instructions().await,
+        );
+        let mut stale_spawn_config = params.spawn_config.clone();
+        stale_spawn_config.model = Some("different-guardian-model".to_string());
+        let stale_reuse_key = GuardianReviewSessionReuseKey::from_spawn_config(
+            &stale_spawn_config,
+            params.parent_session.user_instructions().await,
+        );
+        let stale_cancel_token = CancellationToken::new();
+        let (_stale_completion_tx, stale_completion) = watch::channel(false);
+        let (mut review_session, tx_event, rx_sub) = test_review_session().await;
+        review_session.reuse_key = reuse_key;
+        let manager = GuardianReviewSessionManager {
+            state: Arc::new(Mutex::new(GuardianReviewSessionState {
+                trunk: Some(Arc::new(review_session)),
+                prewarm: Some(GuardianReviewSessionPrewarm {
+                    reuse_key: stale_reuse_key,
+                    cancel_token: stale_cancel_token.clone(),
+                    completion: stale_completion,
+                }),
+                ephemeral_reviews: Vec::new(),
+            })),
+        };
+
+        let review = tokio::spawn(async move { manager.run_review(params).await });
+        let submission = rx_sub.recv().await.expect("guardian submission");
+        tx_event
+            .send(turn_complete_event(
+                submission.id.as_str(),
+                Some("fresh assessment"),
+                Some(42),
+            ))
+            .await
+            .expect("queue guardian completion");
+        let (outcome, analytics_result) = review.await.expect("review should complete");
+
+        let GuardianReviewSessionOutcome::Completed(Ok(last_agent_message)) = outcome else {
+            panic!("expected completed guardian review");
+        };
+        assert_eq!(last_agent_message.as_deref(), Some("fresh assessment"));
+        assert!(stale_cancel_token.is_cancelled());
+        assert!(matches!(
+            analytics_result.guardian_session_kind,
+            Some(GuardianReviewSessionKind::TrunkReused)
+        ));
+    }
+
+    #[tokio::test]
     async fn run_review_waits_for_matching_pending_prewarm() {
         let params = test_review_params().await;
         let reuse_key = GuardianReviewSessionReuseKey::from_spawn_config(
@@ -1581,12 +1677,16 @@ mod tests {
         let review_manager = Arc::clone(&manager);
         let review = tokio::spawn(async move { review_manager.run_review(params).await });
 
-        for _ in 0..50 {
-            if completion_tx.receiver_count() > 1 {
-                break;
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if completion_tx.receiver_count() > 1 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(1)).await;
             }
-            tokio::time::sleep(Duration::from_millis(1)).await;
-        }
+        })
+        .await
+        .expect("review should subscribe to pending prewarm completion");
         assert_eq!(completion_tx.receiver_count(), 2);
         assert!(!cancel_token.is_cancelled());
         assert!(!review.is_finished());

--- a/codex-rs/core/src/guardian/review_session.rs
+++ b/codex-rs/core/src/guardian/review_session.rs
@@ -30,6 +30,7 @@ use serde_json::Value;
 use tokio::sync::Mutex;
 use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
+use tracing::info;
 use tracing::warn;
 
 use crate::codex_delegate::run_codex_thread_interactive;
@@ -84,6 +85,12 @@ pub(crate) struct GuardianReviewSessionParams {
     pub(crate) deadline: tokio::time::Instant,
 }
 
+pub(crate) struct GuardianReviewSessionPrewarmParams {
+    pub(crate) parent_session: Arc<Session>,
+    pub(crate) parent_turn: Arc<TurnContext>,
+    pub(crate) spawn_config: Config,
+}
+
 #[derive(Default)]
 pub(crate) struct GuardianReviewSessionManager {
     state: Arc<Mutex<GuardianReviewSessionState>>,
@@ -92,7 +99,13 @@ pub(crate) struct GuardianReviewSessionManager {
 #[derive(Default)]
 struct GuardianReviewSessionState {
     trunk: Option<Arc<GuardianReviewSession>>,
+    prewarm: Option<GuardianReviewSessionPrewarm>,
     ephemeral_reviews: Vec<Arc<GuardianReviewSession>>,
+}
+
+struct GuardianReviewSessionPrewarm {
+    reuse_key: GuardianReviewSessionReuseKey,
+    cancel_token: CancellationToken,
 }
 
 struct GuardianReviewSession {
@@ -297,19 +310,141 @@ impl GuardianReviewSessionManager {
     }
 
     pub(crate) async fn shutdown(&self) {
-        let (review_session, ephemeral_reviews) = {
+        let (review_session, prewarm, ephemeral_reviews) = {
             let mut state = self.state.lock().await;
             (
                 state.trunk.take(),
+                state.prewarm.take(),
                 std::mem::take(&mut state.ephemeral_reviews),
             )
         };
+        if let Some(prewarm) = prewarm {
+            prewarm.cancel_token.cancel();
+        }
         if let Some(review_session) = review_session {
             review_session.shutdown().await;
         }
         for review_session in ephemeral_reviews {
             review_session.shutdown().await;
         }
+    }
+
+    pub(super) async fn prewarm_trunk(&self, params: GuardianReviewSessionPrewarmParams) {
+        let reuse_key = GuardianReviewSessionReuseKey::from_spawn_config(
+            &params.spawn_config,
+            params.parent_session.user_instructions().await,
+        );
+        let cancel_token = CancellationToken::new();
+        let mut stale_trunk_to_shutdown = None;
+        let mut stale_prewarm_to_cancel = None;
+        let mut should_schedule_prewarm = true;
+
+        {
+            let mut state = self.state.lock().await;
+            if let Some(prewarm) = state.prewarm.as_ref() {
+                if prewarm.reuse_key == reuse_key {
+                    return;
+                }
+                stale_prewarm_to_cancel = state.prewarm.take();
+            }
+
+            if let Some(trunk) = state.trunk.as_ref() {
+                if trunk.reuse_key == reuse_key {
+                    should_schedule_prewarm = false;
+                }
+                if should_schedule_prewarm && trunk.review_lock.try_acquire().is_ok() {
+                    stale_trunk_to_shutdown = state.trunk.take();
+                } else if should_schedule_prewarm {
+                    info!("guardian trunk prewarm skipped because a stale trunk is currently busy");
+                    should_schedule_prewarm = false;
+                }
+            }
+
+            if should_schedule_prewarm {
+                state.prewarm = Some(GuardianReviewSessionPrewarm {
+                    reuse_key: reuse_key.clone(),
+                    cancel_token: cancel_token.clone(),
+                });
+            }
+        }
+
+        if let Some(prewarm) = stale_prewarm_to_cancel {
+            info!("cancelling stale guardian trunk prewarm before scheduling a replacement");
+            prewarm.cancel_token.cancel();
+        }
+        if let Some(review_session) = stale_trunk_to_shutdown {
+            review_session.shutdown_in_background();
+        }
+        if !should_schedule_prewarm {
+            return;
+        }
+
+        let state = Arc::clone(&self.state);
+        drop(tokio::spawn(async move {
+            let spawned_session = spawn_guardian_review_session(
+                Arc::clone(&params.parent_session),
+                Arc::clone(&params.parent_turn),
+                params.spawn_config,
+                reuse_key.clone(),
+                cancel_token.clone(),
+                /*fork_snapshot*/ None,
+            )
+            .await;
+            let review_session = match spawned_session {
+                Ok(review_session) => Arc::new(review_session),
+                Err(err) => {
+                    if !cancel_token.is_cancelled() {
+                        warn!("guardian trunk prewarm failed: {err:#}");
+                    }
+                    let mut state = state.lock().await;
+                    if state
+                        .prewarm
+                        .as_ref()
+                        .is_some_and(|prewarm| prewarm.reuse_key == reuse_key)
+                    {
+                        state.prewarm = None;
+                    }
+                    return;
+                }
+            };
+
+            let mut spawned_session_to_shutdown = Some(review_session);
+            let mut stale_trunk_to_shutdown = None;
+            let installed = {
+                let mut state = state.lock().await;
+                if !state
+                    .prewarm
+                    .as_ref()
+                    .is_some_and(|prewarm| prewarm.reuse_key == reuse_key)
+                {
+                    false
+                } else {
+                    state.prewarm = None;
+                    if let Some(trunk) = state.trunk.as_ref()
+                        && trunk.reuse_key != reuse_key
+                        && trunk.review_lock.try_acquire().is_ok()
+                    {
+                        stale_trunk_to_shutdown = state.trunk.take();
+                    }
+                    if state.trunk.is_none() {
+                        state.trunk = spawned_session_to_shutdown.take();
+                        true
+                    } else {
+                        false
+                    }
+                }
+            };
+
+            if installed {
+                info!("guardian trunk prewarm installed");
+            }
+            if let Some(review_session) = stale_trunk_to_shutdown {
+                review_session.shutdown_in_background();
+            }
+            if let Some(review_session) = spawned_session_to_shutdown {
+                review_session.shutdown().await;
+            }
+        }));
     }
 
     #[expect(
@@ -335,6 +470,14 @@ impl GuardianReviewSessionManager {
         .await
         {
             Ok(mut state) => {
+                if let Some(prewarm) = state.prewarm.as_ref()
+                    && prewarm.reuse_key != next_reuse_key
+                {
+                    info!("cancelling stale guardian trunk prewarm before review");
+                    if let Some(prewarm) = state.prewarm.take() {
+                        prewarm.cancel_token.cancel();
+                    }
+                }
                 if let Some(trunk) = state.trunk.as_ref()
                     && trunk.reuse_key != next_reuse_key
                     && trunk.review_lock.try_acquire().is_ok()
@@ -343,13 +486,20 @@ impl GuardianReviewSessionManager {
                 }
 
                 if state.trunk.is_none() {
+                    if let Some(prewarm) = state.prewarm.take() {
+                        info!(
+                            "guardian trunk prewarm was not ready before review; falling back to lazy spawn"
+                        );
+                        prewarm.cancel_token.cancel();
+                    }
                     let spawn_cancel_token = CancellationToken::new();
                     let review_session = match run_before_review_deadline_with_cancel(
                         deadline,
                         params.external_cancel.as_ref(),
                         &spawn_cancel_token,
                         Box::pin(spawn_guardian_review_session(
-                            &params,
+                            Arc::clone(&params.parent_session),
+                            Arc::clone(&params.parent_turn),
                             params.spawn_config.clone(),
                             next_reuse_key.clone(),
                             spawn_cancel_token.clone(),
@@ -559,7 +709,8 @@ impl GuardianReviewSessionManager {
             params.external_cancel.as_ref(),
             &spawn_cancel_token,
             Box::pin(spawn_guardian_review_session(
-                &params,
+                Arc::clone(&params.parent_session),
+                Arc::clone(&params.parent_turn),
                 fork_config,
                 reuse_key,
                 spawn_cancel_token.clone(),
@@ -600,7 +751,8 @@ impl GuardianReviewSessionManager {
 }
 
 async fn spawn_guardian_review_session(
-    params: &GuardianReviewSessionParams,
+    parent_session: Arc<Session>,
+    parent_turn: Arc<TurnContext>,
     spawn_config: Config,
     reuse_key: GuardianReviewSessionReuseKey,
     cancel_token: CancellationToken,
@@ -616,10 +768,10 @@ async fn spawn_guardian_review_session(
     };
     let codex = Box::pin(run_codex_thread_interactive(
         spawn_config,
-        params.parent_session.services.auth_manager.clone(),
-        params.parent_session.services.models_manager.clone(),
-        Arc::clone(&params.parent_session),
-        Arc::clone(&params.parent_turn),
+        parent_session.services.auth_manager.clone(),
+        parent_session.services.models_manager.clone(),
+        Arc::clone(&parent_session),
+        Arc::clone(&parent_turn),
         cancel_token.clone(),
         SubAgentSource::Other(GUARDIAN_REVIEWER_NAME.to_string()),
         initial_history,
@@ -1072,6 +1224,7 @@ mod tests {
     use codex_protocol::protocol::TurnAbortReason;
     use codex_protocol::protocol::TurnAbortedEvent;
     use codex_protocol::protocol::TurnCompleteEvent;
+    use pretty_assertions::assert_eq;
 
     async fn test_review_session() -> (
         GuardianReviewSession,
@@ -1257,6 +1410,75 @@ mod tests {
                 /*parent_thread_id*/ None
             )
         );
+    }
+
+    #[tokio::test]
+    async fn shutdown_cancels_pending_trunk_prewarm() {
+        let parent_config = crate::config::test_config().await;
+        let reuse_key = GuardianReviewSessionReuseKey::from_spawn_config(
+            &parent_config,
+            /*user_instructions*/ None,
+        );
+        let cancel_token = CancellationToken::new();
+        let manager = GuardianReviewSessionManager {
+            state: Arc::new(Mutex::new(GuardianReviewSessionState {
+                trunk: None,
+                prewarm: Some(GuardianReviewSessionPrewarm {
+                    reuse_key,
+                    cancel_token: cancel_token.clone(),
+                }),
+                ephemeral_reviews: Vec::new(),
+            })),
+        };
+
+        manager.shutdown().await;
+
+        assert!(cancel_token.is_cancelled());
+        assert!(manager.state.lock().await.prewarm.is_none());
+    }
+
+    #[tokio::test]
+    async fn prewarm_trunk_skips_existing_matching_trunk_and_cancels_stale_prewarm() {
+        let params = test_review_params().await;
+        let reuse_key = GuardianReviewSessionReuseKey::from_spawn_config(
+            &params.spawn_config,
+            params.parent_session.user_instructions().await,
+        );
+        let mut stale_spawn_config = params.spawn_config.clone();
+        stale_spawn_config.model = Some("different-guardian-model".to_string());
+        let stale_reuse_key = GuardianReviewSessionReuseKey::from_spawn_config(
+            &stale_spawn_config,
+            params.parent_session.user_instructions().await,
+        );
+        let stale_cancel_token = CancellationToken::new();
+        let (mut review_session, _tx_event, _rx_sub) = test_review_session().await;
+        review_session.reuse_key = reuse_key;
+        let manager = GuardianReviewSessionManager {
+            state: Arc::new(Mutex::new(GuardianReviewSessionState {
+                trunk: Some(Arc::new(review_session)),
+                prewarm: Some(GuardianReviewSessionPrewarm {
+                    reuse_key: stale_reuse_key,
+                    cancel_token: stale_cancel_token.clone(),
+                }),
+                ephemeral_reviews: Vec::new(),
+            })),
+        };
+
+        manager
+            .prewarm_trunk(GuardianReviewSessionPrewarmParams {
+                parent_session: Arc::clone(&params.parent_session),
+                parent_turn: Arc::clone(&params.parent_turn),
+                spawn_config: params.spawn_config,
+            })
+            .await;
+
+        assert!(stale_cancel_token.is_cancelled());
+        {
+            let state = manager.state.lock().await;
+            assert!(state.prewarm.is_none());
+            assert!(state.trunk.is_some());
+        }
+        manager.shutdown().await;
     }
 
     #[tokio::test]
@@ -1525,6 +1747,7 @@ mod tests {
         let manager = GuardianReviewSessionManager {
             state: Arc::new(Mutex::new(GuardianReviewSessionState {
                 trunk: Some(Arc::new(review_session)),
+                prewarm: None,
                 ephemeral_reviews: Vec::new(),
             })),
         };

--- a/codex-rs/core/src/guardian/review_session.rs
+++ b/codex-rs/core/src/guardian/review_session.rs
@@ -29,6 +29,7 @@ use codex_protocol::protocol::TokenUsage;
 use serde_json::Value;
 use tokio::sync::Mutex;
 use tokio::sync::Semaphore;
+use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 use tracing::warn;
@@ -106,6 +107,7 @@ struct GuardianReviewSessionState {
 struct GuardianReviewSessionPrewarm {
     reuse_key: GuardianReviewSessionReuseKey,
     cancel_token: CancellationToken,
+    completion: watch::Receiver<bool>,
 }
 
 struct GuardianReviewSession {
@@ -335,6 +337,7 @@ impl GuardianReviewSessionManager {
             params.parent_session.user_instructions().await,
         );
         let cancel_token = CancellationToken::new();
+        let (completion_tx, completion_rx) = watch::channel(false);
         let mut stale_trunk_to_shutdown = None;
         let mut stale_prewarm_to_cancel = None;
         let mut should_schedule_prewarm = true;
@@ -364,6 +367,7 @@ impl GuardianReviewSessionManager {
                 state.prewarm = Some(GuardianReviewSessionPrewarm {
                     reuse_key: reuse_key.clone(),
                     cancel_token: cancel_token.clone(),
+                    completion: completion_rx,
                 });
             }
         }
@@ -404,6 +408,7 @@ impl GuardianReviewSessionManager {
                     {
                         state.prewarm = None;
                     }
+                    let _ = completion_tx.send(true);
                     return;
                 }
             };
@@ -444,6 +449,7 @@ impl GuardianReviewSessionManager {
             if let Some(review_session) = spawned_session_to_shutdown {
                 review_session.shutdown().await;
             }
+            let _ = completion_tx.send(true);
         }));
     }
 
@@ -462,14 +468,20 @@ impl GuardianReviewSessionManager {
         );
         let mut stale_trunk_to_shutdown = None;
         let mut spawned_trunk = false;
-        let trunk_candidate = match run_before_review_deadline(
-            deadline,
-            params.external_cancel.as_ref(),
-            self.state.lock(),
-        )
-        .await
-        {
-            Ok(mut state) => {
+        let trunk_candidate = loop {
+            let pending_prewarm_completion = {
+                let mut state = match run_before_review_deadline(
+                    deadline,
+                    params.external_cancel.as_ref(),
+                    self.state.lock(),
+                )
+                .await
+                {
+                    Ok(state) => state,
+                    Err(outcome) => {
+                        return (outcome, GuardianReviewAnalyticsResult::without_session());
+                    }
+                };
                 if let Some(prewarm) = state.prewarm.as_ref()
                     && prewarm.reuse_key != next_reuse_key
                 {
@@ -485,47 +497,61 @@ impl GuardianReviewSessionManager {
                     stale_trunk_to_shutdown = state.trunk.take();
                 }
 
-                if state.trunk.is_none() {
-                    if let Some(prewarm) = state.prewarm.take() {
-                        info!(
-                            "guardian trunk prewarm was not ready before review; falling back to lazy spawn"
-                        );
-                        prewarm.cancel_token.cancel();
+                let pending_prewarm_completion = if state.trunk.is_none() {
+                    if let Some(prewarm) = state.prewarm.as_ref() {
+                        info!("guardian trunk prewarm is pending before review; waiting for it");
+                        Some(prewarm.completion.clone())
+                    } else {
+                        let spawn_cancel_token = CancellationToken::new();
+                        let review_session = match run_before_review_deadline_with_cancel(
+                            deadline,
+                            params.external_cancel.as_ref(),
+                            &spawn_cancel_token,
+                            Box::pin(spawn_guardian_review_session(
+                                Arc::clone(&params.parent_session),
+                                Arc::clone(&params.parent_turn),
+                                params.spawn_config.clone(),
+                                next_reuse_key.clone(),
+                                spawn_cancel_token.clone(),
+                                /*fork_snapshot*/ None,
+                            )),
+                        )
+                        .await
+                        {
+                            Ok(Ok(review_session)) => Arc::new(review_session),
+                            Ok(Err(err)) => {
+                                return (
+                                    GuardianReviewSessionOutcome::PromptBuildFailed(err),
+                                    GuardianReviewAnalyticsResult::without_session(),
+                                );
+                            }
+                            Err(outcome) => {
+                                return (outcome, GuardianReviewAnalyticsResult::without_session());
+                            }
+                        };
+                        state.trunk = Some(Arc::clone(&review_session));
+                        spawned_trunk = true;
+                        None
                     }
-                    let spawn_cancel_token = CancellationToken::new();
-                    let review_session = match run_before_review_deadline_with_cancel(
-                        deadline,
-                        params.external_cancel.as_ref(),
-                        &spawn_cancel_token,
-                        Box::pin(spawn_guardian_review_session(
-                            Arc::clone(&params.parent_session),
-                            Arc::clone(&params.parent_turn),
-                            params.spawn_config.clone(),
-                            next_reuse_key.clone(),
-                            spawn_cancel_token.clone(),
-                            /*fork_snapshot*/ None,
-                        )),
-                    )
-                    .await
-                    {
-                        Ok(Ok(review_session)) => Arc::new(review_session),
-                        Ok(Err(err)) => {
-                            return (
-                                GuardianReviewSessionOutcome::PromptBuildFailed(err),
-                                GuardianReviewAnalyticsResult::without_session(),
-                            );
-                        }
-                        Err(outcome) => {
-                            return (outcome, GuardianReviewAnalyticsResult::without_session());
-                        }
-                    };
-                    state.trunk = Some(Arc::clone(&review_session));
-                    spawned_trunk = true;
+                } else {
+                    None
+                };
+
+                if let Some(trunk) = state.trunk.as_ref().cloned() {
+                    break Some(trunk);
                 }
 
-                state.trunk.as_ref().cloned()
-            }
-            Err(outcome) => {
+                pending_prewarm_completion
+            };
+
+            if let Some(pending_prewarm_completion) = pending_prewarm_completion
+                && let Err(outcome) = run_before_review_deadline(
+                    deadline,
+                    params.external_cancel.as_ref(),
+                    wait_for_prewarm_completion(pending_prewarm_completion),
+                )
+                .await
+            {
                 return (outcome, GuardianReviewAnalyticsResult::without_session());
             }
         };
@@ -967,6 +993,13 @@ async fn run_review_on_session(
         state.last_reviewed_transcript_cursor = Some(transcript_cursor);
     }
     (outcome.0, outcome.1, analytics_result)
+}
+
+async fn wait_for_prewarm_completion(mut completion: watch::Receiver<bool>) {
+    if *completion.borrow_and_update() {
+        return;
+    }
+    let _ = completion.changed().await;
 }
 
 async fn append_guardian_followup_reminder(review_session: &GuardianReviewSession) {
@@ -1420,12 +1453,14 @@ mod tests {
             /*user_instructions*/ None,
         );
         let cancel_token = CancellationToken::new();
+        let (_completion_tx, completion) = watch::channel(false);
         let manager = GuardianReviewSessionManager {
             state: Arc::new(Mutex::new(GuardianReviewSessionState {
                 trunk: None,
                 prewarm: Some(GuardianReviewSessionPrewarm {
                     reuse_key,
                     cancel_token: cancel_token.clone(),
+                    completion,
                 }),
                 ephemeral_reviews: Vec::new(),
             })),
@@ -1451,6 +1486,7 @@ mod tests {
             params.parent_session.user_instructions().await,
         );
         let stale_cancel_token = CancellationToken::new();
+        let (_stale_completion_tx, stale_completion) = watch::channel(false);
         let (mut review_session, _tx_event, _rx_sub) = test_review_session().await;
         review_session.reuse_key = reuse_key;
         let manager = GuardianReviewSessionManager {
@@ -1459,6 +1495,7 @@ mod tests {
                 prewarm: Some(GuardianReviewSessionPrewarm {
                     reuse_key: stale_reuse_key,
                     cancel_token: stale_cancel_token.clone(),
+                    completion: stale_completion,
                 }),
                 ephemeral_reviews: Vec::new(),
             })),
@@ -1479,6 +1516,111 @@ mod tests {
             assert!(state.trunk.is_some());
         }
         manager.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn prewarm_trunk_keeps_existing_matching_prewarm() {
+        let params = test_review_params().await;
+        let reuse_key = GuardianReviewSessionReuseKey::from_spawn_config(
+            &params.spawn_config,
+            params.parent_session.user_instructions().await,
+        );
+        let cancel_token = CancellationToken::new();
+        let (_completion_tx, completion) = watch::channel(false);
+        let manager = GuardianReviewSessionManager {
+            state: Arc::new(Mutex::new(GuardianReviewSessionState {
+                trunk: None,
+                prewarm: Some(GuardianReviewSessionPrewarm {
+                    reuse_key: reuse_key.clone(),
+                    cancel_token: cancel_token.clone(),
+                    completion,
+                }),
+                ephemeral_reviews: Vec::new(),
+            })),
+        };
+
+        manager
+            .prewarm_trunk(GuardianReviewSessionPrewarmParams {
+                parent_session: Arc::clone(&params.parent_session),
+                parent_turn: Arc::clone(&params.parent_turn),
+                spawn_config: params.spawn_config,
+            })
+            .await;
+
+        let state = manager.state.lock().await;
+        assert!(!cancel_token.is_cancelled());
+        assert!(state.trunk.is_none());
+        assert!(
+            state
+                .prewarm
+                .as_ref()
+                .is_some_and(|prewarm| prewarm.reuse_key == reuse_key)
+        );
+    }
+
+    #[tokio::test]
+    async fn run_review_waits_for_matching_pending_prewarm() {
+        let params = test_review_params().await;
+        let reuse_key = GuardianReviewSessionReuseKey::from_spawn_config(
+            &params.spawn_config,
+            params.parent_session.user_instructions().await,
+        );
+        let cancel_token = CancellationToken::new();
+        let (completion_tx, completion) = watch::channel(false);
+        let manager = Arc::new(GuardianReviewSessionManager {
+            state: Arc::new(Mutex::new(GuardianReviewSessionState {
+                trunk: None,
+                prewarm: Some(GuardianReviewSessionPrewarm {
+                    reuse_key: reuse_key.clone(),
+                    cancel_token: cancel_token.clone(),
+                    completion,
+                }),
+                ephemeral_reviews: Vec::new(),
+            })),
+        });
+        let review_manager = Arc::clone(&manager);
+        let review = tokio::spawn(async move { review_manager.run_review(params).await });
+
+        for _ in 0..50 {
+            if completion_tx.receiver_count() > 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+        assert_eq!(completion_tx.receiver_count(), 2);
+        assert!(!cancel_token.is_cancelled());
+        assert!(!review.is_finished());
+
+        let (mut review_session, tx_event, rx_sub) = test_review_session().await;
+        review_session.reuse_key = reuse_key;
+        {
+            let mut state = manager.state.lock().await;
+            state.trunk = Some(Arc::new(review_session));
+            state.prewarm = None;
+        }
+        completion_tx
+            .send(true)
+            .expect("review should still be waiting for prewarm completion");
+
+        let submission = rx_sub.recv().await.expect("guardian submission");
+        tx_event
+            .send(turn_complete_event(
+                submission.id.as_str(),
+                Some("fresh assessment"),
+                Some(42),
+            ))
+            .await
+            .expect("queue guardian completion");
+        let (outcome, analytics_result) = review.await.expect("review should complete");
+
+        let GuardianReviewSessionOutcome::Completed(Ok(last_agent_message)) = outcome else {
+            panic!("expected completed guardian review");
+        };
+        assert_eq!(last_agent_message.as_deref(), Some("fresh assessment"));
+        assert!(matches!(
+            analytics_result.guardian_session_kind,
+            Some(GuardianReviewSessionKind::TrunkReused)
+        ));
     }
 
     #[tokio::test]

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -1958,7 +1958,7 @@ impl Session {
     }
 
     pub(crate) async fn persist_network_policy_amendment(
-        &self,
+        self: &Arc<Self>,
         amendment: &NetworkPolicyAmendment,
         network_approval_context: &NetworkApprovalContext,
     ) -> anyhow::Result<()> {
@@ -2006,6 +2006,8 @@ impl Session {
             .map_err(|err| {
                 anyhow::anyhow!("failed to persist network policy amendment to execpolicy: {err}")
             })?;
+
+        self.prewarm_guardian_for_active_regular_turn().await;
 
         Ok(())
     }

--- a/codex-rs/core/src/session/tests/guardian_tests.rs
+++ b/codex-rs/core/src/session/tests/guardian_tests.rs
@@ -82,6 +82,80 @@ async fn wait_for_guardian_trunk_rollout_path(session: &Session) -> PathBuf {
     .expect("guardian trunk prewarm should complete")
 }
 
+fn configure_guardian_auto_review(
+    session: &mut Session,
+    turn_context: &mut TurnContext,
+    model_provider_base_url: Option<String>,
+) {
+    turn_context
+        .approval_policy
+        .set(AskForApproval::OnRequest)
+        .expect("test setup should allow updating approval policy");
+    turn_context
+        .features
+        .enable(Feature::GuardianApproval)
+        .expect("test setup should allow enabling guardian approvals");
+    let mut config = (*turn_context.config).clone();
+    config.approvals_reviewer = ApprovalsReviewer::AutoReview;
+    config.model_provider.base_url = model_provider_base_url;
+    let config = Arc::new(config);
+    let models_manager = models_manager_with_provider(
+        config.codex_home.to_path_buf(),
+        Arc::clone(&session.services.auth_manager),
+        config.model_provider.clone(),
+    );
+    session.services.models_manager = models_manager;
+    turn_context.config = Arc::clone(&config);
+    turn_context.provider = create_model_provider(
+        config.model_provider.clone(),
+        turn_context.auth_manager.clone(),
+    );
+}
+
+struct WaitingRegularTask;
+
+impl SessionTask for WaitingRegularTask {
+    fn kind(&self) -> TaskKind {
+        TaskKind::Regular
+    }
+
+    fn span_name(&self) -> &'static str {
+        "session_task.guardian_prewarm_test"
+    }
+
+    async fn run(
+        self: Arc<Self>,
+        _session: Arc<SessionTaskContext>,
+        _ctx: Arc<TurnContext>,
+        _input: Vec<TurnInput>,
+        cancellation_token: CancellationToken,
+    ) -> Option<String> {
+        cancellation_token.cancelled().await;
+        None
+    }
+}
+
+async fn seed_active_regular_task(session: &Session, turn_context: Arc<TurnContext>) {
+    let task: Arc<dyn crate::tasks::AnySessionTask> = Arc::new(WaitingRegularTask);
+    let active_turn = ActiveTurn {
+        task: Some(crate::state::RunningTask {
+            done: Arc::new(tokio::sync::Notify::new()),
+            kind: TaskKind::Regular,
+            task,
+            cancellation_token: CancellationToken::new(),
+            handle: tokio_util::task::AbortOnDropHandle::new(tokio::spawn(
+                std::future::pending::<()>(),
+            )),
+            turn_context: Arc::clone(&turn_context),
+            turn_extension_data: Arc::clone(&turn_context.extension_data),
+            _agent_execution_guard: None,
+            _timer: None,
+        }),
+        ..ActiveTurn::default()
+    };
+    *session.active_turn.lock().await = Some(active_turn);
+}
+
 #[tokio::test]
 async fn request_permissions_routes_to_guardian_when_reviewer_is_enabled() {
     let server = start_mock_server().await;
@@ -179,6 +253,53 @@ async fn request_permissions_routes_to_guardian_when_reviewer_is_enabled() {
     assert_eq!(guardian_request.path(), "/v1/responses");
     assert!(guardian_request.body_contains_text("request_permissions"));
     assert!(guardian_request.body_contains_text("need network"));
+}
+
+#[tokio::test]
+async fn regular_turn_start_schedules_guardian_trunk_prewarm() {
+    let (mut session, mut turn_context_raw) = make_session_and_context().await;
+    configure_guardian_auto_review(&mut session, &mut turn_context_raw, /*base_url*/ None);
+    let session = Arc::new(session);
+    let turn_context = Arc::new(turn_context_raw);
+
+    session
+        .spawn_task(Arc::clone(&turn_context), Vec::new(), WaitingRegularTask)
+        .await;
+
+    let prewarmed_trunk_rollout_path = wait_for_guardian_trunk_rollout_path(&session).await;
+    assert!(prewarmed_trunk_rollout_path.exists());
+    session.abort_all_tasks(TurnAbortReason::Interrupted).await;
+    session.guardian_review_session.shutdown().await;
+}
+
+#[tokio::test]
+async fn network_policy_amendment_schedules_guardian_trunk_prewarm_for_active_regular_turn() {
+    let (mut session, mut turn_context_raw) = make_session_and_context().await;
+    configure_guardian_auto_review(&mut session, &mut turn_context_raw, /*base_url*/ None);
+    fs::create_dir_all(turn_context_raw.config.codex_home.join("rules"))
+        .expect("create execpolicy rules dir");
+    let session = Arc::new(session);
+    let turn_context = Arc::new(turn_context_raw);
+    seed_active_regular_task(session.as_ref(), Arc::clone(&turn_context)).await;
+
+    session
+        .persist_network_policy_amendment(
+            &codex_protocol::approvals::NetworkPolicyAmendment {
+                host: "api.example.com".to_string(),
+                action: codex_protocol::approvals::NetworkPolicyRuleAction::Allow,
+            },
+            &codex_protocol::protocol::NetworkApprovalContext {
+                host: "api.example.com".to_string(),
+                protocol: NetworkApprovalProtocol::Https,
+            },
+        )
+        .await
+        .expect("network policy amendment should persist");
+
+    let prewarmed_trunk_rollout_path = wait_for_guardian_trunk_rollout_path(&session).await;
+    assert!(prewarmed_trunk_rollout_path.exists());
+    session.abort_all_tasks(TurnAbortReason::Interrupted).await;
+    session.guardian_review_session.shutdown().await;
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/session/tests/guardian_tests.rs
+++ b/codex-rs/core/src/session/tests/guardian_tests.rs
@@ -43,6 +43,7 @@ use core_test_support::responses::sse_response;
 use core_test_support::responses::start_mock_server;
 use pretty_assertions::assert_eq;
 use std::fs;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tempfile::tempdir;
@@ -66,6 +67,19 @@ where
         }
         other => panic!("expected function output, got {other:?}"),
     }
+}
+
+async fn wait_for_guardian_trunk_rollout_path(session: &Session) -> PathBuf {
+    timeout(Duration::from_secs(10), async {
+        loop {
+            if let Some(path) = session.guardian_review_session.trunk_rollout_path().await {
+                return path;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .expect("guardian trunk prewarm should complete")
 }
 
 #[tokio::test]
@@ -165,6 +179,111 @@ async fn request_permissions_routes_to_guardian_when_reviewer_is_enabled() {
     assert_eq!(guardian_request.path(), "/v1/responses");
     assert!(guardian_request.body_contains_text("request_permissions"));
     assert!(guardian_request.body_contains_text("need network"));
+}
+
+#[tokio::test]
+async fn prewarmed_guardian_trunk_is_reused_by_first_review() {
+    let server = start_mock_server().await;
+    let guardian_request_log = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-guardian"),
+            ev_assistant_message(
+                "msg-guardian",
+                &serde_json::json!({
+                    "risk_level": "low",
+                    "user_authorization": "high",
+                    "outcome": "allow",
+                    "rationale": "The request grants narrowly scoped network access for this turn.",
+                })
+                .to_string(),
+            ),
+            ev_completed("resp-guardian"),
+        ]),
+    )
+    .await;
+
+    let (mut session, mut turn_context_raw) = make_session_and_context().await;
+    *session.active_turn.lock().await = Some(ActiveTurn::default());
+    turn_context_raw
+        .approval_policy
+        .set(AskForApproval::OnRequest)
+        .expect("test setup should allow updating approval policy");
+    turn_context_raw
+        .features
+        .enable(Feature::GuardianApproval)
+        .expect("test setup should allow enabling guardian approvals");
+    let mut config = (*turn_context_raw.config).clone();
+    config.approvals_reviewer = ApprovalsReviewer::AutoReview;
+    config.model_provider.base_url = Some(format!("{}/v1", server.uri()));
+    let config = Arc::new(config);
+    let models_manager = models_manager_with_provider(
+        config.codex_home.to_path_buf(),
+        Arc::clone(&session.services.auth_manager),
+        config.model_provider.clone(),
+    );
+    session.services.models_manager = models_manager;
+    turn_context_raw.config = Arc::clone(&config);
+    turn_context_raw.provider = create_model_provider(
+        config.model_provider.clone(),
+        turn_context_raw.auth_manager.clone(),
+    );
+    let session = Arc::new(session);
+    let turn_context = Arc::new(turn_context_raw);
+
+    crate::guardian::prewarm_guardian_review_session(
+        Arc::clone(&session),
+        Arc::clone(&turn_context),
+    )
+    .await;
+    let prewarmed_trunk_rollout_path = wait_for_guardian_trunk_rollout_path(&session).await;
+
+    let requested_permissions = RequestPermissionProfile {
+        network: Some(NetworkPermissions {
+            enabled: Some(true),
+        }),
+        ..RequestPermissionProfile::default()
+    };
+    let environment = turn_context
+        .environments
+        .primary()
+        .expect("primary environment")
+        .selection();
+    let response = timeout(
+        Duration::from_secs(45),
+        session.request_permissions_for_environment(
+            &turn_context,
+            "perm-call-prewarmed".to_string(),
+            RequestPermissionsArgs {
+                environment_id: None,
+                reason: Some("need network".to_string()),
+                permissions: requested_permissions.clone(),
+            },
+            environment,
+            CancellationToken::new(),
+        ),
+    )
+    .await
+    .expect("request_permissions should not wait for a client approval");
+
+    assert_eq!(
+        response,
+        Some(RequestPermissionsResponse {
+            permissions: requested_permissions.clone(),
+            scope: PermissionGrantScope::Turn,
+            strict_auto_review: false,
+        })
+    );
+    assert_eq!(
+        wait_for_guardian_trunk_rollout_path(&session).await,
+        prewarmed_trunk_rollout_path
+    );
+
+    let guardian_request = guardian_request_log.single_request();
+    assert_eq!(guardian_request.path(), "/v1/responses");
+    assert!(guardian_request.body_contains_text("request_permissions"));
+    assert!(guardian_request.body_contains_text("need network"));
+    session.guardian_review_session.shutdown().await;
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -304,6 +304,30 @@ where
 }
 
 impl Session {
+    fn spawn_guardian_prewarm_for_turn(self: &Arc<Self>, turn_context: Arc<TurnContext>) {
+        if !crate::guardian::routes_approval_to_guardian(turn_context.as_ref()) {
+            return;
+        }
+        let session = Arc::clone(self);
+        drop(tokio::spawn(async move {
+            crate::guardian::prewarm_guardian_review_session(session, turn_context).await;
+        }));
+    }
+
+    pub(crate) async fn prewarm_guardian_for_active_regular_turn(self: &Arc<Self>) {
+        let turn_context = {
+            let active = self.active_turn.lock().await;
+            active
+                .as_ref()
+                .and_then(|active_turn| active_turn.task.as_ref())
+                .filter(|task| task.kind == TaskKind::Regular)
+                .map(|task| Arc::clone(&task.turn_context))
+        };
+        if let Some(turn_context) = turn_context {
+            self.spawn_guardian_prewarm_for_turn(turn_context);
+        }
+    }
+
     pub async fn spawn_task<T: SessionTask>(
         self: &Arc<Self>,
         turn_context: Arc<TurnContext>,
@@ -356,6 +380,9 @@ impl Session {
             .await;
         self.emit_turn_start_lifecycle(turn_context.as_ref(), &token_usage_at_turn_start)
             .await;
+        if task_kind == TaskKind::Regular {
+            self.spawn_guardian_prewarm_for_turn(Arc::clone(&turn_context));
+        }
 
         let turn_extension_data = Arc::clone(&turn_context.extension_data);
         let mut active = self.active_turn.lock().await;

--- a/codex-rs/core/src/tasks/regular.rs
+++ b/codex-rs/core/src/tasks/regular.rs
@@ -45,26 +45,30 @@ impl SessionTask for RegularTask {
         let run_turn_span = trace_span!("run_turn");
         // Regular turns emit `TurnStarted` inline so first-turn lifecycle does
         // not wait on startup prewarm resolution.
-        let event = EventMsg::TurnStarted(TurnStartedEvent {
-            turn_id: ctx.sub_id.clone(),
-            trace_id: ctx.trace_id.clone(),
-            started_at: ctx.turn_timing_state.started_at_unix_secs().await,
-            model_context_window: ctx.model_context_window(),
-            collaboration_mode_kind: ctx.collaboration_mode.mode,
-        });
-        sess.send_event(ctx.as_ref(), event).await;
-        sess.set_server_reasoning_included(/*included*/ false).await;
-        if crate::guardian::routes_approval_to_guardian(ctx.as_ref()) {
-            let prewarm_sess = Arc::clone(&sess);
-            let prewarm_ctx = Arc::clone(&ctx);
-            drop(tokio::spawn(async move {
-                crate::guardian::prewarm_guardian_review_session(prewarm_sess, prewarm_ctx).await;
-            }));
+        let prewarmed_client_session = async {
+            let event = EventMsg::TurnStarted(TurnStartedEvent {
+                turn_id: ctx.sub_id.clone(),
+                trace_id: ctx.trace_id.clone(),
+                started_at: ctx.turn_timing_state.started_at_unix_secs().await,
+                model_context_window: ctx.model_context_window(),
+                collaboration_mode_kind: ctx.collaboration_mode.mode,
+            });
+            sess.send_event(ctx.as_ref(), event).await;
+            sess.set_server_reasoning_included(/*included*/ false).await;
+            if crate::guardian::routes_approval_to_guardian(ctx.as_ref()) {
+                let prewarm_sess = Arc::clone(&sess);
+                let prewarm_ctx = Arc::clone(&ctx);
+                drop(tokio::spawn(async move {
+                    crate::guardian::prewarm_guardian_review_session(prewarm_sess, prewarm_ctx)
+                        .await;
+                }));
+            }
+            sess.consume_startup_prewarm_for_regular_turn(&cancellation_token)
+                .await
         }
-        let prewarmed_client_session = match sess
-            .consume_startup_prewarm_for_regular_turn(&cancellation_token)
-            .await
-        {
+        .instrument(trace_span!("regular_task.prepare_run_turn"))
+        .await;
+        let prewarmed_client_session = match prewarmed_client_session {
             SessionStartupPrewarmResolution::Cancelled => return None,
             SessionStartupPrewarmResolution::Unavailable { .. } => None,
             SessionStartupPrewarmResolution::Ready(prewarmed_client_session) => {

--- a/codex-rs/core/src/tasks/regular.rs
+++ b/codex-rs/core/src/tasks/regular.rs
@@ -55,14 +55,6 @@ impl SessionTask for RegularTask {
             });
             sess.send_event(ctx.as_ref(), event).await;
             sess.set_server_reasoning_included(/*included*/ false).await;
-            if crate::guardian::routes_approval_to_guardian(ctx.as_ref()) {
-                let prewarm_sess = Arc::clone(&sess);
-                let prewarm_ctx = Arc::clone(&ctx);
-                drop(tokio::spawn(async move {
-                    crate::guardian::prewarm_guardian_review_session(prewarm_sess, prewarm_ctx)
-                        .await;
-                }));
-            }
             sess.consume_startup_prewarm_for_regular_turn(&cancellation_token)
                 .await
         }

--- a/codex-rs/core/src/tasks/regular.rs
+++ b/codex-rs/core/src/tasks/regular.rs
@@ -54,6 +54,13 @@ impl SessionTask for RegularTask {
         });
         sess.send_event(ctx.as_ref(), event).await;
         sess.set_server_reasoning_included(/*included*/ false).await;
+        if crate::guardian::routes_approval_to_guardian(ctx.as_ref()) {
+            let prewarm_sess = Arc::clone(&sess);
+            let prewarm_ctx = Arc::clone(&ctx);
+            drop(tokio::spawn(async move {
+                crate::guardian::prewarm_guardian_review_session(prewarm_sess, prewarm_ctx).await;
+            }));
+        }
         let prewarmed_client_session = match sess
             .consume_startup_prewarm_for_regular_turn(&cancellation_token)
             .await


### PR DESCRIPTION
## Summary
Create the guardian thread for auto-review to so that it is pre-warmed, reducing latency the first time we ask for a review.
Previously we created the guardian thread lazily at first use. This asynchronously creates it at thread start so that the user experiences less latency. If the prewarmed thread is stale, failed, or not ready, we cancel it and fall back to the previous method of lazy trunk spawn.

Adds test coverage coverage for prewarm cancellation, stale prewarm cleanup, and first-review reuse of a prewarmed trunk

## Motivation
This moves Guardian child-thread setup earlier in the turn while still adding the parent transcript and action-specific prompt only at review time.

## Timing
I ran some basic local tests where each prompt first executed `sleep 3` and then asked for approval escalation. This gives the prewarm a few seconds to complete before the first review.

| version | count | avg_guardian_duration_ms | avg_guardian_ttf_ms |
| --- | ---: | ---: | ---: |
| new | 10 | 3622.3 | 3147.6 |
| old | 10 | 5014.7 | 4539.5 |

