### PR TITLE
[codex] Make plugin runtime loading capability aware

### DIFF
--- a/codex-rs/core-plugins/src/loader.rs
+++ b/codex-rs/core-plugins/src/loader.rs
@@ -73,6 +73,7 @@ enum PluginLoadScope<'a> {
     AllCapabilities {
         restriction_product: Option<Product>,
         skill_config_rules: &'a SkillConfigRules,
+        auth_mode: Option<AuthMode>,
     },
     HooksOnly,
 }
@@ -118,6 +119,7 @@ pub async fn load_plugins_from_layer_stack(
     extra_plugins: HashMap<String, PluginConfig>,
     store: &PluginStore,
     restriction_product: Option<Product>,
+    auth_mode: Option<AuthMode>,
     prefer_remote_curated_conflicts: bool,
 ) -> PluginLoadOutcome<McpServerConfig> {
     let skill_config_rules = skill_config_rules_from_stack(config_layer_stack);
@@ -129,6 +131,7 @@ pub async fn load_plugins_from_layer_stack(
         PluginLoadScope::AllCapabilities {
             restriction_product,
             skill_config_rules: &skill_config_rules,
+            auth_mode,
         },
     )
     .await
@@ -665,6 +668,7 @@ async fn load_plugin(
         PluginLoadScope::AllCapabilities {
             restriction_product,
             skill_config_rules,
+            auth_mode,
         } => {
             loaded_plugin.manifest_name = Some(manifest.display_name().to_string());
             loaded_plugin.manifest_description = manifest.description.clone();
@@ -700,6 +704,15 @@ async fn load_plugin(
             }
             loaded_plugin.mcp_servers = mcp_servers;
             loaded_plugin.apps = load_plugin_apps(plugin_root.as_path()).await;
+            let projected = resolve_plugin_capabilities(
+                PluginCapabilities::new(
+                    std::mem::take(&mut loaded_plugin.apps),
+                    std::mem::take(&mut loaded_plugin.mcp_servers),
+                ),
+                PluginCapabilityContext::new(*auth_mode, loaded_plugin.is_active()),
+            );
+            loaded_plugin.apps = projected.apps;
+            loaded_plugin.mcp_servers = projected.mcp_servers;
         }
         PluginLoadScope::HooksOnly => {}
     }

--- a/codex-rs/core-plugins/src/loader_tests.rs
+++ b/codex-rs/core-plugins/src/loader_tests.rs
@@ -84,7 +84,7 @@ async fn hooks_only_scope_shares_plugin_resolution_without_loading_other_capabil
     );
     write_file(
         &plugin_root.join(".app.json"),
-        r#"{"apps":{"example":{"id":"connector_example"}}}"#,
+        r#"{"apps":{"example_app":{"id":"connector_example"}}}"#,
     );
     write_file(
         &plugin_root.join("hooks/hooks.json"),
@@ -161,6 +161,7 @@ enabled = true
         HashMap::new(),
         &store,
         Some(Product::Codex),
+        Some(AuthMode::Chatgpt),
         /*prefer_remote_curated_conflicts*/ false,
     )
     .await;

--- a/codex-rs/core-plugins/src/manager.rs
+++ b/codex-rs/core-plugins/src/manager.rs
@@ -1,8 +1,5 @@
 use super::PluginLoadOutcome;
 use crate::OPENAI_CURATED_MARKETPLACE_NAME;
-use crate::capabilities::PluginCapabilities;
-use crate::capabilities::PluginCapabilityContext;
-use crate::capabilities::resolve_plugin_capabilities;
 use crate::installed_marketplaces::installed_marketplace_roots_from_layer_stack;
 use crate::loader::PluginHookLoadOutcome;
 use crate::loader::configured_curated_plugin_ids_from_codex_home;
@@ -209,25 +206,6 @@ fn featured_plugin_ids_cache_key(
     }
 }
 
