### PR TITLE
Flatten MCP namespace tools for unsupported providers

### DIFF
--- a/codex-rs/app-server/src/request_processors/thread_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor.rs
@@ -244,6 +244,7 @@ fn validate_dynamic_tools(tools: &[ApiDynamicToolSpec]) -> Result<(), String> {
     }
 
     let mut seen = HashSet::new();
+    let mut seen_canonical_flat_names = HashSet::new();
     for tool in tools {
         let name = tool.name.trim();
         if name.is_empty() {
@@ -296,6 +297,14 @@ fn validate_dynamic_tools(tools: &[ApiDynamicToolSpec]) -> Result<(), String> {
                 ));
             }
             return Err(format!("duplicate dynamic tool name: {name}"));
+        }
+        let tool_name = codex_tools::ToolName::new(namespace.map(str::to_string), name);
+        let canonical_flat_name = tool_name.canonical_flat_name().into_owned();
+        if !seen_canonical_flat_names.insert(canonical_flat_name.clone()) {
+            return Err(format!(
+                "duplicate dynamic tool canonical flat name: {}",
+                escape_identifier_for_error(&canonical_flat_name),
+            ));
         }
         if tool.defer_loading && namespace.is_none() {
             return Err(format!(

--- a/codex-rs/app-server/src/request_processors/thread_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor.rs
@@ -195,7 +195,10 @@ fn has_model_resume_override(
             .is_some_and(|overrides| overrides.contains_key("model_reasoning_effort"))
 }
 
-fn validate_dynamic_tools(tools: &[ApiDynamicToolSpec]) -> Result<(), String> {
+fn validate_dynamic_tools(
+    tools: &[ApiDynamicToolSpec],
+    namespace_tools_enabled: bool,
+) -> Result<(), String> {
     const DYNAMIC_TOOL_NAME_MAX_LEN: usize = 128;
     const DYNAMIC_TOOL_NAMESPACE_MAX_LEN: usize = 64;
     const DYNAMIC_TOOL_IDENTIFIER_PATTERN: &str = "^[a-zA-Z0-9_-]+$";
@@ -298,13 +301,20 @@ fn validate_dynamic_tools(tools: &[ApiDynamicToolSpec]) -> Result<(), String> {
             }
             return Err(format!("duplicate dynamic tool name: {name}"));
         }
-        let tool_name = codex_tools::ToolName::new(namespace.map(str::to_string), name);
-        let canonical_flat_name = tool_name.canonical_flat_name().into_owned();
-        if !seen_canonical_flat_names.insert(canonical_flat_name.clone()) {
-            return Err(format!(
-                "duplicate dynamic tool canonical flat name: {}",
-                escape_identifier_for_error(&canonical_flat_name),
-            ));
+        if !namespace_tools_enabled {
+            let tool_name = codex_tools::ToolName::new(namespace.map(str::to_string), name);
+            let canonical_flat_name = tool_name.canonical_flat_name().into_owned();
+            validate_dynamic_tool_identifier(
+                &canonical_flat_name,
+                "dynamic tool canonical flat name",
+                DYNAMIC_TOOL_NAME_MAX_LEN,
+            )?;
+            if !seen_canonical_flat_names.insert(canonical_flat_name.clone()) {
+                return Err(format!(
+                    "duplicate dynamic tool canonical flat name: {}",
+                    escape_identifier_for_error(&canonical_flat_name),
+                ));
+            }
         }
         if tool.defer_loading && namespace.is_none() {
             return Err(format!(
@@ -1089,7 +1099,12 @@ impl ThreadRequestProcessor {
         let core_dynamic_tools = if dynamic_tools.is_empty() {
             Vec::new()
         } else {
-            validate_dynamic_tools(&dynamic_tools).map_err(invalid_request)?;
+            let namespace_tools_enabled =
+                create_model_provider(config.model_provider.clone(), /*auth_manager*/ None)
+                    .capabilities()
+                    .namespace_tools;
+            validate_dynamic_tools(&dynamic_tools, namespace_tools_enabled)
+                .map_err(invalid_request)?;
             dynamic_tools
                 .into_iter()
                 .map(|tool| CoreDynamicToolSpec {

--- a/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
@@ -670,6 +670,7 @@ mod thread_processor_behavior_tests {
             websocket_connect_timeout_ms: None,
             requires_openai_auth: false,
             supports_websockets: true,
+            namespace_tools: None,
         };
         let config_manager = ConfigManager::new(
             temp_dir.path().to_path_buf(),

--- a/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
@@ -223,6 +223,36 @@ mod thread_processor_behavior_tests {
     }
 
     #[test]
+    fn validate_dynamic_tools_rejects_duplicate_canonical_flat_name() {
+        let tools = vec![
+            ApiDynamicToolSpec {
+                namespace: Some("a".to_string()),
+                name: "b__c".to_string(),
+                description: "test".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false
+                }),
+                defer_loading: true,
+            },
+            ApiDynamicToolSpec {
+                namespace: Some("a__b".to_string()),
+                name: "c".to_string(),
+                description: "test".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": false
+                }),
+                defer_loading: true,
+            },
+        ];
+        let err = validate_dynamic_tools(&tools).expect_err("duplicate canonical flat name");
+        assert!(err.contains("a__b__c"), "unexpected error: {err}");
+    }
+
+    #[test]
     fn validate_dynamic_tools_accepts_responses_compatible_identifiers() {
         let tools = vec![ApiDynamicToolSpec {
             namespace: Some("Codex-App_2".to_string()),

--- a/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
@@ -148,6 +148,27 @@ mod thread_processor_behavior_tests {
     use std::sync::Arc;
     use tempfile::TempDir;
 
+    fn deferred_dynamic_tool(namespace: String, name: String) -> ApiDynamicToolSpec {
+        ApiDynamicToolSpec {
+            namespace: Some(namespace),
+            name,
+            description: "test".to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+            defer_loading: true,
+        }
+    }
+
+    fn canonical_flat_name_collision_tools() -> Vec<ApiDynamicToolSpec> {
+        vec![
+            deferred_dynamic_tool("a".to_string(), "b__c".to_string()),
+            deferred_dynamic_tool("a__b".to_string(), "c".to_string()),
+        ]
+    }
+
     #[test]
     fn validate_dynamic_tools_rejects_unsupported_input_schema() {
         let tools = vec![ApiDynamicToolSpec {
@@ -157,7 +178,8 @@ mod thread_processor_behavior_tests {
             input_schema: json!({"type": "null"}),
             defer_loading: false,
         }];
-        let err = validate_dynamic_tools(&tools).expect_err("invalid schema");
+        let err = validate_dynamic_tools(&tools, /*namespace_tools_enabled*/ true)
+            .expect_err("invalid schema");
         assert!(err.contains("my_tool"), "unexpected error: {err}");
     }
 
@@ -171,7 +193,7 @@ mod thread_processor_behavior_tests {
             input_schema: json!({"properties": {}}),
             defer_loading: false,
         }];
-        validate_dynamic_tools(&tools).expect("valid schema");
+        validate_dynamic_tools(&tools, /*namespace_tools_enabled*/ true).expect("valid schema");
     }
 
     #[test]
@@ -190,7 +212,7 @@ mod thread_processor_behavior_tests {
             }),
             defer_loading: false,
         }];
-        validate_dynamic_tools(&tools).expect("valid schema");
+        validate_dynamic_tools(&tools, /*namespace_tools_enabled*/ true).expect("valid schema");
     }
 
     #[test]
@@ -219,37 +241,60 @@ mod thread_processor_behavior_tests {
                 defer_loading: true,
             },
         ];
-        validate_dynamic_tools(&tools).expect("valid schema");
+        validate_dynamic_tools(&tools, /*namespace_tools_enabled*/ true).expect("valid schema");
     }
 
     #[test]
     fn validate_dynamic_tools_rejects_duplicate_canonical_flat_name() {
-        let tools = vec![
-            ApiDynamicToolSpec {
-                namespace: Some("a".to_string()),
-                name: "b__c".to_string(),
-                description: "test".to_string(),
-                input_schema: json!({
-                    "type": "object",
-                    "properties": {},
-                    "additionalProperties": false
-                }),
-                defer_loading: true,
-            },
-            ApiDynamicToolSpec {
-                namespace: Some("a__b".to_string()),
-                name: "c".to_string(),
-                description: "test".to_string(),
-                input_schema: json!({
-                    "type": "object",
-                    "properties": {},
-                    "additionalProperties": false
-                }),
-                defer_loading: true,
-            },
-        ];
-        let err = validate_dynamic_tools(&tools).expect_err("duplicate canonical flat name");
+        let err = validate_dynamic_tools(
+            &canonical_flat_name_collision_tools(),
+            /*namespace_tools_enabled*/ false,
+        )
+        .expect_err("duplicate canonical flat name");
         assert!(err.contains("a__b__c"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_dynamic_tools_accepts_duplicate_canonical_flat_name_with_namespace_tools() {
+        validate_dynamic_tools(
+            &canonical_flat_name_collision_tools(),
+            /*namespace_tools_enabled*/ true,
+        )
+        .expect("valid schema");
+    }
+
+    #[test]
+    fn validate_dynamic_tools_rejects_overlong_canonical_flat_name_when_flattened() {
+        let long_namespace = "a".repeat(64);
+        let long_name = "b".repeat(128);
+        let tools = vec![deferred_dynamic_tool(
+            long_namespace.clone(),
+            long_name.clone(),
+        )];
+
+        let err = validate_dynamic_tools(&tools, /*namespace_tools_enabled*/ false)
+            .expect_err("canonical flat name too long");
+        assert!(
+            err.contains("dynamic tool canonical flat name"),
+            "unexpected error: {err}"
+        );
+        assert!(err.contains("at most 128"), "unexpected error: {err}");
+        assert!(err.contains(&long_namespace), "unexpected error: {err}");
+        assert!(err.contains(&long_name), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn validate_dynamic_tools_accepts_canonical_flat_name_at_responses_limit() {
+        let tools = vec![deferred_dynamic_tool("a".repeat(64), "b".repeat(62))];
+
+        validate_dynamic_tools(&tools, /*namespace_tools_enabled*/ false).expect("valid schema");
+    }
+
+    #[test]
+    fn validate_dynamic_tools_accepts_overlong_canonical_flat_name_with_namespace_tools() {
+        let tools = vec![deferred_dynamic_tool("a".repeat(64), "b".repeat(128))];
+
+        validate_dynamic_tools(&tools, /*namespace_tools_enabled*/ true).expect("valid schema");
     }
 
     #[test]
@@ -265,7 +310,7 @@ mod thread_processor_behavior_tests {
             }),
             defer_loading: true,
         }];
-        validate_dynamic_tools(&tools).expect("valid schema");
+        validate_dynamic_tools(&tools, /*namespace_tools_enabled*/ true).expect("valid schema");
     }
 
     #[test]
@@ -294,7 +339,8 @@ mod thread_processor_behavior_tests {
                 defer_loading: true,
             },
         ];
-        let err = validate_dynamic_tools(&tools).expect_err("duplicate name");
+        let err = validate_dynamic_tools(&tools, /*namespace_tools_enabled*/ true)
+            .expect_err("duplicate name");
         assert!(err.contains("codex_app"), "unexpected error: {err}");
         assert!(err.contains("my_tool"), "unexpected error: {err}");
     }
@@ -352,7 +398,8 @@ mod thread_processor_behavior_tests {
             }),
             defer_loading: false,
         }];
-        let err = validate_dynamic_tools(&tools).expect_err("empty namespace");
+        let err = validate_dynamic_tools(&tools, /*namespace_tools_enabled*/ true)
+            .expect_err("empty namespace");
         assert!(err.contains("my_tool"), "unexpected error: {err}");
         assert!(err.contains("namespace"), "unexpected error: {err}");
     }
@@ -370,7 +417,8 @@ mod thread_processor_behavior_tests {
             }),
             defer_loading: false,
         }];
