### PR TITLE
Fix child cwd inheritance for review sessions

### DIFF
--- a/codex-rs/core/src/guardian/review.rs
+++ b/codex-rs/core/src/guardian/review.rs
@@ -751,7 +751,7 @@ async fn run_guardian_review_session_before_deadline(
         guardian_model.as_str(),
         guardian_reasoning_effort.clone(),
     );
-    let guardian_config = match guardian_config {
+    let mut guardian_config = match guardian_config {
         Ok(config) => config,
         Err(err) => {
             return (
@@ -760,6 +760,9 @@ async fn run_guardian_review_session_before_deadline(
             );
         }
     };
+    if let Some(primary_environment) = turn.environments.primary() {
+        guardian_config.cwd = primary_environment.cwd.clone();
+    }
 
     let (session_outcome, session_analytics_result) = Box::pin(
         session

--- a/codex-rs/core/src/session/review.rs
+++ b/codex-rs/core/src/session/review.rs
@@ -45,6 +45,9 @@ pub(super) async fn spawn_review_thread(
 
     // Build per‑turn client with the requested model/family.
     let mut per_turn_config = (*config).clone();
+    if let Some(primary_environment) = parent_turn_context.environments.primary() {
+        per_turn_config.cwd = primary_environment.cwd.clone();
+    }
     per_turn_config.model = Some(model.clone());
     per_turn_config.features = review_features.clone();
     let tool_mode = model_info.tool_mode.unwrap_or_else(|| {

--- a/codex-rs/core/tests/suite/review.rs
+++ b/codex-rs/core/tests/suite/review.rs
@@ -796,6 +796,7 @@ async fn review_uses_overridden_cwd_for_base_branch_merge_base() {
     run_git(repo_path, &["config", "user.email", "test@example.com"]);
     run_git(repo_path, &["config", "user.name", "Test User"]);
     std::fs::write(repo_path.join("file.txt"), "hello\n").unwrap();
+    std::fs::write(repo_path.join("AGENTS.md"), "review repo instructions").unwrap();
     run_git(repo_path, &["add", "."]);
     run_git(repo_path, &["commit", "-m", "initial"]);
 
@@ -858,6 +859,13 @@ async fn review_uses_overridden_cwd_for_base_branch_merge_base() {
     assert!(
         saw_merge_base_sha,
         "expected review prompt to include merge-base sha {head_sha}"
+    );
+    assert!(
+        input
+            .iter()
+            .filter_map(|msg| msg["content"][0]["text"].as_str())
+            .any(|text| text.contains("review repo instructions")),
+        "expected review child to load instructions from its overridden cwd"
     );
 
     let _codex_home_guard = codex_home;


### PR DESCRIPTION
Review and guardian child sessions can combine a creation-time config with the current turn environments, leaving `config.cwd` stale after an environment override.

Align each child config with the primary environment at the point where the mixed state is constructed. Extend the review integration test to verify the child loads `AGENTS.md` from the overridden cwd.

Validation not otherwise covered by CI: focused review and guardian regression tests.