### PR TITLE
[core] Allow Sites terms disclosure under never policy

### DIFF
--- a/codex-rs/codex-mcp/src/auth_elicitation.rs
+++ b/codex-rs/codex-mcp/src/auth_elicitation.rs
@@ -15,6 +15,10 @@ pub const CONNECTOR_AUTH_FAILURE_LINK_ID_KEY: &str = "link_id";
 pub const CONNECTOR_AUTH_FAILURE_ERROR_CODE_KEY: &str = "error_code";
 pub const CONNECTOR_AUTH_FAILURE_ERROR_HTTP_STATUS_CODE_KEY: &str = "error_http_status_code";
 pub const CONNECTOR_AUTH_FAILURE_ERROR_ACTION_KEY: &str = "error_action";
+const SITES_CONNECTOR_ID: &str = "connector_20205bf7d4e99a89d7154bb849718324";
+const SITES_PUBLICATION_TERMS_REQUIRED_AUTH_REASON_PREFIX: &str =
+    "sites_publication_terms_required:";
+const SITES_PUBLICATION_TERMS_REQUIRED_HTTP_STATUS_CODE: i64 = 428;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CodexAppsConnectorAuthFailure {
@@ -26,6 +30,23 @@ pub struct CodexAppsConnectorAuthFailure {
     pub error_code: Option<String>,
     pub error_http_status_code: Option<i64>,
     pub error_action: Option<String>,
+}
+
+impl CodexAppsConnectorAuthFailure {
+    /// Returns whether this is the versioned Sites legal disclosure that must
+    /// remain interactive even when ordinary approval prompts are disabled.
+    pub fn is_sites_publication_terms_disclosure(&self) -> bool {
+        self.connector_id == SITES_CONNECTOR_ID
+            && self.error_http_status_code
+                == Some(SITES_PUBLICATION_TERMS_REQUIRED_HTTP_STATUS_CODE)
+            && self
+                .auth_reason
+                .as_deref()
+                .and_then(|reason| {
+                    reason.strip_prefix(SITES_PUBLICATION_TERMS_REQUIRED_AUTH_REASON_PREFIX)
+                })
+                .is_some_and(|version| !version.trim().is_empty())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -167,13 +188,18 @@ pub fn auth_elicitation_completed_result(
     auth_failure: &CodexAppsConnectorAuthFailure,
     meta: Option<serde_json::Value>,
 ) -> CallToolResult {
+    let text = if auth_failure.is_sites_publication_terms_disclosure() {
+        "The ChatGPT Sites Terms were accepted. Retry this tool call now.".to_string()
+    } else {
+        format!(
+            "Authentication for {} was requested and accepted. Retry this tool call now.",
+            auth_failure.connector_name
+        )
+    };
     CallToolResult {
         content: vec![serde_json::json!({
             "type": "text",
-            "text": format!(
-                "Authentication for {} was requested and accepted. Retry this tool call now.",
-                auth_failure.connector_name
-            ),
+            "text": text,
         })],
         structured_content: None,
         is_error: Some(true),
@@ -198,6 +224,9 @@ fn string_auth_failure_field(
 }
 
 fn auth_elicitation_message(auth_failure: &CodexAppsConnectorAuthFailure) -> String {
+    if auth_failure.is_sites_publication_terms_disclosure() {
+        return "Review the ChatGPT Sites Terms to continue.".to_string();
+    }
     match auth_failure.auth_reason.as_deref() {
         Some("oauth_upgrade_required") => format!(
             "Reconnect {} on ChatGPT to grant the permissions needed for this request.",
@@ -343,5 +372,54 @@ mod tests {
 
         assert_eq!(plan.auth_failure.connector_name, "Google Calendar");
         assert_eq!(plan.elicitation.elicitation_id, "codex_apps_auth_call_123");
+    }
+
+    #[test]
+    fn identifies_only_versioned_sites_publication_terms_disclosures() {
+        let mut wrong_status = auth_failure(
+            "connector_20205bf7d4e99a89d7154bb849718324",
+            "sites_publication_terms_required:2026-06-12",
+        );
+        wrong_status.error_http_status_code = Some(401);
+
+        assert_eq!(
+            [
+                auth_failure(
+                    "connector_20205bf7d4e99a89d7154bb849718324",
+                    "sites_publication_terms_required:2026-06-12",
+                )
+                .is_sites_publication_terms_disclosure(),
+                auth_failure(
+                    "connector_calendar",
+                    "sites_publication_terms_required:2026-06-12",
+                )
+                .is_sites_publication_terms_disclosure(),
+                auth_failure(
+                    "connector_20205bf7d4e99a89d7154bb849718324",
+                    "sites_publication_terms_required:",
+                )
+                .is_sites_publication_terms_disclosure(),
+                auth_failure(
+                    "connector_20205bf7d4e99a89d7154bb849718324",
+                    "reauthentication_required",
+                )
+                .is_sites_publication_terms_disclosure(),
+                wrong_status.is_sites_publication_terms_disclosure(),
+            ],
+            [true, false, false, false, false],
+        );
+    }
+
+    fn auth_failure(connector_id: &str, auth_reason: &str) -> CodexAppsConnectorAuthFailure {
+        CodexAppsConnectorAuthFailure {
+            connector_id: connector_id.to_string(),
+            connector_name: "Sites".to_string(),
+            install_url: "https://chatgpt.com/apps/sites".to_string(),
+            auth_reason: Some(auth_reason.to_string()),
+            link_id: None,
+            error_code: None,
+            error_http_status_code: Some(SITES_PUBLICATION_TERMS_REQUIRED_HTTP_STATUS_CODE),
+            error_action: None,
+        }
     }
 }

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -615,17 +615,6 @@ async fn maybe_request_codex_apps_auth_elicitation(
         return result;
     }
 
-    match turn_context.approval_policy.value() {
-        AskForApproval::Never => return result,
-        AskForApproval::Granular(granular_config) if !granular_config.allows_mcp_elicitations() => {
-            return result;
-        }
-        AskForApproval::OnFailure
-        | AskForApproval::OnRequest
-        | AskForApproval::UnlessTrusted
-        | AskForApproval::Granular(_) => {}
-    }
-
     let connector_id = metadata.and_then(|metadata| metadata.connector_id.as_deref());
     let connector_name = metadata.and_then(|metadata| metadata.connector_name.as_deref());
     let install_url = connector_id.map(|connector_id| {
@@ -639,6 +628,20 @@ async fn maybe_request_codex_apps_auth_elicitation(
     else {
         return result;
     };
+
+    match turn_context.approval_policy.value() {
+        AskForApproval::Never if !plan.auth_failure.is_sites_publication_terms_disclosure() => {
+            return result;
+        }
+        AskForApproval::Granular(granular_config) if !granular_config.allows_mcp_elicitations() => {
+            return result;
+        }
+        AskForApproval::Never
+        | AskForApproval::OnFailure
+        | AskForApproval::OnRequest
+        | AskForApproval::UnlessTrusted
+        | AskForApproval::Granular(_) => {}
+    }
 
     let request_id = rmcp::model::RequestId::String(plan.elicitation.elicitation_id.clone().into());
     let params = McpServerElicitationRequestParams {

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -1221,6 +1221,26 @@ async fn codex_apps_tool_call_request_meta_includes_call_id_without_existing_cod
 }
 
 fn codex_apps_auth_failure_result() -> CallToolResult {
+    codex_apps_auth_failure_result_for(
+        "connector_calendar",
+        "reauthentication_required",
+        /*error_http_status_code*/ 401,
+    )
+}
+
+fn codex_apps_sites_publication_terms_failure_result() -> CallToolResult {
+    codex_apps_auth_failure_result_for(
+        "connector_20205bf7d4e99a89d7154bb849718324",
+        "sites_publication_terms_required:2026-06-12",
+        /*error_http_status_code*/ 428,
+    )
+}
+
+fn codex_apps_auth_failure_result_for(
+    connector_id: &str,
+    auth_reason: &str,
+    error_http_status_code: i64,
+) -> CallToolResult {
     CallToolResult {
         content: vec![serde_json::json!({
             "type": "text",
@@ -1232,12 +1252,12 @@ fn codex_apps_auth_failure_result() -> CallToolResult {
             MCP_TOOL_CODEX_APPS_META_KEY: {
                 "connector_auth_failure": {
                     "is_auth_failure": true,
-                    "auth_reason": "reauthentication_required",
-                    "connector_id": "connector_calendar",
+                    "auth_reason": auth_reason,
+                    "connector_id": connector_id,
                     "connector_name": "Untrusted Calendar",
                     "link_id": "link_123",
                     "error_code": "UNAUTHORIZED",
-                    "error_http_status_code": 401,
+                    "error_http_status_code": error_http_status_code,
                     "error_action": "TRIGGER_REAUTHENTICATION",
                 },
             },
@@ -1252,6 +1272,16 @@ fn codex_apps_auth_failure_metadata() -> McpToolApprovalMetadata {
         Some("Manage events and schedules."),
         Some("Create Event"),
         Some("Create a calendar event."),
+    )
+}
+
+fn codex_apps_sites_publication_terms_metadata() -> McpToolApprovalMetadata {
+    approval_metadata(
+        Some("connector_20205bf7d4e99a89d7154bb849718324"),
+        Some("Sites"),
+        Some("Create and publish websites."),
+        Some("Create Site"),
+        Some("Create a new website."),
     )
 }
 
@@ -1334,54 +1364,67 @@ async fn codex_apps_auth_elicitation_non_host_owned_server_returns_original_resu
 }
 
 #[tokio::test]
-async fn codex_apps_auth_elicitation_disallowed_by_policy_returns_original_result() {
-    let (session, mut turn_context, rx_event) = make_session_and_context_with_rx().await;
-    install_host_owned_codex_apps_manager(&session, &turn_context).await;
-    let mut features = Features::with_defaults();
-    features.enable(Feature::AuthElicitation);
-    let turn_context = Arc::get_mut(&mut turn_context).expect("single turn context ref");
-    turn_context.features = ManagedFeatures::from(features);
-    turn_context
-        .approval_policy
-        .set(AskForApproval::Never)
-        .expect("test setup should allow updating approval policy");
-    let result = codex_apps_auth_failure_result();
-    let metadata = codex_apps_auth_failure_metadata();
-
-    let returned = maybe_request_codex_apps_auth_elicitation(
-        &session,
-        turn_context,
-        "call_123",
-        CODEX_APPS_MCP_SERVER_NAME,
-        Some(&metadata),
-        result.clone(),
+async fn non_sites_invocation_cannot_forge_sites_terms_elicitation_under_never_policy() {
+    assert_codex_apps_auth_elicitation_not_requested(
+        AskForApproval::Never,
+        codex_apps_sites_publication_terms_failure_result(),
+        codex_apps_auth_failure_metadata(),
     )
     .await;
-
-    assert_eq!(returned, result);
-    assert!(rx_event.try_recv().is_err());
 }
 
 #[tokio::test]
-async fn codex_apps_auth_elicitation_granular_mcp_disabled_returns_original_result() {
-    let (session, mut turn_context, rx_event) = make_session_and_context_with_rx().await;
-    install_host_owned_codex_apps_manager(&session, &turn_context).await;
-    let mut features = Features::with_defaults();
-    features.enable(Feature::AuthElicitation);
-    let turn_context = Arc::get_mut(&mut turn_context).expect("single turn context ref");
-    turn_context.features = ManagedFeatures::from(features);
-    turn_context
-        .approval_policy
-        .set(AskForApproval::Granular(GranularApprovalConfig {
+async fn codex_apps_auth_elicitation_is_disallowed_by_never_policy() {
+    assert_codex_apps_auth_elicitation_not_requested(
+        AskForApproval::Never,
+        codex_apps_auth_failure_result(),
+        codex_apps_auth_failure_metadata(),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn codex_apps_sites_publication_terms_elicitation_is_allowed_by_never_policy() {
+    assert_codex_apps_auth_elicitation_requested(
+        AskForApproval::Never,
+        codex_apps_sites_publication_terms_failure_result(),
+        codex_apps_sites_publication_terms_metadata(),
+        "The ChatGPT Sites Terms were accepted. Retry this tool call now.",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn codex_apps_sites_terms_elicitation_respects_granular_mcp_disabled() {
+    assert_codex_apps_auth_elicitation_not_requested(
+        AskForApproval::Granular(GranularApprovalConfig {
             sandbox_approval: true,
             rules: true,
             skill_approval: true,
             request_permissions: true,
             mcp_elicitations: false,
-        }))
+        }),
+        codex_apps_sites_publication_terms_failure_result(),
+        codex_apps_sites_publication_terms_metadata(),
+    )
+    .await;
+}
+
+async fn assert_codex_apps_auth_elicitation_not_requested(
+    approval_policy: AskForApproval,
+    result: CallToolResult,
+    metadata: McpToolApprovalMetadata,
+) {
+    let (session, mut turn_context, rx_event) = make_session_and_context_with_rx().await;
+    install_host_owned_codex_apps_manager(&session, &turn_context).await;
+    let mut features = Features::with_defaults();
+    features.enable(Feature::AuthElicitation);
+    let turn_context = Arc::get_mut(&mut turn_context).expect("single turn context ref");
+    turn_context.features = ManagedFeatures::from(features);
+    turn_context
+        .approval_policy
+        .set(approval_policy)
         .expect("test setup should allow updating approval policy");
-    let result = codex_apps_auth_failure_result();
-    let metadata = codex_apps_auth_failure_metadata();
 
     let returned = maybe_request_codex_apps_auth_elicitation(
         &session,
@@ -1399,16 +1442,34 @@ async fn codex_apps_auth_elicitation_granular_mcp_disabled_returns_original_resu
 
 #[tokio::test]
 async fn codex_apps_auth_elicitation_feature_enabled_requests_elicitation() {
+    assert_codex_apps_auth_elicitation_requested(
+        AskForApproval::OnRequest,
+        codex_apps_auth_failure_result(),
+        codex_apps_auth_failure_metadata(),
+        "Authentication for Google Calendar was requested and accepted. Retry this tool call now.",
+    )
+    .await;
+}
+
+async fn assert_codex_apps_auth_elicitation_requested(
+    approval_policy: AskForApproval,
+    result: CallToolResult,
+    metadata: McpToolApprovalMetadata,
+    completion_text: &str,
+) {
     let (session, mut turn_context, rx_event) = make_session_and_context_with_rx().await;
     install_host_owned_codex_apps_manager(&session, &turn_context).await;
     *session.active_turn.lock().await = Some(ActiveTurn::default());
     let mut features = Features::with_defaults();
     features.enable(Feature::AuthElicitation);
-    Arc::get_mut(&mut turn_context)
-        .expect("single turn context ref")
-        .features = ManagedFeatures::from(features);
-    let result = codex_apps_auth_failure_result();
-    let metadata = codex_apps_auth_failure_metadata();
+    {
+        let turn_context = Arc::get_mut(&mut turn_context).expect("single turn context ref");
+        turn_context.features = ManagedFeatures::from(features);
+        turn_context
+            .approval_policy
+            .set(approval_policy)
+            .expect("test setup should allow updating approval policy");
+    }
 
     let request_task = tokio::spawn({
         let session = Arc::clone(&session);
@@ -1465,7 +1526,7 @@ async fn codex_apps_auth_elicitation_feature_enabled_requests_elicitation() {
         returned.content,
         vec![serde_json::json!({
             "type": "text",
-            "text": "Authentication for Google Calendar was requested and accepted. Retry this tool call now.",
+            "text": completion_text,
         })]
     );
 }

--- a/codex-rs/core/tests/suite/mod.rs
+++ b/codex-rs/core/tests/suite/mod.rs
@@ -105,6 +105,7 @@ mod search_tool;
 mod shell_command;
 mod shell_serialization;
 mod shell_snapshot;
+mod sites_publication_terms;
 mod skill_approval;
 mod skills;
 mod spawn_agent_description;

--- a/codex-rs/core/tests/suite/sites_publication_terms.rs
+++ b/codex-rs/core/tests/suite/sites_publication_terms.rs
@@ -1,0 +1,231 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use anyhow::Result;
+use codex_connectors::metadata::connector_install_url;
+use codex_features::Feature;
+use codex_protocol::approvals::ElicitationRequest;
+use codex_protocol::approvals::ElicitationRequestEvent;
+use codex_protocol::mcp::RequestId;
+use codex_protocol::protocol::AskForApproval;
+use codex_protocol::protocol::ElicitationAction;
+use codex_protocol::protocol::EventMsg;
+use codex_protocol::protocol::Op;
+use codex_protocol::user_input::UserInput;
+use core_test_support::apps_test_server::AppsTestServer;
+use core_test_support::apps_test_server::apps_enabled_builder;
+use core_test_support::responses::ev_assistant_message;
+use core_test_support::responses::ev_completed;
+use core_test_support::responses::ev_function_call_with_namespace;
+use core_test_support::responses::ev_response_created;
+use core_test_support::responses::mount_sse_sequence;
+use core_test_support::responses::sse;
+use core_test_support::responses::start_mock_server;
+use core_test_support::skip_if_no_network;
+use core_test_support::wait_for_event;
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+use serde_json::json;
+use wiremock::Mock;
+use wiremock::Request;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::body_partial_json;
+use wiremock::matchers::method;
+use wiremock::matchers::path_regex;
+
+const SITES_CONNECTOR_ID: &str = "connector_20205bf7d4e99a89d7154bb849718324";
+const SITES_CREATE_TOOL: &str = "_create_site";
+const SITES_CREATE_TOOL_NAME: &str = "sites_create_site";
+const SITES_NAMESPACE: &str = "mcp__codex_apps__sites";
+const SITES_TERMS_AUTH_REASON: &str = "sites_publication_terms_required:2026-06-12";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sites_terms_elicitation_is_emitted_on_first_tool_call_under_never_policy() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let apps_server = AppsTestServer::mount(&server).await?;
+
+    Mock::given(method("POST"))
+        .and(path_regex("^/api/codex/apps/?$"))
+        .and(body_partial_json(json!({"method": "tools/list"})))
+        .respond_with(|request: &Request| {
+            let body: Value = serde_json::from_slice(&request.body).expect("valid JSON-RPC body");
+            ResponseTemplate::new(200).set_body_json(json!({
+                "jsonrpc": "2.0",
+                "id": body.get("id").cloned().unwrap_or(Value::Null),
+                "result": {
+                    "tools": [{
+                        "name": SITES_CREATE_TOOL_NAME,
+                        "description": "Create a website.",
+                        "annotations": {
+                            "readOnlyHint": false,
+                            "destructiveHint": false,
+                            "openWorldHint": false
+                        },
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {},
+                            "additionalProperties": false
+                        },
+                        "_meta": {
+                            "connector_id": SITES_CONNECTOR_ID,
+                            "connector_name": "Sites",
+                            "connector_description": "Create and publish websites.",
+                            "_codex_apps": {
+                                "connector_id": SITES_CONNECTOR_ID
+                            }
+                        }
+                    }],
+                    "nextCursor": null
+                }
+            }))
+        })
+        .with_priority(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path_regex("^/api/codex/apps/?$"))
+        .and(body_partial_json(json!({
+            "method": "tools/call",
+            "params": {"name": SITES_CREATE_TOOL_NAME}
+        })))
+        .respond_with(|request: &Request| {
+            let body: Value = serde_json::from_slice(&request.body).expect("valid JSON-RPC body");
+            ResponseTemplate::new(200).set_body_json(json!({
+                "jsonrpc": "2.0",
+                "id": body.get("id").cloned().unwrap_or(Value::Null),
+                "result": {
+                    "content": [{
+                        "type": "text",
+                        "text": "Sites terms acceptance required"
+                    }],
+                    "isError": true,
+                    "_meta": {
+                        "_codex_apps": {
+                            "connector_auth_failure": {
+                                "is_auth_failure": true,
+                                "auth_reason": SITES_TERMS_AUTH_REASON,
+                                "connector_id": SITES_CONNECTOR_ID,
+                                "connector_name": "Untrusted Sites",
+                                "link_id": "link_sites",
+                                "error_code": "TERMS_REQUIRED",
+                                "error_http_status_code": 428,
+                                "error_action": "TRIGGER_TERMS_ACCEPTANCE"
+                            }
+                        }
+                    }
+                }
+            }))
+        })
+        .with_priority(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let responses = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                ev_function_call_with_namespace(
+                    "sites-call-1",
+                    SITES_NAMESPACE,
+                    SITES_CREATE_TOOL,
+                    "{}",
+                ),
+                ev_completed("resp-1"),
+            ]),
+            sse(vec![
+                ev_response_created("resp-2"),
+                ev_assistant_message("msg-1", "done"),
+                ev_completed("resp-2"),
+            ]),
+        ],
+    )
+    .await;
+
+    let mut builder = apps_enabled_builder(apps_server.chatgpt_base_url).with_config(|config| {
+        config
+            .features
+            .enable(Feature::AuthElicitation)
+            .expect("test config should allow feature update");
+    });
+    let test = builder.build(&server).await?;
+
+    test.codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "Create a site.".to_string(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: codex_protocol::protocol::ThreadSettingsOverrides {
+                approval_policy: Some(AskForApproval::Never),
+                ..Default::default()
+            },
+        })
+        .await?;
+
+    let EventMsg::ElicitationRequest(request) = wait_for_event(&test.codex, |event| {
+        matches!(
+            event,
+            EventMsg::ElicitationRequest(_) | EventMsg::TurnComplete(_)
+        )
+    })
+    .await
+    else {
+        panic!("expected Sites terms elicitation before the turn completed");
+    };
+
+    assert!(request.turn_id.is_some());
+    let install_url = connector_install_url("Sites", SITES_CONNECTOR_ID);
+    assert_eq!(
+        request,
+        ElicitationRequestEvent {
+            turn_id: request.turn_id.clone(),
+            server_name: "codex_apps".to_string(),
+            id: RequestId::String("codex_apps_auth_sites-call-1".to_string()),
+            request: ElicitationRequest::Url {
+                meta: Some(json!({
+                    "_codex_apps": {
+                        "connector_auth_failure": {
+                            "is_auth_failure": true,
+                            "connector_id": SITES_CONNECTOR_ID,
+                            "connector_name": "Sites",
+                            "install_url": install_url,
+                            "auth_reason": SITES_TERMS_AUTH_REASON,
+                            "link_id": "link_sites",
+                            "error_code": "TERMS_REQUIRED",
+                            "error_http_status_code": 428,
+                            "error_action": "TRIGGER_TERMS_ACCEPTANCE"
+                        }
+                    }
+                })),
+                message: "Review the ChatGPT Sites Terms to continue.".to_string(),
+                url: install_url.clone(),
+                elicitation_id: "codex_apps_auth_sites-call-1".to_string(),
+            },
+        }
+    );
+
+    test.codex
+        .submit(Op::ResolveElicitation {
+            server_name: request.server_name,
+            request_id: request.id,
+            decision: ElicitationAction::Decline,
+            content: None,
+            meta: None,
+        })
+        .await?;
+
+    wait_for_event(&test.codex, |event| {
+        matches!(event, EventMsg::TurnComplete(_))
+    })
+    .await;
+    assert_eq!(responses.requests().len(), 2);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- allow the exact host-owned, versioned ChatGPT Sites terms disclosure to remain interactive when `AskForApproval::Never` suppresses ordinary approval prompts
- continue suppressing generic connector authentication and granular policies with MCP elicitations disabled
- use terms-specific request and completion copy instead of describing this legal flow as authentication
- cover the policy boundary with focused unit tests and a full first-Sites-tool-call integration test

## Why

The Codex desktop client pauses a personal user's first Sites tool invocation while it shows a versioned legal disclosure. Full Access maps to `AskForApproval::Never`, but that policy currently suppresses every connector elicitation. The exception must therefore be narrow enough to keep generic auth prompts disabled while allowing only the trusted Sites terms challenge.

## Test plan

- `just test -p codex-mcp auth_elicitation`
- `just test -p codex-core codex_apps_auth_elicitation`
- `just test -p codex-core sites`
- `just fix -p codex-mcp`
- `just fix -p codex-core`
- `just fmt`

The broader `codex-core` crate run was also attempted earlier; the focused tests above passed, while unrelated sandbox and missing-test-binary cases in the broad run are not caused by this change.
