### PR TITLE
bazel: add opt-in PowerShell runtime for Wine tests

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -326,6 +326,7 @@ http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "ht
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 new_local_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:local.bzl", "new_local_repository")
 
+include("//bazel/modules:powershell.MODULE.bazel")
 include("//bazel/modules:wine.MODULE.bazel")
 
 new_local_repository(

--- a/bazel/modules/BUILD.bazel
+++ b/bazel/modules/BUILD.bazel
@@ -1,1 +1,4 @@
-exports_files(["wine.MODULE.bazel"])
+exports_files([
+    "powershell.MODULE.bazel",
+    "wine.MODULE.bazel",
+])

--- a/bazel/modules/powershell.MODULE.bazel
+++ b/bazel/modules/powershell.MODULE.bazel
@@ -1,0 +1,14 @@
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# Pin the self-contained Windows distribution so Wine tests need neither a
+# system PowerShell installation nor a separate .NET runtime. This intentionally
+# stays on 7.2.24 for the test fixture: 7.4.16 and 7.6.2 currently fail during
+# CLR startup under the pinned Wine 11 runtime, while 7.2.24 runs successfully.
+http_archive(
+    name = "powershell_windows_x86_64",
+    build_file = "//third_party/powershell:BUILD.bazel",
+    sha256 = "a1ccb6d8ad52f917470a136c3752af4465f261bcbe570cf44f52aa69ae6e867e",
+    urls = [
+        "https://github.com/PowerShell/PowerShell/releases/download/v7.2.24/PowerShell-7.2.24-win-x64.zip",
+    ],
+)

--- a/bazel/rules/testing/wine.bzl
+++ b/bazel/rules/testing/wine.bzl
@@ -10,11 +10,17 @@ _WINE_RUNTIME_BINARIES = {
     "wineserver": "@wine_linux_x86_64//:wineserver",
 }
 
+_POWERSHELL_RUNTIME_BINARIES = {
+    "pwsh": "@powershell_windows_x86_64//:pwsh",
+    "pwsh-runtime-marker": "@powershell_windows_x86_64//:runtime_marker",
+}
+
 def wine_rust_test(
         name,
         windows_binaries,
         host_binaries = {},
         data = [],
+        include_powershell = False,
         target_compatible_with = [],
         **kwargs):
     """Defines an x86-64 Linux Rust test with a pinned Wine runtime.
@@ -28,6 +34,9 @@ def wine_rust_test(
     * `CARGO_BIN_EXE_wine` and `CARGO_BIN_EXE_wineserver` identify Wine tools.
     * `CARGO_BIN_EXE_wine-runtime-marker` identifies a file whose parent is the
       Wine DLL directory to use as `WINEDLLPATH`.
+    * When `include_powershell` is true, `CARGO_BIN_EXE_pwsh` identifies the
+      pinned PowerShell executable and `CARGO_BIN_EXE_pwsh-runtime-marker`
+      identifies a file whose parent is the complete PowerShell runtime.
 
     These are Bazel runfile locations. Resolve binaries with
     `codex_utils_cargo_bin::cargo_bin`; `:wine_test_support` resolves the fixed
@@ -38,13 +47,19 @@ def wine_rust_test(
       windows_binaries: Map from `CARGO_BIN_EXE_*` suffixes to Windows targets.
       host_binaries: Map from `CARGO_BIN_EXE_*` suffixes to Linux host targets.
       data: Additional runtime data for the Linux test.
+      include_powershell: Whether to include the pinned PowerShell runtime for Windows.
       target_compatible_with: Additional compatibility constraints.
       **kwargs: Remaining attributes forwarded to `rust_test`.
     """
     binaries = dict(_WINE_RUNTIME_BINARIES)
+    runtime_data = ["@wine_linux_x86_64//:runtime"]
+    if include_powershell:
+        binaries.update(_POWERSHELL_RUNTIME_BINARIES)
+        runtime_data.append("@powershell_windows_x86_64//:runtime")
+
     for binary_name in sorted(host_binaries.keys()):
         if binary_name in binaries:
-            fail("host test binary name collides with Wine runtime: {}".format(binary_name))
+            fail("host test binary name collides with test runtime: {}".format(binary_name))
         binaries[binary_name] = host_binaries[binary_name]
 
     for index, binary_name in enumerate(sorted(windows_binaries.keys())):
@@ -68,9 +83,7 @@ def wine_rust_test(
 
     rust_test(
         name = name,
-        data = data + [
-            "@wine_linux_x86_64//:runtime",
-        ] + [binary for binary in binaries.values()],
+        data = data + runtime_data + [binary for binary in binaries.values()],
         env = {
             "CARGO_BIN_EXE_{}".format(binary_name): "$(rlocationpath {})".format(binary)
             for binary_name, binary in binaries.items()

--- a/third_party/powershell/BUILD.bazel
+++ b/third_party/powershell/BUILD.bazel
@@ -1,0 +1,27 @@
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["pwsh.exe"])
+
+filegroup(
+    name = "pwsh",
+    srcs = ["pwsh.exe"],
+    tags = ["manual"],
+)
+
+# The executable is also a stable marker whose parent is the runtime root.
+filegroup(
+    name = "runtime_marker",
+    srcs = ["pwsh.exe"],
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "runtime",
+    srcs = glob(
+        ["**"],
+        # This BUILD file is also loaded from the source tree, where the
+        # archive-only paths are intentionally absent.
+        allow_empty = True,
+    ),
+    tags = ["manual"],
+)


### PR DESCRIPTION
Cross-OS exec-server tests need a hermetic Windows shell that runs reliably under the pinned Wine runtime.

This pins the official PowerShell 7.2.24 Windows x64 portable runtime and makes it opt-in for `wine_rust_test`, exposing `pwsh.exe`, the complete runtime, and a dedicated marker only to tests that request it. This PR is stacked on #27989.

Validation: built the PowerShell Bazel targets and ran the Wine helper Bazel test.