### PR TITLE
Use uv as Python SDK build backend

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["hatchling>=1.27.0"]
-build-backend = "hatchling.build"
+requires = ["uv_build>=0.11.19,<0.12"]
+build-backend = "uv_build"
 
 [project]
 name = "openai-codex"
@@ -36,26 +36,17 @@ dev = [
   { include-group = "format" },
 ]
 
-[tool.hatch.build]
-exclude = [
+[tool.uv.build-backend]
+module-name = "openai_codex"
+source-include = [
+  "examples/README.md",
+]
+source-exclude = [
   ".venv/**",
   ".venv2/**",
   ".pytest_cache/**",
   "dist/**",
   "build/**",
-]
-
-[tool.hatch.build.targets.wheel]
-packages = ["src/openai_codex"]
-include = [
-  "src/openai_codex/py.typed",
-]
-
-[tool.hatch.build.targets.sdist]
-include = [
-  "src/openai_codex/**",
-  "README.md",
-  "pyproject.toml",
 ]
 
 [tool.pytest.ini_options]

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -36,12 +36,6 @@ dev = [
   { include-group = "format" },
 ]
 
-[tool.uv.build-backend]
-module-name = "openai_codex"
-source-include = [
-  "examples/README.md",
-]
-
 [tool.pytest.ini_options]
 addopts = "-q"
 testpaths = ["tests"]

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -41,13 +41,6 @@ module-name = "openai_codex"
 source-include = [
   "examples/README.md",
 ]
-source-exclude = [
-  ".venv/**",
-  ".venv2/**",
-  ".pytest_cache/**",
-  "dist/**",
-  "build/**",
-]
 
 [tool.pytest.ini_options]
 addopts = "-q"

--- a/sdk/python/tests/test_artifact_workflow_and_binaries.py
+++ b/sdk/python/tests/test_artifact_workflow_and_binaries.py
@@ -362,8 +362,8 @@ def test_source_sdk_template_pins_published_runtime() -> None:
     }
 
 
-def test_source_sdk_package_declares_beta_documentation_and_release_files() -> None:
-    """Public package metadata should link beta docs and ship package metadata."""
+def test_source_sdk_package_declares_beta_documentation() -> None:
+    """Public package metadata should link beta docs."""
     pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
     readme = (ROOT / "README.md").read_text()
 
@@ -372,7 +372,6 @@ def test_source_sdk_package_declares_beta_documentation_and_release_files() -> N
         "is_beta": "Development Status :: 4 - Beta" in pyproject["project"]["classifiers"],
         "license": pyproject["project"]["license"],
         "documentation": pyproject["project"]["urls"]["Documentation"],
-        "sdist_include": pyproject["tool"]["hatch"]["build"]["targets"]["sdist"]["include"],
         "readme_is_beta": "# OpenAI Codex Python SDK (Beta)" in readme,
         "local_license_file": (ROOT / "LICENSE").exists(),
     } == {
@@ -380,11 +379,6 @@ def test_source_sdk_package_declares_beta_documentation_and_release_files() -> N
         "is_beta": True,
         "license": "Apache-2.0",
         "documentation": "https://github.com/openai/codex/tree/main/sdk/python/docs",
-        "sdist_include": [
-            "src/openai_codex/**",
-            "README.md",
-            "pyproject.toml",
-        ],
         "readme_is_beta": True,
         "local_license_file": False,
     }


### PR DESCRIPTION
## Summary

Replace Hatchling with uv's build backend for the Python SDK. The backend infers the `src/openai_codex` module from the normalized project name and standard source layout, so no uv-specific package configuration is required.

This keeps Python packaging within the uv toolchain already used for dependency management and release builds. A controlled before-and-after PEP 517 comparison produced identical wheel package paths, bytes, permissions, and semantic metadata. The sdist retains the SDK package tree, root README, and project metadata while dropping the unrelated examples README that Hatch included through its broad include matching.
