### PR TITLE
Use deterministic Guardian review for trusted app tools

### DIFF
--- a/codex-rs/codex-mcp/src/connection_manager.rs
+++ b/codex-rs/codex-mcp/src/connection_manager.rs
@@ -64,6 +64,7 @@ use rmcp::model::ReadResourceResult;
 use rmcp::model::RequestId;
 use rmcp::model::Resource;
 use rmcp::model::ResourceTemplate;
+use rmcp::model::ServerResult;
 use serde_json::Value as JsonValue;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
@@ -690,6 +691,28 @@ impl McpConnectionManager {
             is_error: result.is_error,
             meta: result.meta.and_then(|meta| serde_json::to_value(meta).ok()),
         })
+    }
+
+    /// Send a custom JSON-RPC request to the specified MCP server.
+    pub async fn send_custom_request(
+        &self,
+        server: &str,
+        method: &str,
+        params: Option<JsonValue>,
+        timeout: Duration,
+    ) -> Result<JsonValue> {
+        let client = self.client_by_name(server).await?;
+        let result =
+            tokio::time::timeout(timeout, client.client.send_custom_request(method, params))
+                .await
+                .with_context(|| format!("custom request timed out for `{server}/{method}`"))?
+                .with_context(|| format!("custom request failed for `{server}/{method}`"))?;
+        match result {
+            ServerResult::CustomResult(result) => Ok(result.0),
+            _ => Err(anyhow!(
+                "custom request `{server}/{method}` returned an unexpected result"
+            )),
+        }
     }
 
     pub async fn server_supports_sandbox_state_meta_capability(

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -8,6 +8,7 @@ use crate::config::edit::ConfigEdit;
 use crate::config::edit::ConfigEditsBuilder;
 use crate::connectors;
 use crate::guardian::GuardianApprovalRequest;
+use crate::guardian::GuardianAssessment;
 use crate::guardian::GuardianMcpAnnotations;
 use crate::guardian::GuardianReviewMode;
 use crate::guardian::guardian_rejection_message;
@@ -52,6 +53,7 @@ use codex_protocol::items::TurnItem;
 use codex_protocol::mcp::CallToolResult;
 use codex_protocol::mcp_approval_meta::APPROVAL_KIND_KEY as MCP_TOOL_APPROVAL_KIND_KEY;
 use codex_protocol::mcp_approval_meta::APPROVAL_KIND_MCP_TOOL_CALL as MCP_TOOL_APPROVAL_KIND_MCP_TOOL_CALL;
+use codex_protocol::mcp_approval_meta::CODEX_APPS_GUARDIAN_DETERMINISTIC_REVIEW_META_KEY as MCP_TOOL_CODEX_APPS_GUARDIAN_DETERMINISTIC_REVIEW_META_KEY;
 use codex_protocol::mcp_approval_meta::CONNECTOR_DESCRIPTION_KEY as MCP_TOOL_APPROVAL_CONNECTOR_DESCRIPTION_KEY;
 use codex_protocol::mcp_approval_meta::CONNECTOR_ID_KEY as MCP_TOOL_APPROVAL_CONNECTOR_ID_KEY;
 use codex_protocol::mcp_approval_meta::CONNECTOR_NAME_KEY as MCP_TOOL_APPROVAL_CONNECTOR_NAME_KEY;
@@ -66,6 +68,10 @@ use codex_protocol::mcp_approval_meta::TOOL_PARAMS_KEY as MCP_TOOL_APPROVAL_TOOL
 use codex_protocol::mcp_approval_meta::TOOL_TITLE_KEY as MCP_TOOL_APPROVAL_TOOL_TITLE_KEY;
 use codex_protocol::openai_models::InputModality;
 use codex_protocol::protocol::AskForApproval;
+use codex_protocol::protocol::GuardianAssessmentDecisionSource;
+use codex_protocol::protocol::GuardianAssessmentOutcome;
+use codex_protocol::protocol::GuardianRiskLevel;
+use codex_protocol::protocol::GuardianUserAuthorization;
 use codex_protocol::protocol::McpInvocation;
 use codex_protocol::protocol::ReviewDecision;
 use codex_protocol::request_user_input::RequestUserInputAnswer;
@@ -90,6 +96,7 @@ use tracing::Instrument;
 use tracing::Span;
 use tracing::error;
 use tracing::field::Empty;
+use tracing::warn;
 use url::Url;
 
 const MCP_CALL_COUNT_METRIC: &str = "codex.mcp.call";
@@ -968,10 +975,17 @@ pub(crate) struct McpToolApprovalMetadata {
     openai_file_input_params: Option<Vec<String>>,
 }
 
+#[derive(Debug, Deserialize)]
+struct GuardianDeterministicReviewResponse {
+    safe: bool,
+    rationale: Option<String>,
+}
+
 const MCP_TOOL_OPENAI_OUTPUT_TEMPLATE_META_KEY: &str = "openai/outputTemplate";
 const MCP_TOOL_UI_RESOURCE_URI_META_KEY: &str = "ui/resourceUri";
 const MCP_TOOL_PLUGIN_ID_META_KEY: &str = "plugin_id";
 const MCP_TOOL_THREAD_ID_META_KEY: &str = "threadId";
+const GUARDIAN_DETERMINISTIC_REVIEW_TIMEOUT: Duration = Duration::from_secs(/*secs*/ 2);
 
 async fn custom_mcp_tool_approval_mode(
     sess: &Session,
@@ -1088,6 +1102,91 @@ fn with_mcp_tool_call_thread_id_meta(
         }
         other => other,
     }
+}
+
+async fn guardian_review_mode_for_mcp_tool_call(
+    sess: &Session,
+    turn_context: &TurnContext,
+    call_id: &str,
+    invocation: &McpInvocation,
+    metadata: Option<&McpToolApprovalMetadata>,
+) -> GuardianReviewMode {
+    let Some(method) = guardian_deterministic_review_method(metadata) else {
+        return GuardianReviewMode::Agent;
+    };
+    let manager = sess.services.mcp_connection_manager.load_full();
+    if invocation.server != CODEX_APPS_MCP_SERVER_NAME
+        || !manager.is_host_owned_codex_apps_server(&invocation.server)
+    {
+        return GuardianReviewMode::Agent;
+    }
+
+    let mut params = serde_json::Map::new();
+    params.insert(
+        "name".to_string(),
+        JsonValue::String(invocation.tool.clone()),
+    );
+    params.insert(
+        "arguments".to_string(),
+        invocation
+            .arguments
+            .clone()
+            .unwrap_or_else(|| JsonValue::Object(serde_json::Map::new())),
+    );
+    if let Some(meta) = with_mcp_tool_call_thread_id_meta(
+        build_mcp_tool_call_request_meta(turn_context, &invocation.server, call_id, metadata),
+        &sess.thread_id.to_string(),
+    ) {
+        params.insert("_meta".to_string(), meta);
+    }
+
+    let response = match manager
+        .send_custom_request(
+            &invocation.server,
+            method,
+            Some(JsonValue::Object(params)),
+            GUARDIAN_DETERMINISTIC_REVIEW_TIMEOUT,
+        )
+        .await
+    {
+        Ok(response) => response,
+        Err(err) => {
+            warn!("deterministic Guardian review request failed: {err:#}");
+            return GuardianReviewMode::Agent;
+        }
+    };
+    let response = match serde_json::from_value::<GuardianDeterministicReviewResponse>(response) {
+        Ok(response) => response,
+        Err(err) => {
+            warn!("deterministic Guardian review response was invalid: {err:#}");
+            return GuardianReviewMode::Agent;
+        }
+    };
+    if !response.safe {
+        return GuardianReviewMode::Agent;
+    }
+
+    GuardianReviewMode::Deterministic(GuardianAssessment {
+        risk_level: GuardianRiskLevel::Low,
+        user_authorization: GuardianUserAuthorization::High,
+        outcome: GuardianAssessmentOutcome::Allow,
+        rationale: response
+            .rationale
+            .filter(|rationale| !rationale.trim().is_empty())
+            .unwrap_or_else(|| "Trusted deterministic Guardian review approved.".to_string()),
+        source: GuardianAssessmentDecisionSource::Deterministic,
+    })
+}
+
+fn guardian_deterministic_review_method(
+    metadata: Option<&McpToolApprovalMetadata>,
+) -> Option<&str> {
+    metadata?
+        .codex_apps_meta
+        .as_ref()?
+        .get(MCP_TOOL_CODEX_APPS_GUARDIAN_DETERMINISTIC_REVIEW_META_KEY)?
+        .as_str()
+        .filter(|method| !method.is_empty())
 }
 
 #[derive(Clone, Copy)]
