### PR TITLE
[codex] Make marketplace loading capability aware

### DIFF
--- a/codex-rs/core-plugins/src/capabilities.rs
+++ b/codex-rs/core-plugins/src/capabilities.rs
@@ -20,6 +20,11 @@ impl PluginCapabilityContext {
     pub(crate) fn apps_route_available(self) -> bool {
         self.auth_mode.is_some_and(AuthMode::uses_codex_backend)
     }
+
+    pub(crate) fn filters_marketplace_plugins(self) -> bool {
+        self.auth_mode
+            .is_some_and(|auth_mode| !auth_mode.uses_codex_backend())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -37,17 +42,24 @@ impl<M> PluginCapabilities<M> {
     }
 }
 
+fn app_declaration_names(apps: &[AppDeclaration]) -> HashSet<&str> {
+    apps.iter().map(|app| app.name.as_str()).collect()
+}
+
+fn app_declarations_are_covered_by_mcp<M>(capabilities: &PluginCapabilities<M>) -> bool {
+    capabilities
+        .apps
+        .iter()
+        .all(|app| capabilities.mcp_servers.contains_key(app.name.as_str()))
+}
+
 pub(crate) fn resolve_plugin_capabilities<M>(
     mut capabilities: PluginCapabilities<M>,
     context: PluginCapabilityContext,
 ) -> PluginCapabilities<M> {
     if context.apps_route_available() {
         if context.plugin_active && !capabilities.apps.is_empty() {
-            let app_declaration_names = capabilities
-                .apps
-                .iter()
-                .map(|app| app.name.as_str())
-                .collect::<HashSet<_>>();
+            let app_declaration_names = app_declaration_names(&capabilities.apps);
             capabilities
                 .mcp_servers
                 .retain(|name, _| !app_declaration_names.contains(name.as_str()));
@@ -57,6 +69,31 @@ pub(crate) fn resolve_plugin_capabilities<M>(
     }
 
     capabilities
+}
+
+fn plugin_has_usable_capabilities<M>(
+    capabilities: PluginCapabilities<M>,
+    has_skills: bool,
+    context: PluginCapabilityContext,
+) -> bool {
+    if !context.apps_route_available() && !app_declarations_are_covered_by_mcp(&capabilities) {
+        return false;
+    }
+
+    let capabilities = resolve_plugin_capabilities(capabilities, context);
+    has_skills || !capabilities.apps.is_empty() || !capabilities.mcp_servers.is_empty()
+}
+
+pub(crate) fn plugin_is_visible_in_marketplace<M>(
+    capabilities: PluginCapabilities<M>,
+    has_skills: bool,
+    context: PluginCapabilityContext,
+) -> bool {
+    if !context.filters_marketplace_plugins() {
+        return true;
+    }
+
+    plugin_has_usable_capabilities(capabilities, has_skills, context)
 }
 
 #[cfg(test)]

--- a/codex-rs/core-plugins/src/capabilities_tests.rs
+++ b/codex-rs/core-plugins/src/capabilities_tests.rs
@@ -40,6 +40,32 @@ fn sorted_mcp_server_names(capabilities: &PluginCapabilities<i32>) -> Vec<String
     names
 }
 
+fn has_usable_capabilities(
+    apps: Vec<AppDeclaration>,
+    mcp_servers: impl IntoIterator<Item = (&'static str, i32)>,
+    has_skills: bool,
+    auth_mode: Option<AuthMode>,
+) -> bool {
+    plugin_has_usable_capabilities(
+        capabilities(apps, mcp_servers),
+        has_skills,
+        PluginCapabilityContext::new(auth_mode, /*plugin_active*/ true),
+    )
+}
+
+fn visible_in_marketplace(
+    apps: Vec<AppDeclaration>,
+    mcp_servers: impl IntoIterator<Item = (&'static str, i32)>,
+    has_skills: bool,
+    auth_mode: Option<AuthMode>,
+) -> bool {
+    plugin_is_visible_in_marketplace(
+        capabilities(apps, mcp_servers),
+        has_skills,
+        PluginCapabilityContext::new(auth_mode, /*plugin_active*/ true),
+    )
+}
+
 #[test]
 fn apps_route_available_tracks_auth_mode_capabilities() {
     assert!(
@@ -103,4 +129,88 @@ fn resolver_preserves_mcp_conflicts_when_plugin_is_inactive() {
         sorted_mcp_server_names(&resolved),
         vec!["docs".to_string(), "linear".to_string()]
     );
+}
+
+#[test]
+fn usability_requires_apps_to_be_covered_by_mcp_when_apps_route_is_unavailable() {
+    assert!(!has_usable_capabilities(
+        vec![app("linear")],
+        [],
+        /*has_skills*/ false,
+        Some(AuthMode::ApiKey)
+    ));
+    assert!(!has_usable_capabilities(
+        vec![app("linear")],
+        [],
+        /*has_skills*/ true,
+        Some(AuthMode::ApiKey)
+    ));
+    assert!(!has_usable_capabilities(
+        vec![app("linear")],
+        [("other", 1)],
+        /*has_skills*/ false,
+        Some(AuthMode::ApiKey)
+    ));
+    assert!(has_usable_capabilities(
+        vec![app("linear")],
+        [("linear", 1)],
+        /*has_skills*/ false,
+        Some(AuthMode::ApiKey)
+    ));
+    assert!(has_usable_capabilities(
+        vec![],
+        [("other", 1)],
+        /*has_skills*/ false,
+        Some(AuthMode::ApiKey)
+    ));
+    assert!(has_usable_capabilities(
+        vec![],
+        [],
+        /*has_skills*/ true,
+        Some(AuthMode::ApiKey)
+    ));
+}
+
+#[test]
+fn usability_keeps_apps_when_apps_route_is_available() {
+    assert!(has_usable_capabilities(
+        vec![app("linear")],
+        [],
+        /*has_skills*/ false,
+        Some(AuthMode::Chatgpt)
+    ));
+    assert!(has_usable_capabilities(
+        vec![app("linear")],
+        [("linear", 1)],
+        /*has_skills*/ false,
+        Some(AuthMode::Chatgpt)
+    ));
+}
+
+#[test]
+fn marketplace_visibility_filters_only_direct_auth_modes() {
+    assert!(visible_in_marketplace(
+        vec![app("linear")],
+        [],
+        /*has_skills*/ false,
+        /*auth_mode*/ None
+    ));
+    assert!(visible_in_marketplace(
+        vec![app("linear")],
+        [],
+        /*has_skills*/ false,
+        Some(AuthMode::Chatgpt)
+    ));
+    assert!(!visible_in_marketplace(
+        vec![app("linear")],
+        [],
+        /*has_skills*/ false,
+        Some(AuthMode::ApiKey)
+    ));
+    assert!(visible_in_marketplace(
+        vec![app("linear")],
+        [("linear", 1)],
+        /*has_skills*/ false,
+        Some(AuthMode::ApiKey)
+    ));
 }

--- a/codex-rs/core-plugins/src/declared_capabilities.rs
+++ b/codex-rs/core-plugins/src/declared_capabilities.rs
@@ -1,0 +1,194 @@
+use crate::manifest::PluginManifestPaths;
+use codex_utils_absolute_path::AbsolutePathBuf;
+use serde::Deserialize;
+use serde_json::Value as JsonValue;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::fs;
+use std::path::Path;
+use tracing::warn;
+
+const DEFAULT_SKILLS_DIR_NAME: &str = "skills";
+const DEFAULT_MCP_CONFIG_FILE: &str = ".mcp.json";
+const DEFAULT_APP_CONFIG_FILE: &str = ".app.json";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DeclaredPluginCapabilities {
+    pub(crate) skills: HashSet<DeclaredSkill>,
+    pub(crate) apps: HashSet<DeclaredApp>,
+    pub(crate) mcp: HashSet<DeclaredMcp>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct DeclaredSkill {
+    pub(crate) path: AbsolutePathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct DeclaredApp {
+    pub(crate) name: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct DeclaredMcp {
+    pub(crate) name: String,
+}
+
+pub(crate) fn load_declared_plugin_capabilities(
+    plugin_root: &AbsolutePathBuf,
+    manifest_paths: &PluginManifestPaths,
+) -> DeclaredPluginCapabilities {
+    DeclaredPluginCapabilities {
+        skills: load_declared_plugin_skills(plugin_root, manifest_paths),
+        apps: load_declared_plugin_apps(plugin_root.as_path(), manifest_paths),
+        mcp: load_declared_plugin_mcp(plugin_root.as_path(), manifest_paths),
+    }
+}
+
+fn load_declared_plugin_skills(
+    plugin_root: &AbsolutePathBuf,
+    manifest_paths: &PluginManifestPaths,
+) -> HashSet<DeclaredSkill> {
+    let mut skills = HashSet::new();
+    if let Some(path) = &manifest_paths.skills {
+        skills.insert(DeclaredSkill { path: path.clone() });
+    } else {
+        let path = plugin_root.join(DEFAULT_SKILLS_DIR_NAME);
+        if path.as_path().is_dir() {
+            skills.insert(DeclaredSkill { path });
+        }
+    }
+    skills
+}
+
+fn load_declared_plugin_apps(
+    plugin_root: &Path,
+    manifest_paths: &PluginManifestPaths,
+) -> HashSet<DeclaredApp> {
+    let mut apps = HashSet::new();
+    for app_config_path in plugin_app_config_paths(plugin_root, manifest_paths) {
+        let Ok(contents) = fs::read_to_string(app_config_path.as_path()) else {
+            continue;
+        };
+        let parsed = match serde_json::from_str::<DeclaredPluginAppFile>(&contents) {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                warn!(
+                    path = %app_config_path.display(),
+                    "failed to parse plugin app config while loading declared capabilities: {err}"
+                );
+                continue;
+            }
+        };
+
+        apps.extend(parsed.apps.into_iter().filter_map(|(name, app)| {
+            if app.id.trim().is_empty() {
+                None
+            } else {
+                Some(DeclaredApp { name })
+            }
+        }));
+    }
+
+    apps
+}
+
+fn load_declared_plugin_mcp(
+    plugin_root: &Path,
+    manifest_paths: &PluginManifestPaths,
+) -> HashSet<DeclaredMcp> {
+    let mut mcp = HashSet::new();
+    for mcp_config_path in plugin_mcp_config_paths(plugin_root, manifest_paths) {
+        let Ok(contents) = fs::read_to_string(mcp_config_path.as_path()) else {
+            continue;
+        };
+        let parsed = match serde_json::from_str::<DeclaredPluginMcpFile>(&contents) {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                warn!(
+                    path = %mcp_config_path.display(),
+                    "failed to parse plugin MCP config while loading declared capabilities: {err}"
+                );
+                continue;
+            }
+        };
+
+        mcp.extend(
+            parsed
+                .into_mcp_servers()
+                .into_keys()
+                .map(|name| DeclaredMcp { name }),
+        );
+    }
+
+    mcp
+}
+
+fn plugin_app_config_paths(
+    plugin_root: &Path,
+    manifest_paths: &PluginManifestPaths,
+) -> Vec<AbsolutePathBuf> {
+    if let Some(path) = &manifest_paths.apps {
+        return vec![path.clone()];
+    }
+    default_plugin_config_paths(plugin_root, DEFAULT_APP_CONFIG_FILE)
+}
+
+fn plugin_mcp_config_paths(
+    plugin_root: &Path,
+    manifest_paths: &PluginManifestPaths,
+) -> Vec<AbsolutePathBuf> {
+    if let Some(path) = &manifest_paths.mcp_servers {
+        return vec![path.clone()];
+    }
+    default_plugin_config_paths(plugin_root, DEFAULT_MCP_CONFIG_FILE)
+}
+
+fn default_plugin_config_paths(plugin_root: &Path, file_name: &str) -> Vec<AbsolutePathBuf> {
+    let path = plugin_root.join(file_name);
+    if path.is_file()
+        && let Ok(path) = AbsolutePathBuf::try_from(path)
+    {
+        vec![path]
+    } else {
+        Vec::new()
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DeclaredPluginAppFile {
+    #[serde(default)]
+    apps: HashMap<String, DeclaredPluginAppConfig>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DeclaredPluginAppConfig {
+    id: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DeclaredPluginMcpServersFile {
+    mcp_servers: HashMap<String, JsonValue>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum DeclaredPluginMcpFile {
+    McpServersObject(DeclaredPluginMcpServersFile),
+    ServerMap(HashMap<String, JsonValue>),
+}
+
+impl DeclaredPluginMcpFile {
+    fn into_mcp_servers(self) -> HashMap<String, JsonValue> {
+        match self {
+            Self::McpServersObject(file) => file.mcp_servers,
+            Self::ServerMap(mcp_servers) => mcp_servers,
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "declared_capabilities_tests.rs"]
+mod tests;

--- a/codex-rs/core-plugins/src/declared_capabilities_tests.rs
+++ b/codex-rs/core-plugins/src/declared_capabilities_tests.rs
@@ -1,0 +1,156 @@
+use super::*;
+use crate::manifest::PluginManifestPaths;
+use pretty_assertions::assert_eq;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
+
+fn absolute_path(path: impl AsRef<Path>) -> AbsolutePathBuf {
+    AbsolutePathBuf::try_from(path.as_ref().to_path_buf()).unwrap()
+}
+
+fn empty_manifest_paths() -> PluginManifestPaths {
+    PluginManifestPaths {
+        skills: None,
+        mcp_servers: None,
+        apps: None,
+        hooks: None,
+    }
+}
+
+fn sorted_skill_paths(capabilities: &DeclaredPluginCapabilities) -> Vec<String> {
+    let mut paths = capabilities
+        .skills
+        .iter()
+        .map(|skill| skill.path.display().to_string())
+        .collect::<Vec<_>>();
+    paths.sort();
+    paths
+}
+
+fn sorted_app_names(capabilities: &DeclaredPluginCapabilities) -> Vec<String> {
+    let mut apps = capabilities
+        .apps
+        .iter()
+        .map(|app| app.name.clone())
+        .collect::<Vec<_>>();
+    apps.sort();
+    apps
+}
+
+fn sorted_mcp_server_names(capabilities: &DeclaredPluginCapabilities) -> Vec<String> {
+    let mut names = capabilities
+        .mcp
+        .iter()
+        .map(|mcp| mcp.name.clone())
+        .collect::<Vec<_>>();
+    names.sort();
+    names
+}
+
+#[test]
+fn loads_default_declared_capability_paths() {
+    let tmp = TempDir::new().unwrap();
+    let plugin_root = tmp.path().join("plugin");
+    fs::create_dir_all(plugin_root.join("skills/example")).unwrap();
+    fs::write(
+        plugin_root.join(".app.json"),
+        r#"{
+  "apps": {
+    "linear": {
+      "id": "connector_linear",
+      "category": "Productivity"
+    },
+    "missing_id": {
+      "id": ""
+    }
+  }
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        plugin_root.join(".mcp.json"),
+        r#"{
+  "mcpServers": {
+    "linear": {
+      "command": "linear-mcp"
+    },
+    "docs": {
+      "command": "docs-mcp"
+    }
+  }
+}"#,
+    )
+    .unwrap();
+
+    let capabilities =
+        load_declared_plugin_capabilities(&absolute_path(&plugin_root), &empty_manifest_paths());
+
+    assert_eq!(
+        sorted_skill_paths(&capabilities),
+        vec![plugin_root.join("skills").display().to_string()]
+    );
+    assert_eq!(sorted_app_names(&capabilities), vec!["linear".to_string()]);
+    assert_eq!(
+        sorted_mcp_server_names(&capabilities),
+        vec!["docs".to_string(), "linear".to_string()]
+    );
+}
+
+#[test]
+fn manifest_paths_replace_default_declared_capability_paths() {
+    let tmp = TempDir::new().unwrap();
+    let plugin_root = tmp.path().join("plugin");
+    fs::create_dir_all(plugin_root.join("configured")).unwrap();
+    fs::write(
+        plugin_root.join(".app.json"),
+        r#"{"apps":{"default_app":{"id":"connector_default"}}}"#,
+    )
+    .unwrap();
+    fs::write(
+        plugin_root.join(".mcp.json"),
+        r#"{"mcpServers":{"default_mcp":{"command":"default-mcp"}}}"#,
+    )
+    .unwrap();
+    let configured_apps = plugin_root.join("configured/apps.json");
+    let configured_mcp = plugin_root.join("configured/mcp.json");
+    fs::write(
+        &configured_apps,
+        r#"{"apps":{"configured_app":{"id":"connector_configured"}}}"#,
+    )
+    .unwrap();
+    fs::write(
+        &configured_mcp,
+        r#"{"configured_mcp":{"command":"configured-mcp"}}"#,
+    )
+    .unwrap();
+
+    let manifest_paths = PluginManifestPaths {
+        skills: Some(absolute_path(plugin_root.join("configured").join("skills"))),
+        apps: Some(absolute_path(configured_apps)),
+        mcp_servers: Some(absolute_path(configured_mcp)),
+        hooks: None,
+    };
+
+    let capabilities =
+        load_declared_plugin_capabilities(&absolute_path(&plugin_root), &manifest_paths);
+
+    assert_eq!(
+        sorted_skill_paths(&capabilities),
+        vec![
+            plugin_root
+                .join("configured")
+                .join("skills")
+                .display()
+                .to_string()
+        ]
+    );
+    assert_eq!(
+        sorted_app_names(&capabilities),
+        vec!["configured_app".to_string()]
+    );
+    assert_eq!(
+        sorted_mcp_server_names(&capabilities),
+        vec!["configured_mcp".to_string()]
+    );
+}

--- a/codex-rs/core-plugins/src/lib.rs
+++ b/codex-rs/core-plugins/src/lib.rs
@@ -1,4 +1,5 @@
 mod capabilities;
+mod declared_capabilities;
 mod discoverable;
 pub mod installed_marketplaces;
 pub mod loader;

--- a/codex-rs/core-plugins/src/loader.rs
+++ b/codex-rs/core-plugins/src/loader.rs
@@ -5,6 +5,7 @@ use crate::capabilities::resolve_plugin_capabilities;
 use crate::manifest::PluginManifestHooks;
 use crate::manifest::PluginManifestPaths;
 use crate::manifest::load_plugin_manifest;
+use crate::marketplace::MarketplaceLoadContext;
 use crate::marketplace::MarketplacePluginSource;
 use crate::marketplace::list_marketplaces;
 use crate::marketplace::load_marketplace;
@@ -303,8 +304,11 @@ pub fn refresh_curated_plugin_cache(
         .map_err(|err| {
             format!("failed to load curated marketplace plugin names for cache refresh: {err}")
         })?;
-    let curated_marketplace = load_marketplace(&curated_marketplace_path)
-        .map_err(|err| format!("failed to load curated marketplace for cache refresh: {err}"))?;
+    let curated_marketplace = load_marketplace(
+        &curated_marketplace_path,
+        MarketplaceLoadContext::unfiltered(),
+    )
+    .map_err(|err| format!("failed to load curated marketplace for cache refresh: {err}"))?;
 
     let mut plugin_sources = HashMap::<String, AbsolutePathBuf>::new();
     for plugin in curated_marketplace.plugins {
@@ -415,8 +419,9 @@ fn refresh_non_curated_plugin_cache_with_mode(
         .collect::<HashSet<_>>();
 
     let store = PluginStore::try_new(codex_home.to_path_buf()).map_err(|err| err.to_string())?;
-    let marketplace_outcome = list_marketplaces(additional_roots)
-        .map_err(|err| format!("failed to discover marketplaces for cache refresh: {err}"))?;
+    let marketplace_outcome =
+        list_marketplaces(additional_roots, MarketplaceLoadContext::unfiltered())
+            .map_err(|err| format!("failed to discover marketplaces for cache refresh: {err}"))?;
     let mut plugin_sources = HashMap::<String, MarketplacePluginSource>::new();
 
     for marketplace in marketplace_outcome.marketplaces {

--- a/codex-rs/core-plugins/src/manager.rs
+++ b/codex-rs/core-plugins/src/manager.rs
@@ -24,6 +24,7 @@ use crate::marketplace::MarketplaceError;
 use crate::marketplace::MarketplaceInterface;
 use crate::marketplace::MarketplaceListError;
 use crate::marketplace::MarketplaceListOutcome;
+use crate::marketplace::MarketplaceLoadContext;
 use crate::marketplace::MarketplacePluginAuthPolicy;
 use crate::marketplace::MarketplacePluginPolicy;
 use crate::marketplace::MarketplacePluginSource;
@@ -882,6 +883,7 @@ impl PluginsManager {
             &request.marketplace_path,
             &request.plugin_name,
             self.restriction_product,
+            MarketplaceLoadContext::for_auth(self.auth_mode()),
         )?;
         self.install_resolved_plugin(resolved).await
     }
@@ -896,6 +898,7 @@ impl PluginsManager {
             &request.marketplace_path,
             &request.plugin_name,
             self.restriction_product,
+            MarketplaceLoadContext::for_auth(self.auth_mode()),
         )?;
         let plugin_id = resolved.plugin_id.as_key();
         // This only forwards the backend mutation before the local install flow.
@@ -1040,7 +1043,10 @@ impl PluginsManager {
             let curated_repo_root = curated_plugins_repo_path(self.codex_home.as_path());
             marketplace_roots.retain(|root| root.as_path() != curated_repo_root.as_path());
         }
-        let marketplace_outcome = list_marketplaces(&marketplace_roots)?;
+        let marketplace_outcome = list_marketplaces(
+            &marketplace_roots,
+            MarketplaceLoadContext::for_auth(self.auth_mode()),
+        )?;
         let mut seen_plugin_keys = HashSet::new();
         let marketplaces = marketplace_outcome
             .marketplaces
@@ -1127,7 +1133,10 @@ impl PluginsManager {
             return Ok(MarketplaceListOutcome::default());
         }
 
-        list_marketplaces(&self.marketplace_roots(config, additional_roots))
+        list_marketplaces(
+            &self.marketplace_roots(config, additional_roots),
+            MarketplaceLoadContext::for_auth(self.auth_mode()),
+        )
     }
 
     pub async fn read_plugin_for_config(
@@ -1139,7 +1148,11 @@ impl PluginsManager {
             return Err(MarketplaceError::PluginsDisabled);
         }
 
-        let plugin = find_marketplace_plugin(&request.marketplace_path, &request.plugin_name)?;
+        let plugin = find_marketplace_plugin(
+            &request.marketplace_path,
+            &request.plugin_name,
+            MarketplaceLoadContext::for_auth(self.auth_mode()),
+        )?;
         if !self.restriction_product_matches(plugin.policy.products.as_deref()) {
             return Err(MarketplaceError::PluginNotFound {
                 plugin_name: plugin.plugin_id.plugin_name,

--- a/codex-rs/core-plugins/src/manager_tests.rs
+++ b/codex-rs/core-plugins/src/manager_tests.rs
@@ -2941,7 +2941,6 @@ enabled = true
 async fn list_marketplaces_includes_curated_repo_marketplace() {
     let tmp = tempfile::tempdir().unwrap();
     let curated_root = curated_plugins_repo_path(tmp.path());
-    let plugin_root = curated_root.join("plugins/linear");
 
     write_file(
         &tmp.path().join(CONFIG_TOML_FILE),
@@ -2950,7 +2949,6 @@ plugins = true
 "#,
     );
     fs::create_dir_all(curated_root.join(".agents/plugins")).unwrap();
-    fs::create_dir_all(plugin_root.join(".codex-plugin")).unwrap();
     fs::write(
         curated_root.join(".agents/plugins/marketplace.json"),
         r#"{
@@ -2967,11 +2965,7 @@ plugins = true
 }"#,
     )
     .unwrap();
-    fs::write(
-        plugin_root.join(".codex-plugin/plugin.json"),
-        r#"{"name":"linear"}"#,
-    )
-    .unwrap();
+    write_plugin(&curated_root, "plugins/linear", "linear");
 
     let config = load_config(tmp.path(), tmp.path()).await;
     let marketplaces = PluginsManager::new(tmp.path().to_path_buf())
@@ -3062,7 +3056,6 @@ source = "/tmp/debug"
 "#,
     );
     fs::create_dir_all(marketplace_root.join(".agents/plugins")).unwrap();
-    fs::create_dir_all(plugin_root.join(".codex-plugin")).unwrap();
     fs::write(
         marketplace_root.join(".agents/plugins/marketplace.json"),
         r#"{
@@ -3079,11 +3072,7 @@ source = "/tmp/debug"
 }"#,
     )
     .unwrap();
-    fs::write(
-        plugin_root.join(".codex-plugin/plugin.json"),
-        r#"{"name":"sample"}"#,
-    )
-    .unwrap();
+    write_plugin(&marketplace_root, "plugins/sample", "sample");
     let config = load_config(tmp.path(), tmp.path()).await;
     let marketplaces = PluginsManager::new(tmp.path().to_path_buf())
         .list_marketplaces_for_config(&config, &[], /*include_openai_curated*/ true)
@@ -3120,7 +3109,6 @@ source = "/tmp/debug"
 async fn list_marketplaces_uses_config_when_known_registry_is_malformed() {
     let tmp = tempfile::tempdir().unwrap();
     let marketplace_root = marketplace_install_root(tmp.path()).join("debug");
-    let plugin_root = marketplace_root.join("plugins/sample");
     let registry_path = tmp.path().join(".tmp/known_marketplaces.json");
 
     write_file(
@@ -3135,7 +3123,6 @@ source = "/tmp/debug"
 "#,
     );
     fs::create_dir_all(marketplace_root.join(".agents/plugins")).unwrap();
-    fs::create_dir_all(plugin_root.join(".codex-plugin")).unwrap();
     fs::write(
         marketplace_root.join(".agents/plugins/marketplace.json"),
         r#"{
@@ -3152,11 +3139,7 @@ source = "/tmp/debug"
 }"#,
     )
     .unwrap();
-    fs::write(
-        plugin_root.join(".codex-plugin/plugin.json"),
-        r#"{"name":"sample"}"#,
-    )
-    .unwrap();
+    write_plugin(&marketplace_root, "plugins/sample", "sample");
     fs::create_dir_all(registry_path.parent().unwrap()).unwrap();
     fs::write(registry_path, "{not valid json").unwrap();
 

--- a/codex-rs/core-plugins/src/marketplace.rs
+++ b/codex-rs/core-plugins/src/marketplace.rs
@@ -1,14 +1,22 @@
+use crate::capabilities::PluginCapabilities;
+use crate::capabilities::PluginCapabilityContext;
+use crate::capabilities::plugin_is_visible_in_marketplace;
+use crate::declared_capabilities::load_declared_plugin_capabilities;
 use crate::manifest::PluginManifestInterface;
 use crate::manifest::load_plugin_manifest;
+use codex_app_server_protocol::AuthMode;
 use codex_app_server_protocol::PluginAuthPolicy;
 use codex_app_server_protocol::PluginInstallPolicy;
 use codex_git_utils::get_git_repo_root;
+use codex_plugin::AppConnectorId;
+use codex_plugin::AppDeclaration;
 use codex_plugin::PluginId;
 use codex_plugin::PluginIdError;
 use codex_protocol::protocol::Product;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs;
 use std::io;
@@ -21,6 +29,21 @@ const MARKETPLACE_MANIFEST_RELATIVE_PATHS: &[&str] = &[
     ".agents/plugins/marketplace.json",
     ".claude-plugin/marketplace.json",
 ];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MarketplaceLoadContext {
+    auth_mode: Option<AuthMode>,
+}
+
+impl MarketplaceLoadContext {
+    pub fn for_auth(auth_mode: Option<AuthMode>) -> Self {
+        Self { auth_mode }
+    }
+
+    pub fn unfiltered() -> Self {
+        Self { auth_mode: None }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedMarketplacePlugin {
@@ -172,6 +195,7 @@ impl MarketplaceError {
 pub fn find_marketplace_plugin(
     marketplace_path: &AbsolutePathBuf,
     plugin_name: &str,
+    context: MarketplaceLoadContext,
 ) -> Result<ResolvedMarketplacePlugin, MarketplaceError> {
     let marketplace = load_raw_marketplace_manifest(marketplace_path)?;
     let marketplace_name = marketplace.name;
@@ -184,6 +208,9 @@ pub fn find_marketplace_plugin(
         if let Some(plugin) =
             resolve_marketplace_plugin_entry(marketplace_path, &marketplace_name, plugin)?
         {
+            if !marketplace_plugin_is_visible(&plugin, context) {
+                continue;
+            }
             return Ok(plugin);
         }
     }
@@ -198,8 +225,9 @@ pub fn find_installable_marketplace_plugin(
     marketplace_path: &AbsolutePathBuf,
     plugin_name: &str,
     restriction_product: Option<Product>,
+    context: MarketplaceLoadContext,
 ) -> Result<ResolvedMarketplacePlugin, MarketplaceError> {
-    let resolved = find_marketplace_plugin(marketplace_path, plugin_name)?;
+    let resolved = find_marketplace_plugin(marketplace_path, plugin_name, context)?;
     let product_allowed = match resolved.policy.products.as_deref() {
         None => true,
         Some([]) => false,
@@ -221,8 +249,9 @@ pub fn find_installable_marketplace_plugin(
 
 pub fn list_marketplaces(
     additional_roots: &[AbsolutePathBuf],
+    context: MarketplaceLoadContext,
 ) -> Result<MarketplaceListOutcome, MarketplaceError> {
-    list_marketplaces_with_home(additional_roots, home_dir().as_deref())
+    list_marketplaces_with_home(additional_roots, home_dir().as_deref(), context)
 }
 
 pub(crate) fn home_dir() -> Option<PathBuf> {
@@ -242,7 +271,7 @@ pub fn validate_marketplace_root(root: &Path) -> Result<String, MarketplaceError
             message: "marketplace root does not contain a supported manifest".to_string(),
         });
     };
-    let marketplace = load_marketplace(&path)?;
+    let marketplace = load_marketplace(&path, MarketplaceLoadContext::unfiltered())?;
     Ok(marketplace.name)
 }
 
@@ -280,7 +309,10 @@ fn marketplace_root_from_layout(marketplace_path: &Path, relative_path: &str) ->
     Some(current.to_path_buf())
 }
 
-pub fn load_marketplace(path: &AbsolutePathBuf) -> Result<Marketplace, MarketplaceError> {
+pub fn load_marketplace(
+    path: &AbsolutePathBuf,
+    context: MarketplaceLoadContext,
+) -> Result<Marketplace, MarketplaceError> {
     let marketplace = load_raw_marketplace_manifest(path)?;
     let mut plugins = Vec::new();
 
@@ -299,6 +331,9 @@ pub fn load_marketplace(path: &AbsolutePathBuf) -> Result<Marketplace, Marketpla
             }
             Err(err) => return Err(err),
         };
+        if !marketplace_plugin_is_visible(&plugin, context) {
+            continue;
+        }
 
         let local_version = plugin
             .manifest
@@ -341,11 +376,12 @@ pub(crate) fn load_raw_marketplace_plugin_names(
 pub fn list_marketplaces_with_home(
     additional_roots: &[AbsolutePathBuf],
     home_dir: Option<&Path>,
+    context: MarketplaceLoadContext,
 ) -> Result<MarketplaceListOutcome, MarketplaceError> {
     let mut outcome = MarketplaceListOutcome::default();
 
     for marketplace_path in discover_marketplace_paths_from_roots(additional_roots, home_dir) {
-        match load_marketplace(&marketplace_path) {
+        match load_marketplace(&marketplace_path, context) {
             Ok(marketplace) => outcome.marketplaces.push(marketplace),
             Err(err) => {
                 warn!(
@@ -529,6 +565,51 @@ fn resolve_plugin_source(
             unreachable!("unsupported plugin sources should be filtered before resolution")
         }
     }
+}
+
+fn marketplace_plugin_is_visible(
+    plugin: &ResolvedMarketplacePlugin,
+    context: MarketplaceLoadContext,
+) -> bool {
+    let capability_context =
+        PluginCapabilityContext::new(context.auth_mode, /*plugin_active*/ true);
+    if !capability_context.filters_marketplace_plugins() {
+        return true;
+    }
+
+    let MarketplacePluginSource::Local { path } = &plugin.source else {
+        // Remote Git entries are not materialized while listing marketplaces, so keep them visible
+        // until install/read flows have a local plugin root to inspect.
+        return true;
+    };
+
+    let Some(manifest) = &plugin.manifest else {
+        // Preserve existing marketplace behavior for local entries that do not expose a readable
+        // plugin manifest; the marketplace loader cannot prove these are unusable.
+        return true;
+    };
+
+    let declared_capabilities = load_declared_plugin_capabilities(path, &manifest.paths);
+    let has_skills = !declared_capabilities.skills.is_empty();
+    let apps = declared_capabilities
+        .apps
+        .into_iter()
+        .map(|app| AppDeclaration {
+            name: app.name,
+            connector_id: AppConnectorId(String::new()),
+            category: None,
+        })
+        .collect::<Vec<_>>();
+    let mcp_servers = declared_capabilities
+        .mcp
+        .into_iter()
+        .map(|mcp| (mcp.name, ()))
+        .collect::<HashMap<_, _>>();
+    plugin_is_visible_in_marketplace(
+        PluginCapabilities::new(apps, mcp_servers),
+        has_skills,
+        capability_context,
+    )
 }
 
 fn resolve_local_plugin_source_path(

--- a/codex-rs/core-plugins/src/marketplace_tests.rs
+++ b/codex-rs/core-plugins/src/marketplace_tests.rs
@@ -7,6 +7,41 @@ use tempfile::tempdir;
 const ALTERNATE_MARKETPLACE_RELATIVE_PATH: &str = ".claude-plugin/marketplace.json";
 const ALTERNATE_PLUGIN_MANIFEST_RELATIVE_PATH: &str = ".claude-plugin/plugin.json";
 
+fn find_marketplace_plugin(
+    marketplace_path: &AbsolutePathBuf,
+    plugin_name: &str,
+) -> Result<ResolvedMarketplacePlugin, MarketplaceError> {
+    super::find_marketplace_plugin(
+        marketplace_path,
+        plugin_name,
+        MarketplaceLoadContext::unfiltered(),
+    )
+}
+
+fn find_installable_marketplace_plugin(
+    marketplace_path: &AbsolutePathBuf,
+    plugin_name: &str,
+    restriction_product: Option<Product>,
+) -> Result<ResolvedMarketplacePlugin, MarketplaceError> {
+    super::find_installable_marketplace_plugin(
+        marketplace_path,
+        plugin_name,
+        restriction_product,
+        MarketplaceLoadContext::unfiltered(),
+    )
+}
+
+fn list_marketplaces_with_home(
+    additional_roots: &[AbsolutePathBuf],
+    home_dir: Option<&Path>,
+) -> Result<MarketplaceListOutcome, MarketplaceError> {
+    super::list_marketplaces_with_home(
+        additional_roots,
+        home_dir,
+        MarketplaceLoadContext::unfiltered(),
+    )
+}
+
 fn write_alternate_marketplace(repo_root: &Path, contents: &str) -> AbsolutePathBuf {
     let marketplace_path = repo_root.join(ALTERNATE_MARKETPLACE_RELATIVE_PATH);
     fs::create_dir_all(marketplace_path.parent().unwrap()).unwrap();
@@ -16,6 +51,19 @@ fn write_alternate_marketplace(repo_root: &Path, contents: &str) -> AbsolutePath
 
 fn write_alternate_plugin_manifest(plugin_root: &Path, contents: &str) {
     let manifest_path = plugin_root.join(ALTERNATE_PLUGIN_MANIFEST_RELATIVE_PATH);
+    fs::create_dir_all(manifest_path.parent().unwrap()).unwrap();
+    fs::write(manifest_path, contents).unwrap();
+}
+
+fn write_default_marketplace(repo_root: &Path, contents: &str) -> AbsolutePathBuf {
+    let marketplace_path = repo_root.join(".agents/plugins/marketplace.json");
+    fs::create_dir_all(marketplace_path.parent().unwrap()).unwrap();
+    fs::write(&marketplace_path, contents).unwrap();
+    AbsolutePathBuf::try_from(marketplace_path).unwrap()
+}
+
+fn write_default_plugin_manifest(plugin_root: &Path, contents: &str) {
+    let manifest_path = plugin_root.join(".codex-plugin/plugin.json");
     fs::create_dir_all(manifest_path.parent().unwrap()).unwrap();
     fs::write(manifest_path, contents).unwrap();
 }
@@ -468,6 +516,200 @@ fn list_marketplaces_includes_plugins_without_discoverable_manifest() {
                 keywords: Vec::new(),
             }],
         }]
+    );
+}
+
+#[test]
+fn load_marketplace_for_api_key_filters_plugins_without_surviving_capabilities() {
+    let tmp = tempdir().unwrap();
+    let repo_root = tmp.path().join("repo");
+    let app_only_root = repo_root.join("plugins/app-only");
+    let app_and_skills_root = repo_root.join("plugins/app-and-skills");
+    let app_and_mcp_root = repo_root.join("plugins/app-and-mcp");
+    let app_and_other_mcp_root = repo_root.join("plugins/app-and-other-mcp");
+    let mcp_only_root = repo_root.join("plugins/mcp-only");
+    let skills_only_root = repo_root.join("plugins/skills-only");
+
+    fs::create_dir_all(repo_root.join(".git")).unwrap();
+    let marketplace_path = write_default_marketplace(
+        &repo_root,
+        r#"{
+  "name": "codex-curated",
+  "plugins": [
+    {
+      "name": "app-only",
+      "source": {
+        "source": "local",
+        "path": "./plugins/app-only"
+      }
+    },
+    {
+      "name": "app-and-skills",
+      "source": {
+        "source": "local",
+        "path": "./plugins/app-and-skills"
+      }
+    },
+    {
+      "name": "app-and-mcp",
+      "source": {
+        "source": "local",
+        "path": "./plugins/app-and-mcp"
+      }
+    },
+    {
+      "name": "app-and-other-mcp",
+      "source": {
+        "source": "local",
+        "path": "./plugins/app-and-other-mcp"
+      }
+    },
+    {
+      "name": "mcp-only",
+      "source": {
+        "source": "local",
+        "path": "./plugins/mcp-only"
+      }
+    },
+    {
+      "name": "skills-only",
+      "source": {
+        "source": "local",
+        "path": "./plugins/skills-only"
+      }
+    },
+    {
+      "name": "remote-plugin",
+      "source": {
+        "source": "git-subdir",
+        "url": "openai/toolkit",
+        "path": "plugins/toolkit"
+      }
+    }
+  ]
+}"#,
+    );
+
+    write_default_plugin_manifest(&app_only_root, r#"{"name":"app-only"}"#);
+    fs::write(
+        app_only_root.join(".app.json"),
+        r#"{"apps":{"linear":{"id":"connector_linear"}}}"#,
+    )
+    .unwrap();
+
+    write_default_plugin_manifest(
+        &app_and_skills_root,
+        r#"{"name":"app-and-skills","skills":"./skills/"}"#,
+    );
+    fs::write(
+        app_and_skills_root.join(".app.json"),
+        r#"{"apps":{"linear":{"id":"connector_linear"}}}"#,
+    )
+    .unwrap();
+    fs::create_dir_all(app_and_skills_root.join("skills/example")).unwrap();
+    fs::write(
+        app_and_skills_root.join("skills/example/SKILL.md"),
+        "---\nname: example\ndescription: example skill\n---\n",
+    )
+    .unwrap();
+
+    write_default_plugin_manifest(&app_and_mcp_root, r#"{"name":"app-and-mcp"}"#);
+    fs::write(
+        app_and_mcp_root.join(".app.json"),
+        r#"{"apps":{"linear":{"id":"connector_linear"}}}"#,
+    )
+    .unwrap();
+    fs::write(
+        app_and_mcp_root.join(".mcp.json"),
+        r#"{"mcpServers":{"linear":{"command":"linear-mcp"}}}"#,
+    )
+    .unwrap();
+
+    write_default_plugin_manifest(&app_and_other_mcp_root, r#"{"name":"app-and-other-mcp"}"#);
+    fs::write(
+        app_and_other_mcp_root.join(".app.json"),
+        r#"{"apps":{"linear":{"id":"connector_linear"}}}"#,
+    )
+    .unwrap();
+    fs::write(
+        app_and_other_mcp_root.join(".mcp.json"),
+        r#"{"mcpServers":{"other":{"command":"other-mcp"}}}"#,
+    )
+    .unwrap();
+
+    write_default_plugin_manifest(&mcp_only_root, r#"{"name":"mcp-only"}"#);
+    fs::write(
+        mcp_only_root.join(".mcp.json"),
+        r#"{"mcpServers":{"toolkit":{"command":"toolkit-mcp"}}}"#,
+    )
+    .unwrap();
+
+    write_default_plugin_manifest(&skills_only_root, r#"{"name":"skills-only"}"#);
+    fs::create_dir_all(skills_only_root.join("skills/example")).unwrap();
+    fs::write(
+        skills_only_root.join("skills/example/SKILL.md"),
+        "---\nname: example\ndescription: example skill\n---\n",
+    )
+    .unwrap();
+
+    let marketplace = super::load_marketplace(
+        &marketplace_path,
+        MarketplaceLoadContext::for_auth(Some(codex_app_server_protocol::AuthMode::ApiKey)),
+    )
+    .unwrap();
+
+    let plugin_names = marketplace
+        .plugins
+        .iter()
+        .map(|plugin| plugin.name.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        plugin_names,
+        vec!["app-and-mcp", "mcp-only", "skills-only", "remote-plugin"]
+    );
+}
+
+#[test]
+fn find_marketplace_plugin_for_api_key_treats_app_only_local_plugins_as_not_found() {
+    let tmp = tempdir().unwrap();
+    let repo_root = tmp.path().join("repo");
+    let plugin_root = repo_root.join("plugins/app-only");
+
+    fs::create_dir_all(repo_root.join(".git")).unwrap();
+    let marketplace_path = write_default_marketplace(
+        &repo_root,
+        r#"{
+  "name": "codex-curated",
+  "plugins": [
+    {
+      "name": "app-only",
+      "source": {
+        "source": "local",
+        "path": "./plugins/app-only"
+      }
+    }
+  ]
+}"#,
+    );
+    write_default_plugin_manifest(&plugin_root, r#"{"name":"app-only"}"#);
+    fs::write(
+        plugin_root.join(".app.json"),
+        r#"{"apps":{"linear":{"id":"connector_linear"}}}"#,
+    )
+    .unwrap();
+
+    assert!(find_marketplace_plugin(&marketplace_path, "app-only").is_ok());
+
+    let err = super::find_marketplace_plugin(
+        &marketplace_path,
+        "app-only",
+        MarketplaceLoadContext::for_auth(Some(codex_app_server_protocol::AuthMode::ApiKey)),
+    )
+    .unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        "plugin `app-only` was not found in marketplace `codex-curated`"
     );
 }
 


### PR DESCRIPTION
## Summary

Makes marketplace plugin loading auth-aware for local plugin entries by checking declared apps, MCP servers, and skills before exposing installable plugins in auth-filtered contexts.

## Why

API-key sessions cannot use app declarations directly, so app-backed local marketplace plugins should be hidden unless their app declarations are fully covered by same-named MCP servers. This keeps the plugin browser and install flows aligned with what can actually be used.

## Validation


- `just fmt`
- `just test -p codex-core-plugins`
- `git diff --check`

Manual Checks:
- local test that the plugins that should be hidden are indeed hidden when using api key ("Linear" plugin has app declaration without accompanying mcp with the same name, and thus should be hidden)
- verified swic is unaffected by this change
<img width="706" height="454" alt="Screenshot 2026-06-12 at 21 54 09" src="https://github.com/user-attachments/assets/670afa6f-e49f-48b6-b272-dd5867a1d07d" />

---

Code flow:

```mermaid
flowchart TD
    A[Marketplace listing / lookup] --> B[load_marketplace / find_marketplace_plugin]
    B --> C[resolve_marketplace_plugin_entry]
    C --> D[marketplace_plugin_is_visible]

    D --> E{Codex-backed auth?}
    E -- yes --> F[Show plugin]

    E -- no --> G{Remote Git source not materialized?}
    G -- yes --> F

    G -- no --> H{No readable manifest?}
    H -- yes --> F

    H -- no --> I[load_declared_plugin_capabilities]
    I --> J[DeclaredPluginCapabilities<br/>skills / apps / mcp]

    J --> K[Convert declared facts into capability policy input]
    K --> L[plugin_is_visible_in_marketplace]
    L --> M{Usable for auth mode?}
    M -- yes --> F
    M -- no --> N[Hide plugin]
```