### PR TITLE
Seed session pickers from the state DB

### DIFF
--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
+mod loading;
 
 use crate::app_server_session::AppServerSession;
 use crate::clipboard_paste::normalize_pasted_search_query;
@@ -58,9 +59,8 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::warn;
 use unicode_width::UnicodeWidthStr;
 
-mod loading;
-
 use loading::BackgroundEvent;
+use loading::InitialPageLoad;
 use loading::PageCursor;
 use loading::PageLoadRequest;
 use loading::PickerLoadRequest;
@@ -242,6 +242,7 @@ struct SessionPickerRunOptions {
     view_persistence: Option<SessionPickerViewPersistence>,
     pager_keymap: PagerKeymap,
     list_keymap: ListKeymap,
+    initial_page_load: InitialPageLoad,
 }
 
 /// Interactive session picker that lists app-server threads with simple search,
@@ -256,6 +257,10 @@ struct SessionPickerRunOptions {
 /// `thread/list` API returns pages ordered by the selected sort key, and the
 /// picker deduplicates across pages to handle overlapping windows when new
 /// sessions appear during pagination.
+///
+/// For local workspaces, the picker seeds its first page from the State DB,
+/// then replaces those provisional rows when the normal scan-and-repair lookup
+/// completes. Remote workspaces use the normal lookup directly.
 ///
 /// Filtering happens in two layers:
 /// 1. Provider, source, and eligible working-directory filtering at the backend.
@@ -328,6 +333,11 @@ async fn run_resume_picker_with_launch_context(
         }),
         pager_keymap: runtime_keymap.pager,
         list_keymap: runtime_keymap.list,
+        initial_page_load: if uses_remote_workspace {
+            InitialPageLoad::default()
+        } else {
+            InitialPageLoad::state_db_first()
+        },
     };
     run_session_picker_with_loader(
         tui,
@@ -373,6 +383,11 @@ pub async fn run_fork_picker_with_app_server(
         }),
         pager_keymap: runtime_keymap.pager,
         list_keymap: runtime_keymap.list,
+        initial_page_load: if uses_remote_workspace {
+            InitialPageLoad::default()
+        } else {
+            InitialPageLoad::state_db_first()
+        },
     };
     run_session_picker_with_loader(
         tui,
@@ -409,6 +424,7 @@ async fn run_session_picker_with_loader(
     state.pager_keymap = options.pager_keymap;
     state.list_keymap = options.list_keymap;
     state.launch_context = options.launch_context;
+    state.initial_page_load = options.initial_page_load;
     state.start_initial_load();
     state.request_frame();
 
@@ -569,6 +585,7 @@ struct PickerState {
     overlay: Option<Overlay>,
     pager_keymap: PagerKeymap,
     list_keymap: ListKeymap,
+    initial_page_load: InitialPageLoad,
 }
 
 struct PaginationState {
@@ -806,6 +823,7 @@ impl PickerState {
             overlay: None,
             pager_keymap: RuntimeKeymap::defaults().pager,
             list_keymap: RuntimeKeymap::defaults().list,
+            initial_page_load: InitialPageLoad::default(),
         }
     }
 
@@ -970,6 +988,12 @@ impl PickerState {
                 self.toggle_density().await;
             }
             _ if self.list_keymap.accept.is_pressed(key) => {
+                if self.initial_page_load.is_provisional() {
+                    self.inline_error =
+                        Some(String::from("Wait for session verification to finish"));
+                    self.request_frame();
+                    return Ok(None);
+                }
                 if let Some(row) = self.filtered_rows.get(self.selected) {
                     let path = row.path.clone();
                     let thread_id = match row.thread_id {
@@ -1110,6 +1134,7 @@ impl PickerState {
 
     fn start_initial_load(&mut self) {
         self.relative_time_reference = Some(Utc::now());
+        let seed_from_state_db = self.initial_page_load.begin_load();
         self.reset_pagination();
         self.all_rows.clear();
         self.filtered_rows.clear();
@@ -1141,6 +1166,7 @@ impl PickerState {
             cwd_filter: self.active_cwd_filter(),
             provider_filter: self.provider_filter.clone(),
             sort_key: self.sort_key,
+            seed_from_state_db,
         }));
     }
 
@@ -1241,15 +1267,20 @@ impl PickerState {
         self.query = new_query;
         self.selected = 0;
         self.apply_filter();
-        if self.query.is_empty() {
-            self.search_state = SearchState::Idle;
-            return;
-        }
-        if !self.filtered_rows.is_empty() {
-            self.search_state = SearchState::Idle;
-            return;
-        }
-        if self.pagination.reached_scan_cap || self.pagination.next_cursor.is_none() {
+        self.reevaluate_search();
+    }
+
+    /// Restarts cursor-based search when the current rows contain no match and
+    /// more pages remain.
+    ///
+    /// This must also run after reconciliation because replacing the provisional
+    /// State DB page can invalidate the previous search result.
+    fn reevaluate_search(&mut self) {
+        if self.query.is_empty()
+            || !self.filtered_rows.is_empty()
+            || self.pagination.reached_scan_cap
+            || self.pagination.next_cursor.is_none()
+        {
             self.search_state = SearchState::Idle;
             return;
         }
@@ -1392,6 +1423,7 @@ impl PickerState {
             cwd_filter: self.active_cwd_filter(),
             provider_filter: self.provider_filter.clone(),
             sort_key: self.sort_key,
+            seed_from_state_db: false,
         }));
     }
 
@@ -1911,7 +1943,6 @@ fn footer_hint_lines(state: &PickerState, width: u16) -> Vec<Line<'static>> {
             .unwrap_or_default();
         return vec![line, Line::default()];
     }
-
     let action_label = state.action.action_label();
     let (esc_label, esc_compact_label) = if state.query.is_empty() {
         match state.launch_context {
@@ -1933,13 +1964,23 @@ fn footer_hint_lines(state: &PickerState, width: u16) -> Vec<Line<'static>> {
         SessionListDensity::Comfortable => "dense",
         SessionListDensity::Dense => "comfy",
     };
-    let first_row_hints = vec![
+    let primary_hint = if state.initial_page_load.is_provisional() {
+        PickerFooterHint {
+            key: "verifying",
+            wide_label: String::from("sessions"),
+            compact_label: String::from("sessions"),
+            priority: 0,
+        }
+    } else {
         PickerFooterHint {
             key: "enter",
             wide_label: action_label.to_string(),
             compact_label: action_label.to_string(),
             priority: 0,
-        },
+        }
+    };
+    let first_row_hints = vec![
+        primary_hint,
         PickerFooterHint {
             key: "esc",
             wide_label: esc_label.to_string(),
@@ -3414,7 +3455,7 @@ mod tests {
             SessionPickerAction::Resume,
         );
         state.inline_error = Some(String::from(
-            "Failed to read session metadata from /tmp/missing.jsonl",
+            "Could not refresh sessions; showing the first page of indexed results",
         ));
 
         let width: u16 = 80;
@@ -5407,6 +5448,25 @@ session_picker_view = "dense"
             })) => assert_eq!(selected_thread_id, thread_id),
             other => panic!("unexpected selection: {other:?}"),
         }
+    }
+
+    #[test]
+    fn hint_line_snapshot_blocks_accept_for_provisional_rows() {
+        let loader = page_only_loader(|_| {});
+        let mut state = PickerState::new(
+            FrameRequester::test_dummy(),
+            loader,
+            ProviderFilter::MatchDefault(String::from("openai")),
+            /*show_all*/ true,
+            /*filter_cwd*/ None,
+            SessionPickerAction::Resume,
+        );
+        state.initial_page_load = InitialPageLoad::Provisional;
+
+        assert_snapshot!(
+            "resume_picker_footer_verifying",
+            footer_snapshot(&state, /*width*/ 220, /*list_height*/ 20)
+        );
     }
 
     #[test]

--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -24,7 +24,6 @@ use crate::terminal_palette::default_bg;
 use crate::text_formatting::truncate_text;
 use crate::thread_transcript::RawReasoningVisibility;
 use crate::thread_transcript::TranscriptCells;
-use crate::thread_transcript::load_session_transcript;
 use crate::tui::FrameRequester;
 use crate::tui::Tui;
 use crate::tui::TuiEvent;
@@ -633,16 +632,11 @@ impl LoadingState {
     }
 }
 
-async fn load_transcript_preview(
-    app_server: &mut AppServerSession,
-    thread_id: ThreadId,
-) -> std::io::Result<Vec<TranscriptPreviewLine>> {
+fn transcript_preview_lines(
+    thread: &codex_app_server_protocol::Thread,
+) -> Vec<TranscriptPreviewLine> {
     const MAX_PREVIEW_LINES: usize = 6;
 
-    let thread = app_server
-        .thread_read(thread_id, /*include_turns*/ true)
-        .await
-        .map_err(std::io::Error::other)?;
     let cwd = thread.cwd.as_path();
     let mut lines = thread
         .turns
@@ -682,7 +676,7 @@ async fn load_transcript_preview(
     if lines.len() > MAX_PREVIEW_LINES {
         lines.drain(..lines.len() - MAX_PREVIEW_LINES);
     }
-    Ok(lines)
+    lines
 }
 
 impl SearchState {

--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use crate::app_server_session::AppServerSession;
 use crate::clipboard_paste::normalize_pasted_search_query;
@@ -33,10 +32,7 @@ use crate::wrapping::RtOptions;
 use crate::wrapping::adaptive_wrap_lines;
 use chrono::DateTime;
 use chrono::Utc;
-use codex_app_server_protocol::Thread;
 use codex_app_server_protocol::ThreadItem;
-use codex_app_server_protocol::ThreadListCwdFilter;
-use codex_app_server_protocol::ThreadListParams;
 use codex_app_server_protocol::ThreadSortKey;
 use codex_config::types::SessionPickerViewMode;
 use codex_protocol::ThreadId;
@@ -63,7 +59,16 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::warn;
 use unicode_width::UnicodeWidthStr;
 
-const PAGE_SIZE: usize = 25;
+mod loading;
+
+use loading::BackgroundEvent;
+use loading::PageCursor;
+use loading::PageLoadRequest;
+use loading::PickerLoadRequest;
+use loading::PickerLoader;
+use loading::PickerPage;
+use loading::spawn_app_server_page_loader;
+
 const LOAD_NEAR_THRESHOLD: usize = 5;
 const SESSION_META_INDENT_WIDTH: usize = 2;
 const SESSION_META_DATE_WIDTH: usize = 12;
@@ -135,22 +140,6 @@ impl SessionPickerAction {
             SessionPickerAction::Fork => SessionSelection::Fork(target_session),
         }
     }
-}
-
-#[derive(Clone)]
-struct PageLoadRequest {
-    cursor: Option<PageCursor>,
-    request_token: usize,
-    search_token: Option<usize>,
-    cwd_filter: Option<PathBuf>,
-    provider_filter: ProviderFilter,
-    sort_key: ThreadSortKey,
-}
-
-enum PickerLoadRequest {
-    Page(PageLoadRequest),
-    Preview { thread_id: ThreadId },
-    Transcript { thread_id: ThreadId },
 }
 
 #[derive(Clone)]
@@ -236,35 +225,6 @@ impl From<SessionListDensity> for SessionPickerViewMode {
             SessionListDensity::Dense => Self::Dense,
         }
     }
-}
-
-type PickerLoader = Arc<dyn Fn(PickerLoadRequest) + Send + Sync>;
-enum BackgroundEvent {
-    Page {
-        request_token: usize,
-        search_token: Option<usize>,
-        page: std::io::Result<PickerPage>,
-    },
-    Preview {
-        thread_id: ThreadId,
-        preview: std::io::Result<Vec<TranscriptPreviewLine>>,
-    },
-    Transcript {
-        thread_id: ThreadId,
-        transcript: std::io::Result<TranscriptCells>,
-    },
-}
-
-#[derive(Clone)]
-enum PageCursor {
-    AppServer(String),
-}
-
-struct PickerPage {
-    rows: Vec<Row>,
-    next_cursor: Option<PageCursor>,
-    num_scanned_files: usize,
-    reached_scan_cap: bool,
 }
 
 #[derive(Clone)]
@@ -547,63 +507,6 @@ fn picker_cwd_filter(
     }
 }
 
-fn spawn_app_server_page_loader(
-    app_server: AppServerSession,
-    include_non_interactive: bool,
-    raw_reasoning_visibility: RawReasoningVisibility,
-    bg_tx: mpsc::UnboundedSender<BackgroundEvent>,
-) -> PickerLoader {
-    let (request_tx, mut request_rx) = mpsc::unbounded_channel::<PickerLoadRequest>();
-
-    tokio::spawn(async move {
-        let mut app_server = app_server;
-        while let Some(request) = request_rx.recv().await {
-            match request {
-                PickerLoadRequest::Page(request) => {
-                    let cursor = request.cursor.map(|PageCursor::AppServer(cursor)| cursor);
-                    let page = load_app_server_page(
-                        &mut app_server,
-                        cursor,
-                        request.cwd_filter.as_deref(),
-                        request.provider_filter,
-                        request.sort_key,
-                        include_non_interactive,
-                    )
-                    .await;
-                    let _ = bg_tx.send(BackgroundEvent::Page {
-                        request_token: request.request_token,
-                        search_token: request.search_token,
-                        page,
-                    });
-                }
-                PickerLoadRequest::Preview { thread_id } => {
-                    let preview = load_transcript_preview(&mut app_server, thread_id).await;
-                    let _ = bg_tx.send(BackgroundEvent::Preview { thread_id, preview });
-                }
-                PickerLoadRequest::Transcript { thread_id } => {
-                    let transcript = load_session_transcript(
-                        &mut app_server,
-                        thread_id,
-                        raw_reasoning_visibility,
-                    )
-                    .await;
-                    let _ = bg_tx.send(BackgroundEvent::Transcript {
-                        thread_id,
-                        transcript,
-                    });
-                }
-            }
-        }
-        if let Err(err) = app_server.shutdown().await {
-            warn!(%err, "Failed to shut down app-server picker session");
-        }
-    });
-
-    Arc::new(move |request: PickerLoadRequest| {
-        let _ = request_tx.send(request);
-    })
-}
-
 /// Returns the human-readable column header for the given sort key.
 fn sort_key_label(sort_key: ThreadSortKey) -> &'static str {
     match sort_key {
@@ -728,38 +631,6 @@ impl LoadingState {
     fn is_pending(&self) -> bool {
         matches!(self, LoadingState::Pending(_))
     }
-}
-
-async fn load_app_server_page(
-    app_server: &mut AppServerSession,
-    cursor: Option<String>,
-    cwd_filter: Option<&Path>,
-    provider_filter: ProviderFilter,
-    sort_key: ThreadSortKey,
-    include_non_interactive: bool,
-) -> std::io::Result<PickerPage> {
-    let response = app_server
-        .thread_list(thread_list_params(
-            cursor,
-            cwd_filter,
-            provider_filter,
-            sort_key,
-            include_non_interactive,
-        ))
-        .await
-        .map_err(std::io::Error::other)?;
-    let num_scanned_files = response.data.len();
-
-    Ok(PickerPage {
-        rows: response
-            .data
-            .into_iter()
-            .filter_map(row_from_app_server_thread)
-            .collect(),
-        next_cursor: response.next_cursor.map(PageCursor::AppServer),
-        num_scanned_files,
-        reached_scan_cap: false,
-    })
 }
 
 async fn load_transcript_preview(
@@ -1279,65 +1150,6 @@ impl PickerState {
         }));
     }
 
