### PR TITLE
Fix Windows fs-helper sandbox bypass

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2183,6 +2183,7 @@ dependencies = [
  "codex-shell-escalation",
  "codex-utils-absolute-path",
  "codex-utils-home-dir",
+ "codex-windows-sandbox",
  "dotenvy",
  "pretty_assertions",
  "tempfile",
@@ -3001,6 +3002,7 @@ name = "codex-file-system"
 version = "0.0.0"
 dependencies = [
  "codex-protocol",
+ "codex-utils-absolute-path",
  "codex-utils-path-uri",
  "serde",
 ]
@@ -3747,7 +3749,9 @@ dependencies = [
  "codex-network-proxy",
  "codex-protocol",
  "codex-utils-absolute-path",
+ "codex-utils-home-dir",
  "codex-utils-path-uri",
+ "codex-windows-sandbox",
  "dunce",
  "libc",
  "pretty_assertions",

--- a/codex-rs/arg0/Cargo.toml
+++ b/codex-rs/arg0/Cargo.toml
@@ -26,5 +26,8 @@ dotenvy = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 
+[target.'cfg(windows)'.dependencies]
+codex-windows-sandbox = { workspace = true }
+
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/codex-rs/arg0/src/lib.rs
+++ b/codex-rs/arg0/src/lib.rs
@@ -9,6 +9,8 @@ use codex_exec_server::CODEX_FS_HELPER_ARG1;
 use codex_install_context::InstallContext;
 use codex_sandboxing::landlock::CODEX_LINUX_SANDBOX_ARG0;
 use codex_utils_home_dir::find_codex_home;
+#[cfg(target_os = "windows")]
+use codex_windows_sandbox::CODEX_WINDOWS_SANDBOX_ARG1;
 #[cfg(unix)]
 use std::os::unix::fs::symlink;
 use tempfile::TempDir;
@@ -98,6 +100,10 @@ pub fn arg0_dispatch() -> Option<Arg0PathEntryGuard> {
     let argv1 = args.next().unwrap_or_default();
     if argv1 == CODEX_FS_HELPER_ARG1 {
         codex_exec_server::run_fs_helper_main();
+    }
+    #[cfg(target_os = "windows")]
+    if argv1 == CODEX_WINDOWS_SANDBOX_ARG1 {
+        codex_windows_sandbox::run_windows_sandbox_wrapper_main();
     }
     if argv1 == CODEX_CORE_APPLY_PATCH_ARG1 {
         let patch_arg = args.next().and_then(|s| s.to_str().map(str::to_owned));

--- a/codex-rs/cli/src/debug_sandbox.rs
+++ b/codex-rs/cli/src/debug_sandbox.rs
@@ -369,52 +369,30 @@ async fn run_command_under_windows_session(
 ) -> ! {
     use codex_core::windows_sandbox::WindowsSandboxLevelExt;
     use codex_protocol::config_types::WindowsSandboxLevel;
-    use codex_windows_sandbox::spawn_windows_sandbox_session_elevated_for_permission_profile;
-    use codex_windows_sandbox::spawn_windows_sandbox_session_legacy;
+    use codex_windows_sandbox::WindowsSandboxSessionRequest;
+    use codex_windows_sandbox::spawn_windows_sandbox_session_for_level;
 
     let permission_profile = config.permissions.effective_permission_profile();
-
-    let use_elevated = matches!(
-        WindowsSandboxLevel::from_config(config),
-        WindowsSandboxLevel::Elevated
-    );
-
-    let spawned = if use_elevated {
-        spawn_windows_sandbox_session_elevated_for_permission_profile(
-            &permission_profile,
-            workspace_roots.as_slice(),
-            config.codex_home.as_path(),
-            command,
-            cwd.as_path(),
-            env,
-            None,
-            /*read_roots_override*/ None,
-            /*read_roots_include_platform_defaults*/ false,
-            /*write_roots_override*/ None,
-            /*deny_read_paths_override*/ &[],
-            /*deny_write_paths_override*/ &[],
-            /*tty*/ false,
-            /*stdin_open*/ true,
-            config.permissions.windows_sandbox_private_desktop,
-        )
-        .await
-    } else {
-        spawn_windows_sandbox_session_legacy(
-            &permission_profile,
-            workspace_roots.as_slice(),
-            config.codex_home.as_path(),
-            command,
-            cwd.as_path(),
-            env,
-            None,
-            /*additional_deny_read_paths*/ &[],
-            /*additional_deny_write_paths*/ &[],
-            /*tty*/ false,
-            /*stdin_open*/ true,
-            config.permissions.windows_sandbox_private_desktop,
-        )
-        .await
-    };
+    let empty_paths: &[AbsolutePathBuf] = &[];
+    let spawned = spawn_windows_sandbox_session_for_level(WindowsSandboxSessionRequest {
+        permission_profile: &permission_profile,
+        workspace_roots: workspace_roots.as_slice(),
+        codex_home: config.codex_home.as_path(),
+        command,
+        cwd: cwd.as_path(),
+        env_map: env,
+        windows_sandbox_level: WindowsSandboxLevel::from_config(config),
+        timeout_ms: None,
+        read_roots_override: None,
+        read_roots_include_platform_defaults: false,
+        write_roots_override: None,
+        deny_read_paths_override: empty_paths,
+        deny_write_paths_override: empty_paths,
+        tty: false,
+        stdin_open: true,
+        use_private_desktop: config.permissions.windows_sandbox_private_desktop,
+    })
+    .await;
 
     let spawned = match spawned {
         Ok(spawned) => spawned,
@@ -424,63 +402,7 @@ async fn run_command_under_windows_session(
         }
     };
 
-    let session = std::sync::Arc::new(spawned.session);
-    let tokio_runtime = tokio::runtime::Handle::current();
-    // Give large or slow tail output a better chance to finish draining
-    // without letting rare EOF issues hang the wrapper indefinitely.
-    let output_drain_timeout = std::time::Duration::from_secs(5);
-    // A helper thread watches our stdin. When the input source closes it,
-    // the thread tells the main async code so we can also close stdin for
-    // the sandboxed child process.
-    let (stdin_eof_tx, stdin_eof_rx) = tokio::sync::oneshot::channel();
-
-    // Start background threads that copy stdin/stdout/stderr. We
-    // intentionally do not keep their JoinHandles; dropping the handle does
-    // not stop the thread, it just means we are not going to wait on it
-    // later.
-    drop(windows_stdio_bridge::spawn_input_forwarder(
-        std::io::stdin(),
-        session.writer_sender(),
-        stdin_eof_tx,
-    ));
-    let (stdout_forwarder, stdout_forwarder_done_rx) = windows_stdio_bridge::spawn_output_forwarder(
-        tokio_runtime.clone(),
-        spawned.stdout_rx,
-        std::io::stdout(),
-    );
-    drop(stdout_forwarder);
-    let (stderr_forwarder, stderr_forwarder_done_rx) = windows_stdio_bridge::spawn_output_forwarder(
-        tokio_runtime.clone(),
-        spawned.stderr_rx,
-        std::io::stderr(),
-    );
-    drop(stderr_forwarder);
-
-    let stdin_close_task = tokio::spawn({
-        let session = std::sync::Arc::clone(&session);
-        async move {
-            let _ = stdin_eof_rx.await;
-            session.close_stdin();
-        }
-    });
-
-    let mut exit_rx = spawned.exit_rx;
-    let exit_code = tokio::select! {
-        res = &mut exit_rx => res.unwrap_or(-1),
-        res = tokio::signal::ctrl_c() => {
-            if let Ok(()) = res {
-                session.request_terminate();
-            }
-            exit_rx.await.unwrap_or(-1)
-        }
-    };
-
-    stdin_close_task.abort();
-    let _ = tokio::time::timeout(output_drain_timeout, async {
-        let _ = stdout_forwarder_done_rx.await;
-        let _ = stderr_forwarder_done_rx.await;
-    })
-    .await;
+    let exit_code = codex_windows_sandbox::forward_sandbox_session_stdio(spawned).await;
     std::process::exit(exit_code);
 }
 
@@ -513,141 +435,6 @@ async fn spawn_debug_sandbox_child(
         .stderr(Stdio::inherit())
         .kill_on_drop(true)
         .spawn()
-}
-
-#[cfg(target_os = "windows")]
-mod windows_stdio_bridge {
-    use std::io::Read;
-    use std::io::Write;
-
-    use tokio::sync::mpsc;
-    use tokio::sync::oneshot;
-
-    const STDIN_FORWARD_CHUNK_SIZE: usize = 8 * 1024;
-
-    pub(super) fn spawn_input_forwarder<R>(
-        mut input: R,
-        writer_tx: mpsc::Sender<Vec<u8>>,
-        stdin_eof_tx: oneshot::Sender<()>,
-    ) -> std::thread::JoinHandle<()>
-    where
-        R: Read + Send + 'static,
-    {
-        std::thread::spawn(move || {
-            let mut buffer = [0_u8; STDIN_FORWARD_CHUNK_SIZE];
-            loop {
-                match input.read(&mut buffer) {
-                    Ok(0) => break,
-                    Ok(n) => {
-                        if writer_tx.blocking_send(buffer[..n].to_vec()).is_err() {
-                            break;
-                        }
-                    }
-                    Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
-                    Err(err) => {
-                        eprintln!("windows sandbox stdin forwarder failed: {err}");
-                        break;
-                    }
-                }
-            }
-            let _ = stdin_eof_tx.send(());
-        })
-    }
-
-    pub(super) fn spawn_output_forwarder<W>(
-        tokio_runtime: tokio::runtime::Handle,
-        output_rx: mpsc::Receiver<Vec<u8>>,
-        mut writer: W,
-    ) -> (std::thread::JoinHandle<()>, oneshot::Receiver<()>)
-    where
-        W: Write + Send + 'static,
-    {
-        let (done_tx, done_rx) = oneshot::channel();
-        // The sandbox session emits output on Tokio channels, but writing to the
-        // caller's stdio is simplest from a dedicated blocking thread.
-        let handle = std::thread::spawn(move || {
-            let mut output_rx = output_rx;
-            while let Some(chunk) = tokio_runtime.block_on(output_rx.recv()) {
-                if let Err(err) = writer.write_all(&chunk) {
-                    eprintln!("windows sandbox output forwarder failed to write: {err}");
-                    break;
-                }
-                if let Err(err) = writer.flush() {
-                    eprintln!("windows sandbox output forwarder failed to flush: {err}");
-                    break;
-                }
-            }
-            let _ = done_tx.send(());
-        });
-        (handle, done_rx)
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use std::sync::Mutex;
-
-        use pretty_assertions::assert_eq;
-
-        use super::*;
-
-        #[tokio::test]
-        async fn input_forwarder_sends_chunks_and_reports_eof() -> anyhow::Result<()> {
-            let (writer_tx, mut writer_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(4);
-            let (stdin_closed_tx, stdin_closed_rx) = tokio::sync::oneshot::channel();
-            let input = std::io::Cursor::new(b"first\nsecond\n".to_vec());
-
-            let forwarder = spawn_input_forwarder(input, writer_tx, stdin_closed_tx);
-            let mut received = Vec::new();
-            while let Some(chunk) = writer_rx.recv().await {
-                received.extend_from_slice(&chunk);
-            }
-            stdin_closed_rx.await?;
-            forwarder.join().expect("stdin forwarder should finish");
-
-            assert_eq!(received, b"first\nsecond\n".to_vec());
-            Ok(())
-        }
-
-        #[tokio::test]
-        async fn output_forwarder_writes_all_chunks() -> anyhow::Result<()> {
-            #[derive(Clone, Default)]
-            struct SharedWriter(std::sync::Arc<Mutex<Vec<u8>>>);
-
-            impl std::io::Write for SharedWriter {
-                fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-                    let mut guard = self
-                        .0
-                        .lock()
-                        .map_err(|_| std::io::Error::other("writer poisoned"))?;
-                    guard.extend_from_slice(buf);
-                    Ok(buf.len())
-                }
-
-                fn flush(&mut self) -> std::io::Result<()> {
-                    Ok(())
-                }
-            }
-
-            let runtime = tokio::runtime::Handle::current();
-            let (output_tx, output_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(4);
-            let writer = SharedWriter::default();
-            let sink = std::sync::Arc::clone(&writer.0);
-
-            let (forwarder, done_rx) = spawn_output_forwarder(runtime, output_rx, writer);
-            output_tx.send(b"alpha".to_vec()).await?;
-            output_tx.send(b"beta".to_vec()).await?;
-            drop(output_tx);
-            forwarder.join().expect("output forwarder should finish");
-            done_rx.await?;
-
-            let output = sink
-                .lock()
-                .map_err(|_| anyhow::anyhow!("writer poisoned"))?
-                .clone();
-            assert_eq!(output, b"alphabeta".to_vec());
-            Ok(())
-        }
-    }
 }
 
 async fn load_debug_sandbox_config(

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -343,6 +343,7 @@ impl TurnContext {
         FileSystemSandboxContext {
             permissions,
             cwd: Some(cwd.clone()),
+            workspace_roots: self.config.effective_workspace_roots(),
             windows_sandbox_level: self.windows_sandbox_level,
             windows_sandbox_private_desktop: self
                 .config

--- a/codex-rs/core/src/tools/runtimes/apply_patch.rs
+++ b/codex-rs/core/src/tools/runtimes/apply_patch.rs
@@ -99,6 +99,7 @@ impl ApplyPatchRuntime {
         Some(FileSystemSandboxContext {
             permissions,
             cwd: Some(attempt.sandbox_cwd.clone()),
+            workspace_roots: attempt.workspace_roots.to_vec(),
             windows_sandbox_level: attempt.windows_sandbox_level,
             windows_sandbox_private_desktop: attempt.windows_sandbox_private_desktop,
             use_legacy_landlock: attempt.use_legacy_landlock,

--- a/codex-rs/core/src/tools/runtimes/mod_tests.rs
+++ b/codex-rs/core/src/tools/runtimes/mod_tests.rs
@@ -26,7 +26,6 @@ use codex_sandboxing::SandboxType;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_path_uri::PathUri;
 use core_test_support::PathBufExt;
-use core_test_support::PathExt;
 use pretty_assertions::assert_eq;
 use std::path::PathBuf;
 use std::process::Command;

--- a/codex-rs/exec-server/src/fs_sandbox.rs
+++ b/codex-rs/exec-server/src/fs_sandbox.rs
@@ -9,6 +9,7 @@ use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::FileSystemSpecialPath;
 use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_sandboxing::SandboxCommand;
+use codex_sandboxing::SandboxDirectSpawnTransformRequest;
 use codex_sandboxing::SandboxExecRequest;
 use codex_sandboxing::SandboxManager;
 use codex_sandboxing::SandboxTransformRequest;
@@ -112,18 +113,27 @@ impl FileSystemSandboxRunner {
             env: self.helper_env.clone(),
             additional_permissions: None,
         };
+        let workspace_roots = if sandbox_context.workspace_roots.is_empty() {
+            std::slice::from_ref(&cwd.native)
+        } else {
+            sandbox_context.workspace_roots.as_slice()
+        };
         sandbox_manager
-            .transform(SandboxTransformRequest {
-                command,
-                permissions: permission_profile,
-                sandbox,
-                enforce_managed_network: false,
-                network: None,
-                sandbox_policy_cwd: cwd,
-                codex_linux_sandbox_exe: self.runtime_paths.codex_linux_sandbox_exe.as_deref(),
-                use_legacy_landlock: sandbox_context.use_legacy_landlock,
-                windows_sandbox_level: sandbox_context.windows_sandbox_level,
-                windows_sandbox_private_desktop: sandbox_context.windows_sandbox_private_desktop,
+            .transform_for_direct_spawn(SandboxDirectSpawnTransformRequest {
+                workspace_roots,
+                transform: SandboxTransformRequest {
+                    command,
+                    permissions: permission_profile,
+                    sandbox,
+                    enforce_managed_network: false,
+                    network: None,
+                    sandbox_policy_cwd: cwd.as_path(),
+                    codex_linux_sandbox_exe: self.runtime_paths.codex_linux_sandbox_exe.as_deref(),
+                    use_legacy_landlock: sandbox_context.use_legacy_landlock,
+                    windows_sandbox_level: sandbox_context.windows_sandbox_level,
+                    windows_sandbox_private_desktop: sandbox_context
+                        .windows_sandbox_private_desktop,
+                },
             })
             .map_err(|err| invalid_request(format!("failed to prepare fs sandbox: {err}")))
     }

--- a/codex-rs/exec-server/src/fs_sandbox.rs
+++ b/codex-rs/exec-server/src/fs_sandbox.rs
@@ -85,7 +85,7 @@ impl FileSystemSandboxRunner {
             &file_system_policy,
             network_policy,
         );
-        let command = self.sandbox_exec_request(&permission_profile, &cwd.uri, sandbox)?;
+        let command = self.sandbox_exec_request(&permission_profile, &cwd, sandbox)?;
         let request_json = serde_json::to_vec(&request).map_err(json_error)?;
         run_command(command, request_json).await
     }
@@ -93,7 +93,7 @@ impl FileSystemSandboxRunner {
     fn sandbox_exec_request(
         &self,
         permission_profile: &PermissionProfile,
-        cwd: &PathUri,
+        cwd: &SandboxCwd,
         sandbox_context: &FileSystemSandboxContext,
     ) -> Result<SandboxExecRequest, JSONRPCErrorError> {
         let helper = &self.runtime_paths.codex_self_exe;
@@ -109,7 +109,7 @@ impl FileSystemSandboxRunner {
         let command = SandboxCommand {
             program: helper.as_path().as_os_str().to_owned(),
             args: vec![CODEX_FS_HELPER_ARG1.to_string()],
-            cwd: cwd.clone(),
+            cwd: cwd.uri.clone(),
             env: self.helper_env.clone(),
             additional_permissions: None,
         };
@@ -127,7 +127,7 @@ impl FileSystemSandboxRunner {
                     sandbox,
                     enforce_managed_network: false,
                     network: None,
-                    sandbox_policy_cwd: cwd.as_path(),
+                    sandbox_policy_cwd: &cwd.uri,
                     codex_linux_sandbox_exe: self.runtime_paths.codex_linux_sandbox_exe.as_deref(),
                     use_legacy_landlock: sandbox_context.use_legacy_landlock,
                     windows_sandbox_level: sandbox_context.windows_sandbox_level,
@@ -526,15 +526,21 @@ mod tests {
         let runner = FileSystemSandboxRunner::new(runtime_paths);
         let native_cwd = AbsolutePathBuf::current_dir().expect("cwd");
         let cwd = PathUri::from_abs_path(&native_cwd);
-        let file_system_policy =
-            restricted_policy(vec![path_entry(native_cwd, FileSystemAccessMode::Write)]);
+        let file_system_policy = restricted_policy(vec![path_entry(
+            native_cwd.clone(),
+            FileSystemAccessMode::Write,
+        )]);
         let network_policy = NetworkSandboxPolicy::Restricted;
         let permission_profile =
             PermissionProfile::from_runtime_permissions(&file_system_policy, network_policy);
         let sandbox_context = sandbox_context_with_cwd(&file_system_policy, cwd.clone());
+        let sandbox_cwd = SandboxCwd {
+            uri: cwd,
+            native: native_cwd,
+        };
 
         let request = runner
-            .sandbox_exec_request(&permission_profile, &cwd, &sandbox_context)
+            .sandbox_exec_request(&permission_profile, &sandbox_cwd, &sandbox_context)
             .expect("sandbox exec request");
 
         assert_eq!(request.env.get(&path_key), Some(&path));

--- a/codex-rs/file-system/Cargo.toml
+++ b/codex-rs/file-system/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 codex-protocol = { workspace = true }
+codex-utils-absolute-path = { workspace = true }
 codex-utils-path-uri = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 

--- a/codex-rs/file-system/src/lib.rs
+++ b/codex-rs/file-system/src/lib.rs
@@ -7,6 +7,7 @@ use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::FileSystemSpecialPath;
 use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_protocol::protocol::SandboxPolicy;
+use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_path_uri::PathUri;
 use std::future::Future;
 use std::io;
@@ -53,6 +54,8 @@ pub struct FileSystemSandboxContext {
     pub permissions: PermissionProfile,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cwd: Option<PathUri>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub workspace_roots: Vec<AbsolutePathBuf>,
     pub windows_sandbox_level: WindowsSandboxLevel,
     #[serde(default)]
     pub windows_sandbox_private_desktop: bool,
@@ -93,6 +96,7 @@ impl FileSystemSandboxContext {
         Self {
             permissions,
             cwd,
+            workspace_roots: Vec::new(),
             windows_sandbox_level: WindowsSandboxLevel::Disabled,
             windows_sandbox_private_desktop: false,
             use_legacy_landlock: false,
@@ -113,6 +117,7 @@ impl FileSystemSandboxContext {
     pub fn drop_cwd_if_unused(mut self) -> Self {
         if !self.has_cwd_dependent_permissions() {
             self.cwd = None;
+            self.workspace_roots.clear();
         }
         self
     }

--- a/codex-rs/sandboxing/Cargo.toml
+++ b/codex-rs/sandboxing/Cargo.toml
@@ -25,6 +25,10 @@ tracing = { workspace = true, features = ["log"] }
 url = { workspace = true }
 which = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+codex-utils-home-dir = { workspace = true }
+codex-windows-sandbox = { workspace = true }
+
 [dev-dependencies]
 anyhow = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/codex-rs/sandboxing/src/lib.rs
+++ b/codex-rs/sandboxing/src/lib.rs
@@ -11,6 +11,7 @@ pub use bwrap::find_system_bwrap_in_path;
 #[cfg(target_os = "linux")]
 pub use bwrap::system_bwrap_warning;
 pub use manager::SandboxCommand;
+pub use manager::SandboxDirectSpawnTransformRequest;
 pub use manager::SandboxExecRequest;
 pub use manager::SandboxManager;
 pub use manager::SandboxTransformError;
@@ -48,6 +49,10 @@ impl From<SandboxTransformError> for CodexErr {
             SandboxTransformError::SeatbeltUnavailable => CodexErr::UnsupportedOperation(
                 "seatbelt sandbox is only available on macOS".to_string(),
             ),
+            #[cfg(target_os = "windows")]
+            SandboxTransformError::WindowsSandboxPreparation(message) => {
+                CodexErr::UnsupportedOperation(message)
+            }
         }
     }
 }

--- a/codex-rs/sandboxing/src/manager.rs
+++ b/codex-rs/sandboxing/src/manager.rs
@@ -362,11 +362,13 @@ impl SandboxManager {
         &self,
         request: SandboxDirectSpawnTransformRequest<'_>,
     ) -> Result<SandboxExecRequest, SandboxTransformError> {
-        let SandboxDirectSpawnTransformRequest {
-            transform,
-            workspace_roots,
-        } = request;
+        let transform = request.transform;
+        #[cfg(target_os = "windows")]
+        let workspace_roots = request.workspace_roots;
+        #[cfg(target_os = "windows")]
         let mut request = self.transform(transform)?;
+        #[cfg(not(target_os = "windows"))]
+        let request = self.transform(transform)?;
         #[cfg(target_os = "windows")]
         if request.sandbox == SandboxType::WindowsRestrictedToken {
             wrap_windows_sandbox_exec_request_for_direct_spawn(&mut request, workspace_roots)?;

--- a/codex-rs/sandboxing/src/manager.rs
+++ b/codex-rs/sandboxing/src/manager.rs
@@ -21,6 +21,9 @@ use std::ffi::OsString;
 use std::io;
 use std::path::Path;
 
+#[cfg(target_os = "windows")]
+const WINDOWS_SANDBOX_WRAPPER_SETUP_ENV_ALLOWLIST: &[&str] = &["USERNAME", "USERPROFILE"];
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SandboxType {
     None,
@@ -131,6 +134,16 @@ pub struct SandboxTransformRequest<'a> {
     pub windows_sandbox_private_desktop: bool,
 }
 
+/// Bundled arguments for a sandbox transformation whose result will be spawned
+/// directly from argv.
+///
+/// Direct-spawn callers will not run a later platform-specific launcher, so the
+/// returned command must encode any sandbox wrapper it needs.
+pub struct SandboxDirectSpawnTransformRequest<'a> {
+    pub transform: SandboxTransformRequest<'a>,
+    pub workspace_roots: &'a [AbsolutePathBuf],
+}
+
 #[derive(Debug)]
 pub enum SandboxTransformError {
     InvalidCommandCwd {
@@ -146,6 +159,8 @@ pub enum SandboxTransformError {
     Wsl1UnsupportedForBubblewrap,
     #[cfg(not(target_os = "macos"))]
     SeatbeltUnavailable,
+    #[cfg(target_os = "windows")]
+    WindowsSandboxPreparation(String),
 }
 
 impl std::fmt::Display for SandboxTransformError {
@@ -168,6 +183,10 @@ impl std::fmt::Display for SandboxTransformError {
             Self::Wsl1UnsupportedForBubblewrap => write!(f, "{WSL1_BWRAP_WARNING}"),
             #[cfg(not(target_os = "macos"))]
             Self::SeatbeltUnavailable => write!(f, "seatbelt sandbox is only available on macOS"),
+            #[cfg(target_os = "windows")]
+            Self::WindowsSandboxPreparation(err) => {
+                write!(f, "failed to prepare windows sandbox wrapper: {err}")
+            }
         }
     }
 }
@@ -182,6 +201,8 @@ impl std::error::Error for SandboxTransformError {
             Self::Wsl1UnsupportedForBubblewrap => None,
             #[cfg(not(target_os = "macos"))]
             Self::SeatbeltUnavailable => None,
+            #[cfg(target_os = "windows")]
+            Self::WindowsSandboxPreparation(_) => None,
         }
     }
 }
@@ -335,6 +356,84 @@ impl SandboxManager {
             network_sandbox_policy: effective_network_policy,
             arg0: arg0_override,
         })
+    }
+
+    pub fn transform_for_direct_spawn(
+        &self,
+        request: SandboxDirectSpawnTransformRequest<'_>,
+    ) -> Result<SandboxExecRequest, SandboxTransformError> {
+        let SandboxDirectSpawnTransformRequest {
+            transform,
+            workspace_roots,
+        } = request;
+        let mut request = self.transform(transform)?;
+        #[cfg(target_os = "windows")]
+        if request.sandbox == SandboxType::WindowsRestrictedToken {
+            wrap_windows_sandbox_exec_request_for_direct_spawn(&mut request, workspace_roots)?;
+        }
+        Ok(request)
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn wrap_windows_sandbox_exec_request_for_direct_spawn(
+    request: &mut SandboxExecRequest,
+    workspace_roots: &[AbsolutePathBuf],
+) -> Result<(), SandboxTransformError> {
+    let codex_home = codex_utils_home_dir::find_codex_home()
+        .map_err(|err| SandboxTransformError::WindowsSandboxPreparation(err.to_string()))?;
+    let Some(program) = request.command.first_mut() else {
+        return Err(SandboxTransformError::WindowsSandboxPreparation(
+            "sandbox command was empty".to_string(),
+        ));
+    };
+    let source = std::path::PathBuf::from(&program);
+    let helper =
+        codex_windows_sandbox::resolve_exe_for_launch(source.as_path(), codex_home.as_path());
+    *program = helper.to_string_lossy().into_owned();
+
+    let inner_command = std::mem::take(&mut request.command);
+    let mut wrapper_args =
+        codex_windows_sandbox::create_windows_sandbox_command_args_for_permission_profile(
+            inner_command,
+            &request.cwd,
+            workspace_roots,
+            &request.env,
+            &request.permission_profile,
+            request.windows_sandbox_level,
+            request.windows_sandbox_private_desktop,
+            codex_home.as_path(),
+        );
+
+    request.command = Vec::with_capacity(1 + wrapper_args.len());
+    request.command.push(source.to_string_lossy().into_owned());
+    request.command.append(&mut wrapper_args);
+    request.sandbox = SandboxType::None;
+    request.arg0 = None;
+    add_windows_sandbox_wrapper_setup_env(&mut request.env);
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn add_windows_sandbox_wrapper_setup_env(env: &mut HashMap<String, String>) {
+    add_windows_sandbox_wrapper_setup_env_from_vars(env, std::env::vars_os());
+}
+
+#[cfg(target_os = "windows")]
+fn add_windows_sandbox_wrapper_setup_env_from_vars(
+    env: &mut HashMap<String, String>,
+    vars: impl IntoIterator<Item = (std::ffi::OsString, std::ffi::OsString)>,
+) {
+    for (key, value) in vars {
+        let key = key.to_string_lossy().into_owned();
+        if !WINDOWS_SANDBOX_WRAPPER_SETUP_ENV_ALLOWLIST
+            .iter()
+            .any(|allowed| key.eq_ignore_ascii_case(allowed))
+        {
+            continue;
+        }
+        env.retain(|existing, _| !existing.eq_ignore_ascii_case(&key));
+        env.insert(key, value.to_string_lossy().into_owned());
     }
 }
 

--- a/codex-rs/sandboxing/src/manager_tests.rs
+++ b/codex-rs/sandboxing/src/manager_tests.rs
@@ -488,10 +488,11 @@ fn transform_for_direct_spawn_windows_materializes_inner_helper() {
     let configured_helper = helper_dir.path().join("configured-codex-helper.exe");
     std::fs::write(&configured_helper, b"helper").expect("write configured helper");
     let cwd = AbsolutePathBuf::from_absolute_path(helper_dir.path()).expect("absolute cwd");
+    let cwd_uri = PathUri::from_abs_path(&cwd).expect("cwd URI");
     let other_workspace = tempfile::TempDir::new().expect("other workspace");
     let other_workspace_root = AbsolutePathBuf::from_absolute_path(other_workspace.path())
         .expect("absolute other workspace");
-    let workspace_roots = vec![cwd.clone(), other_workspace_root];
+    let workspace_roots = vec![cwd, other_workspace_root];
     let manager = SandboxManager::new();
     let exec_request = manager
         .transform_for_direct_spawn(SandboxDirectSpawnTransformRequest {
@@ -500,7 +501,7 @@ fn transform_for_direct_spawn_windows_materializes_inner_helper() {
                 command: SandboxCommand {
                     program: configured_helper.as_os_str().to_owned(),
                     args: vec!["--codex-run-as-fs-helper".to_string()],
-                    cwd: cwd.clone(),
+                    cwd: cwd_uri.clone(),
                     env: HashMap::from([("Path".to_string(), r"C:\Windows\System32".to_string())]),
                     additional_permissions: None,
                 },
@@ -508,7 +509,7 @@ fn transform_for_direct_spawn_windows_materializes_inner_helper() {
                 sandbox: SandboxType::WindowsRestrictedToken,
                 enforce_managed_network: false,
                 network: None,
-                sandbox_policy_cwd: cwd.as_path(),
+                sandbox_policy_cwd: &cwd_uri,
                 codex_linux_sandbox_exe: None,
                 use_legacy_landlock: false,
                 windows_sandbox_level: WindowsSandboxLevel::RestrictedToken,

--- a/codex-rs/sandboxing/src/manager_tests.rs
+++ b/codex-rs/sandboxing/src/manager_tests.rs
@@ -1,4 +1,5 @@
 use super::SandboxCommand;
+use super::SandboxDirectSpawnTransformRequest;
 use super::SandboxManager;
 use super::SandboxTransformRequest;
 use super::SandboxType;
@@ -409,4 +410,152 @@ fn transform_linux_seccomp_uses_helper_alias_when_launcher_is_not_helper_path() 
     let exec_request = transform_linux_seccomp_request(&codex_linux_sandbox_exe);
 
     assert_eq!(exec_request.arg0, Some("codex-linux-sandbox".to_string()));
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn transform_for_direct_spawn_windows_preserves_only_wrapper_setup_identity() {
+    let mut env = HashMap::from([
+        ("Path".to_string(), r"C:\Windows\System32".to_string()),
+        ("username".to_string(), "wrong-user".to_string()),
+        ("UserProfile".to_string(), r"C:\wrong".to_string()),
+    ]);
+
+    super::add_windows_sandbox_wrapper_setup_env_from_vars(
+        &mut env,
+        [
+            ("USERNAME", "alice"),
+            ("USERPROFILE", r"C:\Users\alice"),
+            ("OPENAI_API_KEY", "secret"),
+        ]
+        .map(|(key, value)| {
+            (
+                std::ffi::OsString::from(key),
+                std::ffi::OsString::from(value),
+            )
+        }),
+    );
+
+    assert_eq!(
+        env,
+        HashMap::from([
+            ("Path".to_string(), r"C:\Windows\System32".to_string()),
+            ("USERNAME".to_string(), "alice".to_string()),
+            ("USERPROFILE".to_string(), r"C:\Users\alice".to_string()),
+        ])
+    );
+}
+
+#[cfg(target_os = "windows")]
+static CODEX_HOME_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(target_os = "windows")]
+struct EnvVarGuard {
+    key: &'static str,
+    original: Option<std::ffi::OsString>,
+}
+
+#[cfg(target_os = "windows")]
+impl EnvVarGuard {
+    fn set(key: &'static str, value: &std::ffi::OsStr) -> Self {
+        let original = std::env::var_os(key);
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, original }
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        unsafe {
+            match &self.original {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn transform_for_direct_spawn_windows_materializes_inner_helper() {
+    let _lock = CODEX_HOME_TEST_LOCK.lock().expect("lock CODEX_HOME test");
+    let codex_home = tempfile::TempDir::new().expect("codex home");
+    let _guard = EnvVarGuard::set("CODEX_HOME", codex_home.path().as_os_str());
+    let helper_dir = tempfile::TempDir::new().expect("helper dir");
+    let configured_helper = helper_dir.path().join("configured-codex-helper.exe");
+    std::fs::write(&configured_helper, b"helper").expect("write configured helper");
+    let cwd = AbsolutePathBuf::from_absolute_path(helper_dir.path()).expect("absolute cwd");
+    let other_workspace = tempfile::TempDir::new().expect("other workspace");
+    let other_workspace_root = AbsolutePathBuf::from_absolute_path(other_workspace.path())
+        .expect("absolute other workspace");
+    let workspace_roots = vec![cwd.clone(), other_workspace_root];
+    let manager = SandboxManager::new();
+    let exec_request = manager
+        .transform_for_direct_spawn(SandboxDirectSpawnTransformRequest {
+            workspace_roots: workspace_roots.as_slice(),
+            transform: SandboxTransformRequest {
+                command: SandboxCommand {
+                    program: configured_helper.as_os_str().to_owned(),
+                    args: vec!["--codex-run-as-fs-helper".to_string()],
+                    cwd: cwd.clone(),
+                    env: HashMap::from([("Path".to_string(), r"C:\Windows\System32".to_string())]),
+                    additional_permissions: None,
+                },
+                permissions: &PermissionProfile::read_only(),
+                sandbox: SandboxType::WindowsRestrictedToken,
+                enforce_managed_network: false,
+                network: None,
+                sandbox_policy_cwd: cwd.as_path(),
+                codex_linux_sandbox_exe: None,
+                use_legacy_landlock: false,
+                windows_sandbox_level: WindowsSandboxLevel::RestrictedToken,
+                windows_sandbox_private_desktop: false,
+            },
+        })
+        .expect("transform for direct spawn");
+
+    let separator_index = exec_request
+        .command
+        .iter()
+        .position(|arg| arg == "--")
+        .expect("wrapper argv separator");
+    let materialized_helper = std::path::PathBuf::from(&exec_request.command[separator_index + 1]);
+    assert_eq!(exec_request.sandbox, SandboxType::None);
+    assert_eq!(
+        exec_request.command.first(),
+        Some(&configured_helper.display().to_string())
+    );
+    assert!(
+        exec_request
+            .command
+            .iter()
+            .any(|arg| arg == "--run-as-windows-sandbox")
+    );
+    assert_eq!(
+        exec_request.command[separator_index + 2],
+        "--codex-run-as-fs-helper"
+    );
+    assert_eq!(
+        exec_request
+            .command
+            .windows(2)
+            .filter_map(|args| {
+                (args[0] == "--workspace-root").then_some(std::path::PathBuf::from(&args[1]))
+            })
+            .collect::<Vec<_>>(),
+        workspace_roots
+            .iter()
+            .map(|root| root.as_path().to_path_buf())
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        materialized_helper
+            .parent()
+            .and_then(std::path::Path::file_name),
+        Some(std::ffi::OsStr::new(".sandbox-bin"))
+    );
+    assert!(materialized_helper.exists());
 }

--- a/codex-rs/sandboxing/src/manager_tests.rs
+++ b/codex-rs/sandboxing/src/manager_tests.rs
@@ -1,4 +1,5 @@
 use super::SandboxCommand;
+#[cfg(target_os = "windows")]
 use super::SandboxDirectSpawnTransformRequest;
 use super::SandboxManager;
 use super::SandboxTransformRequest;
@@ -488,7 +489,7 @@ fn transform_for_direct_spawn_windows_materializes_inner_helper() {
     let configured_helper = helper_dir.path().join("configured-codex-helper.exe");
     std::fs::write(&configured_helper, b"helper").expect("write configured helper");
     let cwd = AbsolutePathBuf::from_absolute_path(helper_dir.path()).expect("absolute cwd");
-    let cwd_uri = PathUri::from_abs_path(&cwd).expect("cwd URI");
+    let cwd_uri = PathUri::from_abs_path(&cwd);
     let other_workspace = tempfile::TempDir::new().expect("other workspace");
     let other_workspace_root = AbsolutePathBuf::from_absolute_path(other_workspace.path())
         .expect("absolute other workspace");

--- a/codex-rs/windows-sandbox-rs/Cargo.toml
+++ b/codex-rs/windows-sandbox-rs/Cargo.toml
@@ -37,7 +37,7 @@ glob = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3"
-tokio = { workspace = true, features = ["sync", "rt"] }
+tokio = { workspace = true, features = ["sync", "rt", "signal", "time"] }
 tracing-appender = { workspace = true }
 windows = { version = "0.58", features = [
     "Win32_Foundation",

--- a/codex-rs/windows-sandbox-rs/src/helper_materialization.rs
+++ b/codex-rs/windows-sandbox-rs/src/helper_materialization.rs
@@ -96,22 +96,26 @@ pub fn resolve_current_exe_for_launch(codex_home: &Path, fallback_executable: &s
         Ok(path) => path,
         Err(_) => return PathBuf::from(fallback_executable),
     };
+    resolve_exe_for_launch(&source, codex_home)
+}
+
+pub fn resolve_exe_for_launch(source: &Path, codex_home: &Path) -> PathBuf {
     let Some(file_name) = source.file_name() else {
-        return source;
+        return source.to_path_buf();
     };
     let destination = helper_bin_dir(codex_home).join(file_name);
-    match copy_from_source_if_needed(&source, &destination) {
+    match copy_from_source_if_needed(source, &destination) {
         Ok(_) => destination,
         Err(err) => {
             let sandbox_log_dir = crate::sandbox_dir(codex_home);
             log_note(
                 &format!(
-                    "helper copy failed for current executable: {err:#}; falling back to legacy path {}",
+                    "helper copy failed for executable: {err:#}; falling back to legacy path {}",
                     source.display()
                 ),
                 Some(&sandbox_log_dir),
             );
-            source
+            source.to_path_buf()
         }
     }
 }

--- a/codex-rs/windows-sandbox-rs/src/lib.rs
+++ b/codex-rs/windows-sandbox-rs/src/lib.rs
@@ -105,7 +105,12 @@ mod setup_error;
 mod spawn_prep;
 
 #[cfg(target_os = "windows")]
+mod stdio_bridge;
+
+#[cfg(target_os = "windows")]
 mod unified_exec;
+#[cfg(target_os = "windows")]
+mod wrapper;
 
 #[cfg(target_os = "windows")]
 pub(crate) use elevated::ipc_framed;
@@ -168,6 +173,8 @@ pub use elevated_impl::ElevatedSandboxProfileCaptureRequest;
 pub use elevated_impl::run_windows_sandbox_capture_for_permission_profile as run_windows_sandbox_capture_for_permission_profile_elevated;
 #[cfg(target_os = "windows")]
 pub use helper_materialization::resolve_current_exe_for_launch;
+#[cfg(target_os = "windows")]
+pub use helper_materialization::resolve_exe_for_launch;
 #[cfg(target_os = "windows")]
 pub use hide_users::hide_current_user_profile_dir;
 #[cfg(target_os = "windows")]
@@ -269,6 +276,8 @@ pub use setup_error::setup_error_path;
 #[cfg(target_os = "windows")]
 pub use setup_error::write_setup_error_report;
 #[cfg(target_os = "windows")]
+pub use stdio_bridge::forward_sandbox_session_stdio;
+#[cfg(target_os = "windows")]
 #[doc(hidden)]
 pub use token::LocalSid;
 #[cfg(target_os = "windows")]
@@ -286,7 +295,11 @@ pub use token::create_workspace_write_token_with_caps_from;
 #[cfg(target_os = "windows")]
 pub use token::get_current_token_for_restriction;
 #[cfg(target_os = "windows")]
+pub use unified_exec::WindowsSandboxSessionRequest;
+#[cfg(target_os = "windows")]
 pub use unified_exec::spawn_windows_sandbox_session_elevated_for_permission_profile;
+#[cfg(target_os = "windows")]
+pub use unified_exec::spawn_windows_sandbox_session_for_level;
 #[cfg(target_os = "windows")]
 pub use unified_exec::spawn_windows_sandbox_session_legacy;
 #[cfg(target_os = "windows")]
@@ -309,6 +322,12 @@ pub use winutil::string_from_sid_bytes;
 pub use winutil::to_wide;
 #[cfg(target_os = "windows")]
 pub use workspace_acl::is_command_cwd_root;
+#[cfg(target_os = "windows")]
+pub use wrapper::CODEX_WINDOWS_SANDBOX_ARG1;
+#[cfg(target_os = "windows")]
+pub use wrapper::create_windows_sandbox_command_args_for_permission_profile;
+#[cfg(target_os = "windows")]
+pub use wrapper::run_windows_sandbox_wrapper_main;
 
 #[cfg(not(target_os = "windows"))]
 pub use stub::CaptureResult;

--- a/codex-rs/windows-sandbox-rs/src/stdio_bridge.rs
+++ b/codex-rs/windows-sandbox-rs/src/stdio_bridge.rs
@@ -1,0 +1,126 @@
+use std::io::Read;
+use std::io::Write;
+use std::sync::Arc;
+use std::time::Duration;
+
+use codex_utils_pty::SpawnedProcess;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+
+/// Forwards this process' stdio to a Windows sandbox session and returns the
+/// session exit code.
+pub async fn forward_sandbox_session_stdio(spawned: SpawnedProcess) -> i32 {
+    let session = Arc::new(spawned.session);
+    let tokio_runtime = tokio::runtime::Handle::current();
+    // Give large or slow tail output a better chance to finish draining without
+    // letting rare EOF issues hang the wrapper indefinitely.
+    let output_drain_timeout = Duration::from_secs(5);
+    // A helper thread watches our stdin. When the input source closes it, the
+    // thread tells the main async code so we can also close stdin for the
+    // sandboxed child process.
+    let (stdin_eof_tx, stdin_eof_rx) = oneshot::channel();
+
+    // Start background threads that copy stdin/stdout/stderr. We intentionally
+    // do not keep their JoinHandles; dropping the handle does not stop the
+    // thread, it just means we are not going to wait on it later.
+    drop(spawn_input_forwarder(
+        std::io::stdin(),
+        session.writer_sender(),
+        stdin_eof_tx,
+    ));
+    let (stdout_forwarder, stdout_forwarder_done_rx) =
+        spawn_output_forwarder(tokio_runtime.clone(), spawned.stdout_rx, std::io::stdout());
+    drop(stdout_forwarder);
+    let (stderr_forwarder, stderr_forwarder_done_rx) =
+        spawn_output_forwarder(tokio_runtime.clone(), spawned.stderr_rx, std::io::stderr());
+    drop(stderr_forwarder);
+
+    let stdin_close_task = tokio::spawn({
+        let session = Arc::clone(&session);
+        async move {
+            let _ = stdin_eof_rx.await;
+            session.close_stdin();
+        }
+    });
+
+    let mut exit_rx = spawned.exit_rx;
+    let exit_code = tokio::select! {
+        res = &mut exit_rx => res.unwrap_or(-1),
+        res = tokio::signal::ctrl_c() => {
+            if let Ok(()) = res {
+                session.request_terminate();
+            }
+            exit_rx.await.unwrap_or(-1)
+        }
+    };
+
+    stdin_close_task.abort();
+    let _ = tokio::time::timeout(output_drain_timeout, async {
+        let _ = stdout_forwarder_done_rx.await;
+        let _ = stderr_forwarder_done_rx.await;
+    })
+    .await;
+    exit_code
+}
+
+fn spawn_input_forwarder<R>(
+    mut input: R,
+    writer_tx: mpsc::Sender<Vec<u8>>,
+    stdin_eof_tx: oneshot::Sender<()>,
+) -> std::thread::JoinHandle<()>
+where
+    R: Read + Send + 'static,
+{
+    const STDIN_FORWARD_CHUNK_SIZE: usize = 8 * 1024;
+    std::thread::spawn(move || {
+        let mut buffer = [0_u8; STDIN_FORWARD_CHUNK_SIZE];
+        loop {
+            match input.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if writer_tx.blocking_send(buffer[..n].to_vec()).is_err() {
+                        break;
+                    }
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(err) => {
+                    eprintln!("windows sandbox stdin forwarder failed: {err}");
+                    break;
+                }
+            }
+        }
+        let _ = stdin_eof_tx.send(());
+    })
+}
+
+fn spawn_output_forwarder<W>(
+    tokio_runtime: tokio::runtime::Handle,
+    output_rx: mpsc::Receiver<Vec<u8>>,
+    mut writer: W,
+) -> (std::thread::JoinHandle<()>, oneshot::Receiver<()>)
+where
+    W: Write + Send + 'static,
+{
+    let (done_tx, done_rx) = oneshot::channel();
+    // The sandbox session emits output on Tokio channels, but writing to the
+    // caller's stdio is simplest from a dedicated blocking thread.
+    let handle = std::thread::spawn(move || {
+        let mut output_rx = output_rx;
+        while let Some(chunk) = tokio_runtime.block_on(output_rx.recv()) {
+            if let Err(err) = writer.write_all(&chunk) {
+                eprintln!("windows sandbox output forwarder failed to write: {err}");
+                break;
+            }
+            if let Err(err) = writer.flush() {
+                eprintln!("windows sandbox output forwarder failed to flush: {err}");
+                break;
+            }
+        }
+        let _ = done_tx.send(());
+    });
+    (handle, done_rx)
+}
+
+#[cfg(test)]
+#[path = "stdio_bridge_tests.rs"]
+mod tests;

--- a/codex-rs/windows-sandbox-rs/src/stdio_bridge_tests.rs
+++ b/codex-rs/windows-sandbox-rs/src/stdio_bridge_tests.rs
@@ -1,0 +1,63 @@
+use std::sync::Mutex;
+
+use pretty_assertions::assert_eq;
+
+use super::*;
+
+#[tokio::test]
+async fn input_forwarder_sends_chunks_and_reports_eof() -> anyhow::Result<()> {
+    let (writer_tx, mut writer_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(4);
+    let (stdin_closed_tx, stdin_closed_rx) = tokio::sync::oneshot::channel();
+    let input = std::io::Cursor::new(b"first\nsecond\n".to_vec());
+
+    let forwarder = spawn_input_forwarder(input, writer_tx, stdin_closed_tx);
+    let mut received = Vec::new();
+    while let Some(chunk) = writer_rx.recv().await {
+        received.extend_from_slice(&chunk);
+    }
+    stdin_closed_rx.await?;
+    forwarder.join().expect("stdin forwarder should finish");
+
+    assert_eq!(received, b"first\nsecond\n".to_vec());
+    Ok(())
+}
+
+#[tokio::test]
+async fn output_forwarder_writes_all_chunks() -> anyhow::Result<()> {
+    #[derive(Clone, Default)]
+    struct SharedWriter(std::sync::Arc<Mutex<Vec<u8>>>);
+
+    impl std::io::Write for SharedWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            let mut guard = self
+                .0
+                .lock()
+                .map_err(|_| std::io::Error::other("writer poisoned"))?;
+            guard.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let runtime = tokio::runtime::Handle::current();
+    let (output_tx, output_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(4);
+    let writer = SharedWriter::default();
+    let sink = std::sync::Arc::clone(&writer.0);
+
+    let (forwarder, done_rx) = spawn_output_forwarder(runtime, output_rx, writer);
+    output_tx.send(b"alpha".to_vec()).await?;
+    output_tx.send(b"beta".to_vec()).await?;
+    drop(output_tx);
+    forwarder.join().expect("output forwarder should finish");
+    done_rx.await?;
+
+    let output = sink
+        .lock()
+        .map_err(|_| anyhow::anyhow!("writer poisoned"))?
+        .clone();
+    assert_eq!(output, b"alphabeta".to_vec());
+    Ok(())
+}

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/mod.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/mod.rs
@@ -10,12 +10,80 @@
 mod backends;
 
 use anyhow::Result;
+use codex_protocol::config_types::WindowsSandboxLevel;
 use codex_protocol::models::PermissionProfile;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_pty::SpawnedProcess;
 use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
+
+/// Fully resolved Windows sandbox session launch request.
+///
+/// Callers should parse their own input shape first, then use this request to
+/// share the elevated-vs-legacy backend selection and session launch path.
+pub struct WindowsSandboxSessionRequest<'a> {
+    pub permission_profile: &'a PermissionProfile,
+    pub workspace_roots: &'a [AbsolutePathBuf],
+    pub codex_home: &'a Path,
+    pub command: Vec<String>,
+    pub cwd: &'a Path,
+    pub env_map: HashMap<String, String>,
+    pub windows_sandbox_level: WindowsSandboxLevel,
+    pub timeout_ms: Option<u64>,
+    pub read_roots_override: Option<&'a [PathBuf]>,
+    pub read_roots_include_platform_defaults: bool,
+    pub write_roots_override: Option<&'a [PathBuf]>,
+    pub deny_read_paths_override: &'a [AbsolutePathBuf],
+    pub deny_write_paths_override: &'a [AbsolutePathBuf],
+    pub tty: bool,
+    pub stdin_open: bool,
+    pub use_private_desktop: bool,
+}
+
+pub async fn spawn_windows_sandbox_session_for_level(
+    request: WindowsSandboxSessionRequest<'_>,
+) -> Result<SpawnedProcess> {
+    match request.windows_sandbox_level {
+        WindowsSandboxLevel::Elevated => {
+            spawn_windows_sandbox_session_elevated_for_permission_profile(
+                request.permission_profile,
+                request.workspace_roots,
+                request.codex_home,
+                request.command,
+                request.cwd,
+                request.env_map,
+                request.timeout_ms,
+                request.read_roots_override,
+                request.read_roots_include_platform_defaults,
+                request.write_roots_override,
+                request.deny_read_paths_override,
+                request.deny_write_paths_override,
+                request.tty,
+                request.stdin_open,
+                request.use_private_desktop,
+            )
+            .await
+        }
+        WindowsSandboxLevel::RestrictedToken | WindowsSandboxLevel::Disabled => {
+            spawn_windows_sandbox_session_legacy(
+                request.permission_profile,
+                request.workspace_roots,
+                request.codex_home,
+                request.command,
+                request.cwd,
+                request.env_map,
+                request.timeout_ms,
+                request.deny_read_paths_override,
+                request.deny_write_paths_override,
+                request.tty,
+                request.stdin_open,
+                request.use_private_desktop,
+            )
+            .await
+        }
+    }
+}
 
 #[allow(clippy::too_many_arguments)]
 pub async fn spawn_windows_sandbox_session_legacy(

--- a/codex-rs/windows-sandbox-rs/src/wrapper.rs
+++ b/codex-rs/windows-sandbox-rs/src/wrapper.rs
@@ -1,0 +1,232 @@
+//! Internal `codex.exe --run-as-windows-sandbox` wrapper.
+//!
+//! This gives direct-spawn callers an argv-shaped Windows sandbox launcher,
+//! analogous to the macOS seatbelt and Linux sandbox wrapper paths. The wrapper
+//! parses sandbox metadata from argv, launches the requested inner command in a
+//! Windows sandbox session, and forwards stdio to that inner command.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use anyhow::bail;
+use codex_protocol::config_types::WindowsSandboxLevel;
+use codex_protocol::models::PermissionProfile;
+use codex_utils_absolute_path::AbsolutePathBuf;
+
+pub const CODEX_WINDOWS_SANDBOX_ARG1: &str = "--run-as-windows-sandbox";
+
+const COMMAND_CWD_FLAG: &str = "--command-cwd";
+const CODEX_HOME_FLAG: &str = "--codex-home";
+const ENV_JSON_FLAG: &str = "--env-json";
+const PERMISSION_PROFILE_FLAG: &str = "--permission-profile";
+const PRIVATE_DESKTOP_FLAG: &str = "--windows-sandbox-private-desktop";
+const SANDBOX_LEVEL_FLAG: &str = "--windows-sandbox-level";
+const WORKSPACE_ROOT_FLAG: &str = "--workspace-root";
+
+#[allow(clippy::too_many_arguments)]
+pub fn create_windows_sandbox_command_args_for_permission_profile(
+    command: Vec<String>,
+    command_cwd: &AbsolutePathBuf,
+    workspace_roots: &[AbsolutePathBuf],
+    env_map: &HashMap<String, String>,
+    permission_profile: &PermissionProfile,
+    windows_sandbox_level: WindowsSandboxLevel,
+    windows_sandbox_private_desktop: bool,
+    codex_home: &Path,
+) -> Vec<String> {
+    let permission_profile_json = serde_json::to_string(permission_profile)
+        .unwrap_or_else(|err| panic!("failed to serialize permission profile: {err}"));
+    let env_json = serde_json::to_string(env_map)
+        .unwrap_or_else(|err| panic!("failed to serialize env: {err}"));
+    let mut args = vec![
+        CODEX_WINDOWS_SANDBOX_ARG1.to_string(),
+        CODEX_HOME_FLAG.to_string(),
+        codex_home.to_string_lossy().into_owned(),
+        COMMAND_CWD_FLAG.to_string(),
+        command_cwd.as_path().to_string_lossy().into_owned(),
+        PERMISSION_PROFILE_FLAG.to_string(),
+        permission_profile_json,
+        ENV_JSON_FLAG.to_string(),
+        env_json,
+        SANDBOX_LEVEL_FLAG.to_string(),
+        windows_sandbox_level.to_string(),
+    ];
+    let workspace_roots = if workspace_roots.is_empty() {
+        std::slice::from_ref(command_cwd)
+    } else {
+        workspace_roots
+    };
+    for root in workspace_roots {
+        args.push(WORKSPACE_ROOT_FLAG.to_string());
+        args.push(root.as_path().to_string_lossy().into_owned());
+    }
+    if windows_sandbox_private_desktop {
+        args.push(PRIVATE_DESKTOP_FLAG.to_string());
+    }
+    args.push("--".to_string());
+    args.extend(command);
+    args
+}
+
+pub fn run_windows_sandbox_wrapper_main() -> ! {
+    let args = std::env::args().skip(2).collect::<Vec<_>>();
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(runtime) => runtime,
+        Err(err) => {
+            eprintln!("windows sandbox failed to build runtime: {err}");
+            std::process::exit(1);
+        }
+    };
+    let exit_code = match runtime.block_on(run_windows_sandbox_wrapper_args(args)) {
+        Ok(exit_code) => exit_code,
+        Err(err) => {
+            eprintln!("windows sandbox failed: {err:#}");
+            1
+        }
+    };
+    std::process::exit(exit_code);
+}
+
+async fn run_windows_sandbox_wrapper_args(args: Vec<String>) -> Result<i32> {
+    let request = parse_windows_sandbox_wrapper_args(args)?;
+    run_windows_sandbox_wrapper_request(request).await
+}
+
+struct WindowsSandboxWrapperRequest {
+    codex_home: PathBuf,
+    command_cwd: AbsolutePathBuf,
+    workspace_roots: Vec<AbsolutePathBuf>,
+    env_map: HashMap<String, String>,
+    permission_profile: PermissionProfile,
+    windows_sandbox_level: WindowsSandboxLevel,
+    windows_sandbox_private_desktop: bool,
+    command: Vec<String>,
+}
+
+async fn run_windows_sandbox_wrapper_request(request: WindowsSandboxWrapperRequest) -> Result<i32> {
+    if request.command.is_empty() {
+        bail!("missing sandboxed command in windows sandbox wrapper request");
+    }
+    let empty_paths: &[AbsolutePathBuf] = &[];
+    let spawned =
+        crate::spawn_windows_sandbox_session_for_level(crate::WindowsSandboxSessionRequest {
+            permission_profile: &request.permission_profile,
+            workspace_roots: request.workspace_roots.as_slice(),
+            codex_home: request.codex_home.as_path(),
+            command: request.command,
+            cwd: request.command_cwd.as_path(),
+            env_map: request.env_map,
+            windows_sandbox_level: request.windows_sandbox_level,
+            timeout_ms: None,
+            read_roots_override: None,
+            read_roots_include_platform_defaults: false,
+            write_roots_override: None,
+            deny_read_paths_override: empty_paths,
+            deny_write_paths_override: empty_paths,
+            tty: false,
+            stdin_open: true,
+            use_private_desktop: request.windows_sandbox_private_desktop,
+        })
+        .await?;
+
+    Ok(crate::forward_sandbox_session_stdio(spawned).await)
+}
+
+fn parse_windows_sandbox_wrapper_args(args: Vec<String>) -> Result<WindowsSandboxWrapperRequest> {
+    let mut args = args.into_iter();
+    let mut codex_home = None;
+    let mut command_cwd = None;
+    let mut workspace_roots = Vec::new();
+    let mut env_map = None;
+    let mut permission_profile = None;
+    let mut windows_sandbox_level = None;
+    let mut windows_sandbox_private_desktop = false;
+    let mut command = None;
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            CODEX_HOME_FLAG => codex_home = Some(PathBuf::from(next_flag_value(&mut args, &arg)?)),
+            COMMAND_CWD_FLAG => {
+                command_cwd = Some(absolute_path_arg(next_flag_value(&mut args, &arg)?, &arg)?);
+            }
+            WORKSPACE_ROOT_FLAG => {
+                workspace_roots.push(absolute_path_arg(next_flag_value(&mut args, &arg)?, &arg)?);
+            }
+            ENV_JSON_FLAG => {
+                let value = next_flag_value(&mut args, &arg)?;
+                env_map = Some(serde_json::from_str(&value).context("failed to parse env json")?);
+            }
+            PERMISSION_PROFILE_FLAG => {
+                let value = next_flag_value(&mut args, &arg)?;
+                permission_profile = Some(
+                    serde_json::from_str(&value).context("failed to parse permission profile")?,
+                );
+            }
+            SANDBOX_LEVEL_FLAG => {
+                let value = next_flag_value(&mut args, &arg)?;
+                windows_sandbox_level = Some(parse_windows_sandbox_level(&value)?);
+            }
+            PRIVATE_DESKTOP_FLAG => windows_sandbox_private_desktop = true,
+            "--" => {
+                command = Some(args.collect::<Vec<_>>());
+                break;
+            }
+            _ => bail!("unexpected windows sandbox wrapper argument: {arg}"),
+        }
+    }
+
+    let codex_home = codex_home.ok_or_else(|| anyhow!("missing required {CODEX_HOME_FLAG}"))?;
+    if !codex_home.is_absolute() {
+        bail!(
+            "{CODEX_HOME_FLAG} must be absolute: {}",
+            codex_home.display()
+        );
+    }
+    let command_cwd = command_cwd.ok_or_else(|| anyhow!("missing required {COMMAND_CWD_FLAG}"))?;
+    if workspace_roots.is_empty() {
+        workspace_roots.push(command_cwd.clone());
+    }
+    Ok(WindowsSandboxWrapperRequest {
+        codex_home,
+        command_cwd,
+        workspace_roots,
+        env_map: env_map.ok_or_else(|| anyhow!("missing required {ENV_JSON_FLAG}"))?,
+        permission_profile: permission_profile
+            .ok_or_else(|| anyhow!("missing required {PERMISSION_PROFILE_FLAG}"))?,
+        windows_sandbox_level: windows_sandbox_level
+            .ok_or_else(|| anyhow!("missing required {SANDBOX_LEVEL_FLAG}"))?,
+        windows_sandbox_private_desktop,
+        command: command.ok_or_else(|| anyhow!("missing sandboxed command separator --"))?,
+    })
+}
+
+fn next_flag_value(args: &mut impl Iterator<Item = String>, flag: &str) -> Result<String> {
+    args.next()
+        .ok_or_else(|| anyhow!("missing value for {flag}"))
+}
+
+fn absolute_path_arg(value: String, flag: &str) -> Result<AbsolutePathBuf> {
+    let path = PathBuf::from(value);
+    AbsolutePathBuf::from_absolute_path(path.as_path())
+        .with_context(|| format!("{flag} must be absolute: {}", path.display()))
+}
+
+fn parse_windows_sandbox_level(value: &str) -> Result<WindowsSandboxLevel> {
+    match value {
+        "disabled" => Ok(WindowsSandboxLevel::Disabled),
+        "restricted-token" => Ok(WindowsSandboxLevel::RestrictedToken),
+        "elevated" => Ok(WindowsSandboxLevel::Elevated),
+        _ => bail!("invalid windows sandbox level: {value}"),
+    }
+}
+
+#[cfg(test)]
+#[path = "wrapper_tests.rs"]
+mod tests;

--- a/codex-rs/windows-sandbox-rs/src/wrapper_tests.rs
+++ b/codex-rs/windows-sandbox-rs/src/wrapper_tests.rs
@@ -1,0 +1,71 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use codex_protocol::config_types::WindowsSandboxLevel;
+use codex_protocol::models::PermissionProfile;
+use codex_protocol::permissions::NetworkSandboxPolicy;
+use codex_utils_absolute_path::AbsolutePathBuf;
+use pretty_assertions::assert_eq;
+
+use super::CODEX_HOME_FLAG;
+use super::CODEX_WINDOWS_SANDBOX_ARG1;
+use super::COMMAND_CWD_FLAG;
+use super::ENV_JSON_FLAG;
+use super::PERMISSION_PROFILE_FLAG;
+use super::PRIVATE_DESKTOP_FLAG;
+use super::SANDBOX_LEVEL_FLAG;
+use super::WORKSPACE_ROOT_FLAG;
+use super::create_windows_sandbox_command_args_for_permission_profile;
+use super::parse_windows_sandbox_wrapper_args;
+
+#[test]
+fn windows_wrapper_args_round_trip() {
+    let command_cwd = AbsolutePathBuf::from_absolute_path(Path::new(r"C:\workspace"))
+        .expect("absolute command cwd");
+    let workspace_roots = vec![
+        command_cwd.clone(),
+        AbsolutePathBuf::from_absolute_path(Path::new(r"D:\other-workspace"))
+            .expect("absolute workspace root"),
+    ];
+    let env = HashMap::from([("Path".to_string(), r"C:\Windows\System32".to_string())]);
+    let permission_profile = PermissionProfile::External {
+        network: NetworkSandboxPolicy::Restricted,
+    };
+
+    let args = create_windows_sandbox_command_args_for_permission_profile(
+        vec![
+            "codex.exe".to_string(),
+            "--codex-run-as-fs-helper".to_string(),
+        ],
+        &command_cwd,
+        workspace_roots.as_slice(),
+        &env,
+        &permission_profile,
+        WindowsSandboxLevel::Elevated,
+        /*windows_sandbox_private_desktop*/ true,
+        Path::new(r"C:\Users\me\.codex"),
+    );
+
+    assert_eq!(args[0], CODEX_WINDOWS_SANDBOX_ARG1);
+    assert!(args.contains(&CODEX_HOME_FLAG.to_string()));
+    assert!(args.contains(&COMMAND_CWD_FLAG.to_string()));
+    assert!(args.contains(&WORKSPACE_ROOT_FLAG.to_string()));
+    assert!(args.contains(&PERMISSION_PROFILE_FLAG.to_string()));
+    assert!(args.contains(&ENV_JSON_FLAG.to_string()));
+    assert!(args.contains(&SANDBOX_LEVEL_FLAG.to_string()));
+    assert!(args.contains(&PRIVATE_DESKTOP_FLAG.to_string()));
+
+    let parsed =
+        parse_windows_sandbox_wrapper_args(args[1..].to_vec()).expect("parse wrapper args");
+
+    assert_eq!(
+        parsed.command,
+        vec!["codex.exe", "--codex-run-as-fs-helper"]
+    );
+    assert_eq!(parsed.command_cwd, command_cwd);
+    assert_eq!(parsed.workspace_roots, workspace_roots);
+    assert_eq!(parsed.env_map, env);
+    assert_eq!(parsed.permission_profile, permission_profile);
+    assert_eq!(parsed.windows_sandbox_level, WindowsSandboxLevel::Elevated);
+    assert_eq!(parsed.windows_sandbox_private_desktop, true);
+}


### PR DESCRIPTION
## Why

The exec-server filesystem helper path is a direct-spawn path: it asks `SandboxManager` for a `SandboxExecRequest`, then launches the returned argv itself. That is safe on macOS/Linux because the transformed argv is a self-contained sandbox wrapper (`sandbox-exec` / `codex-linux-sandbox`). On Windows, the transform result carried `WindowsRestrictedToken` sandbox metadata, but the filesystem helper runner still spawned the helper argv directly.

As a result, Windows filesystem built-ins that route through the fs-helper could run with the parent Codex process permissions instead of the configured Windows sandbox. In practice, that means a helper-backed operation could write where the active permission profile says it should not.

## What Changed

- Added a hidden Windows arg1 wrapper, `--run-as-windows-sandbox`, so direct-spawn callers can receive a self-contained Windows sandbox argv.
- Added `SandboxManager::transform_for_direct_spawn`, which preserves the existing transform behavior for normal command execution but wraps Windows restricted-token requests for direct-spawn callers.
- Updated the fs-helper runner to use the direct-spawn transform.
- Materialized the inner Codex helper executable into `.sandbox-bin` before it is launched by the sandboxed user.
- Moved the Windows sandbox stdio bridge out of the debug CLI path so `codex sandbox windows` and the hidden wrapper share the same forwarding code.
- Carried runtime workspace roots through `FileSystemSandboxContext` so symbolic `:workspace_roots` policies are resolved correctly for the wrapped helper.
- Ensured the outer wrapper setup env gets authoritative `USERNAME` / `USERPROFILE` values while preserving the serialized inner command env.

## Verification

- `just test -p codex-sandboxing transform_for_direct_spawn_windows`
- `just test -p codex-windows-sandbox windows_wrapper_args_round_trip`
- `just test -p codex-exec-server fs_sandbox::tests`
- `just test -p codex-core apply_patch`
- Manual built-binary check: `--run-as-windows-sandbox -- ... --codex-run-as-apply-patch` patched an allowed file and failed to write a denied file.
- Manual built-binary check through `codex exec-server --listen stdio`: `fs/writeFile` wrote inside the allowed root, failed with `Access is denied. (os error 5)` outside it, and used the materialized helper at `.sandbox-bin/codex.exe`.