-        let err = validate_dynamic_tools(&tools).expect_err("reserved namespace");
+        let err = validate_dynamic_tools(&tools, /*namespace_tools_enabled*/ true)
+            .expect_err("reserved namespace");
         assert!(err.contains("my_tool"), "unexpected error: {err}");
         assert!(err.contains("reserved"), "unexpected error: {err}");
     }
@@ -388,7 +436,8 @@ mod thread_processor_behavior_tests {
             }),
             defer_loading: false,
         }];
-        let err = validate_dynamic_tools(&tools).expect_err("invalid name");
+        let err = validate_dynamic_tools(&tools, /*namespace_tools_enabled*/ true)
+            .expect_err("invalid name");
         assert!(err.contains("lookup.ticket"), "unexpected error: {err}");
         assert!(
             err.contains("Responses API") && err.contains("^[a-zA-Z0-9_-]+$"),
@@ -409,7 +458,8 @@ mod thread_processor_behavior_tests {
             }),
             defer_loading: true,
         }];
-        let err = validate_dynamic_tools(&tools).expect_err("invalid namespace");
+        let err = validate_dynamic_tools(&tools, /*namespace_tools_enabled*/ true)
+            .expect_err("invalid namespace");
         assert!(err.contains("codex.app"), "unexpected error: {err}");
         assert!(
             err.contains("Responses API") && err.contains("^[a-zA-Z0-9_-]+$"),
@@ -431,7 +481,8 @@ mod thread_processor_behavior_tests {
             }),
             defer_loading: false,
         }];
-        let err = validate_dynamic_tools(&tools).expect_err("name too long");
+        let err = validate_dynamic_tools(&tools, /*namespace_tools_enabled*/ true)
+            .expect_err("name too long");
         assert!(err.contains("at most 128"), "unexpected error: {err}");
         assert!(err.contains(&long_name), "unexpected error: {err}");
     }
@@ -450,7 +501,8 @@ mod thread_processor_behavior_tests {
             }),
             defer_loading: true,
         }];
-        let err = validate_dynamic_tools(&tools).expect_err("namespace too long");
+        let err = validate_dynamic_tools(&tools, /*namespace_tools_enabled*/ true)
+            .expect_err("namespace too long");
         assert!(err.contains("at most 64"), "unexpected error: {err}");
         assert!(err.contains(&long_namespace), "unexpected error: {err}");
     }
@@ -468,7 +520,8 @@ mod thread_processor_behavior_tests {
             }),
             defer_loading: true,
         }];
-        let err = validate_dynamic_tools(&tools).expect_err("reserved Responses namespace");
+        let err = validate_dynamic_tools(&tools, /*namespace_tools_enabled*/ true)
+            .expect_err("reserved Responses namespace");
         assert!(err.contains("functions"), "unexpected error: {err}");
         assert!(err.contains("Responses API"), "unexpected error: {err}");
     }

--- a/codex-rs/app-server/tests/suite/v2/dynamic_tools.rs
+++ b/codex-rs/app-server/tests/suite/v2/dynamic_tools.rs
@@ -281,6 +281,46 @@ async fn thread_start_rejects_dynamic_tools_not_supported_by_responses() -> Resu
     Ok(())
 }
 
