### PR TITLE
[codex] Reference writable roots from environment context

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/turn_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start.rs
@@ -2573,26 +2573,25 @@ stream_max_retries = 0
 
     let requests = response_mock.requests();
     assert_eq!(requests.len(), 2, "expected two Responses API requests");
-    let latest_permissions_instructions =
-        |request: &core_test_support::responses::ResponsesRequest| {
-            request
-                .message_input_texts("developer")
-                .into_iter()
-                .rev()
-                .find(|text| text.contains("<permissions instructions>"))
-                .expect("permissions instructions")
-        };
-    let first_permissions = latest_permissions_instructions(&requests[0]);
-    assert!(first_permissions.contains(&old_root_text));
+    let latest_environment_context = |request: &core_test_support::responses::ResponsesRequest| {
+        request
+            .message_input_texts("user")
+            .into_iter()
+            .rev()
+            .find(|text| text.contains("<environment_context>"))
+            .expect("environment context")
+    };
+    let first_environment_context = latest_environment_context(&requests[0]);
+    assert!(first_environment_context.contains(&old_root_text));
     assert!(
-        !first_permissions.contains(&new_root_text),
+        !first_environment_context.contains(&new_root_text),
         "first turn should materialize the initial runtime workspace root"
     );
 
-    let second_permissions = latest_permissions_instructions(&requests[1]);
-    assert!(second_permissions.contains(&new_root_text));
+    let second_environment_context = latest_environment_context(&requests[1]);
+    assert!(second_environment_context.contains(&new_root_text));
     assert!(
-        !second_permissions.contains(&old_root_text),
+        !second_environment_context.contains(&old_root_text),
         "second turn should rebind :workspace_roots to the updated runtime workspace root"
     );
 

--- a/codex-rs/core/tests/suite/permissions_messages.rs
+++ b/codex-rs/core/tests/suite/permissions_messages.rs
@@ -510,7 +510,7 @@ async fn resume_and_fork_append_permissions_messages() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn permissions_message_includes_writable_roots() -> Result<()> {
+async fn permissions_message_references_environment_context_for_writable_roots() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
@@ -576,6 +576,10 @@ async fn permissions_message_includes_writable_roots() -> Result<()> {
         .map(|s| normalize_line_endings(s))
         .collect();
     assert_eq!(actual_normalized, vec![expected_normalized]);
+    assert!(permissions[0].contains(
+        "Filesystem access is specified by `<entry>` rules in the `<filesystem>` section of `<environment_context>`. An entry's `access` attribute indicates whether its path is readable, writable, or denied. More-specific rules may restrict access within broader paths."
+    ));
+    assert!(!permissions[0].contains(writable_root.to_string_lossy().as_ref()));
 
     Ok(())
 }

--- a/codex-rs/prompts/src/permissions_instructions.rs
+++ b/codex-rs/prompts/src/permissions_instructions.rs
@@ -259,21 +259,13 @@ fn sandbox_text(mode: SandboxMode, network_access: NetworkAccess) -> String {
 }
 
 fn writable_roots_text(writable_roots: Option<Vec<WritableRoot>>) -> Option<String> {
-    let mut roots = writable_roots?;
-    if roots.is_empty() {
+    if writable_roots?.is_empty() {
         return None;
     }
-    roots.sort_by(|left, right| left.root.as_path().cmp(right.root.as_path()));
-
-    let roots_list: Vec<String> = roots
-        .iter()
-        .map(|r| format!("`{}`", r.root.to_string_lossy()))
-        .collect();
-    Some(if roots_list.len() == 1 {
-        format!(" The writable root is {}.", roots_list[0])
-    } else {
-        format!(" The writable roots are {}.", roots_list.join(", "))
-    })
+    Some(
+        "Filesystem access is specified by `<entry>` rules in the `<filesystem>` section of `<environment_context>`. An entry's `access` attribute indicates whether its path is readable, writable, or denied. More-specific rules may restrict access within broader paths."
+            .to_string(),
+    )
 }
 
 fn denied_reads_text(file_system_policy: &FileSystemSandboxPolicy, cwd: &Path) -> Option<String> {

--- a/codex-rs/prompts/src/permissions_instructions_tests.rs
+++ b/codex-rs/prompts/src/permissions_instructions_tests.rs
@@ -81,7 +81,10 @@ fn builds_permissions_from_profile() {
     let text = instructions.body();
     assert!(text.contains("`sandbox_mode` is `workspace-write`"));
     assert!(text.contains("Network access is enabled."));
-    assert!(text.contains(writable_root.to_string_lossy().as_ref()));
+    assert!(text.contains(
+        "Filesystem access is specified by `<entry>` rules in the `<filesystem>` section of `<environment_context>`. An entry's `access` attribute indicates whether its path is readable, writable, or denied. More-specific rules may restrict access within broader paths."
+    ));
+    assert!(!text.contains(writable_root.to_string_lossy().as_ref()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Writable roots are already present in the structured `<filesystem>` environment context. Lets deduplicate this context.

- stop listing writable-root paths in the developer permissions message
- replace that list with a reference to `<environment_context><filesystem>`
- preserve the existing sandbox-mode, network-access, approval, and denied-read guidance

## Validation
- [x] Updated unit tests