### PR TITLE
[codex] Send request-scoped turn state over WebSocket

### DIFF
--- a/codex-rs/codex-api/src/endpoint/responses_websocket.rs
+++ b/codex-rs/codex-api/src/endpoint/responses_websocket.rs
@@ -215,6 +215,7 @@ impl ResponsesWebsocketConnection {
         &self,
         request: ResponsesWsRequest,
         connection_reused: bool,
+        turn_state: Option<Arc<StdMutex<String>>>,
     ) -> Result<ResponseStream, ApiError> {
         let (tx_event, rx_event) =
             mpsc::channel::<std::result::Result<ResponseEvent, ApiError>>(1600);
@@ -264,6 +265,7 @@ impl ResponsesWebsocketConnection {
                         idle_timeout,
                         telemetry,
                         connection_reused,
+                        turn_state.as_deref(),
                     )
                     .await
                 };
@@ -633,6 +635,7 @@ async fn run_websocket_response_stream(
     idle_timeout: Duration,
     telemetry: Option<Arc<dyn WebsocketTelemetry>>,
     connection_reused: bool,
+    turn_state: Option<&StdMutex<String>>,
 ) -> Result<(), ApiError> {
     let mut last_server_model: Option<String> = None;
     send_websocket_request(
@@ -684,6 +687,13 @@ async fn run_websocket_response_stream(
                         continue;
                     }
                 };
+                if let Some(response_turn_state) = event.turn_state()
+                    && let Some(turn_state) = turn_state
+                {
+                    *turn_state
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner) = response_turn_state;
+                }
                 let model_verifications = event.model_verifications();
                 let turn_moderation_metadata = event.turn_moderation_metadata();
                 if event.kind() == "codex.rate_limits" {

--- a/codex-rs/codex-api/src/sse/responses.rs
+++ b/codex-rs/codex-api/src/sse/responses.rs
@@ -191,6 +191,16 @@ impl ResponsesStreamEvent {
         }
     }
 
