### PR TITLE
[codex] Dispatch network approval reviews through extensions

### DIFF
--- a/codex-rs/core/src/tools/approval_dispatch.rs
+++ b/codex-rs/core/src/tools/approval_dispatch.rs
@@ -1,9 +1,12 @@
 //! Ordered approval dispatch for the normal orchestrated tool runtimes.
 
+use crate::guardian::GuardianApprovalRequest;
 use crate::guardian::format_guardian_action_pretty;
 use crate::guardian::guardian_assessment_action;
+use crate::guardian::guardian_rejection_message;
 use crate::guardian::guardian_request_target_item_id;
 use crate::guardian::guardian_request_turn_id;
+use crate::guardian::guardian_timeout_message;
 use crate::guardian::review_approval_request;
 use crate::hook_runtime::run_permission_request_hooks;
 use crate::tools::flat_tool_name;
@@ -17,6 +20,101 @@ use codex_extension_api::ApprovalReviewSource;
 use codex_hooks::PermissionRequestDecision;
 use codex_otel::ToolDecisionSource;
 use codex_protocol::protocol::ReviewDecision;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum AutomatedApprovalSource {
+    Extension,
+    ExtensionError,
+    Guardian,
+}
+
+#[derive(Debug)]
+pub(crate) struct AutomatedApprovalDecision {
+    pub decision: ReviewDecision,
+    pub denial_message: Option<String>,
+    pub source: AutomatedApprovalSource,
+}
+
+impl AutomatedApprovalDecision {
+    pub(crate) fn denial_message(&self) -> String {
+        self.denial_message
+            .clone()
+            .unwrap_or_else(|| match self.source {
+                AutomatedApprovalSource::Extension => {
+                    "automatic approval reviewer denied the action".to_string()
+                }
+                AutomatedApprovalSource::ExtensionError => {
+                    "automatic approval review failed".to_string()
+                }
+                AutomatedApprovalSource::Guardian => "Guardian denied this request.".to_string(),
+            })
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn request_automated_approval(
+    session: &std::sync::Arc<crate::session::session::Session>,
+    turn: &std::sync::Arc<crate::session::turn_context::TurnContext>,
+    review_id: String,
+    request: GuardianApprovalRequest,
+    reviewer: codex_protocol::config_types::ApprovalsReviewer,
+    retry_reason: Option<String>,
+    source: ApprovalReviewSource,
+) -> Result<AutomatedApprovalDecision, String> {
+    let action = guardian_assessment_action(&request);
+    let prompt = format_guardian_action_pretty(&request)
+        .map_err(|error| format!("failed to render review prompt: {error}"))?
+        .text;
+    let approval_policy = turn.approval_policy.value();
+    let review_input = ApprovalReviewInput {
+        session_store: &session.services.session_extension_data,
+        thread_store: &session.services.thread_extension_data,
+        turn_store: turn.extension_data.as_ref(),
+        review_id: &review_id,
+        turn_id: guardian_request_turn_id(&request, &turn.sub_id),
+        target_item_id: guardian_request_target_item_id(&request),
+        prompt: &prompt,
+        action: &action,
+        reviewer,
+        approval_policy: &approval_policy,
+        retry_reason: retry_reason.as_deref(),
+        source,
+    };
+
+    match session
+        .services
+        .extensions
+        .approval_review(review_input)
+        .await
+    {
+        Ok(ApprovalReviewOutcome::Decision {
+            decision,
+            denial_message,
+        }) => Ok(AutomatedApprovalDecision {
+            decision,
+            denial_message,
+            source: AutomatedApprovalSource::Extension,
+        }),
+        Ok(ApprovalReviewOutcome::Abstain) => {
+            let decision =
+                review_approval_request(session, turn, review_id.clone(), request, retry_reason)
+                    .await;
+            let denial_message = match decision {
+                ReviewDecision::Denied | ReviewDecision::Abort => {
+                    Some(guardian_rejection_message(session, &review_id).await)
+                }
+                ReviewDecision::TimedOut => Some(guardian_timeout_message()),
+                _ => None,
+            };
+            Ok(AutomatedApprovalDecision {
+                decision,
+                denial_message,
+                source: AutomatedApprovalSource::Guardian,
+            })
+        }
+        Err(error) => Err(format!("automatic approval review failed: {error}")),
+    }
+}
 
 pub(crate) async fn request_approval<Rq, Out, T>(
     tool: &mut T,
@@ -74,82 +172,45 @@ where
                     "automatic approval review is not supported for this tool".to_string(),
                 )
             })?;
