### PR TITLE
Fix realtime input text payloads

### DIFF
--- a/codex-rs/codex-api/src/endpoint/realtime_websocket/methods.rs
+++ b/codex-rs/codex-api/src/endpoint/realtime_websocket/methods.rs
@@ -1581,6 +1581,7 @@ mod tests {
                 .expect("text");
             let third_json: Value = serde_json::from_str(&third).expect("json");
             assert_eq!(third_json["type"], "conversation.item.create");
+            assert_eq!(third_json["item"]["content"][0]["type"], "input_text");
             assert_eq!(third_json["item"]["content"][0]["text"], "hello agent");
 
             let fourth = ws

--- a/codex-rs/codex-api/src/endpoint/realtime_websocket/methods_v1.rs
+++ b/codex-rs/codex-api/src/endpoint/realtime_websocket/methods_v1.rs
@@ -21,7 +21,7 @@ pub(super) fn conversation_item_create_message(text: String) -> RealtimeOutbound
             r#type: ConversationItemType::Message,
             role: ConversationRole::User,
             content: vec![ConversationItemContent {
-                r#type: ConversationContentType::Text,
+                r#type: ConversationContentType::InputText,
                 text,
             }],
         }),

--- a/codex-rs/codex-api/src/endpoint/realtime_websocket/protocol.rs
+++ b/codex-rs/codex-api/src/endpoint/realtime_websocket/protocol.rs
@@ -199,7 +199,6 @@ pub(super) struct ConversationItemContent {
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(super) enum ConversationContentType {
-    Text,
     InputText,
 }
 

--- a/codex-rs/core/src/realtime_conversation.rs
+++ b/codex-rs/core/src/realtime_conversation.rs
@@ -1401,7 +1401,10 @@ async fn handle_realtime_server_event(
             }
             false
         }
-        RealtimeEvent::Error(_) => true,
+        RealtimeEvent::Error(message) => {
+            error!(message, "realtime stream error event received");
+            true
+        }
         RealtimeEvent::SessionUpdated {
             realtime_session_id,
             ..


### PR DESCRIPTION
## Summary
- send Realtime V1 user messages as `input_text`
- log the server-provided Realtime error message

## Validation
- `cargo test -p codex-api e2e_connect_and_exchange_events_against_mock_ws_server --offline`
- `cargo fmt --all -- --check`