-fn project_plugin_load_outcome_for_auth(
-    outcome: PluginLoadOutcome,
-    auth_mode: Option<AuthMode>,
-) -> PluginLoadOutcome {
-    let mut plugins = outcome.plugins().to_vec();
-    for plugin in &mut plugins {
-        let projected = resolve_plugin_capabilities(
-            PluginCapabilities::new(
-                std::mem::take(&mut plugin.apps),
-                std::mem::take(&mut plugin.mcp_servers),
-            ),
-            PluginCapabilityContext::new(auth_mode, plugin.is_active()),
-        );
-        plugin.apps = projected.apps;
-        plugin.mcp_servers = projected.mcp_servers;
-    }
-    PluginLoadOutcome::from_plugins(plugins)
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PluginInstallRequest {
     pub plugin_name: String,
@@ -366,6 +344,7 @@ struct PluginLoadCacheKey {
     configured_plugins: HashMap<String, PluginConfig>,
     skill_config_rules: SkillConfigRules,
     remote_plugin_enabled: bool,
+    auth_mode: Option<AuthMode>,
 }
 
 impl PluginsManager {
@@ -464,13 +443,15 @@ impl PluginsManager {
             return PluginLoadOutcome::default();
         }
 
+        let auth_mode = self.auth_mode();
         let cache_key = PluginLoadCacheKey {
             configured_plugins: configured_plugins_from_stack(&config.config_layer_stack),
             skill_config_rules: skill_config_rules_from_stack(&config.config_layer_stack),
             remote_plugin_enabled: config.remote_plugin_enabled,
+            auth_mode,
         };
         if !force_reload && let Some(outcome) = self.cached_enabled_outcome(&cache_key) {
-            return self.project_plugins_for_auth(outcome);
+            return outcome;
         }
 
         let Ok(_load_permit) = self.enabled_outcome_load_semaphore.acquire().await else {
@@ -478,7 +459,7 @@ impl PluginsManager {
             return PluginLoadOutcome::default();
         };
         if !force_reload && let Some(outcome) = self.cached_enabled_outcome(&cache_key) {
-            return self.project_plugins_for_auth(outcome);
+            return outcome;
         }
         let cache_generation = self.enabled_outcome_cache_generation();
         let outcome = load_plugins_from_layer_stack(
@@ -486,16 +467,13 @@ impl PluginsManager {
             self.remote_installed_plugin_configs(),
             &self.store,
             self.restriction_product,
+            auth_mode,
             config.remote_plugin_enabled,
         )
         .await;
         log_plugin_load_errors(&outcome);
         self.cache_enabled_outcome_if_current(cache_generation, cache_key, outcome.clone());
-        self.project_plugins_for_auth(outcome)
-    }
-
-    fn project_plugins_for_auth(&self, outcome: PluginLoadOutcome) -> PluginLoadOutcome {
-        project_plugin_load_outcome_for_auth(outcome, self.auth_mode())
+        outcome
     }
 
     pub fn clear_cache(&self) {
@@ -525,15 +503,15 @@ impl PluginsManager {
         if !config.plugins_enabled {
             return PluginLoadOutcome::default();
         }
-        let outcome = load_plugins_from_layer_stack(
+        load_plugins_from_layer_stack(
             config_layer_stack,
             self.remote_installed_plugin_configs(),
             &self.store,
             self.restriction_product,
+            self.auth_mode(),
             config.remote_plugin_enabled,
         )
-        .await;
-        self.project_plugins_for_auth(outcome)
+        .await
     }
 
     /// Resolve plugin hooks for a config layer stack without loading other plugin capabilities.

--- a/codex-rs/core-plugins/src/manager_tests.rs
+++ b/codex-rs/core-plugins/src/manager_tests.rs
@@ -356,7 +356,7 @@ enabled = true
 }
 
 #[tokio::test]
-async fn plugin_auth_projection_reprojects_cached_outcome_when_auth_changes() {
+async fn plugin_auth_cache_key_reloads_when_auth_changes() {
     let codex_home = TempDir::new().unwrap();
     write_auth_projection_plugin(codex_home.path(), "sample", /*include_app*/ true);
     write_auth_projection_plugin(codex_home.path(), "docs", /*include_app*/ false);
@@ -377,12 +377,18 @@ async fn plugin_auth_projection_reprojects_cached_outcome_when_auth_changes() {
         vec![AppConnectorId("connector_sample".to_string())]
     );
 
+    std::fs::remove_file(
+        codex_home
+            .path()
+            .join("plugins/cache/test/sample/local/.mcp.json"),
+    )
+    .unwrap();
     assert!(manager.set_auth_mode(Some(AuthMode::ApiKey)));
     let api_key_outcome = manager.plugins_for_config(&config).await;
 
     assert_eq!(
         sorted_effective_mcp_server_names(&api_key_outcome),
-        vec!["docs".to_string(), "sample".to_string()]
+        vec!["docs".to_string()]
     );
     assert!(api_key_outcome.effective_apps().is_empty());
 }
@@ -1781,6 +1787,7 @@ fn plugin_cache_invalidation_rejects_stale_load_completion() {
         configured_plugins: HashMap::new(),
         skill_config_rules: SkillConfigRules::default(),
         remote_plugin_enabled: false,
+        auth_mode: None,
     };
     let stale_generation = manager.enabled_outcome_cache_generation();
 
@@ -4078,6 +4085,7 @@ async fn load_plugins_ignores_project_config_files() {
         std::collections::HashMap::new(),
         &PluginStore::new(codex_home.path().to_path_buf()),
         Some(Product::Codex),
+        /*auth_mode*/ None,
         /*prefer_remote_curated_conflicts*/ false,
     )
     .await;


### PR DESCRIPTION
## Summary

This builds on the shared capability resolver from PR1 and applies it at the runtime loading boundary.

That boundary matters because it is where installed/configured plugin declarations become the effective apps and MCP servers that downstream consumers can see. This sets up the code to enable moving **auth context aware filtering logic to the highest possible level** .

## Why

We want auth-level routing to be centralized, but it also needs to run at the right layer. The runtime loader is the layer that turns plugin files into usable capabilities, so this PR wires that layer through the resolver:

- Codex-backed auth keeps app connectors available and removes conflicting MCP servers for active plugins.
- API-key/direct auth removes app connectors but keeps usable MCP servers.
- Downstream consumers receive already-projected capabilities instead of needing their own auth-specific filtering.

This keeps the product rule close to where plugin capabilities become real, while leaving the rule itself owned by `capabilities.rs`.

## Validation

- `cargo fmt`
- `cargo test -p codex-core-plugins`