-    async fn handle_background_event(&mut self, event: BackgroundEvent) -> Result<()> {
-        match event {
-            BackgroundEvent::Page {
-                request_token,
-                search_token,
-                page,
-            } => {
-                let pending = match self.pagination.loading {
-                    LoadingState::Pending(pending) => pending,
-                    LoadingState::Idle => return Ok(()),
-                };
-                if pending.request_token != request_token {
-                    return Ok(());
-                }
-                self.pagination.loading = LoadingState::Idle;
-                let page = page.map_err(color_eyre::Report::from)?;
-                self.ingest_page(page);
-                self.complete_pending_page_down();
-                let completed_token = pending.search_token.or(search_token);
-                self.continue_search_if_token_matches(completed_token);
-            }
-            BackgroundEvent::Preview { thread_id, preview } => {
-                self.transcript_previews.insert(
-                    thread_id,
-                    match preview {
-                        Ok(lines) => TranscriptPreviewState::Loaded(lines),
-                        Err(_) => TranscriptPreviewState::Failed,
-                    },
-                );
-                self.request_frame();
-            }
-            BackgroundEvent::Transcript {
-                thread_id,
-                transcript,
-            } => match transcript {
-                Ok(cells) => {
-                    let should_open = self.pending_transcript_open == Some(thread_id);
-                    self.transcript_cells
-                        .insert(thread_id, SessionTranscriptState::Loaded(cells.clone()));
-                    if should_open {
-                        self.open_pending_transcript_if_ready();
-                    }
-                    self.request_frame();
-                }
-                Err(_) => {
-                    self.transcript_cells
-                        .insert(thread_id, SessionTranscriptState::Failed);
-                    if self.pending_transcript_open == Some(thread_id) {
-                        self.pending_transcript_open = None;
-                        self.transcript_loading_frame_shown = false;
-                        self.inline_error = Some("Could not load transcript preview".to_string());
-                    }
-                    self.request_frame();
-                }
-            },
-        }
-        Ok(())
-    }
-
     fn reset_pagination(&mut self) {
         self.pagination.next_cursor = None;
         self.pagination.num_scanned_files = 0;
@@ -1773,58 +1585,6 @@ impl PickerState {
             SessionListDensity::Comfortable => 1,
             SessionListDensity::Dense => 0,
         }
-    }
-}
-
-fn row_from_app_server_thread(thread: Thread) -> Option<Row> {
-    let thread_id = match ThreadId::from_string(&thread.id) {
-        Ok(thread_id) => thread_id,
-        Err(err) => {
-            warn!(thread_id = thread.id, %err, "Skipping app-server picker row with invalid id");
-            return None;
-        }
-    };
-    let preview = thread.preview.trim();
-    Some(Row {
-        path: thread.path,
-        preview: if preview.is_empty() {
-            String::from("(no message yet)")
-        } else {
-            preview.to_string()
-        },
-        thread_id: Some(thread_id),
-        thread_name: thread.name,
-        created_at: chrono::DateTime::from_timestamp(thread.created_at, 0)
-            .map(|dt| dt.with_timezone(&Utc)),
-        updated_at: chrono::DateTime::from_timestamp(thread.updated_at, 0)
-            .map(|dt| dt.with_timezone(&Utc)),
-        cwd: Some(thread.cwd.to_path_buf()),
-        git_branch: thread.git_info.and_then(|git_info| git_info.branch),
-    })
-}
-
-fn thread_list_params(
-    cursor: Option<String>,
-    cwd_filter: Option<&Path>,
-    provider_filter: ProviderFilter,
-    sort_key: ThreadSortKey,
-    include_non_interactive: bool,
-) -> ThreadListParams {
-    ThreadListParams {
-        cursor,
-        limit: Some(PAGE_SIZE as u32),
-        sort_key: Some(sort_key),
-        sort_direction: None,
-        model_providers: match provider_filter {
-            ProviderFilter::Any => None,
-            ProviderFilter::MatchDefault(default_provider) => Some(vec![default_provider]),
-        },
-        source_kinds: Some(crate::resume_source_kinds(include_non_interactive)),
-        archived: Some(false),
-        parent_thread_id: None,
-        cwd: cwd_filter.map(|cwd| ThreadListCwdFilter::One(cwd.to_string_lossy().into_owned())),
-        use_state_db_only: false,
-        search_term: None,
     }
 }
 
@@ -3197,7 +2957,7 @@ fn render_empty_state_line(state: &PickerState) -> Line<'static> {
 mod tests {
     use super::*;
     use chrono::Duration;
-    use codex_app_server_protocol::ThreadSourceKind;
+    use codex_app_server_protocol::Thread;
     use codex_config::CONFIG_TOML_FILE;
     use codex_protocol::ThreadId;
     use codex_utils_absolute_path::test_support::PathBufExt;
@@ -3296,28 +3056,6 @@ mod tests {
         };
 
         assert_eq!(row.display_preview(), "My session");
-    }
-
-    #[test]
-    fn local_picker_thread_list_params_include_cwd_filter() {
-        let cwd_filter = picker_cwd_filter(
-            Path::new("/tmp/project"),
-            /*show_all*/ false,
-            /*uses_remote_workspace*/ false,
-            /*remote_cwd_override*/ None,
-        );
-        let params = thread_list_params(
-            Some(String::from("cursor-1")),
-            cwd_filter.as_deref(),
-            ProviderFilter::MatchDefault(String::from("openai")),
-            ThreadSortKey::UpdatedAt,
-            /*include_non_interactive*/ false,
-        );
-
-        assert_eq!(
-            params.cwd,
-            Some(ThreadListCwdFilter::One(String::from("/tmp/project")))
-        );
     }
 
     #[test]
@@ -3527,44 +3265,6 @@ mod tests {
         let first_index = rendered.find(first).expect("first metadata item");
         let second_index = rendered.find(second).expect("second metadata item");
         assert!(first_index < second_index);
-    }
-
-    #[test]
-    fn remote_thread_list_params_omit_provider_filter() {
-        let params = thread_list_params(
-            Some(String::from("cursor-1")),
-            Some(Path::new("repo/on/server")),
-            ProviderFilter::Any,
-            ThreadSortKey::UpdatedAt,
-            /*include_non_interactive*/ false,
-        );
-
-        assert_eq!(params.cursor, Some(String::from("cursor-1")));
-        assert_eq!(params.model_providers, None);
-        assert_eq!(
-            params.source_kinds,
-            Some(vec![ThreadSourceKind::Cli, ThreadSourceKind::VsCode])
-        );
-        assert_eq!(
-            params.cwd,
-            Some(ThreadListCwdFilter::One(String::from("repo/on/server")))
-        );
-    }
-
-    #[test]
-    fn remote_thread_list_params_can_include_non_interactive_sources() {
-        let params = thread_list_params(
-            Some(String::from("cursor-1")),
-            /*cwd_filter*/ None,
-            ProviderFilter::Any,
-            ThreadSortKey::UpdatedAt,
-            /*include_non_interactive*/ true,
-        );
-
-        assert_eq!(params.cursor, Some(String::from("cursor-1")));
-        assert_eq!(params.model_providers, None);
-        let source_kinds = crate::resume_source_kinds(/*include_non_interactive*/ true);
-        assert_eq!(params.source_kinds, Some(source_kinds));
     }
 
     #[test]
@@ -5713,39 +5413,6 @@ session_picker_view = "dense"
             })) => assert_eq!(selected_thread_id, thread_id),
             other => panic!("unexpected selection: {other:?}"),
         }
-    }
-
-    #[test]
-    fn app_server_row_keeps_pathless_threads() {
-        let thread_id = ThreadId::new();
-        let thread = Thread {
-            id: thread_id.to_string(),
-            session_id: thread_id.to_string(),
-            forked_from_id: None,
-            parent_thread_id: None,
-            preview: String::from("remote thread"),
-            ephemeral: false,
-            model_provider: String::from("openai"),
-            created_at: 1,
-            updated_at: 2,
-            status: codex_app_server_protocol::ThreadStatus::Idle,
-            path: None,
-            cwd: test_path_buf("/tmp").abs(),
-            cli_version: String::from("0.0.0"),
-            source: codex_app_server_protocol::SessionSource::Cli,
-            thread_source: None,
-            agent_nickname: None,
-            agent_role: None,
-            git_info: None,
-            name: Some(String::from("Named thread")),
-            turns: Vec::new(),
-        };
-
-        let row = row_from_app_server_thread(thread).expect("row should be preserved");
-
-        assert_eq!(row.path, None);
-        assert_eq!(row.thread_id, Some(thread_id));
-        assert_eq!(row.thread_name, Some(String::from("Named thread")));
     }
 
     #[test]

--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -66,7 +66,9 @@ use loading::PageLoadRequest;
 use loading::PickerLoadRequest;
 use loading::PickerLoader;
 use loading::PickerPage;
+use loading::SelectionValidation;
 use loading::spawn_app_server_page_loader;
+use loading::validate_provisional_session_target;
 
 const LOAD_NEAR_THRESHOLD: usize = 5;
 const SESSION_META_INDENT_WIDTH: usize = 2;
@@ -243,6 +245,7 @@ struct SessionPickerRunOptions {
     pager_keymap: PagerKeymap,
     list_keymap: ListKeymap,
     initial_page_load: InitialPageLoad,
+    include_non_interactive: bool,
 }
 
 /// Interactive session picker that lists app-server threads with simple search,
@@ -338,6 +341,7 @@ async fn run_resume_picker_with_launch_context(
         } else {
             InitialPageLoad::state_db_first()
         },
