### PR TITLE
[codex] Structure approval review contributions

### DIFF
--- a/codex-rs/ext/extension-api/src/approval_review.rs
+++ b/codex-rs/ext/extension-api/src/approval_review.rs
@@ -1,0 +1,73 @@
+use std::error::Error;
+use std::fmt;
+
+use codex_protocol::approvals::GuardianAssessmentAction;
+use codex_protocol::config_types::ApprovalsReviewer;
+use codex_protocol::protocol::AskForApproval;
+use codex_protocol::protocol::ReviewDecision;
+
+use crate::ExtensionData;
+
+/// Identifies the runtime that originated an approval-review request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApprovalReviewSource {
+    MainTurn,
+    DelegatedSubagent,
+}
+
+/// Structured input supplied to an approval-review extension.
+///
+/// The stores let an implementation retain private state at the matching
+/// lifetime without exposing host runtime objects.
+#[derive(Clone, Copy)]
+pub struct ApprovalReviewInput<'a> {
+    pub session_store: &'a ExtensionData,
+    pub thread_store: &'a ExtensionData,
+    pub turn_store: &'a ExtensionData,
+    pub review_id: &'a str,
+    pub turn_id: &'a str,
+    pub target_item_id: Option<&'a str>,
+    /// Bounded review prompt rendered by the host.
+    ///
+    /// The action is useful assessment metadata but does not yet carry all
+    /// details needed to reproduce the current review prompt.
+    pub prompt: &'a str,
+    pub action: &'a GuardianAssessmentAction,
+    pub reviewer: ApprovalsReviewer,
+    pub approval_policy: &'a AskForApproval,
+    pub retry_reason: Option<&'a str>,
+    pub source: ApprovalReviewSource,
+}
+
+/// Result of offering an approval request to one extension contributor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApprovalReviewOutcome {
+    /// The contributor does not own this request; dispatch should continue.
+    Abstain,
+    /// The contributor claims the request with an authoritative decision.
+    Decision(ReviewDecision),
+}
+
+/// Failure while an extension reviews an approval request.
+///
+/// The registry stops dispatch on errors so the host can fail closed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApprovalReviewError {
+    message: String,
+}
+
+impl ApprovalReviewError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for ApprovalReviewError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.message.fmt(formatter)
+    }
+}
+
+impl Error for ApprovalReviewError {}

--- a/codex-rs/ext/extension-api/src/contributors.rs
+++ b/codex-rs/ext/extension-api/src/contributors.rs
@@ -4,11 +4,13 @@ use std::sync::Arc;
 
 use codex_context_fragments::ContextualUserFragment;
 use codex_protocol::items::TurnItem;
-use codex_protocol::protocol::ReviewDecision;
 use codex_protocol::protocol::TokenUsageInfo;
 use codex_tools::ToolCall;
 use codex_tools::ToolExecutor;
 
+use crate::ApprovalReviewError;
+use crate::ApprovalReviewInput;
+use crate::ApprovalReviewOutcome;
 use crate::ExtensionData;
 
 mod mcp;
@@ -228,14 +230,16 @@ pub trait ToolLifecycleContributor: Send + Sync {
     }
 }
 
-/// Extension contribution that can claim rendered approval-review prompts.
+/// Extension contribution that can review structured approval requests.
+///
+/// Implementations should return [`ApprovalReviewOutcome::Abstain`] for
+/// requests they do not own. A claimed decision is authoritative, while an
+/// error must be treated as fail-closed by the host.
 pub trait ApprovalReviewContributor: Send + Sync {
-    fn contribute<'a>(
+    fn review<'a>(
         &'a self,
-        session_store: &'a ExtensionData,
-        thread_store: &'a ExtensionData,
-        prompt: &'a str,
-    ) -> ExtensionFuture<'a, Option<ReviewDecision>>;
+        input: ApprovalReviewInput<'a>,
+    ) -> ExtensionFuture<'a, Result<ApprovalReviewOutcome, ApprovalReviewError>>;
 }
 
 /// Ordered post-processing contribution for one parsed turn item.

