### PR TITLE
[codex] parallelize Windows package archives

### DIFF
--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -277,13 +277,24 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          for bundle in primary app-server; do
-            bash "${GITHUB_WORKSPACE}/.github/scripts/build-codex-package-archive.sh" \
-              --target "${{ matrix.target }}" \
-              --bundle "$bundle" \
-              --entrypoint-dir "target/${{ matrix.target }}/release" \
-              --archive-dir "dist/${{ matrix.target }}"
-          done
+          target="${{ matrix.target }}"
+          archive_script="${GITHUB_WORKSPACE}/.github/scripts/build-codex-package-archive.sh"
+          temp_root="${RUNNER_TEMP}/codex-package-archives"
+
+          # The package helper rewrites cached DotSlash executables. Keep the
+          # concurrent processes in separate temp roots because Windows cannot
+          # replace an executable while another process is using it.
+          mkdir -p "$temp_root/primary" "$temp_root/app-server"
+          printf '%s\0' primary app-server |
+            xargs -0 -P0 -I{} env \
+              TMPDIR="$temp_root/{}" \
+              TMP="$temp_root/{}" \
+              TEMP="$temp_root/{}" \
+              bash "$archive_script" \
+                --target "$target" \
+                --bundle "{}" \
+                --entrypoint-dir "target/$target/release" \
+                --archive-dir "dist/$target"
 
       - name: Build Python runtime wheel
         shell: bash


### PR DESCRIPTION
In the Windows x64 packaging job from

https://github.com/openai/codex/actions/runs/27391514823

building the primary and app-server package archives serially took 116
seconds.

Both archives read the same signed-binary directory but write separate
package trees and output files. Run them concurrently with xargs -P2.

The package helper rewrites DotSlash executables under the process temp
directory. A naive concurrent run failed when one process tried to
replace an executable used by the other. Give each bundle separate TMP
and TEMP roots to keep those caches independent.

On Windows x64 in

https://github.com/openai/codex/actions/runs/27397197944

three serial trials took 127, 128, and 126 seconds. Concurrent trials
took 76, 74, and 74 seconds, saving 52 to 54 seconds. This removes about
50 seconds from the release critical path without changing the packaging
commands or output set.