### PR TITLE
[codex] Dispatch normal approval reviews through extensions

### DIFF
--- a/codex-rs/core/src/guardian/mod.rs
+++ b/codex-rs/core/src/guardian/mod.rs
@@ -27,8 +27,12 @@ use serde::Serialize;
 pub(crate) use approval_request::GuardianApprovalRequest;
 pub(crate) use approval_request::GuardianMcpAnnotations;
 pub(crate) use approval_request::GuardianNetworkAccessTrigger;
+pub(crate) use approval_request::format_guardian_action_pretty;
 #[cfg(test)]
 pub(crate) use approval_request::guardian_approval_request_to_json;
+pub(crate) use approval_request::guardian_assessment_action;
+pub(crate) use approval_request::guardian_request_target_item_id;
+pub(crate) use approval_request::guardian_request_turn_id;
 pub(crate) use review::guardian_rejection_message;
 pub(crate) use review::guardian_timeout_message;
 pub(crate) use review::is_guardian_reviewer_source;
@@ -133,12 +137,6 @@ impl GuardianRejectionCircuitBreaker {
     }
 }
 
-#[cfg(test)]
-use approval_request::format_guardian_action_pretty;
-#[cfg(test)]
-use approval_request::guardian_assessment_action;
-#[cfg(test)]
-use approval_request::guardian_request_turn_id;
 #[cfg(test)]
 use prompt::GuardianPromptMode;
 #[cfg(test)]