--- a/codex-rs/ext/extension-api/src/lib.rs
+++ b/codex-rs/ext/extension-api/src/lib.rs
@@ -1,9 +1,14 @@
+mod approval_review;
 mod capabilities;
 mod contributors;
 mod registry;
 mod state;
 mod user_instructions;
 
+pub use approval_review::ApprovalReviewError;
+pub use approval_review::ApprovalReviewInput;
+pub use approval_review::ApprovalReviewOutcome;
+pub use approval_review::ApprovalReviewSource;
 pub use capabilities::AgentSpawnFuture;
 pub use capabilities::AgentSpawner;
 pub use capabilities::ExtensionEventSink;

--- a/codex-rs/ext/extension-api/src/registry.rs
+++ b/codex-rs/ext/extension-api/src/registry.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
-use codex_protocol::protocol::ReviewDecision;
-
 use crate::ApprovalReviewContributor;
+use crate::ApprovalReviewError;
+use crate::ApprovalReviewInput;
+use crate::ApprovalReviewOutcome;
 use crate::ConfigContributor;
 use crate::ContextContributor;
-use crate::ExtensionData;
 use crate::ExtensionEventSink;
 use crate::McpServerContributor;
 use crate::NoopExtensionEventSink;
@@ -190,24 +190,22 @@ impl<C: Sync> ExtensionRegistry<C> {
         &self.token_usage_contributors
     }
 
-    /// Claims the first rendered approval-review prompt accepted by an
-    /// installed contributor.
+    /// Returns the first non-abstaining approval-review contribution.
+    ///
+    /// Contributors run in registration order. Errors stop dispatch so the
+    /// host can fail closed instead of silently falling through.
     pub async fn approval_review(
         &self,
-        session_store: &ExtensionData,
-        thread_store: &ExtensionData,
-        prompt: &str,
-    ) -> Option<ReviewDecision> {
+        input: ApprovalReviewInput<'_>,
+    ) -> Result<ApprovalReviewOutcome, ApprovalReviewError> {
         for contributor in &self.approval_review_contributors {
-            if let Some(decision) = contributor
-                .contribute(session_store, thread_store, prompt)
-                .await
-            {
-                return Some(decision);
+            match contributor.review(input).await? {
+                ApprovalReviewOutcome::Abstain => {}
+                outcome @ ApprovalReviewOutcome::Decision(_) => return Ok(outcome),
             }
         }
 
-        None
+        Ok(ApprovalReviewOutcome::Abstain)
     }
 
     /// Returns the registered prompt contributors.

--- a/codex-rs/ext/extension-api/tests/registry.rs
+++ b/codex-rs/ext/extension-api/tests/registry.rs
@@ -2,6 +2,10 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use codex_extension_api::ApprovalReviewContributor;
+use codex_extension_api::ApprovalReviewError;
+use codex_extension_api::ApprovalReviewInput;
+use codex_extension_api::ApprovalReviewOutcome;
+use codex_extension_api::ApprovalReviewSource;
 use codex_extension_api::ConfigContributor;
 use codex_extension_api::ContextContributor;
 use codex_extension_api::ContextualUserFragment;
@@ -21,8 +25,11 @@ use codex_extension_api::TurnInputContributor;
 use codex_extension_api::TurnItemContributor;
 use codex_extension_api::TurnLifecycleContributor;
 use codex_extension_api::empty_extension_registry;
+use codex_protocol::approvals::GuardianAssessmentAction;
+use codex_protocol::config_types::ApprovalsReviewer;
 use codex_protocol::items::HookPromptItem;
 use codex_protocol::items::TurnItem;
+use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::Event;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::ReviewDecision;
@@ -92,15 +99,15 @@ impl TurnItemContributor for AllContributors {
 }
 
 impl ApprovalReviewContributor for AllContributors {
-    fn contribute<'a>(
+    fn review<'a>(
         &'a self,
-        _session_store: &'a ExtensionData,
-        _thread_store: &'a ExtensionData,
-        _prompt: &'a str,
-    ) -> ExtensionFuture<'a, Option<ReviewDecision>> {
+        _input: ApprovalReviewInput<'a>,
+    ) -> ExtensionFuture<'a, Result<ApprovalReviewOutcome, ApprovalReviewError>> {
         Box::pin(async move {
             let _self = self;
-            Some(ReviewDecision::ApprovedForSession)
+            Ok(ApprovalReviewOutcome::Decision(
+                ReviewDecision::ApprovedForSession,
+            ))
         })
     }
 }