+        include_non_interactive,
     };
     run_session_picker_with_loader(
         tui,
@@ -388,6 +392,7 @@ pub async fn run_fork_picker_with_app_server(
         } else {
             InitialPageLoad::state_db_first()
         },
+        include_non_interactive: false,
     };
     run_session_picker_with_loader(
         tui,
@@ -425,6 +430,7 @@ async fn run_session_picker_with_loader(
     state.list_keymap = options.list_keymap;
     state.launch_context = options.launch_context;
     state.initial_page_load = options.initial_page_load;
+    state.include_non_interactive = options.include_non_interactive;
     state.start_initial_load();
     state.request_frame();
 
@@ -586,6 +592,7 @@ struct PickerState {
     pager_keymap: PagerKeymap,
     list_keymap: ListKeymap,
     initial_page_load: InitialPageLoad,
+    include_non_interactive: bool,
 }
 
 struct PaginationState {
@@ -824,6 +831,7 @@ impl PickerState {
             pager_keymap: RuntimeKeymap::defaults().pager,
             list_keymap: RuntimeKeymap::defaults().list,
             initial_page_load: InitialPageLoad::default(),
+            include_non_interactive: false,
         }
     }
 
@@ -988,14 +996,10 @@ impl PickerState {
                 self.toggle_density().await;
             }
             _ if self.list_keymap.accept.is_pressed(key) => {
-                if self.initial_page_load.is_provisional() {
-                    self.inline_error =
-                        Some(String::from("Wait for session verification to finish"));
-                    self.request_frame();
-                    return Ok(None);
-                }
                 if let Some(row) = self.filtered_rows.get(self.selected) {
                     let path = row.path.clone();
+                    let thread_name = row.thread_name.clone();
+                    let git_branch = row.git_branch.clone();
                     let thread_id = match row.thread_id {
                         Some(thread_id) => Some(thread_id),
                         None => match path.as_ref() {
@@ -1007,6 +1011,52 @@ impl PickerState {
                         },
                     };
                     if let Some(thread_id) = thread_id {
+                        if self.initial_page_load.is_provisional() {
+                            let Some(validation_path) = path.clone() else {
+                                warn!(%thread_id, "Cannot validate selected session without rollout path");
+                                self.inline_error = Some(String::from(
+                                    "Selected session is no longer available",
+                                ));
+                                self.request_frame();
+                                return Ok(None);
+                            };
+                            let Some(codex_home) = self
+                                .view_persistence
+                                .as_ref()
+                                .map(|persistence| persistence.codex_home.clone())
+                            else {
+                                warn!(%thread_id, "Cannot validate selected session without Codex home");
+                                self.inline_error = Some(String::from(
+                                    "Selected session is no longer available",
+                                ));
+                                self.request_frame();
+                                return Ok(None);
+                            };
+                            let validation = SelectionValidation {
+                                path: validation_path,
+                                thread_id,
+                                thread_name,
+                                git_branch,
+                                codex_home,
+                                cwd_filter: self.active_cwd_filter(),
+                                provider_filter: self.provider_filter.clone(),
+                                include_non_interactive: self.include_non_interactive,
+                                query: self.query.clone(),
+                            };
+                            return match validate_provisional_session_target(validation).await {
+                                Ok(target) => {
+                                    Ok(Some(self.action.selection(target.path, target.thread_id)))
+                                }
+                                Err(err) => {
+                                    warn!(%err, %thread_id, "Selected session failed validation");
+                                    self.inline_error = Some(String::from(
+                                        "Selected session is no longer available",
+                                    ));
+                                    self.request_frame();
+                                    Ok(None)
+                                }
+                            };
+                        }
                         return Ok(Some(self.action.selection(path, thread_id)));
                     }
                     self.inline_error = Some(match path {
@@ -1964,23 +2014,13 @@ fn footer_hint_lines(state: &PickerState, width: u16) -> Vec<Line<'static>> {
         SessionListDensity::Comfortable => "dense",
         SessionListDensity::Dense => "comfy",
     };
-    let primary_hint = if state.initial_page_load.is_provisional() {
-        PickerFooterHint {
-            key: "verifying",
-            wide_label: String::from("sessions"),
-            compact_label: String::from("sessions"),
-            priority: 0,
-        }
-    } else {
+    let first_row_hints = vec![
         PickerFooterHint {
             key: "enter",
             wide_label: action_label.to_string(),
             compact_label: action_label.to_string(),
             priority: 0,
-        }
-    };
-    let first_row_hints = vec![
-        primary_hint,
+        },
         PickerFooterHint {
             key: "esc",
             wide_label: esc_label.to_string(),
@@ -5451,7 +5491,7 @@ session_picker_view = "dense"
     }
 
     #[test]
-    fn hint_line_snapshot_blocks_accept_for_provisional_rows() {
+    fn hint_line_snapshot_allows_accept_for_provisional_rows() {
         let loader = page_only_loader(|_| {});
         let mut state = PickerState::new(
             FrameRequester::test_dummy(),

--- a/codex-rs/tui/src/resume_picker/loading.rs
+++ b/codex-rs/tui/src/resume_picker/loading.rs
@@ -1,0 +1,285 @@
+//! Session picker loading and background event handling.
+
+use std::io;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use chrono::Utc;
+use codex_app_server_protocol::Thread;
+use codex_app_server_protocol::ThreadListCwdFilter;
+use codex_app_server_protocol::ThreadListParams;
+use codex_app_server_protocol::ThreadSortKey;
+use codex_protocol::ThreadId;
+use tokio::sync::mpsc;
+use tracing::warn;
+
+use super::AppServerSession;
+use super::LoadingState;
+use super::PickerState;
+use super::ProviderFilter;
+use super::RawReasoningVisibility;
+use super::Row;
+use super::SessionTranscriptState;
+use super::TranscriptCells;
+use super::TranscriptPreviewLine;
+use super::TranscriptPreviewState;
+use super::load_session_transcript;
+use super::load_transcript_preview;
+
+const PAGE_SIZE: usize = 25;
+
+#[derive(Clone)]
+pub(super) struct PageLoadRequest {
+    pub(super) cursor: Option<PageCursor>,
+    pub(super) request_token: usize,
+    pub(super) search_token: Option<usize>,
+    pub(super) cwd_filter: Option<PathBuf>,
+    pub(super) provider_filter: ProviderFilter,
+    pub(super) sort_key: ThreadSortKey,
+}
+
+pub(super) enum PickerLoadRequest {
+    Page(PageLoadRequest),
+    Preview { thread_id: ThreadId },
+    Transcript { thread_id: ThreadId },
+}
+
+pub(super) type PickerLoader = Arc<dyn Fn(PickerLoadRequest) + Send + Sync>;
+
+pub(super) enum BackgroundEvent {
+    Page {
+        request_token: usize,
+        search_token: Option<usize>,
+        page: io::Result<PickerPage>,
+    },
+    Preview {
+        thread_id: ThreadId,
+        preview: io::Result<Vec<TranscriptPreviewLine>>,
+    },
+    Transcript {
+        thread_id: ThreadId,
+        transcript: io::Result<TranscriptCells>,
+    },
+}
+
+#[derive(Clone)]
+pub(super) enum PageCursor {
+    AppServer(String),
+}
+
+pub(super) struct PickerPage {
+    pub(super) rows: Vec<Row>,
+    pub(super) next_cursor: Option<PageCursor>,
+    pub(super) num_scanned_files: usize,
+    pub(super) reached_scan_cap: bool,
+}
+
+pub(super) fn spawn_app_server_page_loader(
+    app_server: AppServerSession,
+    include_non_interactive: bool,
+    raw_reasoning_visibility: RawReasoningVisibility,
+    bg_tx: mpsc::UnboundedSender<BackgroundEvent>,
+) -> PickerLoader {
+    let (request_tx, mut request_rx) = mpsc::unbounded_channel::<PickerLoadRequest>();
+
+    tokio::spawn(async move {
+        let mut app_server = app_server;
+        while let Some(request) = request_rx.recv().await {
+            match request {
+                PickerLoadRequest::Page(request) => {
+                    let cursor = request.cursor.map(|PageCursor::AppServer(cursor)| cursor);
+                    let page = load_app_server_page(
+                        &mut app_server,
+                        cursor,
+                        request.cwd_filter.as_deref(),
+                        request.provider_filter,
+                        request.sort_key,
+                        include_non_interactive,
+                    )
+                    .await;
+                    let _ = bg_tx.send(BackgroundEvent::Page {
+                        request_token: request.request_token,
+                        search_token: request.search_token,
+                        page,
+                    });
+                }
+                PickerLoadRequest::Preview { thread_id } => {
+                    let preview = load_transcript_preview(&mut app_server, thread_id).await;
+                    let _ = bg_tx.send(BackgroundEvent::Preview { thread_id, preview });
+                }
+                PickerLoadRequest::Transcript { thread_id } => {
+                    let transcript = load_session_transcript(
+                        &mut app_server,
+                        thread_id,
+                        raw_reasoning_visibility,
+                    )
+                    .await;
+                    let _ = bg_tx.send(BackgroundEvent::Transcript {
+                        thread_id,
+                        transcript,
+                    });
+                }
+            }
+        }
+        if let Err(err) = app_server.shutdown().await {
+            warn!(%err, "Failed to shut down app-server picker session");
+        }
+    });
+
+    Arc::new(move |request: PickerLoadRequest| {
+        let _ = request_tx.send(request);
+    })
+}
+
+async fn load_app_server_page(
+    app_server: &mut AppServerSession,
+    cursor: Option<String>,
+    cwd_filter: Option<&Path>,
+    provider_filter: ProviderFilter,
+    sort_key: ThreadSortKey,
+    include_non_interactive: bool,
+) -> io::Result<PickerPage> {
+    let response = app_server
+        .thread_list(thread_list_params(
+            cursor,
+            cwd_filter,
+            provider_filter,
+            sort_key,
+            include_non_interactive,
+        ))
+        .await
+        .map_err(io::Error::other)?;
+    let num_scanned_files = response.data.len();
+
+    Ok(PickerPage {
+        rows: response
+            .data
+            .into_iter()
+            .filter_map(row_from_app_server_thread)
+            .collect(),
+        next_cursor: response.next_cursor.map(PageCursor::AppServer),
+        num_scanned_files,
+        reached_scan_cap: false,
+    })
+}
+
+fn row_from_app_server_thread(thread: Thread) -> Option<Row> {
+    let thread_id = match ThreadId::from_string(&thread.id) {
+        Ok(thread_id) => thread_id,
+        Err(err) => {
+            warn!(thread_id = thread.id, %err, "Skipping app-server picker row with invalid id");
+            return None;
+        }
+    };
+    let preview = thread.preview.trim();
+    Some(Row {
+        path: thread.path,
+        preview: if preview.is_empty() {
+            String::from("(no message yet)")
+        } else {
+            preview.to_string()
+        },
+        thread_id: Some(thread_id),
+        thread_name: thread.name,
+        created_at: chrono::DateTime::from_timestamp(thread.created_at, 0)
+            .map(|dt| dt.with_timezone(&Utc)),
+        updated_at: chrono::DateTime::from_timestamp(thread.updated_at, 0)
+            .map(|dt| dt.with_timezone(&Utc)),
+        cwd: Some(thread.cwd.to_path_buf()),
+        git_branch: thread.git_info.and_then(|git_info| git_info.branch),
+    })
+}
+
+fn thread_list_params(
+    cursor: Option<String>,
+    cwd_filter: Option<&Path>,
+    provider_filter: ProviderFilter,
+    sort_key: ThreadSortKey,
+    include_non_interactive: bool,
+) -> ThreadListParams {
+    ThreadListParams {
+        cursor,
+        limit: Some(PAGE_SIZE as u32),
+        sort_key: Some(sort_key),
+        sort_direction: None,
+        model_providers: match provider_filter {
+            ProviderFilter::Any => None,
+            ProviderFilter::MatchDefault(default_provider) => Some(vec![default_provider]),
+        },
+        source_kinds: Some(crate::resume_source_kinds(include_non_interactive)),
+        archived: Some(false),
+        parent_thread_id: None,
+        cwd: cwd_filter.map(|cwd| ThreadListCwdFilter::One(cwd.to_string_lossy().into_owned())),
+        use_state_db_only: false,
+        search_term: None,
+    }
+}
+
+impl PickerState {
+    pub(super) async fn handle_background_event(
+        &mut self,
+        event: BackgroundEvent,
+    ) -> color_eyre::eyre::Result<()> {
+        match event {
+            BackgroundEvent::Page {
+                request_token,
+                search_token,
+                page,
+            } => {
+                let pending = match self.pagination.loading {
+                    LoadingState::Pending(pending) => pending,
+                    LoadingState::Idle => return Ok(()),
+                };
+                if pending.request_token != request_token {
+                    return Ok(());
+                }
+                self.pagination.loading = LoadingState::Idle;
+                let page = page.map_err(color_eyre::Report::from)?;
+                self.ingest_page(page);
+                self.complete_pending_page_down();
+                let completed_token = pending.search_token.or(search_token);
+                self.continue_search_if_token_matches(completed_token);
+            }
+            BackgroundEvent::Preview { thread_id, preview } => {
+                self.transcript_previews.insert(
+                    thread_id,
+                    match preview {
+                        Ok(lines) => TranscriptPreviewState::Loaded(lines),
+                        Err(_) => TranscriptPreviewState::Failed,
+                    },
+                );
+                self.request_frame();
+            }
+            BackgroundEvent::Transcript {
+                thread_id,
+                transcript,
+            } => match transcript {
+                Ok(cells) => {
+                    let should_open = self.pending_transcript_open == Some(thread_id);
+                    self.transcript_cells
+                        .insert(thread_id, SessionTranscriptState::Loaded(cells.clone()));
+                    if should_open {
+                        self.open_pending_transcript_if_ready();
+                    }
+                    self.request_frame();
+                }
+                Err(_) => {
+                    self.transcript_cells
+                        .insert(thread_id, SessionTranscriptState::Failed);
+                    if self.pending_transcript_open == Some(thread_id) {
+                        self.pending_transcript_open = None;
+                        self.transcript_loading_frame_shown = false;
+                        self.inline_error = Some("Could not load transcript preview".to_string());
+                    }
+                    self.request_frame();
+                }
+            },
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "loading_tests.rs"]
+mod tests;

--- a/codex-rs/tui/src/resume_picker/loading.rs
+++ b/codex-rs/tui/src/resume_picker/loading.rs
@@ -1,18 +1,28 @@
 //! Session picker loading and background event handling.
 
+use std::future::Future;
 use std::io;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
 use chrono::Utc;
+use codex_app_server_client::AppServerRequestHandle;
+use codex_app_server_protocol::ClientRequest;
+use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::Thread;
 use codex_app_server_protocol::ThreadListCwdFilter;
 use codex_app_server_protocol::ThreadListParams;
+use codex_app_server_protocol::ThreadListResponse;
+use codex_app_server_protocol::ThreadReadParams;
+use codex_app_server_protocol::ThreadReadResponse;
 use codex_app_server_protocol::ThreadSortKey;
 use codex_protocol::ThreadId;
 use tokio::sync::mpsc;
+use tokio::task::JoinError;
+use tokio::task::JoinSet;
 use tracing::warn;
+use uuid::Uuid;
 
 use super::AppServerSession;
 use super::LoadingState;
@@ -24,10 +34,12 @@ use super::SessionTranscriptState;
 use super::TranscriptCells;
 use super::TranscriptPreviewLine;
 use super::TranscriptPreviewState;
-use super::load_session_transcript;
-use super::load_transcript_preview;
+use super::transcript_preview_lines;
+use crate::thread_transcript::thread_to_transcript_cells;
 
 const PAGE_SIZE: usize = 25;
+// Expanded rows read full transcripts, so keep preview I/O narrowly bounded.
+const MAX_CONCURRENT_PREVIEW_READS: usize = 2;
 
 #[derive(Clone)]
 pub(super) struct PageLoadRequest {
@@ -81,47 +93,20 @@ pub(super) fn spawn_app_server_page_loader(
     raw_reasoning_visibility: RawReasoningVisibility,
     bg_tx: mpsc::UnboundedSender<BackgroundEvent>,
 ) -> PickerLoader {
-    let (request_tx, mut request_rx) = mpsc::unbounded_channel::<PickerLoadRequest>();
+    let (request_tx, request_rx) = mpsc::unbounded_channel::<PickerLoadRequest>();
+    let request_handle = app_server.request_handle();
 
     tokio::spawn(async move {
-        let mut app_server = app_server;
-        while let Some(request) = request_rx.recv().await {
-            match request {
-                PickerLoadRequest::Page(request) => {
-                    let cursor = request.cursor.map(|PageCursor::AppServer(cursor)| cursor);
-                    let page = load_app_server_page(
-                        &mut app_server,
-                        cursor,
-                        request.cwd_filter.as_deref(),
-                        request.provider_filter,
-                        request.sort_key,
-                        include_non_interactive,
-                    )
-                    .await;
-                    let _ = bg_tx.send(BackgroundEvent::Page {
-                        request_token: request.request_token,
-                        search_token: request.search_token,
-                        page,
-                    });
-                }
-                PickerLoadRequest::Preview { thread_id } => {
-                    let preview = load_transcript_preview(&mut app_server, thread_id).await;
-                    let _ = bg_tx.send(BackgroundEvent::Preview { thread_id, preview });
-                }
-                PickerLoadRequest::Transcript { thread_id } => {
-                    let transcript = load_session_transcript(
-                        &mut app_server,
-                        thread_id,
-                        raw_reasoning_visibility,
-                    )
-                    .await;
-                    let _ = bg_tx.send(BackgroundEvent::Transcript {
-                        thread_id,
-                        transcript,
-                    });
-                }
-            }
-        }
+        run_picker_loader(request_rx, move |request| {
+            handle_picker_load_request(
+                request,
+                request_handle.clone(),
+                include_non_interactive,
+                raw_reasoning_visibility,
+                bg_tx.clone(),
+            )
+        })
+        .await;
         if let Err(err) = app_server.shutdown().await {
             warn!(%err, "Failed to shut down app-server picker session");
         }
@@ -132,22 +117,194 @@ pub(super) fn spawn_app_server_page_loader(
     })
 }
 
+async fn run_picker_loader<F, Fut>(
+    mut request_rx: mpsc::UnboundedReceiver<PickerLoadRequest>,
+    load_request: F,
+) where
+    F: Fn(PickerLoadRequest) -> Fut + Clone + Send + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let (page_tx, page_rx) = mpsc::unbounded_channel();
+    let page_load_request = load_request.clone();
+    let page_task = tokio::spawn(run_page_loader(page_rx, move |request| {
+        page_load_request(PickerLoadRequest::Page(request))
+    }));
+    let (preview_tx, preview_rx) = mpsc::unbounded_channel();
+    let preview_load_request = load_request.clone();
+    let preview_task = tokio::spawn(run_preview_loader(preview_rx, move |thread_id| {
+        preview_load_request(PickerLoadRequest::Preview { thread_id })
+    }));
+    let mut tasks = JoinSet::new();
+    loop {
+        tokio::select! {
+            request = request_rx.recv() => {
+                let Some(request) = request else {
+                    break;
+                };
+                match request {
+                    PickerLoadRequest::Page(request) => {
+                        let _ = page_tx.send(request);
+                    }
+                    PickerLoadRequest::Preview { thread_id } => {
+                        let _ = preview_tx.send(thread_id);
+                    }
+                    request @ PickerLoadRequest::Transcript { .. } => {
+                        tasks.spawn(load_request(request));
+                    }
+                }
+            }
+            result = tasks.join_next(), if !tasks.is_empty() => {
+                if let Some(result) = result {
+                    log_loader_task_result(result);
+                }
+            }
+        }
+    }
+
+    drop(page_tx);
+    drop(preview_tx);
+    page_task.abort();
+    log_loader_task_result(page_task.await);
+    preview_task.abort();
+    log_loader_task_result(preview_task.await);
+    tasks.abort_all();
+    while let Some(result) = tasks.join_next().await {
+        log_loader_task_result(result);
+    }
+}
+
+async fn run_preview_loader<F, Fut>(
+    mut request_rx: mpsc::UnboundedReceiver<ThreadId>,
+    mut load_preview: F,
+) where
+    F: FnMut(ThreadId) -> Fut + Send + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let mut tasks = JoinSet::new();
+    let mut request_channel_open = true;
+    while request_channel_open || !tasks.is_empty() {
+        tokio::select! {
+            request = request_rx.recv(), if request_channel_open && tasks.len() < MAX_CONCURRENT_PREVIEW_READS => {
+                match request {
+                    Some(thread_id) => {
+                        tasks.spawn(load_preview(thread_id));
+                    }
+                    None => request_channel_open = false,
+                }
+            }
+            result = tasks.join_next(), if !tasks.is_empty() => {
+                if let Some(result) = result {
+                    log_loader_task_result(result);
+                }
+            }
+        }
+    }
+}
+
+async fn run_page_loader<F, Fut>(
+    mut request_rx: mpsc::UnboundedReceiver<PageLoadRequest>,
+    load_page: F,
+) where
+    F: Fn(PageLoadRequest) -> Fut + Send + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+{
+    let Some(mut request) = request_rx.recv().await else {
+        return;
+    };
+    loop {
+        let load = load_page(request);
+        tokio::pin!(load);
+        tokio::select! {
+            () = &mut load => {
+                let Some(next_request) = request_rx.recv().await else {
+                    break;
+                };
+                request = next_request;
+            }
+            next_request = request_rx.recv() => {
+                let Some(next_request) = next_request else {
+                    load.await;
+                    break;
+                };
+                request = next_request;
+            }
+        }
+        while let Ok(next_request) = request_rx.try_recv() {
+            request = next_request;
+        }
+    }
+}
+
+fn log_loader_task_result(result: Result<(), JoinError>) {
+    if let Err(err) = result
+        && !err.is_cancelled()
+    {
+        warn!(%err, "Session picker loader task failed");
+    }
+}
+
+async fn handle_picker_load_request(
+    request: PickerLoadRequest,
+    request_handle: AppServerRequestHandle,
+    include_non_interactive: bool,
+    raw_reasoning_visibility: RawReasoningVisibility,
+    bg_tx: mpsc::UnboundedSender<BackgroundEvent>,
+) {
+    match request {
+        PickerLoadRequest::Page(request) => {
+            let cursor = request.cursor.map(|PageCursor::AppServer(cursor)| cursor);
+            let page = load_app_server_page(
+                &request_handle,
+                cursor,
+                request.cwd_filter.as_deref(),
+                request.provider_filter,
+                request.sort_key,
+                include_non_interactive,
+            )
+            .await;
+            let _ = bg_tx.send(BackgroundEvent::Page {
+                request_token: request.request_token,
+                search_token: request.search_token,
+                page,
+            });
+        }
+        PickerLoadRequest::Preview { thread_id } => {
+            let preview = read_app_server_thread(&request_handle, thread_id)
+                .await
+                .map(|thread| transcript_preview_lines(&thread));
+            let _ = bg_tx.send(BackgroundEvent::Preview { thread_id, preview });
+        }
+        PickerLoadRequest::Transcript { thread_id } => {
+            let transcript = read_app_server_thread(&request_handle, thread_id)
+                .await
+                .map(|thread| thread_to_transcript_cells(&thread, raw_reasoning_visibility));
+            let _ = bg_tx.send(BackgroundEvent::Transcript {
+                thread_id,
+                transcript,
+            });
+        }
+    }
+}
+
 async fn load_app_server_page(
-    app_server: &mut AppServerSession,
+    request_handle: &AppServerRequestHandle,
     cursor: Option<String>,
     cwd_filter: Option<&Path>,
     provider_filter: ProviderFilter,
     sort_key: ThreadSortKey,
     include_non_interactive: bool,
 ) -> io::Result<PickerPage> {
-    let response = app_server
-        .thread_list(thread_list_params(
-            cursor,
-            cwd_filter,
-            provider_filter,
-            sort_key,
-            include_non_interactive,
-        ))
+    let response: ThreadListResponse = request_handle
+        .request_typed(ClientRequest::ThreadList {
+            request_id: RequestId::String(format!("resume-picker-thread-list-{}", Uuid::new_v4())),
+            params: thread_list_params(
+                cursor,
+                cwd_filter,
+                provider_filter,
+                sort_key,
+                include_non_interactive,
+            ),
+        })
         .await
         .map_err(io::Error::other)?;
     let num_scanned_files = response.data.len();
@@ -162,6 +319,23 @@ async fn load_app_server_page(
         num_scanned_files,
         reached_scan_cap: false,
     })
+}
+
+async fn read_app_server_thread(
+    request_handle: &AppServerRequestHandle,
+    thread_id: ThreadId,
+) -> io::Result<Thread> {
+    let response: ThreadReadResponse = request_handle
+        .request_typed(ClientRequest::ThreadRead {
+            request_id: RequestId::String(format!("resume-picker-thread-read-{}", Uuid::new_v4())),
+            params: ThreadReadParams {
+                thread_id: thread_id.to_string(),
+                include_turns: true,
+            },
+        })
+        .await
+        .map_err(io::Error::other)?;
+    Ok(response.thread)
 }
 
 fn row_from_app_server_thread(thread: Thread) -> Option<Row> {

--- a/codex-rs/tui/src/resume_picker/loading.rs
+++ b/codex-rs/tui/src/resume_picker/loading.rs
@@ -2,10 +2,12 @@
 
 use std::future::Future;
 use std::io;
+use std::path::Component;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use chrono::NaiveDateTime;
 use codex_app_server_client::AppServerRequestHandle;
 use codex_app_server_protocol::ClientRequest;
 use codex_app_server_protocol::RequestId;
@@ -17,6 +19,7 @@ use codex_app_server_protocol::ThreadReadParams;
 use codex_app_server_protocol::ThreadReadResponse;
 use codex_app_server_protocol::ThreadSortKey;
 use codex_protocol::ThreadId;
+use codex_protocol::protocol::SessionSource;
 use tokio::sync::mpsc;
 use tokio::task::JoinError;
 use tokio::task::JoinSet;
@@ -29,12 +32,13 @@ use super::PickerState;
 use super::ProviderFilter;
 use super::RawReasoningVisibility;
 use super::Row;
+use super::SessionTarget;
 use super::SessionTranscriptState;
 use super::TranscriptCells;
 use super::TranscriptPreviewLine;
 use super::TranscriptPreviewState;
-#[cfg(test)]
 use super::parse_timestamp_str;
+use super::paths_match;
 use super::transcript_preview_lines;
 use crate::thread_transcript::thread_to_transcript_cells;
 
@@ -131,6 +135,18 @@ impl InitialPageLoad {
 enum ThreadListLookupMode {
     StateDbOnly,
     ScanAndRepair,
+}
+
+pub(super) struct SelectionValidation {
+    pub(super) path: PathBuf,
+    pub(super) thread_id: ThreadId,
+    pub(super) thread_name: Option<String>,
+    pub(super) git_branch: Option<String>,
+    pub(super) codex_home: PathBuf,
+    pub(super) cwd_filter: Option<PathBuf>,
+    pub(super) provider_filter: ProviderFilter,
+    pub(super) include_non_interactive: bool,
+    pub(super) query: String,
 }
 
 pub(super) fn spawn_app_server_page_loader(
@@ -474,6 +490,168 @@ fn thread_list_params(
         use_state_db_only: lookup_mode == ThreadListLookupMode::StateDbOnly,
         search_term: None,
     }
+}
+
+/// Validates a selected provisional row against the same rollout summary used
+/// by scan-and-repair before allowing a resume or fork.
+pub(super) async fn validate_provisional_session_target(
+    input: SelectionValidation,
+) -> io::Result<SessionTarget> {
+    let rollout_path = codex_rollout::existing_rollout_path(input.path.as_path())
+        .await
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "selected session rollout no longer exists",
+            )
+        })?;
+    if !is_discoverable_active_rollout_path(&input.codex_home, &rollout_path) {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "selected session is not an active rollout",
+        ));
+    }
+    let item = codex_rollout::read_thread_item_from_rollout(rollout_path.clone())
+        .await
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "selected session rollout is not eligible for the picker",
+            )
+        })?;
+    let provider_matches = match &input.provider_filter {
+        ProviderFilter::Any => true,
+        ProviderFilter::MatchDefault(default_provider) => item
+            .model_provider
+            .as_deref()
+            .is_none_or(|provider| provider == default_provider),
+    };
+    let source_matches = match item.source.as_ref() {
+        Some(SessionSource::Cli | SessionSource::VSCode) => true,
+        Some(SessionSource::Exec | SessionSource::Mcp) => input.include_non_interactive,
+        Some(
+            SessionSource::Custom(_)
+            | SessionSource::Internal(_)
+            | SessionSource::SubAgent(_)
+            | SessionSource::Unknown,
+        )
+        | None => false,
+    };
+    let cwd_matches = input.cwd_filter.as_ref().is_none_or(|filter| {
+        item.cwd
+            .as_ref()
+            .is_some_and(|cwd| paths_match(cwd, filter))
+    });
+    let row = row_from_rollout_item(
+        item,
+        rollout_path.clone(),
+        input.thread_name,
+        input.git_branch,
+    )
+    .ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "selected session rollout is not eligible for the picker",
+        )
+    })?;
+    let query = input.query.to_lowercase();
+    if row.thread_id != Some(input.thread_id)
+        || !provider_matches
+        || !source_matches
+        || !cwd_matches
+        || (!query.is_empty() && !row.matches_query(&query))
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "selected session no longer matches the picker",
+        ));
+    }
+
+    Ok(SessionTarget {
+        path: Some(rollout_path),
+        thread_id: input.thread_id,
+    })
+}
+
+fn is_discoverable_active_rollout_path(codex_home: &Path, path: &Path) -> bool {
+    let Ok(relative_path) = path.strip_prefix(codex_home.join(codex_rollout::SESSIONS_SUBDIR))
+    else {
+        return false;
+    };
+    let mut components = relative_path.components();
+    let (
+        Some(Component::Normal(year)),
+        Some(Component::Normal(month)),
+        Some(Component::Normal(day)),
+        Some(Component::Normal(file_name)),
+        None,
+    ) = (
+        components.next(),
+        components.next(),
+        components.next(),
+        components.next(),
+        components.next(),
+    )
+    else {
+        return false;
+    };
+    year.to_str()
+        .and_then(|year| year.parse::<u16>().ok())
+        .is_some()
+        && month
+            .to_str()
+            .and_then(|month| month.parse::<u8>().ok())
+            .is_some()
+        && day
+            .to_str()
+            .and_then(|day| day.parse::<u8>().ok())
+            .is_some()
+        && file_name.to_str().is_some_and(is_rollout_file_name)
+}
+
+fn is_rollout_file_name(file_name: &str) -> bool {
+    let file_name = file_name.strip_suffix(".zst").unwrap_or(file_name);
+    let Some(core) = file_name
+        .strip_prefix("rollout-")
+        .and_then(|name| name.strip_suffix(".jsonl"))
+    else {
+        return false;
+    };
+    let Some(separator_index) = core.len().checked_sub(37) else {
+        return false;
+    };
+    if core.as_bytes().get(separator_index) != Some(&b'-') {
+        return false;
+    }
+    let timestamp = &core[..separator_index];
+    let thread_id = &core[separator_index + 1..];
+    NaiveDateTime::parse_from_str(timestamp, "%Y-%m-%dT%H-%M-%S").is_ok()
+        && ThreadId::from_string(thread_id).is_ok()
+}
+
+fn row_from_rollout_item(
+    item: codex_rollout::ThreadItem,
+    path: PathBuf,
+    thread_name: Option<String>,
+    git_branch: Option<String>,
+) -> Option<Row> {
+    let thread_id = item.thread_id?;
+    let preview = item.preview.or(item.first_user_message)?;
+    let preview = preview.trim();
+    Some(Row {
+        path: Some(path),
+        preview: if preview.is_empty() {
+            String::from("(no message yet)")
+        } else {
+            preview.to_string()
+        },
+        thread_id: Some(thread_id),
+        thread_name,
+        created_at: parse_timestamp_str(item.created_at.as_deref().unwrap_or_default()),
+        updated_at: parse_timestamp_str(item.updated_at.as_deref().unwrap_or_default()),
+        cwd: item.cwd,
+        git_branch: git_branch.or(item.git_branch),
+    })
 }
 
 impl PickerState {

--- a/codex-rs/tui/src/resume_picker/loading.rs
+++ b/codex-rs/tui/src/resume_picker/loading.rs
@@ -1,4 +1,4 @@
-//! Session picker loading and background event handling.
+//! Session picker loading, State DB seeding, and authoritative reconciliation.
 
 use std::future::Future;
 use std::io;
@@ -6,7 +6,6 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use chrono::Utc;
 use codex_app_server_client::AppServerRequestHandle;
 use codex_app_server_protocol::ClientRequest;
 use codex_app_server_protocol::RequestId;
@@ -34,6 +33,8 @@ use super::SessionTranscriptState;
 use super::TranscriptCells;
 use super::TranscriptPreviewLine;
 use super::TranscriptPreviewState;
+#[cfg(test)]
+use super::parse_timestamp_str;
 use super::transcript_preview_lines;
 use crate::thread_transcript::thread_to_transcript_cells;
 
@@ -49,6 +50,7 @@ pub(super) struct PageLoadRequest {
     pub(super) cwd_filter: Option<PathBuf>,
     pub(super) provider_filter: ProviderFilter,
     pub(super) sort_key: ThreadSortKey,
+    pub(super) seed_from_state_db: bool,
 }
 
 pub(super) enum PickerLoadRequest {
@@ -60,6 +62,10 @@ pub(super) enum PickerLoadRequest {
 pub(super) type PickerLoader = Arc<dyn Fn(PickerLoadRequest) + Send + Sync>;
 
 pub(super) enum BackgroundEvent {
+    SeedPage {
+        request_token: usize,
+        page: PickerPage,
+    },
     Page {
         request_token: usize,
         search_token: Option<usize>,
@@ -85,6 +91,46 @@ pub(super) struct PickerPage {
     pub(super) next_cursor: Option<PageCursor>,
     pub(super) num_scanned_files: usize,
     pub(super) reached_scan_cap: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) enum InitialPageLoad {
+    #[default]
+    Authoritative,
+    SeedPending,
+    Provisional,
+}
+
+impl InitialPageLoad {
+    pub(super) fn state_db_first() -> Self {
+        Self::SeedPending
+    }
+
+    pub(super) fn begin_load(&mut self) -> bool {
+        let seed_from_state_db = *self == Self::SeedPending;
+        *self = Self::Authoritative;
+        seed_from_state_db
+    }
+
+    fn mark_seeded(&mut self) {
+        *self = Self::Provisional;
+    }
+
+    fn finish_reconciliation(&mut self) -> bool {
+        let was_provisional = *self == Self::Provisional;
+        *self = Self::Authoritative;
+        was_provisional
+    }
+
+    pub(super) fn is_provisional(self) -> bool {
+        self == Self::Provisional
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ThreadListLookupMode {
+    StateDbOnly,
+    ScanAndRepair,
 }
 
 pub(super) fn spawn_app_server_page_loader(
@@ -252,6 +298,33 @@ async fn handle_picker_load_request(
 ) {
     match request {
         PickerLoadRequest::Page(request) => {
+            if request.seed_from_state_db {
+                match load_app_server_page(
+                    &request_handle,
+                    /*cursor*/ None,
+                    request.cwd_filter.as_deref(),
+                    request.provider_filter.clone(),
+                    request.sort_key,
+                    include_non_interactive,
+                    ThreadListLookupMode::StateDbOnly,
+                )
+                .await
+                {
+                    Ok(page) => {
+                        let _ = bg_tx.send(BackgroundEvent::SeedPage {
+                            request_token: request.request_token,
+                            page,
+                        });
+                    }
+                    Err(err) => {
+                        warn!(
+                            %err,
+                            "State DB picker lookup failed; falling back to scan-and-repair"
+                        );
+                    }
+                }
+            }
+
             let cursor = request.cursor.map(|PageCursor::AppServer(cursor)| cursor);
             let page = load_app_server_page(
                 &request_handle,
@@ -260,6 +333,7 @@ async fn handle_picker_load_request(
                 request.provider_filter,
                 request.sort_key,
                 include_non_interactive,
+                ThreadListLookupMode::ScanAndRepair,
             )
             .await;
             let _ = bg_tx.send(BackgroundEvent::Page {
@@ -293,6 +367,7 @@ async fn load_app_server_page(
     provider_filter: ProviderFilter,
     sort_key: ThreadSortKey,
     include_non_interactive: bool,
+    lookup_mode: ThreadListLookupMode,
 ) -> io::Result<PickerPage> {
     let response: ThreadListResponse = request_handle
         .request_typed(ClientRequest::ThreadList {
@@ -303,6 +378,7 @@ async fn load_app_server_page(
                 provider_filter,
                 sort_key,
                 include_non_interactive,
+                lookup_mode,
             ),
         })
         .await
@@ -346,23 +422,32 @@ fn row_from_app_server_thread(thread: Thread) -> Option<Row> {
             return None;
         }
     };
-    let preview = thread.preview.trim();
-    Some(Row {
-        path: thread.path,
-        preview: if preview.is_empty() {
-            String::from("(no message yet)")
-        } else {
-            preview.to_string()
-        },
-        thread_id: Some(thread_id),
-        thread_name: thread.name,
-        created_at: chrono::DateTime::from_timestamp(thread.created_at, 0)
-            .map(|dt| dt.with_timezone(&Utc)),
-        updated_at: chrono::DateTime::from_timestamp(thread.updated_at, 0)
-            .map(|dt| dt.with_timezone(&Utc)),
-        cwd: Some(thread.cwd.to_path_buf()),
-        git_branch: thread.git_info.and_then(|git_info| git_info.branch),
-    })
+    Some(Row::from_app_server_thread(&thread, thread_id))
+}
+
+impl Row {
+    fn from_app_server_thread(thread: &Thread, thread_id: ThreadId) -> Self {
+        let preview = thread.preview.trim();
+        Self {
+            path: thread.path.clone(),
+            preview: if preview.is_empty() {
+                String::from("(no message yet)")
+            } else {
+                preview.to_string()
+            },
+            thread_id: Some(thread_id),
+            thread_name: thread.name.clone(),
+            created_at: chrono::DateTime::from_timestamp(thread.created_at, 0)
+                .map(|dt| dt.with_timezone(&chrono::Utc)),
+            updated_at: chrono::DateTime::from_timestamp(thread.updated_at, 0)
+                .map(|dt| dt.with_timezone(&chrono::Utc)),
+            cwd: Some(thread.cwd.to_path_buf()),
+            git_branch: thread
+                .git_info
+                .as_ref()
+                .and_then(|git_info| git_info.branch.clone()),
+        }
+    }
 }
 
 fn thread_list_params(
@@ -371,6 +456,7 @@ fn thread_list_params(
     provider_filter: ProviderFilter,
     sort_key: ThreadSortKey,
     include_non_interactive: bool,
+    lookup_mode: ThreadListLookupMode,
 ) -> ThreadListParams {
     ThreadListParams {
         cursor,
@@ -385,7 +471,7 @@ fn thread_list_params(
         archived: Some(false),
         parent_thread_id: None,
         cwd: cwd_filter.map(|cwd| ThreadListCwdFilter::One(cwd.to_string_lossy().into_owned())),
-        use_state_db_only: false,
+        use_state_db_only: lookup_mode == ThreadListLookupMode::StateDbOnly,
         search_term: None,
     }
 }
@@ -396,6 +482,19 @@ impl PickerState {
         event: BackgroundEvent,
     ) -> color_eyre::eyre::Result<()> {
         match event {
+            BackgroundEvent::SeedPage {
+                request_token,
+                page,
+            } => {
+                let LoadingState::Pending(pending) = self.pagination.loading else {
+                    return Ok(());
+                };
+                if pending.request_token != request_token {
+                    return Ok(());
+                }
+                self.initial_page_load.mark_seeded();
+                self.replace_with_page(page);
+            }
             BackgroundEvent::Page {
                 request_token,
                 search_token,
@@ -409,11 +508,38 @@ impl PickerState {
                     return Ok(());
                 }
                 self.pagination.loading = LoadingState::Idle;
-                let page = page.map_err(color_eyre::Report::from)?;
-                self.ingest_page(page);
-                self.complete_pending_page_down();
-                let completed_token = pending.search_token.or(search_token);
-                self.continue_search_if_token_matches(completed_token);
+                match page {
+                    Ok(page) if self.initial_page_load.finish_reconciliation() => {
+                        self.replace_with_page(page);
+                        self.complete_pending_page_down();
+                        self.reevaluate_search();
+                    }
+                    Ok(page) => {
+                        self.ingest_page(page);
+                        self.complete_pending_page_down();
+                        let completed_token = pending.search_token.or(search_token);
+                        self.continue_search_if_token_matches(completed_token);
+                    }
+                    Err(err) if self.initial_page_load.is_provisional() => {
+                        warn!(
+                            %err,
+                            "Session picker reconciliation failed; keeping State DB results"
+                        );
+                        let cached_results_are_truncated = self.pagination.next_cursor.is_some();
+                        self.pagination.next_cursor = None;
+                        self.inline_error = Some(if cached_results_are_truncated {
+                            String::from(
+                                "Could not refresh sessions; showing the first page of indexed results",
+                            )
+                        } else {
+                            String::from("Could not refresh sessions; showing indexed results")
+                        });
+                        self.complete_pending_page_down();
+                        self.reevaluate_search();
+                        self.request_frame();
+                    }
+                    Err(err) => return Err(color_eyre::Report::from(err)),
+                }
             }
             BackgroundEvent::Preview { thread_id, preview } => {
                 self.transcript_previews.insert(
@@ -451,6 +577,51 @@ impl PickerState {
             },
         }
         Ok(())
+    }
+
+    /// Replaces the current result set with a new first page while preserving
+    /// the selected thread when it is still present.
+    fn replace_with_page(&mut self, page: PickerPage) {
+        let selected_row = self.filtered_rows.get(self.selected);
+        let selected_thread_id = selected_row.and_then(|row| row.thread_id);
+        let selected_key = selected_row.and_then(Row::seen_key);
+        let selected_index = self.selected;
+
+        self.pagination.next_cursor = page.next_cursor;
+        self.pagination.num_scanned_files = page.num_scanned_files;
+        self.pagination.reached_scan_cap = page.reached_scan_cap;
+        self.frozen_footer_percent = None;
+        self.all_rows.clear();
+        self.filtered_rows.clear();
+        self.seen_rows.clear();
+
+        for row in page.rows {
+            if let Some(seen_key) = row.seen_key() {
+                if self.seen_rows.insert(seen_key) {
+                    self.all_rows.push(row);
+                }
+            } else {
+                self.all_rows.push(row);
+            }
+        }
+
+        self.apply_filter();
+        self.selected = selected_thread_id
+            .and_then(|selected_thread_id| {
+                self.filtered_rows
+                    .iter()
+                    .position(|row| row.thread_id == Some(selected_thread_id))
+            })
+            .or_else(|| {
+                selected_key.and_then(|selected_key| {
+                    self.filtered_rows
+                        .iter()
+                        .position(|row| row.seen_key().as_ref() == Some(&selected_key))
+                })
+            })
+            .unwrap_or_else(|| selected_index.min(self.filtered_rows.len().saturating_sub(1)));
+        self.ensure_selected_visible();
+        self.request_frame();
     }
 }
 

--- a/codex-rs/tui/src/resume_picker/loading_tests.rs
+++ b/codex-rs/tui/src/resume_picker/loading_tests.rs
@@ -1,0 +1,106 @@
+use std::path::Path;
+
+use codex_app_server_protocol::Thread;
+use codex_app_server_protocol::ThreadListCwdFilter;
+use codex_app_server_protocol::ThreadSortKey;
+use codex_app_server_protocol::ThreadSourceKind;
+use codex_protocol::ThreadId;
+use codex_utils_absolute_path::test_support::PathBufExt;
+use codex_utils_absolute_path::test_support::test_path_buf;
+use pretty_assertions::assert_eq;
+
+use super::*;
+use crate::resume_picker::picker_cwd_filter;
+
+#[test]
+fn local_picker_thread_list_params_include_cwd_filter() {
+    let cwd_filter = picker_cwd_filter(
+        Path::new("/tmp/project"),
+        /*show_all*/ false,
+        /*uses_remote_workspace*/ false,
+        /*remote_cwd_override*/ None,
+    );
+    let params = thread_list_params(
+        Some(String::from("cursor-1")),
+        cwd_filter.as_deref(),
+        ProviderFilter::MatchDefault(String::from("openai")),
+        ThreadSortKey::UpdatedAt,
+        /*include_non_interactive*/ false,
+    );
+
+    assert_eq!(
+        params.cwd,
+        Some(ThreadListCwdFilter::One(String::from("/tmp/project")))
+    );
+}
+
+#[test]
+fn remote_thread_list_params_omit_provider_filter() {
+    let params = thread_list_params(
+        Some(String::from("cursor-1")),
+        Some(Path::new("repo/on/server")),
+        ProviderFilter::Any,
+        ThreadSortKey::UpdatedAt,
+        /*include_non_interactive*/ false,
+    );
+
+    assert_eq!(params.cursor, Some(String::from("cursor-1")));
+    assert_eq!(params.model_providers, None);
+    assert_eq!(
+        params.source_kinds,
+        Some(vec![ThreadSourceKind::Cli, ThreadSourceKind::VsCode])
+    );
+    assert_eq!(
+        params.cwd,
+        Some(ThreadListCwdFilter::One(String::from("repo/on/server")))
+    );
+}
+
+#[test]
+fn remote_thread_list_params_can_include_non_interactive_sources() {
+    let params = thread_list_params(
+        Some(String::from("cursor-1")),
+        /*cwd_filter*/ None,
+        ProviderFilter::Any,
+        ThreadSortKey::UpdatedAt,
+        /*include_non_interactive*/ true,
+    );
+
+    assert_eq!(params.cursor, Some(String::from("cursor-1")));
+    assert_eq!(params.model_providers, None);
+    let source_kinds = crate::resume_source_kinds(/*include_non_interactive*/ true);
+    assert_eq!(params.source_kinds, Some(source_kinds));
+}
+
+#[test]
+fn app_server_row_keeps_pathless_threads() {
+    let thread_id = ThreadId::new();
+    let thread = Thread {
+        id: thread_id.to_string(),
+        session_id: thread_id.to_string(),
+        forked_from_id: None,
+        parent_thread_id: None,
+        preview: String::from("remote thread"),
+        ephemeral: false,
+        model_provider: String::from("openai"),
+        created_at: 1,
+        updated_at: 2,
+        status: codex_app_server_protocol::ThreadStatus::Idle,
+        path: None,
+        cwd: test_path_buf("/tmp").abs(),
+        cli_version: String::from("0.0.0"),
+        source: codex_app_server_protocol::SessionSource::Cli,
+        thread_source: None,
+        agent_nickname: None,
+        agent_role: None,
+        git_info: None,
+        name: Some(String::from("Named thread")),
+        turns: Vec::new(),
+    };
+
+    let row = row_from_app_server_thread(thread).expect("row should be preserved");
+
+    assert_eq!(row.path, None);
+    assert_eq!(row.thread_id, Some(thread_id));
+    assert_eq!(row.thread_name, Some(String::from("Named thread")));
+}

--- a/codex-rs/tui/src/resume_picker/loading_tests.rs
+++ b/codex-rs/tui/src/resume_picker/loading_tests.rs
@@ -1,14 +1,17 @@
 use std::future::pending;
+use std::io;
 use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
+use codex_app_server_protocol::SessionSource as ApiSessionSource;
 use codex_app_server_protocol::Thread;
 use codex_app_server_protocol::ThreadListCwdFilter;
-use codex_app_server_protocol::ThreadSortKey;
 use codex_app_server_protocol::ThreadSourceKind;
 use codex_protocol::ThreadId;
 use codex_utils_absolute_path::test_support::PathBufExt;
@@ -16,7 +19,31 @@ use codex_utils_absolute_path::test_support::test_path_buf;
 use pretty_assertions::assert_eq;
 
 use super::*;
-use crate::resume_picker::picker_cwd_filter;
+use crate::resume_picker::FrameRequester;
+use crate::resume_picker::LoadTrigger;
+use crate::resume_picker::SessionPickerAction;
+
+fn page(
+    rows: Vec<Row>,
+    next_cursor: Option<&str>,
+    num_scanned_files: usize,
+    reached_scan_cap: bool,
+) -> PickerPage {
+    PickerPage {
+        rows,
+        next_cursor: next_cursor.map(|cursor| PageCursor::AppServer(cursor.to_string())),
+        num_scanned_files,
+        reached_scan_cap,
+    }
+}
+
+fn page_only_loader(loader: impl Fn(PageLoadRequest) + Send + Sync + 'static) -> PickerLoader {
+    Arc::new(move |request| {
+        if let PickerLoadRequest::Page(request) = request {
+            loader(request);
+        }
+    })
+}
 
 fn page_request(request_token: usize) -> PageLoadRequest {
     PageLoadRequest {
@@ -26,7 +53,80 @@ fn page_request(request_token: usize) -> PageLoadRequest {
         cwd_filter: None,
         provider_filter: ProviderFilter::Any,
         sort_key: ThreadSortKey::UpdatedAt,
+        seed_from_state_db: true,
     }
+}
+
+fn recording_picker_state() -> (PickerState, Arc<Mutex<Vec<PageLoadRequest>>>) {
+    let recorded_requests = Arc::new(Mutex::new(Vec::new()));
+    let request_sink = recorded_requests.clone();
+    let loader = page_only_loader(move |request| {
+        request_sink.lock().unwrap().push(request);
+    });
+    let mut state = PickerState::new(
+        FrameRequester::test_dummy(),
+        loader,
+        ProviderFilter::MatchDefault(String::from("openai")),
+        /*show_all*/ true,
+        /*filter_cwd*/ None,
+        SessionPickerAction::Resume,
+    );
+    state.initial_page_load = InitialPageLoad::state_db_first();
+    (state, recorded_requests)
+}
+
+fn make_row(path: &str, ts: &str, preview: &str) -> Row {
+    let timestamp = parse_timestamp_str(ts).expect("timestamp should parse");
+    Row {
+        path: Some(PathBuf::from(path)),
+        preview: preview.to_string(),
+        thread_id: None,
+        thread_name: None,
+        created_at: Some(timestamp),
+        updated_at: Some(timestamp),
+        cwd: None,
+        git_branch: None,
+    }
+}
+
+fn make_thread(thread_id: ThreadId) -> Thread {
+    Thread {
+        id: thread_id.to_string(),
+        session_id: thread_id.to_string(),
+        forked_from_id: None,
+        parent_thread_id: None,
+        preview: String::new(),
+        ephemeral: false,
+        model_provider: String::from("openai"),
+        created_at: 1,
+        updated_at: 2,
+        status: codex_app_server_protocol::ThreadStatus::Idle,
+        path: None,
+        cwd: test_path_buf("/tmp").abs(),
+        cli_version: String::from("0.0.0"),
+        source: ApiSessionSource::Cli,
+        thread_source: None,
+        agent_nickname: None,
+        agent_role: None,
+        git_info: None,
+        name: None,
+        turns: Vec::new(),
+    }
+}
+
+#[test]
+fn initial_page_load_tracks_one_time_seed_and_reconciliation() {
+    let mut state = InitialPageLoad::state_db_first();
+
+    assert!(state.begin_load());
+    assert!(!state.begin_load());
+    assert!(!state.is_provisional());
+
+    state.mark_seeded();
+    assert!(state.is_provisional());
+    assert!(state.finish_reconciliation());
+    assert!(!state.is_provisional());
+    assert!(!state.finish_reconciliation());
 }
 
 #[tokio::test]
@@ -215,29 +315,35 @@ async fn loader_bounds_concurrent_preview_reads() {
     tokio::time::timeout(Duration::from_secs(1), worker)
         .await
         .expect("loader should stop")
-        .expect("loader task should not panic");
+        .expect("loader should not panic");
 }
 
 #[test]
-fn local_picker_thread_list_params_include_cwd_filter() {
-    let cwd_filter = picker_cwd_filter(
-        Path::new("/tmp/project"),
-        /*show_all*/ false,
-        /*uses_remote_workspace*/ false,
-        /*remote_cwd_override*/ None,
-    );
+fn state_db_page_params_honor_cwd_filter() {
     let params = thread_list_params(
         Some(String::from("cursor-1")),
-        cwd_filter.as_deref(),
+        Some(Path::new("/tmp/project")),
         ProviderFilter::MatchDefault(String::from("openai")),
         ThreadSortKey::UpdatedAt,
         /*include_non_interactive*/ false,
+        ThreadListLookupMode::StateDbOnly,
     );
 
     assert_eq!(
         params.cwd,
         Some(ThreadListCwdFilter::One(String::from("/tmp/project")))
     );
+    assert!(params.use_state_db_only);
+
+    let params = thread_list_params(
+        /*cursor*/ None,
+        /*cwd_filter*/ None,
+        ProviderFilter::MatchDefault(String::from("openai")),
+        ThreadSortKey::UpdatedAt,
+        /*include_non_interactive*/ false,
+        ThreadListLookupMode::StateDbOnly,
+    );
+    assert_eq!(params.cwd, None);
 }
 
 #[test]
@@ -248,6 +354,7 @@ fn remote_thread_list_params_omit_provider_filter() {
         ProviderFilter::Any,
         ThreadSortKey::UpdatedAt,
         /*include_non_interactive*/ false,
+        ThreadListLookupMode::ScanAndRepair,
     );
 
     assert_eq!(params.cursor, Some(String::from("cursor-1")));
@@ -260,6 +367,7 @@ fn remote_thread_list_params_omit_provider_filter() {
         params.cwd,
         Some(ThreadListCwdFilter::One(String::from("repo/on/server")))
     );
+    assert!(!params.use_state_db_only);
 }
 
 #[test]
@@ -270,6 +378,7 @@ fn remote_thread_list_params_can_include_non_interactive_sources() {
         ProviderFilter::Any,
         ThreadSortKey::UpdatedAt,
         /*include_non_interactive*/ true,
+        ThreadListLookupMode::ScanAndRepair,
     );
 
     assert_eq!(params.cursor, Some(String::from("cursor-1")));
@@ -281,32 +390,244 @@ fn remote_thread_list_params_can_include_non_interactive_sources() {
 #[test]
 fn app_server_row_keeps_pathless_threads() {
     let thread_id = ThreadId::new();
-    let thread = Thread {
-        id: thread_id.to_string(),
-        session_id: thread_id.to_string(),
-        forked_from_id: None,
-        parent_thread_id: None,
-        preview: String::from("remote thread"),
-        ephemeral: false,
-        model_provider: String::from("openai"),
-        created_at: 1,
-        updated_at: 2,
-        status: codex_app_server_protocol::ThreadStatus::Idle,
-        path: None,
-        cwd: test_path_buf("/tmp").abs(),
-        cli_version: String::from("0.0.0"),
-        source: codex_app_server_protocol::SessionSource::Cli,
-        thread_source: None,
-        agent_nickname: None,
-        agent_role: None,
-        git_info: None,
-        name: Some(String::from("Named thread")),
-        turns: Vec::new(),
-    };
+    let mut thread = make_thread(thread_id);
+    thread.preview = String::from("remote thread");
+    thread.name = Some(String::from("Named thread"));
 
     let row = row_from_app_server_thread(thread).expect("row should be preserved");
 
     assert_eq!(row.path, None);
     assert_eq!(row.thread_id, Some(thread_id));
     assert_eq!(row.thread_name, Some(String::from("Named thread")));
+}
+
+#[tokio::test]
+async fn local_picker_replaces_seed_page_and_preserves_selection() {
+    let (mut state, recorded_requests) = recording_picker_state();
+    let first_thread_id = ThreadId::new();
+    let selected_thread_id = ThreadId::new();
+    let replacement_thread_id = ThreadId::new();
+
+    state.start_initial_load();
+
+    let request = recorded_requests.lock().unwrap()[0].clone();
+    assert!(request.seed_from_state_db);
+    let mut first_row = make_row("/tmp/a.jsonl", "2025-01-03T00:00:00Z", "a");
+    first_row.thread_id = Some(first_thread_id);
+    let mut selected_row = make_row("/tmp/stale-b.jsonl", "2025-01-02T00:00:00Z", "b");
+    selected_row.thread_id = Some(selected_thread_id);
+    state
+        .handle_background_event(BackgroundEvent::SeedPage {
+            request_token: request.request_token,
+            page: page(
+                vec![first_row, selected_row],
+                Some("db-cursor"),
+                /*num_scanned_files*/ 2,
+                /*reached_scan_cap*/ false,
+            ),
+        })
+        .await
+        .expect("State DB page should seed the picker");
+
+    assert!(state.pagination.loading.is_pending());
+    assert!(state.initial_page_load.is_provisional());
+    state.selected = 1;
+    state.load_more_if_needed(LoadTrigger::Scroll);
+    assert_eq!(recorded_requests.lock().unwrap().len(), 1);
+    let mut repaired_selected_row = make_row(
+        "/tmp/repaired-b.jsonl",
+        "2025-01-02T00:00:00Z",
+        "b repaired",
+    );
+    repaired_selected_row.thread_id = Some(selected_thread_id);
+    let mut replacement_row = make_row("/tmp/c.jsonl", "2025-01-01T00:00:00Z", "c");
+    replacement_row.thread_id = Some(replacement_thread_id);
+
+    state
+        .handle_background_event(BackgroundEvent::Page {
+            request_token: request.request_token,
+            search_token: request.search_token,
+            page: Ok(page(
+                vec![repaired_selected_row, replacement_row],
+                Some("scan-cursor"),
+                /*num_scanned_files*/ 3,
+                /*reached_scan_cap*/ false,
+            )),
+        })
+        .await
+        .expect("reconciled page should load");
+
+    assert!(!state.pagination.loading.is_pending());
+    assert!(!state.initial_page_load.is_provisional());
+    assert_eq!(state.selected, 0);
+    assert_eq!(
+        state.filtered_rows[state.selected].thread_id,
+        Some(selected_thread_id)
+    );
+    assert_eq!(
+        state
+            .filtered_rows
+            .iter()
+            .map(|row| row.preview.as_str())
+            .collect::<Vec<_>>(),
+        vec!["b repaired", "c"]
+    );
+    assert!(matches!(
+        state.pagination.next_cursor.as_ref(),
+        Some(PageCursor::AppServer(cursor)) if cursor == "scan-cursor"
+    ));
+
+    state.load_more_if_needed(LoadTrigger::Scroll);
+    let requests = recorded_requests.lock().unwrap();
+    assert_eq!(requests.len(), 2);
+    assert!(!requests[1].seed_from_state_db);
+    assert!(matches!(
+        requests[1].cursor.as_ref(),
+        Some(PageCursor::AppServer(cursor)) if cursor == "scan-cursor"
+    ));
+}
+
+#[tokio::test]
+async fn local_picker_keeps_seed_page_when_reconciliation_fails() {
+    let (mut state, recorded_requests) = recording_picker_state();
+    let thread_id = ThreadId::new();
+
+    state.start_initial_load();
+
+    let request = recorded_requests.lock().unwrap()[0].clone();
+    assert!(request.seed_from_state_db);
+    let mut provisional_row = make_row("/tmp/a.jsonl", "2025-01-03T00:00:00Z", "a");
+    provisional_row.thread_id = Some(thread_id);
+    state
+        .handle_background_event(BackgroundEvent::SeedPage {
+            request_token: request.request_token,
+            page: page(
+                vec![provisional_row],
+                Some("db-cursor"),
+                /*num_scanned_files*/ 1,
+                /*reached_scan_cap*/ false,
+            ),
+        })
+        .await
+        .expect("State DB page should seed the picker");
+    state
+        .handle_background_event(BackgroundEvent::Page {
+            request_token: request.request_token,
+            search_token: request.search_token,
+            page: Err(io::Error::other("scan failed")),
+        })
+        .await
+        .expect("fast page should remain usable");
+
+    assert!(!state.pagination.loading.is_pending());
+    assert!(state.initial_page_load.is_provisional());
+    assert_eq!(
+        state
+            .filtered_rows
+            .iter()
+            .map(|row| row.preview.as_str())
+            .collect::<Vec<_>>(),
+        vec!["a"]
+    );
+    assert!(state.pagination.next_cursor.is_none());
+    assert_eq!(
+        state.inline_error,
+        Some(String::from(
+            "Could not refresh sessions; showing the first page of indexed results"
+        ))
+    );
+
+    state.load_more_if_needed(LoadTrigger::Scroll);
+    assert_eq!(recorded_requests.lock().unwrap().len(), 1);
+}
+
+#[test]
+fn reloads_do_not_reuse_initial_state_db_seed() {
+    let (mut state, recorded_requests) = recording_picker_state();
+    state.start_initial_load();
+    state.initial_page_load.mark_seeded();
+    state.replace_with_page(page(
+        vec![make_row(
+            "/tmp/provisional.jsonl",
+            "2025-01-03T00:00:00Z",
+            "provisional",
+        )],
+        /*next_cursor*/ None,
+        /*num_scanned_files*/ 1,
+        /*reached_scan_cap*/ false,
+    ));
+
+    state.toggle_sort_key();
+
+    assert!(!state.initial_page_load.is_provisional());
+    assert!(state.all_rows.is_empty());
+    let requests = recorded_requests.lock().unwrap();
+    assert_eq!(requests.len(), 2);
+    assert!(requests[0].seed_from_state_db);
+    assert!(!requests[1].seed_from_state_db);
+    assert_eq!(requests[1].sort_key, ThreadSortKey::CreatedAt);
+}
+
+async fn assert_reconciliation_restarts_search(provisional_preview: &str) {
+    let (mut state, recorded_requests) = recording_picker_state();
+
+    state.start_initial_load();
+
+    let initial_request = recorded_requests.lock().unwrap()[0].clone();
+    state
+        .handle_background_event(BackgroundEvent::SeedPage {
+            request_token: initial_request.request_token,
+            page: page(
+                vec![make_row(
+                    "/tmp/provisional.jsonl",
+                    "2025-01-03T00:00:00Z",
+                    provisional_preview,
+                )],
+                /*next_cursor*/ None,
+                /*num_scanned_files*/ 1,
+                /*reached_scan_cap*/ false,
+            ),
+        })
+        .await
+        .expect("State DB page should seed the picker");
+    state.set_query(String::from("target"));
+    assert!(!state.search_state.is_active());
+
+    state
+        .handle_background_event(BackgroundEvent::Page {
+            request_token: initial_request.request_token,
+            search_token: initial_request.search_token,
+            page: Ok(page(
+                vec![make_row(
+                    "/tmp/reconciled.jsonl",
+                    "2025-01-02T00:00:00Z",
+                    "other",
+                )],
+                Some("scan-cursor"),
+                /*num_scanned_files*/ 2,
+                /*reached_scan_cap*/ false,
+            )),
+        })
+        .await
+        .expect("reconciled page should load");
+
+    assert!(state.filtered_rows.is_empty());
+    assert!(state.search_state.is_active());
+    let requests = recorded_requests.lock().unwrap();
+    assert_eq!(requests.len(), 2);
+    assert!(requests[1].search_token.is_some());
+    assert!(matches!(
+        requests[1].cursor.as_ref(),
+        Some(PageCursor::AppServer(cursor)) if cursor == "scan-cursor"
+    ));
+}
+
+#[tokio::test]
+async fn reconciliation_restarts_search_when_provisional_match_disappears() {
+    assert_reconciliation_restarts_search("target").await;
+}
+
+#[tokio::test]
+async fn reconciliation_restarts_search_when_authoritative_page_adds_cursor() {
+    assert_reconciliation_restarts_search("other").await;
 }

--- a/codex-rs/tui/src/resume_picker/loading_tests.rs
+++ b/codex-rs/tui/src/resume_picker/loading_tests.rs
@@ -1,4 +1,10 @@
+use std::future::pending;
 use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
 
 use codex_app_server_protocol::Thread;
 use codex_app_server_protocol::ThreadListCwdFilter;
@@ -11,6 +17,206 @@ use pretty_assertions::assert_eq;
 
 use super::*;
 use crate::resume_picker::picker_cwd_filter;
+
+fn page_request(request_token: usize) -> PageLoadRequest {
+    PageLoadRequest {
+        cursor: None,
+        request_token,
+        search_token: None,
+        cwd_filter: None,
+        provider_filter: ProviderFilter::Any,
+        sort_key: ThreadSortKey::UpdatedAt,
+    }
+}
+
+#[tokio::test]
+async fn loader_does_not_block_followup_requests_and_cancels_on_close() {
+    struct SetOnDrop(Arc<AtomicBool>);
+
+    impl Drop for SetOnDrop {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    let (request_tx, request_rx) = mpsc::unbounded_channel();
+    let (signal_tx, mut signal_rx) = mpsc::unbounded_channel();
+    let page_dropped = Arc::new(AtomicBool::new(false));
+    let worker_page_dropped = page_dropped.clone();
+    let worker = tokio::spawn(run_picker_loader(request_rx, move |request| {
+        let signal_tx = signal_tx.clone();
+        let page_dropped = worker_page_dropped.clone();
+        async move {
+            match request {
+                PickerLoadRequest::Page(_) => {
+                    let _drop_guard = SetOnDrop(page_dropped);
+                    let _ = signal_tx.send("page");
+                    pending::<()>().await;
+                }
+                PickerLoadRequest::Transcript { .. } => {
+                    let _ = signal_tx.send("transcript");
+                }
+                PickerLoadRequest::Preview { .. } => {}
+            }
+        }
+    }));
+
+    request_tx
+        .send(PickerLoadRequest::Page(page_request(
+            /*request_token*/ 1,
+        )))
+        .expect("send page request");
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(1), signal_rx.recv())
+            .await
+            .expect("page request should start"),
+        Some("page")
+    );
+
+    request_tx
+        .send(PickerLoadRequest::Transcript {
+            thread_id: ThreadId::new(),
+        })
+        .expect("send transcript request");
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(1), signal_rx.recv())
+            .await
+            .expect("transcript request should not wait for page load"),
+        Some("transcript")
+    );
+
+    drop(request_tx);
+    tokio::time::timeout(Duration::from_secs(1), worker)
+        .await
+        .expect("loader should stop promptly")
+        .expect("loader task should not panic");
+    assert!(page_dropped.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn page_loader_cancels_and_coalesces_obsolete_requests() {
+    struct ActiveLoad(Arc<AtomicUsize>);
+
+    impl ActiveLoad {
+        fn start(active_loads: Arc<AtomicUsize>) -> Self {
+            assert_eq!(active_loads.fetch_add(1, Ordering::SeqCst), 0);
+            Self(active_loads)
+        }
+    }
+
+    impl Drop for ActiveLoad {
+        fn drop(&mut self) {
+            self.0.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    let (request_tx, request_rx) = mpsc::unbounded_channel();
+    let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+    let release = Arc::new(tokio::sync::Semaphore::new(0));
+    let worker_release = release.clone();
+    let active_loads = Arc::new(AtomicUsize::new(0));
+    let worker_active_loads = active_loads.clone();
+    let worker = tokio::spawn(run_page_loader(request_rx, move |request| {
+        let started_tx = started_tx.clone();
+        let release = worker_release.clone();
+        let active_loads = worker_active_loads.clone();
+        async move {
+            let _active_load = ActiveLoad::start(active_loads);
+            let _ = started_tx.send(request.request_token);
+            let _permit = release
+                .acquire_owned()
+                .await
+                .expect("release semaphore should remain open");
+        }
+    }));
+
+    request_tx
+        .send(page_request(/*request_token*/ 1))
+        .expect("send first page");
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(1), started_rx.recv())
+            .await
+            .expect("first page should start"),
+        Some(1)
+    );
+    request_tx
+        .send(page_request(/*request_token*/ 2))
+        .expect("send second page");
+    request_tx
+        .send(page_request(/*request_token*/ 3))
+        .expect("send third page");
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(1), started_rx.recv())
+            .await
+            .expect("latest page should supersede the active load"),
+        Some(3)
+    );
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), started_rx.recv())
+            .await
+            .is_err()
+    );
+
+    drop(request_tx);
+    release.add_permits(1);
+    tokio::time::timeout(Duration::from_secs(1), worker)
+        .await
+        .expect("page loader should stop")
+        .expect("page loader should not panic");
+    assert_eq!(active_loads.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn loader_bounds_concurrent_preview_reads() {
+    let (request_tx, request_rx) = mpsc::unbounded_channel();
+    let (started_tx, mut started_rx) = mpsc::unbounded_channel();
+    let release = Arc::new(tokio::sync::Semaphore::new(0));
+    let worker_release = release.clone();
+    let worker = tokio::spawn(run_picker_loader(request_rx, move |request| {
+        let started_tx = started_tx.clone();
+        let release = worker_release.clone();
+        async move {
+            if let PickerLoadRequest::Preview { thread_id } = request {
+                let _ = started_tx.send(thread_id);
+                let _permit = release
+                    .acquire_owned()
+                    .await
+                    .expect("release semaphore should remain open");
+            }
+        }
+    }));
+
+    for _ in 0..=MAX_CONCURRENT_PREVIEW_READS {
+        request_tx
+            .send(PickerLoadRequest::Preview {
+                thread_id: ThreadId::new(),
+            })
+            .expect("send preview request");
+    }
+    for _ in 0..MAX_CONCURRENT_PREVIEW_READS {
+        tokio::time::timeout(Duration::from_secs(1), started_rx.recv())
+            .await
+            .expect("preview should start")
+            .expect("preview signal channel should remain open");
+    }
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), started_rx.recv())
+            .await
+            .is_err()
+    );
+
+    release.add_permits(MAX_CONCURRENT_PREVIEW_READS + 1);
+    tokio::time::timeout(Duration::from_secs(1), started_rx.recv())
+        .await
+        .expect("queued preview should start")
+        .expect("preview signal channel should remain open");
+
+    drop(request_tx);
+    tokio::time::timeout(Duration::from_secs(1), worker)
+        .await
+        .expect("loader should stop")
+        .expect("loader task should not panic");
+}
 
 #[test]
 fn local_picker_thread_list_params_include_cwd_filter() {

--- a/codex-rs/tui/src/resume_picker/loading_tests.rs
+++ b/codex-rs/tui/src/resume_picker/loading_tests.rs
@@ -16,12 +16,18 @@ use codex_app_server_protocol::ThreadSourceKind;
 use codex_protocol::ThreadId;
 use codex_utils_absolute_path::test_support::PathBufExt;
 use codex_utils_absolute_path::test_support::test_path_buf;
+use crossterm::event::KeyCode;
+use crossterm::event::KeyEvent;
+use crossterm::event::KeyModifiers;
 use pretty_assertions::assert_eq;
+use tempfile::TempDir;
+use tempfile::tempdir;
 
 use super::*;
 use crate::resume_picker::FrameRequester;
 use crate::resume_picker::LoadTrigger;
 use crate::resume_picker::SessionPickerAction;
+use crate::resume_picker::SessionPickerViewPersistence;
 
 fn page(
     rows: Vec<Row>,
@@ -111,6 +117,68 @@ fn make_thread(thread_id: ThreadId) -> Thread {
         git_info: None,
         name: None,
         turns: Vec::new(),
+    }
+}
+
+struct RolloutFixture {
+    _temp_dir: TempDir,
+    codex_home: PathBuf,
+    path: PathBuf,
+    thread_id: ThreadId,
+}
+
+fn write_rollout(cwd: &Path, model_provider: &str, source: &str, preview: &str) -> RolloutFixture {
+    let temp_dir = tempdir().expect("tmpdir");
+    let codex_home = temp_dir.path().to_path_buf();
+    let day_dir = codex_home.join("sessions/2025/01/01");
+    std::fs::create_dir_all(&day_dir).expect("sessions dir");
+    let thread_id = ThreadId::new();
+    let path = day_dir.join(format!("rollout-2025-01-01T00-00-00-{thread_id}.jsonl"));
+    let session_meta = serde_json::json!({
+        "timestamp": "2025-01-01T00:00:00Z",
+        "type": "session_meta",
+        "payload": {
+            "id": thread_id,
+            "timestamp": "2025-01-01T00:00:00Z",
+            "cwd": cwd,
+            "originator": "test",
+            "cli_version": "test",
+            "source": source,
+            "model_provider": model_provider,
+            "git": {
+                "branch": "main"
+            }
+        }
+    });
+    let user_event = serde_json::json!({
+        "timestamp": "2025-01-01T00:00:01Z",
+        "type": "event_msg",
+        "payload": {
+            "type": "user_message",
+            "message": preview,
+            "kind": "plain"
+        }
+    });
+    std::fs::write(&path, format!("{session_meta}\n{user_event}\n")).expect("write rollout");
+    RolloutFixture {
+        _temp_dir: temp_dir,
+        codex_home,
+        path,
+        thread_id,
+    }
+}
+
+fn validation(fixture: &RolloutFixture) -> SelectionValidation {
+    SelectionValidation {
+        path: fixture.path.clone(),
+        thread_id: fixture.thread_id,
+        thread_name: None,
+        git_branch: None,
+        codex_home: fixture.codex_home.clone(),
+        cwd_filter: Some(PathBuf::from("/tmp/current")),
+        provider_filter: ProviderFilter::MatchDefault(String::from("openai")),
+        include_non_interactive: false,
+        query: String::new(),
     }
 }
 
@@ -316,6 +384,16 @@ async fn loader_bounds_concurrent_preview_reads() {
         .await
         .expect("loader should stop")
         .expect("loader should not panic");
+}
+
+#[test]
+fn rollout_file_name_requires_timestamp_and_thread_id() {
+    let thread_id = ThreadId::new();
+    let file_name = format!("rollout-2025-01-01T00-00-00-{thread_id}.jsonl");
+
+    assert!(is_rollout_file_name(&file_name));
+    assert!(is_rollout_file_name(&format!("{file_name}.zst")));
+    assert!(!is_rollout_file_name(&format!("rollout-{thread_id}.jsonl")));
 }
 
 #[test]
@@ -630,4 +708,189 @@ async fn reconciliation_restarts_search_when_provisional_match_disappears() {
 #[tokio::test]
 async fn reconciliation_restarts_search_when_authoritative_page_adds_cursor() {
     assert_reconciliation_restarts_search("other").await;
+}
+
+#[tokio::test]
+async fn provisional_accept_rechecks_stale_cwd_from_rollout() {
+    let fixture = write_rollout(Path::new("/tmp/on-disk"), "openai", "cli", "target preview");
+    let loader = page_only_loader(|_| {});
+    let mut state = PickerState::new(
+        FrameRequester::test_dummy(),
+        loader,
+        ProviderFilter::MatchDefault(String::from("openai")),
+        /*show_all*/ false,
+        Some(PathBuf::from("/tmp/current")),
+        SessionPickerAction::Resume,
+    );
+    state.view_persistence = Some(SessionPickerViewPersistence {
+        codex_home: fixture.codex_home.clone(),
+    });
+    state.initial_page_load = InitialPageLoad::Provisional;
+    let row = Row {
+        path: Some(fixture.path),
+        preview: String::from("target preview"),
+        thread_id: Some(fixture.thread_id),
+        thread_name: None,
+        created_at: None,
+        updated_at: None,
+        cwd: Some(PathBuf::from("/tmp/current")),
+        git_branch: None,
+    };
+    state.all_rows = vec![row.clone()];
+    state.filtered_rows = vec![row];
+
+    let selection = state
+        .handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))
+        .await
+        .expect("validation failure should not abort the picker");
+
+    assert!(selection.is_none());
+    assert_eq!(
+        state.inline_error,
+        Some(String::from("Selected session is no longer available"))
+    );
+}
+
+#[tokio::test]
+async fn provisional_selection_validates_authoritative_filters() {
+    let fixture = write_rollout(Path::new("/tmp/current"), "openai", "cli", "target preview");
+
+    let target = validate_provisional_session_target(validation(&fixture))
+        .await
+        .expect("matching rollout should validate");
+    assert_eq!(target.thread_id, fixture.thread_id);
+    assert_eq!(target.path, Some(fixture.path.clone()));
+
+    let mut stale_cwd = validation(&fixture);
+    stale_cwd.cwd_filter = Some(PathBuf::from("/tmp/other"));
+    assert_eq!(
+        validate_provisional_session_target(stale_cwd)
+            .await
+            .expect_err("stale cwd should fail")
+            .kind(),
+        io::ErrorKind::NotFound
+    );
+
+    let mut stale_provider = validation(&fixture);
+    stale_provider.provider_filter = ProviderFilter::MatchDefault(String::from("other"));
+    assert_eq!(
+        validate_provisional_session_target(stale_provider)
+            .await
+            .expect_err("stale provider should fail")
+            .kind(),
+        io::ErrorKind::NotFound
+    );
+
+    let mut stale_query = validation(&fixture);
+    stale_query.query = String::from("missing");
+    assert_eq!(
+        validate_provisional_session_target(stale_query)
+            .await
+            .expect_err("stale query should fail")
+            .kind(),
+        io::ErrorKind::NotFound
+    );
+
+    let mut named_query = validation(&fixture);
+    named_query.thread_name = Some(String::from("saved title"));
+    named_query.query = String::from("saved title");
+    validate_provisional_session_target(named_query)
+        .await
+        .expect("authoritative list reattaches the selected thread name");
+
+    let mut stale_head_branch = validation(&fixture);
+    stale_head_branch.git_branch = Some(String::from("db-branch"));
+    stale_head_branch.query = String::from("main");
+    assert_eq!(
+        validate_provisional_session_target(stale_head_branch)
+            .await
+            .expect_err("DB branch should replace the rollout-head branch")
+            .kind(),
+        io::ErrorKind::NotFound
+    );
+
+    let mut db_branch = validation(&fixture);
+    db_branch.git_branch = Some(String::from("db-branch"));
+    db_branch.query = String::from("db-branch");
+    validate_provisional_session_target(db_branch)
+        .await
+        .expect("query should match the branch retained by reconciliation");
+}
+
+#[tokio::test]
+async fn provisional_selection_rechecks_source_and_thread_id() {
+    let exec_fixture = write_rollout(
+        Path::new("/tmp/current"),
+        "openai",
+        "exec",
+        "target preview",
+    );
+    assert_eq!(
+        validate_provisional_session_target(validation(&exec_fixture))
+            .await
+            .expect_err("interactive-only picker should reject exec sessions")
+            .kind(),
+        io::ErrorKind::NotFound
+    );
+
+    let mut include_non_interactive = validation(&exec_fixture);
+    include_non_interactive.include_non_interactive = true;
+    validate_provisional_session_target(include_non_interactive)
+        .await
+        .expect("all-source picker should accept exec sessions");
+
+    let cli_fixture = write_rollout(Path::new("/tmp/current"), "openai", "cli", "target preview");
+    let mut stale_id = validation(&cli_fixture);
+    stale_id.thread_id = ThreadId::new();
+    assert_eq!(
+        validate_provisional_session_target(stale_id)
+            .await
+            .expect_err("stale thread id should fail")
+            .kind(),
+        io::ErrorKind::NotFound
+    );
+}
+
+#[tokio::test]
+async fn provisional_selection_rejects_non_discoverable_rollout_path() {
+    let fixture = write_rollout(Path::new("/tmp/current"), "openai", "cli", "target preview");
+    let outside_path = fixture.codex_home.join("rollout.jsonl");
+    std::fs::copy(&fixture.path, &outside_path).expect("copy rollout");
+    let mut outside = validation(&fixture);
+    outside.path = outside_path;
+
+    assert_eq!(
+        validate_provisional_session_target(outside)
+            .await
+            .expect_err("rollout outside active sessions should fail")
+            .kind(),
+        io::ErrorKind::NotFound
+    );
+
+    let invalid_layout = fixture.codex_home.join("sessions/orphan.jsonl");
+    std::fs::copy(&fixture.path, &invalid_layout).expect("copy rollout");
+    let mut undiscoverable = validation(&fixture);
+    undiscoverable.path = invalid_layout;
+    assert_eq!(
+        validate_provisional_session_target(undiscoverable)
+            .await
+            .expect_err("filesystem scan should not discover invalid layout")
+            .kind(),
+        io::ErrorKind::NotFound
+    );
+
+    let invalid_file_name = fixture.codex_home.join(format!(
+        "sessions/2025/01/01/rollout-{}.jsonl",
+        fixture.thread_id
+    ));
+    std::fs::copy(&fixture.path, &invalid_file_name).expect("copy rollout");
+    let mut undiscoverable = validation(&fixture);
+    undiscoverable.path = invalid_file_name;
+    assert_eq!(
+        validate_provisional_session_target(undiscoverable)
+            .await
+            .expect_err("filesystem scan should skip invalid rollout filename")
+            .kind(),
+        io::ErrorKind::NotFound
+    );
 }

--- a/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_footer_verifying.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_footer_verifying.snap
@@ -1,0 +1,8 @@
+---
+source: tui/src/resume_picker.rs
+assertion_line: 5499
+expression: "footer_snapshot(&state, 220, 20)"
+---
+───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 0 / 0 · 100% ─
+ verifying sessions   esc start new   ctrl+c quit   tab focus sort/filter   ←/→ change option
+ ctrl+o dense view   ctrl+t transcript   ctrl+e expand   ↑/↓ browse

--- a/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_footer_verifying.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_footer_verifying.snap
@@ -1,8 +1,8 @@
 ---
 source: tui/src/resume_picker.rs
-assertion_line: 5499
+assertion_line: 6545
 expression: "footer_snapshot(&state, 220, 20)"
 ---
 ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 0 / 0 · 100% ─
- verifying sessions   esc start new   ctrl+c quit   tab focus sort/filter   ←/→ change option
+ enter resume   esc start new   ctrl+c quit   tab focus sort/filter   ←/→ change option
  ctrl+o dense view   ctrl+t transcript   ctrl+e expand   ↑/↓ browse

--- a/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_search_error.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_search_error.snap
@@ -2,4 +2,4 @@
 source: tui/src/resume_picker.rs
 expression: snapshot
 ---
-Failed to read session metadata from /tmp/missing.jsonl
+Could not refresh sessions; showing the first page of indexed results

--- a/codex-rs/tui/src/thread_transcript.rs
+++ b/codex-rs/tui/src/thread_transcript.rs
@@ -2,7 +2,6 @@
 
 use std::sync::Arc;
 
-use crate::app_server_session::AppServerSession;
 use crate::git_action_directives::parse_assistant_markdown;
 use crate::history_cell::AgentMarkdownCell;
 use crate::history_cell::HistoryCell;
@@ -12,7 +11,6 @@ use crate::history_cell::UserHistoryCell;
 use crate::multi_agents::sub_agent_activity_summary;
 use codex_app_server_protocol::Thread;
 use codex_app_server_protocol::ThreadItem;
-use codex_protocol::ThreadId;
 use codex_protocol::items::UserMessageItem;
 use ratatui::style::Stylize as _;
 use ratatui::text::Line;
@@ -23,21 +21,6 @@ pub(crate) type TranscriptCells = Vec<Arc<dyn HistoryCell>>;
 pub(crate) enum RawReasoningVisibility {
     Hidden,
     Visible,
-}
-
-pub(crate) async fn load_session_transcript(
-    app_server: &mut AppServerSession,
-    thread_id: ThreadId,
-    raw_reasoning_visibility: RawReasoningVisibility,
-) -> std::io::Result<TranscriptCells> {
-    let thread = app_server
-        .thread_read(thread_id, /*include_turns*/ true)
-        .await
-        .map_err(std::io::Error::other)?;
-    Ok(thread_to_transcript_cells(
-        &thread,
-        raw_reasoning_visibility,
-    ))
 }
 
 pub(crate) fn thread_to_transcript_cells(


### PR DESCRIPTION
## Summary

Local resume and fork pickers currently wait for the filesystem-backed scan-and-repair lookup before showing sessions, even when the State DB can provide an indexed first page immediately. This change uses that indexed page to make the picker interactive sooner while preserving scan-and-repair as the authoritative result.

For local workspaces, the initial load now:

- reads the first page from the State DB and displays those rows as provisional;
- continues the existing scan-and-repair lookup in the background;
- replaces the provisional page with the repaired page, preserving the selected thread by ID and reevaluating search and pagination; and
- keeps the indexed rows without a continuation cursor if reconciliation fails.

Picker page, preview, and transcript RPCs run as independently tracked tasks. This lets provisional transcript actions proceed while reconciliation is pending. Closing the picker aborts and drains those client tasks before shutting down its dedicated app-server session, instead of waiting for reconciliation to finish first.

Selecting a provisional row validates only that rollout before resuming or forking. The validation uses the same bounded rollout summary as filesystem listing and rechecks that the path is discoverable under active sessions, the thread ID still matches, and the current provider, source, cwd, and typed-search filters still accept the authoritative metadata. Search validation also preserves the State DB title and Git branch overlays that the reconciled row would display.

The loading, provisional-state, reconciliation, validation, and focused tests now live in `tui/src/resume_picker/loading.rs` and `tui/src/resume_picker/loading_tests.rs` instead of extending the already-large picker module.

Remote workspaces keep the existing direct scan-and-repair behavior. This reduces initial display latency; it does not reduce the total filesystem work performed by reconciliation.

## Testing

- `just test -p codex-tui resume_picker` (103 tests)
