### PR TITLE
[codex] Remove the Guardian extension core dependency

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -3069,7 +3069,6 @@ dependencies = [
 name = "codex-guardian"
 version = "0.0.0"
 dependencies = [
- "codex-core",
  "codex-extension-api",
  "codex-protocol",
 ]

--- a/codex-rs/ext/guardian/Cargo.toml
+++ b/codex-rs/ext/guardian/Cargo.toml
@@ -14,6 +14,5 @@ doctest = false
 workspace = true
 
 [dependencies]
-codex-core = { workspace = true }
 codex-extension-api = { workspace = true }
 codex-protocol = { workspace = true }

--- a/codex-rs/ext/guardian/src/lib.rs
+++ b/codex-rs/ext/guardian/src/lib.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use codex_core::config::Config;
 use codex_extension_api::AgentSpawnFuture;
 use codex_extension_api::AgentSpawner;
 use codex_extension_api::ApprovalReviewContributor;
@@ -53,14 +52,12 @@ impl GuardianThreadContext {
     }
 }
 
-impl<S> ThreadLifecycleContributor<Config> for GuardianExtension<S>
+impl<C, S> ThreadLifecycleContributor<C> for GuardianExtension<S>
 where
+    C: Sync,
     S: Send + Sync,
 {
-    fn on_thread_start<'a>(
-        &'a self,
-        input: ThreadStartInput<'a, Config>,
-    ) -> ExtensionFuture<'a, ()> {
+    fn on_thread_start<'a>(&'a self, input: ThreadStartInput<'a, C>) -> ExtensionFuture<'a, ()> {
         Box::pin(async move {
             let Ok(forked_from_thread_id) = ThreadId::from_string(input.thread_store.level_id())
             else {
@@ -97,8 +94,9 @@ where
 }
 
 /// Installs the guardian contributors into the extension registry.
-pub fn install<S>(registry: &mut ExtensionRegistryBuilder<Config>, agent_spawner: S)
+pub fn install<C, S>(registry: &mut ExtensionRegistryBuilder<C>, agent_spawner: S)
 where
+    C: Sync,
     S: Send + Sync + 'static,
 {
     let extension = Arc::new(GuardianExtension::new(agent_spawner));


### PR DESCRIPTION
## Summary

- make Guardian lifecycle and installation generic over the host config type
- remove `codex-guardian`'s dependency on `codex-core`
- update the Cargo lockfile to reflect the dependency removal

## Why

The Guardian extension only depended on core to name `Config`. Removing that dependency establishes the correct dependency direction for moving review types and implementation out of core in later stack entries.

## Stack

- Depends on #27787
- Earlier migration PRs: #27782, #27779, #27777, #27774, #27770, #27769, #27767

## Validation

- `cargo check -p codex-guardian`
- app-server installed Guardian contributor test
- `just bazel-lock-update`
- `just bazel-lock-check`
- `just fmt`
- `git diff --check`

An optional Bazel target build hit local disk exhaustion after the required lock checks passed; generated Cargo artifacts were subsequently cleaned.
