### PR TITLE
[codex] Reject unusable Git plugin installs

### DIFF
--- a/codex-rs/core-plugins/src/capabilities.rs
+++ b/codex-rs/core-plugins/src/capabilities.rs
@@ -74,6 +74,7 @@ pub(crate) fn resolve_plugin_capabilities<M>(
 fn plugin_has_usable_capabilities<M>(
     capabilities: PluginCapabilities<M>,
     has_skills: bool,
+    has_hooks: bool,
     context: PluginCapabilityContext,
 ) -> bool {
     if !context.apps_route_available() && !app_declarations_are_covered_by_mcp(&capabilities) {
@@ -81,19 +82,20 @@ fn plugin_has_usable_capabilities<M>(
     }
 
     let capabilities = resolve_plugin_capabilities(capabilities, context);
-    has_skills || !capabilities.apps.is_empty() || !capabilities.mcp_servers.is_empty()
+    has_skills || has_hooks || !capabilities.apps.is_empty() || !capabilities.mcp_servers.is_empty()
 }
 
 pub(crate) fn plugin_is_visible_in_marketplace<M>(
     capabilities: PluginCapabilities<M>,
     has_skills: bool,
+    has_hooks: bool,
     context: PluginCapabilityContext,
 ) -> bool {
     if !context.filters_marketplace_plugins() {
         return true;
     }
 
-    plugin_has_usable_capabilities(capabilities, has_skills, context)
+    plugin_has_usable_capabilities(capabilities, has_skills, has_hooks, context)
 }
 
 #[cfg(test)]

--- a/codex-rs/core-plugins/src/capabilities_tests.rs
+++ b/codex-rs/core-plugins/src/capabilities_tests.rs
@@ -44,11 +44,13 @@ fn has_usable_capabilities(
     apps: Vec<AppDeclaration>,
     mcp_servers: impl IntoIterator<Item = (&'static str, i32)>,
     has_skills: bool,
+    has_hooks: bool,
     auth_mode: Option<AuthMode>,
 ) -> bool {
     plugin_has_usable_capabilities(
         capabilities(apps, mcp_servers),
         has_skills,
+        has_hooks,
         PluginCapabilityContext::new(auth_mode, /*plugin_active*/ true),
     )
 }
@@ -57,11 +59,13 @@ fn visible_in_marketplace(
     apps: Vec<AppDeclaration>,
     mcp_servers: impl IntoIterator<Item = (&'static str, i32)>,
     has_skills: bool,
+    has_hooks: bool,
     auth_mode: Option<AuthMode>,
 ) -> bool {
     plugin_is_visible_in_marketplace(
         capabilities(apps, mcp_servers),
         has_skills,
+        has_hooks,
         PluginCapabilityContext::new(auth_mode, /*plugin_active*/ true),
     )
 }
@@ -137,36 +141,49 @@ fn usability_requires_apps_to_be_covered_by_mcp_when_apps_route_is_unavailable()
         vec![app("linear")],
         [],
         /*has_skills*/ false,
+        /*has_hooks*/ false,
         Some(AuthMode::ApiKey)
     ));
     assert!(!has_usable_capabilities(
         vec![app("linear")],
         [],
         /*has_skills*/ true,
+        /*has_hooks*/ false,
         Some(AuthMode::ApiKey)
     ));
     assert!(!has_usable_capabilities(
         vec![app("linear")],
         [("other", 1)],
         /*has_skills*/ false,
+        /*has_hooks*/ false,
         Some(AuthMode::ApiKey)
     ));
     assert!(has_usable_capabilities(
         vec![app("linear")],
         [("linear", 1)],
         /*has_skills*/ false,
+        /*has_hooks*/ false,
         Some(AuthMode::ApiKey)
     ));
     assert!(has_usable_capabilities(
         vec![],
         [("other", 1)],
         /*has_skills*/ false,
+        /*has_hooks*/ false,
         Some(AuthMode::ApiKey)
     ));
     assert!(has_usable_capabilities(
         vec![],
         [],
         /*has_skills*/ true,
+        /*has_hooks*/ false,
+        Some(AuthMode::ApiKey)
+    ));
+    assert!(has_usable_capabilities(
+        vec![],
+        [],
+        /*has_skills*/ false,
+        /*has_hooks*/ true,
         Some(AuthMode::ApiKey)
     ));
 }
@@ -177,12 +194,14 @@ fn usability_keeps_apps_when_apps_route_is_available() {
         vec![app("linear")],
         [],
         /*has_skills*/ false,
+        /*has_hooks*/ false,
         Some(AuthMode::Chatgpt)
     ));
     assert!(has_usable_capabilities(
         vec![app("linear")],
         [("linear", 1)],
         /*has_skills*/ false,
+        /*has_hooks*/ false,
         Some(AuthMode::Chatgpt)
     ));
 }
