### PR TITLE
[codex] parallelize Windows compression

### DIFF
--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -306,6 +306,8 @@ jobs:
           # ${{ matrix.target }}
           dest="dist/${{ matrix.target }}"
           repo_root=$PWD
+          target="${{ matrix.target }}"
+          export dest repo_root target
 
           # For compatibility with environments that lack the `zstd` tool we
           # additionally create a `.tar.gz` and `.zip` for every Windows binary.
@@ -313,33 +315,38 @@ jobs:
           #   codex-<target>.zst
           #   codex-<target>.tar.gz
           #   codex-<target>.zip
-          for f in "$dest"/*; do
+          # Variables in the single-quoted script expand in the child shell.
+          # shellcheck disable=SC2016
+          printf '%s\0' "$dest"/* |
+            xargs -0 -n1 -P2 bash -c '
+            set -euo pipefail
+            f=$1
             base="$(basename "$f")"
-            # Skip files that are already archives (shouldn't happen, but be
+            # Skip files that are already archives (should not happen, but be
             # safe).
             if [[ "$base" == *.tar.gz || "$base" == *.tar.zst || "$base" == *.zip || "$base" == *.dmg ]]; then
-              continue
+              exit 0
             fi
 
-            # Don't try to compress signature bundles.
+            # Do not try to compress signature bundles.
             if [[ "$base" == *.sigstore ]]; then
-              continue
+              exit 0
             fi
 
             # Create per-binary tar.gz
             tar -C "$dest" -czf "$dest/${base}.tar.gz" "$base"
 
             # Create zip archive for Windows binaries.
-            # Must run from inside the dest dir so 7z won't embed the
+            # Must run from inside the dest dir so 7z does not embed the
             # directory path inside the zip.
-            if [[ "$base" == "codex-${{ matrix.target }}.exe" ]]; then
+            if [[ "$base" == "codex-${target}.exe" ]]; then
               # Bundle the sandbox helper binaries into the main codex zip so
               # WinGet installs include the required helpers next to codex.exe.
               # Fall back to the single-binary zip if the helpers are missing
               # to avoid breaking releases.
               bundle_dir="$(mktemp -d)"
-              runner_src="$dest/codex-command-runner-${{ matrix.target }}.exe"
-              setup_src="$dest/codex-windows-sandbox-setup-${{ matrix.target }}.exe"
+              runner_src="$dest/codex-command-runner-${target}.exe"
+              setup_src="$dest/codex-windows-sandbox-setup-${target}.exe"
               if [[ -f "$runner_src" && -f "$setup_src" ]]; then
                 cp "$dest/$base" "$bundle_dir/$base"
                 cp "$runner_src" "$bundle_dir/codex-command-runner.exe"
@@ -359,7 +366,7 @@ jobs:
 
             # Keep raw executables and produce .zst alongside them.
             "${GITHUB_WORKSPACE}/.github/workflows/zstd" -T0 -19 "$dest/$base"
-          done
+          ' _
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:


### PR DESCRIPTION
Each Windows packaging job creates three compressed forms of five
binaries in sequence. This takes roughly two minutes and is on the
release critical path.

Use two xargs workers to compress independent binaries concurrently.
The workers only read the raw executables and write per-binary archive
names. The Codex zip can safely read the helper executables while their
own archives are generated.

On a 16-vCPU AMD EPYC 9V74 Windows x64 release runner, alternating
trials against artifacts from release run 27391514823 measured:

  serial:   121 s, 123 s, 121 s
  parallel:  73 s,  73 s,  74 s

This saves 47 to 50 seconds in the x64 packaging lane, reducing the
observed release critical path by about 48 seconds when x64 remains the
limiting lane.

https://github.com/openai/codex/actions/runs/27401905938