### PR TITLE
Show standalone image generation as active TUI status

### DIFF
--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__standalone_image_generation_status.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__standalone_image_generation_status.snap
@@ -1,0 +1,12 @@
+---
+source: tui/src/chatwidget/tests/exec_flow.rs
+assertion_line: 917
+expression: normalized_backend_snapshot(terminal.backend())
+---
+"                                                                                "
+"• Generating image (0s • esc to interrupt)                                      "
+"                                                                                "
+"                                                                                "
+"› Ask Codex to do anything                                                      "
+"                                                                                "
+"  gpt-5.5 default · /tmp/project                                                "

--- a/codex-rs/tui/src/chatwidget/tests/exec_flow.rs
+++ b/codex-rs/tui/src/chatwidget/tests/exec_flow.rs
@@ -895,9 +895,11 @@ async fn image_generation_call_adds_history_cell() {
 }
 
 #[tokio::test]
-async fn standalone_image_generation_started_updates_status() {
+async fn standalone_image_generation_started_restores_hidden_status() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
     handle_turn_started(&mut chat, "turn-1");
+    chat.bottom_pane.hide_status_indicator();
+    assert!(!chat.bottom_pane.status_indicator_visible());
 
     handle_image_generation_started(&mut chat, "call-image-generation");
     assert_eq!(chat.status_state.current_status.header, "Generating image");
@@ -906,7 +908,6 @@ async fn standalone_image_generation_started_updates_status() {
         .status_widget()
         .expect("status indicator should be visible");
     assert_eq!(status.header(), "Generating image");
-    assert!(chat.transcript.active_cell.is_none());
 
     let height = chat.desired_height(/*width*/ 80);
     let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(80, height))
@@ -918,6 +919,27 @@ async fn standalone_image_generation_started_updates_status() {
         "standalone_image_generation_status",
         normalized_backend_snapshot(terminal.backend())
     );
+}
+
+#[tokio::test]
+async fn standalone_image_generation_preserves_background_wait_status() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    handle_turn_started(&mut chat, "turn-1");
+    begin_unified_exec_startup(&mut chat, "call-exec", "process-1", "just fix");
+    terminal_interaction(&mut chat, "call-wait", "process-1", "");
+    let expected_status = chat.status_state.current_status.clone();
+
+    handle_image_generation_started(&mut chat, "call-image-generation");
+    assert_eq!(chat.status_state.current_status, expected_status);
+    handle_image_generation_end(
+        &mut chat,
+        "call-image-generation",
+        "completed",
+        /*revised_prompt*/ None,
+        /*saved_path*/ None,
+    );
+
+    assert_eq!(chat.status_state.current_status, expected_status);
 }
 
 #[tokio::test]

--- a/codex-rs/tui/src/chatwidget/tests/exec_flow.rs
+++ b/codex-rs/tui/src/chatwidget/tests/exec_flow.rs
@@ -895,6 +895,32 @@ async fn image_generation_call_adds_history_cell() {
 }
 
 #[tokio::test]
+async fn standalone_image_generation_started_updates_status() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    handle_turn_started(&mut chat, "turn-1");
+
+    handle_image_generation_started(&mut chat, "call-image-generation");
+    assert_eq!(chat.status_state.current_status.header, "Generating image");
+    let status = chat
+        .bottom_pane
+        .status_widget()
+        .expect("status indicator should be visible");
+    assert_eq!(status.header(), "Generating image");
+    assert!(chat.transcript.active_cell.is_none());
+
+    let height = chat.desired_height(/*width*/ 80);
+    let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(80, height))
+        .expect("create terminal");
+    terminal
+        .draw(|f| chat.render(f.area(), f.buffer_mut()))
+        .expect("draw image generation status");
+    assert_chatwidget_snapshot!(
+        "standalone_image_generation_status",
+        normalized_backend_snapshot(terminal.backend())
+    );
+}
+
+#[tokio::test]
 async fn exec_history_extends_previous_when_consecutive() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
 

--- a/codex-rs/tui/src/chatwidget/tests/helpers.rs
+++ b/codex-rs/tui/src/chatwidget/tests/helpers.rs
@@ -715,6 +715,24 @@ pub(super) fn handle_image_generation_end(
     );
 }
 
