### PR TITLE
tui: use app server config writes

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -50,7 +50,6 @@ use crate::legacy_core::config::Config;
 use crate::legacy_core::config::ConfigBuilder;
 use crate::legacy_core::config::ConfigOverrides;
 use crate::legacy_core::config::PermissionProfileSnapshot;
-use crate::legacy_core::config::edit::ConfigEditsBuilder;
 use crate::model_catalog::ModelCatalog;
 use crate::model_migration::ModelMigrationOutcome;
 use crate::model_migration::migration_copy_for_models;

--- a/codex-rs/tui/src/app/config_persistence.rs
+++ b/codex-rs/tui/src/app/config_persistence.rs
@@ -1063,6 +1063,7 @@ mod tests {
     use crate::app::test_support::app_enabled_in_effective_config;
     use crate::app::test_support::make_test_app;
     use crate::legacy_core::config::edit::ConfigEdit;
+    use crate::legacy_core::config::edit::ConfigEditsBuilder;
     use crate::test_support::PathBufExt;
     use codex_protocol::models::PermissionProfile;
     use pretty_assertions::assert_eq;

--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -440,7 +440,7 @@ impl App {
                 self.handle_pet_selected(tui, pet_id);
             }
             AppEvent::PetDisabled => {
-                self.handle_pet_disabled(tui).await;
+                self.handle_pet_disabled(tui, app_server).await;
             }
             AppEvent::PetPreviewRequested { pet_id } => {
                 self.chat_widget.start_pet_picker_preview(pet_id);
@@ -454,7 +454,7 @@ impl App {
                 result,
             } => {
                 return self
-                    .handle_pet_selection_loaded(tui, request_id, pet_id, result)
+                    .handle_pet_selection_loaded(tui, app_server, request_id, pet_id, result)
                     .await;
             }
             AppEvent::ConfiguredPetLoaded { pet_id, result } => {
@@ -1390,12 +1390,12 @@ impl App {
                 self.chat_widget.on_plugin_mentions_loaded(plugins);
             }
             AppEvent::PersistPersonalitySelection { personality } => {
-                match crate::config_update::write_config_batch(
+                match crate::config_update::write_config_edit(
                     app_server.request_handle(),
-                    vec![crate::config_update::replace_config_value(
+                    crate::config_update::replace_config_value(
                         "personality",
                         serde_json::json!(personality.to_string()),
-                    )],
+                    ),
                 )
                 .await
                 {
@@ -1443,19 +1443,24 @@ impl App {
                 }
             }
             AppEvent::PersistRealtimeAudioDeviceSelection { kind, name } => {
-                let builder = match kind {
-                    RealtimeAudioDeviceKind::Microphone => {
-                        ConfigEditsBuilder::for_config(&self.config)
-                            .set_realtime_microphone(name.as_deref())
-                    }
-                    RealtimeAudioDeviceKind::Speaker => {
-                        ConfigEditsBuilder::for_config(&self.config)
-                            .set_realtime_speaker(name.as_deref())
-                    }
+                let key_path = match kind {
+                    RealtimeAudioDeviceKind::Microphone => "audio.microphone",
+                    RealtimeAudioDeviceKind::Speaker => "audio.speaker",
                 };
+                let edit = name.as_ref().map_or_else(
+                    || crate::config_update::clear_config_value(key_path),
+                    |name| {
+                        crate::config_update::replace_config_value(
+                            key_path,
+                            serde_json::json!(name),
+                        )
+                    },
+                );
 
-                match builder.apply().await {
-                    Ok(()) => {
+                match crate::config_update::write_config_edit(app_server.request_handle(), edit)
+                    .await
+                {
+                    Ok(_) => {
                         match kind {
                             RealtimeAudioDeviceKind::Microphone => {
                                 self.config.realtime_audio.microphone = name.clone();
@@ -1592,12 +1597,12 @@ impl App {
                 self.chat_widget.set_approvals_reviewer(policy);
                 self.sync_active_thread_permission_settings_to_cached_session()
                     .await;
-                if let Err(err) = crate::config_update::write_config_batch(
+                if let Err(err) = crate::config_update::write_config_edit(
                     app_server.request_handle(),
-                    vec![crate::config_update::replace_config_value(
+                    crate::config_update::replace_config_value(
                         "approvals_reviewer",
                         serde_json::json!(policy.to_string()),
-                    )],
+                    ),
                 )
                 .await
                 {
@@ -1646,10 +1651,14 @@ impl App {
                     .await;
             }
             AppEvent::PersistFullAccessWarningAcknowledged => {
-                if let Err(err) = ConfigEditsBuilder::for_config(&self.config)
-                    .set_hide_full_access_warning(/*acknowledged*/ true)
-                    .apply()
-                    .await
+                if let Err(err) = crate::config_update::write_config_edit(
+                    app_server.request_handle(),
+                    crate::config_update::replace_config_value(
+                        "notice.hide_full_access_warning",
+                        serde_json::json!(true),
+                    ),
+                )
+                .await
                 {
                     tracing::error!(
                         error = %err,
@@ -1661,10 +1670,14 @@ impl App {
                 }
             }
             AppEvent::PersistWorldWritableWarningAcknowledged => {
-                if let Err(err) = ConfigEditsBuilder::for_config(&self.config)
-                    .set_hide_world_writable_warning(/*acknowledged*/ true)
-                    .apply()
-                    .await
+                if let Err(err) = crate::config_update::write_config_edit(
+                    app_server.request_handle(),
+                    crate::config_update::replace_config_value(
+                        "notice.hide_world_writable_warning",
+                        serde_json::json!(true),
+                    ),
+                )
+                .await
                 {
                     tracing::error!(
                         error = %err,
@@ -1676,10 +1689,14 @@ impl App {
                 }
             }
             AppEvent::PersistRateLimitSwitchPromptHidden => {
-                if let Err(err) = ConfigEditsBuilder::for_config(&self.config)
-                    .set_hide_rate_limit_model_nudge(/*acknowledged*/ true)
-                    .apply()
-                    .await
+                if let Err(err) = crate::config_update::write_config_edit(
+                    app_server.request_handle(),
+                    crate::config_update::replace_config_value(
+                        "notice.hide_rate_limit_model_nudge",
+                        serde_json::json!(true),
+                    ),
+                )
+                .await
                 {
                     tracing::error!(
                         error = %err,
@@ -1700,11 +1717,8 @@ impl App {
                 } else {
                     crate::config_update::clear_config_value(key_path)
                 };
-                if let Err(err) = crate::config_update::write_config_batch(
-                    app_server.request_handle(),
-                    vec![edit],
-                )
-                .await
+                if let Err(err) =
+                    crate::config_update::write_config_edit(app_server.request_handle(), edit).await
                 {
                     tracing::error!(
                         error = %err,
@@ -1719,10 +1733,18 @@ impl App {
                 from_model,
                 to_model,
             } => {
-                if let Err(err) = ConfigEditsBuilder::for_config(&self.config)
-                    .record_model_migration_seen(from_model.as_str(), to_model.as_str())
-                    .apply()
-                    .await
+                let key_path = format!(
+                    "notice.model_migrations.{}",
+                    crate::config_update::quoted_key_path_segment(&from_model)
+                );
+                if let Err(err) = crate::config_update::write_config_edit(
+                    app_server.request_handle(),
+                    crate::config_update::replace_config_value(
+                        key_path,
+                        serde_json::json!(to_model),
+                    ),
+                )
+                .await
                 {
                     tracing::error!(
                         error = %err,
@@ -1960,15 +1982,22 @@ impl App {
                 use_theme_colors,
             } => {
                 let ids = items.iter().map(ToString::to_string).collect::<Vec<_>>();
-                let items_edit = crate::legacy_core::config::edit::status_line_items_edit(&ids);
-                let colors_edit =
-                    crate::legacy_core::config::edit::status_line_use_colors_edit(use_theme_colors);
-                let apply_result = ConfigEditsBuilder::for_config(&self.config)
-                    .with_edits([items_edit, colors_edit])
-                    .apply()
-                    .await;
+                let apply_result = crate::config_update::write_config_batch(
+                    app_server.request_handle(),
+                    vec![
+                        crate::config_update::replace_config_value(
+                            "tui.status_line",
+                            serde_json::json!(&ids),
+                        ),
+                        crate::config_update::replace_config_value(
+                            "tui.status_line_use_colors",
+                            serde_json::json!(use_theme_colors),
+                        ),
+                    ],
+                )
+                .await;
                 match apply_result {
-                    Ok(()) => {
+                    Ok(_) => {
                         self.config.tui_status_line = Some(ids.clone());
                         self.config.tui_status_line_use_colors = use_theme_colors;
                         self.chat_widget.setup_status_line(items, use_theme_colors);
@@ -1995,13 +2024,16 @@ impl App {
             }
             AppEvent::TerminalTitleSetup { items } => {
                 let ids = items.iter().map(ToString::to_string).collect::<Vec<_>>();
-                let edit = crate::legacy_core::config::edit::terminal_title_items_edit(&ids);
-                let apply_result = ConfigEditsBuilder::for_config(&self.config)
-                    .with_edits([edit])
-                    .apply()
-                    .await;
+                let apply_result = crate::config_update::write_config_edit(
+                    app_server.request_handle(),
+                    crate::config_update::replace_config_value(
+                        "tui.terminal_title",
+                        serde_json::json!(&ids),
+                    ),
+                )
+                .await;
                 match apply_result {
-                    Ok(()) => {
+                    Ok(_) => {
                         self.config.tui_terminal_title = Some(ids.clone());
                         self.chat_widget.setup_terminal_title(items);
                     }
@@ -2021,13 +2053,16 @@ impl App {
                 self.chat_widget.cancel_terminal_title_setup();
             }
             AppEvent::SyntaxThemeSelected { name } => {
-                let edit = crate::legacy_core::config::edit::syntax_theme_edit(&name);
-                let apply_result = ConfigEditsBuilder::for_config(&self.config)
-                    .with_edits([edit])
-                    .apply()
-                    .await;
+                let apply_result = crate::config_update::write_config_edit(
+                    app_server.request_handle(),
+                    crate::config_update::replace_config_value(
+                        "tui.theme",
+                        serde_json::json!(&name),
+                    ),
+                )
+                .await;
                 match apply_result {
-                    Ok(()) => {
+                    Ok(_) => {
                         // Ensure the selected theme is active in the current
                         // session.  The preview callback covers arrow-key
                         // navigation, but if the user presses Enter without
@@ -2078,11 +2113,11 @@ impl App {
                 key,
                 intent,
             } => {
-                self.apply_keymap_capture(context, action, key, intent)
+                self.apply_keymap_capture(app_server, context, action, key, intent)
                     .await;
             }
             AppEvent::KeymapCleared { context, action } => {
-                self.apply_keymap_clear(context, action).await;
+                self.apply_keymap_clear(app_server, context, action).await;
             }
         }
         Ok(AppRunControl::Continue)
@@ -2090,6 +2125,7 @@ impl App {
 
     async fn apply_keymap_capture(
         &mut self,
+        app_server: &AppServerSession,
         context: String,
         action: String,
         key: String,
@@ -2132,14 +2168,9 @@ impl App {
             }
         };
 
-        let edit =
-            crate::legacy_core::config::edit::keymap_bindings_edit(&context, &action, &bindings);
-        match ConfigEditsBuilder::for_config(&self.config)
-            .with_edits([edit])
-            .apply()
-            .await
-        {
-            Ok(()) => {
+        let edit = crate::config_update::build_keymap_bindings_edit(&context, &action, &bindings);
+        match crate::config_update::write_config_edit(app_server.request_handle(), edit).await {
+            Ok(_) => {
                 self.config.tui_keymap = keymap_config.clone();
                 self.keymap = runtime_keymap.clone();
                 self.chat_widget
@@ -2161,7 +2192,12 @@ impl App {
         self.chat_widget.submit_op(AppCommand::reload_user_config());
     }
 
-    async fn apply_keymap_clear(&mut self, context: String, action: String) {
+    async fn apply_keymap_clear(
+        &mut self,
+        app_server: &AppServerSession,
+        context: String,
+        action: String,
+    ) {
         let keymap_config = match crate::keymap_setup::keymap_without_custom_binding(
             &self.config.tui_keymap,
             &context,
@@ -2183,13 +2219,9 @@ impl App {
             }
         };
 
-        let edit = crate::legacy_core::config::edit::keymap_binding_clear_edit(&context, &action);
-        match ConfigEditsBuilder::for_config(&self.config)
-            .with_edits([edit])
-            .apply()
-            .await
-        {
-            Ok(()) => {
+        let edit = crate::config_update::build_keymap_binding_clear_edit(&context, &action);
+        match crate::config_update::write_config_edit(app_server.request_handle(), edit).await {
+            Ok(_) => {
                 self.config.tui_keymap = keymap_config.clone();
                 self.keymap = runtime_keymap.clone();
                 self.chat_widget

--- a/codex-rs/tui/src/app/pets.rs
+++ b/codex-rs/tui/src/app/pets.rs
@@ -102,14 +102,21 @@ impl App {
         }));
     }
 
-    pub(super) async fn handle_pet_disabled(&mut self, tui: &mut tui::Tui) {
-        let edit = crate::legacy_core::config::edit::tui_pet_edit(crate::pets::DISABLED_PET_ID);
-        let apply_result = ConfigEditsBuilder::new(&self.config.codex_home)
-            .with_edits([edit])
-            .apply()
-            .await;
+    pub(super) async fn handle_pet_disabled(
+        &mut self,
+        tui: &mut tui::Tui,
+        app_server: &AppServerSession,
+    ) {
+        let apply_result = crate::config_update::write_config_edit(
+            app_server.request_handle(),
+            crate::config_update::replace_config_value(
+                "tui.pet",
+                serde_json::json!(crate::pets::DISABLED_PET_ID),
+            ),
+        )
+        .await;
         match apply_result {
-            Ok(()) => {
+            Ok(_) => {
                 self.sync_tui_pet_disabled();
                 tui.frame_requester().schedule_frame();
             }
@@ -134,6 +141,7 @@ impl App {
     pub(super) async fn handle_pet_selection_loaded(
         &mut self,
         tui: &mut tui::Tui,
+        app_server: &AppServerSession,
         request_id: u64,
         pet_id: String,
         result: Result<Option<crate::pets::AmbientPet>, String>,
@@ -146,13 +154,16 @@ impl App {
         }
         match result {
             Ok(ambient_pet) => {
-                let edit = crate::legacy_core::config::edit::tui_pet_edit(&pet_id);
-                match ConfigEditsBuilder::new(&self.config.codex_home)
-                    .with_edits([edit])
-                    .apply()
-                    .await
+                match crate::config_update::write_config_edit(
+                    app_server.request_handle(),
+                    crate::config_update::replace_config_value(
+                        "tui.pet",
+                        serde_json::json!(&pet_id),
+                    ),
+                )
+                .await
                 {
-                    Ok(()) => {
+                    Ok(_) => {
                         self.config.tui_pet = Some(pet_id.clone());
                         self.chat_widget
                             .set_tui_pet_loaded(Some(pet_id), ambient_pet);

--- a/codex-rs/tui/src/app/startup_prompts.rs
+++ b/codex-rs/tui/src/app/startup_prompts.rs
@@ -4,6 +4,7 @@
 //! catalog state into one-time TUI prompts or warning cells without owning the main event loop.
 
 use super::*;
+use crate::legacy_core::config::edit::ConfigEditsBuilder;
 use std::collections::HashSet;
 use std::path::PathBuf;
 

--- a/codex-rs/tui/src/config_update.rs
+++ b/codex-rs/tui/src/config_update.rs
@@ -39,9 +39,13 @@ pub(crate) fn clear_config_value(key_path: impl Into<String>) -> ConfigEdit {
     replace_config_value(key_path, JsonValue::Null)
 }
 
+pub(crate) fn quoted_key_path_segment(segment: &str) -> String {
+    let segment = segment.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{segment}\"")
+}
+
 pub(crate) fn app_scoped_key_path(app_id: &str, key_path: &str) -> String {
-    let app_id = serde_json::Value::String(app_id.to_string()).to_string();
-    format!("apps.{app_id}.{key_path}")
+    format!("apps.{}.{key_path}", quoted_key_path_segment(app_id))
 }
 
 pub(crate) fn format_config_error(err: &impl Display) -> String {
@@ -144,6 +148,30 @@ pub(crate) fn build_oss_provider_edit(provider: &str) -> ConfigEdit {
     replace_config_value("oss_provider", serde_json::json!(provider))
 }
 
+fn keymap_binding_key_path(context: &str, action: &str) -> String {
+    format!(
+        "tui.keymap.{}.{}",
+        quoted_key_path_segment(context),
+        quoted_key_path_segment(action)
+    )
+}
+
+pub(crate) fn build_keymap_bindings_edit(
+    context: &str,
+    action: &str,
+    keys: &[String],
+) -> ConfigEdit {
+    let value = match keys {
+        [key] => serde_json::json!(key),
+        keys => serde_json::json!(keys),
+    };
+    replace_config_value(keymap_binding_key_path(context, action), value)
+}
+
+pub(crate) fn build_keymap_binding_clear_edit(context: &str, action: &str) -> ConfigEdit {
+    clear_config_value(keymap_binding_key_path(context, action))
+}
+
 pub(crate) async fn write_config_batch(
     request_handle: AppServerRequestHandle,
     edits: Vec<ConfigEdit>,
@@ -161,6 +189,13 @@ pub(crate) async fn write_config_batch(
         })
         .await
         .wrap_err("config/batchWrite failed in TUI")
+}
+
+pub(crate) async fn write_config_edit(
+    request_handle: AppServerRequestHandle,
+    edit: ConfigEdit,
+) -> Result<ConfigWriteResponse> {
+    write_config_batch(request_handle, vec![edit]).await
 }
 
 pub(crate) async fn write_trusted_project(


### PR DESCRIPTION
## Summary

The TUI is being moved off direct `codex-core` config edit helpers so it can persist settings through the app server layer, including when the UI is connected to a remote app server. A few event-layer paths still built config edits through `legacy_core::config::edit`, which kept those flows coupled to local core config persistence.

This PR routes those TUI config writes through app-server-backed `ConfigEdit` requests instead.

## Changes

- Persist audio device choices, approval reviewer changes, notice acknowledgements, plan-mode effort, model migration acknowledgements, status line setup, terminal title setup, syntax theme selection, keymap edits, personality selection, and pet selection through `config_update`.
- Add small TUI-side helpers for single-edit app-server writes, quoted key-path segments, and keymap edit construction.
- Remove production `ConfigEditsBuilder` usage from the touched event and pet flows while leaving unrelated legacy config dependencies for later cleanup.