@@ -193,24 +212,28 @@ fn marketplace_visibility_filters_only_direct_auth_modes() {
         vec![app("linear")],
         [],
         /*has_skills*/ false,
+        /*has_hooks*/ false,
         /*auth_mode*/ None
     ));
     assert!(visible_in_marketplace(
         vec![app("linear")],
         [],
         /*has_skills*/ false,
+        /*has_hooks*/ false,
         Some(AuthMode::Chatgpt)
     ));
     assert!(!visible_in_marketplace(
         vec![app("linear")],
         [],
         /*has_skills*/ false,
+        /*has_hooks*/ false,
         Some(AuthMode::ApiKey)
     ));
     assert!(visible_in_marketplace(
         vec![app("linear")],
         [("linear", 1)],
         /*has_skills*/ false,
+        /*has_hooks*/ false,
         Some(AuthMode::ApiKey)
     ));
 }

--- a/codex-rs/core-plugins/src/declared_capabilities.rs
+++ b/codex-rs/core-plugins/src/declared_capabilities.rs
@@ -1,4 +1,7 @@
+use crate::manifest::PluginManifestHooks;
 use crate::manifest::PluginManifestPaths;
+use codex_config::HooksFile;
+use codex_protocol::protocol::HookEventName;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
@@ -11,12 +14,14 @@ use tracing::warn;
 const DEFAULT_SKILLS_DIR_NAME: &str = "skills";
 const DEFAULT_MCP_CONFIG_FILE: &str = ".mcp.json";
 const DEFAULT_APP_CONFIG_FILE: &str = ".app.json";