-        let action = guardian_assessment_action(&request);
-        let prompt = format_guardian_action_pretty(&request)
-            .map_err(|error| {
-                ToolError::Rejected(format!("failed to render review prompt: {error}"))
-            })?
-            .text;
-        let approval_policy = approval_ctx.turn.approval_policy.value();
-        let review_input = ApprovalReviewInput {
-            session_store: &approval_ctx.session.services.session_extension_data,
-            thread_store: &approval_ctx.session.services.thread_extension_data,
-            turn_store: approval_ctx.turn.extension_data.as_ref(),
-            review_id: &review_id,
-            turn_id: guardian_request_turn_id(&request, &approval_ctx.turn.sub_id),
-            target_item_id: guardian_request_target_item_id(&request),
-            prompt: &prompt,
-            action: &action,
-            reviewer: approval_ctx.turn.config.approvals_reviewer,
-            approval_policy: &approval_policy,
-            retry_reason: approval_ctx.retry_reason.as_deref(),
-            source: ApprovalReviewSource::MainTurn,
-        };
-
-        let decision = match approval_ctx
-            .session
-            .services
-            .extensions
-            .approval_review(review_input)
-            .await
+        let automated = match request_automated_approval(
+            approval_ctx.session,
+            approval_ctx.turn,
+            review_id,
+            request,
+            approval_ctx.turn.config.approvals_reviewer,
+            approval_ctx.retry_reason,
+            ApprovalReviewSource::MainTurn,
+        )
+        .await
         {
-            Ok(ApprovalReviewOutcome::Decision {
-                decision,
-                denial_message,
-            }) => {
-                if matches!(decision, ReviewDecision::Denied | ReviewDecision::Abort) {
-                    let message = denial_message.unwrap_or_else(|| {
-                        "automatic approval reviewer denied the action".to_string()
-                    });
-                    otel.tool_decision(
-                        tool_name.as_ref(),
-                        &tool_ctx.call_id,
-                        &decision,
-                        ToolDecisionSource::AutomatedReviewer,
-                    );
-                    return Err(ToolError::Rejected(message));
-                }
-                decision
-            }
-            Ok(ApprovalReviewOutcome::Abstain) => {
-                review_approval_request(
-                    approval_ctx.session,
-                    approval_ctx.turn,
-                    review_id,
-                    request,
-                    approval_ctx.retry_reason,
-                )
-                .await
-            }
-            Err(error) => {
-                let decision = ReviewDecision::Denied;
+            Ok(automated) => automated,
+            Err(message) => {
                 otel.tool_decision(
                     tool_name.as_ref(),
                     &tool_ctx.call_id,
-                    &decision,
+                    &ReviewDecision::Denied,
                     ToolDecisionSource::AutomatedReviewer,
                 );
-                return Err(ToolError::Rejected(format!(
-                    "automatic approval review failed: {error}"
-                )));
+                return Err(ToolError::Rejected(message));
             }
         };
+        let decision = automated.decision.clone();
         otel.tool_decision(
             tool_name.as_ref(),
             &tool_ctx.call_id,
             &decision,
             ToolDecisionSource::AutomatedReviewer,
         );
+        if matches!(decision, ReviewDecision::Denied | ReviewDecision::Abort) {
+            return Err(ToolError::Rejected(automated.denial_message()));
+        }
+        if decision == ReviewDecision::TimedOut {
+            return Err(ToolError::Rejected(
+                automated
+                    .denial_message
+                    .unwrap_or_else(guardian_timeout_message),
+            ));
+        }
         return Ok(decision);
     }
 

--- a/codex-rs/core/src/tools/network_approval.rs
+++ b/codex-rs/core/src/tools/network_approval.rs
@@ -1,15 +1,15 @@
 use crate::guardian::GuardianApprovalRequest;
 use crate::guardian::GuardianNetworkAccessTrigger;
-use crate::guardian::guardian_rejection_message;
-use crate::guardian::guardian_timeout_message;
 use crate::guardian::new_guardian_review_id;
-use crate::guardian::review_approval_request;
 use crate::guardian::routes_approval_to_guardian;
 use crate::hook_runtime::run_permission_request_hooks;
 use crate::network_policy_decision::denied_network_policy_message;
 use crate::session::session::Session;
+use crate::tools::approval_dispatch::AutomatedApprovalDecision;
+use crate::tools::approval_dispatch::request_automated_approval;
 use crate::tools::sandboxing::PermissionRequestPayload;
 use crate::tools::sandboxing::ToolError;
+use codex_extension_api::ApprovalReviewSource;
 use codex_hooks::PermissionRequestDecision;
 use codex_network_proxy::BlockedRequest;
 use codex_network_proxy::BlockedRequestObserver;
