### PR TITLE
core: fail turns when environment metadata is unavailable

### DIFF
--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -709,16 +709,19 @@ impl Session {
         ) = match update_result {
             Ok(update) => update,
             Err(err) => {
-                let message = err.to_string();
-                self.send_event_raw(Event {
-                    id: sub_id.clone(),
-                    msg: EventMsg::Error(ErrorEvent {
-                        message: message.clone(),
-                        codex_error_info: Some(CodexErrorInfo::BadRequest),
-                    }),
-                })
-                .await;
-                return Err(CodexErr::InvalidRequest(message));
+                return Err(self.emit_turn_configuration_error(&sub_id, err).await);
+            }
+        };
+
+        let turn_environments = match crate::environment_selection::resolve_environment_selections(
+            self.services.environment_manager.as_ref(),
+            session_configuration.environment_selections(),
+        )
+        .await
+        {
+            Ok(turn_environments) => turn_environments,
+            Err(err) => {
+                return Err(self.emit_turn_configuration_error(&sub_id, err).await);
             }
         };
 
@@ -740,8 +743,22 @@ impl Session {
                 sub_id,
                 session_configuration,
                 updates.final_output_json_schema,
+                turn_environments,
             )
             .await)
+    }
+
+    async fn emit_turn_configuration_error(&self, sub_id: &str, err: CodexErr) -> CodexErr {
+        let message = err.to_string();
+        self.send_event_raw(Event {
+            id: sub_id.to_string(),
+            msg: EventMsg::Error(ErrorEvent {
+                message: message.clone(),
+                codex_error_info: Some(CodexErrorInfo::BadRequest),
+            }),
+        })
+        .await;
+        CodexErr::InvalidRequest(message)
     }
 
     async fn new_turn_from_configuration(
@@ -749,12 +766,14 @@ impl Session {
         sub_id: String,
         session_configuration: SessionConfiguration,
         final_output_json_schema: Option<Option<Value>>,
+        turn_environments: ResolvedTurnEnvironments,
     ) -> Arc<TurnContext> {
         self.new_turn_context_from_configuration(
             sub_id,
             session_configuration,
             final_output_json_schema,
             TurnMultiAgentRuntime::ResolveAndStore,
+            turn_environments,
         )
         .await
     }
@@ -763,12 +782,14 @@ impl Session {
         &self,
         sub_id: String,
         session_configuration: SessionConfiguration,
+        turn_environments: ResolvedTurnEnvironments,
     ) -> Arc<TurnContext> {
         self.new_turn_context_from_configuration(
             sub_id,
             session_configuration,
             /*final_output_json_schema*/ None,
             TurnMultiAgentRuntime::Preview,
+            turn_environments,
         )
         .await
     }
@@ -780,16 +801,8 @@ impl Session {
         session_configuration: SessionConfiguration,
         final_output_json_schema: Option<Option<Value>>,
         multi_agent_runtime: TurnMultiAgentRuntime,
+        turn_environments: ResolvedTurnEnvironments,
     ) -> Arc<TurnContext> {
-        let turn_environments = crate::environment_selection::resolve_environment_selections(
-            self.services.environment_manager.as_ref(),
-            session_configuration.environment_selections(),
-        )
-        .await
-        .unwrap_or_else(|err| {
-            warn!("failed to resolve turn environments: {err}");
-            ResolvedTurnEnvironments::default()
-        });
         let primary_turn_environment = turn_environments.primary().cloned();
         let cwd = session_configuration.cwd().clone();
         let per_turn_config = Self::build_per_turn_config(&session_configuration, cwd.clone());
@@ -900,10 +913,14 @@ impl Session {
 
     pub(crate) async fn new_default_turn_with_sub_id(&self, sub_id: String) -> Arc<TurnContext> {
         let session_configuration = self.default_turn_configuration().await;
+        let turn_environments = self
+            .resolve_turn_environments_or_default(&session_configuration)
+            .await;
         self.new_turn_from_configuration(
             sub_id,
             session_configuration,
             /*final_output_json_schema*/ None,
+            turn_environments,
         )
         .await
     }
@@ -913,8 +930,30 @@ impl Session {
         sub_id: String,
     ) -> Arc<TurnContext> {
         let session_configuration = self.default_turn_configuration().await;
-        self.new_startup_prewarm_turn_from_configuration(sub_id, session_configuration)
-            .await
+        let turn_environments = self
+            .resolve_turn_environments_or_default(&session_configuration)
+            .await;
+        self.new_startup_prewarm_turn_from_configuration(
+            sub_id,
+            session_configuration,
+            turn_environments,
+        )
+        .await
+    }
+
+    async fn resolve_turn_environments_or_default(
+        &self,
+        session_configuration: &SessionConfiguration,
+    ) -> ResolvedTurnEnvironments {
+        crate::environment_selection::resolve_environment_selections(
+            self.services.environment_manager.as_ref(),
+            session_configuration.environment_selections(),
+        )
+        .await
+        .unwrap_or_else(|err| {
+            warn!("failed to resolve turn environments: {err}");
+            ResolvedTurnEnvironments::default()
+        })
     }
 
     async fn default_turn_configuration(&self) -> SessionConfiguration {

--- a/codex-rs/core/tests/suite/tools.rs
+++ b/codex-rs/core/tests/suite/tools.rs
@@ -16,6 +16,12 @@ use codex_protocol::permissions::FileSystemSandboxEntry;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_protocol::protocol::AskForApproval;
+use codex_protocol::protocol::EventMsg;
+use codex_protocol::protocol::Op;
+use codex_protocol::protocol::TurnEnvironmentSelection;
+use codex_protocol::protocol::TurnEnvironmentSelections;
+use codex_protocol::user_input::UserInput;
+use codex_utils_path_uri::PathUri;
 use core_test_support::assert_regex_match;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
@@ -30,6 +36,7 @@ use core_test_support::skip_if_no_network;
 use core_test_support::skip_if_sandbox;
 use core_test_support::test_codex::local;
 use core_test_support::test_codex::test_codex;
+use core_test_support::wait_for_event;
 use regex_lite::Regex;
 use serde_json::Value;
 use serde_json::json;
@@ -125,6 +132,66 @@ async fn turn_environment_selection_keeps_environment_backed_tools() -> Result<(
     assert!(
         tools.contains(&"exec_command".to_string()),
         "environment tool should remain available with selected local environment; got {tools:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn turn_environment_metadata_failure_stops_before_model_inference() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let response_mock = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-1"),
+            ev_assistant_message("msg-1", "should not run"),
+            ev_completed("resp-1"),
+        ]),
+    )
+    .await;
+    let test = test_codex().build(&server).await?;
+    test.thread_manager
+        .environment_manager()
+        .upsert_environment("unreachable".to_string(), "ws://127.0.0.1:1".to_string())?;
+
+    test.codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "do not send this to the model".to_string(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: codex_protocol::protocol::ThreadSettingsOverrides {
+                environments: Some(TurnEnvironmentSelections::new(
+                    test.config.cwd.clone(),
+                    vec![TurnEnvironmentSelection {
+                        environment_id: "unreachable".to_string(),
+                        cwd: PathUri::from_abs_path(&test.config.cwd),
+                    }],
+                )),
+                ..Default::default()
+            },
+        })
+        .await?;
+
+    let event = wait_for_event(&test.codex, |event| matches!(event, EventMsg::Error(_))).await;
+    let EventMsg::Error(error) = event else {
+        unreachable!("wait predicate only accepts error events");
+    };
+    assert!(
+        error
+            .message
+            .contains("failed to get info for environment `unreachable`"),
+        "unexpected environment metadata error: {}",
+        error.message
+    );
+    assert!(
+        response_mock.requests().is_empty(),
+        "environment metadata failure must stop before model inference"
     );
 
     Ok(())


### PR DESCRIPTION
Prevent a selected executor with unavailable or malformed metadata from silently falling back to the app-server host before model inference.

Resolve explicit turn environment selections during turn creation, emit a bad-request event, and abort the turn on failure. Keep the existing best-effort fallback for internal default and prewarm turns.

Validated with an integration test that selects an unreachable environment and asserts no Responses request is sent.