@@ -1209,12 +1308,20 @@ async fn maybe_request_mcp_tool_approval(
 
     if routes_approval_to_guardian_with_reviewer(turn_context, approvals_reviewer) {
         let review_id = new_guardian_review_id();
+        let review_mode = guardian_review_mode_for_mcp_tool_call(
+            sess,
+            turn_context,
+            call_id,
+            invocation,
+            metadata,
+        )
+        .await;
         let decision = review_approval_request(
             sess,
             turn_context,
             review_id.clone(),
             build_guardian_mcp_tool_review_request(call_id, invocation, metadata),
-            GuardianReviewMode::Agent,
+            review_mode,
             /*retry_reason*/ None,
         )
         .await;

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -1612,6 +1612,30 @@ fn guardian_mcp_review_request_includes_invocation_metadata() {
 }
 
 #[test]
+fn guardian_deterministic_review_method_reads_codex_apps_meta() {
+    let mut metadata = approval_metadata(
+        Some("search"),
+        Some("Search"),
+        Some("Search the web"),
+        Some("web.run"),
+        Some("Search the web"),
+    );
+    metadata.codex_apps_meta = Some(
+        [(
+            MCP_TOOL_CODEX_APPS_GUARDIAN_DETERMINISTIC_REVIEW_META_KEY.to_string(),
+            serde_json::json!("tools/deterministic-review"),
+        )]
+        .into_iter()
+        .collect(),
+    );
+
+    assert_eq!(
+        guardian_deterministic_review_method(Some(&metadata)),
+        Some("tools/deterministic-review")
+    );
+}
+
+#[test]
 fn guardian_mcp_review_request_includes_annotations_when_present() {
     let invocation = McpInvocation {
         server: "custom_server".to_string(),

--- a/codex-rs/core/tests/common/apps_test_server.rs
+++ b/codex-rs/core/tests/common/apps_test_server.rs
@@ -22,6 +22,8 @@ const DISCOVERABLE_CALENDAR_ID: &str = "connector_2128aebfecb84f64a069897515042a
 const DISCOVERABLE_GMAIL_ID: &str = "connector_68df038e0ba48191908c8434991bbac2";
 const CONNECTOR_DESCRIPTION: &str = "Plan events and manage your calendar.";
 const CODEX_APPS_META_KEY: &str = "_codex_apps";
+const GUARDIAN_DETERMINISTIC_REVIEW_META_KEY: &str = "guardian_deterministic_review";
+const GUARDIAN_DETERMINISTIC_REVIEW_METHOD: &str = "tools/deterministic-review";
 const PROTOCOL_VERSION: &str = "2025-11-25";
 const SERVER_NAME: &str = "codex-apps-test";
 const SERVER_VERSION: &str = "1.0.0";
@@ -72,6 +74,7 @@ impl AppsTestServer {
             CONNECTOR_DESCRIPTION.to_string(),
             /*searchable*/ true,
             /*include_app_only_tool*/ false,
+            /*deterministic_review_safe*/ None,
         )
         .await;
         Ok(Self {
@@ -91,6 +94,7 @@ impl AppsTestServer {
             CONNECTOR_DESCRIPTION.to_string(),
             /*searchable*/ false,
             /*include_app_only_tool*/ false,
+            /*deterministic_review_safe*/ None,
         )
         .await;
         Ok(Self {
@@ -110,6 +114,24 @@ impl AppsTestServer {
             CONNECTOR_DESCRIPTION.to_string(),
             matches!(tool_loading, AppsTestToolLoading::Searchable),
             /*include_app_only_tool*/ true,
+            /*deterministic_review_safe*/ None,
+        )
+        .await;
+        Ok(Self {
+            chatgpt_base_url: server.uri(),
+        })
+    }
+
+    pub async fn mount_with_deterministic_review(server: &MockServer, safe: bool) -> Result<Self> {
+        mount_oauth_metadata(server).await;
+        mount_connectors_directory(server).await;
+        mount_streamable_http_json_rpc(
+            server,
+            CONNECTOR_NAME.to_string(),
+            CONNECTOR_DESCRIPTION.to_string(),
+            /*searchable*/ false,
+            /*include_app_only_tool*/ false,
+            Some(safe),
         )
         .await;
         Ok(Self {
@@ -167,6 +189,10 @@ fn apps_tool_call_id(body: &Value) -> Option<&str> {
 }
 
 pub async fn recorded_apps_tool_calls(server: &MockServer) -> Vec<Value> {
+    recorded_apps_json_rpc_requests(server, "tools/call").await
+}
+
+pub async fn recorded_apps_json_rpc_requests(server: &MockServer, method: &str) -> Vec<Value> {
     server
         .received_requests()
         .await
@@ -175,7 +201,7 @@ pub async fn recorded_apps_tool_calls(server: &MockServer) -> Vec<Value> {
         .filter_map(|request| {
             let body: Value = serde_json::from_slice(&request.body).ok()?;
             (request.url.path() == "/api/codex/apps"
-                && body.get("method").and_then(Value::as_str) == Some("tools/call"))
+                && body.get("method").and_then(Value::as_str) == Some(method))
             .then_some(body)
         })
         .collect()
@@ -264,6 +290,7 @@ async fn mount_streamable_http_json_rpc(
     connector_description: String,
     searchable: bool,
     include_app_only_tool: bool,
+    deterministic_review_safe: Option<bool>,
 ) {
     Mock::given(method("POST"))
         .and(path_regex("^/api/codex/apps/?$"))
@@ -272,6 +299,7 @@ async fn mount_streamable_http_json_rpc(
             connector_description,
             searchable,
             include_app_only_tool,
+            deterministic_review_safe,
         })
         .mount(server)
         .await;
@@ -282,6 +310,7 @@ struct CodexAppsJsonRpcResponder {
     connector_description: String,
     searchable: bool,
     include_app_only_tool: bool,
+    deterministic_review_safe: Option<bool>,
 }
 
 impl Respond for CodexAppsJsonRpcResponder {
@@ -339,7 +368,7 @@ impl Respond for CodexAppsJsonRpcResponder {
                                 "annotations": {
                                     "readOnlyHint": false,
                                     "destructiveHint": false,
-                                    "openWorldHint": false
+                                    "openWorldHint": self.deterministic_review_safe.is_some()
                                 },
                                 "inputSchema": {
                                     "type": "object",
@@ -425,6 +454,16 @@ impl Respond for CodexAppsJsonRpcResponder {
                         "nextCursor": null
                     }
                 });
+                if self.deterministic_review_safe.is_some()
+                    && let Some(codex_apps_meta) = response
+                        .pointer_mut("/result/tools/0/_meta/_codex_apps")
+                        .and_then(Value::as_object_mut)
+                {
+                    codex_apps_meta.insert(
+                        GUARDIAN_DETERMINISTIC_REVIEW_META_KEY.to_string(),
+                        Value::String(GUARDIAN_DETERMINISTIC_REVIEW_METHOD.to_string()),
+                    );
+                }
                 if self.searchable
                     && let Some(tools) = response
                         .pointer_mut("/result/tools")
@@ -509,6 +548,18 @@ impl Respond for CodexAppsJsonRpcResponder {
                             "_codex_apps": codex_apps_meta,
                         },
                         "isError": false
+                    }
+                }))
+            }
+            GUARDIAN_DETERMINISTIC_REVIEW_METHOD => {
+                let id = body.get("id").cloned().unwrap_or(Value::Null);
+                let safe = self.deterministic_review_safe.unwrap_or(false);
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "safe": safe,
+                        "rationale": safe.then_some("safe search"),
                     }
                 }))
             }

--- a/codex-rs/core/tests/suite/search_tool.rs
+++ b/codex-rs/core/tests/suite/search_tool.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use anyhow::Result;
+use codex_config::types::ApprovalsReviewer;
 use codex_config::types::McpServerConfig;
 use codex_config::types::McpServerTransportConfig;
 use codex_features::Feature;
@@ -29,6 +30,7 @@ use core_test_support::apps_test_server::SEARCH_CALENDAR_NAMESPACE;
 use core_test_support::apps_test_server::apps_enabled_builder;
 use core_test_support::apps_test_server::configure_search_capable_apps;
 use core_test_support::apps_test_server::configure_search_capable_model;
+use core_test_support::apps_test_server::recorded_apps_json_rpc_requests;
 use core_test_support::apps_test_server::recorded_apps_tool_call_by_call_id;
 use core_test_support::apps_test_server::recorded_apps_tool_calls;
 use core_test_support::apps_test_server::search_capable_apps_builder as configured_builder;
@@ -290,6 +292,71 @@ async fn app_only_tools_are_not_visible_or_runnable_by_direct_model_calls() -> R
     assert!(
         recorded_apps_tool_calls(&server).await.is_empty(),
         "forced app-only direct call should not reach the MCP server"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn trusted_deterministic_app_review_skips_guardian_model_review() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let apps_server =
+        AppsTestServer::mount_with_deterministic_review(&server, /*safe*/ true).await?;
+    let call_id = "calendar-deterministic-review-call";
+    let mock = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                ev_function_call_with_namespace(
+                    call_id,
+                    SEARCH_CALENDAR_NAMESPACE,
+                    SEARCH_CALENDAR_CREATE_TOOL,
+                    r#"{"title":"Lunch","starts_at":"2026-06-12T12:00:00Z"}"#,
+                ),
+                ev_completed("resp-1"),
+            ]),
+            sse(vec![
+                ev_response_created("resp-2"),
+                ev_assistant_message("msg-1", "done"),
+                ev_completed("resp-2"),
+            ]),
+        ],
+    )
+    .await;
+
+    let mut builder =
+        apps_enabled_builder(apps_server.chatgpt_base_url.clone()).with_config(|config| {
+            config.approvals_reviewer = ApprovalsReviewer::AutoReview;
+        });
+    let test = builder.build(&server).await?;
+    test.submit_turn_with_approval_and_permission_profile(
+        "Create a lunch calendar event.",
+        AskForApproval::OnRequest,
+        PermissionProfile::Disabled,
+    )
+    .await?;
+
+    assert_eq!(
+        mock.requests().len(),
+        2,
+        "deterministic review should not start a Guardian model request"
+    );
+    let review_requests =
+        recorded_apps_json_rpc_requests(&server, "tools/deterministic-review").await;
+    assert_eq!(review_requests.len(), 1);
+    assert_eq!(
+        review_requests[0]
+            .pointer("/params/name")
+            .and_then(Value::as_str),
+        Some("calendar_create_event")
+    );
+    let tool_call = recorded_apps_tool_call_by_call_id(&server, call_id).await;
+    assert_eq!(
+        tool_call.pointer("/params/name").and_then(Value::as_str),
+        Some("calendar_create_event")
     );
 
     Ok(())

