### PR TITLE
[codex] preserve deferred namespace guidance in ALL_TOOLS

### DIFF
--- a/codex-rs/codex-mcp/src/connection_manager_tests.rs
+++ b/codex-rs/codex-mcp/src/connection_manager_tests.rs
@@ -13,6 +13,8 @@ use crate::rmcp_client::AsyncManagedClient;
 use crate::rmcp_client::ManagedClient;
 use crate::rmcp_client::StartupOutcomeError;
 use crate::server::McpServerOrigin;
+use crate::tools::MAX_MCP_NAMESPACE_DESCRIPTION_BYTES;
+use crate::tools::MCP_NAMESPACE_DESCRIPTION_TRUNCATION_SUFFIX;
 use crate::tools::ToolFilter;
 use crate::tools::ToolInfo;
 use crate::tools::filter_tools;
@@ -320,6 +322,32 @@ fn test_normalize_tools_short_non_duplicated_names() {
             ToolName::namespaced("mcp__server1", "tool1"),
             ToolName::namespaced("mcp__server1", "tool2")
         ])
+    );
+}
+
+#[test]
+fn test_normalize_tools_bounds_namespace_descriptions() {
+    let mut short = create_test_tool("short", "tool");
+    short.namespace_description = Some("brief guidance".to_string());
+    let mut long = create_test_tool("long", "tool");
+    long.namespace_description = Some("é".repeat(MAX_MCP_NAMESPACE_DESCRIPTION_BYTES));
+
+    let model_tools =
+        normalize_tools_for_model_with_prefix([short, long], /*prefix_mcp_tool_names*/ true);
+    let expected_prefix_bytes =
+        MAX_MCP_NAMESPACE_DESCRIPTION_BYTES - MCP_NAMESPACE_DESCRIPTION_TRUNCATION_SUFFIX.len();
+    let expected_long = format!(
+        "{}{}",
+        "é".repeat(expected_prefix_bytes / "é".len()),
+        MCP_NAMESPACE_DESCRIPTION_TRUNCATION_SUFFIX
+    );
+
+    assert_eq!(
+        model_tools
+            .iter()
+            .map(|tool| tool.namespace_description.clone())
+            .collect::<Vec<_>>(),
+        vec![Some(expected_long), Some("brief guidance".to_string())]
     );
 }
 

