### PR TITLE
[codex] increase Windows x64 codegen units

### DIFF
--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -100,6 +100,11 @@ jobs:
           target="${{ matrix.target }}"
           if [[ "$target" == "x86_64-pc-windows-msvc" ]]; then
             export LIBSQLITE3_FLAGS=SQLITE_DISABLE_INTRINSIC
+            if [[ "${{ matrix.bundle }}" == "primary" ]]; then
+              # At four units, this build was the release critical path; eight
+              # measured faster on its 16-logical-CPU runner.
+              export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=8
+            fi
           fi
           build_args=()
           for binary in ${{ matrix.binaries }}; do


### PR DESCRIPTION
The first release with four codegen units moved the critical path to the
Windows x64 primary build. Its Cargo step took 31m35s on an AMD EPYC
9V74 runner with 16 logical CPUs and 64 GiB RAM, using Rust 1.95.0 and
rust-lld:

https://github.com/openai/codex/actions/runs/27391514823

The release tag differs from its parent only in the workspace version.
Running the same Cargo command against that parent with eight units took
28m37s, saving 2m58s (9.4%). The final codex unit fell from 19m26s to
16m11s:

https://github.com/openai/codex/actions/runs/27393628521/job/80956269234

Limit the override to the critical build, leaving every other release
build at the global four units. The raw, unstripped codex.exe grew by
about 5%, from 291 to 305 MiB. Previous four-versus-eight runtime
measurements found unchanged user and system CPU time and only 1-2 ms
CLI startup shifts.