--- a/codex-rs/protocol/src/mcp_approval_meta.rs
+++ b/codex-rs/protocol/src/mcp_approval_meta.rs
@@ -17,3 +17,4 @@ pub const TOOL_TITLE_KEY: &str = "tool_title";
 pub const TOOL_DESCRIPTION_KEY: &str = "tool_description";
 pub const TOOL_PARAMS_KEY: &str = "tool_params";
 pub const TOOL_PARAMS_DISPLAY_KEY: &str = "tool_params_display";
+pub const CODEX_APPS_GUARDIAN_DETERMINISTIC_REVIEW_META_KEY: &str = "guardian_deterministic_review";


### PR DESCRIPTION
Stacked on #27839. Runtime pair: openai/openai#1024035.

Summary:
- let trusted host-owned Codex Apps MCP metadata advertise a deterministic Guardian review method
- preflight only host-owned Codex Apps tools; a safe result becomes a deterministic Guardian allow assessment, while unsafe/missing/error responses fall back to the existing Agent Guardian review
- add the MCP custom-request helper and coverage showing a trusted deterministic result skips the Guardian model request

Validation:
- `just fmt`
- `just test -p codex-core trusted_deterministic_app_review_skips_guardian_model_review`
- `just test -p codex-core guardian_deterministic_review_method_reads_codex_apps_meta`
- `just test -p codex-mcp` (`75 passed`)
- `just test -p codex-protocol` (`228 passed`)
- `just test -p codex-core` attempted: `2667 passed`, `8 flaky`, `69 failed`, `17 skipped`; failures were local sandbox/harness signatures including PATH alias `Operation not permitted`, missing `test_stdio_server`, Seatbelt env mismatch, and related timeout fallout
- `just fix -p codex-core`; `just fix -p codex-mcp`; `just fix -p codex-protocol`

Not run: full workspace `just test` (repo instructions require asking before that complete suite).