### PR TITLE
fix: serialize auth environment tests

### DIFF
--- a/codex-rs/login/src/auth/auth_tests.rs
+++ b/codex-rs/login/src/auth/auth_tests.rs
@@ -424,6 +424,7 @@ fn logout_removes_auth_file() -> Result<(), std::io::Error> {
 }
 
 #[tokio::test]
+#[serial(codex_auth_env)]
 async fn unauthorized_recovery_reports_mode_and_step_names() {
     let dir = tempdir().unwrap();
     let manager = AuthManager::shared(
@@ -1321,6 +1322,7 @@ async fn enforce_login_restrictions_logs_out_for_agent_identity_workspace_mismat
 }
 
 #[tokio::test]
+#[serial(codex_auth_env)]
 async fn enforce_login_restrictions_allows_api_key_if_login_method_not_set_but_forced_chatgpt_workspace_id_is_set()
  {
     let codex_home = tempdir().unwrap();

--- a/codex-rs/login/src/auth/bedrock_api_key_tests.rs
+++ b/codex-rs/login/src/auth/bedrock_api_key_tests.rs
@@ -1,6 +1,7 @@
 use codex_app_server_protocol::AuthMode;
 use codex_config::types::AuthCredentialsStoreMode;
 use pretty_assertions::assert_eq;
+use serial_test::serial;
 use tempfile::tempdir;
 
 use super::*;
@@ -41,6 +42,7 @@ fn bedrock_auth() -> BedrockApiKeyAuth {
 }
 
 #[tokio::test]
+#[serial(codex_auth_env)]
 async fn login_with_bedrock_api_key_replaces_openai_auth() -> anyhow::Result<()> {
     let codex_home = tempdir()?;
     let storage = FileAuthStorage::new(codex_home.path().to_path_buf());
@@ -87,6 +89,7 @@ async fn login_with_bedrock_api_key_replaces_openai_auth() -> anyhow::Result<()>
 }
 
 #[tokio::test]
+#[serial(codex_auth_env)]
 async fn logout_removes_bedrock_auth() -> anyhow::Result<()> {
     let codex_home = tempdir()?;
     let storage = FileAuthStorage::new(codex_home.path().to_path_buf());
@@ -112,6 +115,7 @@ async fn logout_removes_bedrock_auth() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+#[serial(codex_auth_env)]
 async fn bedrock_only_auth_storage_creates_primary_auth() -> anyhow::Result<()> {
     let codex_home = tempdir()?;
     let storage = FileAuthStorage::new(codex_home.path().to_path_buf());


### PR DESCRIPTION
## Summary
- serialize the remaining login tests that mutate or read the process-global auth environment
- include Bedrock auth-manager tests in the existing `codex_auth_env` serial group

## Root cause
The login unit-test binary runs tests concurrently. One test removed `CODEX_ACCESS_TOKEN` without joining the existing serial group, while several Bedrock tests constructed `AuthManager` and read that same process-global environment outside the group. An interleaving could restore a stale personal access token while another test was loading file-backed auth, causing the observed mismatched `/whoami` request count and related auth-state flakes.

## Verification
- `just fmt`
- `git diff --check`
- `bazel test //codex-rs/login:login-unit-tests --nocache_test_results --runs_per_test=20 --test_output=errors` (20/20 passed)
- `just test -p codex-login` (135/135 passed)