--- a/codex-rs/core/src/tools/approval_dispatch.rs
+++ b/codex-rs/core/src/tools/approval_dispatch.rs
@@ -1,0 +1,164 @@
+//! Ordered approval dispatch for the normal orchestrated tool runtimes.
+
+use crate::guardian::format_guardian_action_pretty;
+use crate::guardian::guardian_assessment_action;
+use crate::guardian::guardian_request_target_item_id;
+use crate::guardian::guardian_request_turn_id;
+use crate::guardian::review_approval_request;
+use crate::hook_runtime::run_permission_request_hooks;
+use crate::tools::flat_tool_name;
+use crate::tools::sandboxing::ApprovalCtx;
+use crate::tools::sandboxing::ToolCtx;
+use crate::tools::sandboxing::ToolError;
+use crate::tools::sandboxing::ToolRuntime;
+use codex_extension_api::ApprovalReviewInput;
+use codex_extension_api::ApprovalReviewOutcome;
+use codex_extension_api::ApprovalReviewSource;
+use codex_hooks::PermissionRequestDecision;
+use codex_otel::ToolDecisionSource;
+use codex_protocol::protocol::ReviewDecision;
+
+pub(crate) async fn request_approval<Rq, Out, T>(
+    tool: &mut T,
+    req: &Rq,
+    permission_request_run_id: &str,
+    approval_ctx: ApprovalCtx<'_>,
+    tool_ctx: &ToolCtx,
+    evaluate_permission_request_hooks: bool,
+    otel: &codex_otel::SessionTelemetry,
+) -> Result<ReviewDecision, ToolError>
+where
+    T: ToolRuntime<Rq, Out>,
+{
+    let tool_name = flat_tool_name(&tool_ctx.tool_name);
+    if evaluate_permission_request_hooks
+        && let Some(permission_request) = tool.permission_request_payload(req)
+    {
+        match run_permission_request_hooks(
+            approval_ctx.session,
+            approval_ctx.turn,
+            permission_request_run_id,
+            permission_request,
+        )
+        .await
+        {
+            Some(PermissionRequestDecision::Allow) => {
+                let decision = ReviewDecision::Approved;
+                otel.tool_decision(
+                    tool_name.as_ref(),
+                    &tool_ctx.call_id,
+                    &decision,
+                    ToolDecisionSource::Config,
+                );
+                return Ok(decision);
+            }
+            Some(PermissionRequestDecision::Deny { message }) => {
+                let decision = ReviewDecision::Denied;
+                otel.tool_decision(
+                    tool_name.as_ref(),
+                    &tool_ctx.call_id,
+                    &decision,
+                    ToolDecisionSource::Config,
+                );
+                return Err(ToolError::Rejected(message));
+            }
+            None => {}
+        }
+    }
+
+    if let Some(review_id) = approval_ctx.guardian_review_id.clone() {
+        let request = tool
+            .guardian_approval_request(req, approval_ctx.call_id)
+            .ok_or_else(|| {
+                ToolError::Rejected(
+                    "automatic approval review is not supported for this tool".to_string(),
+                )
+            })?;
+        let action = guardian_assessment_action(&request);
+        let prompt = format_guardian_action_pretty(&request)
+            .map_err(|error| {
+                ToolError::Rejected(format!("failed to render review prompt: {error}"))
+            })?
+            .text;
+        let approval_policy = approval_ctx.turn.approval_policy.value();
+        let review_input = ApprovalReviewInput {
+            session_store: &approval_ctx.session.services.session_extension_data,
+            thread_store: &approval_ctx.session.services.thread_extension_data,
+            turn_store: approval_ctx.turn.extension_data.as_ref(),
+            review_id: &review_id,
+            turn_id: guardian_request_turn_id(&request, &approval_ctx.turn.sub_id),
+            target_item_id: guardian_request_target_item_id(&request),
+            prompt: &prompt,
+            action: &action,
+            reviewer: approval_ctx.turn.config.approvals_reviewer,
+            approval_policy: &approval_policy,
+            retry_reason: approval_ctx.retry_reason.as_deref(),
+            source: ApprovalReviewSource::MainTurn,
+        };
+
+        let decision = match approval_ctx
+            .session
+            .services
+            .extensions
+            .approval_review(review_input)
+            .await
+        {
+            Ok(ApprovalReviewOutcome::Decision {
+                decision,
+                denial_message,
+            }) => {
+                if matches!(decision, ReviewDecision::Denied | ReviewDecision::Abort) {
+                    let message = denial_message.unwrap_or_else(|| {
+                        "automatic approval reviewer denied the action".to_string()
+                    });
+                    otel.tool_decision(
+                        tool_name.as_ref(),
+                        &tool_ctx.call_id,
+                        &decision,
+                        ToolDecisionSource::AutomatedReviewer,
+                    );
+                    return Err(ToolError::Rejected(message));
+                }
+                decision
+            }
+            Ok(ApprovalReviewOutcome::Abstain) => {
+                review_approval_request(
+                    approval_ctx.session,
+                    approval_ctx.turn,
+                    review_id,
+                    request,
+                    approval_ctx.retry_reason,
+                )
+                .await
+            }
+            Err(error) => {
+                let decision = ReviewDecision::Denied;
+                otel.tool_decision(
+                    tool_name.as_ref(),
+                    &tool_ctx.call_id,
+                    &decision,
+                    ToolDecisionSource::AutomatedReviewer,
+                );
+                return Err(ToolError::Rejected(format!(
+                    "automatic approval review failed: {error}"
+                )));
+            }
+        };
+        otel.tool_decision(
+            tool_name.as_ref(),
+            &tool_ctx.call_id,
+            &decision,
+            ToolDecisionSource::AutomatedReviewer,
+        );
+        return Ok(decision);
+    }
+
+    let decision = tool.start_approval_async(req, approval_ctx).await;
+    otel.tool_decision(
+        tool_name.as_ref(),
+        &tool_ctx.call_id,
+        &decision,
+        ToolDecisionSource::User,
+    );
+    Ok(decision)
+}

--- a/codex-rs/core/src/tools/mod.rs
+++ b/codex-rs/core/src/tools/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod approval_dispatch;
 pub(crate) mod code_mode;
 pub(crate) mod context;
 pub(crate) mod events;

--- a/codex-rs/core/src/tools/orchestrator.rs
+++ b/codex-rs/core/src/tools/orchestrator.rs
@@ -10,8 +10,8 @@ use crate::guardian::guardian_rejection_message;
 use crate::guardian::guardian_timeout_message;
 use crate::guardian::new_guardian_review_id;
 use crate::guardian::routes_approval_to_guardian;
-use crate::hook_runtime::run_permission_request_hooks;
 use crate::network_policy_decision::network_approval_context_from_payload;
+use crate::tools::approval_dispatch::request_approval;
 use crate::tools::flat_tool_name;
 use crate::tools::network_approval::ActiveNetworkApproval;
 use crate::tools::network_approval::DeferredNetworkApproval;
