### PR TITLE
Specify platform support in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,3 +297,7 @@ This project uses Python 3+. You should not use the `__future__` module.
 
 If you need to worry about feature compatibility between different 3.xx point releases, check the
 closest `pyproject.toml`'s `requires-python` field to see what minimum runtime version is supported.
+
+## Platform Support
+
+Tests and features must support Linux, macOS and Windows unless feature is explicitly OS-specific.


### PR DESCRIPTION
Codex seems to do interesting things with `cfg`'s sometimes and it seems it would be good to give it guidance about how broadly our Rust needs to work.

This adds a very brief section to AGENTS.md explaining that we target the major desktop OSes and that we want the vast majority of our logic to be portable across them.