+    pub(crate) fn turn_state(&self) -> Option<String> {
+        if self.kind() != "codex.response.metadata" {
+            return None;
+        }
+
+        self.headers
+            .as_ref()
+            .and_then(header_turn_state_value_from_json)
+    }
+
     pub(crate) fn model_verifications(&self) -> Option<Vec<ModelVerification>> {
         if self.kind() != "response.metadata" {
             return None;
@@ -220,6 +230,17 @@ fn header_openai_model_value_from_json(value: &Value) -> Option<String> {
     headers.iter().find_map(|(name, value)| {
         if name.eq_ignore_ascii_case("openai-model") || name.eq_ignore_ascii_case("x-openai-model")
         {
+            json_value_as_string(value)
+        } else {
+            None
+        }
+    })
+}
+
+fn header_turn_state_value_from_json(value: &Value) -> Option<String> {
+    let headers = value.as_object()?;
+    headers.iter().find_map(|(name, value)| {
+        if name.eq_ignore_ascii_case(X_CODEX_TURN_STATE_HEADER) {
             json_value_as_string(value)
         } else {
             None

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -801,13 +801,10 @@ impl ModelClient {
         api_provider: codex_api::Provider,
         api_auth: SharedAuthProvider,
         responses_metadata: &CodexResponsesMetadata,
-        turn_state: Option<Arc<StdMutex<String>>>,
         auth_context: AuthRequestTelemetryContext,
         request_route_telemetry: RequestRouteTelemetry,
     ) -> std::result::Result<ApiWebSocketConnection, ApiError> {
-        let headers = self
-            .build_websocket_headers(responses_metadata, turn_state.as_ref())
-            .await;
+        let headers = self.build_websocket_headers(responses_metadata).await;
         let websocket_telemetry = ModelClientSession::build_websocket_telemetry(
             session_telemetry,
             auth_context,
@@ -821,7 +818,7 @@ impl ModelClient {
             ApiWebSocketResponsesClient::new(api_provider, api_auth).connect(
                 headers,
                 codex_login::default_client::default_headers(),
-                turn_state,
+                /*turn_state*/ None,
                 Some(websocket_telemetry),
             ),
         )
@@ -881,16 +878,14 @@ impl ModelClient {
     }
 
     /// Builds websocket handshake headers for both prewarm and turn-time reconnect.
-    ///
-    /// Callers should pass the current turn-state lock when available so sticky-routing state is
-    /// replayed on reconnect within the same turn.
     async fn build_websocket_headers(
         &self,
         responses_metadata: &CodexResponsesMetadata,
-        turn_state: Option<&Arc<StdMutex<String>>>,
     ) -> ApiHeaderMap {
-        let mut headers =
-            build_responses_headers(self.state.beta_features_header.as_deref(), turn_state);
+        let mut headers = build_responses_headers(
+            self.state.beta_features_header.as_deref(),
+            /*turn_state*/ None,
+        );
         if let Ok(header_value) = HeaderValue::from_str(&responses_metadata.thread_id) {
             headers.insert("x-client-request-id", header_value);
         }
@@ -1087,7 +1082,6 @@ impl ModelClientSession {
                 client_setup.api_provider,
                 client_setup.api_auth,
                 responses_metadata,
-                Some(Arc::clone(&self.turn_state)),
                 auth_context,
                 RequestRouteTelemetry::for_endpoint(RESPONSES_ENDPOINT),
             )
@@ -1119,7 +1113,6 @@ impl ModelClientSession {
             api_provider,
             api_auth,
             responses_metadata,
-            options,
             auth_context,
             request_route_telemetry,
         } = params;
@@ -1139,7 +1132,6 @@ impl ModelClientSession {
                     api_provider,
                     api_auth,
                     responses_metadata,
-                    options.turn_state.clone(),
                     auth_context,
                     request_route_telemetry,
                 )
@@ -1341,15 +1333,6 @@ impl ModelClientSession {
                 client_setup.api_auth.as_ref(),
                 pending_retry,
             );
-            let compression = self.responses_request_compression(client_setup.auth.as_ref());
-
-            let options = self
-                .build_responses_options(
-                    responses_metadata,
-                    compression,
-                    model_info.use_responses_lite,
-                )
-                .await;
             let request = self.client.build_responses_request(
                 &client_setup.api_provider,
                 prompt,
@@ -1359,12 +1342,19 @@ impl ModelClientSession {
                 service_tier.clone(),
                 responses_metadata,
             )?;
+            let mut client_metadata = self
+                .client
+                .build_ws_client_metadata(responses_metadata, model_info.use_responses_lite);
+            client_metadata.insert(
+                X_CODEX_TURN_STATE_HEADER.to_string(),
+                self.turn_state
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .clone(),
+            );
             let mut ws_payload = ResponseCreateWsRequest {
                 client_metadata: response_create_client_metadata(
-                    Some(self.client.build_ws_client_metadata(
-                        responses_metadata,
-                        model_info.use_responses_lite,
-                    )),
+                    Some(client_metadata),
                     request_trace.as_ref(),
                 ),
                 ..ResponseCreateWsRequest::from(&request)
@@ -1379,7 +1369,6 @@ impl ModelClientSession {
                     api_provider: client_setup.api_provider,
                     api_auth: client_setup.api_auth,
                     responses_metadata,
-                    options: &options,
                     auth_context: request_auth_context,
                     request_route_telemetry: RequestRouteTelemetry::for_endpoint(
                         RESPONSES_ENDPOINT,
@@ -1436,7 +1425,11 @@ impl ModelClientSession {
                     ))
                 })?;
             let stream_result = websocket_connection
-                .stream_request(ws_request, self.websocket_session.connection_reused())
+                .stream_request(
+                    ws_request,
+                    self.websocket_session.connection_reused(),
+                    Some(Arc::clone(&self.turn_state)),
+                )
                 .await
                 .map_err(|err| {
                     let response_debug_context =
@@ -1919,7 +1912,6 @@ struct WebsocketConnectParams<'a> {
     api_provider: codex_api::Provider,
     api_auth: SharedAuthProvider,
     responses_metadata: &'a CodexResponsesMetadata,
-    options: &'a ApiResponsesOptions,
     auth_context: AuthRequestTelemetryContext,
     request_route_telemetry: RequestRouteTelemetry,
 }

--- a/codex-rs/core/src/client_tests.rs
+++ b/codex-rs/core/src/client_tests.rs
@@ -585,7 +585,7 @@ async fn websocket_handshake_includes_attestation_for_chatgpt_codex_responses() 
     );
 
     let headers = model_client
-        .build_websocket_headers(&responses_metadata, /*turn_state*/ None)
+        .build_websocket_headers(&responses_metadata)
         .await;
 
     assert_eq!(

--- a/codex-rs/core/tests/common/Cargo.toml
+++ b/codex-rs/core/tests/common/Cargo.toml
@@ -39,7 +39,7 @@ regex-lite = { workspace = true }
 serde_json = { workspace = true }
 similar = { workspace = true }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["net", "time"] }
+tokio = { workspace = true, features = ["io-util", "net", "time"] }
 tokio-tungstenite = { workspace = true }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }

--- a/codex-rs/core/tests/common/responses.rs
+++ b/codex-rs/core/tests/common/responses.rs
@@ -13,7 +13,10 @@ use codex_protocol::openai_models::ModelsResponse;
 use futures::SinkExt;
 use futures::StreamExt;
 use serde_json::Value;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
+use tokio::net::TcpStream;
 use tokio::sync::Notify;
 use tokio::sync::oneshot;
 use tokio_tungstenite::accept_hdr_async_with_config;
@@ -422,6 +425,30 @@ impl WebSocketRequest {
 }
 
 #[derive(Debug, Clone)]
+pub struct CompactHttpRequest {
+    path: String,
+    headers: Vec<(String, String)>,
+    body: Value,
+}
+
+impl CompactHttpRequest {
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    pub fn header(&self, name: &str) -> Option<String> {
+        self.headers
+            .iter()
+            .find(|(header, _)| header.eq_ignore_ascii_case(name))
+            .map(|(_, value)| value.clone())
+    }
+
+    pub fn body_json(&self) -> Value {
+        self.body.clone()
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct WebSocketHandshake {
     uri: String,
     headers: Vec<(String, String)>,
@@ -460,6 +487,7 @@ pub struct WebSocketTestServer {
     uri: String,
     connections: Arc<Mutex<Vec<Vec<WebSocketRequest>>>>,
     handshakes: Arc<Mutex<Vec<WebSocketHandshake>>>,
+    compact_requests: Arc<Mutex<Vec<CompactHttpRequest>>>,
     request_log_updated: Arc<Notify>,
     shutdown: oneshot::Sender<()>,
     task: tokio::task::JoinHandle<()>,
@@ -468,6 +496,12 @@ pub struct WebSocketTestServer {
 impl WebSocketTestServer {
     pub fn uri(&self) -> &str {
         &self.uri
+    }
+
+    pub fn http_uri(&self) -> String {
+        // Model providers derive the WebSocket URL from this HTTP base and can also issue unary
+        // requests, such as v1 compact, against the same listener.
+        self.uri.replacen("ws://", "http://", /*count*/ 1)
     }
 
     pub fn connections(&self) -> Vec<Vec<WebSocketRequest>> {
@@ -504,6 +538,10 @@ impl WebSocketTestServer {
 
     pub fn handshakes(&self) -> Vec<WebSocketHandshake> {
         self.handshakes.lock().unwrap().clone()
+    }
+
+    pub fn compact_requests(&self) -> Vec<CompactHttpRequest> {
+        self.compact_requests.lock().unwrap().clone()
     }
 
     /// Waits until at least `expected` websocket handshakes have been observed or timeout elapses.
@@ -1211,6 +1249,25 @@ pub async fn start_websocket_server(connections: Vec<Vec<Vec<Value>>>) -> WebSoc
 pub async fn start_websocket_server_with_headers(
     connections: Vec<WebSocketConnectionConfig>,
 ) -> WebSocketTestServer {
+    start_websocket_server_inner(connections, /*compact_response*/ None).await
+}
+
+pub async fn start_websocket_server_with_compact_response(
+    connections: Vec<WebSocketConnectionConfig>,
+    compact_response: Value,
+    turn_state: &str,
+) -> WebSocketTestServer {
+    start_websocket_server_inner(
+        connections,
+        Some((compact_response, turn_state.to_string())),
+    )
+    .await
+}
+
+async fn start_websocket_server_inner(
+    connections: Vec<WebSocketConnectionConfig>,
+    compact_response: Option<(Value, String)>,
+) -> WebSocketTestServer {
     let start = std::time::Instant::now();
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
@@ -1219,11 +1276,15 @@ pub async fn start_websocket_server_with_headers(
     let uri = format!("ws://{addr}");
     let connections_log = Arc::new(Mutex::new(Vec::new()));
     let handshakes_log = Arc::new(Mutex::new(Vec::new()));
+    let compact_requests_log = Arc::new(Mutex::new(Vec::new()));
     let request_log_updated = Arc::new(Notify::new());
     let requests = Arc::clone(&connections_log);
     let handshakes = Arc::clone(&handshakes_log);
+    let compact_requests = Arc::clone(&compact_requests_log);
     let request_log = Arc::clone(&request_log_updated);
     let connections = Arc::new(Mutex::new(VecDeque::from(connections)));
+    let serve_http_requests = compact_response.is_some();
+    let compact_response = Arc::new(Mutex::new(compact_response));
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
 
     let task = tokio::spawn(async move {
@@ -1236,6 +1297,28 @@ pub async fn start_websocket_server_with_headers(
                 Ok(value) => value,
                 Err(_) => return,
             };
+
+            let mut request_prefix = [0_u8; 16];
+            let prefix_len = stream.peek(&mut request_prefix).await.unwrap_or_default();
+            // The hybrid test advertises an HTTP base URL, so normal startup model discovery must
+            // be answered without consuming one of the scripted WebSocket connections.
+            if serve_http_requests && request_prefix[..prefix_len].starts_with(b"GET /v1/models") {
+                serve_models_http_request(stream).await;
+                continue;
+            }
+            // WebSocket handshakes are GET requests; the only POST served by this helper is the
+            // unary v1 compact call between scripted WebSocket requests.
+            if request_prefix[..prefix_len].first() == Some(&b'P') {
+                let response = compact_response.lock().unwrap().take();
+                if let Some((body, turn_state)) = response
+                    && let Some(request) =
+                        serve_compact_http_request(stream, body, &turn_state).await
+                {
+                    compact_requests.lock().unwrap().push(request);
+                }
+                continue;
+            }
+
             let connection = {
                 let mut pending = connections.lock().unwrap();
                 pending.pop_front()
@@ -1377,10 +1460,110 @@ pub async fn start_websocket_server_with_headers(
         uri,
         connections: connections_log,
         handshakes: handshakes_log,
+        compact_requests: compact_requests_log,
         request_log_updated,
         shutdown: shutdown_tx,
         task,
     }
+}
+
+async fn serve_models_http_request(mut stream: TcpStream) {
+    let mut request = Vec::new();
+    while find_http_header_end(&request).is_none() {
+        let mut buffer = [0_u8; 4096];
+        let Ok(read) = stream.read(&mut buffer).await else {
+            return;
+        };
+        if read == 0 {
+            return;
+        }
+        request.extend_from_slice(&buffer[..read]);
+    }
+
+    let body = serde_json::to_vec(&ModelsResponse { models: Vec::new() })
+        .expect("serialize empty models response");
+    let response_head = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+        body.len()
+    );
+    let _ = stream.write_all(response_head.as_bytes()).await;
+    let _ = stream.write_all(&body).await;
+}
+
+async fn serve_compact_http_request(
+    mut stream: TcpStream,
+    response_body: Value,
+    turn_state: &str,
+) -> Option<CompactHttpRequest> {
+    let mut bytes = Vec::new();
+    let (header_end, content_length) = loop {
+        let mut buffer = [0_u8; 4096];
+        let read = stream.read(&mut buffer).await.ok()?;
+        if read == 0 {
+            return None;
+        }
+        bytes.extend_from_slice(&buffer[..read]);
+        if let Some(header_end) = find_http_header_end(&bytes) {
+            let content_length = parse_content_length(&bytes[..header_end])?;
+            if bytes.len() >= header_end + content_length {
+                break (header_end, content_length);
+            }
+        }
+    };
+
+    let request = parse_compact_http_request(&bytes, header_end, content_length)?;
+    let response_body = serde_json::to_vec(&response_body).ok()?;
+    let response_head = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nx-codex-turn-state: {turn_state}\r\nconnection: close\r\n\r\n",
+        response_body.len()
+    );
+    stream.write_all(response_head.as_bytes()).await.ok()?;
+    stream.write_all(&response_body).await.ok()?;
+    Some(request)
+}
+
+fn find_http_header_end(bytes: &[u8]) -> Option<usize> {
+    bytes
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .map(|position| position + 4)
+}
+
+fn parse_content_length(headers: &[u8]) -> Option<usize> {
+    let headers = std::str::from_utf8(headers).ok()?;
+    headers.lines().find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        name.eq_ignore_ascii_case("content-length")
+            .then(|| value.trim().parse().ok())
+            .flatten()
+    })
+}
+
+fn parse_compact_http_request(
+    bytes: &[u8],
+    header_end: usize,
+    content_length: usize,
+) -> Option<CompactHttpRequest> {
+    let headers_text = std::str::from_utf8(&bytes[..header_end]).ok()?;
+    let mut lines = headers_text.lines();
+    let path = lines.next()?.split_whitespace().nth(1)?.to_string();
+    let headers = lines
+        .filter_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            Some((name.trim().to_string(), value.trim().to_string()))
+        })
+        .collect::<Vec<_>>();
+    let content_encoding = headers
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case("content-encoding"))
+        .map(|(_, value)| value.as_str());
+    let body_end = header_end + content_length;
+    let body = decode_body_bytes(&bytes[header_end..body_end], content_encoding);
+    Some(CompactHttpRequest {
+        path,
+        headers,
+        body: serde_json::from_slice(&body).ok()?,
+    })
 }
 
 fn parse_ws_request_body(message: Message) -> Option<Value> {

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -440,7 +440,23 @@ impl TestCodexBuilder {
         &mut self,
         server: &WebSocketTestServer,
     ) -> anyhow::Result<TestCodex> {
-        let base_url = format!("{}/v1", server.uri());
+        self.build_with_websocket_base_url(format!("{}/v1", server.uri()))
+            .await
+    }
+
+    /// Builds against a listener that accepts both WebSocket upgrades and unary HTTP requests.
+    pub async fn build_with_http_and_websocket_server(
+        &mut self,
+        server: &WebSocketTestServer,
+    ) -> anyhow::Result<TestCodex> {
+        self.build_with_websocket_base_url(format!("{}/v1", server.http_uri()))
+            .await
+    }
+
+    async fn build_with_websocket_base_url(
+        &mut self,
+        base_url: String,
+    ) -> anyhow::Result<TestCodex> {
         let home = match self.home.clone() {
             Some(home) => home,
             None => Arc::new(TempDir::new()?),

--- a/codex-rs/core/tests/suite/client_websockets.rs
+++ b/codex-rs/core/tests/suite/client_websockets.rs
@@ -65,6 +65,7 @@ const OPENAI_BETA_HEADER: &str = "OpenAI-Beta";
 const USER_AGENT_HEADER: &str = "user-agent";
 const WS_V2_BETA_HEADER_VALUE: &str = "responses_websockets=2026-02-06";
 const X_CLIENT_REQUEST_ID_HEADER: &str = "x-client-request-id";
+const X_CODEX_TURN_STATE_HEADER: &str = "x-codex-turn-state";
 const WS_REQUEST_HEADER_RESPONSES_LITE_CLIENT_METADATA_KEY: &str =
     "ws_request_header_x_openai_internal_codex_responses_lite";
 const TEST_INSTALLATION_ID: &str = "11111111-1111-4111-8111-111111111111";
@@ -690,6 +691,126 @@ async fn responses_websocket_sends_responses_lite_metadata_per_request() {
                 "parallel_tool_calls": false,
             }),
         ]
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn responses_websocket_turn_state_is_replaced_by_response_metadata() {
+    skip_if_no_network!();
+
+    let server = start_websocket_server(vec![vec![
+        vec![
+            json!({
+                "type": "codex.response.metadata",
+                "headers": {(X_CODEX_TURN_STATE_HEADER): "state-a"},
+            }),
+            ev_response_created("resp-a-1"),
+            ev_assistant_message("msg-a-1", "assistant a one"),
+            ev_completed("resp-a-1"),
+        ],
+        vec![
+            ev_response_created("resp-a-2"),
+            ev_assistant_message("msg-a-2", "assistant a two"),
+            ev_completed("resp-a-2"),
+        ],
+        vec![
+            json!({
+                "type": "codex.response.metadata",
+                "headers": {(X_CODEX_TURN_STATE_HEADER): "state-b"},
+            }),
+            ev_response_created("resp-b-1"),
+            ev_assistant_message("msg-b-1", "assistant b one"),
+            ev_completed("resp-b-1"),
+        ],
+        vec![ev_response_created("resp-b-2"), ev_completed("resp-b-2")],
+    ]])
+    .await;
+
+    let harness = websocket_harness(&server).await;
+    let model_a = harness.model_info.clone();
+    let mut model_b = harness.model_info.clone();
+    model_b.slug = "gpt-5.3-codex-other".to_string();
+    let mut session = harness.client.new_session();
+    let prompt_a_one = prompt_with_input(vec![message_item("model a one")]);
+    let prompt_a_two = prompt_with_input(vec![
+        message_item("model a one"),
+        assistant_message_item("msg-a-1", "assistant a one"),
+        message_item("model a two"),
+    ]);
+    let prompt_b_one = prompt_with_input(vec![
+        message_item("model a one"),
+        assistant_message_item("msg-a-1", "assistant a one"),
+        message_item("model a two"),
+        assistant_message_item("msg-a-2", "assistant a two"),
+        message_item("model b one"),
+    ]);
+    let prompt_b_two = prompt_with_input(vec![
+        message_item("model a one"),
+        assistant_message_item("msg-a-1", "assistant a one"),
+        message_item("model a two"),
+        assistant_message_item("msg-a-2", "assistant a two"),
+        message_item("model b one"),
+        assistant_message_item("msg-b-1", "assistant b one"),
+        message_item("model b two"),
+    ]);
+
+    // Phase 1: model A mints state and replays it with an incremental follow-up.
+    // Phase 2: model B receives that state but must start with a full create because the model
+    // changed; its response then replaces the state.
+    // Phase 3: model B replays its replacement with another incremental follow-up.
+    for (model_info, prompt, response_id) in [
+        (&model_a, &prompt_a_one, "resp-a-1"),
+        (&model_a, &prompt_a_two, "resp-a-2"),
+        (&model_b, &prompt_b_one, "resp-b-1"),
+        (&model_b, &prompt_b_two, "resp-b-2"),
+    ] {
+        stream_until_complete_with_model_info(
+            &mut session,
+            &harness,
+            prompt,
+            model_info,
+            response_id,
+        )
+        .await;
+    }
+
+    let requests = server.single_connection();
+    assert_eq!(requests.len(), 4);
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| {
+                let body = request.body_json();
+                json!({
+                    "model": body["model"],
+                    "turn_state": body["client_metadata"][X_CODEX_TURN_STATE_HEADER],
+                })
+            })
+            .collect::<Vec<_>>(),
+        vec![
+            json!({"model": model_a.slug.as_str(), "turn_state": ""}),
+            json!({"model": model_a.slug.as_str(), "turn_state": "state-a"}),
+            json!({"model": model_b.slug.as_str(), "turn_state": "state-a"}),
+            json!({"model": model_b.slug.as_str(), "turn_state": "state-b"}),
+        ]
+    );
+    let model_a_follow_up = requests[1].body_json();
+    let model_switch = requests[2].body_json();
+    let model_b_follow_up = requests[3].body_json();
+    assert_eq!(
+        model_a_follow_up["previous_response_id"].as_str(),
+        Some("resp-a-1")
+    );
+    assert_eq!(model_switch.get("previous_response_id"), None);
+    assert_eq!(
+        model_switch["input"],
+        serde_json::to_value(&prompt_b_one.input).expect("serialize full model B input")
+    );
+    assert_eq!(
+        model_b_follow_up["previous_response_id"].as_str(),
+        Some("resp-b-1")
     );
 
     server.shutdown().await;

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -30,9 +30,11 @@ use core_test_support::context_snapshot;
 use core_test_support::context_snapshot::ContextSnapshotOptions;
 use core_test_support::context_snapshot::ContextSnapshotRenderMode;
 use core_test_support::responses;
+use core_test_support::responses::WebSocketConnectionConfig;
 use core_test_support::responses::mount_sse_once;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_websocket_server;
+use core_test_support::responses::start_websocket_server_with_compact_response;
 use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::TestCodexBuilder;
 use core_test_support::test_codex::TestCodexHarness;
@@ -3947,6 +3949,223 @@ async fn remote_mid_turn_compact_v2_round_trips_turn_state_over_http() -> Result
         Some("continuation-state")
     );
 
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_mid_turn_compact_v2_round_trips_turn_state_over_websocket() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_websocket_server(vec![vec![
+        vec![
+            responses::ev_response_created("warm-1"),
+            responses::ev_completed("warm-1"),
+        ],
+        vec![
+            json!({
+                "type": "codex.response.metadata",
+                "headers": {(TURN_STATE_HEADER): "sampling-state"},
+            }),
+            responses::ev_function_call("call-before-compact", DUMMY_FUNCTION_NAME, "{}"),
+            responses::ev_completed_with_tokens("r1", /*total_tokens*/ 500),
+        ],
+        vec![
+            json!({
+                "type": "codex.response.metadata",
+                "headers": {(TURN_STATE_HEADER): "compact-state"},
+            }),
+            json!({
+                "type": "response.output_item.done",
+                "item": {
+                    "type": "compaction",
+                    "encrypted_content": "V2_WS_COMPACT_SUMMARY",
+                }
+            }),
+            responses::ev_completed("r-compact"),
+        ],
+        vec![
+            json!({
+                "type": "codex.response.metadata",
+                "headers": {(TURN_STATE_HEADER): "continuation-state"},
+            }),
+            responses::ev_function_call("call-after-compact", DUMMY_FUNCTION_NAME, "{}"),
+            responses::ev_completed_with_tokens("r2", /*total_tokens*/ 80),
+        ],
+        vec![
+            responses::ev_assistant_message("m1", "FINAL_REPLY"),
+            responses::ev_completed_with_tokens("r3", /*total_tokens*/ 80),
+        ],
+    ]])
+    .await;
+    let mut builder = test_codex()
+        .with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing())
+        .with_config(|config| {
+            let _ = config.features.enable(Feature::RemoteCompactionV2);
+            config.model_auto_compact_token_limit = Some(200);
+        });
+    let test = builder.build_with_websocket_server(&server).await?;
+
+    // Phase 1: startup prewarm stays empty, then WebSocket sampling mints state and schedules
+    // inline v2 compaction.
+    test.codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "RUN_WITH_WS_MID_TURN_COMPACT_V2".to_string(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: Default::default(),
+        })
+        .await?;
+    wait_for_turn_complete(&test.codex).await;
+
+    let requests = server.single_connection();
+    assert_eq!(requests.len(), 5);
+    assert_eq!(requests[0].body_json()["generate"].as_bool(), Some(false));
+    // Phase 2: the v2 compact request replays sampling state and returns compact state.
+    assert!(
+        requests[2]
+            .body_json()
+            .to_string()
+            .contains("\"type\":\"compaction_trigger\"")
+    );
+    // Phase 3: both post-compact requests replay the latest metadata update.
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| request.body_json()["client_metadata"][TURN_STATE_HEADER].clone())
+            .collect::<Vec<_>>(),
+        vec![
+            json!(""),
+            json!(""),
+            json!("sampling-state"),
+            json!("compact-state"),
+            json!("continuation-state"),
+        ]
+    );
+
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_mid_turn_compact_v1_round_trips_turn_state_across_websocket_and_http() -> Result<()>
+{
+    skip_if_no_network!(Ok(()));
+
+    let server = start_websocket_server_with_compact_response(
+        vec![
+            WebSocketConnectionConfig {
+                requests: vec![vec![
+                    responses::ev_response_created("warm-1"),
+                    responses::ev_completed("warm-1"),
+                ]],
+                response_headers: Vec::new(),
+                accept_delay: None,
+                close_after_requests: true,
+            },
+            WebSocketConnectionConfig {
+                requests: vec![vec![
+                    json!({
+                        "type": "codex.response.metadata",
+                        "headers": {(TURN_STATE_HEADER): "sampling-state"},
+                    }),
+                    responses::ev_function_call("call-before-compact", DUMMY_FUNCTION_NAME, "{}"),
+                    responses::ev_completed_with_tokens("r1", /*total_tokens*/ 500),
+                ]],
+                response_headers: Vec::new(),
+                accept_delay: None,
+                close_after_requests: true,
+            },
+            WebSocketConnectionConfig {
+                requests: vec![
+                    vec![
+                        json!({
+                            "type": "codex.response.metadata",
+                            "headers": {(TURN_STATE_HEADER): "continuation-state"},
+                        }),
+                        responses::ev_function_call(
+                            "call-after-compact",
+                            DUMMY_FUNCTION_NAME,
+                            "{}",
+                        ),
+                        responses::ev_completed_with_tokens("r2", /*total_tokens*/ 80),
+                    ],
+                    vec![
+                        responses::ev_assistant_message("m1", "FINAL_REPLY"),
+                        responses::ev_completed_with_tokens("r3", /*total_tokens*/ 80),
+                    ],
+                ],
+                response_headers: Vec::new(),
+                accept_delay: None,
+                close_after_requests: false,
+            },
+        ],
+        json!({
+            "output": compacted_summary_only_output("V1_WS_COMPACT_SUMMARY"),
+        }),
+        /*turn_state*/ "compact-state",
+    )
+    .await;
+    let mut builder = test_codex()
+        .with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing())
+        .with_config(|config| {
+            config.model_auto_compact_token_limit = Some(200);
+        });
+    let test = builder
+        .build_with_http_and_websocket_server(&server)
+        .await?;
+
+    // Phase 1: startup prewarm is isolated on its own connection, then WebSocket sampling mints
+    // state before mid-turn v1 compaction.
+    test.codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "RUN_WITH_WS_MID_TURN_COMPACT_V1".to_string(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: Default::default(),
+        })
+        .await?;
+    wait_for_turn_complete(&test.codex).await;
+
+    // Phase 2: the HTTP compact request receives sampling state and returns compact state.
+    let compact_requests = server.compact_requests();
+    assert_eq!(compact_requests.len(), 1);
+    assert_eq!(compact_requests[0].path(), "/v1/responses/compact");
+    assert!(compact_requests[0].body_json()["input"].is_array());
+    assert_eq!(
+        compact_requests[0].header(TURN_STATE_HEADER).as_deref(),
+        Some("sampling-state")
+    );
+
+    // Phase 3: WebSocket continuation replays compact state and its next metadata update.
+    let requests = server
+        .connections()
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    assert_eq!(requests.len(), 4);
+    assert_eq!(requests[0].body_json()["generate"].as_bool(), Some(false));
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| request.body_json()["client_metadata"][TURN_STATE_HEADER].clone())
+            .collect::<Vec<_>>(),
+        vec![
+            json!(""),
+            json!(""),
+            json!("compact-state"),
+            json!("continuation-state")
+        ]
+    );
+
+    server.shutdown().await;
     Ok(())
 }
 

--- a/codex-rs/core/tests/suite/turn_state.rs
+++ b/codex-rs/core/tests/suite/turn_state.rs
@@ -16,6 +16,7 @@ use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::test_codex;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
+use serde_json::json;
 
 const TURN_STATE_HEADER: &str = "x-codex-turn-state";
 
@@ -145,56 +146,111 @@ async fn responses_turn_state_updates_are_replayed_within_turn() -> Result<()> {
 async fn websocket_turn_state_persists_within_turn_and_resets_after() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
-    let call_id = "ws-shell-turn-state";
-    // First connection delivers turn_state; second (same turn) must send it; third (new turn) must not.
-    let server = start_websocket_server_with_headers(vec![
-        WebSocketConnectionConfig {
-            requests: vec![vec![
+    let server = start_websocket_server_with_headers(vec![WebSocketConnectionConfig {
+        requests: vec![
+            vec![
+                json!({
+                    "type": "codex.response.metadata",
+                    "headers": {(TURN_STATE_HEADER): "ts-1"},
+                }),
                 ev_response_created("resp-1"),
                 ev_reasoning_item("rsn-1", &["thinking"], &[]),
-                ev_shell_command_call(call_id, "echo websocket"),
+                ev_shell_command_call("ws-shell-turn-state", "echo websocket"),
                 ev_completed("resp-1"),
-            ]],
-            response_headers: vec![(TURN_STATE_HEADER.to_string(), "ts-1".to_string())],
-            accept_delay: None,
-            close_after_requests: true,
-        },
-        WebSocketConnectionConfig {
-            requests: vec![vec![
+            ],
+            vec![
                 ev_response_created("resp-2"),
                 ev_assistant_message("msg-1", "done"),
                 ev_completed("resp-2"),
-            ]],
-            response_headers: Vec::new(),
-            accept_delay: None,
-            close_after_requests: true,
-        },
-        WebSocketConnectionConfig {
-            requests: vec![vec![
+            ],
+            vec![
                 ev_response_created("resp-3"),
                 ev_assistant_message("msg-2", "done"),
                 ev_completed("resp-3"),
-            ]],
-            response_headers: Vec::new(),
-            accept_delay: None,
-            close_after_requests: true,
-        },
-    ])
+            ],
+        ],
+        response_headers: Vec::new(),
+        accept_delay: None,
+        close_after_requests: false,
+    }])
     .await;
 
     let mut builder = test_codex();
     let test = builder.build_with_websocket_server(&server).await?;
+    // Phase 1: the first response mints state for its same-turn tool follow-up.
     test.submit_turn("run the echo command").await?;
-    test.submit_turn("second turn").await?;
+    // Phase 2: the follow-up replays that state on the same physical connection.
+    // Phase 3: the next logical turn reuses the connection but starts with empty state.
+    test.submit_turn("start another turn").await?;
 
-    let handshakes = server.handshakes();
-    assert_eq!(handshakes.len(), 3);
-    assert_eq!(handshakes[0].header(TURN_STATE_HEADER), None);
+    assert_eq!(server.handshakes().len(), 1);
+    let requests = server.single_connection();
+    assert_eq!(requests.len(), 3);
     assert_eq!(
-        handshakes[1].header(TURN_STATE_HEADER),
-        Some("ts-1".to_string())
+        requests
+            .iter()
+            .map(|request| request.body_json()["client_metadata"][TURN_STATE_HEADER].clone())
+            .collect::<Vec<_>>(),
+        vec![json!(""), json!("ts-1"), json!("")]
     );
-    assert_eq!(handshakes[2].header(TURN_STATE_HEADER), None);
+
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn websocket_turn_state_updates_are_replayed_within_turn() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_websocket_server_with_headers(vec![WebSocketConnectionConfig {
+        requests: vec![
+            vec![
+                json!({
+                    "type": "codex.response.metadata",
+                    "headers": {(TURN_STATE_HEADER): "ts-1"},
+                }),
+                ev_response_created("resp-1"),
+                ev_shell_command_call("ws-shell-1", "echo one"),
+                ev_completed("resp-1"),
+            ],
+            vec![
+                json!({
+                    "type": "codex.response.metadata",
+                    "headers": {(TURN_STATE_HEADER): "ts-2"},
+                }),
+                ev_response_created("resp-2"),
+                ev_shell_command_call("ws-shell-2", "echo two"),
+                ev_completed("resp-2"),
+            ],
+            vec![
+                ev_response_created("resp-3"),
+                ev_assistant_message("msg-1", "done"),
+                ev_completed("resp-3"),
+            ],
+        ],
+        response_headers: Vec::new(),
+        accept_delay: None,
+        close_after_requests: false,
+    }])
+    .await;
+    let mut builder = test_codex();
+    let test = builder.build_with_websocket_server(&server).await?;
+
+    // Phase 1: the initial request starts empty and receives the first metadata value.
+    // Phase 2: the first tool follow-up replays it and receives a replacement.
+    // Phase 3: the second follow-up sends the replacement on the same connection.
+    test.submit_turn("run two echo commands").await?;
+
+    assert_eq!(server.handshakes().len(), 1);
+    let requests = server.single_connection();
+    assert_eq!(requests.len(), 3);
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| request.body_json()["client_metadata"][TURN_STATE_HEADER].clone())
+            .collect::<Vec<_>>(),
+        vec![json!(""), json!("ts-1"), json!("ts-2")]
+    );
 
     server.shutdown().await;
     Ok(())


### PR DESCRIPTION
## Summary

Carry opaque turn state in each WebSocket `response.create` request and accept updates from response metadata.

- send state per request rather than in connection upgrade headers
- reuse the latest value across requests in the same turn and on reconnect
- reset state for each new logical turn, even when the WebSocket connection is reused
- preserve updates when compaction crosses between WebSocket and HTTP

## Stack

1. #27930 — replaceable HTTP turn state
2. #27931 — compact round-trip
3. **#27929 — WebSocket request metadata (this PR)**

## Coverage

- WebSocket response metadata replaces state within a session
- same-turn follow-ups replay updates while the next turn starts empty
- a model change on a reused connection sends a full create and then accepts replacement state
- WebSocket v2 compact round-trips state on one connection
- WebSocket sampling with v1 HTTP compact carries the update back to WebSocket continuation