+#[tokio::test]
+async fn thread_start_rejects_overlong_flat_dynamic_tool_name() -> Result<()> {
+    let server = MockServer::start().await;
+
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), &server.uri())?;
+
+    let mut mcp = TestAppServer::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let dynamic_tool = DynamicToolSpec {
+        namespace: Some("a".repeat(64)),
+        name: "b".repeat(128),
+        description: "Overlong flat dynamic tool".to_string(),
+        input_schema: json!({
+            "type": "object",
+            "properties": {},
+            "additionalProperties": false,
+        }),
+        defer_loading: false,
+    };
+
+    let thread_req = mcp
+        .send_thread_start_request(ThreadStartParams {
+            dynamic_tools: Some(vec![dynamic_tool]),
+            ..Default::default()
+        })
+        .await?;
+    let error = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(thread_req)),
+    )
+    .await??;
+    assert_eq!(error.error.code, -32600);
+    assert!(error.error.message.contains("canonical flat name"));
+    assert!(error.error.message.contains("at most 128"));
+
+    Ok(())
+}
+
 /// Exercises the full dynamic tool call path (server request, client response, model output).
 #[tokio::test]
 async fn dynamic_tool_call_round_trip_sends_text_content_items_to_model() -> Result<()> {

--- a/codex-rs/codex-mcp/src/connection_manager_tests.rs
+++ b/codex-rs/codex-mcp/src/connection_manager_tests.rs
@@ -482,6 +482,27 @@ fn test_normalize_tools_disambiguates_sanitized_tool_name_collisions() {
 }
 
 #[test]
+fn test_normalize_tools_disambiguates_canonical_flat_name_collisions() {
+    let tools = vec![create_test_tool("a", "b__c"), create_test_tool("a__b", "c")];
+
+    let model_tools =
+        normalize_tools_for_model_with_prefix(tools, /*prefix_mcp_tool_names*/ true);
+
+    assert_eq!(model_tools.len(), 2);
+    assert_eq!(model_tool_names(&model_tools).len(), 2);
+    let canonical_flat_names = model_tools
+        .iter()
+        .map(|tool| {
+            tool.canonical_tool_name()
+                .canonical_flat_name()
+                .into_owned()
+        })
+        .collect::<HashSet<_>>();
+    assert_eq!(canonical_flat_names.len(), 2);
+    assert!(canonical_flat_names.contains("mcp__a__b__c"));
+}
+
+#[test]
 fn tool_filter_allows_by_default() {
     let filter = ToolFilter::default();
 

--- a/codex-rs/codex-mcp/src/tools.rs
+++ b/codex-rs/codex-mcp/src/tools.rs
@@ -376,8 +376,8 @@ fn unique_callable_parts(
     used_names: &mut HashSet<String>,
     reserved_len: usize,
 ) -> (String, String) {
-    let model_name = format!("{namespace}{tool_name}");
-    if model_name.len() + reserved_len <= MAX_TOOL_NAME_LENGTH && used_names.insert(model_name) {
+    let canonical_flat_name = canonical_flat_tool_name(namespace, tool_name);
+    if canonical_flat_name.len() <= MAX_TOOL_NAME_LENGTH && used_names.insert(canonical_flat_name) {
         return (namespace.to_string(), tool_name.to_string());
     }
 
@@ -390,10 +390,15 @@ fn unique_callable_parts(
         };
         let (namespace, tool_name) =
             fit_callable_parts_with_hash(namespace, tool_name, &hash_input, reserved_len);
-        let model_name = format!("{namespace}{tool_name}");
-        if used_names.insert(model_name) {
+        if used_names.insert(canonical_flat_tool_name(&namespace, &tool_name)) {
             return (namespace, tool_name);
         }
         attempt = attempt.saturating_add(1);
     }
+}
+
+fn canonical_flat_tool_name(namespace: &str, tool_name: &str) -> String {
+    ToolName::namespaced(namespace, tool_name)
+        .canonical_flat_name()
+        .into_owned()
 }

--- a/codex-rs/config/src/thread_config.rs
+++ b/codex-rs/config/src/thread_config.rs
@@ -316,6 +316,7 @@ mod tests {
             websocket_connect_timeout_ms: None,
             requires_openai_auth: false,
             supports_websockets: true,
+            namespace_tools: None,
         }
     }
 }

--- a/codex-rs/config/src/thread_config/proto/codex.thread_config.v1.proto
+++ b/codex-rs/config/src/thread_config/proto/codex.thread_config.v1.proto
@@ -48,6 +48,7 @@ message ModelProvider {
   optional uint64 websocket_connect_timeout_ms = 15;
   bool requires_openai_auth = 16;
   bool supports_websockets = 17;
+  optional bool namespace_tools = 18;
 }
 
 message StringMap {

--- a/codex-rs/config/src/thread_config/proto/codex.thread_config.v1.rs
+++ b/codex-rs/config/src/thread_config/proto/codex.thread_config.v1.rs
@@ -75,6 +75,8 @@ pub struct ModelProvider {
     pub requires_openai_auth: bool,
     #[prost(bool, tag = "17")]
     pub supports_websockets: bool,
+    #[prost(bool, optional, tag = "18")]
+    pub namespace_tools: ::core::option::Option<bool>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StringMap {

--- a/codex-rs/config/src/thread_config/remote.rs
+++ b/codex-rs/config/src/thread_config/remote.rs
@@ -190,6 +190,7 @@ fn model_provider_from_proto(
         websocket_connect_timeout_ms: provider.websocket_connect_timeout_ms,
         requires_openai_auth: provider.requires_openai_auth,
         supports_websockets: provider.supports_websockets,
+        namespace_tools: provider.namespace_tools,
     };
     Ok((id, info))
 }
@@ -217,6 +218,7 @@ fn model_provider_to_proto(
         websocket_connect_timeout_ms,
         requires_openai_auth,
         supports_websockets,
+        namespace_tools,
     } = provider;
 
     proto::ModelProvider {
@@ -237,6 +239,7 @@ fn model_provider_to_proto(
         websocket_connect_timeout_ms,
         requires_openai_auth,
         supports_websockets,
+        namespace_tools,
     }
 }
 
@@ -473,6 +476,7 @@ mod tests {
                             websocket_connect_timeout_ms: Some(10_000),
                             requires_openai_auth: false,
                             supports_websockets: true,
+                            namespace_tools: Some(false),
                         }],
                         features: HashMap::from([
                             ("plugins".to_string(), false),
@@ -537,6 +541,7 @@ mod tests {
             requires_openai_auth: false,
             supports_websockets: true,
             aws: None,
+            namespace_tools: Some(false),
         }
     }
 

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -1531,6 +1531,11 @@
           "description": "Friendly display name.",
           "type": "string"
         },
+        "namespace_tools": {
+          "default": null,
+          "description": "Whether this provider understands Codex's `type: \"namespace\"` tool wrapper. When false, namespace tools are flattened to plain `<namespace>__<tool>` functions. When unset, provider-specific defaults apply: built-in OpenAI, Azure, and Amazon Bedrock providers keep namespaces while other configured providers flatten them.",
+          "type": "boolean"
+        },
         "query_params": {
           "additionalProperties": {
             "type": "string"

--- a/codex-rs/core/src/compact_tests.rs
+++ b/codex-rs/core/src/compact_tests.rs
@@ -235,6 +235,7 @@ fn should_use_remote_compact_task_for_azure_provider() {
         websocket_connect_timeout_ms: None,
         requires_openai_auth: false,
         supports_websockets: false,
+        namespace_tools: None,
     };
 
     assert!(should_use_remote_compact_task(&provider));

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -523,6 +523,24 @@ region = "us-west-2"
     );
 }
 
+#[test]
+fn accepts_amazon_bedrock_namespace_tools_override() {
+    let cfg = toml::from_str::<ConfigToml>(
+        r#"
+[model_providers.amazon-bedrock]
+namespace_tools = false
+"#,
+    )
+    .expect("Amazon Bedrock namespace tool override should deserialize");
+
+    assert_eq!(
+        cfg.model_providers
+            .get("amazon-bedrock")
+            .and_then(|provider| provider.namespace_tools),
+        Some(false)
+    );
+}
+
 #[tokio::test]
 async fn load_config_applies_amazon_bedrock_aws_profile_override() {
     let cfg = toml::from_str::<ConfigToml>(
@@ -545,6 +563,73 @@ region = "us-west-2"
     .expect("load config");
 
     assert_eq!(config.model_provider_id, "amazon-bedrock");
+    assert_eq!(
+        config
+            .model_provider
+            .aws
+            .as_ref()
+            .and_then(|aws| aws.profile.as_deref()),
+        Some("codex-bedrock")
+    );
+    assert_eq!(
+        config
+            .model_provider
+            .aws
+            .as_ref()
+            .and_then(|aws| aws.region.as_deref()),
+        Some("us-west-2")
+    );
+}
+
+#[tokio::test]
+async fn load_config_applies_amazon_bedrock_namespace_tools_override() {
+    let cfg = toml::from_str::<ConfigToml>(
+        r#"
+model_provider = "amazon-bedrock"
+
+[model_providers.amazon-bedrock]
+namespace_tools = false
+"#,
+    )
+    .expect("Amazon Bedrock namespace tool override should deserialize");
+
+    let config = Config::load_from_base_config_with_overrides(
+        cfg,
+        ConfigOverrides::default(),
+        tempdir().expect("tempdir").abs(),
+    )
+    .await
+    .expect("load config");
+
+    assert_eq!(config.model_provider_id, "amazon-bedrock");
+    assert_eq!(config.model_provider.namespace_tools, Some(false));
+}
+
+#[tokio::test]
+async fn load_config_applies_amazon_bedrock_allowed_overrides_together() {
+    let cfg = toml::from_str::<ConfigToml>(
+        r#"
+model_provider = "amazon-bedrock"
+
+[model_providers.amazon-bedrock]
+namespace_tools = false
+
+[model_providers.amazon-bedrock.aws]
+profile = "codex-bedrock"
+region = "us-west-2"
+"#,
+    )
+    .expect("Amazon Bedrock allowed overrides should deserialize");
+
+    let config = Config::load_from_base_config_with_overrides(
+        cfg,
+        ConfigOverrides::default(),
+        tempdir().expect("tempdir").abs(),
+    )
+    .await
+    .expect("load config");
+
+    assert_eq!(config.model_provider.namespace_tools, Some(false));
     assert_eq!(
         config
             .model_provider
@@ -592,7 +677,7 @@ region = "us-west-2"
 
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     assert!(err.to_string().contains(
-        "model_providers.amazon-bedrock only supports changing `aws.profile` and `aws.region`; other non-default provider fields are not supported"
+        "model_providers.amazon-bedrock only supports changing `aws.profile`, `aws.region`, and `namespace_tools`; other non-default provider fields are not supported"
     ));
 }
 

--- a/codex-rs/core/src/tools/handlers/mcp.rs
+++ b/codex-rs/core/src/tools/handlers/mcp.rs
@@ -4,7 +4,6 @@ use std::time::Instant;
 use crate::function_tool::FunctionCallError;
 use crate::mcp_tool_call::handle_mcp_tool_call;
 use crate::original_image_detail::can_request_original_image_detail;
-use crate::tools::canonical_flat_tool_name;
 use crate::tools::context::McpToolOutput;
 use crate::tools::context::ToolInvocation;
 use crate::tools::context::ToolPayload;
@@ -42,7 +41,7 @@ impl McpHandler {
 
     fn hook_tool_name(&self) -> HookToolName {
         let tool_name = self.tool_name();
-        let canonical = canonical_flat_tool_name(&tool_name);
+        let canonical = tool_name.canonical_flat_name();
         HookToolName::new(ensure_mcp_prefix(&canonical))
     }
 }

--- a/codex-rs/core/src/tools/handlers/mcp.rs
+++ b/codex-rs/core/src/tools/handlers/mcp.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 use crate::function_tool::FunctionCallError;
 use crate::mcp_tool_call::handle_mcp_tool_call;
 use crate::original_image_detail::can_request_original_image_detail;
+use crate::tools::canonical_flat_tool_name;
 use crate::tools::context::McpToolOutput;
 use crate::tools::context::ToolInvocation;
 use crate::tools::context::ToolPayload;
@@ -27,7 +28,6 @@ use serde_json::Map;
 use serde_json::Value;
 
 const LEGACY_MCP_TOOL_NAME_PREFIX: &str = "mcp__";
-const MCP_TOOL_NAME_DELIMITER: &str = "__";
 
 pub struct McpHandler {
     tool_info: ToolInfo,
@@ -41,18 +41,9 @@ impl McpHandler {
     }
 
     fn hook_tool_name(&self) -> HookToolName {
-        HookToolName::new(ensure_mcp_prefix(&join_tool_name(&self.tool_name())))
-    }
-}
-
-fn join_tool_name(tool_name: &ToolName) -> String {
-    match tool_name.namespace.as_deref() {
-        Some(namespace) => {
-            let namespace = namespace.trim_end_matches('_');
-            let name = tool_name.name.trim_start_matches('_');
-            format!("{namespace}{MCP_TOOL_NAME_DELIMITER}{name}")
-        }
-        None => tool_name.name.clone(),
+        let tool_name = self.tool_name();
+        let canonical = canonical_flat_tool_name(&tool_name);
+        HookToolName::new(ensure_mcp_prefix(&canonical))
     }
 }
 

--- a/codex-rs/core/src/tools/handlers/mod.rs
+++ b/codex-rs/core/src/tools/handlers/mod.rs
@@ -69,6 +69,7 @@ pub use request_user_input::RequestUserInputHandler;
 pub use shell::ShellCommandHandler;
 pub(crate) use shell::ShellCommandHandlerOptions;
 pub use test_sync::TestSyncHandler;
+pub(crate) use tool_search::NamespaceToolSpecMode;
 pub use tool_search::ToolSearchHandler;
 pub use unified_exec::ExecCommandHandler;
 pub(crate) use unified_exec::ExecCommandHandlerOptions;

--- a/codex-rs/core/src/tools/handlers/tool_search.rs
+++ b/codex-rs/core/src/tools/handlers/tool_search.rs
@@ -19,15 +19,26 @@ use codex_tools::ToolSearchInfo;
 use codex_tools::ToolSearchSourceInfo;
 use codex_tools::ToolSpec;
 use codex_tools::coalesce_loadable_tool_specs;
+use codex_tools::flatten_responses_api_namespace;
 
 pub struct ToolSearchHandler {
     entries: Vec<ToolSearchEntry>,
+    namespace_tool_spec_mode: NamespaceToolSpecMode,
     search_source_infos: Vec<ToolSearchSourceInfo>,
     search_engine: SearchEngine<usize>,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) enum NamespaceToolSpecMode {
+    Preserve,
+    Flatten,
+}
+
 impl ToolSearchHandler {
-    pub(crate) fn new(search_infos: Vec<ToolSearchInfo>) -> Self {
+    pub(crate) fn new(
+        search_infos: Vec<ToolSearchInfo>,
+        namespace_tool_spec_mode: NamespaceToolSpecMode,
+    ) -> Self {
         let mut entries = Vec::with_capacity(search_infos.len());
         let mut search_source_infos = Vec::new();
         for search_info in search_infos {
@@ -47,6 +58,7 @@ impl ToolSearchHandler {
 
         Self {
             entries,
+            namespace_tool_spec_mode,
             search_source_infos,
             search_engine,
         }
@@ -132,9 +144,27 @@ impl ToolSearchHandler {
         &self,
         results: impl IntoIterator<Item = &'a ToolSearchEntry>,
     ) -> Result<Vec<LoadableToolSpec>, FunctionCallError> {
-        Ok(coalesce_loadable_tool_specs(
-            results.into_iter().map(|entry| entry.output.clone()),
-        ))
+        let tools =
+            coalesce_loadable_tool_specs(results.into_iter().map(|entry| entry.output.clone()));
+        if matches!(
+            self.namespace_tool_spec_mode,
+            NamespaceToolSpecMode::Preserve
+        ) {
+            return Ok(tools);
+        }
+
+        Ok(tools
+            .into_iter()
+            .flat_map(|tool| match tool {
+                LoadableToolSpec::Function(tool) => vec![LoadableToolSpec::Function(tool)],
+                LoadableToolSpec::Namespace(namespace) => {
+                    flatten_responses_api_namespace(namespace)
+                        .into_iter()
+                        .map(LoadableToolSpec::Function)
+                        .collect()
+                }
+            })
+            .collect())
     }
 }
 
@@ -187,7 +217,7 @@ mod tests {
                 .search_info()
                 .expect("dynamic handler should return search info")
         }));
-        let handler = ToolSearchHandler::new(search_infos);
+        let handler = ToolSearchHandler::new(search_infos, NamespaceToolSpecMode::Preserve);
         let results = [
             &handler.entries[0],
             &handler.entries[2],
@@ -252,6 +282,35 @@ mod tests {
                     })],
                 }),
             ],
+        );
+    }
+
+    #[test]
+    fn search_results_flatten_mcp_namespaces_without_namespace_tools() {
+        let search_info = McpHandler::new(tool_info("calendar", "create_event", "Create events"))
+            .expect("MCP tool should convert")
+            .search_info()
+            .expect("MCP handler should return search info");
+        let handler = ToolSearchHandler::new(vec![search_info], NamespaceToolSpecMode::Flatten);
+
+        let tools = handler
+            .search_output_tools([&handler.entries[0]])
+            .expect("MCP search output should serialize");
+
+        assert_eq!(
+            tools,
+            vec![LoadableToolSpec::Function(ResponsesApiTool {
+                name: "mcp__calendar__create_event".to_string(),
+                description: "Create events desktop tool".to_string(),
+                strict: false,
+                defer_loading: Some(true),
+                parameters: codex_tools::JsonSchema::object(
+                    Default::default(),
+                    /*required*/ None,
+                    Some(false.into()),
+                ),
+                output_schema: None,
+            })],
         );
     }
 

