### PR TITLE
[codex] Add crate API surface review rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,10 @@ Likewise, when reviewing code, do not hesitate to push back on PRs that would un
 
 ## Code Review Rules
 
+### Crate API surface
+
+Keep crate API surfaces as small as possible. Avoid proliferating test-only helpers.
+
 ### Model visible context
 
 Codex maintains a context (history of messages) that is sent to the model in inference requests.


### PR DESCRIPTION
## Why

Review guidance should explicitly discourage widening crate APIs for testing convenience. Keeping those boundaries narrow reduces accidental coupling and prevents one-off test utilities from becoming durable public surface area.

## What

- Add a crate API surface rule to `AGENTS.md`.
- Ask reviewers to keep crate APIs small and avoid proliferating test-only helpers.

## Test plan

- Not run (documentation-only change).