@@ -29,7 +29,6 @@ use crate::tools::sandboxing::ToolRuntime;
 use crate::tools::sandboxing::default_exec_approval_requirement;
 use crate::tools::sandboxing::sandbox_override_for_first_attempt;
 use crate::tools::sandboxing::unsandboxed_execution_allowed;
-use codex_hooks::PermissionRequestDecision;
 use codex_otel::ToolDecisionSource;
 use codex_protocol::error::CodexErr;
 use codex_protocol::error::SandboxErr;
@@ -165,7 +164,7 @@ impl ToolOrchestrator {
                         retry_reason: None,
                         network_approval_context: None,
                     };
-                    let decision = Self::request_approval(
+                    let decision = request_approval(
                         tool,
                         req,
                         tool_ctx.call_id.as_str(),
@@ -200,7 +199,7 @@ impl ToolOrchestrator {
                     retry_reason: reason.clone(),
                     network_approval_context: None,
                 };
-                let decision = Self::request_approval(
+                let decision = request_approval(
                     tool,
                     req,
                     tool_ctx.call_id.as_str(),
@@ -382,7 +381,7 @@ impl ToolOrchestrator {
                     };
 
                     let permission_request_run_id = format!("{}:retry", tool_ctx.call_id);
-                    let decision = Self::request_approval(
+                    let decision = request_approval(
                         tool,
                         req,
                         &permission_request_run_id,
@@ -477,73 +476,6 @@ impl ToolOrchestrator {
                 Err(err)
             }
         }
-    }
-
-    // PermissionRequest hooks take top precedence for answering approval
-    // prompts. If no matching hook returns a decision, fall back to the
-    // normal guardian or user approval path.
-    async fn request_approval<Rq, Out, T>(
-        tool: &mut T,
-        req: &Rq,
-        permission_request_run_id: &str,
-        approval_ctx: ApprovalCtx<'_>,
-        tool_ctx: &ToolCtx,
-        evaluate_permission_request_hooks: bool,
-        otel: &codex_otel::SessionTelemetry,
-    ) -> Result<ReviewDecision, ToolError>
-    where
-        T: ToolRuntime<Rq, Out>,
-    {
-        if evaluate_permission_request_hooks
-            && let Some(permission_request) = tool.permission_request_payload(req)
-        {
-            let tool_name = flat_tool_name(&tool_ctx.tool_name);
-            match run_permission_request_hooks(
-                approval_ctx.session,
-                approval_ctx.turn,
-                permission_request_run_id,
-                permission_request,
-            )
-            .await
-            {
-                Some(PermissionRequestDecision::Allow) => {
-                    let decision = ReviewDecision::Approved;
-                    otel.tool_decision(
-                        tool_name.as_ref(),
-                        &tool_ctx.call_id,
-                        &decision,
-                        ToolDecisionSource::Config,
-                    );
-                    return Ok(decision);
-                }
-                Some(PermissionRequestDecision::Deny { message }) => {
-                    let decision = ReviewDecision::Denied;
-                    otel.tool_decision(
-                        tool_name.as_ref(),
-                        &tool_ctx.call_id,
-                        &decision,
-                        ToolDecisionSource::Config,
-                    );
-                    return Err(ToolError::Rejected(message));
-                }
-                None => {}
-            }
-        }
-
-        let otel_source = if approval_ctx.guardian_review_id.is_some() {
-            ToolDecisionSource::AutomatedReviewer
-        } else {
-            ToolDecisionSource::User
-        };
-        let decision = tool.start_approval_async(req, approval_ctx).await;
-        let tool_name = flat_tool_name(&tool_ctx.tool_name);
-        otel.tool_decision(
-            tool_name.as_ref(),
-            &tool_ctx.call_id,
-            &decision,
-            otel_source,
-        );
-        Ok(decision)
     }
 
     async fn reject_if_not_approved(

--- a/codex-rs/core/src/tools/runtimes/apply_patch.rs
+++ b/codex-rs/core/src/tools/runtimes/apply_patch.rs
@@ -5,7 +5,6 @@
 //! sandboxing enforced by the explicit filesystem sandbox context.
 use crate::exec::is_likely_sandbox_denied;
 use crate::guardian::GuardianApprovalRequest;
-use crate::guardian::review_approval_request;
 use crate::session::turn_context::TurnEnvironment;
 use crate::tools::hook_names::HookToolName;
 use crate::tools::sandboxing::Approvable;
@@ -129,6 +128,14 @@ impl Approvable<ApplyPatchRequest> for ApplyPatchRuntime {
             .collect()
     }
 
+    fn guardian_approval_request(
+        &self,
+        req: &ApplyPatchRequest,
+        call_id: &str,
+    ) -> Option<GuardianApprovalRequest> {
+        Some(Self::build_guardian_review_request(req, call_id))
+    }
+
     fn start_approval_async<'a>(
         &'a mut self,
         req: &'a ApplyPatchRequest,
@@ -140,13 +147,7 @@ impl Approvable<ApplyPatchRequest> for ApplyPatchRuntime {
         let retry_reason = ctx.retry_reason.clone();
         let approval_keys = self.approval_keys(req);
         let changes = req.changes.clone();
-        let guardian_review_id = ctx.guardian_review_id.clone();
         Box::pin(async move {
-            if let Some(review_id) = guardian_review_id {
-                let action = ApplyPatchRuntime::build_guardian_review_request(req, ctx.call_id);
-                return review_approval_request(session, turn, review_id, action, retry_reason)
-                    .await;
-            }
             if req.permissions_preapproved && retry_reason.is_none() {
                 return ReviewDecision::Approved;
             }

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -12,7 +12,6 @@ use crate::command_canonicalization::canonicalize_command_for_approval;
 use crate::exec::ExecCapturePolicy;
 use crate::guardian::GuardianApprovalRequest;
 use crate::guardian::GuardianNetworkAccessTrigger;
-use crate::guardian::review_approval_request;
 use crate::sandboxing::ExecOptions;
 use crate::sandboxing::SandboxPermissions;
 use crate::sandboxing::execute_env;
@@ -140,30 +139,14 @@ impl Approvable<ShellRequest> for ShellRuntime {
         let keys = self.approval_keys(req);
         let command = req.command.clone();
         let cwd = req.cwd.clone();
-        let retry_reason = ctx.retry_reason.clone();
-        let reason = retry_reason.clone().or_else(|| req.justification.clone());
+        let reason = ctx
+            .retry_reason
+            .clone()
+            .or_else(|| req.justification.clone());
         let session = ctx.session;
         let turn = ctx.turn;
         let call_id = ctx.call_id.to_string();
-        let guardian_review_id = ctx.guardian_review_id.clone();
         Box::pin(async move {
-            if let Some(review_id) = guardian_review_id {
-                return review_approval_request(
-                    session,
-                    turn,
-                    review_id,
-                    GuardianApprovalRequest::Shell {
-                        id: call_id,
-                        command,
-                        cwd: cwd.clone(),
-                        sandbox_permissions: req.sandbox_permissions,
-                        additional_permissions: req.additional_permissions.clone(),
-                        justification: req.justification.clone(),
-                    },
-                    retry_reason,
-                )
-                .await;
-            }
             with_cached_approval(&session.services, "shell", keys, move || async move {
                 let available_decisions = None;
                 session
@@ -196,6 +179,21 @@ impl Approvable<ShellRequest> for ShellRuntime {
             req.hook_command.clone(),
             req.justification.clone(),
         ))
+    }
+
+    fn guardian_approval_request(
+        &self,
+        req: &ShellRequest,
+        call_id: &str,
+    ) -> Option<GuardianApprovalRequest> {
+        Some(GuardianApprovalRequest::Shell {
+            id: call_id.to_string(),
+            command: req.command.clone(),
+            cwd: req.cwd.clone(),
+            sandbox_permissions: req.sandbox_permissions,
+            additional_permissions: req.additional_permissions.clone(),
+            justification: req.justification.clone(),
+        })
     }
 
     fn sandbox_permissions(&self, req: &ShellRequest) -> SandboxPermissions {

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -9,7 +9,6 @@ use crate::exec::ExecCapturePolicy;
 use crate::exec::ExecExpiration;
 use crate::guardian::GuardianApprovalRequest;
 use crate::guardian::GuardianNetworkAccessTrigger;
-use crate::guardian::review_approval_request;
 use crate::sandboxing::ExecOptions;
 use crate::sandboxing::ExecServerEnvConfig;
 use crate::sandboxing::SandboxPermissions;
@@ -155,28 +154,11 @@ impl Approvable<UnifiedExecRequest> for UnifiedExecRuntime<'_> {
         let call_id = ctx.call_id.to_string();
         let command = req.command.clone();
         let cwd = req.cwd.clone();
-        let retry_reason = ctx.retry_reason.clone();
-        let reason = retry_reason.clone().or_else(|| req.justification.clone());
-        let guardian_review_id = ctx.guardian_review_id.clone();
+        let reason = ctx
+            .retry_reason
+            .clone()
+            .or_else(|| req.justification.clone());
         Box::pin(async move {
-            if let Some(review_id) = guardian_review_id {
-                return review_approval_request(
-                    session,
-                    turn,
-                    review_id,
-                    GuardianApprovalRequest::ExecCommand {
-                        id: call_id,
-                        command,
-                        cwd: cwd.clone(),
-                        sandbox_permissions: req.sandbox_permissions,
-                        additional_permissions: req.additional_permissions.clone(),
-                        justification: req.justification.clone(),
-                        tty: req.tty,
-                    },
-                    retry_reason,
-                )
-                .await;
-            }
             with_cached_approval(&session.services, "unified_exec", keys, || async move {
                 let available_decisions = None;
                 session
@@ -215,6 +197,22 @@ impl Approvable<UnifiedExecRequest> for UnifiedExecRuntime<'_> {
             req.hook_command.clone(),
             req.justification.clone(),
         ))
+    }
+
+    fn guardian_approval_request(
+        &self,
+        req: &UnifiedExecRequest,
+        call_id: &str,
+    ) -> Option<GuardianApprovalRequest> {
+        Some(GuardianApprovalRequest::ExecCommand {
+            id: call_id.to_string(),
+            command: req.command.clone(),
+            cwd: req.cwd.clone(),
+            sandbox_permissions: req.sandbox_permissions,
+            additional_permissions: req.additional_permissions.clone(),
+            justification: req.justification.clone(),
+            tty: req.tty,
+        })
     }
 
     fn sandbox_permissions(&self, req: &UnifiedExecRequest) -> SandboxPermissions {

--- a/codex-rs/core/src/tools/sandboxing.rs
+++ b/codex-rs/core/src/tools/sandboxing.rs
@@ -351,6 +351,16 @@ pub(crate) trait Approvable<Req> {
         None
     }
 
+    /// Builds the legacy core Guardian request while auto-review migrates to
+    /// an extension-owned implementation.
+    fn guardian_approval_request(
+        &self,
+        _req: &Req,
+        _call_id: &str,
+    ) -> Option<crate::guardian::GuardianApprovalRequest> {
+        None
+    }
+
     /// Decide we can request an approval for no-sandbox execution.
     fn wants_no_sandbox_approval(&self, policy: AskForApproval) -> bool {
         match policy {

--- a/codex-rs/core/tests/suite/guardian_review.rs
+++ b/codex-rs/core/tests/suite/guardian_review.rs
@@ -1,8 +1,15 @@
 #![cfg(not(target_os = "windows"))]
 
 use anyhow::Result;
+use codex_core::config::Config;
 use codex_core::config::Constrained;
 use codex_core::sandboxing::SandboxPermissions;
+use codex_extension_api::ApprovalReviewContributor;
+use codex_extension_api::ApprovalReviewError;
+use codex_extension_api::ApprovalReviewInput;
+use codex_extension_api::ApprovalReviewOutcome;
+use codex_extension_api::ExtensionFuture;
+use codex_extension_api::ExtensionRegistryBuilder;
 use codex_protocol::config_types::ApprovalsReviewer;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
@@ -27,8 +34,22 @@ use serde_json::Value;
 use serde_json::json;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
+use std::sync::Arc;
 use std::time::Duration;
 use tempfile::TempDir;
+
+struct DenyingApprovalReviewContributor {
+    rationale: String,
+}
+
+impl ApprovalReviewContributor for DenyingApprovalReviewContributor {
+    fn review<'a>(
+        &'a self,
+        _input: ApprovalReviewInput<'a>,
+    ) -> ExtensionFuture<'a, std::result::Result<ApprovalReviewOutcome, ApprovalReviewError>> {
+        Box::pin(async move { Ok(ApprovalReviewOutcome::denied(self.rationale.clone())) })
+    }
+}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn guardian_review_session_does_not_inherit_legacy_notify() -> Result<()> {
@@ -258,6 +279,85 @@ async fn auto_review_denial_blocks_escalated_command_and_returns_rationale() -> 
         !output_file.exists(),
         "auto-review denial should prevent command execution"
     );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approval_review_extension_denial_precedes_core_guardian_and_preserves_rationale()
+-> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let output_dir = TempDir::new()?;
+    let output_file = output_dir.path().join("extension-review-denied.txt");
+    let command = format!("printf denied > {}", output_file.display());
+    let call_id = "extension-review-denied-command";
+    let rationale = "The installed approval reviewer denied this exact command.";
+    let tool_args = json!({
+        "cmd": command,
+        "yield_time_ms": 1_000_u64,
+        "sandbox_permissions": SandboxPermissions::RequireEscalated,
+        "justification": "Exercise extension approval review.",
+    });
+    let responses = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-parent-tool"),
+                ev_function_call(call_id, "exec_command", &serde_json::to_string(&tool_args)?),
+                ev_completed("resp-parent-tool"),
+            ]),
+            sse(vec![
+                ev_response_created("resp-parent-done"),
+                ev_assistant_message("msg-parent-done", "done"),
+                ev_completed("resp-parent-done"),
+            ]),
+        ],
+    )
+    .await;
+
+    let mut extension_builder = ExtensionRegistryBuilder::<Config>::new();
+    extension_builder.approval_review_contributor(Arc::new(DenyingApprovalReviewContributor {
+        rationale: rationale.to_string(),
+    }));
+    let mut builder = test_codex().with_extensions(Arc::new(extension_builder.build()));
+    let test = builder.build(&server).await?;
+    test.codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "run a command that the extension reviewer should deny".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: codex_protocol::protocol::ThreadSettingsOverrides {
+                environments: Some(local_selections(test.config.cwd.clone())),
+                approval_policy: Some(AskForApproval::OnRequest),
+                approvals_reviewer: Some(ApprovalsReviewer::AutoReview),
+                sandbox_policy: Some(SandboxPolicy::WorkspaceWrite {
+                    writable_roots: vec![],
+                    network_access: false,
+                    exclude_tmpdir_env_var: true,
+                    exclude_slash_tmp: true,
+                }),
+                ..Default::default()
+            },
+        })
+        .await?;
+    wait_for_event(&test.codex, |event| {
+        matches!(event, EventMsg::TurnComplete(_))
+    })
+    .await;
+
+    let requests = responses.requests();
+    assert_eq!(requests.len(), 2, "core Guardian should not run");
+    let output = requests[1]
+        .function_call_output_text(call_id)
+        .expect("parent continuation should receive the denied tool output");
+    assert!(output.contains(rationale));
+    assert!(!output_file.exists());
 
     Ok(())
 }

--- a/codex-rs/ext/extension-api/src/approval_review.rs
+++ b/codex-rs/ext/extension-api/src/approval_review.rs
@@ -45,7 +45,29 @@ pub enum ApprovalReviewOutcome {
     /// The contributor does not own this request; dispatch should continue.
     Abstain,
     /// The contributor claims the request with an authoritative decision.
-    Decision(ReviewDecision),
+    Decision {
+        decision: ReviewDecision,
+        /// Contributor-owned rationale to return when the decision rejects the request.
+        denial_message: Option<String>,
+    },
+}
+
+impl ApprovalReviewOutcome {
+    /// Claims the request with a decision that does not need a denial rationale.
+    pub fn decision(decision: ReviewDecision) -> Self {
+        Self::Decision {
+            decision,
+            denial_message: None,
+        }
+    }
+
+    /// Denies the request with a contributor-owned rationale for the caller.
+    pub fn denied(message: impl Into<String>) -> Self {
+        Self::Decision {
+            decision: ReviewDecision::Denied,
+            denial_message: Some(message.into()),
+        }
+    }
 }
 
 /// Failure while an extension reviews an approval request.

--- a/codex-rs/ext/extension-api/src/registry.rs
+++ b/codex-rs/ext/extension-api/src/registry.rs
@@ -201,7 +201,7 @@ impl<C: Sync> ExtensionRegistry<C> {
         for contributor in &self.approval_review_contributors {
             match contributor.review(input).await? {
                 ApprovalReviewOutcome::Abstain => {}
-                outcome @ ApprovalReviewOutcome::Decision(_) => return Ok(outcome),
+                outcome @ ApprovalReviewOutcome::Decision { .. } => return Ok(outcome),
             }
         }
 

--- a/codex-rs/ext/extension-api/tests/registry.rs
+++ b/codex-rs/ext/extension-api/tests/registry.rs
@@ -105,7 +105,7 @@ impl ApprovalReviewContributor for AllContributors {
     ) -> ExtensionFuture<'a, Result<ApprovalReviewOutcome, ApprovalReviewError>> {
         Box::pin(async move {
             let _self = self;
-            Ok(ApprovalReviewOutcome::Decision(
+            Ok(ApprovalReviewOutcome::decision(
                 ReviewDecision::ApprovedForSession,
             ))
         })
@@ -147,7 +147,7 @@ async fn build_round_trips_every_contributor_category() {
                 &AskForApproval::OnRequest,
             ))
             .await,
-        Ok(ApprovalReviewOutcome::Decision(
+        Ok(ApprovalReviewOutcome::decision(
             ReviewDecision::ApprovedForSession
         ))
     );
@@ -327,11 +327,11 @@ async fn approval_review_returns_first_claim_and_short_circuits() {
         ("first", Ok(ApprovalReviewOutcome::Abstain)),
         (
             "second",
-            Ok(ApprovalReviewOutcome::Decision(ReviewDecision::Approved)),
+            Ok(ApprovalReviewOutcome::decision(ReviewDecision::Approved)),
         ),
         (
             "third",
-            Ok(ApprovalReviewOutcome::Decision(ReviewDecision::Denied)),
+            Ok(ApprovalReviewOutcome::decision(ReviewDecision::Denied)),
         ),
     ] {
         builder.approval_review_contributor(Arc::new(RecordingApprovalContributor {
@@ -359,7 +359,7 @@ async fn approval_review_returns_first_claim_and_short_circuits() {
 
     assert_eq!(
         decision,
-        Ok(ApprovalReviewOutcome::Decision(ReviewDecision::Approved))
+        Ok(ApprovalReviewOutcome::decision(ReviewDecision::Approved))
     );
     let expected_call = |contributor| ApprovalCall {
         contributor,
@@ -391,7 +391,7 @@ async fn approval_review_error_stops_dispatch() {
         ("second", Err(ApprovalReviewError::new("review failed"))),
         (
             "third",
-            Ok(ApprovalReviewOutcome::Decision(ReviewDecision::Approved)),
+            Ok(ApprovalReviewOutcome::decision(ReviewDecision::Approved)),
         ),
     ] {
         builder.approval_review_contributor(Arc::new(RecordingApprovalContributor {


### PR DESCRIPTION
## Summary

- centralize normal shell, unified-exec, and apply-patch approval dispatch in a dedicated module
- preserve ordering: configured `PermissionRequest` hooks, installed approval-review contributors, core Guardian fallback, then user approval
- make the three runtimes' approval methods user-only and move Guardian request construction to the temporary migration seam
- preserve contributor-owned denial rationales and fail closed on contributor errors

## Why

Approval routing was split between the orchestrator and individual runtimes, which prevented an extension from owning auto-review consistently. This creates the central seam while retaining the current core Guardian implementation as a behavior-preserving fallback.

## Stack

- Depends on #27769
- Base characterization: #27767

## Validation

- `just test -p codex-extension-api` (12 passed)
- targeted approval-review extension denial integration test (passed)
- `just test -p codex-core permission_request_hook_` (10 passed)
- Guardian review group: 43 passed; one unrelated sandbox mock-server bind test failed with `Operation not permitted`
- `just fix -p codex-core`
- `git diff --check`
