### PR TITLE
bazel: exclude Wine e2e from host-only sweeps

### DIFF
--- a/scripts/list-bazel-release-targets.sh
+++ b/scripts/list-bazel-release-targets.sh
@@ -11,9 +11,10 @@ cd "${repo_root}"
 # Exclude the experimental `v8-poc` target because it pulls in expensive V8
 # build machinery that is unrelated to the release-only Rust regression this
 # workflow is meant to catch.
-# The normal test job covers the Wine smoke test; omit its downloaded runtime
-# and cross-compile from this build-only release sweep.
+# The normal test job covers the Wine tests; omit their downloaded runtime and
+# cross-compile from this build-only release sweep.
 printf '%s\n' \
   "//codex-rs/..." \
   "-//codex-rs/core/tests/remote_env_windows:smoke-test" \
+  "-//codex-rs/core/tests/remote_env_windows:wine-app-server-windows-exec-server-test" \
   "-//codex-rs/v8-poc:all"

--- a/tools/argument-comment-lint/list-bazel-targets.sh
+++ b/tools/argument-comment-lint/list-bazel-targets.sh
@@ -21,5 +21,6 @@ fi
 # The lint configuration does not register the transitioned Windows toolchain.
 printf '%s\n' \
   "//codex-rs/..." \
-  "-//codex-rs/core/tests/remote_env_windows:smoke-test"
+  "-//codex-rs/core/tests/remote_env_windows:smoke-test" \
+  "-//codex-rs/core/tests/remote_env_windows:wine-app-server-windows-exec-server-test"
 printf '%s\n' "${manual_rust_test_targets}"


### PR DESCRIPTION
Keep the hermetic Windows e2e test out of host-only Bazel sweeps that do not register its transitioned Windows toolchain.

Exclude the target from the release-target and argument-comment-lint target lists. Dedicated Wine test coverage remains unchanged.