+const DEFAULT_HOOKS_CONFIG_FILE: &str = "hooks/hooks.json";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct DeclaredPluginCapabilities {
     pub(crate) skills: HashSet<DeclaredSkill>,
     pub(crate) apps: HashSet<DeclaredApp>,
     pub(crate) mcp: HashSet<DeclaredMcp>,
+    pub(crate) hooks: Vec<DeclaredHook>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -34,6 +39,11 @@ pub(crate) struct DeclaredMcp {
     pub(crate) name: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DeclaredHook {
+    pub(crate) name: String,
+}
+
 pub(crate) fn load_declared_plugin_capabilities(
     plugin_root: &AbsolutePathBuf,
     manifest_paths: &PluginManifestPaths,
@@ -42,6 +52,7 @@ pub(crate) fn load_declared_plugin_capabilities(
         skills: load_declared_plugin_skills(plugin_root, manifest_paths),
         apps: load_declared_plugin_apps(plugin_root.as_path(), manifest_paths),
         mcp: load_declared_plugin_mcp(plugin_root.as_path(), manifest_paths),
+        hooks: load_declared_plugin_hooks(plugin_root.as_path(), manifest_paths),
     }
 }
 
@@ -122,6 +133,70 @@ fn load_declared_plugin_mcp(
     }
 
     mcp
+}
+
+fn load_declared_plugin_hooks(
+    plugin_root: &Path,
+    manifest_paths: &PluginManifestPaths,
+) -> Vec<DeclaredHook> {
+    let hook_files = match &manifest_paths.hooks {
+        Some(PluginManifestHooks::Inline(hooks_files)) => {
+            return hooks_files
+                .iter()
+                .cloned()
+                .flat_map(declared_hooks_from_hooks_file)
+                .collect();
+        }
+        Some(PluginManifestHooks::Paths(paths)) => paths.clone(),
+        None => default_plugin_config_paths(plugin_root, DEFAULT_HOOKS_CONFIG_FILE),
+    };
+
+    let mut hooks = Vec::new();
+    for hook_config_path in hook_files {
+        let Ok(contents) = fs::read_to_string(hook_config_path.as_path()) else {
+            continue;
+        };
+        let parsed = match serde_json::from_str::<HooksFile>(&contents) {
+            Ok(parsed) => parsed,
+            Err(err) => {
+                warn!(
+                    path = %hook_config_path.display(),
+                    "failed to parse plugin hooks config while loading declared capabilities: {err}"
+                );
+                continue;
+            }
+        };
+
+        hooks.extend(declared_hooks_from_hooks_file(parsed));
+    }
+
+    hooks
+}
+
+fn declared_hooks_from_hooks_file(hooks_file: HooksFile) -> Vec<DeclaredHook> {
+    hooks_file
+        .hooks
+        .into_matcher_groups()
+        .into_iter()
+        .filter(|(_, groups)| !groups.is_empty())
+        .map(|(event, _)| {
+            let name = match event {
+                HookEventName::PreToolUse => "PreToolUse",
+                HookEventName::PermissionRequest => "PermissionRequest",
+                HookEventName::PostToolUse => "PostToolUse",
+                HookEventName::PreCompact => "PreCompact",
+                HookEventName::PostCompact => "PostCompact",
+                HookEventName::SessionStart => "SessionStart",
+                HookEventName::UserPromptSubmit => "UserPromptSubmit",
+                HookEventName::SubagentStart => "SubagentStart",
+                HookEventName::SubagentStop => "SubagentStop",
+                HookEventName::Stop => "Stop",
+            };
+            DeclaredHook {
+                name: name.to_string(),
+            }
+        })
+        .collect()
 }
 
 fn plugin_app_config_paths(

--- a/codex-rs/core-plugins/src/declared_capabilities_tests.rs
+++ b/codex-rs/core-plugins/src/declared_capabilities_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
+use crate::manifest::PluginManifestHooks;
 use crate::manifest::PluginManifestPaths;
+use codex_config::HooksFile;
 use pretty_assertions::assert_eq;
 use std::fs;
 use std::path::Path;
@@ -48,11 +50,22 @@ fn sorted_mcp_server_names(capabilities: &DeclaredPluginCapabilities) -> Vec<Str
     names
 }
 
+fn sorted_hook_names(capabilities: &DeclaredPluginCapabilities) -> Vec<String> {
+    let mut names = capabilities
+        .hooks
+        .iter()
+        .map(|hook| hook.name.clone())
+        .collect::<Vec<_>>();
+    names.sort();
+    names
+}
+
 #[test]
 fn loads_default_declared_capability_paths() {
     let tmp = TempDir::new().unwrap();
     let plugin_root = tmp.path().join("plugin");
     fs::create_dir_all(plugin_root.join("skills/example")).unwrap();
+    fs::create_dir_all(plugin_root.join("hooks")).unwrap();
     fs::write(
         plugin_root.join(".app.json"),
         r#"{
@@ -82,6 +95,19 @@ fn loads_default_declared_capability_paths() {
 }"#,
     )
     .unwrap();
+    fs::write(
+        plugin_root.join("hooks/hooks.json"),
+        r#"{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [{ "type": "command", "command": "echo session" }]
+      }
+    ]
+  }
+}"#,
+    )
+    .unwrap();
 
     let capabilities =
         load_declared_plugin_capabilities(&absolute_path(&plugin_root), &empty_manifest_paths());
@@ -95,6 +121,10 @@ fn loads_default_declared_capability_paths() {
         sorted_mcp_server_names(&capabilities),
         vec!["docs".to_string(), "linear".to_string()]
     );
+    assert_eq!(
+        sorted_hook_names(&capabilities),
+        vec!["SessionStart".to_string()]
+    );
 }
 
 #[test]
