### PR TITLE
path-uri: reject reserved Windows device names

### DIFF
--- a/codex-rs/utils/path-uri/src/api_path_string.rs
+++ b/codex-rs/utils/path-uri/src/api_path_string.rs
@@ -336,6 +336,19 @@ fn is_valid_windows_component(component: &str) -> bool {
         .chars()
         .any(|character| character <= '\u{1f}' || r#"<>:"/\|?*"#.contains(character))
         && !component.ends_with([' ', '.'])
+        && !is_reserved_windows_component(component)
+}
+
+fn is_reserved_windows_component(component: &str) -> bool {
+    let stem = component.split('.').next().unwrap_or(component);
+    let stem = stem.to_ascii_uppercase();
+    matches!(stem.as_str(), "CON" | "PRN" | "AUX" | "NUL" | "CLOCK$")
+        || stem.strip_prefix("COM").is_some_and(|suffix| {
+            matches!(suffix, "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9")
+        })
+        || stem.strip_prefix("LPT").is_some_and(|suffix| {
+            matches!(suffix, "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9")
+        })
 }
 
 fn reject_opaque_base(path: &PathUri) -> Result<(), ApiPathStringError> {

--- a/codex-rs/utils/path-uri/src/api_path_string_tests.rs
+++ b/codex-rs/utils/path-uri/src/api_path_string_tests.rs
@@ -493,3 +493,24 @@ fn relative_resolution_rejects_incompatible_and_opaque_bases() {
         Ok(PathUri::parse("file:///tmp").expect("absolute URI"))
     );
 }
+
+#[test]
+fn native_resolution_rejects_reserved_windows_device_names() {
+    let base = PathUri::parse("file:///C:/workspace").expect("Windows URI");
+
+    for path in [
+        r"C:\AUX",
+        r"C:\prn.txt",
+        r"C:\COM9.log",
+        r"C:\lpt1",
+        r"child\NUL.txt",
+    ] {
+        assert!(
+            matches!(
+                base.resolve_native(path, PathConvention::Windows),
+                Err(ApiPathStringError::InvalidNativePath { .. })
+            ),
+            "expected reserved Windows path to fail: {path}"
+        );
+    }
+}


### PR DESCRIPTION
Reject Windows device names when resolving executor-native workdirs so command paths cannot alias reserved devices.

Extend strict Windows native-path resolution to reject reserved names such as `CON`, `NUL`, `COM1`, and `LPT9`, including names with extensions. Add host-independent coverage for absolute and relative Windows paths.

Validated with the `codex-utils-path-uri` test suite.