@@ -132,13 +139,17 @@ async fn build_round_trips_every_contributor_category() {
     assert_eq!(registry.turn_item_contributors().len(), 1);
     assert_eq!(
         registry
-            .approval_review(
+            .approval_review(approval_review_input(
                 &ExtensionData::new("session"),
                 &ExtensionData::new("thread"),
-                "review this",
-            )
+                &ExtensionData::new("turn"),
+                &test_action(),
+                &AskForApproval::OnRequest,
+            ))
             .await,
-        Some(ReviewDecision::ApprovedForSession)
+        Ok(ApprovalReviewOutcome::Decision(
+            ReviewDecision::ApprovedForSession
+        ))
     );
 }
 
@@ -226,39 +237,85 @@ async fn contributors_preserve_registration_order() {
     );
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq)]
 struct ApprovalCall {
     contributor: &'static str,
     session_id: String,
     thread_id: String,
+    turn_store_id: String,
+    review_id: String,
+    turn_id: String,
+    target_item_id: Option<String>,
     prompt: String,
+    action: GuardianAssessmentAction,
+    reviewer: ApprovalsReviewer,
+    approval_policy: AskForApproval,
+    retry_reason: Option<String>,
+    source: ApprovalReviewSource,
 }
 
 struct RecordingApprovalContributor {
     name: &'static str,
-    decision: Option<ReviewDecision>,
+    result: Result<ApprovalReviewOutcome, ApprovalReviewError>,
     calls: Arc<Mutex<Vec<ApprovalCall>>>,
 }
 
 impl ApprovalReviewContributor for RecordingApprovalContributor {
-    fn contribute<'a>(
+    fn review<'a>(
         &'a self,
-        session_store: &'a ExtensionData,
-        thread_store: &'a ExtensionData,
-        prompt: &'a str,
-    ) -> ExtensionFuture<'a, Option<ReviewDecision>> {
+        input: ApprovalReviewInput<'a>,
+    ) -> ExtensionFuture<'a, Result<ApprovalReviewOutcome, ApprovalReviewError>> {
         Box::pin(async move {
             self.calls
                 .lock()
                 .unwrap_or_else(|error| panic!("approval calls lock poisoned: {error}"))
                 .push(ApprovalCall {
                     contributor: self.name,
-                    session_id: session_store.level_id().to_string(),
-                    thread_id: thread_store.level_id().to_string(),
-                    prompt: prompt.to_string(),
+                    session_id: input.session_store.level_id().to_string(),
+                    thread_id: input.thread_store.level_id().to_string(),
+                    turn_store_id: input.turn_store.level_id().to_string(),
+                    review_id: input.review_id.to_string(),
+                    turn_id: input.turn_id.to_string(),
+                    target_item_id: input.target_item_id.map(str::to_string),
+                    prompt: input.prompt.to_string(),
+                    action: input.action.clone(),
+                    reviewer: input.reviewer,
+                    approval_policy: input.approval_policy.clone(),
+                    retry_reason: input.retry_reason.map(str::to_string),
+                    source: input.source,
                 });
-            self.decision.clone()
+            self.result.clone()
         })
