### PR TITLE
[codex] refresh environment context before sampling

### DIFF
--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -299,14 +299,19 @@ async fn run_compact_task_inner_impl(
     let mut new_history = build_compacted_history(Vec::new(), &user_messages, &summary_text);
     let window_id = sess.advance_auto_compact_window_id().await;
 
-    if matches!(
+    let reference_environment_context = if matches!(
         initial_context_injection,
         InitialContextInjection::BeforeLastUserMessage
     ) {
-        let initial_context = sess.build_initial_context(turn_context.as_ref()).await;
+        let (initial_context, environment_context) = sess
+            .build_initial_context_snapshot(turn_context.as_ref())
+            .await;
         new_history =
             insert_initial_context_before_last_real_user_or_summary(new_history, initial_context);
-    }
+        environment_context
+    } else {
+        None
+    };
     let reference_context_item = match initial_context_injection {
         InitialContextInjection::DoNotInject => None,
         InitialContextInjection::BeforeLastUserMessage => Some(turn_context.to_turn_context_item()),
@@ -316,8 +321,13 @@ async fn run_compact_task_inner_impl(
         replacement_history: Some(new_history.clone()),
         window_id: Some(window_id),
     };
-    sess.replace_compacted_history(new_history, reference_context_item, compacted_item)
-        .await;
+    sess.replace_compacted_history(
+        new_history,
+        reference_context_item,
+        reference_environment_context,
+        compacted_item,
+    )
+    .await;
     sess.recompute_token_usage(&turn_context).await;
 
     sess.emit_turn_item_completed(&turn_context, compaction_item)

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -231,7 +231,7 @@ async fn run_remote_compact_task_inner_impl(
         window_id,
         CodexResponsesRequestKind::Compaction(compaction_metadata),
     );
-    let mut new_history = sess
+    let new_history = sess
         .services
         .model_client
         .compact_conversation_history(
@@ -252,7 +252,7 @@ async fn run_remote_compact_task_inner_impl(
         )
         .await?;
     let new_window_id = sess.advance_auto_compact_window_id().await;
-    new_history = process_compacted_history(
+    let (new_history, reference_environment_context) = process_compacted_history(
         sess.as_ref(),
         turn_context.as_ref(),
         new_history,
@@ -276,8 +276,13 @@ async fn run_remote_compact_task_inner_impl(
         input_history: &trace_input_history,
         replacement_history: &new_history,
     });
-    sess.replace_compacted_history(new_history, reference_context_item, compacted_item)
-        .await;
+    sess.replace_compacted_history(
+        new_history,
+        reference_context_item,
+        reference_environment_context,
+        compacted_item,
+    )
+    .await;
     sess.recompute_token_usage(turn_context).await;
 
     sess.emit_turn_item_completed(turn_context, compaction_item)
@@ -290,21 +295,27 @@ pub(crate) async fn process_compacted_history(
     turn_context: &TurnContext,
     mut compacted_history: Vec<ResponseItem>,
     initial_context_injection: InitialContextInjection,
-) -> Vec<ResponseItem> {
+) -> (
+    Vec<ResponseItem>,
+    Option<crate::context::EnvironmentContext>,
+) {
     // Mid-turn compaction is the only path that must inject initial context above the last user
     // message in the replacement history. Pre-turn compaction instead injects context after the
     // compaction item, but mid-turn compaction keeps the compaction item last for model training.
-    let initial_context = if matches!(
+    let (initial_context, reference_environment_context) = if matches!(
         initial_context_injection,
         InitialContextInjection::BeforeLastUserMessage
     ) {
-        sess.build_initial_context(turn_context).await
+        sess.build_initial_context_snapshot(turn_context).await
     } else {
-        Vec::new()
+        (Vec::new(), None)
     };
 
     compacted_history.retain(should_keep_compacted_history_item);
-    insert_initial_context_before_last_real_user_or_summary(compacted_history, initial_context)
+    (
+        insert_initial_context_before_last_real_user_or_summary(compacted_history, initial_context),
+        reference_environment_context,
+    )
 }
 
 /// Returns whether an item from remote compaction output should be preserved.

--- a/codex-rs/core/src/compact_remote_v2.rs
+++ b/codex-rs/core/src/compact_remote_v2.rs
@@ -290,7 +290,7 @@ async fn run_remote_compact_task_inner_impl(
         build_v2_compacted_history(&prompt_input, compaction_output);
     analytics_details.retained_image_count = Some(retained_images);
     let new_window_id = sess.advance_auto_compact_window_id().await;
-    let new_history = process_compacted_history(
+    let (new_history, reference_environment_context) = process_compacted_history(
         sess.as_ref(),
         turn_context.as_ref(),
         compacted_history,
@@ -311,8 +311,13 @@ async fn run_remote_compact_task_inner_impl(
         input_history: &trace_input_history,
         replacement_history: &new_history,
     });
-    sess.replace_compacted_history(new_history, reference_context_item, compacted_item)
-        .await;
+    sess.replace_compacted_history(
+        new_history,
+        reference_context_item,
+        reference_environment_context,
+        compacted_item,
+    )
+    .await;
     sess.recompute_token_usage(turn_context).await;
 
     sess.emit_turn_item_completed(turn_context, compaction_item)

--- a/codex-rs/core/src/compact_tests.rs
+++ b/codex-rs/core/src/compact_tests.rs
@@ -13,7 +13,7 @@ async fn process_compacted_history_with_test_session(
         .set_previous_turn_settings(previous_turn_settings.cloned())
         .await;
     let initial_context = session.build_initial_context(&turn_context).await;
-    let refreshed = crate::compact_remote::process_compacted_history(
+    let (refreshed, _) = crate::compact_remote::process_compacted_history(
         &session,
         &turn_context,
         compacted_history,

--- a/codex-rs/core/src/context/environment_context.rs
+++ b/codex-rs/core/src/context/environment_context.rs
@@ -93,7 +93,7 @@ impl EnvironmentContextEnvironments {
         }
     }
 
-    fn equals_except_shell(&self, other: &Self) -> bool {
+    pub(crate) fn equals_except_shell(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::None, Self::None) => true,
             (Self::Single(left), Self::Single(right)) => left.cwd == right.cwd,
@@ -104,6 +104,17 @@ impl EnvironmentContextEnvironments {
                         .zip(right.iter())
                         .all(|(left, right)| left.id == right.id && left.cwd == right.cwd)
             }
+            _ => false,
+        }
+    }
+
+    pub(crate) fn equals_visible(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::None, Self::None) => true,
+            (Self::Single(left), Self::Single(right)) => {
+                left.cwd == right.cwd && left.shell == right.shell
+            }
+            (Self::Multiple(left), Self::Multiple(right)) => left == right,
             _ => false,
         }
     }
@@ -362,7 +373,7 @@ impl EnvironmentContext {
         }
     }
 
-    fn new_with_environments(
+    pub(crate) fn new_with_environments(
         environments: EnvironmentContextEnvironments,
         current_date: Option<String>,
         timezone: Option<String>,

--- a/codex-rs/core/src/context_manager/updates.rs
+++ b/codex-rs/core/src/context_manager/updates.rs
@@ -18,24 +18,40 @@ use codex_protocol::models::ResponseItem;
 use codex_protocol::openai_models::ModelInfo;
 use codex_protocol::protocol::TurnContextItem;
 
-fn build_environment_update_item(
+fn build_turn_settings_environment_update_item(
     previous: Option<&TurnContextItem>,
-    next: &TurnContext,
+    next: Option<&EnvironmentContext>,
     shell: &Shell,
 ) -> Option<ResponseItem> {
-    if !next.config.include_environment_context {
-        return None;
-    }
-
     let prev = previous?;
+    let next_context = next?;
     let prev_context = EnvironmentContext::from_turn_context_item(prev, shell.name().to_string());
-    let next_context = EnvironmentContext::from_turn_context(next, shell);
-    if prev_context.equals_except_shell(&next_context) {
+    if prev_context.equals_except_shell(next_context) {
         return None;
     }
 
     Some(ContextualUserFragment::into(
-        EnvironmentContext::diff_from_turn_context_item(prev, &next_context),
+        EnvironmentContext::diff_from_turn_context_item(prev, next_context),
+    ))
+}
+
+pub(crate) fn build_environment_update_item(
+    previous: Option<&EnvironmentContext>,
+    next: &EnvironmentContext,
+) -> Option<ResponseItem> {
+    if previous.is_some_and(|previous| previous.environments.equals_visible(&next.environments)) {
+        return None;
+    }
+
+    Some(ContextualUserFragment::into(
+        EnvironmentContext::new_with_environments(
+            next.environments.clone(),
+            /*current_date*/ None,
+            /*timezone*/ None,
+            /*network*/ None,
+            /*filesystem*/ None,
+            /*subagents*/ None,
+        ),
     ))
 }
 
@@ -210,6 +226,7 @@ pub(crate) fn build_settings_update_items(
     previous: Option<&TurnContextItem>,
     previous_turn_settings: Option<&PreviousTurnSettings>,
     next: &TurnContext,
+    next_environment_context: Option<&EnvironmentContext>,
     shell: &Shell,
     exec_policy: &Policy,
     personality_feature_enabled: bool,
@@ -218,7 +235,8 @@ pub(crate) fn build_settings_update_items(
     // model-visible item emitted by build_initial_context. Persist the remaining
     // inputs or add explicit replay events so fork/resume can diff everything
     // deterministically.
-    let contextual_user_message = build_environment_update_item(previous, next, shell);
+    let contextual_user_message =
+        build_turn_settings_environment_update_item(previous, next_environment_context, shell);
     let developer_update_sections = [
         // Keep model-switch instructions first so model-specific guidance is read before
         // any other context diffs on this turn.

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -27,6 +27,7 @@ use crate::context::AvailablePluginsInstructions;
 use crate::context::AvailableSkillsInstructions;
 use crate::context::CollaborationModeInstructions;
 use crate::context::ContextualUserFragment;
+use crate::context::EnvironmentContext;
 use crate::context::NetworkRuleSaved;
 use crate::context::PermissionsInstructions;
 use crate::context::PersonalitySpecInstructions;
@@ -1662,10 +1663,26 @@ impl Session {
         self.refresh_runtime_config(next_config).await;
     }
 
+    #[cfg(test)]
     async fn build_settings_update_items(
         &self,
         reference_context_item: Option<&TurnContextItem>,
         current_context: &TurnContext,
+    ) -> Vec<ResponseItem> {
+        let environment_context = self.environment_context(current_context);
+        self.build_settings_update_items_with_environment_context(
+            reference_context_item,
+            current_context,
+            environment_context.as_ref(),
+        )
+        .await
+    }
+
+    async fn build_settings_update_items_with_environment_context(
+        &self,
+        reference_context_item: Option<&TurnContextItem>,
+        current_context: &TurnContext,
+        environment_context: Option<&EnvironmentContext>,
     ) -> Vec<ResponseItem> {
         // TODO: Make context updates a pure diff of persisted previous/current TurnContextItem
         // state so replay/backtracking is deterministic. Runtime inputs that affect model-visible
@@ -1681,6 +1698,7 @@ impl Session {
             reference_context_item,
             previous_turn_settings.as_ref(),
             current_context,
+            environment_context,
             shell.as_ref(),
             exec_policy.as_ref(),
             self.features.enabled(Feature::Personality),
@@ -2733,11 +2751,13 @@ impl Session {
         &self,
         items: Vec<ResponseItem>,
         reference_context_item: Option<TurnContextItem>,
+        reference_environment_context: Option<EnvironmentContext>,
         compacted_item: CompactedItem,
     ) {
         {
             let mut state = self.state.lock().await;
             state.replace_history(items, reference_context_item.clone());
+            state.set_reference_environment_context(reference_environment_context);
         }
 
         self.persist_rollout_items(&[RolloutItem::Compacted(compacted_item)])
@@ -2811,9 +2831,38 @@ impl Session {
         }
     }
 
+    #[cfg(test)]
     pub(crate) async fn build_initial_context(
         &self,
         turn_context: &TurnContext,
+    ) -> Vec<ResponseItem> {
+        self.build_initial_context_snapshot(turn_context).await.0
+    }
+
+    pub(crate) async fn build_initial_context_snapshot(
+        &self,
+        turn_context: &TurnContext,
+    ) -> (Vec<ResponseItem>, Option<EnvironmentContext>) {
+        let environment_context = self.environment_context(turn_context);
+        let context_items = self
+            .build_initial_context_with_environment_context(
+                turn_context,
+                environment_context.as_ref(),
+            )
+            .await;
+        (context_items, environment_context)
+    }
+
+    fn environment_context(&self, turn_context: &TurnContext) -> Option<EnvironmentContext> {
+        turn_context.config.include_environment_context.then(|| {
+            EnvironmentContext::from_turn_context(turn_context, self.user_shell().as_ref())
+        })
+    }
+
+    async fn build_initial_context_with_environment_context(
+        &self,
+        turn_context: &TurnContext,
+        environment_context: Option<&EnvironmentContext>,
     ) -> Vec<ResponseItem> {
         let mut developer_sections = Vec::<String>::with_capacity(8);
         let mut contextual_user_sections = Vec::<String>::with_capacity(2);
@@ -2996,15 +3045,15 @@ impl Session {
                 .render(),
             );
         }
-        if turn_context.config.include_environment_context {
-            let shell = self.user_shell();
+        if let Some(environment_context) = environment_context {
             let subagents = self
                 .services
                 .agent_control
                 .format_environment_context_subagents(self.thread_id)
                 .await;
             contextual_user_sections.push(
-                crate::context::EnvironmentContext::from_turn_context(turn_context, shell.as_ref())
+                environment_context
+                    .clone()
                     .with_subagents(subagents)
                     .render(),
             );
@@ -3093,12 +3142,14 @@ impl Session {
             state.start_new_context_window_if_requested()
         };
         let window_id = window_id?;
-        let context_items = self.build_initial_context(turn_context).await;
+        let (context_items, environment_context) =
+            self.build_initial_context_snapshot(turn_context).await;
         let turn_context_item = turn_context.to_turn_context_item();
         let replacement_history = context_items;
         {
             let mut state = self.state.lock().await;
             state.replace_history(replacement_history.clone(), Some(turn_context_item.clone()));
+            state.set_reference_environment_context(environment_context);
         };
         self.persist_rollout_items(&[
             RolloutItem::Compacted(CompactedItem {
@@ -3140,17 +3191,64 @@ impl Session {
         &self,
         turn_context: &TurnContext,
     ) {
-        let reference_context_item = {
+        let environment_context = self.environment_context(turn_context);
+        let (reference_context_item, reference_environment_context) = {
             let state = self.state.lock().await;
-            state.reference_context_item()
+            (
+                state.reference_context_item(),
+                state.reference_environment_context(),
+            )
         };
         let should_inject_full_context = reference_context_item.is_none();
-        let context_items = if should_inject_full_context {
-            self.build_initial_context(turn_context).await
+        let mut context_items = if should_inject_full_context {
+            self.build_initial_context_with_environment_context(
+                turn_context,
+                environment_context.as_ref(),
+            )
+            .await
         } else {
             // Steady-state path: append only context diffs to minimize token overhead.
-            self.build_settings_update_items(reference_context_item.as_ref(), turn_context)
-                .await
+            self.build_settings_update_items_with_environment_context(
+                reference_context_item.as_ref(),
+                turn_context,
+                environment_context.as_ref(),
+            )
+            .await
+        };
+        let settings_emitted_environments = reference_context_item
+            .as_ref()
+            .zip(environment_context.as_ref())
+            .is_some_and(|(previous, current)| {
+                let previous = EnvironmentContext::from_turn_context_item(
+                    previous,
+                    self.user_shell().name().to_string(),
+                );
+                !previous
+                    .environments
+                    .equals_except_shell(&current.environments)
+            });
+        let reference_environment_context = if should_inject_full_context {
+            environment_context
+        } else {
+            match (reference_environment_context, environment_context) {
+                (Some(previous), Some(mut current)) => {
+                    // Turn-setting diffs do not emit shell-only changes. Preserve the shell the
+                    // model last saw until the sample-boundary update records the new value.
+                    if !settings_emitted_environments {
+                        current.environments = previous.environments;
+                    }
+                    Some(current)
+                }
+                (None, Some(current)) => {
+                    if !settings_emitted_environments {
+                        // Resume cannot recover the exact environment snapshot from older
+                        // rollouts. Re-establish it before the new user message is recorded.
+                        context_items.push(ContextualUserFragment::into(current.clone()));
+                    }
+                    Some(current)
+                }
+                (_, None) => None,
+            }
         };
         let turn_context_item = turn_context.to_turn_context_item();
         if !context_items.is_empty() {
@@ -3166,6 +3264,31 @@ impl Session {
         // context items. This keeps later runtime diffing aligned with the current turn state.
         let mut state = self.state.lock().await;
         state.set_reference_context_item(Some(turn_context_item));
+        state.set_reference_environment_context(reference_environment_context);
+    }
+
+    pub(crate) async fn record_environment_context_update_if_changed(
+        &self,
+        turn_context: &TurnContext,
+    ) {
+        let Some(environment_context) = self.environment_context(turn_context) else {
+            return;
+        };
+        let reference_environment_context = {
+            let state = self.state.lock().await;
+            state.reference_environment_context()
+        };
+        let Some(item) = crate::context_manager::updates::build_environment_update_item(
+            reference_environment_context.as_ref(),
+            &environment_context,
+        ) else {
+            return;
+        };
+
+        self.record_conversation_items(turn_context, std::slice::from_ref(&item))
+            .await;
+        let mut state = self.state.lock().await;
+        state.set_reference_environment_context(Some(environment_context));
     }
 
     pub(crate) async fn update_token_usage_info(

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -8197,6 +8197,85 @@ async fn record_context_updates_and_set_reference_context_item_persists_baseline
 }
 
 #[tokio::test]
+async fn environment_baseline_tracks_visible_multi_and_single_updates() {
+    let (session, mut turn_context) = make_session_and_context().await;
+    let mut second_environment = turn_context.environments.turn_environments[0].clone();
+    turn_context.environments.turn_environments[0].environment_id = "first".to_string();
+    turn_context.environments.turn_environments[0].environment = Arc::new(
+        codex_exec_server::Environment::create_for_tests(Some("ws://127.0.0.1:1".to_string()))
+            .expect("create first remote environment"),
+    );
+    second_environment.environment_id = "second".to_string();
+    second_environment.environment = Arc::new(
+        codex_exec_server::Environment::create_for_tests(Some("ws://127.0.0.1:2".to_string()))
+            .expect("create second remote environment"),
+    );
+    turn_context
+        .environments
+        .turn_environments
+        .push(second_environment);
+
+    let previous_environment_context = session
+        .environment_context(&turn_context)
+        .expect("environment context enabled");
+    turn_context.environments.turn_environments[0].shell = Some(crate::shell::Shell {
+        shell_type: crate::shell::ShellType::Cmd,
+        shell_path: PathBuf::from("cmd"),
+        shell_snapshot: crate::shell::empty_shell_snapshot_receiver(),
+    });
+    turn_context.environments.turn_environments[1].shell = Some(crate::shell::Shell {
+        shell_type: crate::shell::ShellType::PowerShell,
+        shell_path: PathBuf::from("powershell"),
+        shell_snapshot: crate::shell::empty_shell_snapshot_receiver(),
+    });
+    {
+        let mut state = session.state.lock().await;
+        state.set_reference_context_item(Some(turn_context.to_turn_context_item()));
+        state.set_reference_environment_context(Some(previous_environment_context));
+    }
+
+    session
+        .record_context_updates_and_set_reference_context_item(&turn_context)
+        .await;
+    let history_after_settings = session.clone_history().await.raw_items().to_vec();
+    session
+        .record_environment_context_update_if_changed(&turn_context)
+        .await;
+
+    assert_eq!(
+        session.clone_history().await.raw_items().to_vec(),
+        history_after_settings
+    );
+
+    turn_context.environments.turn_environments.truncate(1);
+    session
+        .record_context_updates_and_set_reference_context_item(&turn_context)
+        .await;
+    let history_before_reduction_update = session.clone_history().await.raw_items().to_vec();
+    assert_eq!(history_before_reduction_update, history_after_settings);
+    session
+        .record_environment_context_update_if_changed(&turn_context)
+        .await;
+    let history_after_reduction_update = session.clone_history().await.raw_items().to_vec();
+    assert_eq!(
+        history_after_reduction_update.len(),
+        history_before_reduction_update.len() + 1
+    );
+
+    turn_context.environments.turn_environments[0].environment_id = "renamed".to_string();
+    session
+        .record_context_updates_and_set_reference_context_item(&turn_context)
+        .await;
+    session
+        .record_environment_context_update_if_changed(&turn_context)
+        .await;
+    assert_eq!(
+        session.clone_history().await.raw_items().to_vec(),
+        history_after_reduction_update
+    );
+}
+
+#[tokio::test]
 async fn record_context_updates_and_set_reference_context_item_persists_split_file_system_policy_to_rollout()
  {
     let (mut session, mut turn_context) = make_session_and_context().await;

--- a/codex-rs/core/src/session/tests/guardian_tests.rs
+++ b/codex-rs/core/src/session/tests/guardian_tests.rs
@@ -525,7 +525,7 @@ async fn process_compacted_history_preserves_separate_guardian_developer_message
     turn_context.session_source = guardian_source;
     turn_context.developer_instructions = Some(guardian_policy.clone());
 
-    let refreshed = crate::compact_remote::process_compacted_history(
+    let (refreshed, _) = crate::compact_remote::process_compacted_history(
         &session,
         &turn_context,
         vec![

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -215,6 +215,9 @@ pub(crate) async fn run_turn(
             break;
         }
 
+        sess.record_environment_context_update_if_changed(turn_context.as_ref())
+            .await;
+
         // Construct the input that we will send to the model.
         let sampling_request_input: Vec<ResponseItem> = async {
             sess.clone_history()

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -10,6 +10,7 @@ use std::collections::VecDeque;
 use super::AdditionalContextStore;
 use super::auto_compact_window::AutoCompactWindow;
 use super::auto_compact_window::AutoCompactWindowSnapshot;
+use crate::context::EnvironmentContext;
 use crate::context_manager::ContextManager;
 use crate::session::PreviousTurnSettings;
 use crate::session::session::SessionConfiguration;
@@ -36,6 +37,7 @@ pub(crate) struct SessionState {
     auto_compact_window: AutoCompactWindow,
     /// Startup prewarmed session prepared during session initialization.
     pub(crate) startup_prewarm: Option<SessionStartupPrewarmHandle>,
+    reference_environment_context: Option<EnvironmentContext>,
     pub(crate) active_connector_selection: HashSet<String>,
     pub(crate) pending_session_start_sources: VecDeque<codex_hooks::SessionStartSource>,
     granted_permissions_by_environment_id: HashMap<String, AdditionalPermissionProfile>,
@@ -56,6 +58,7 @@ impl SessionState {
             previous_turn_settings: None,
             auto_compact_window: AutoCompactWindow::new(),
             startup_prewarm: None,
+            reference_environment_context: None,
             active_connector_selection: HashSet::new(),
             pending_session_start_sources: VecDeque::new(),
             granted_permissions_by_environment_id: HashMap::new(),
@@ -104,6 +107,7 @@ impl SessionState {
         self.history.replace(items);
         self.history
             .set_reference_context_item(reference_context_item);
+        self.reference_environment_context = None;
         self.auto_compact_window.clear_prefill();
     }
 
@@ -117,6 +121,17 @@ impl SessionState {
 
     pub(crate) fn reference_context_item(&self) -> Option<TurnContextItem> {
         self.history.reference_context_item()
+    }
+
+    pub(crate) fn reference_environment_context(&self) -> Option<EnvironmentContext> {
+        self.reference_environment_context.clone()
+    }
+
+    pub(crate) fn set_reference_environment_context(
+        &mut self,
+        context: Option<EnvironmentContext>,
+    ) {
+        self.reference_environment_context = context;
     }
 
     // Token/rate limit helpers

--- a/codex-rs/core/tests/suite/environment_readiness.rs
+++ b/codex-rs/core/tests/suite/environment_readiness.rs
@@ -1,0 +1,185 @@
+use std::time::Duration;
+
+use anyhow::Context;
+use anyhow::Result;
+use codex_exec_server::ExecServerRuntimePaths;
+use codex_protocol::protocol::EventMsg;
+use codex_protocol::protocol::Op;
+use codex_protocol::protocol::ThreadSettingsOverrides;
+use codex_protocol::protocol::TurnEnvironmentSelection;
+use codex_protocol::protocol::TurnEnvironmentSelections;
+use codex_protocol::user_input::UserInput;
+use core_test_support::responses;
+use core_test_support::streaming_sse::StreamingSseChunk;
+use core_test_support::streaming_sse::start_streaming_sse_server;
+use core_test_support::test_codex::test_codex;
+use core_test_support::wait_for_event;
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+use serde_json::json;
+use tokio::sync::oneshot;
+use tokio::time::timeout;
+
+fn environment_contexts(body: &Value) -> Vec<String> {
+    body.get("input")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|item| item.get("role").and_then(Value::as_str) == Some("user"))
+        .filter_map(|item| item.get("content").and_then(Value::as_array))
+        .flatten()
+        .filter_map(|content| content.get("text").and_then(Value::as_str))
+        .filter(|text| text.starts_with("<environment_context>"))
+        .map(str::to_string)
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pending_environment_context_updates_before_next_sample() -> Result<()> {
+    let first_plan = serde_json::to_string(&json!({
+        "plan": [{"step": "wait for environment", "status": "in_progress"}]
+    }))?;
+    let second_plan = serde_json::to_string(&json!({
+        "plan": [{"step": "wait for environment", "status": "completed"}]
+    }))?;
+    let (release_first_response, first_response_gate) = oneshot::channel();
+    let (server, completions) = start_streaming_sse_server(vec![
+        vec![
+            StreamingSseChunk {
+                gate: None,
+                body: responses::sse(vec![
+                    responses::ev_response_created("resp-1"),
+                    responses::ev_function_call("plan-1", "update_plan", &first_plan),
+                ]),
+            },
+            StreamingSseChunk {
+                gate: Some(first_response_gate),
+                body: responses::sse(vec![responses::ev_completed("resp-1")]),
+            },
+        ],
+        vec![StreamingSseChunk {
+            gate: None,
+            body: responses::sse(vec![
+                responses::ev_response_created("resp-2"),
+                responses::ev_function_call("plan-2", "update_plan", &second_plan),
+                responses::ev_completed("resp-2"),
+            ]),
+        }],
+        vec![StreamingSseChunk {
+            gate: None,
+            body: responses::sse(vec![
+                responses::ev_response_created("resp-3"),
+                responses::ev_assistant_message("msg-1", "done"),
+                responses::ev_completed("resp-3"),
+            ]),
+        }],
+    ])
+    .await;
+    let test = test_codex().build_with_streaming_server(&server).await?;
+    let environment_manager = test.thread_manager.environment_manager();
+    let environment =
+        environment_manager.register_pending_environment("pending-environment".to_string())?;
+    let environment_selections = TurnEnvironmentSelections::new(
+        test.config.cwd.clone(),
+        vec![TurnEnvironmentSelection {
+            environment_id: "pending-environment".to_string(),
+            cwd: test.config.cwd.clone(),
+        }],
+    );
+
+    test.codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "continue when the environment is ready".to_string(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: ThreadSettingsOverrides {
+                environments: Some(environment_selections),
+                ..Default::default()
+            },
+        })
+        .await?;
+
+    timeout(Duration::from_secs(10), server.wait_for_request_count(1)).await?;
+    let first_request = server
+        .requests()
+        .await
+        .into_iter()
+        .next()
+        .context("first model request")?;
+    let first_request: Value = serde_json::from_slice(&first_request)?;
+    let first_contexts = environment_contexts(&first_request);
+    assert_eq!(first_contexts.len(), 1);
+    assert!(first_contexts[0].contains("<shell>still loading</shell>"));
+
+    let reserved_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let exec_server_address = reserved_listener.local_addr()?;
+    drop(reserved_listener);
+    let exec_server_url = format!("ws://{exec_server_address}");
+    let exec_server_url_for_task = exec_server_url.clone();
+    let runtime_paths = ExecServerRuntimePaths::new(
+        std::env::current_exe()?,
+        /*codex_linux_sandbox_exe*/ None,
+    )?;
+    let exec_server_task = tokio::spawn(async move {
+        codex_exec_server::run_main(&exec_server_url_for_task, runtime_paths).await
+    });
+    timeout(Duration::from_secs(2), async {
+        loop {
+            if tokio::net::TcpStream::connect(exec_server_address)
+                .await
+                .is_ok()
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await?;
+
+    environment_manager.upsert_environment("pending-environment".to_string(), exec_server_url)?;
+    let loaded_info = timeout(Duration::from_secs(2), async {
+        loop {
+            if let Some(info) = environment.current_info() {
+                break info;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await?;
+    release_first_response
+        .send(())
+        .map_err(|_| anyhow::anyhow!("first response gate closed"))?;
+
+    timeout(Duration::from_secs(10), server.wait_for_request_count(3)).await?;
+    for completion in completions {
+        timeout(Duration::from_secs(10), completion).await??;
+    }
+    wait_for_event(&test.codex, |event| {
+        matches!(event, EventMsg::TurnComplete(_))
+    })
+    .await;
+
+    let requests = server.requests().await;
+    let second_request: Value = serde_json::from_slice(&requests[1])?;
+    let third_request: Value = serde_json::from_slice(&requests[2])?;
+    let second_contexts = environment_contexts(&second_request);
+    let third_contexts = environment_contexts(&third_request);
+    assert_eq!(second_contexts.len(), 2);
+    assert!(second_contexts[0].contains("<shell>still loading</shell>"));
+    let environment_update = &second_contexts[1];
+    assert!(environment_update.contains(&format!("<shell>{}</shell>", loaded_info.shell.name)));
+    assert!(!environment_update.contains("<current_date>"));
+    assert!(!environment_update.contains("<timezone>"));
+    assert!(!environment_update.contains("<network"));
+    assert!(!environment_update.contains("<filesystem>"));
+    assert_eq!(third_contexts, second_contexts);
+
+    server.shutdown().await;
+    exec_server_task.abort();
+    let _ = exec_server_task.await;
+    Ok(())
+}

--- a/codex-rs/core/tests/suite/mod.rs
+++ b/codex-rs/core/tests/suite/mod.rs
@@ -49,6 +49,7 @@ mod compact_remote;
 mod compact_remote_parity;
 mod compact_resume_fork;
 mod deprecation_notice;
+mod environment_readiness;
 mod exec;
 mod exec_policy;
 #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
## Summary

- keep the last model-visible environment snapshot in session state
- before each model sample, compare only cached environment metadata and append an environment-only context item when the visible cwd/shell state changed
- carry the exact rendered snapshot through initial context, turn-setting updates, and local/remote compaction so history and the in-memory baseline stay aligned
- conservatively re-establish an unknown resume/rollback baseline before the next user message, without rewriting history
- avoid new lifecycle enums, event buses, or readiness coordinators

## Stack

- builds on #27824
- #27824 builds on #27815
- required-MCP startup semantics and global `EnvironmentContext` size limits are intentionally separate follow-ups

## Testing

- `just test -p codex-core environment_context` (20 passed)
- `just test -p codex-core environment_baseline_tracks_visible_multi_and_single_updates`
- `just test -p codex-core compact_resume_fork` (4 passed)
- `just test -p codex-core snapshot_request_shape_mid_turn_continuation_compaction`
- `just test -p codex-core snapshot_model_visible_layout_resume_override_matches_rollout_model`
- `just test -p codex-core build_settings_update_items` (6 passed)
- `just fix -p codex-core`
- `just fmt`

Three independent review passes, including a `review-like-pavel` pass, reported no findings on the final revision.