--- a/codex-rs/core/src/tools/mod.rs
+++ b/codex-rs/core/src/tools/mod.rs
@@ -45,6 +45,25 @@ pub(crate) fn flat_tool_name(tool_name: &ToolName) -> Cow<'_, str> {
     }
 }
 
+const NAMESPACED_TOOL_NAME_DELIMITER: &str = "__";
+
+/// Joins a namespace and tool name into the canonical `<namespace>__<tool>` form,
+/// trimming stray underscores so the `__` delimiter is never doubled.
+pub(in crate::tools) fn join_namespaced_tool_name(namespace: &str, name: &str) -> String {
+    let namespace = namespace.trim_end_matches('_');
+    let name = name.trim_start_matches('_');
+    format!("{namespace}{NAMESPACED_TOOL_NAME_DELIMITER}{name}")
+}
+
+/// Canonical flat name with the `__` delimiter, matching what hooks emit and
+/// proxies expect. Unlike `flat_tool_name`, namespace and tool are not joined raw.
+pub(in crate::tools) fn canonical_flat_tool_name(tool_name: &ToolName) -> Cow<'_, str> {
+    match tool_name.namespace.as_deref() {
+        Some(namespace) => Cow::Owned(join_namespaced_tool_name(namespace, &tool_name.name)),
+        None => Cow::Borrowed(tool_name.name.as_str()),
+    }
+}
+
 pub(crate) fn tool_user_shell_type(
     user_shell: &crate::shell::Shell,
 ) -> codex_tools::ToolUserShellType {

--- a/codex-rs/core/src/tools/mod.rs
+++ b/codex-rs/core/src/tools/mod.rs
@@ -45,25 +45,6 @@ pub(crate) fn flat_tool_name(tool_name: &ToolName) -> Cow<'_, str> {
     }
 }
 
-const NAMESPACED_TOOL_NAME_DELIMITER: &str = "__";
-
-/// Joins a namespace and tool name into the canonical `<namespace>__<tool>` form,
-/// trimming stray underscores so the `__` delimiter is never doubled.
-pub(in crate::tools) fn join_namespaced_tool_name(namespace: &str, name: &str) -> String {
-    let namespace = namespace.trim_end_matches('_');
-    let name = name.trim_start_matches('_');
-    format!("{namespace}{NAMESPACED_TOOL_NAME_DELIMITER}{name}")
-}
-
-/// Canonical flat name with the `__` delimiter, matching what hooks emit and
-/// proxies expect. Unlike `flat_tool_name`, namespace and tool are not joined raw.
-pub(in crate::tools) fn canonical_flat_tool_name(tool_name: &ToolName) -> Cow<'_, str> {
-    match tool_name.namespace.as_deref() {
-        Some(namespace) => Cow::Owned(join_namespaced_tool_name(namespace, &tool_name.name)),
-        None => Cow::Borrowed(tool_name.name.as_str()),
-    }
-}
-
 pub(crate) fn tool_user_shell_type(
     user_shell: &crate::shell::Shell,
 ) -> codex_tools::ToolUserShellType {

--- a/codex-rs/core/src/tools/registry.rs
+++ b/codex-rs/core/src/tools/registry.rs
@@ -13,6 +13,7 @@ use crate::memory_usage::emit_metric_for_tool_read;
 use crate::sandbox_tags::permission_profile_policy_tag;
 use crate::sandbox_tags::permission_profile_sandbox_tag;
 use crate::session::turn_context::TurnContext;
+use crate::tools::canonical_flat_tool_name;
 use crate::tools::context::FunctionToolOutput;
 use crate::tools::context::ToolInvocation;
 use crate::tools::context::ToolOutput;
@@ -355,7 +356,17 @@ impl ToolRegistry {
     }
 
     fn tool(&self, name: &ToolName) -> Option<Arc<dyn CoreToolRuntime>> {
-        self.tools.get(name).map(Arc::clone)
+        if let Some(tool) = self.tools.get(name) {
+            return Some(Arc::clone(tool));
+        }
+        // Fall back to matching by canonical flattened name so a flat
+        // `<namespace>__<tool>` call (emitted for providers without namespace
+        // support, or flattened by a proxy) resolves to its namespaced runtime.
+        let canonical = canonical_flat_tool_name(name);
+        self.tools
+            .iter()
+            .find(|(key, _)| canonical_flat_tool_name(key) == canonical)
+            .map(|(_, tool)| Arc::clone(tool))
     }
 
     #[cfg(test)]

--- a/codex-rs/core/src/tools/registry.rs
+++ b/codex-rs/core/src/tools/registry.rs
@@ -13,7 +13,6 @@ use crate::memory_usage::emit_metric_for_tool_read;
 use crate::sandbox_tags::permission_profile_policy_tag;
 use crate::sandbox_tags::permission_profile_sandbox_tag;
 use crate::session::turn_context::TurnContext;
-use crate::tools::canonical_flat_tool_name;
 use crate::tools::context::FunctionToolOutput;
 use crate::tools::context::ToolInvocation;
 use crate::tools::context::ToolOutput;
@@ -362,10 +361,10 @@ impl ToolRegistry {
         // Fall back to matching by canonical flattened name so a flat
         // `<namespace>__<tool>` call (emitted for providers without namespace
         // support, or flattened by a proxy) resolves to its namespaced runtime.
-        let canonical = canonical_flat_tool_name(name);
+        let canonical = name.canonical_flat_name();
         self.tools
             .iter()
-            .find(|(key, _)| canonical_flat_tool_name(key) == canonical)
+            .find(|(key, _)| key.canonical_flat_name() == canonical)
             .map(|(_, tool)| Arc::clone(tool))
     }
 

--- a/codex-rs/core/src/tools/registry_tests.rs
+++ b/codex-rs/core/src/tools/registry_tests.rs
@@ -178,6 +178,32 @@ fn handler_looks_up_namespaced_aliases_explicitly() {
     );
 }
 