+    }
+}
+
+fn test_action() -> GuardianAssessmentAction {
+    GuardianAssessmentAction::RequestPermissions {
+        reason: Some("run delegated command".to_string()),
+        permissions: Default::default(),
+    }
+}
+
+fn approval_review_input<'a>(
+    session_store: &'a ExtensionData,
+    thread_store: &'a ExtensionData,
+    turn_store: &'a ExtensionData,
+    action: &'a GuardianAssessmentAction,
+    approval_policy: &'a AskForApproval,
+) -> ApprovalReviewInput<'a> {
+    ApprovalReviewInput {
+        session_store,
+        thread_store,
+        turn_store,
+        review_id: "review-1",
+        turn_id: "turn-1",
+        target_item_id: Some("item-1"),
+        prompt: "allow delegated command?",
+        action,
+        reviewer: ApprovalsReviewer::AutoReview,
+        approval_policy,
+        retry_reason: Some("initial review timed out"),
+        source: ApprovalReviewSource::DelegatedSubagent,
     }
 }
 
@@ -266,44 +323,109 @@ impl ApprovalReviewContributor for RecordingApprovalContributor {
 async fn approval_review_returns_first_claim_and_short_circuits() {
     let calls = Arc::new(Mutex::new(Vec::new()));
     let mut builder = ExtensionRegistryBuilder::<()>::new();
-    for (name, decision) in [
-        ("first", None),
-        ("second", Some(ReviewDecision::Approved)),
-        ("third", Some(ReviewDecision::Denied)),
+    for (name, result) in [
+        ("first", Ok(ApprovalReviewOutcome::Abstain)),
+        (
+            "second",
+            Ok(ApprovalReviewOutcome::Decision(ReviewDecision::Approved)),
+        ),
+        (
+            "third",
+            Ok(ApprovalReviewOutcome::Decision(ReviewDecision::Denied)),
+        ),
     ] {
         builder.approval_review_contributor(Arc::new(RecordingApprovalContributor {
             name,
-            decision,
+            result,
             calls: Arc::clone(&calls),
         }));
     }
     let registry = builder.build();
+    let session_store = ExtensionData::new("session-1");
+    let thread_store = ExtensionData::new("thread-1");
+    let turn_store = ExtensionData::new("turn-store-1");
+    let action = test_action();
+    let approval_policy = AskForApproval::OnRequest;
 
     let decision = registry
-        .approval_review(
-            &ExtensionData::new("session-1"),
-            &ExtensionData::new("thread-1"),
-            "allow command?",
-        )
+        .approval_review(approval_review_input(
+            &session_store,
+            &thread_store,
+            &turn_store,
+            &action,
+            &approval_policy,
+        ))
         .await;
 
-    assert_eq!(decision, Some(ReviewDecision::Approved));
+    assert_eq!(
+        decision,
+        Ok(ApprovalReviewOutcome::Decision(ReviewDecision::Approved))
+    );
+    let expected_call = |contributor| ApprovalCall {
+        contributor,
+        session_id: "session-1".to_string(),
+        thread_id: "thread-1".to_string(),
+        turn_store_id: "turn-store-1".to_string(),
+        review_id: "review-1".to_string(),
+        turn_id: "turn-1".to_string(),
+        target_item_id: Some("item-1".to_string()),
+        prompt: "allow delegated command?".to_string(),
+        action: action.clone(),
+        reviewer: ApprovalsReviewer::AutoReview,
+        approval_policy: AskForApproval::OnRequest,
+        retry_reason: Some("initial review timed out".to_string()),
+        source: ApprovalReviewSource::DelegatedSubagent,
+    };
     assert_eq!(
         calls.lock().expect("approval calls lock").as_slice(),
-        [
-            ApprovalCall {
-                contributor: "first",
-                session_id: "session-1".to_string(),
-                thread_id: "thread-1".to_string(),
-                prompt: "allow command?".to_string(),
-            },
-            ApprovalCall {
-                contributor: "second",
-                session_id: "session-1".to_string(),
-                thread_id: "thread-1".to_string(),
-                prompt: "allow command?".to_string(),
-            },
-        ]
+        [expected_call("first"), expected_call("second")]
+    );
+}
+
+#[tokio::test]
+async fn approval_review_error_stops_dispatch() {
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let mut builder = ExtensionRegistryBuilder::<()>::new();
+    for (name, result) in [
+        ("first", Ok(ApprovalReviewOutcome::Abstain)),
+        ("second", Err(ApprovalReviewError::new("review failed"))),
+        (
+            "third",
+            Ok(ApprovalReviewOutcome::Decision(ReviewDecision::Approved)),
+        ),
+    ] {
+        builder.approval_review_contributor(Arc::new(RecordingApprovalContributor {
+            name,
+            result,
+            calls: Arc::clone(&calls),
+        }));
+    }
+    let registry = builder.build();
+    let session_store = ExtensionData::new("session");
+    let thread_store = ExtensionData::new("thread");
+    let turn_store = ExtensionData::new("turn");
+    let action = test_action();
+    let approval_policy = AskForApproval::OnRequest;
+
+    let result = registry
+        .approval_review(approval_review_input(
+            &session_store,
+            &thread_store,
+            &turn_store,
+            &action,
+            &approval_policy,
+        ))
+        .await;
+
+    assert_eq!(result, Err(ApprovalReviewError::new("review failed")));
+    assert_eq!(
+        calls
+            .lock()
+            .expect("approval calls lock")
+            .iter()
+            .map(|call| call.contributor)
+            .collect::<Vec<_>>(),
+        ["first", "second"]
     );
 }
 
@@ -352,16 +474,23 @@ fn custom_event_sink_survives_registry_build() {
 #[tokio::test]
 async fn empty_registry_does_not_claim_approval_review() {
     let registry = empty_extension_registry::<()>();
+    let session_store = ExtensionData::new("session");
+    let thread_store = ExtensionData::new("thread");
+    let turn_store = ExtensionData::new("turn");
+    let action = test_action();
+    let approval_policy = AskForApproval::OnRequest;
 
     assert_eq!(
         registry
-            .approval_review(
-                &ExtensionData::new("session"),
-                &ExtensionData::new("thread"),
-                "unclaimed",
-            )
+            .approval_review(approval_review_input(
+                &session_store,
+                &thread_store,
+                &turn_store,
+                &action,
+                &approval_policy,
+            ))
             .await,
-        None
+        Ok(ApprovalReviewOutcome::Abstain)
     );
 }
 

--- a/codex-rs/ext/extension-api/tests/registry.rs
+++ b/codex-rs/ext/extension-api/tests/registry.rs
@@ -280,7 +280,7 @@ impl ApprovalReviewContributor for RecordingApprovalContributor {
                     prompt: input.prompt.to_string(),
                     action: input.action.clone(),
                     reviewer: input.reviewer,
-                    approval_policy: input.approval_policy.clone(),
+                    approval_policy: *input.approval_policy,
                     retry_reason: input.retry_reason.map(str::to_string),
                     source: input.source,
                 });


### PR DESCRIPTION
## Summary

- evolve `ApprovalReviewContributor` from a rendered-prompt callback into a structured review interface
- provide session, thread, and turn extension stores plus stable request metadata
- model abstention, authoritative decisions, and terminal contributor errors explicitly
- preserve the bounded host-rendered prompt while richer Guardian prompt inputs are extracted later in the stack

## Why

Guardian needs an extension-owned approval-review boundary before its routing and implementation can leave core. The previous `Option<ReviewDecision>` API did not expose turn state, request identity, reviewer selection, policy, source, or error semantics.

## Stack

- Depends on #27767

## Validation

- `just fmt`
- `just test -p codex-extension-api` (12 passed)
- `git diff --check`