@@ -155,6 +155,10 @@ enum PendingApprovalDecision {
 enum NetworkApprovalOutcome {
     DeniedByUser,
     DeniedByPolicy(String),
+}
+
+fn automated_network_denial(approval: &AutomatedApprovalDecision) -> NetworkApprovalOutcome {
+    NetworkApprovalOutcome::DeniedByPolicy(approval.denial_message())
 }
 
 fn network_approval_outcome_to_result(
@@ -498,25 +502,41 @@ impl NetworkApprovalService {
         }
         let use_guardian = routes_approval_to_guardian(&turn_context);
         let guardian_review_id = use_guardian.then(new_guardian_review_id);
-        let approval_decision = if let Some(review_id) = guardian_review_id.clone() {
-            review_approval_request(
-                &session,
-                &turn_context,
-                review_id,
-                GuardianApprovalRequest::NetworkAccess {
-                    id: guardian_approval_id.clone(),
-                    turn_id: owner_call
-                        .as_ref()
-                        .map_or_else(|| turn_context.sub_id.clone(), |call| call.turn_id.clone()),
-                    target,
-                    host: request.host,
-                    protocol,
-                    port: key.port,
-                    trigger: owner_call.as_ref().map(|call| call.trigger.clone()),
-                },
-                Some(policy_denial_message.clone()),
+        let automated_approval = if let Some(review_id) = guardian_review_id.clone() {
+            let request = GuardianApprovalRequest::NetworkAccess {
+                id: guardian_approval_id.clone(),
+                turn_id: owner_call
+                    .as_ref()
+                    .map_or_else(|| turn_context.sub_id.clone(), |call| call.turn_id.clone()),
+                target,
+                host: request.host,
+                protocol,
+                port: key.port,
+                trigger: owner_call.as_ref().map(|call| call.trigger.clone()),
+            };
+            Some(
+                request_automated_approval(
+                    &session,
+                    &turn_context,
+                    review_id,
+                    request,
+                    turn_context.config.approvals_reviewer,
+                    Some(policy_denial_message.clone()),
+                    ApprovalReviewSource::MainTurn,
+                )
+                .await
+                .unwrap_or_else(|message| AutomatedApprovalDecision {
+                    decision: ReviewDecision::Denied,
+                    denial_message: Some(message),
+                    source:
+                        crate::tools::approval_dispatch::AutomatedApprovalSource::ExtensionError,
+                }),
             )
-            .await
+        } else {
+            None
+        };
+        let approval_decision = if let Some(automated) = automated_approval.as_ref() {
+            automated.decision.clone()
         } else {
             let available_decisions = None;
             session
@@ -615,12 +635,11 @@ impl NetworkApprovalService {
                 }
             },
             ReviewDecision::Denied | ReviewDecision::Abort => {
-                if let Some(review_id) = guardian_review_id.as_deref() {
+                if let Some(automated) = automated_approval.as_ref() {
                     if let Some(owner_call) = owner_call.as_ref() {
-                        let message = guardian_rejection_message(session.as_ref(), review_id).await;
                         self.record_call_outcome(
                             &owner_call.registration_id,
-                            NetworkApprovalOutcome::DeniedByPolicy(message),
+                            automated_network_denial(automated),
                         )
                         .await;
                     }
@@ -637,7 +656,14 @@ impl NetworkApprovalService {
                 if let Some(owner_call) = owner_call.as_ref() {
                     self.record_call_outcome(
                         &owner_call.registration_id,
-                        NetworkApprovalOutcome::DeniedByPolicy(guardian_timeout_message()),
+                        automated_approval.as_ref().map_or_else(
+                            || {
+                                NetworkApprovalOutcome::DeniedByPolicy(
+                                    "automatic approval review timed out".to_string(),
+                                )
+                            },
+                            automated_network_denial,
+                        ),
                     )
                     .await;
                 }

--- a/codex-rs/core/src/tools/network_approval_tests.rs
+++ b/codex-rs/core/src/tools/network_approval_tests.rs
@@ -178,6 +178,21 @@ fn allow_once_and_allow_for_session_both_allow_network() {
 }
 
 #[test]
+fn automated_network_denial_preserves_extension_rationale() {
+    let rationale = "the requested host is unrelated to the user's task";
+    let approval = AutomatedApprovalDecision {
+        decision: ReviewDecision::Denied,
+        denial_message: Some(rationale.to_string()),
+        source: crate::tools::approval_dispatch::AutomatedApprovalSource::Extension,
+    };
+
+    assert_eq!(
+        automated_network_denial(&approval),
+        NetworkApprovalOutcome::DeniedByPolicy(rationale.to_string())
+    );
+}
+
+#[test]
 fn only_never_policy_disables_network_approval_flow() {
     assert!(!allows_network_approval_flow(AskForApproval::Never));
     assert!(allows_network_approval_flow(AskForApproval::OnRequest));


### PR DESCRIPTION
## Summary

- route network auto-review through the reusable approval-review extension dispatcher
- preserve existing command-hook precedence and user fallback
- retain network host caching, policy amendment persistence, and approval outcome accounting
- carry exact extension or Guardian denial rationale through network policy outcomes

## Why

Network approval had its own direct Guardian branch outside the normal tool orchestrator. Moving its automated stage onto the shared dispatcher removes another core-specific routing path without mixing network-specific caching and amendment behavior into the generic dispatcher.

## Stack

- Depends on #27770
- Earlier: #27769, #27767

## Validation

- `just test -p codex-core network_approval --no-capture` (20 passed; sandbox-only integrations skipped)
- focused automated network denial rationale test (passed)
- Guardian review selection: 44 passed; one unrelated sandbox mock-server bind failure
- `just fix -p codex-core`
- `git diff --check`