@@ -102,6 +132,7 @@ fn manifest_paths_replace_default_declared_capability_paths() {
     let tmp = TempDir::new().unwrap();
     let plugin_root = tmp.path().join("plugin");
     fs::create_dir_all(plugin_root.join("configured")).unwrap();
+    fs::create_dir_all(plugin_root.join("hooks")).unwrap();
     fs::write(
         plugin_root.join(".app.json"),
         r#"{"apps":{"default_app":{"id":"connector_default"}}}"#,
@@ -112,8 +143,14 @@ fn manifest_paths_replace_default_declared_capability_paths() {
         r#"{"mcpServers":{"default_mcp":{"command":"default-mcp"}}}"#,
     )
     .unwrap();
+    fs::write(
+        plugin_root.join("hooks/hooks.json"),
+        r#"{"hooks":{"SessionStart":[{"hooks":[{"type":"command","command":"echo default"}]}]}}"#,
+    )
+    .unwrap();
     let configured_apps = plugin_root.join("configured/apps.json");
     let configured_mcp = plugin_root.join("configured/mcp.json");
+    let configured_hooks = plugin_root.join("configured/hooks.json");
     fs::write(
         &configured_apps,
         r#"{"apps":{"configured_app":{"id":"connector_configured"}}}"#,
@@ -124,12 +161,19 @@ fn manifest_paths_replace_default_declared_capability_paths() {
         r#"{"configured_mcp":{"command":"configured-mcp"}}"#,
     )
     .unwrap();
+    fs::write(
+        &configured_hooks,
+        r#"{"hooks":{"PostToolUse":[{"hooks":[{"type":"command","command":"echo configured"}]}]}}"#,
+    )
+    .unwrap();
 
     let manifest_paths = PluginManifestPaths {
         skills: Some(absolute_path(plugin_root.join("configured").join("skills"))),
         apps: Some(absolute_path(configured_apps)),
         mcp_servers: Some(absolute_path(configured_mcp)),
-        hooks: None,
+        hooks: Some(PluginManifestHooks::Paths(vec![absolute_path(
+            configured_hooks,
+        )])),
     };
 
     let capabilities =
@@ -153,4 +197,38 @@ fn manifest_paths_replace_default_declared_capability_paths() {
         sorted_mcp_server_names(&capabilities),
         vec!["configured_mcp".to_string()]
     );
+    assert_eq!(
+        sorted_hook_names(&capabilities),
+        vec!["PostToolUse".to_string()]
+    );
+}
+
+#[test]
+fn loads_inline_declared_hooks() {
+    let tmp = TempDir::new().unwrap();
+    let plugin_root = tmp.path().join("plugin");
+    let hooks_file = serde_json::from_str::<HooksFile>(
+        r#"{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [{ "type": "command", "command": "echo stop" }]
+      }
+    ]
+  }
+}"#,
+    )
+    .unwrap();
+
+    let manifest_paths = PluginManifestPaths {
+        skills: None,
+        apps: None,
+        mcp_servers: None,
+        hooks: Some(PluginManifestHooks::Inline(vec![hooks_file])),
+    };
+
+    let capabilities =
+        load_declared_plugin_capabilities(&absolute_path(&plugin_root), &manifest_paths);
+
+    assert_eq!(sorted_hook_names(&capabilities), vec!["Stop".to_string()]);
 }

--- a/codex-rs/core-plugins/src/manager.rs
+++ b/codex-rs/core-plugins/src/manager.rs
@@ -32,6 +32,7 @@ use crate::marketplace::ResolvedMarketplacePlugin;
 use crate::marketplace::find_installable_marketplace_plugin;
 use crate::marketplace::find_marketplace_plugin;
 use crate::marketplace::list_marketplaces;
+use crate::marketplace::marketplace_plugin_root_is_visible;
 use crate::marketplace::plugin_interface_with_marketplace_category;
 use crate::marketplace_upgrade::ConfiguredMarketplaceUpgradeError;
 use crate::marketplace_upgrade::ConfiguredMarketplaceUpgradeOutcome;
@@ -931,11 +932,21 @@ impl PluginsManager {
             };
         let store = self.store.clone();
         let codex_home = self.codex_home.clone();