+#[test]
+fn handler_resolves_flat_name_to_namespaced_runtime() {
+    // Runtime namespace shape: `mcp__mini` with no trailing `__`.
+    let namespaced_name = codex_tools::ToolName::namespaced("mcp__mini", "record_note");
+    let handler = Arc::new(TestHandler {
+        tool_name: namespaced_name.clone(),
+    }) as Arc<dyn CoreToolRuntime>;
+    let registry = ToolRegistry::new(HashMap::from([(
+        namespaced_name.clone(),
+        Arc::clone(&handler),
+    )]));
+
+    // The canonical flat name (what flattening emits, and what a proxy produces)
+    // resolves to the namespaced runtime.
+    let canonical = registry.tool(&codex_tools::ToolName::plain("mcp__mini__record_note"));
+    assert!(canonical.as_ref().is_some_and(|h| Arc::ptr_eq(h, &handler)));
+
+    // Exact namespaced lookup still works, and unrelated names do not resolve.
+    assert!(registry.tool(&namespaced_name).is_some());
+    assert!(
+        registry
+            .tool(&codex_tools::ToolName::plain("mcp__other__record_note"))
+            .is_none()
+    );
+}
+
 #[tokio::test]
 async fn function_tools_expose_default_hook_payloads_and_rewrites() -> anyhow::Result<()> {
     let (session, turn) = crate::session::tests::make_session_and_context().await;

--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -49,6 +49,7 @@ use crate::tools::handlers::view_image_spec::ViewImageToolOptions;
 use crate::tools::hosted_spec::WebSearchToolOptions;
 use crate::tools::hosted_spec::create_image_generation_tool;
 use crate::tools::hosted_spec::create_web_search_tool;
+use crate::tools::join_namespaced_tool_name;
 use crate::tools::registry::CoreToolRuntime;
 use crate::tools::registry::ToolExposure;
 use crate::tools::registry::ToolRegistry;
@@ -221,14 +222,37 @@ fn build_model_visible_specs_and_registry(
     specs.extend(hosted_specs);
 
     let registry = ToolRegistry::from_tools(runtimes);
-    let model_visible_specs = merge_into_namespaces(specs)
-        .into_iter()
-        .filter(|spec| {
-            namespace_tools_enabled(turn_context) || !matches!(spec, ToolSpec::Namespace(_))
-        })
-        .collect();
+    let merged_specs = merge_into_namespaces(specs);
+    // Providers that do not understand the `type: "namespace"` wrapper get the
+    // namespaced tools flattened into plain functions rather than dropped.
+    let model_visible_specs = if namespace_tools_enabled(turn_context) {
+        merged_specs
+    } else {
+        merged_specs
+            .into_iter()
+            .flat_map(|spec| match spec {
+                ToolSpec::Namespace(namespace) => flatten_namespace_spec(namespace),
+                other => vec![other],
+            })
+            .collect()
+    };
 
     (model_visible_specs, registry)
+}
+
+/// Flattens a namespace into plain `function` specs named `<namespace>__<tool>`.
+/// The canonical names match hooks and proxies, so the registry resolves them.
+fn flatten_namespace_spec(namespace: ResponsesApiNamespace) -> Vec<ToolSpec> {
+    namespace
+        .tools
+        .into_iter()
+        .map(|tool| match tool {
+            ResponsesApiNamespaceTool::Function(mut function) => {
+                function.name = join_namespaced_tool_name(&namespace.name, &function.name);
+                ToolSpec::Function(function)
+            }
+        })
+        .collect()
 }
 
 fn spec_for_model_request(

--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -14,6 +14,7 @@ use crate::tools::handlers::ListAvailablePluginsToInstallHandler;
 use crate::tools::handlers::ListMcpResourceTemplatesHandler;
 use crate::tools::handlers::ListMcpResourcesHandler;
 use crate::tools::handlers::McpHandler;
+use crate::tools::handlers::NamespaceToolSpecMode;
 use crate::tools::handlers::NewContextWindowHandler;
 use crate::tools::handlers::PlanHandler;
 use crate::tools::handlers::ReadMcpResourceHandler;
@@ -81,6 +82,7 @@ use codex_tools::can_request_original_image_detail;
 use codex_tools::collect_code_mode_exec_prompt_tool_definitions;
 use codex_tools::collect_request_plugin_install_entries;
 use codex_tools::default_namespace_description;
+use codex_tools::flatten_responses_api_namespace;
 use codex_tools::request_user_input_available_modes;
 use codex_tools::shell_command_backend_for_features;
 use codex_tools::shell_type_for_model_and_features;
@@ -230,29 +232,16 @@ fn build_model_visible_specs_and_registry(
         merged_specs
             .into_iter()
             .flat_map(|spec| match spec {
-                ToolSpec::Namespace(namespace) => flatten_namespace_spec(namespace),
+                ToolSpec::Namespace(namespace) => flatten_responses_api_namespace(namespace)
+                    .into_iter()
+                    .map(ToolSpec::Function)
+                    .collect(),
                 other => vec![other],
             })
             .collect()
     };
 
     (model_visible_specs, registry)
-}
-
-/// Flattens a namespace into plain `function` specs named `<namespace>__<tool>`.
-/// The canonical names match hooks and proxies, so the registry resolves them.
-fn flatten_namespace_spec(namespace: ResponsesApiNamespace) -> Vec<ToolSpec> {
-    namespace
-        .tools
-        .into_iter()
-        .map(|tool| match tool {
-            ResponsesApiNamespaceTool::Function(mut function) => {
-                let tool_name = ToolName::namespaced(namespace.name.as_str(), function.name);
-                function.name = tool_name.canonical_flat_name().into_owned();
-                ToolSpec::Function(function)
-            }
-        })
-        .collect()
 }
 
 fn spec_for_model_request(
@@ -778,12 +767,11 @@ fn add_collaboration_tools(context: &CoreToolPlanContext<'_>, planned_tools: &mu
         } else {
             let agent_type_description =
                 agent_type_description(turn_context, context.default_agent_type_description);
-            let exposure =
-                if search_tool_enabled(turn_context) && namespace_tools_enabled(turn_context) {
-                    ToolExposure::Deferred
-                } else {
-                    ToolExposure::Direct
-                };
+            let exposure = if search_tool_enabled(turn_context) {
+                ToolExposure::Deferred
+            } else {
+                ToolExposure::Direct
+            };
             planned_tools.add_with_exposure(
                 SpawnAgentHandler::new(SpawnAgentToolOptions {
                     available_models: turn_context.available_models.clone(),
@@ -866,7 +854,7 @@ fn append_tool_search_executor(
     planned_tools: &mut PlannedTools,
 ) {
     let turn_context = context.turn_context;
-    if !(search_tool_enabled(turn_context) && namespace_tools_enabled(turn_context)) {
+    if !search_tool_enabled(turn_context) {
         return;
     }
 
@@ -880,7 +868,15 @@ fn append_tool_search_executor(
         return;
     }
 
-    planned_tools.add(ToolSearchHandler::new(search_infos));
+    let namespace_tool_spec_mode = if namespace_tools_enabled(turn_context) {
+        NamespaceToolSpecMode::Preserve
+    } else {
+        NamespaceToolSpecMode::Flatten
+    };
+    planned_tools.add(ToolSearchHandler::new(
+        search_infos,
+        namespace_tool_spec_mode,
+    ));
 }
 
 fn prepend_code_mode_executors(
@@ -914,7 +910,6 @@ fn append_extension_tool_executors(
         reserved_tool_names.insert(ToolName::plain(codex_code_mode::WAIT_TOOL_NAME));
     }
     if search_tool_enabled(turn_context)
-        && namespace_tools_enabled(turn_context)
         && planned_tools
             .runtimes()
             .iter()

--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -49,7 +49,6 @@ use crate::tools::handlers::view_image_spec::ViewImageToolOptions;
 use crate::tools::hosted_spec::WebSearchToolOptions;
 use crate::tools::hosted_spec::create_image_generation_tool;
 use crate::tools::hosted_spec::create_web_search_tool;
-use crate::tools::join_namespaced_tool_name;
 use crate::tools::registry::CoreToolRuntime;
 use crate::tools::registry::ToolExposure;
 use crate::tools::registry::ToolRegistry;
@@ -248,7 +247,8 @@ fn flatten_namespace_spec(namespace: ResponsesApiNamespace) -> Vec<ToolSpec> {
         .into_iter()
         .map(|tool| match tool {
             ResponsesApiNamespaceTool::Function(mut function) => {
-                function.name = join_namespaced_tool_name(&namespace.name, &function.name);
+                let tool_name = ToolName::namespaced(namespace.name.as_str(), function.name);
+                function.name = tool_name.canonical_flat_name().into_owned();
                 ToolSpec::Function(function)
             }
         })

--- a/codex-rs/core/src/tools/spec_plan_tests.rs
+++ b/codex-rs/core/src/tools/spec_plan_tests.rs
@@ -692,13 +692,14 @@ async fn mcp_and_tool_search_follow_direct_and_deferred_tool_exposure() {
         deferred_mcp_tools: Some(vec![mcp_tool("searchable", "mcp__searchable", "lookup")]),
         ..ToolPlanInputs::default()
     };
+    let searchable_deferred_mcp_tools = searchable_mcp.deferred_mcp_tools.clone();
 
     let missing_model_capability = probe_with(
         |turn| {
             turn.model_info.supports_search_tool = false;
         },
         ToolPlanInputs {
-            deferred_mcp_tools: searchable_mcp.deferred_mcp_tools.clone(),
+            deferred_mcp_tools: searchable_deferred_mcp_tools.clone(),
             ..ToolPlanInputs::default()
         },
     )
@@ -723,7 +724,7 @@ async fn mcp_and_tool_search_follow_direct_and_deferred_tool_exposure() {
             use_bedrock_provider(turn);
         },
         ToolPlanInputs {
-            deferred_mcp_tools: searchable_mcp.deferred_mcp_tools.clone(),
+            deferred_mcp_tools: searchable_deferred_mcp_tools.clone(),
             ..ToolPlanInputs::default()
         },
     )
@@ -739,6 +740,23 @@ async fn mcp_and_tool_search_follow_direct_and_deferred_tool_exposure() {
     .await;
     enabled.assert_visible_contains(&["tool_search"]);
     enabled.assert_registered_contains(&[
+        "tool_search",
+        &ToolName::namespaced("mcp__searchable", "lookup").to_string(),
+    ]);
+
+    let namespace_tools_disabled = probe_with(
+        |turn| {
+            turn.model_info.supports_search_tool = true;
+            disable_namespace_tools(turn);
+        },
+        ToolPlanInputs {
+            deferred_mcp_tools: searchable_deferred_mcp_tools,
+            ..ToolPlanInputs::default()
+        },
+    )
+    .await;
+    namespace_tools_disabled.assert_visible_contains(&["tool_search"]);
+    namespace_tools_disabled.assert_registered_contains(&[
         "tool_search",
         &ToolName::namespaced("mcp__searchable", "lookup").to_string(),
     ]);

--- a/codex-rs/core/src/tools/spec_plan_tests.rs
+++ b/codex-rs/core/src/tools/spec_plan_tests.rs
@@ -264,6 +264,15 @@ fn set_web_search_mode(turn: &mut TurnContext, mode: WebSearchMode) {
     });
 }
 
+fn disable_namespace_tools(turn: &mut TurnContext) {
+    let mut provider_info = turn.config.model_provider.clone();
+    provider_info.namespace_tools = Some(false);
+    update_config(turn, |config| {
+        config.model_provider = provider_info.clone();
+    });
+    turn.provider = create_model_provider(provider_info, turn.auth_manager.clone());
+}
+
 fn use_chatgpt_auth(turn: &mut TurnContext) {
     turn.auth_manager = Some(AuthManager::from_auth_for_testing(
         CodexAuth::create_dummy_chatgpt_auth_for_testing(),
@@ -732,6 +741,34 @@ async fn mcp_and_tool_search_follow_direct_and_deferred_tool_exposure() {
     enabled.assert_registered_contains(&[
         "tool_search",
         &ToolName::namespaced("mcp__searchable", "lookup").to_string(),
+    ]);
+}
+
+#[tokio::test]
+async fn namespace_tools_disabled_flattens_mcp_namespace_into_function() {
+    // Use the runtime namespace shape (`mcp__mini`, no trailing `__`).
+    let probe = probe_with(
+        disable_namespace_tools,
+        ToolPlanInputs {
+            mcp_tools: Some(vec![mcp_tool("mini", "mcp__mini", "record_note")]),
+            ..ToolPlanInputs::default()
+        },
+    )
+    .await;
+
+    // The MCP tool is exposed as a flat function with the canonical `__`
+    // delimiter, not a namespace wrapper and not a delimiter-less concatenation.
+    probe.assert_visible_contains(&["mcp__mini__record_note"]);
+    probe.assert_visible_lacks(&["mcp__minirecord_note"]);
+    assert!(probe.namespace_function_names("mcp__mini").is_empty());
+    assert!(matches!(
+        probe.visible_spec("mcp__mini__record_note"),
+        ToolSpec::Function(_)
+    ));
+
+    // The runtime is still registered under its namespaced identity.
+    probe.assert_registered_contains(&[
+        &ToolName::namespaced("mcp__mini", "record_note").to_string()
     ]);
 }
 

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -87,6 +87,7 @@ async fn responses_stream_includes_subagent_header_on_review() {
         websocket_connect_timeout_ms: None,
         requires_openai_auth: false,
         supports_websockets: false,
+        namespace_tools: None,
     };
 
     let codex_home = TempDir::new().expect("failed to create TempDir");
@@ -217,6 +218,7 @@ async fn responses_stream_includes_subagent_header_on_other() {
         websocket_connect_timeout_ms: None,
         requires_openai_auth: false,
         supports_websockets: false,
+        namespace_tools: None,
     };
 
     let codex_home = TempDir::new().expect("failed to create TempDir");
@@ -328,6 +330,7 @@ async fn responses_respects_model_info_overrides_from_config() {
         websocket_connect_timeout_ms: None,
         requires_openai_auth: false,
         supports_websockets: false,
+        namespace_tools: None,
     };
 
     let codex_home = TempDir::new().expect("failed to create TempDir");

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -927,6 +927,7 @@ async fn send_provider_auth_request(server: &MockServer, auth: ModelProviderAuth
         websocket_connect_timeout_ms: None,
         requires_openai_auth: false,
         supports_websockets: false,
+        namespace_tools: None,
     };
 
     let codex_home = TempDir::new().unwrap();
@@ -2421,6 +2422,7 @@ async fn azure_responses_request_includes_store_and_reasoning_ids() {
         websocket_connect_timeout_ms: None,
         requires_openai_auth: false,
         supports_websockets: false,
+        namespace_tools: None,
     };
 
     let codex_home = TempDir::new().unwrap();
@@ -3028,6 +3030,7 @@ async fn azure_overrides_assign_properties_used_for_responses_url() {
         websocket_connect_timeout_ms: None,
         requires_openai_auth: false,
         supports_websockets: false,
+        namespace_tools: None,
     };
 
     // Init session
@@ -3117,6 +3120,7 @@ async fn env_var_overrides_loaded_auth() {
         websocket_connect_timeout_ms: None,
         requires_openai_auth: false,
         supports_websockets: false,
+        namespace_tools: None,
     };
 
     // Init session

--- a/codex-rs/core/tests/suite/client_websockets.rs
+++ b/codex-rs/core/tests/suite/client_websockets.rs
@@ -2109,6 +2109,7 @@ fn websocket_provider_with_connect_timeout(
         websocket_connect_timeout_ms,
         requires_openai_auth: false,
         supports_websockets: true,
+        namespace_tools: None,
     }
 }
 

--- a/codex-rs/core/tests/suite/rmcp_client.rs
+++ b/codex-rs/core/tests/suite/rmcp_client.rs
@@ -830,6 +830,96 @@ async fn stdio_mcp_tool_call_includes_sandbox_state_meta() -> anyhow::Result<()>
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn stdio_mcp_tool_call_flattens_namespace_when_provider_disables_it() -> anyhow::Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = responses::start_mock_server().await;
+
+    let call_id = "flat-mcp-call";
+    let server_name = "rmcp";
+    let flat_tool_name = format!("mcp__{server_name}__echo");
+    let call_mock = mount_sse_once(
+        &server,
+        responses::sse(vec![
+            responses::ev_response_created("resp-1"),
+            responses::ev_function_call(call_id, &flat_tool_name, r#"{"message":"ping"}"#),
+            responses::ev_completed("resp-1"),
+        ]),
+    )
+    .await;
+    let final_mock = mount_sse_once(
+        &server,
+        responses::sse(vec![
+            responses::ev_assistant_message("msg-1", "rmcp flat tool completed successfully."),
+            responses::ev_completed("resp-2"),
+        ]),
+    )
+    .await;
+
+    let rmcp_test_server_bin = remote_aware_stdio_server_bin()?;
+    let fixture = test_codex()
+        .with_config(move |config| {
+            config.model_provider.namespace_tools = Some(false);
+            insert_mcp_server(
+                config,
+                server_name,
+                stdio_transport(rmcp_test_server_bin, /*env*/ None, Vec::new()),
+                TestMcpServerOptions {
+                    environment_id: remote_aware_environment_id(),
+                    ..Default::default()
+                },
+            );
+        })
+        .build_with_remote_env(&server)
+        .await?;
+
+    wait_for_mcp_server(&fixture.codex, server_name).await?;
+
+    fixture
+        .submit_turn_with_permission_profile(
+            "call the flat rmcp echo tool",
+            PermissionProfile::read_only(),
+        )
+        .await?;
+
+    let request = call_mock.single_request();
+    let request_body = request.body_json();
+    let tools = request_body
+        .get("tools")
+        .and_then(Value::as_array)
+        .expect("Responses request should include tools");
+    assert!(
+        tools.iter().any(|tool| {
+            tool.get("type").and_then(Value::as_str) == Some("function")
+                && tool.get("name").and_then(Value::as_str) == Some(flat_tool_name.as_str())
+        }),
+        "MCP tool should be sent as a flat function: {:?}",
+        request_body
+    );
+    assert!(
+        tools.iter().all(|tool| {
+            tool.get("type").and_then(Value::as_str) != Some("namespace")
+                || tool.get("name").and_then(Value::as_str) != Some("mcp__rmcp")
+        }),
+        "MCP namespace wrapper should be omitted: {:?}",
+        request_body
+    );
+
+    let output = final_mock
+        .single_request()
+        .function_call_output_text(call_id)
+        .expect("function_call_output should be present for flat MCP call");
+    assert!(
+        output.contains("ECHOING: ping"),
+        "flat MCP call should execute against the namespaced runtime: {output}"
+    );
+
+    server.verify().await;
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn stdio_mcp_parallel_tool_calls_default_false_runs_serially() -> anyhow::Result<()> {
     skip_if_no_network!(Ok(()));

--- a/codex-rs/core/tests/suite/rmcp_client.rs
+++ b/codex-rs/core/tests/suite/rmcp_client.rs
@@ -894,16 +894,14 @@ async fn stdio_mcp_tool_call_flattens_namespace_when_provider_disables_it() -> a
             tool.get("type").and_then(Value::as_str) == Some("function")
                 && tool.get("name").and_then(Value::as_str) == Some(flat_tool_name.as_str())
         }),
-        "MCP tool should be sent as a flat function: {:?}",
-        request_body
+        "MCP tool should be sent as a flat function: {request_body:?}"
     );
     assert!(
         tools.iter().all(|tool| {
             tool.get("type").and_then(Value::as_str) != Some("namespace")
                 || tool.get("name").and_then(Value::as_str) != Some("mcp__rmcp")
         }),
-        "MCP namespace wrapper should be omitted: {:?}",
-        request_body
+        "MCP namespace wrapper should be omitted: {request_body:?}"
     );
 
     let output = final_mock

--- a/codex-rs/core/tests/suite/stream_error_allows_next_turn.rs
+++ b/codex-rs/core/tests/suite/stream_error_allows_next_turn.rs
@@ -81,6 +81,7 @@ async fn continue_after_stream_error() {
         websocket_connect_timeout_ms: None,
         requires_openai_auth: false,
         supports_websockets: false,
+        namespace_tools: None,
     };
 
     let TestCodex { codex, .. } = test_codex()

--- a/codex-rs/core/tests/suite/stream_no_completed.rs
+++ b/codex-rs/core/tests/suite/stream_no_completed.rs
@@ -64,6 +64,7 @@ async fn retries_on_early_close() {
         websocket_connect_timeout_ms: None,
         requires_openai_auth: false,
         supports_websockets: false,
+        namespace_tools: None,
     };
 
     let TestCodex { codex, .. } = test_codex()

--- a/codex-rs/login/src/auth_env_telemetry.rs
+++ b/codex-rs/login/src/auth_env_telemetry.rs
@@ -76,6 +76,7 @@ mod tests {
             websocket_connect_timeout_ms: None,
             requires_openai_auth: false,
             supports_websockets: false,
+            namespace_tools: None,
         };
 
         let telemetry =

--- a/codex-rs/model-provider-info/src/lib.rs
+++ b/codex-rs/model-provider-info/src/lib.rs
@@ -453,7 +453,7 @@ pub fn built_in_model_providers(
 ///
 /// Configured providers extend the built-in set. Built-in providers are not
 /// generally overridable, but the built-in Amazon Bedrock provider allows the
-/// user to set `aws.profile` and `aws.region`.
+/// user to set `aws.profile`, `aws.region`, and `namespace_tools`.
 pub fn merge_configured_model_providers(
     mut model_providers: HashMap<String, ModelProviderInfo>,
     configured_model_providers: HashMap<String, ModelProviderInfo>,
@@ -461,22 +461,27 @@ pub fn merge_configured_model_providers(
     for (key, mut provider) in configured_model_providers {
         if key == AMAZON_BEDROCK_PROVIDER_ID {
             let aws_override = provider.aws.take();
+            let namespace_tools_override = provider.namespace_tools.take();
             if provider != ModelProviderInfo::default() {
                 return Err(format!(
                     "model_providers.{AMAZON_BEDROCK_PROVIDER_ID} only supports changing \
-`aws.profile` and `aws.region`; other non-default provider fields are not supported"
+`aws.profile`, `aws.region`, and `namespace_tools`; other non-default provider fields are not supported"
                 ));
             }
 
-            if let Some(aws_override) = aws_override
-                && let Some(built_in_provider) = model_providers.get_mut(AMAZON_BEDROCK_PROVIDER_ID)
-                && let Some(built_in_aws) = built_in_provider.aws.as_mut()
-            {
-                if let Some(profile) = aws_override.profile {
-                    built_in_aws.profile = Some(profile);
+            if let Some(built_in_provider) = model_providers.get_mut(AMAZON_BEDROCK_PROVIDER_ID) {
+                if namespace_tools_override.is_some() {
+                    built_in_provider.namespace_tools = namespace_tools_override;
                 }
-                if let Some(region) = aws_override.region {
-                    built_in_aws.region = Some(region);
+                if let Some(aws_override) = aws_override
+                    && let Some(built_in_aws) = built_in_provider.aws.as_mut()
+                {
+                    if let Some(profile) = aws_override.profile {
+                        built_in_aws.profile = Some(profile);
+                    }
+                    if let Some(region) = aws_override.region {
+                        built_in_aws.region = Some(region);
+                    }
                 }
             }
         } else {

--- a/codex-rs/model-provider-info/src/lib.rs
+++ b/codex-rs/model-provider-info/src/lib.rs
@@ -134,6 +134,13 @@ pub struct ModelProviderInfo {
     /// Whether this provider supports the Responses API WebSocket transport.
     #[serde(default)]
     pub supports_websockets: bool,
+    /// Whether this provider understands Codex's `type: "namespace"` tool wrapper.
+    /// When false, namespace tools are flattened to plain `<namespace>__<tool>`
+    /// functions. When unset, provider-specific defaults apply: built-in
+    /// OpenAI, Azure, and Amazon Bedrock providers keep namespaces while other
+    /// configured providers flatten them.
+    #[serde(default)]
+    pub namespace_tools: Option<bool>,
 }
 
 /// AWS SigV4 auth configuration for a model provider.
@@ -355,6 +362,7 @@ impl ModelProviderInfo {
             websocket_connect_timeout_ms: None,
             requires_openai_auth: true,
             supports_websockets: true,
+            namespace_tools: None,
         }
     }
 
@@ -385,6 +393,7 @@ impl ModelProviderInfo {
             websocket_connect_timeout_ms: None,
             requires_openai_auth: false,
             supports_websockets: false,
+            namespace_tools: None,
         }
     }
 
@@ -516,6 +525,7 @@ pub fn create_oss_provider_with_base_url(base_url: &str, wire_api: WireApi) -> M
         websocket_connect_timeout_ms: None,
         requires_openai_auth: false,
         supports_websockets: false,
+        namespace_tools: None,
     }
 }
 

--- a/codex-rs/model-provider-info/src/model_provider_info_tests.rs
+++ b/codex-rs/model-provider-info/src/model_provider_info_tests.rs
@@ -368,6 +368,64 @@ fn test_merge_configured_model_providers_applies_amazon_bedrock_profile_override
 }
 
 #[test]
+fn test_merge_configured_model_providers_applies_amazon_bedrock_namespace_tools_override() {
+    let configured_model_providers = std::collections::HashMap::from([(
+        AMAZON_BEDROCK_PROVIDER_ID.to_string(),
+        ModelProviderInfo {
+            namespace_tools: Some(false),
+            ..ModelProviderInfo::default()
+        },
+    )]);
+
+    let mut expected = built_in_model_providers(/*openai_base_url*/ None);
+    expected
+        .get_mut(AMAZON_BEDROCK_PROVIDER_ID)
+        .expect("Amazon Bedrock provider should be built in")
+        .namespace_tools = Some(false);
+
+    assert_eq!(
+        merge_configured_model_providers(
+            built_in_model_providers(/*openai_base_url*/ None),
+            configured_model_providers,
+        ),
+        Ok(expected)
+    );
+}
+
+#[test]
+fn test_merge_configured_model_providers_applies_amazon_bedrock_allowed_overrides_together() {
+    let configured_model_providers = std::collections::HashMap::from([(
+        AMAZON_BEDROCK_PROVIDER_ID.to_string(),
+        ModelProviderInfo {
+            aws: Some(ModelProviderAwsAuthInfo {
+                profile: Some("codex-bedrock".to_string()),
+                region: Some("us-west-2".to_string()),
+            }),
+            namespace_tools: Some(false),
+            ..ModelProviderInfo::default()
+        },
+    )]);
+
+    let mut expected = built_in_model_providers(/*openai_base_url*/ None);
+    let expected_bedrock = expected
+        .get_mut(AMAZON_BEDROCK_PROVIDER_ID)
+        .expect("Amazon Bedrock provider should be built in");
+    expected_bedrock.aws = Some(ModelProviderAwsAuthInfo {
+        profile: Some("codex-bedrock".to_string()),
+        region: Some("us-west-2".to_string()),
+    });
+    expected_bedrock.namespace_tools = Some(false);
+
+    assert_eq!(
+        merge_configured_model_providers(
+            built_in_model_providers(/*openai_base_url*/ None),
+            configured_model_providers,
+        ),
+        Ok(expected)
+    );
+}
+
+#[test]
 fn test_merge_configured_model_providers_rejects_amazon_bedrock_non_default_fields() {
     let configured_model_providers = std::collections::HashMap::from([(
         AMAZON_BEDROCK_PROVIDER_ID.to_string(),
@@ -387,7 +445,7 @@ fn test_merge_configured_model_providers_rejects_amazon_bedrock_non_default_fiel
             configured_model_providers,
         ),
         Err(
-            "model_providers.amazon-bedrock only supports changing `aws.profile` and `aws.region`; other non-default provider fields are not supported"
+            "model_providers.amazon-bedrock only supports changing `aws.profile`, `aws.region`, and `namespace_tools`; other non-default provider fields are not supported"
                 .to_string()
         )
     );

--- a/codex-rs/model-provider-info/src/model_provider_info_tests.rs
+++ b/codex-rs/model-provider-info/src/model_provider_info_tests.rs
@@ -29,6 +29,7 @@ base_url = "http://localhost:11434/v1"
         websocket_connect_timeout_ms: None,
         requires_openai_auth: false,
         supports_websockets: false,
+        namespace_tools: None,
     };
 
     let provider: ModelProviderInfo = toml::from_str(azure_provider_toml).unwrap();
@@ -63,6 +64,7 @@ query_params = { api-version = "2025-04-01-preview" }
         websocket_connect_timeout_ms: None,
         requires_openai_auth: false,
         supports_websockets: false,
+        namespace_tools: None,
     };
 
     let provider: ModelProviderInfo = toml::from_str(azure_provider_toml).unwrap();
@@ -77,6 +79,7 @@ base_url = "https://example.com"
 env_key = "API_KEY"
 http_headers = { "X-Example-Header" = "example-value" }
 env_http_headers = { "X-Example-Env-Header" = "EXAMPLE_ENV_VAR" }
+namespace_tools = false
         "#;
     let expected_provider = ModelProviderInfo {
         name: "Example".into(),
@@ -100,6 +103,7 @@ env_http_headers = { "X-Example-Env-Header" = "EXAMPLE_ENV_VAR" }
         websocket_connect_timeout_ms: None,
         requires_openai_auth: false,
         supports_websockets: false,
+        namespace_tools: Some(false),
     };
 
     let provider: ModelProviderInfo = toml::from_str(azure_provider_toml).unwrap();
@@ -168,6 +172,7 @@ fn test_supports_remote_compaction_for_azure_name() {
         websocket_connect_timeout_ms: None,
         requires_openai_auth: false,
         supports_websockets: false,
+        namespace_tools: None,
     };
 
     assert!(provider.supports_remote_compaction());
@@ -193,6 +198,7 @@ fn test_supports_remote_compaction_for_non_openai_non_azure_provider() {
         websocket_connect_timeout_ms: None,
         requires_openai_auth: false,
         supports_websockets: false,
+        namespace_tools: None,
     };
 
     assert!(!provider.supports_remote_compaction());
@@ -276,6 +282,7 @@ fn test_create_amazon_bedrock_provider() {
             websocket_connect_timeout_ms: None,
             requires_openai_auth: false,
             supports_websockets: false,
+            namespace_tools: None,
         }
     );
 }

--- a/codex-rs/model-provider/src/amazon_bedrock/mod.rs
+++ b/codex-rs/model-provider/src/amazon_bedrock/mod.rs
@@ -101,8 +101,11 @@ impl ModelProvider for AmazonBedrockModelProvider {
     }
 
     fn capabilities(&self) -> ProviderCapabilities {
+        // Bedrock hosts OpenAI models that expand the namespace wrapper, so it
+        // defaults on. Mantle endpoints that reject the wrapper can opt out with
+        // an explicit `namespace_tools = false`.
         ProviderCapabilities {
-            namespace_tools: true,
+            namespace_tools: self.info.namespace_tools.unwrap_or(true),
             image_generation: false,
             web_search: false,
         }
@@ -255,6 +258,15 @@ mod tests {
                 web_search: false,
             }
         );
+    }
+
+    #[test]
+    fn capabilities_namespace_tools_honors_explicit_opt_out() {
+        let mut info = ModelProviderInfo::create_amazon_bedrock_provider(/*aws*/ None);
+        info.namespace_tools = Some(false);
+        let provider = AmazonBedrockModelProvider::new(info, /*auth_manager*/ None);
+
+        assert!(!provider.capabilities().namespace_tools);
     }
 
     #[test]

--- a/codex-rs/model-provider/src/provider.rs
+++ b/codex-rs/model-provider/src/provider.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use codex_api::Provider;
 use codex_api::SharedAuthProvider;
+use codex_api::is_azure_responses_provider;
 use codex_login::AuthManager;
 use codex_login::CodexAuth;
 use codex_model_provider_info::ModelProviderInfo;
@@ -40,6 +41,15 @@ impl Default for ProviderCapabilities {
             web_search: true,
         }
     }
+}
+
+/// Whether a provider advertises the `type: "namespace"` tool wrapper: an
+/// explicit `namespace_tools` if set, otherwise providers known to support it.
+fn resolve_namespace_tools(info: &ModelProviderInfo) -> bool {
+    info.namespace_tools.unwrap_or_else(|| {
+        info.requires_openai_auth
+            || is_azure_responses_provider(&info.name, info.base_url.as_deref())
+    })
 }
 
 /// Current app-visible account state for a model provider.
@@ -218,6 +228,13 @@ impl ModelProvider for ConfiguredModelProvider {
         &self.info
     }
 
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            namespace_tools: resolve_namespace_tools(&self.info),
+            ..ProviderCapabilities::default()
+        }
+    }
+
     fn auth_manager(&self) -> Option<Arc<AuthManager>> {
         self.auth_manager.clone()
     }
@@ -367,6 +384,7 @@ mod tests {
             websocket_connect_timeout_ms: None,
             requires_openai_auth: false,
             supports_websockets: false,
+            namespace_tools: None,
         }
     }
 
@@ -412,6 +430,38 @@ mod tests {
         );
 
         assert_eq!(provider.capabilities(), ProviderCapabilities::default());
+    }
+
+    #[test]
+    fn configured_non_openai_provider_flattens_namespace_tools() {
+        let provider = create_model_provider(
+            provider_for("https://example.test/v1".to_string()),
+            /*auth_manager*/ None,
+        );
+
+        assert!(!provider.capabilities().namespace_tools);
+    }
+
+    #[test]
+    fn configured_azure_provider_keeps_namespace_tools() {
+        let mut azure = provider_for("https://xxxxx.openai.azure.com/openai".to_string());
+        azure.name = "azure".to_string();
+        let provider = create_model_provider(azure, /*auth_manager*/ None);
+
+        assert!(provider.capabilities().namespace_tools);
+    }
+
+    #[test]
+    fn configured_provider_namespace_tools_honors_explicit_override() {
+        let mut non_openai = provider_for("https://example.test/v1".to_string());
+        non_openai.namespace_tools = Some(true);
+        let provider = create_model_provider(non_openai, /*auth_manager*/ None);
+        assert!(provider.capabilities().namespace_tools);
+
+        let mut openai = ModelProviderInfo::create_openai_provider(/*base_url*/ None);
+        openai.namespace_tools = Some(false);
+        let provider = create_model_provider(openai, /*auth_manager*/ None);
+        assert!(!provider.capabilities().namespace_tools);
     }
 
     #[test]

--- a/codex-rs/protocol/src/tool_name.rs
+++ b/codex-rs/protocol/src/tool_name.rs
@@ -1,7 +1,10 @@
 use serde::Deserialize;
 use serde::Serialize;
+use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::fmt;
+
+const NAMESPACED_TOOL_NAME_DELIMITER: &str = "__";
 
 /// Identifies a callable tool, preserving the namespace split when the model
 /// provides one.
@@ -32,6 +35,22 @@ impl ToolName {
             namespace: Some(namespace.into()),
         }
     }
+
+    /// Canonical flat name with the `__` delimiter used when a boundary cannot
+    /// preserve the namespace split. Stray underscores around the delimiter
+    /// are trimmed to match Responses-facing flattened tool names.
+    pub fn canonical_flat_name(&self) -> Cow<'_, str> {
+        match self.namespace.as_deref() {
+            Some(namespace) => Cow::Owned(join_namespaced_tool_name(namespace, &self.name)),
+            None => Cow::Borrowed(self.name.as_str()),
+        }
+    }
+}
+
+fn join_namespaced_tool_name(namespace: &str, name: &str) -> String {
+    let namespace = namespace.trim_end_matches('_');
+    let name = name.trim_start_matches('_');
+    format!("{namespace}{NAMESPACED_TOOL_NAME_DELIMITER}{name}")
 }
 
 impl fmt::Display for ToolName {

--- a/codex-rs/tools/src/lib.rs
+++ b/codex-rs/tools/src/lib.rs
@@ -59,6 +59,7 @@ pub use responses_api::ResponsesApiTool;
 pub use responses_api::coalesce_loadable_tool_specs;
 pub use responses_api::default_namespace_description;
 pub use responses_api::dynamic_tool_to_responses_api_tool;
+pub use responses_api::flatten_responses_api_namespace;
 pub use responses_api::mcp_tool_to_deferred_responses_api_tool;
 pub use responses_api::mcp_tool_to_responses_api_tool;
 pub use responses_api::tool_definition_to_responses_api_tool;

--- a/codex-rs/tools/src/responses_api.rs
+++ b/codex-rs/tools/src/responses_api.rs
@@ -104,6 +104,22 @@ pub fn coalesce_loadable_tool_specs(
     coalesced_specs
 }
 
+/// Flattens a namespace into plain Responses API functions named
+/// `<namespace>__<tool>`.
+pub fn flatten_responses_api_namespace(namespace: ResponsesApiNamespace) -> Vec<ResponsesApiTool> {
+    namespace
+        .tools
+        .into_iter()
+        .map(|tool| match tool {
+            ResponsesApiNamespaceTool::Function(mut function) => {
+                let tool_name = ToolName::namespaced(namespace.name.as_str(), function.name);
+                function.name = tool_name.canonical_flat_name().into_owned();
+                function
+            }
+        })
+        .collect()
+}
+
 pub fn mcp_tool_to_responses_api_tool(
     tool_name: &ToolName,
     tool: &rmcp::model::Tool,


### PR DESCRIPTION
## Summary

Fixes #26234.

Some Responses API-compatible providers do not understand Codex's proprietary `type: "namespace"` tool wrapper. When MCP tools are only exposed through that wrapper, those providers never see callable MCP functions.

This change adds a provider capability for namespace tool support and flattens namespace tools into plain functions when the active provider does not support the wrapper.

Manual repro is attached on #26234.

## What Changed

- Added `namespace_tools` to `ModelProviderInfo`.
- Kept namespace support enabled by default for built-in OpenAI, Azure, and Amazon Bedrock providers; non-OpenAI configured providers flatten by default unless explicitly overridden.
- Allowed Amazon Bedrock config to opt out with `namespace_tools = false`.
- Flattened namespaced tools to canonical `<namespace>__<tool>` function names when namespace tools are disabled.
- Kept deferred MCP discovery available through `tool_search` when namespaces are flattened, and flattened deferred search results before returning them to the model.
- Rejected duplicate canonical flat names for app-server dynamic tools before they can become ambiguous after flattening.
- Added registry fallback so flat `<namespace>__<tool>` calls resolve back to the namespaced runtime.
- Preserved `namespace_tools` through remote thread config serialization.
- Regenerated config schema.
- Added unit and RMCP integration coverage for flattened MCP exposure, deferred discovery, collision rejection, and Bedrock opt-out.


## Test Plan

- `just test -p codex-app-server validate_dynamic_tools_rejects_duplicate_canonical_flat_name`
- `just test -p codex-core handler_resolves_flat_name_to_namespaced_runtime namespace_tools_disabled_flattens_mcp_namespace_into_function mcp_and_tool_search_follow_direct_and_deferred_tool_exposure search_results_flatten_mcp_namespaces_without_namespace_tools`
- `just test -p codex-protocol`
- `just test -p codex-tools`
- `just test -p codex-model-provider-info test_merge_configured_model_providers_applies_amazon_bedrock_namespace_tools_override test_merge_configured_model_providers_applies_amazon_bedrock_allowed_overrides_together test_merge_configured_model_providers_rejects_amazon_bedrock_non_default_fields`
- `just test -p codex-core accepts_amazon_bedrock_namespace_tools_override load_config_applies_amazon_bedrock_namespace_tools_override load_config_applies_amazon_bedrock_allowed_overrides_together load_config_rejects_unsupported_amazon_bedrock_overrides`