### PR TITLE
[codex] path-uri: cover invalid Windows workdir forms

### DIFF
--- a/codex-rs/utils/path-uri/src/api_path_string_tests.rs
+++ b/codex-rs/utils/path-uri/src/api_path_string_tests.rs
@@ -571,3 +571,23 @@ fn native_resolution_rejects_reserved_windows_device_names() {
         );
     }
 }
+
+#[test]
+fn native_resolution_rejects_drive_relative_and_incomplete_unc_paths() {
+    let base = PathUri::parse("file:///C:/workspace").expect("Windows URI");
+
+    for (path, rejected_path) in [
+        (r"C:relative", r"C:\workspace\C:relative"),
+        (r"\\server", r"\\server"),
+        ("\\\\server\\", "\\\\server\\"),
+    ] {
+        assert_eq!(
+            base.resolve_native(path, PathConvention::Windows),
+            Err(ApiPathStringError::InvalidNativePath {
+                path: rejected_path.to_string(),
+                convention: PathConvention::Windows,
+            }),
+            "resolving {path:?}"
+        );
+    }
+}


### PR DESCRIPTION
Ensures Windows workdir validation is explicitly covered for drive-relative and incomplete UNC inputs.

Adds host-independent `PathUri::resolve_native` cases for `C:relative`, `\\server`, and `\\server\\`, asserting invalid-native-path errors.

Validation: `just test -p codex-utils-path-uri -E 'test(native_resolution_rejects_drive_relative_and_incomplete_unc_paths)'`.