+        let auth_mode = self.auth_mode();
         let result: StorePluginInstallResult = tokio::task::spawn_blocking(move || {
             let materialized =
                 materialize_marketplace_plugin_source(codex_home.as_path(), &resolved.source)
                     .map_err(PluginStoreError::Invalid)?;
             let source_path = materialized.path;
+            if !marketplace_plugin_root_is_visible(
+                &source_path,
+                MarketplaceLoadContext::for_auth(auth_mode),
+            ) {
+                return Err(PluginStoreError::Invalid(format!(
+                    "plugin `{}` does not declare usable capabilities for the current authentication mode",
+                    resolved.plugin_id.as_key()
+                )));
+            }
             if let Some(plugin_version) = plugin_version {
                 store.install_with_version(source_path, resolved.plugin_id, plugin_version)
             } else {

--- a/codex-rs/core-plugins/src/manager_tests.rs
+++ b/codex-rs/core-plugins/src/manager_tests.rs
@@ -2106,6 +2106,82 @@ async fn install_plugin_rejects_git_sources_without_capabilities_for_auth_mode()
 }
 
 #[tokio::test]
+async fn install_plugin_allows_git_sources_with_hooks_for_auth_mode() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo_root = tmp.path().join("marketplace");
+    let remote_repo = tmp.path().join("remote-plugin-repo");
+    let remote_repo_url = url::Url::from_directory_path(&remote_repo)
+        .unwrap()
+        .to_string();
+    fs::create_dir_all(repo_root.join(".git")).unwrap();
+    fs::create_dir_all(repo_root.join(".agents/plugins")).unwrap();
+    let remote_plugin_root = remote_repo.join("plugins/hooks");
+    write_file(
+        &remote_plugin_root.join(".codex-plugin/plugin.json"),
+        r#"{"name":"hooks"}"#,
+    );
+    write_file(
+        &remote_plugin_root.join("hooks/hooks.json"),
+        r#"{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [{ "type": "command", "command": "echo hooks" }]
+      }
+    ]
+  }
+}"#,
+    );
+    init_git_repo(&remote_repo);
+    fs::write(
+        repo_root.join(".agents/plugins/marketplace.json"),
+        format!(
+            r#"{{
+  "name": "debug",
+  "plugins": [
+    {{
+      "name": "hooks",
+      "source": {{
+        "source": "git-subdir",
+        "url": "{remote_repo_url}",
+        "path": "plugins/hooks"
+      }}
+    }}
+  ]
+}}"#
+        ),
+    )
+    .unwrap();
+
+    let result = PluginsManager::new_with_options(
+        tmp.path().to_path_buf(),
+        Some(Product::Codex),
+        Some(AuthMode::ApiKey),
+    )
+    .install_plugin(PluginInstallRequest {
+        plugin_name: "hooks".to_string(),
+        marketplace_path: AbsolutePathBuf::try_from(
+            repo_root.join(".agents/plugins/marketplace.json"),
+        )
+        .unwrap(),
+    })
+    .await
+    .unwrap();
+
+    let installed_path = tmp.path().join("plugins/cache/debug/hooks/local");
+    assert_eq!(
+        result,
+        PluginInstallOutcome {
+            plugin_id: PluginId::new("hooks".to_string(), "debug".to_string()).unwrap(),
+            plugin_version: "local".to_string(),
+            installed_path: AbsolutePathBuf::try_from(installed_path.clone()).unwrap(),
+            auth_policy: MarketplacePluginAuthPolicy::OnInstall,
+        }
+    );
+    assert!(installed_path.join("hooks/hooks.json").is_file());
+}
+
+#[tokio::test]
 async fn install_plugin_supports_relative_git_subdir_marketplace_sources() {
     let tmp = tempfile::tempdir().unwrap();
     let repo_root = tmp.path().join("marketplace");

--- a/codex-rs/core-plugins/src/manager_tests.rs
+++ b/codex-rs/core-plugins/src/manager_tests.rs
@@ -2043,6 +2043,69 @@ async fn install_plugin_supports_git_subdir_marketplace_sources() {
 }
 
 #[tokio::test]
+async fn install_plugin_rejects_git_sources_without_capabilities_for_auth_mode() {
+    let tmp = tempfile::tempdir().unwrap();
+    let repo_root = tmp.path().join("marketplace");
+    let remote_repo = tmp.path().join("remote-plugin-repo");
+    let remote_repo_url = url::Url::from_directory_path(&remote_repo)
+        .unwrap()
+        .to_string();
+    fs::create_dir_all(repo_root.join(".git")).unwrap();
+    fs::create_dir_all(repo_root.join(".agents/plugins")).unwrap();
+    let remote_plugin_root = remote_repo.join("plugins/linear");
+    write_file(
+        &remote_plugin_root.join(".codex-plugin/plugin.json"),
+        r#"{"name":"linear"}"#,
+    );
+    write_file(
+        &remote_plugin_root.join(".app.json"),
+        r#"{"apps":{"linear":{"id":"connector_linear"}}}"#,
+    );
+    init_git_repo(&remote_repo);
+    fs::write(
+        repo_root.join(".agents/plugins/marketplace.json"),
+        format!(
+            r#"{{
+  "name": "debug",
+  "plugins": [
+    {{
+      "name": "linear",
+      "source": {{
+        "source": "git-subdir",
+        "url": "{remote_repo_url}",
+        "path": "plugins/linear"
+      }}
+    }}
+  ]
+}}"#
+        ),
+    )
+    .unwrap();
+
+    let err = PluginsManager::new_with_options(
+        tmp.path().to_path_buf(),
+        Some(Product::Codex),
+        Some(AuthMode::ApiKey),
+    )
+    .install_plugin(PluginInstallRequest {
+        plugin_name: "linear".to_string(),
+        marketplace_path: AbsolutePathBuf::try_from(
+            repo_root.join(".agents/plugins/marketplace.json"),
+        )
+        .unwrap(),
+    })
+    .await
+    .unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        "plugin `linear@debug` does not declare usable capabilities for the current authentication mode"
+    );
+    assert!(!tmp.path().join("plugins/cache/debug/linear/local").exists());
+    assert!(!tmp.path().join(CONFIG_TOML_FILE).exists());
+}
+
+#[tokio::test]
 async fn install_plugin_supports_relative_git_subdir_marketplace_sources() {
     let tmp = tempfile::tempdir().unwrap();
     let repo_root = tmp.path().join("marketplace");

--- a/codex-rs/core-plugins/src/marketplace.rs
+++ b/codex-rs/core-plugins/src/marketplace.rs
@@ -597,6 +597,7 @@ pub(crate) fn marketplace_plugin_root_is_visible(
 
     let declared_capabilities = load_declared_plugin_capabilities(plugin_root, &manifest.paths);
     let has_skills = !declared_capabilities.skills.is_empty();
+    let has_hooks = !declared_capabilities.hooks.is_empty();
     let apps = declared_capabilities
         .apps
         .into_iter()
@@ -614,6 +615,7 @@ pub(crate) fn marketplace_plugin_root_is_visible(
     plugin_is_visible_in_marketplace(
         PluginCapabilities::new(apps, mcp_servers),
         has_skills,
+        has_hooks,
         capability_context,
     )
 }

--- a/codex-rs/core-plugins/src/marketplace.rs
+++ b/codex-rs/core-plugins/src/marketplace.rs
@@ -571,25 +571,31 @@ fn marketplace_plugin_is_visible(
     plugin: &ResolvedMarketplacePlugin,
     context: MarketplaceLoadContext,
 ) -> bool {
-    let capability_context =
-        PluginCapabilityContext::new(context.auth_mode, /*plugin_active*/ true);
-    if !capability_context.filters_marketplace_plugins() {
-        return true;
-    }
-
     let MarketplacePluginSource::Local { path } = &plugin.source else {
         // Remote Git entries are not materialized while listing marketplaces, so keep them visible
         // until install/read flows have a local plugin root to inspect.
         return true;
     };
 
-    let Some(manifest) = &plugin.manifest else {
-        // Preserve existing marketplace behavior for local entries that do not expose a readable
-        // plugin manifest; the marketplace loader cannot prove these are unusable.
+    marketplace_plugin_root_is_visible(path, context)
+}
+
+pub(crate) fn marketplace_plugin_root_is_visible(
+    plugin_root: &AbsolutePathBuf,
+    context: MarketplaceLoadContext,
+) -> bool {
+    let capability_context =
+        PluginCapabilityContext::new(context.auth_mode, /*plugin_active*/ true);
+    if !capability_context.filters_marketplace_plugins() {
+        return true;
+    }
+
+    let Some(manifest) = load_plugin_manifest(plugin_root.as_path()) else {
+        // Preserve existing validation errors for missing or invalid plugin manifests.
         return true;
     };
 
-    let declared_capabilities = load_declared_plugin_capabilities(path, &manifest.paths);
+    let declared_capabilities = load_declared_plugin_capabilities(plugin_root, &manifest.paths);
     let has_skills = !declared_capabilities.skills.is_empty();
     let apps = declared_capabilities
         .apps


### PR DESCRIPTION
## Summary

Adds an install-time capability recheck after remote Git marketplace plugins are materialized.

## Why

Remote Git marketplace entries have to remain visible before install because their plugin roots are not available to inspect. Once install clones/materializes the source, API-key sessions should reject plugins that declare no usable capabilities for that auth mode instead of installing an enabled plugin that later projects down to nothing.

## Changes

- Reuses marketplace capability visibility policy for materialized plugin roots.
- Runs that policy before `store.install` in the install path.
- Adds a Git-source regression test for an app-only remote plugin under API-key auth, including assertions that cache/config are not written.

## Validation

- `cargo fmt --manifest-path codex-rs/Cargo.toml --package codex-core-plugins`
- `cargo test --manifest-path codex-rs/Cargo.toml -p codex-core-plugins`
- `git diff --check`

Stacked on #27904.