### PR TITLE
[codex] Preserve file param array unions

### DIFF
--- a/codex-rs/codex-mcp/src/connection_manager_tests.rs
+++ b/codex-rs/codex-mcp/src/connection_manager_tests.rs
@@ -136,6 +136,16 @@ fn tool_with_model_visible_input_schema_masks_file_params() {
                 "files": {
                     "type": "array",
                     "items": {"type": "object"}
+                },
+                "file_or_files": {
+                    "description": "One or more file payloads.",
+                    "anyOf": [
+                        {"type": "object"},
+                        {
+                            "type": "array",
+                            "items": {"type": "object"}
+                        }
+                    ]
                 }
             }
         })
@@ -145,7 +155,7 @@ fn tool_with_model_visible_input_schema_masks_file_params() {
     );
     tool.meta = Some(Meta(
         serde_json::json!({
-            "openai/fileParams": ["file", "files"]
+            "openai/fileParams": ["file", "files", "file_or_files"]
         })
         .as_object()
         .expect("object")
@@ -167,6 +177,16 @@ fn tool_with_model_visible_input_schema_masks_file_params() {
                     "type": "array",
                     "items": {"type": "string"},
                     "description": "This parameter expects an absolute local file path. If you want to upload a file, provide the absolute path to that file here."
+                },
+                "file_or_files": {
+                    "description": "One or more file payloads. This parameter expects an absolute local file path. If you want to upload a file, provide the absolute path to that file here.",
+                    "anyOf": [
+                        {"type": "string"},
+                        {
+                            "type": "array",
+                            "items": {"type": "string"}
+                        }
+                    ]
                 }
             }
         })

--- a/codex-rs/codex-mcp/src/tools.rs
+++ b/codex-rs/codex-mcp/src/tools.rs
@@ -260,7 +260,7 @@ fn mask_input_schema_for_file_path_params(input_schema: &mut JsonValue, file_par
 }
 
 fn mask_input_property_schema(schema: &mut JsonValue) {
-    let Some(object) = schema.as_object_mut() else {
+    let Some(object) = schema.as_object() else {
         return;
     };
 
@@ -276,16 +276,67 @@ fn mask_input_property_schema(schema: &mut JsonValue) {
         description = format!("{description} {guidance}");
     }
 
-    let is_array = object.get("type").and_then(JsonValue::as_str) == Some("array")
-        || object.get("items").is_some();
+    let shape = file_param_schema_shape(schema);
+    let Some(object) = schema.as_object_mut() else {
+        return;
+    };
     object.clear();
     object.insert("description".to_string(), JsonValue::String(description));
-    if is_array {
-        object.insert("type".to_string(), JsonValue::String("array".to_string()));
-        object.insert("items".to_string(), serde_json::json!({ "type": "string" }));
-    } else {
-        object.insert("type".to_string(), JsonValue::String("string".to_string()));
+    match shape {
+        FileParamSchemaShape::Scalar => {
+            object.insert("type".to_string(), JsonValue::String("string".to_string()));
+        }
+        FileParamSchemaShape::Array => {
+            object.insert("type".to_string(), JsonValue::String("array".to_string()));
+            object.insert("items".to_string(), serde_json::json!({ "type": "string" }));
+        }
+        FileParamSchemaShape::ScalarOrArray => {
+            object.insert(
+                "anyOf".to_string(),
+                serde_json::json!([
+                    { "type": "string" },
+                    {
+                        "type": "array",
+                        "items": { "type": "string" },
+                    },
+                ]),
+            );
+        }
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FileParamSchemaShape {
+    Scalar,
+    Array,
+    ScalarOrArray,
+}
+
+fn file_param_schema_shape(schema: &JsonValue) -> FileParamSchemaShape {
+    let Some(object) = schema.as_object() else {
+        return FileParamSchemaShape::Scalar;
+    };
+    let Some(any_of) = object.get("anyOf").and_then(JsonValue::as_array) else {
+        return if is_array_schema(schema) {
+            FileParamSchemaShape::Array
+        } else {
+            FileParamSchemaShape::Scalar
+        };
+    };
+    let has_array = any_of.iter().any(is_array_schema);
+    let has_scalar = any_of.iter().any(|variant| !is_array_schema(variant));
+    match (has_scalar, has_array) {
+        (true, true) => FileParamSchemaShape::ScalarOrArray,
+        (false, true) => FileParamSchemaShape::Array,
+        _ => FileParamSchemaShape::Scalar,
+    }
+}
+
+fn is_array_schema(schema: &JsonValue) -> bool {
+    let Some(object) = schema.as_object() else {
+        return false;
+    };
+    object.get("type").and_then(JsonValue::as_str) == Some("array") || object.get("items").is_some()
 }
 
 fn sha1_hex(s: &str) -> String {


### PR DESCRIPTION
## Why
Apps SDK `openai/fileParams` may declare a parameter that accepts one local path or an array of local paths. Codex execution rewrite already accepts either raw shape, but model-visible schema masking flattened a scalar-or-array `anyOf` to string.

## What
- Preserve scalar-or-array file param schemas as `string | string[]` when masking model-visible input schemas.
- Add a focused `codex-mcp` test for an `anyOf` file param.

## Testing
- `just fmt`
- `CARGO_BUILD_JOBS=1 CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/lt/code/codex/target cargo test -p codex-mcp tool_with_model_visible_input_schema_masks_file_params --lib`

## Related
- Unblocks openai/openai#1031234.