### PR TITLE
unified-exec: resolve shell and workdir for target

### DIFF
--- a/codex-rs/core/src/memory_usage.rs
+++ b/codex-rs/core/src/memory_usage.rs
@@ -69,6 +69,7 @@ fn shell_command_for_invocation(invocation: &ToolInvocation) -> Option<(Vec<Stri
                     invocation.session.user_shell(),
                     &invocation.turn.unified_exec_shell_mode,
                     invocation.turn.config.permissions.allow_login_shell,
+                    crate::tools::handlers::unified_exec::CommandShellResolution::LocalHost,
                 )
                 .ok()?;
                 #[allow(deprecated)]

--- a/codex-rs/core/src/tools/handlers/unified_exec.rs
+++ b/codex-rs/core/src/tools/handlers/unified_exec.rs
@@ -10,6 +10,8 @@ use crate::tools::registry::PostToolUsePayload;
 use codex_exec_server::Environment;
 use codex_protocol::models::AdditionalPermissionProfile;
 use codex_tools::UnifiedExecShellMode;
+use codex_utils_path_uri::PathConvention;
+use codex_utils_path_uri::PathUri;
 use serde::Deserialize;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -71,10 +73,16 @@ fn default_tty() -> bool {
     false
 }
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub(crate) struct ResolvedCommand {
     pub(crate) command: Vec<String>,
     pub(crate) shell_type: ShellType,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CommandShellResolution {
+    LocalHost,
+    RemoteTarget,
 }
 
 fn post_unified_exec_tool_use_payload(
@@ -98,9 +106,10 @@ fn post_unified_exec_tool_use_payload(
 
 pub(crate) fn get_command(
     args: &ExecCommandArgs,
-    session_shell: Arc<Shell>,
+    default_shell: Arc<Shell>,
     shell_mode: &UnifiedExecShellMode,
     allow_login_shell: bool,
+    shell_resolution: CommandShellResolution,
 ) -> Result<ResolvedCommand, String> {
     let use_login_shell = match args.login {
         Some(true) if !allow_login_shell => {
@@ -114,12 +123,12 @@ pub(crate) fn get_command(
 
     match shell_mode {
         UnifiedExecShellMode::Direct => {
-            let model_shell = args.shell.as_ref().map(|shell_str| {
-                let mut shell = get_shell_by_model_provided_path(&PathBuf::from(shell_str));
-                shell.shell_snapshot = crate::shell::empty_shell_snapshot_receiver();
-                shell
-            });
-            let shell = model_shell.as_ref().unwrap_or(session_shell.as_ref());
+            let model_shell = args
+                .shell
+                .as_deref()
+                .map(|shell| resolve_model_shell(shell, shell_resolution))
+                .transpose()?;
+            let shell = model_shell.as_ref().unwrap_or(default_shell.as_ref());
             Ok(ResolvedCommand {
                 command: shell.derive_exec_args(&args.cmd, use_login_shell),
                 shell_type: shell.shell_type,
@@ -141,6 +150,60 @@ pub(crate) fn get_command(
                 shell_type: ShellType::Zsh,
             })
         }
+    }
+}
+
+fn resolve_model_shell(
+    shell_path: &str,
+    shell_resolution: CommandShellResolution,
+) -> Result<Shell, String> {
+    match shell_resolution {
+        CommandShellResolution::LocalHost => {
+            let mut shell = get_shell_by_model_provided_path(&PathBuf::from(shell_path));
+            shell.shell_snapshot = crate::shell::empty_shell_snapshot_receiver();
+            Ok(shell)
+        }
+        CommandShellResolution::RemoteTarget => {
+            let file_name = shell_path
+                .rsplit(['/', '\\'])
+                .next()
+                .filter(|file_name| !file_name.is_empty())
+                .ok_or_else(|| {
+                    format!("remote shell path `{shell_path}` has no executable name")
+                })?;
+            let file_name = file_name.to_ascii_lowercase();
+            let shell_name = file_name.strip_suffix(".exe").unwrap_or(&file_name);
+            let shell_type = match shell_name {
+                "zsh" => ShellType::Zsh,
+                "bash" => ShellType::Bash,
+                "sh" => ShellType::Sh,
+                "pwsh" | "powershell" => ShellType::PowerShell,
+                "cmd" => ShellType::Cmd,
+                _ => {
+                    return Err(format!(
+                        "unsupported remote shell `{shell_path}`; expected zsh, bash, sh, pwsh, powershell, or cmd"
+                    ));
+                }
+            };
+            Ok(Shell {
+                shell_type,
+                shell_path: PathBuf::from(shell_path),
+                shell_snapshot: crate::shell::empty_shell_snapshot_receiver(),
+            })
+        }
+    }
+}
+
+pub(crate) fn resolve_workdir_uri(
+    base: &PathUri,
+    workdir: Option<&str>,
+    convention: PathConvention,
+) -> Result<PathUri, String> {
+    match workdir.filter(|workdir| !workdir.is_empty()) {
+        None => Ok(base.clone()),
+        Some(workdir) => base
+            .resolve_native(workdir, convention)
+            .map_err(|error| format!("invalid working directory `{workdir}`: {error}")),
     }
 }
 

--- a/codex-rs/core/src/tools/handlers/unified_exec/exec_command.rs
+++ b/codex-rs/core/src/tools/handlers/unified_exec/exec_command.rs
@@ -34,10 +34,12 @@ use codex_utils_output_truncation::approx_token_count;
 
 use super::super::shell_spec::CommandToolOptions;
 use super::super::shell_spec::create_exec_command_tool_with_environment_id;
+use super::CommandShellResolution;
 use super::ExecCommandArgs;
 use super::ExecCommandEnvironmentArgs;
 use super::get_command;
 use super::post_unified_exec_tool_use_payload;
+use super::resolve_workdir_uri;
 use super::shell_mode_for_environment;
 
 #[derive(Clone, Copy)]
@@ -129,17 +131,27 @@ impl ExecCommandHandler {
                 "unified exec is unavailable in this session".to_string(),
             ));
         };
+        let environment = Arc::clone(&turn_environment.environment);
+        let workdir = environment_args
+            .workdir
+            .as_deref()
+            .filter(|workdir| !workdir.is_empty());
+        let cwd_uri = resolve_workdir_uri(
+            turn_environment.cwd_uri(),
+            workdir,
+            turn_environment.path_convention(),
+        )
+        .map_err(FunctionCallError::RespondToModel)?;
         let base_cwd = turn_environment.compatible_cwd().ok_or_else(|| {
             FunctionCallError::RespondToModel(
                 "cross-platform unified exec requires native remote routing".to_string(),
             )
         })?;
-        let cwd = environment_args
-            .workdir
-            .as_deref()
-            .filter(|workdir| !workdir.is_empty())
-            .map_or_else(|| base_cwd.clone(), |workdir| base_cwd.join(workdir));
-        let environment = Arc::clone(&turn_environment.environment);
+        let cwd = cwd_uri.to_abs_path().map_err(|error| {
+            FunctionCallError::RespondToModel(format!(
+                "working directory `{cwd_uri}` cannot be used on the app-server host: {error}"
+            ))
+        })?;
         let fs = environment.get_filesystem();
         let args: ExecCommandArgs = parse_arguments_with_base_path(&arguments, &cwd)?;
         let hook_command = args.cmd.clone();
@@ -150,19 +162,28 @@ impl ExecCommandHandler {
             &cwd,
         )
         .await;
-        let process_id = manager.allocate_process_id().await;
         let shell_mode =
             shell_mode_for_environment(&turn.unified_exec_shell_mode, environment.as_ref());
+        let (default_shell, shell_resolution) = if environment.is_remote() {
+            (
+                Arc::new(turn_environment.shell.clone()),
+                CommandShellResolution::RemoteTarget,
+            )
+        } else {
+            (session.user_shell(), CommandShellResolution::LocalHost)
+        };
         let resolved_command = get_command(
             &args,
-            session.user_shell(),
+            default_shell,
             &shell_mode,
             turn.config.permissions.allow_login_shell,
+            shell_resolution,
         )
         .map_err(FunctionCallError::RespondToModel)?;
         let command = resolved_command.command;
         let shell_type = resolved_command.shell_type;
         let command_for_display = codex_shell_command::parse_command::shlex_join(&command);
+        let process_id = manager.allocate_process_id().await;
 
         let ExecCommandArgs {
             tty,

--- a/codex-rs/core/src/tools/handlers/unified_exec_tests.rs
+++ b/codex-rs/core/src/tools/handlers/unified_exec_tests.rs
@@ -6,6 +6,8 @@ use codex_tools::UnifiedExecShellMode;
 use codex_tools::ZshForkConfig;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_output_truncation::TruncationPolicy;
+use codex_utils_path_uri::PathConvention;
+use codex_utils_path_uri::PathUri;
 use pretty_assertions::assert_eq;
 use std::sync::Arc;
 
@@ -52,6 +54,7 @@ fn test_get_command_uses_default_shell_when_unspecified() -> anyhow::Result<()> 
         Arc::new(default_user_shell()),
         &UnifiedExecShellMode::Direct,
         /*allow_login_shell*/ true,
+        CommandShellResolution::LocalHost,
     )
     .map_err(anyhow::Error::msg)?;
     let command = resolved.command;
@@ -74,6 +77,7 @@ fn test_get_command_respects_explicit_bash_shell() -> anyhow::Result<()> {
         Arc::new(default_user_shell()),
         &UnifiedExecShellMode::Direct,
         /*allow_login_shell*/ true,
+        CommandShellResolution::LocalHost,
     )
     .map_err(anyhow::Error::msg)?;
     let command = resolved.command;
@@ -115,6 +119,7 @@ fn test_get_command_respects_explicit_powershell_shell() -> anyhow::Result<()> {
         Arc::new(default_user_shell()),
         &UnifiedExecShellMode::Direct,
         /*allow_login_shell*/ true,
+        CommandShellResolution::LocalHost,
     )
     .map_err(anyhow::Error::msg)?;
     let command = resolved.command;
@@ -137,12 +142,146 @@ fn test_get_command_respects_explicit_cmd_shell() -> anyhow::Result<()> {
         Arc::new(default_user_shell()),
         &UnifiedExecShellMode::Direct,
         /*allow_login_shell*/ true,
+        CommandShellResolution::LocalHost,
     )
     .map_err(anyhow::Error::msg)?;
     let command = resolved.command;
 
     assert_eq!(command[2], "echo hello");
     Ok(())
+}
+
+#[test]
+fn remote_command_uses_target_default_shell() -> anyhow::Result<()> {
+    let args: ExecCommandArgs = parse_arguments(r#"{"cmd":"Get-Location"}"#)?;
+    let shell_path = r"C:\Program Files\PowerShell\7\pwsh.exe";
+    let default_shell = Arc::new(crate::shell::Shell::from_environment_shell_info(
+        codex_exec_server::ShellInfo {
+            name: "powershell".to_string(),
+            path: shell_path.to_string(),
+        },
+    )?);
+
+    assert_eq!(
+        get_command(
+            &args,
+            default_shell,
+            &UnifiedExecShellMode::Direct,
+            /*allow_login_shell*/ false,
+            CommandShellResolution::RemoteTarget,
+        ),
+        Ok(ResolvedCommand {
+            command: vec![
+                shell_path.to_string(),
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                "Get-Location".to_string(),
+            ],
+            shell_type: ShellType::PowerShell,
+        })
+    );
+    Ok(())
+}
+
+#[test]
+fn remote_command_classifies_explicit_shell_without_host_lookup() -> anyhow::Result<()> {
+    let default_shell = Arc::new(default_user_shell());
+
+    for (shell, expected) in [
+        (
+            r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+            ResolvedCommand {
+                command: vec![
+                    r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe".to_string(),
+                    "-NoProfile".to_string(),
+                    "-Command".to_string(),
+                    "echo hello".to_string(),
+                ],
+                shell_type: ShellType::PowerShell,
+            },
+        ),
+        (
+            r"C:\Windows\System32\cmd.exe",
+            ResolvedCommand {
+                command: vec![
+                    r"C:\Windows\System32\cmd.exe".to_string(),
+                    "/c".to_string(),
+                    "echo hello".to_string(),
+                ],
+                shell_type: ShellType::Cmd,
+            },
+        ),
+        (
+            "/usr/bin/bash",
+            ResolvedCommand {
+                command: vec![
+                    "/usr/bin/bash".to_string(),
+                    "-c".to_string(),
+                    "echo hello".to_string(),
+                ],
+                shell_type: ShellType::Bash,
+            },
+        ),
+    ] {
+        let args: ExecCommandArgs = parse_arguments(
+            &serde_json::json!({ "cmd": "echo hello", "shell": shell }).to_string(),
+        )?;
+
+        assert_eq!(
+            get_command(
+                &args,
+                Arc::clone(&default_shell),
+                &UnifiedExecShellMode::Direct,
+                /*allow_login_shell*/ false,
+                CommandShellResolution::RemoteTarget,
+            ),
+            Ok(expected),
+            "resolving {shell}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn remote_command_rejects_unknown_shell() -> anyhow::Result<()> {
+    let args: ExecCommandArgs =
+        parse_arguments(r#"{"cmd":"echo hello","shell":"C:\\tools\\fish.exe"}"#)?;
+
+    let error = get_command(
+        &args,
+        Arc::new(default_user_shell()),
+        &UnifiedExecShellMode::Direct,
+        /*allow_login_shell*/ false,
+        CommandShellResolution::RemoteTarget,
+    )
+    .expect_err("unknown remote shell should fail");
+
+    assert_eq!(
+        error,
+        "unsupported remote shell `C:\\tools\\fish.exe`; expected zsh, bash, sh, pwsh, powershell, or cmd"
+    );
+    Ok(())
+}
+
+#[test]
+fn workdir_resolution_uses_target_path_convention() {
+    let windows = PathUri::parse("file:///C:/workspace/src").expect("Windows cwd URI");
+    let posix = PathUri::parse("file:///workspace/src").expect("POSIX cwd URI");
+
+    assert_eq!(
+        [
+            resolve_workdir_uri(&windows, Some(r"..\build"), PathConvention::Windows),
+            resolve_workdir_uri(&windows, Some(r"D:\tools"), PathConvention::Windows),
+            resolve_workdir_uri(&posix, Some("../../../tmp"), PathConvention::Posix),
+            resolve_workdir_uri(&posix, Some("/var/tmp"), PathConvention::Posix),
+        ],
+        [
+            Ok(PathUri::parse("file:///C:/workspace/build").expect("relative Windows URI")),
+            Ok(PathUri::parse("file:///D:/tools").expect("absolute Windows URI")),
+            Ok(PathUri::parse("file:///tmp").expect("bounded POSIX URI")),
+            Ok(PathUri::parse("file:///var/tmp").expect("absolute POSIX URI")),
+        ]
+    );
 }
 
 #[test]
@@ -155,6 +294,7 @@ fn test_get_command_rejects_explicit_login_when_disallowed() -> anyhow::Result<(
         Arc::new(default_user_shell()),
         &UnifiedExecShellMode::Direct,
         /*allow_login_shell*/ false,
+        CommandShellResolution::LocalHost,
     )
     .expect_err("explicit login should be rejected");
 
@@ -188,6 +328,7 @@ fn test_get_command_rejects_explicit_shell_in_zsh_fork_mode() -> anyhow::Result<
         Arc::new(default_user_shell()),
         &shell_mode,
         /*allow_login_shell*/ true,
+        CommandShellResolution::LocalHost,
     )
     .expect_err("explicit shell should be rejected");
 


### PR DESCRIPTION
Resolve unified-exec command paths using the selected environment rather than app-server host syntax.

This adds target-convention workdir resolution, uses remote environment metadata for the default shell, classifies explicit remote shell paths lexically across slash styles, preserves exact argv spelling, and rejects unknown remote shells. Local shell lookup behavior remains unchanged.

Validation not otherwise covered by CI: `just test -p codex-core tools::handlers::unified_exec::tests` (18 passed).