### PR TITLE
feat: accept user submissions at idle turn boundaries

### DIFF
--- a/codex-rs/core/src/codex_thread.rs
+++ b/codex-rs/core/src/codex_thread.rs
@@ -33,6 +33,7 @@ use codex_protocol::protocol::ThreadSource;
 use codex_protocol::protocol::TokenUsageInfo;
 use codex_protocol::protocol::TurnEnvironmentSelection;
 use codex_protocol::protocol::TurnEnvironmentSelections;
+use codex_protocol::protocol::UserSubmission;
 use codex_protocol::protocol::W3cTraceContext;
 use codex_protocol::user_input::UserInput;
 use codex_thread_store::StoredThread;
@@ -74,6 +75,15 @@ pub struct ThreadConfigSnapshot {
     pub thread_source: Option<ThreadSource>,
 }
 
+/// Model-visible input that may start an automatic turn while a thread is idle.
+#[derive(Clone, Debug, PartialEq)]
+pub enum IdleTurnInput {
+    /// Synthetic model input, such as a goal continuation.
+    ResponseItems(Vec<ResponseItem>),
+    /// User-authored input that should behave like a direct user submission.
+    UserSubmission(UserSubmission),
+}
+
 /// Explains why `CodexThread::try_start_turn_if_idle` rejected an automatic
 /// idle turn.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -94,11 +104,11 @@ pub enum TryStartTurnIfIdleRejectionReason {
 #[derive(Debug)]
 pub struct TryStartTurnIfIdleError {
     reason: TryStartTurnIfIdleRejectionReason,
-    input: Vec<ResponseItem>,
+    input: IdleTurnInput,
 }
 
 impl TryStartTurnIfIdleError {
-    pub(crate) fn new(reason: TryStartTurnIfIdleRejectionReason, input: Vec<ResponseItem>) -> Self {
+    pub(crate) fn new(reason: TryStartTurnIfIdleRejectionReason, input: IdleTurnInput) -> Self {
         Self { reason, input }
     }
 
@@ -109,7 +119,7 @@ impl TryStartTurnIfIdleError {
 
     /// Consumes the rejection and returns the original model-visible input
     /// unchanged, so callers can retry, drop, or log it explicitly.
-    pub fn into_input(self) -> Vec<ResponseItem> {
+    pub fn into_input(self) -> IdleTurnInput {
         self.input
     }
 }
@@ -298,24 +308,25 @@ impl CodexThread {
         self.codex.session.inject_if_running(items).await
     }
 
-    /// Starts an automatic regular turn with model-visible items only when idle
+    /// Starts an automatic regular turn with model-visible input only when idle
     /// work is allowed for this thread.
     ///
     /// This is the required entry point for extensions that want to launch
     /// model-visible work from `ThreadLifecycleContributor::on_thread_idle`.
     /// The call succeeds only if no user/client-triggered turn is queued, no
-    /// task is currently active, and the thread is not in Plan mode. Active
-    /// Review tasks are rejected by the active-task check because Review turns
-    /// are not steerable.
+    /// task is currently active, and synthetic input is not running in Plan
+    /// mode. User submissions remain valid in Plan mode, like direct input.
+    /// Active Review tasks are rejected by the active-task check because Review
+    /// turns are not steerable.
     ///
     /// On rejection, the returned error includes a stable reason and carries
-    /// the original `items` unchanged so the caller can decide whether to drop
-    /// them, retry later, or log why no automatic turn was started.
+    /// the original input unchanged so the caller can decide whether to drop
+    /// it, retry later, or log why no automatic turn was started.
     pub async fn try_start_turn_if_idle(
         &self,
-        items: Vec<ResponseItem>,
+        input: IdleTurnInput,
     ) -> Result<(), TryStartTurnIfIdleError> {
-        self.codex.session.try_start_turn_if_idle(items).await
+        self.codex.session.try_start_turn_if_idle(input).await
     }
 
     pub async fn set_app_server_client_info(

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -25,6 +25,7 @@ mod config_lock;
 pub use codex_thread::BackgroundTerminalInfo;
 pub use codex_thread::CodexThread;
 pub use codex_thread::CodexThreadSettingsOverrides;
+pub use codex_thread::IdleTurnInput;
 pub use codex_thread::ThreadConfigSnapshot;
 pub use codex_thread::TryStartTurnIfIdleError;
 pub use codex_thread::TryStartTurnIfIdleRejectionReason;

--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -194,19 +194,13 @@ pub(super) async fn user_input_or_turn_inner(
     else {
         unreachable!();
     };
-    let UserSubmission {
-        items,
-        final_output_json_schema,
-        responsesapi_client_metadata,
-        additional_context,
-    } = submission;
     let emit_thread_settings_applied = thread_settings != ThreadSettingsOverrides::default();
     let mut updates = if emit_thread_settings_applied {
         thread_settings_update(sess, thread_settings).await
     } else {
         SessionSettingsUpdate::default()
     };
-    updates.final_output_json_schema = Some(final_output_json_schema);
+    updates.final_output_json_schema = Some(submission.final_output_json_schema.clone());
 
     let Ok(current_context) = sess.new_turn_with_sub_id(sub_id.clone(), updates).await else {
         // new_turn_with_sub_id already emits the error event.
@@ -223,44 +217,27 @@ pub(super) async fn user_input_or_turn_inner(
         .await;
     match sess
         .steer_input(
-            items.clone(),
-            additional_context.clone(),
+            submission.items.clone(),
+            submission.additional_context.clone(),
             /*expected_turn_id*/ None,
             client_user_message_id.clone(),
-            responsesapi_client_metadata.clone(),
+            submission.responsesapi_client_metadata.clone(),
         )
         .await
     {
         Ok(_) => {
-            current_context.session_telemetry.user_prompt(&items);
+            current_context
+                .session_telemetry
+                .user_prompt(&submission.items);
         }
-        Err(SteerInputError::NoActiveTurn(items)) => {
-            if let Some(responsesapi_client_metadata) = responsesapi_client_metadata {
-                current_context
-                    .turn_metadata_state
-                    .set_responsesapi_client_metadata(responsesapi_client_metadata);
-            }
-            current_context.session_telemetry.user_prompt(&items);
-            sess.refresh_mcp_servers_if_requested(
+        Err(SteerInputError::NoActiveTurn(_)) => {
+            let task_input = prepare_user_submission_task_input(
+                sess,
                 &current_context,
-                Some(sess.mcp_elicitation_reviewer()),
+                submission,
+                client_user_message_id,
             )
             .await;
-            let additional_context_input = {
-                let mut state = sess.state.lock().await;
-                state.additional_context.merge(additional_context)
-            };
-            let mut task_input = additional_context_input
-                .into_iter()
-                .map(ResponseItem::from)
-                .map(TurnInput::ResponseItem)
-                .collect::<Vec<_>>();
-            if !items.is_empty() {
-                task_input.push(TurnInput::UserInput {
-                    content: items,
-                    client_id: client_user_message_id,
-                });
-            }
             sess.spawn_task(
                 Arc::clone(&current_context),
                 task_input,
@@ -276,6 +253,44 @@ pub(super) async fn user_input_or_turn_inner(
             .await;
         }
     }
+}
+
+pub(crate) async fn prepare_user_submission_task_input(
+    sess: &Arc<Session>,
+    turn_context: &Arc<crate::session::TurnContext>,
+    submission: UserSubmission,
+    client_user_message_id: Option<String>,
+) -> Vec<TurnInput> {
+    let UserSubmission {
+        items,
+        final_output_json_schema: _,
+        responsesapi_client_metadata,
+        additional_context,
+    } = submission;
+    if let Some(responsesapi_client_metadata) = responsesapi_client_metadata {
+        turn_context
+            .turn_metadata_state
+            .set_responsesapi_client_metadata(responsesapi_client_metadata);
+    }
+    turn_context.session_telemetry.user_prompt(&items);
+    sess.refresh_mcp_servers_if_requested(turn_context, Some(sess.mcp_elicitation_reviewer()))
+        .await;
+    let additional_context_input = {
+        let mut state = sess.state.lock().await;
+        state.additional_context.merge(additional_context)
+    };
+    let mut task_input = additional_context_input
+        .into_iter()
+        .map(ResponseItem::from)
+        .map(TurnInput::ResponseItem)
+        .collect::<Vec<_>>();
+    if !items.is_empty() {
+        task_input.push(TurnInput::UserInput {
+            content: items,
+            client_id: client_user_message_id,
+        });
+    }
+    task_input
 }
 
 /// Queues an inter-agent message, then lets the shared pending-work scheduler

--- a/codex-rs/core/src/session/inject.rs
+++ b/codex-rs/core/src/session/inject.rs
@@ -1,6 +1,8 @@
+use super::handlers::prepare_user_submission_task_input;
 use super::input_queue::TurnInput;
 use super::session::Session;
 use super::turn_context::TurnContext;
+use crate::codex_thread::IdleTurnInput;
 use crate::codex_thread::TryStartTurnIfIdleError;
 use crate::codex_thread::TryStartTurnIfIdleRejectionReason;
 use crate::state::ActiveTurn;
@@ -35,18 +37,19 @@ impl Session {
         }
     }
 
-    /// Starts a regular turn with the provided items only if automatic idle work
+    /// Starts a regular turn with the provided input only if automatic idle work
     /// is allowed for the current session state.
     ///
     /// This is the shared gate for extension-initiated idle work. It refuses to
-    /// start a turn when user/client-triggered work is queued, any task is still
-    /// active, or the session is currently in Plan mode. Active Review tasks are
-    /// covered by the active-task check because Review turns are not steerable.
+    /// start a turn when user/client-triggered work is queued or any task is
+    /// still active. Synthetic input is also rejected in Plan mode; user
+    /// submissions are allowed there. Active Review tasks are covered by the
+    /// active-task check because Review turns are not steerable.
     pub(crate) async fn try_start_turn_if_idle(
         self: &Arc<Self>,
-        input: Vec<ResponseItem>,
+        input: IdleTurnInput,
     ) -> Result<(), TryStartTurnIfIdleError> {
-        if input.is_empty() {
+        if matches!(&input, IdleTurnInput::ResponseItems(items) if items.is_empty()) {
             return Ok(());
         }
         if self.input_queue.has_trigger_turn_mailbox_items().await {
@@ -55,7 +58,9 @@ impl Session {
                 input,
             ));
         }
-        if self.collaboration_mode().await.mode == ModeKind::Plan {
+        if matches!(&input, IdleTurnInput::ResponseItems(_))
+            && self.collaboration_mode().await.mode == ModeKind::Plan
+        {
             return Err(TryStartTurnIfIdleError::new(
                 TryStartTurnIfIdleRejectionReason::PlanMode,
                 input,
@@ -74,23 +79,33 @@ impl Session {
             Arc::clone(&active_turn.turn_state)
         };
 
-        if self.input_queue.has_trigger_turn_mailbox_items().await {
-            self.clear_reserved_idle_turn(&turn_state).await;
-            self.maybe_start_turn_for_pending_work().await;
-            return Err(TryStartTurnIfIdleError::new(
-                TryStartTurnIfIdleRejectionReason::PendingTriggerTurn,
-                input,
-            ));
-        }
-
         let turn_context = self
             .new_default_turn_with_sub_id(uuid::Uuid::new_v4().to_string())
             .await;
-        if turn_context.collaboration_mode.mode == ModeKind::Plan {
+        if matches!(&input, IdleTurnInput::ResponseItems(_))
+            && turn_context.collaboration_mode.mode == ModeKind::Plan
+        {
             self.clear_reserved_idle_turn(&turn_state).await;
             self.maybe_start_turn_for_pending_work().await;
             return Err(TryStartTurnIfIdleError::new(
                 TryStartTurnIfIdleRejectionReason::PlanMode,
+                input,
+            ));
+        }
+        if matches!(&input, IdleTurnInput::UserSubmission(_))
+            && self
+                .services
+                .agent_control
+                .ensure_execution_capacity(
+                    turn_context.multi_agent_version,
+                    &turn_context.session_source,
+                )
+                .is_err()
+        {
+            self.clear_reserved_idle_turn(&turn_state).await;
+            self.maybe_start_turn_for_pending_work().await;
+            return Err(TryStartTurnIfIdleError::new(
+                TryStartTurnIfIdleRejectionReason::Busy,
                 input,
             ));
         }
@@ -118,14 +133,30 @@ impl Session {
             ));
         }
 
-        self.input_queue
-            .extend_pending_input_for_turn_state(
-                turn_state.as_ref(),
-                input.into_iter().map(TurnInput::ResponseItem).collect(),
-            )
-            .await;
-        self.start_task(turn_context, Vec::new(), RegularTask::new())
-            .await;
+        match input {
+            IdleTurnInput::ResponseItems(items) => {
+                self.input_queue
+                    .extend_pending_input_for_turn_state(
+                        turn_state.as_ref(),
+                        items.into_iter().map(TurnInput::ResponseItem).collect(),
+                    )
+                    .await;
+                self.start_task(turn_context, Vec::new(), RegularTask::new())
+                    .await;
+            }
+            IdleTurnInput::UserSubmission(submission) => {
+                let task_input = prepare_user_submission_task_input(
+                    self,
+                    &turn_context,
+                    submission,
+                    /*client_user_message_id*/ None,
+                )
+                .await;
+                self.clear_connector_selection().await;
+                self.start_task(turn_context, task_input, RegularTask::new())
+                    .await;
+            }
+        }
         Ok(())
     }
 

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -1,5 +1,6 @@
 use super::turn_context::TurnEnvironment;
 use super::*;
+use crate::codex_thread::IdleTurnInput;
 use crate::codex_thread::TryStartTurnIfIdleRejectionReason;
 use crate::config::ConfigBuilder;
 use crate::config::ConfigOverrides;
@@ -8968,12 +8969,12 @@ async fn try_start_turn_if_idle_rejects_active_turn_without_injecting() {
 
     let item = user_message("synthetic idle input");
     let err = sess
-        .try_start_turn_if_idle(vec![item.clone()])
+        .try_start_turn_if_idle(IdleTurnInput::ResponseItems(vec![item.clone()]))
         .await
         .expect_err("active turn should reject idle-only input");
 
     assert_eq!(TryStartTurnIfIdleRejectionReason::Busy, err.reason());
-    assert_eq!(vec![item], err.into_input());
+    assert_eq!(IdleTurnInput::ResponseItems(vec![item]), err.into_input());
     assert_eq!(
         Vec::<TurnInput>::new(),
         sess.input_queue.get_pending_input(&sess.active_turn).await
@@ -8994,17 +8995,132 @@ async fn try_start_turn_if_idle_rejects_plan_mode_without_injecting() {
 
     let item = user_message("synthetic idle input");
     let err = sess
-        .try_start_turn_if_idle(vec![item.clone()])
+        .try_start_turn_if_idle(IdleTurnInput::ResponseItems(vec![item.clone()]))
         .await
         .expect_err("plan mode should reject automatic idle input");
 
     assert_eq!(TryStartTurnIfIdleRejectionReason::PlanMode, err.reason());
-    assert_eq!(vec![item], err.into_input());
+    assert_eq!(IdleTurnInput::ResponseItems(vec![item]), err.into_input());
     assert!(sess.active_turn.lock().await.is_none());
     assert_eq!(
         Vec::<TurnInput>::new(),
         sess.input_queue.get_pending_input(&sess.active_turn).await
     );
+}
+
+#[tokio::test]
+async fn try_start_turn_if_idle_allows_user_submission_in_plan_mode() {
+    let (sess, _tc, rx) = make_session_and_context_with_rx().await;
+    let mut collaboration_mode = sess.collaboration_mode().await;
+    collaboration_mode.mode = ModeKind::Plan;
+    {
+        let mut state = sess.state.lock().await;
+        state.session_configuration.collaboration_mode = collaboration_mode;
+    }
+    sess.merge_connector_selection(std::collections::HashSet::from([
+        "stale-connector".to_string()
+    ]))
+    .await;
+    let (_tx, startup_prewarm_rx) = tokio::sync::oneshot::channel::<()>();
+    let handle = tokio::spawn(async move {
+        let _ = startup_prewarm_rx.await;
+        Ok(test_model_client_session())
+    });
+    sess.set_session_startup_prewarm(
+        crate::session_startup_prewarm::SessionStartupPrewarmHandle::new(
+            handle,
+            std::time::Instant::now(),
+            crate::client::WEBSOCKET_CONNECT_TIMEOUT,
+        ),
+    )
+    .await;
+
+    let submission = UserSubmission {
+        items: vec![UserInput::Text {
+            text: "queued plan input".to_string(),
+            text_elements: Vec::new(),
+        }],
+        responsesapi_client_metadata: Some(std::collections::HashMap::from([(
+            "workspace_kind".to_string(),
+            "local".to_string(),
+        )])),
+        ..Default::default()
+    };
+
+    sess.try_start_turn_if_idle(IdleTurnInput::UserSubmission(submission))
+        .await
+        .expect("user submission should start in plan mode");
+
+    assert!(sess.get_connector_selection().await.is_empty());
+
+    let event = tokio::time::timeout(StdDuration::from_secs(2), rx.recv())
+        .await
+        .expect("turn started event")
+        .expect("event channel open");
+    assert!(matches!(event.msg, EventMsg::TurnStarted(_)));
+    {
+        let active = sess.active_turn.lock().await;
+        let turn_context = &active
+            .as_ref()
+            .and_then(|turn| turn.task.as_ref())
+            .expect("active user turn")
+            .turn_context;
+        assert_eq!(ModeKind::Plan, turn_context.collaboration_mode.mode);
+        assert_eq!(None, turn_context.final_output_json_schema);
+        assert_eq!(
+            Some("local".to_string()),
+            turn_context.turn_metadata_state.workspace_kind()
+        );
+    }
+
+    sess.abort_all_tasks(TurnAbortReason::Interrupted).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_idle_user_submissions_start_at_most_one_turn() {
+    let (sess, _tc, _rx) = make_session_and_context_with_rx().await;
+    let (_tx, startup_prewarm_rx) = tokio::sync::oneshot::channel::<()>();
+    let handle = tokio::spawn(async move {
+        let _ = startup_prewarm_rx.await;
+        Ok(test_model_client_session())
+    });
+    sess.set_session_startup_prewarm(
+        crate::session_startup_prewarm::SessionStartupPrewarmHandle::new(
+            handle,
+            std::time::Instant::now(),
+            crate::client::WEBSOCKET_CONNECT_TIMEOUT,
+        ),
+    )
+    .await;
+
+    let first = IdleTurnInput::UserSubmission(UserSubmission {
+        items: vec![UserInput::Text {
+            text: "first".to_string(),
+            text_elements: Vec::new(),
+        }],
+        ..Default::default()
+    });
+    let second = IdleTurnInput::UserSubmission(UserSubmission {
+        items: vec![UserInput::Text {
+            text: "second".to_string(),
+            text_elements: Vec::new(),
+        }],
+        ..Default::default()
+    });
+    let (first_result, second_result) = tokio::join!(
+        sess.try_start_turn_if_idle(first.clone()),
+        sess.try_start_turn_if_idle(second.clone())
+    );
+
+    let (accepted, rejected) = match (first_result, second_result) {
+        (Ok(()), Err(err)) => (first, err),
+        (Err(err), Ok(())) => (second, err),
+        results => panic!("expected one accepted idle turn, got {results:?}"),
+    };
+    assert_eq!(TryStartTurnIfIdleRejectionReason::Busy, rejected.reason());
+    assert_ne!(accepted, rejected.into_input());
+
+    sess.abort_all_tasks(TurnAbortReason::Interrupted).await;
 }
 
 #[tokio::test]
@@ -9022,7 +9138,7 @@ async fn try_start_turn_if_idle_rejects_pending_trigger_turn_without_injecting()
 
     let item = user_message("synthetic idle input");
     let err = sess
-        .try_start_turn_if_idle(vec![item.clone()])
+        .try_start_turn_if_idle(IdleTurnInput::ResponseItems(vec![item.clone()]))
         .await
         .expect_err("pending trigger-turn mail should reject automatic idle input");
 
@@ -9030,7 +9146,41 @@ async fn try_start_turn_if_idle_rejects_pending_trigger_turn_without_injecting()
         TryStartTurnIfIdleRejectionReason::PendingTriggerTurn,
         err.reason()
     );
-    assert_eq!(vec![item], err.into_input());
+    assert_eq!(IdleTurnInput::ResponseItems(vec![item]), err.into_input());
+    assert!(sess.active_turn.lock().await.is_none());
+    assert!(sess.input_queue.has_trigger_turn_mailbox_items().await);
+}
+
+#[tokio::test]
+async fn trigger_turn_mail_takes_precedence_over_idle_user_submission() {
+    let (sess, _tc, _rx) = make_session_and_context_with_rx().await;
+    sess.input_queue
+        .enqueue_mailbox_communication(InterAgentCommunication::new(
+            AgentPath::root(),
+            AgentPath::root(),
+            Vec::new(),
+            "pending trigger".to_string(),
+            /*trigger_turn*/ true,
+        ))
+        .await;
+    let input = IdleTurnInput::UserSubmission(UserSubmission {
+        items: vec![UserInput::Text {
+            text: "queued user input".to_string(),
+            text_elements: Vec::new(),
+        }],
+        ..Default::default()
+    });
+
+    let err = sess
+        .try_start_turn_if_idle(input.clone())
+        .await
+        .expect_err("trigger-turn mail should win over queued user input");
+
+    assert_eq!(
+        TryStartTurnIfIdleRejectionReason::PendingTriggerTurn,
+        err.reason()
+    );
+    assert_eq!(input, err.into_input());
     assert!(sess.active_turn.lock().await.is_none());
     assert!(sess.input_queue.has_trigger_turn_mailbox_items().await);
 }
@@ -9050,12 +9200,12 @@ async fn try_start_turn_if_idle_rejects_active_review_turn_without_injecting() {
 
     let item = user_message("synthetic idle input");
     let err = sess
-        .try_start_turn_if_idle(vec![item.clone()])
+        .try_start_turn_if_idle(IdleTurnInput::ResponseItems(vec![item.clone()]))
         .await
         .expect_err("active review turn should reject automatic idle input");
 
     assert_eq!(TryStartTurnIfIdleRejectionReason::Busy, err.reason());
-    assert_eq!(vec![item], err.into_input());
+    assert_eq!(IdleTurnInput::ResponseItems(vec![item]), err.into_input());
     assert_eq!(
         Vec::<TurnInput>::new(),
         sess.input_queue.get_pending_input(&sess.active_turn).await

--- a/codex-rs/core/tests/suite/idle_turn.rs
+++ b/codex-rs/core/tests/suite/idle_turn.rs
@@ -1,0 +1,78 @@
+use anyhow::Result;
+use codex_core::IdleTurnInput;
+use codex_protocol::config_types::CollaborationMode;
+use codex_protocol::config_types::ModeKind;
+use codex_protocol::config_types::Settings;
+use codex_protocol::protocol::EventMsg;
+use codex_protocol::protocol::ThreadSettingsOverrides;
+use codex_protocol::protocol::UserSubmission;
+use codex_protocol::user_input::UserInput;
+use core_test_support::responses;
+use core_test_support::responses::start_mock_server;
+use core_test_support::skip_if_no_network;
+use core_test_support::submit_thread_settings;
+use core_test_support::test_codex::test_codex;
+use core_test_support::wait_for_event_match;
+use pretty_assertions::assert_eq;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn idle_user_submission_starts_a_model_turn() -> Result<()> {
+    idle_user_submission_starts_a_model_turn_in_mode(ModeKind::Default).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn idle_user_submission_starts_a_model_turn_in_plan_mode() -> Result<()> {
+    idle_user_submission_starts_a_model_turn_in_mode(ModeKind::Plan).await
+}
+
+async fn idle_user_submission_starts_a_model_turn_in_mode(mode: ModeKind) -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let request =
+        responses::mount_sse_once(&server, responses::sse_completed("queued turn complete")).await;
+    let test = test_codex()
+        .with_config(|config| config.include_environment_context = false)
+        .build(&server)
+        .await?;
+    submit_thread_settings(
+        &test.codex,
+        ThreadSettingsOverrides {
+            collaboration_mode: Some(CollaborationMode {
+                mode,
+                settings: Settings {
+                    model: test.session_configured.model.clone(),
+                    reasoning_effort: None,
+                    developer_instructions: None,
+                },
+            }),
+            ..Default::default()
+        },
+    )
+    .await?;
+    let thread = test
+        .thread_manager
+        .get_thread(test.session_configured.thread_id)
+        .await?;
+
+    thread
+        .try_start_turn_if_idle(IdleTurnInput::UserSubmission(UserSubmission {
+            items: vec![UserInput::Text {
+                text: "durable follow-up".to_string(),
+                text_elements: Vec::new(),
+            }],
+            ..Default::default()
+        }))
+        .await
+        .map_err(|err| anyhow::anyhow!("idle user submission rejected: {:?}", err.reason()))?;
+
+    wait_for_event_match(test.codex.as_ref(), |event| {
+        matches!(event, EventMsg::TurnComplete(_)).then_some(())
+    })
+    .await;
+    assert_eq!(
+        request.single_request().message_input_texts("user"),
+        vec!["durable follow-up"]
+    );
+    Ok(())
+}

--- a/codex-rs/core/tests/suite/mod.rs
+++ b/codex-rs/core/tests/suite/mod.rs
@@ -61,6 +61,7 @@ mod hierarchical_agents;
 mod hooks;
 #[cfg(not(target_os = "windows"))]
 mod hooks_mcp;
+mod idle_turn;
 mod image_rollout;
 mod items;
 mod json_result;

--- a/codex-rs/ext/goal/src/runtime.rs
+++ b/codex-rs/ext/goal/src/runtime.rs
@@ -3,6 +3,7 @@ use std::sync::Weak;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 
+use codex_core::IdleTurnInput;
 use codex_core::ThreadManager;
 use codex_protocol::ThreadId;
 use codex_protocol::models::ResponseItem;
@@ -391,7 +392,10 @@ impl GoalRuntimeHandle {
         }
         let item = continuation_steering_item(&protocol_goal_from_state(goal));
 
-        if let Err(err) = thread.try_start_turn_if_idle(vec![item]).await {
+        if let Err(err) = thread
+            .try_start_turn_if_idle(IdleTurnInput::ResponseItems(vec![item]))
+            .await
+        {
             let reason = err.reason();
             tracing::debug!(
                 ?reason,


### PR DESCRIPTION
## Summary

Core's idle extension gate previously accepted only synthetic `ResponseItem` values. A queued user message needs the same atomic idle admission while preserving ordinary user-submission behavior such as additional context, Responses API metadata, telemetry, and Plan mode.

This change extends the existing gate with `IdleTurnInput::UserSubmission`. The extension still decides when to request work; core remains responsible only for atomically accepting the idle turn and starting the normal regular task. Idle user submissions create their turn context from the thread's current settings and do not apply `final_output_json_schema`.

## Changes

- Add `IdleTurnInput::{ResponseItems, UserSubmission}`.
- Let `try_start_turn_if_idle` return the original typed input on rejection.
- Extract the existing user-submission task-input preparation so direct and idle starts share one path.
- Preserve trigger-mailbox precedence and the atomic active-turn reservation.
- Keep goals on `ResponseItems` without changing goal behavior.

## Design decisions

- `UserSubmission` is allowed in Plan mode because it represents user-authored work. Synthetic `ResponseItems` remain rejected there.
- Core does not claim queue rows or schedule retries. Those responsibilities stay in the queue extension.
- The rejection enum names only stable admission outcomes: pending trigger work, Plan mode, or busy.
- Turn-scoped output schemas remain supported by ordinary direct turns. Queued output-schema support requires a later direct turn-context construction path.

## Testing

Tests: targeted idle-admission, concurrency, mailbox-precedence, Plan-mode, and model-turn coverage; affected Rust test targets compile locally; formatter and clippy cleanup pass. Full suites run in CI.

## Stack

1. [#28264](https://github.com/openai/codex/pull/28264) - extract the core user-submission payload
2. **[#28265](https://github.com/openai/codex/pull/28265) - accept user submissions at idle turn boundaries (this PR)**
3. [#28266](https://github.com/openai/codex/pull/28266) - add durable queue storage
4. [#28267](https://github.com/openai/codex/pull/28267) - dispatch queued messages through ordered idle extensions
5. [#28268](https://github.com/openai/codex/pull/28268) - expose the app-server queue API
6. [#28307](https://github.com/openai/codex/pull/28307) - queue TUI follow-ups through app-server