--- a/codex-rs/codex-mcp/src/tools.rs
+++ b/codex-rs/codex-mcp/src/tools.rs
@@ -155,7 +155,10 @@ where
 {
     let mut seen_raw_names = HashSet::new();
     let mut candidates = Vec::new();
-    for tool in tools {
+    for mut tool in tools {
+        if let Some(description) = tool.namespace_description.take() {
+            tool.namespace_description = Some(truncate_namespace_description(description));
+        }
         let raw_namespace_identity = format!(
             "{}\0{}\0{}",
             tool.server_name,
@@ -259,6 +262,8 @@ struct CallableToolCandidate {
 
 const MCP_TOOL_NAME_DELIMITER: &str = "__";
 const MAX_TOOL_NAME_LENGTH: usize = 64;
+pub(crate) const MAX_MCP_NAMESPACE_DESCRIPTION_BYTES: usize = 4 * 1024;
+pub(crate) const MCP_NAMESPACE_DESCRIPTION_TRUNCATION_SUFFIX: &str = "\n[truncated]";
 const CALLABLE_NAME_HASH_LEN: usize = 12;
 const META_OPENAI_FILE_PARAMS: &str = "openai/fileParams";
 
@@ -347,6 +352,21 @@ fn append_namespace_hash_suffix(namespace: &str, raw_identity: &str) -> String {
 
 fn truncate_name(value: &str, max_len: usize) -> String {
     value.chars().take(max_len).collect()
+}
+
+fn truncate_namespace_description(mut description: String) -> String {
+    if description.len() <= MAX_MCP_NAMESPACE_DESCRIPTION_BYTES {
+        return description;
+    }
+
+    let mut end = MAX_MCP_NAMESPACE_DESCRIPTION_BYTES
+        .saturating_sub(MCP_NAMESPACE_DESCRIPTION_TRUNCATION_SUFFIX.len());
+    while !description.is_char_boundary(end) {
+        end = end.saturating_sub(1);
+    }
+    description.truncate(end);
+    description.push_str(MCP_NAMESPACE_DESCRIPTION_TRUNCATION_SUFFIX);
+    description
 }
 
 fn fit_callable_parts_with_hash(

--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -85,7 +85,6 @@ use codex_tools::request_user_input_available_modes;
 use codex_tools::shell_command_backend_for_features;
 use codex_tools::shell_type_for_model_and_features;
 use std::collections::BTreeMap;
-use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 use tracing::instrument;
@@ -427,7 +426,6 @@ fn is_excluded_from_code_mode(turn_context: &TurnContext, tool_name: &ToolName) 
 fn build_code_mode_executors(
     turn_context: &TurnContext,
     executors: &[Arc<dyn CoreToolRuntime>],
-    deferred_mcp_tools: Option<&[ToolInfo]>,
 ) -> Vec<Arc<dyn CoreToolRuntime>> {
     if !matches!(
         turn_context.tool_mode,
@@ -440,17 +438,6 @@ fn build_code_mode_executors(
     let mut exec_prompt_tool_specs = Vec::new();
     let mut deferred_tools_available = false;
     let deferred_tools_guidance_enabled = search_tool_enabled(turn_context);
-    let deferred_mcp_instructions = deferred_mcp_tools
-        .unwrap_or_default()
-        .iter()
-        .filter_map(|tool| {
-            tool.namespace_description
-                .as_deref()
-                .map(str::trim)
-                .filter(|instructions| !instructions.is_empty())
-                .map(|instructions| (tool.canonical_tool_name(), instructions))
-        })
-        .collect::<HashMap<_, _>>();
     for executor in executors {
         let exposure = executor.exposure();
         if exposure == ToolExposure::DirectModelOnly {
@@ -468,16 +455,17 @@ fn build_code_mode_executors(
         let mut spec = executor.spec();
 
         if exposure == ToolExposure::Deferred {
-            if let Some(instructions) = deferred_mcp_instructions.get(&executor.tool_name())
-                && let ToolSpec::Namespace(namespace) = &mut spec
+            if let ToolSpec::Namespace(namespace) = &mut spec
+                && !namespace.description.trim().is_empty()
             {
+                let namespace_description = namespace.description.trim();
                 for tool in &mut namespace.tools {
                     let ResponsesApiNamespaceTool::Function(tool) = tool;
                     if tool.description.trim().is_empty() {
-                        tool.description = (*instructions).to_string();
+                        tool.description = namespace_description.to_string();
                     } else {
                         tool.description =
-                            format!("{}\n\n{instructions}", tool.description.trim_end());
+                            format!("{}\n\n{namespace_description}", tool.description.trim_end());
                     }
                 }
             }
@@ -890,11 +878,7 @@ fn prepend_code_mode_executors(
     planned_tools: &mut PlannedTools,
 ) {
     let turn_context = context.turn_context;
-    let code_mode_executors = build_code_mode_executors(
-        turn_context,
-        planned_tools.runtimes(),
-        context.deferred_mcp_tools,
-    );
+    let code_mode_executors = build_code_mode_executors(turn_context, planned_tools.runtimes());
     planned_tools.runtimes.splice(0..0, code_mode_executors);
 }
 

--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -85,6 +85,7 @@ use codex_tools::request_user_input_available_modes;
 use codex_tools::shell_command_backend_for_features;
 use codex_tools::shell_type_for_model_and_features;
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
 use tracing::instrument;
@@ -426,6 +427,7 @@ fn is_excluded_from_code_mode(turn_context: &TurnContext, tool_name: &ToolName) 
 fn build_code_mode_executors(
     turn_context: &TurnContext,
     executors: &[Arc<dyn CoreToolRuntime>],
+    deferred_mcp_tools: Option<&[ToolInfo]>,
 ) -> Vec<Arc<dyn CoreToolRuntime>> {
     if !matches!(
         turn_context.tool_mode,
@@ -438,6 +440,17 @@ fn build_code_mode_executors(
     let mut exec_prompt_tool_specs = Vec::new();
     let mut deferred_tools_available = false;
     let deferred_tools_guidance_enabled = search_tool_enabled(turn_context);
+    let deferred_mcp_instructions = deferred_mcp_tools
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|tool| {
+            tool.namespace_description
+                .as_deref()
+                .map(str::trim)
+                .filter(|instructions| !instructions.is_empty())
+                .map(|instructions| (tool.canonical_tool_name(), instructions))
+        })
+        .collect::<HashMap<_, _>>();
     for executor in executors {
         let exposure = executor.exposure();
         if exposure == ToolExposure::DirectModelOnly {
@@ -452,9 +465,22 @@ fn build_code_mode_executors(
             continue;
         }
 
-        let spec = executor.spec();
+        let mut spec = executor.spec();
 
         if exposure == ToolExposure::Deferred {
+            if let Some(instructions) = deferred_mcp_instructions.get(&executor.tool_name())
+                && let ToolSpec::Namespace(namespace) = &mut spec
+            {
+                for tool in &mut namespace.tools {
+                    let ResponsesApiNamespaceTool::Function(tool) = tool;
+                    if tool.description.trim().is_empty() {
+                        tool.description = (*instructions).to_string();
+                    } else {
+                        tool.description =
+                            format!("{}\n\n{instructions}", tool.description.trim_end());
+                    }
+                }
+            }
             // Only show deferred-tool guidance when supported and an included spec is usable by code mode.
             deferred_tools_available |= deferred_tools_guidance_enabled
                 && !collect_code_mode_exec_prompt_tool_definitions(std::iter::once(&spec))
@@ -864,7 +890,11 @@ fn prepend_code_mode_executors(
     planned_tools: &mut PlannedTools,
 ) {
     let turn_context = context.turn_context;
-    let code_mode_executors = build_code_mode_executors(turn_context, planned_tools.runtimes());
+    let code_mode_executors = build_code_mode_executors(
+        turn_context,
+        planned_tools.runtimes(),
+        context.deferred_mcp_tools,
+    );
     planned_tools.runtimes.splice(0..0, code_mode_executors);
 }
 

--- a/codex-rs/core/tests/suite/code_mode.rs
+++ b/codex-rs/core/tests/suite/code_mode.rs
@@ -3329,7 +3329,7 @@ text(JSON.stringify(tool));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn code_mode_appends_server_instructions_to_deferred_mcp_tool_descriptions() -> Result<()> {
+async fn code_mode_appends_namespace_description_to_deferred_tool_descriptions() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = responses::start_mock_server().await;

--- a/codex-rs/core/tests/suite/code_mode.rs
+++ b/codex-rs/core/tests/suite/code_mode.rs
@@ -330,8 +330,13 @@ async fn run_code_mode_turn_with_rmcp_model(
     model: &'static str,
 ) -> Result<(TestCodex, ResponseMock)> {
     run_code_mode_turn_with_rmcp_config(
-        server, prompt, code, model, /*code_mode_only*/ false,
+        server,
+        prompt,
+        code,
+        model,
+        /*code_mode_only*/ false,
         /*non_prefixed_mcp_tool_names*/ false,
+        McpToolLoading::Direct,
     )
     .await
 }
@@ -349,8 +354,15 @@ async fn run_code_mode_turn_with_rmcp_mode(
         "test-gpt-5.1-codex",
         code_mode_only,
         /*non_prefixed_mcp_tool_names*/ false,
+        McpToolLoading::Direct,
     )
     .await
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum McpToolLoading {
+    Direct,
+    Deferred,
 }
 
 async fn run_code_mode_turn_with_rmcp_config(
@@ -360,6 +372,7 @@ async fn run_code_mode_turn_with_rmcp_config(
     model: &'static str,
     code_mode_only: bool,
     non_prefixed_mcp_tool_names: bool,
+    tool_loading: McpToolLoading,
 ) -> Result<(TestCodex, ResponseMock)> {
     let rmcp_test_server_bin = stdio_server_bin()?;
     let mut builder = test_codex().with_model(model).with_config(move |config| {
@@ -370,6 +383,21 @@ async fn run_code_mode_turn_with_rmcp_config(
         };
         if non_prefixed_mcp_tool_names {
             let _ = config.features.enable(Feature::NonPrefixedMcpToolNames);
+        }
+        if tool_loading == McpToolLoading::Deferred {
+            config
+                .features
+                .enable(Feature::ToolSearchAlwaysDeferMcpTools)
+                .expect("test config should allow feature update");
+            let mut model_catalog = bundled_models_response()
+                .unwrap_or_else(|err| panic!("bundled models.json should parse: {err}"));
+            let model = model_catalog
+                .models
+                .iter_mut()
+                .find(|model_info| model_info.slug == model)
+                .unwrap_or_else(|| panic!("{model} exists in bundled models.json"));
+            model.supports_search_tool = true;
+            config.model_catalog = Some(model_catalog);
         }
 
         let mut servers = config.mcp_servers.get().clone();
@@ -3019,6 +3047,7 @@ text(JSON.stringify({
         "test-gpt-5.1-codex",
         /*code_mode_only*/ false,
         /*non_prefixed_mcp_tool_names*/ true,
+        McpToolLoading::Direct,
     )
     .await?;
 
@@ -3287,6 +3316,60 @@ text(JSON.stringify(tool));
             "name": "mcp__rmcp__echo",
             "description": concat!(
                 "Echo back the provided message and include environment data.\n\n",
+                "exec tool declaration:\n",
+                "```ts\n",
+                "declare const tools: { mcp__rmcp__echo(args: { env_var?: string; message: string; }): ",
+                "Promise<CallToolResult<{ echo: string; env: string | null; }>>; };\n",
+                "```",
+            ),
+        })
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn code_mode_appends_server_instructions_to_deferred_mcp_tool_descriptions() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = responses::start_mock_server().await;
+    let code = r#"
+const tool = ALL_TOOLS.find(
+  ({ name }) => name === "mcp__rmcp__echo"
+);
+text(JSON.stringify(tool));
+"#;
+
+    let (_test, second_mock) = run_code_mode_turn_with_rmcp_config(
+        &server,
+        "use exec to inspect ALL_TOOLS",
+        code,
+        "gpt-5.4",
+        /*code_mode_only*/ true,
+        /*non_prefixed_mcp_tool_names*/ false,
+        McpToolLoading::Deferred,
+    )
+    .await?;
+
+    let req = second_mock.single_request();
+    let (output, success) = custom_tool_output_body_and_success(&req, "call-1");
+    assert_ne!(
+        success,
+        Some(false),
+        "exec ALL_TOOLS MCP lookup failed unexpectedly: {output}"
+    );
+
+    let parsed: Value = serde_json::from_str(
+        &custom_tool_output_last_non_empty_text(&req, "call-1")
+            .expect("exec ALL_TOOLS lookup should emit JSON"),
+    )?;
+    assert_eq!(
+        parsed,
+        serde_json::json!({
+            "name": "mcp__rmcp__echo",
+            "description": concat!(
+                "Echo back the provided message and include environment data.\n\n",
+                "Use these tools to exercise the rmcp test server.\n\n",
                 "exec tool declaration:\n",
                 "```ts\n",
                 "declare const tools: { mcp__rmcp__echo(args: { env_var?: string; message: string; }): ",


### PR DESCRIPTION
## Why

In CodeModeOnly, deferred namespaced tools are available through `ALL_TOOLS`, but their shared namespace guidance is lost when the namespace is flattened into individual tools. This makes routing guidance, such as when to choose browser tools, invisible even though the tools themselves remain callable.

MCP namespace descriptions are also supplied by external servers without a protocol size limit. Repeating an unbounded description across a deferred tool set could create excessive code-mode metadata.

## What changed

- Append a deferred namespace's existing description to each child tool description used by `ALL_TOOLS`.
- Keep direct tool descriptions unchanged because their shared namespace guidance is already shown in the `exec` description.
- Bound model-visible MCP namespace descriptions to 4 KiB during MCP tool normalization, including cached tools.
- Cover the deferred CodeModeOnly behavior, the unchanged direct behavior, and UTF-8-safe description truncation.

## Testing

- `just test -p codex-mcp`
- `just test -p codex-core code_mode_appends_namespace_description_to_deferred_tool_descriptions`
- `just test -p codex-core code_mode_exports_all_tools_metadata_for_namespaced_mcp_tools`

The full `just test -p codex-core` suite was also attempted earlier. The focused tests pass, but the full local run remains non-clean because of unrelated local-harness failures in CLI fixture discovery, code-mode output-limit tests, and shell-snapshot tests.