+pub(super) fn handle_image_generation_started(chat: &mut ChatWidget, call_id: impl Into<String>) {
+    chat.handle_server_notification(
+        ServerNotification::ItemStarted(ItemStartedNotification {
+            thread_id: thread_id(chat),
+            turn_id: "turn-1".to_string(),
+            started_at_ms: 0,
+            item: AppServerThreadItem::ImageGeneration {
+                id: call_id.into(),
+                status: "in_progress".to_string(),
+                revised_prompt: None,
+                result: String::new(),
+                saved_path: None,
+            },
+        }),
+        /*replay_kind*/ None,
+    );
+}
+
 pub(super) fn replay_user_message_inputs(
     chat: &mut ChatWidget,
     item_id: &str,

--- a/codex-rs/tui/src/chatwidget/tests/mcp_startup.rs
+++ b/codex-rs/tui/src/chatwidget/tests/mcp_startup.rs
@@ -140,6 +140,27 @@ async fn mcp_startup_complete_does_not_clear_running_task() {
 }
 
 #[tokio::test]
+async fn image_generation_completion_preserves_newer_mcp_startup_status() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    handle_turn_started(&mut chat, "turn-1");
+    handle_image_generation_started(&mut chat, "call-image-generation");
+
+    notify_mcp_status(&mut chat, "schaltwerk", McpServerStartupState::Starting);
+    assert!(chat.status_header_is_mcp_startup_owned());
+    let expected_status = chat.status_state.current_status.clone();
+
+    handle_image_generation_end(
+        &mut chat,
+        "call-image-generation",
+        "completed",
+        /*revised_prompt*/ None,
+        /*saved_path*/ None,
+    );
+
+    assert_eq!(chat.status_state.current_status, expected_status);
+}
+
+#[tokio::test]
 async fn turn_start_preserves_active_mcp_startup_header() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
     chat.set_mcp_startup_expected_servers(["schaltwerk".to_string()]);

--- a/codex-rs/tui/src/chatwidget/tool_lifecycle.rs
+++ b/codex-rs/tui/src/chatwidget/tool_lifecycle.rs
@@ -24,6 +24,9 @@ impl ChatWidget {
     pub(super) fn on_image_generation_begin(&mut self) {
         self.record_visible_turn_activity();
         self.flush_answer_stream_with_separator();
+        self.status_state.terminal_title_status_kind = TerminalTitleStatusKind::Working;
+        self.set_status_header(String::from("Generating image"));
+        self.request_redraw();
     }
 
     pub(super) fn on_image_generation_end(
@@ -40,6 +43,7 @@ impl ChatWidget {
             revised_prompt,
             saved_path,
         ));
+        self.restore_reasoning_status_header();
         self.request_redraw();
     }
 

--- a/codex-rs/tui/src/chatwidget/tool_lifecycle.rs
+++ b/codex-rs/tui/src/chatwidget/tool_lifecycle.rs
@@ -24,7 +24,6 @@ impl ChatWidget {
     pub(super) fn on_image_generation_begin(&mut self) {
         self.record_visible_turn_activity();
         self.flush_answer_stream_with_separator();
-        self.status_state.terminal_title_status_kind = TerminalTitleStatusKind::Working;
         self.set_status_header(String::from("Generating image"));
         self.request_redraw();
     }

--- a/codex-rs/tui/src/chatwidget/tool_lifecycle.rs
+++ b/codex-rs/tui/src/chatwidget/tool_lifecycle.rs
@@ -24,7 +24,15 @@ impl ChatWidget {
     pub(super) fn on_image_generation_begin(&mut self) {
         self.record_visible_turn_activity();
         self.flush_answer_stream_with_separator();
-        self.set_status_header(String::from("Generating image"));
+        let mcp_startup_owns_status =
+            self.mcp_startup_status.is_some() && self.status_header_is_mcp_startup_owned();
+        if self.unified_exec_wait_streak.is_none()
+            && self.status_state.pending_guardian_review_status.is_empty()
+            && !mcp_startup_owns_status
+        {
+            self.bottom_pane.ensure_status_indicator();
+            self.set_status_header(String::from("Generating image"));
+        }
         self.request_redraw();
     }
 
@@ -42,7 +50,9 @@ impl ChatWidget {
             revised_prompt,
             saved_path,
         ));
-        self.restore_reasoning_status_header();
+        if self.status_state.current_status.header == "Generating image" {
+            self.restore_reasoning_status_header();
+        }
         self.request_redraw();
     }
 


### PR DESCRIPTION
## Summary

- update standalone image generation start handling to set the active status header to `Generating image`
- restore the prior reasoning/status header when image generation completes
- add snapshot coverage for the active image generation status row

## UI 

<img width="1406" height="322" alt="image" src="https://github.com/user-attachments/assets/6bc7e846-1774-49b7-ab92-ca8e7580fd64" />

(Standard Working replaced with Generating Image... while image generation is not completed) 

## Testing

- `just fmt`
