### PR TITLE
feat: resume exec-server sessions after disconnect

### DIFF
--- a/codex-rs/core/src/unified_exec/mod_tests.rs
+++ b/codex-rs/core/src/unified_exec/mod_tests.rs
@@ -224,7 +224,9 @@ impl BlockingTerminateExecProcess {
             next_seq: 1,
             exited: false,
             exit_code: None,
+            exit_seq: None,
             closed: false,
+            closed_seq: None,
             failure: None,
         })
     }

--- a/codex-rs/core/src/unified_exec/process.rs
+++ b/codex-rs/core/src/unified_exec/process.rs
@@ -435,7 +435,9 @@ impl UnifiedExecProcess {
                             next_seq,
                             exited,
                             exit_code,
+                            exit_seq: _,
                             closed,
+                            closed_seq: _,
                             failure,
                         } = response;
 

--- a/codex-rs/core/src/unified_exec/process_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_tests.rs
@@ -38,7 +38,9 @@ impl MockExecProcess {
                 next_seq: 1,
                 exited: false,
                 exit_code: None,
+                exit_seq: None,
                 closed: false,
+                closed_seq: None,
                 failure: None,
             }))
     }
@@ -185,10 +187,12 @@ async fn remote_process_waits_for_early_exit_event() {
             },
             read_responses: Mutex::new(VecDeque::from([ReadResponse {
                 chunks: Vec::new(),
-                next_seq: 2,
+                next_seq: 3,
                 exited: true,
                 exit_code: Some(17),
+                exit_seq: Some(1),
                 closed: true,
+                closed_seq: Some(2),
                 failure: None,
             }])),
             terminate_error: None,

--- a/codex-rs/exec-server/src/client.rs
+++ b/codex-rs/exec-server/src/client.rs
@@ -2,8 +2,10 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
-use std::sync::OnceLock;
+use std::sync::RwLock as StdRwLock;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use arc_swap::ArcSwap;
@@ -12,6 +14,8 @@ use futures::FutureExt;
 use futures::future::BoxFuture;
 use serde_json::Value;
 use tokio::sync::Mutex;
+use tokio::sync::RwLock;
+use tokio::sync::RwLockReadGuard;
 use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
@@ -163,19 +167,12 @@ pub(crate) struct Session {
 }
 
 struct Inner {
-    client: ArcSwap<ClientGeneration>,
+    transport: RwLock<TransportState>,
     // The remote transport delivers one shared notification stream for every
     // process on the connection. Keep a local process_id -> session registry so
     // we can turn those connection-global notifications into process wakeups
     // without making notifications the source of truth for output delivery.
-    sessions: ArcSwap<HashMap<ProcessId, Arc<SessionState>>>,
-    // ArcSwap makes reads cheap on the hot notification path, but writes still
-    // need serialization so concurrent register/remove operations do not
-    // overwrite each other's copy-on-write updates.
-    sessions_write_lock: Mutex<()>,
-    // Once recovery is exhausted, every environment operation should fail
-    // quickly with the same canonical message.
-    disconnected: OnceLock<String>,
+    sessions: StdRwLock<HashMap<ProcessId, Arc<SessionState>>>,
     // Streaming HTTP responses are keyed by a client-generated request id
     // because they share the same connection-global notification channel as
     // process output. Keep the routing table local to the client so higher
@@ -184,23 +181,68 @@ struct Inner {
     http_body_stream_failures: ArcSwap<HashMap<String, String>>,
     http_body_streams_write_lock: Mutex<()>,
     http_body_stream_next_id: AtomicU64,
-    session_id: std::sync::RwLock<Option<String>>,
+    session_id: String,
     remote_connect_args: Option<RemoteExecServerConnectArgs>,
-    recovery_lock: Mutex<()>,
-    connection_state_tx: watch::Sender<ConnectionState>,
     next_generation_id: AtomicU64,
 }
 
 struct ClientGeneration {
     id: u64,
     client: RpcClient,
+    terminal: AtomicBool,
 }
 
-#[derive(Clone, Debug)]
-enum ConnectionState {
-    Connected(u64),
-    Recovering,
+enum TransportState {
+    Connected(Arc<ClientGeneration>),
     Failed(String),
+}
+
+struct GenerationLease<'a> {
+    generation: Arc<ClientGeneration>,
+    _state: RwLockReadGuard<'a, TransportState>,
+}
+
+struct SessionRegistration {
+    client: ExecServerClient,
+    process_id: ProcessId,
+    state: Arc<SessionState>,
+    active: bool,
+}
+
+impl ClientGeneration {
+    fn new(id: u64, client: RpcClient) -> Self {
+        Self {
+            id,
+            client,
+            terminal: AtomicBool::new(false),
+        }
+    }
+
+    fn mark_terminal(&self) -> bool {
+        !self.terminal.swap(true, Ordering::AcqRel)
+    }
+
+    fn is_terminal(&self) -> bool {
+        self.terminal.load(Ordering::Acquire) || self.client.is_disconnected()
+    }
+}
+
+impl Drop for SessionRegistration {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        self.client
+            .inner
+            .remove_session_if(&self.process_id, &self.state);
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            let client = self.client.clone();
+            let process_id = self.process_id.clone();
+            handle.spawn(async move {
+                let _ = client.terminate(&process_id).await;
+            });
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -336,23 +378,6 @@ pub enum ExecServerError {
 }
 
 impl ExecServerClient {
-    pub async fn initialize(
-        &self,
-        options: ExecServerClientConnectOptions,
-    ) -> Result<InitializeResponse, ExecServerError> {
-        let generation = self.inner.client.load_full();
-        let response = Self::initialize_generation(&generation, options).await?;
-        {
-            let mut session_id = self
-                .inner
-                .session_id
-                .write()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            *session_id = Some(response.session_id.clone());
-        }
-        Ok(response)
-    }
-
     async fn initialize_generation(
         generation: &ClientGeneration,
         options: ExecServerClientConnectOptions,
@@ -493,14 +518,9 @@ impl ExecServerClient {
         self.call(FS_COPY_METHOD, &params).await
     }
 
-    pub(crate) async fn register_session(
-        &self,
-        process_id: &ProcessId,
-    ) -> Result<Session, ExecServerError> {
+    fn create_session(&self, process_id: &ProcessId) -> Result<Session, ExecServerError> {
         let state = Arc::new(SessionState::new());
-        self.inner
-            .insert_session(process_id, Arc::clone(&state))
-            .await?;
+        self.inner.insert_session(process_id, Arc::clone(&state))?;
         Ok(Session {
             client: self.clone(),
             process_id: process_id.clone(),
@@ -508,20 +528,42 @@ impl ExecServerClient {
         })
     }
 
-    pub(crate) async fn unregister_session(&self, process_id: &ProcessId) {
-        self.inner.remove_session(process_id).await;
+    pub(crate) async fn start_process(
+        &self,
+        params: ExecParams,
+    ) -> Result<Session, ExecServerError> {
+        let generation = self.inner.generation().await?;
+        let process_id = params.process_id.clone();
+        let session = self.create_session(&process_id)?;
+        let mut registration = SessionRegistration {
+            client: self.clone(),
+            process_id,
+            state: Arc::clone(&session.state),
+            active: true,
+        };
+        if let Err(error) = self
+            .call_generation::<_, ExecResponse>(&generation.generation, EXEC_METHOD, &params)
+            .await
+        {
+            return Err(error);
+        }
+        registration.active = false;
+        Ok(session)
+    }
+
+    pub(crate) fn unregister_session(&self, process_id: &ProcessId) {
+        self.inner.remove_session(process_id);
     }
 
     pub fn session_id(&self) -> Option<String> {
-        self.inner
-            .session_id
-            .read()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .clone()
+        Some(self.inner.session_id.clone())
     }
 
     fn is_disconnected(&self) -> bool {
-        self.inner.disconnected.get().is_some()
+        self.inner
+            .transport
+            .try_read()
+            .is_ok_and(|state| matches!(&*state, TransportState::Failed(_)))
     }
 
     pub(crate) async fn connect(
@@ -538,58 +580,53 @@ impl ExecServerClient {
     ) -> Result<Self, ExecServerError> {
         let (rpc_client, events_rx) = RpcClient::new(connection);
         let generation_id = 1;
-        let generation = Arc::new(ClientGeneration {
-            id: generation_id,
-            client: rpc_client,
-        });
-        let (connection_state_tx, _connection_state_rx) =
-            watch::channel(ConnectionState::Connected(generation_id));
+        let generation = Arc::new(ClientGeneration::new(generation_id, rpc_client));
+        let response = Self::initialize_generation(&generation, options).await?;
         let inner = Arc::new(Inner {
-            client: ArcSwap::from(generation),
-            sessions: ArcSwap::from_pointee(HashMap::new()),
-            sessions_write_lock: Mutex::new(()),
-            disconnected: OnceLock::new(),
+            transport: RwLock::new(TransportState::Connected(Arc::clone(&generation))),
+            sessions: StdRwLock::new(HashMap::new()),
             http_body_streams: ArcSwap::from_pointee(HashMap::new()),
             http_body_stream_failures: ArcSwap::from_pointee(HashMap::new()),
             http_body_streams_write_lock: Mutex::new(()),
             http_body_stream_next_id: AtomicU64::new(1),
-            session_id: std::sync::RwLock::new(None),
+            session_id: response.session_id,
             remote_connect_args,
-            recovery_lock: Mutex::new(()),
-            connection_state_tx,
             next_generation_id: AtomicU64::new(generation_id + 1),
         });
 
         let client = Self { inner };
-        client.spawn_generation_reader(generation_id, events_rx);
-        client.initialize(options).await?;
+        client.spawn_generation_reader(generation, events_rx);
         Ok(client)
     }
 
     fn spawn_generation_reader(
         &self,
-        generation_id: u64,
+        generation: Arc<ClientGeneration>,
         mut events_rx: mpsc::Receiver<RpcClientEvent>,
     ) {
-        let weak = Arc::downgrade(&self.inner);
+        let inner = Arc::downgrade(&self.inner);
+        let generation = Arc::downgrade(&generation);
         tokio::spawn(async move {
             while let Some(event) = events_rx.recv().await {
+                let Some(generation) = generation.upgrade() else {
+                    return;
+                };
                 match event {
                     RpcClientEvent::Notification(notification) => {
-                        if let Some(inner) = weak.upgrade()
+                        if let Some(inner) = inner.upgrade()
                             && let Err(err) = handle_server_notification(&inner, notification).await
                         {
                             inner.handle_generation_disconnect(
-                                generation_id,
+                                Arc::clone(&generation),
                                 format!("exec-server notification handling failed: {err}"),
                             );
                             return;
                         }
                     }
                     RpcClientEvent::Disconnected { reason } => {
-                        if let Some(inner) = weak.upgrade() {
+                        if let Some(inner) = inner.upgrade() {
                             inner.handle_generation_disconnect(
-                                generation_id,
+                                Arc::clone(&generation),
                                 disconnected_message(reason.as_deref()),
                             );
                         }
@@ -605,7 +642,7 @@ impl ExecServerClient {
             .client
             .notify(INITIALIZED_METHOD, &serde_json::json!({}))
             .await
-            .map_err(ExecServerError::Json)
+            .map_err(ExecServerError::from)
     }
 
     async fn call<P, T>(&self, method: &str, params: &P) -> Result<T, ExecServerError>
@@ -613,13 +650,30 @@ impl ExecServerClient {
         P: serde::Serialize,
         T: serde::de::DeserializeOwned,
     {
-        let generation = self.inner.connected_generation().await?;
+        let generation = self.inner.generation().await?;
+        self.call_generation(&generation.generation, method, params)
+            .await
+    }
 
+    async fn call_generation<P, T>(
+        &self,
+        generation: &Arc<ClientGeneration>,
+        method: &str,
+        params: &P,
+    ) -> Result<T, ExecServerError>
+    where
+        P: serde::Serialize,
+        T: serde::de::DeserializeOwned,
+    {
         match generation.client.call(method, params).await {
             Ok(response) => Ok(response),
             Err(error) => {
                 let error = ExecServerError::from(error);
                 if is_transport_closed_error(&error) {
+                    self.inner.handle_generation_disconnect(
+                        Arc::clone(generation),
+                        disconnected_message(/*reason*/ None),
+                    );
                     Err(ExecServerError::Disconnected(disconnected_message(
                         /*reason*/ None,
                     )))
@@ -735,7 +789,6 @@ impl SessionState {
                 "process failed while recovering: {message}"
             )));
         }
-
         let mut recovered = BTreeMap::new();
         for chunk in chunks {
             recovered.insert(chunk.seq, ExecProcessEvent::Output(chunk));
@@ -839,31 +892,40 @@ impl Session {
         max_bytes: Option<usize>,
         wait_ms: Option<u64>,
     ) -> Result<ReadResponse, ExecServerError> {
-        if let Some(response) = self.state.failed_response().await {
-            return Ok(response);
-        }
-
         loop {
-            let generation_id = self.client.inner.client.load().id;
-            match self
+            if let Some(response) = self.state.failed_response().await {
+                return Ok(response);
+            }
+            let generation = match self.client.inner.generation().await {
+                Ok(generation) => generation,
+                Err(error) => {
+                    if let Some(response) = self.state.failed_response().await {
+                        return Ok(response);
+                    }
+                    return Err(error);
+                }
+            };
+            let result = self
                 .client
-                .read(ReadParams {
-                    process_id: self.process_id.clone(),
-                    after_seq,
-                    max_bytes,
-                    wait_ms,
-                })
-                .await
-            {
+                .call_generation::<_, ReadResponse>(
+                    &generation.generation,
+                    EXEC_READ_METHOD,
+                    &ReadParams {
+                        process_id: self.process_id.clone(),
+                        after_seq,
+                        max_bytes,
+                        wait_ms,
+                    },
+                )
+                .await;
+            drop(generation);
+            match result {
                 Ok(response) => return Ok(response),
                 Err(err)
                     if is_transport_closed_error(&err)
                         && self.client.inner.remote_connect_args.is_some() =>
                 {
-                    self.client
-                        .inner
-                        .wait_for_generation_recovery(generation_id)
-                        .await?;
+                    continue;
                 }
                 Err(err) if is_transport_closed_error(&err) => {
                     let message = disconnected_message(/*reason*/ None);
@@ -888,71 +950,87 @@ impl Session {
         Ok(())
     }
 
-    pub(crate) async fn unregister(&self) {
-        self.client.unregister_session(&self.process_id).await;
+    pub(crate) fn unregister(&self) {
+        self.client.unregister_session(&self.process_id);
     }
 }
 
 impl Inner {
-    fn disconnected_error(&self) -> Option<ExecServerError> {
-        self.disconnected
-            .get()
-            .cloned()
-            .map(ExecServerError::Disconnected)
-    }
-
-    fn set_disconnected(&self, message: String) -> Option<String> {
-        match self.disconnected.set(message.clone()) {
-            Ok(()) => Some(message),
-            Err(_) => None,
+    async fn generation(&self) -> Result<GenerationLease<'_>, ExecServerError> {
+        loop {
+            let state = self.transport.read().await;
+            match &*state {
+                TransportState::Connected(generation) if !generation.is_terminal() => {
+                    return Ok(GenerationLease {
+                        generation: Arc::clone(generation),
+                        _state: state,
+                    });
+                }
+                TransportState::Connected(_) => {
+                    drop(state);
+                    tokio::task::yield_now().await;
+                }
+                TransportState::Failed(message) => {
+                    return Err(ExecServerError::Disconnected(message.clone()));
+                }
+            }
         }
     }
 
     fn get_session(&self, process_id: &ProcessId) -> Option<Arc<SessionState>> {
-        self.sessions.load().get(process_id).cloned()
+        self.sessions
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(process_id)
+            .cloned()
     }
 
-    async fn insert_session(
+    fn insert_session(
         &self,
         process_id: &ProcessId,
         session: Arc<SessionState>,
     ) -> Result<(), ExecServerError> {
-        let _sessions_write_guard = self.sessions_write_lock.lock().await;
-        // Do not register a process session that can never receive environment
-        // notifications. Without this check, remote MCP startup could create a
-        // dead session and wait for process output that will never arrive.
-        if let Some(error) = self.disconnected_error() {
-            return Err(error);
-        }
-        let sessions = self.sessions.load();
+        let mut sessions = self
+            .sessions
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         if sessions.contains_key(process_id) {
             return Err(ExecServerError::Protocol(format!(
                 "session already registered for process {process_id}"
             )));
         }
-        let mut next_sessions = sessions.as_ref().clone();
-        next_sessions.insert(process_id.clone(), session);
-        self.sessions.store(Arc::new(next_sessions));
+        sessions.insert(process_id.clone(), session);
         Ok(())
     }
 
-    async fn remove_session(&self, process_id: &ProcessId) -> Option<Arc<SessionState>> {
-        let _sessions_write_guard = self.sessions_write_lock.lock().await;
-        let sessions = self.sessions.load();
-        let session = sessions.get(process_id).cloned();
-        session.as_ref()?;
-        let mut next_sessions = sessions.as_ref().clone();
-        next_sessions.remove(process_id);
-        self.sessions.store(Arc::new(next_sessions));
-        session
+    fn remove_session(&self, process_id: &ProcessId) -> Option<Arc<SessionState>> {
+        self.sessions
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(process_id)
     }
 
-    async fn take_all_sessions(&self) -> HashMap<ProcessId, Arc<SessionState>> {
-        let _sessions_write_guard = self.sessions_write_lock.lock().await;
-        let sessions = self.sessions.load();
-        let drained_sessions = sessions.as_ref().clone();
-        self.sessions.store(Arc::new(HashMap::new()));
-        drained_sessions
+    fn remove_session_if(&self, process_id: &ProcessId, expected: &Arc<SessionState>) {
+        let mut sessions = self
+            .sessions
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !sessions
+            .get(process_id)
+            .is_some_and(|session| Arc::ptr_eq(session, expected))
+        {
+            return;
+        }
+        sessions.remove(process_id);
+    }
+
+    fn take_all_sessions(&self) -> HashMap<ProcessId, Arc<SessionState>> {
+        std::mem::take(
+            &mut *self
+                .sessions
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        )
     }
 }
 
@@ -976,19 +1054,8 @@ fn is_transport_closed_error(error: &ExecServerError) -> bool {
     )
 }
 
-fn record_disconnected(inner: &Arc<Inner>, message: String) -> String {
-    // The first observer records the canonical disconnect reason. Session
-    // draining stays with the reader task so it can preserve notification
-    // ordering before publishing the terminal failure.
-    if let Some(message) = inner.set_disconnected(message.clone()) {
-        message
-    } else {
-        inner.disconnected.get().cloned().unwrap_or(message)
-    }
-}
-
-async fn fail_all_sessions(inner: &Arc<Inner>, message: String) {
-    let sessions = inner.take_all_sessions().await;
+async fn fail_all_sessions(inner: &Inner, message: String) {
+    let sessions = inner.take_all_sessions();
 
     for (_, session) in sessions {
         // Sessions synthesize a closed read response and emit a pushed Failed
@@ -999,7 +1066,7 @@ async fn fail_all_sessions(inner: &Arc<Inner>, message: String) {
 }
 
 /// Fails all in-flight work that depends on the shared JSON-RPC transport.
-async fn fail_all_in_flight_work(inner: &Arc<Inner>, message: String) {
+async fn fail_all_in_flight_work(inner: &Inner, message: String) {
     fail_all_sessions(inner, message.clone()).await;
     inner.fail_all_http_body_streams(message).await;
 }
@@ -1021,7 +1088,7 @@ async fn handle_server_notification(
                         chunk: params.chunk,
                     }));
                 if published_closed {
-                    inner.remove_session(&params.process_id).await;
+                    inner.remove_session(&params.process_id);
                 }
             }
         }
@@ -1035,7 +1102,7 @@ async fn handle_server_notification(
                     exit_code: params.exit_code,
                 });
                 if published_closed {
-                    inner.remove_session(&params.process_id).await;
+                    inner.remove_session(&params.process_id);
                 }
             }
         }
@@ -1050,7 +1117,7 @@ async fn handle_server_notification(
                 let published_closed =
                     session.publish_ordered_event(ExecProcessEvent::Closed { seq: params.seq });
                 if published_closed {
-                    inner.remove_session(&params.process_id).await;
+                    inner.remove_session(&params.process_id);
                 }
             }
         }
@@ -1068,9 +1135,12 @@ async fn handle_server_notification(
 
 #[cfg(test)]
 mod tests {
+    use codex_app_server_protocol::JSONRPCError;
+    use codex_app_server_protocol::JSONRPCErrorError;
     use codex_app_server_protocol::JSONRPCMessage;
     use codex_app_server_protocol::JSONRPCNotification;
     use codex_app_server_protocol::JSONRPCResponse;
+    use codex_utils_path_uri::PathUri;
     use futures::SinkExt;
     use futures::StreamExt;
     use pretty_assertions::assert_eq;
@@ -1090,7 +1160,6 @@ mod tests {
     use tokio::sync::mpsc;
     use tokio::sync::oneshot;
     use tokio::time::Duration;
-    #[cfg(unix)]
     use tokio::time::sleep;
     use tokio::time::timeout;
     use tokio_tungstenite::WebSocketStream;
@@ -1100,6 +1169,9 @@ mod tests {
     use super::ExecServerClient;
     use super::ExecServerClientConnectOptions;
     use super::LazyRemoteExecServerClient;
+    use super::RemoteExecServerConnectArgs;
+    use super::SessionRegistration;
+    use super::SessionState;
     use crate::ProcessId;
     #[cfg(not(windows))]
     use crate::client_api::DEFAULT_REMOTE_EXEC_SERVER_INITIALIZE_TIMEOUT;
@@ -1112,17 +1184,24 @@ mod tests {
     use crate::protocol::EXEC_EXITED_METHOD;
     use crate::protocol::EXEC_OUTPUT_DELTA_METHOD;
     use crate::protocol::EXEC_READ_METHOD;
+    use crate::protocol::EXEC_TERMINATE_METHOD;
     use crate::protocol::EXEC_WRITE_METHOD;
+    use crate::protocol::EnvironmentInfo;
     use crate::protocol::ExecClosedNotification;
     use crate::protocol::ExecExitedNotification;
     use crate::protocol::ExecOutputDeltaNotification;
     use crate::protocol::ExecOutputStream;
+    use crate::protocol::ExecParams;
+    use crate::protocol::HttpRequestParams;
     use crate::protocol::INITIALIZE_METHOD;
     use crate::protocol::INITIALIZED_METHOD;
     use crate::protocol::InitializeResponse;
     use crate::protocol::ProcessOutputChunk;
     use crate::protocol::ReadParams;
     use crate::protocol::ReadResponse;
+    use crate::protocol::ShellInfo;
+    use crate::protocol::TerminateParams;
+    use crate::protocol::TerminateResponse;
     use crate::protocol::WriteResponse;
     use crate::protocol::WriteStatus;
 
@@ -1229,24 +1308,33 @@ mod tests {
     async fn wait_for_generation(client: &ExecServerClient, generation_id: u64) {
         let result = timeout(Duration::from_secs(1), async {
             loop {
-                if matches!(
-                    client.inner.connection_state_tx.borrow().clone(),
-                    super::ConnectionState::Connected(current_generation_id)
-                        if current_generation_id == generation_id
-                ) {
+                let state = client.inner.transport.read().await;
+                if matches!(&*state, super::TransportState::Connected(generation) if generation.id == generation_id)
+                {
                     return;
                 }
+                drop(state);
                 tokio::task::yield_now().await;
             }
         })
         .await;
         assert!(
             result.is_ok(),
-            "client should connect generation {generation_id}; state: {:?}, current generation: {}, disconnected: {:?}",
-            client.inner.connection_state_tx.borrow().clone(),
-            client.inner.client.load().id,
-            client.inner.disconnected.get(),
+            "client should connect generation {generation_id}",
         );
+    }
+
+    fn test_exec_params(process_id: &str) -> ExecParams {
+        ExecParams {
+            process_id: ProcessId::from(process_id),
+            argv: vec!["ignored".to_string()],
+            cwd: PathUri::from_path(std::env::current_dir().expect("cwd")).expect("cwd URI"),
+            env_policy: None,
+            env: HashMap::new(),
+            tty: false,
+            pipe_stdin: false,
+            arg0: None,
+        }
     }
 
     #[cfg(not(windows))]
@@ -1486,8 +1574,7 @@ mod tests {
 
         let process_id = ProcessId::from("reordered");
         let session = client
-            .register_session(&process_id)
-            .await
+            .create_session(&process_id)
             .expect("session should register");
         let mut events = session.subscribe_events();
 
@@ -1628,8 +1715,7 @@ mod tests {
 
         let process_id = ProcessId::from("disconnect");
         let session = client
-            .register_session(&process_id)
-            .await
+            .create_session(&process_id)
             .expect("session should register");
         let mut events = session.subscribe_events();
 
@@ -1656,13 +1742,222 @@ mod tests {
         );
         assert!(response.closed);
 
-        let new_session = client.register_session(&ProcessId::from("new")).await;
         assert!(matches!(
-            new_session,
+            client.inner.generation().await,
             Err(super::ExecServerError::Disconnected(_))
         ));
 
         drop(client);
+        server.await.expect("server task should finish");
+    }
+
+    #[tokio::test]
+    async fn recovery_retries_generation_that_disconnects_during_handoff() {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("listener should bind");
+        let websocket_url = format!(
+            "ws://{}",
+            listener.local_addr().expect("listener should have address")
+        );
+        let (release_tx, release_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let mut first = accept_websocket(&listener).await;
+            complete_websocket_initialize(
+                &mut first,
+                "session-1",
+                /*expected_resume_session_id*/ None,
+            )
+            .await;
+            first.close(None).await.expect("first websocket closes");
+
+            let mut second = accept_websocket(&listener).await;
+            complete_websocket_initialize(
+                &mut second,
+                "session-1",
+                /*expected_resume_session_id*/ Some("session-1"),
+            )
+            .await;
+            second.close(None).await.expect("second websocket closes");
+
+            let mut third = accept_websocket(&listener).await;
+            complete_websocket_initialize(
+                &mut third,
+                "session-1",
+                /*expected_resume_session_id*/ Some("session-1"),
+            )
+            .await;
+            let request = match read_jsonrpc_websocket(&mut third).await {
+                JSONRPCMessage::Request(request)
+                    if request.method == super::ENVIRONMENT_INFO_METHOD =>
+                {
+                    request
+                }
+                other => panic!("expected environment info request, got {other:?}"),
+            };
+            write_jsonrpc_websocket(
+                &mut third,
+                JSONRPCMessage::Response(JSONRPCResponse {
+                    id: request.id,
+                    result: serde_json::to_value(EnvironmentInfo {
+                        shell: ShellInfo {
+                            name: "sh".to_string(),
+                            path: "/bin/sh".to_string(),
+                        },
+                    })
+                    .expect("environment info should serialize"),
+                }),
+            )
+            .await;
+            release_rx.await.expect("test should release websocket");
+        });
+
+        let mut args = RemoteExecServerConnectArgs::new(websocket_url, "test-client".to_string());
+        args.connect_timeout = Duration::from_secs(1);
+        args.initialize_timeout = Duration::from_secs(1);
+        let client = ExecServerClient::connect_websocket(args)
+            .await
+            .expect("initial client should connect");
+
+        wait_for_generation(&client, /*generation_id*/ 3).await;
+        assert_eq!(
+            client
+                .environment_info()
+                .await
+                .expect("replacement generation should serve requests"),
+            EnvironmentInfo {
+                shell: ShellInfo {
+                    name: "sh".to_string(),
+                    path: "/bin/sh".to_string(),
+                },
+            }
+        );
+        drop(client);
+        release_tx.send(()).expect("websocket should still be open");
+        server.await.expect("server task should finish");
+    }
+
+    #[tokio::test]
+    async fn process_and_http_routes_wait_for_transport_handoff() {
+        let (client_stdin, server_reader) = duplex(1 << 20);
+        let (mut server_writer, client_stdout) = duplex(1 << 20);
+        let (terminate_seen_tx, terminate_seen_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let mut lines = BufReader::new(server_reader).lines();
+            let initialize = read_jsonrpc_line(&mut lines).await;
+            let request = match initialize {
+                JSONRPCMessage::Request(request) if request.method == INITIALIZE_METHOD => request,
+                other => panic!("expected initialize request, got {other:?}"),
+            };
+            write_jsonrpc_line(
+                &mut server_writer,
+                JSONRPCMessage::Response(JSONRPCResponse {
+                    id: request.id,
+                    result: serde_json::to_value(InitializeResponse {
+                        session_id: "session-1".to_string(),
+                    })
+                    .expect("initialize response should serialize"),
+                }),
+            )
+            .await;
+            assert!(matches!(
+                read_jsonrpc_line(&mut lines).await,
+                JSONRPCMessage::Notification(notification)
+                    if notification.method == INITIALIZED_METHOD
+            ));
+            let request = match read_jsonrpc_line(&mut lines).await {
+                JSONRPCMessage::Request(request) if request.method == EXEC_TERMINATE_METHOD => {
+                    request
+                }
+                other => panic!("expected terminate request, got {other:?}"),
+            };
+            let params: TerminateParams =
+                serde_json::from_value(request.params.expect("terminate params should exist"))
+                    .expect("terminate params should deserialize");
+            assert_eq!(params.process_id, ProcessId::from("cancelled"));
+            write_jsonrpc_line(
+                &mut server_writer,
+                JSONRPCMessage::Response(JSONRPCResponse {
+                    id: request.id,
+                    result: serde_json::to_value(TerminateResponse { running: false })
+                        .expect("terminate response should serialize"),
+                }),
+            )
+            .await;
+            terminate_seen_tx
+                .send(())
+                .expect("terminate request should signal");
+            release_rx.await.expect("test should release server");
+        });
+
+        let client = ExecServerClient::connect(
+            JsonRpcConnection::from_stdio(client_stdout, client_stdin, "handoff-test".to_string()),
+            ExecServerClientConnectOptions::default(),
+        )
+        .await
+        .expect("client should connect");
+        let handoff = client.inner.transport.write().await;
+
+        let process_client = client.clone();
+        let process_task = tokio::spawn(async move {
+            process_client
+                .start_process(test_exec_params("after-handoff"))
+                .await
+        });
+        let http_client = client.clone();
+        let http_task = tokio::spawn(async move {
+            http_client
+                .http_request_stream(HttpRequestParams {
+                    method: "GET".to_string(),
+                    url: "https://example.test".to_string(),
+                    headers: Vec::new(),
+                    body: None,
+                    timeout_ms: None,
+                    request_id: String::new(),
+                    stream_response: false,
+                })
+                .await
+        });
+
+        sleep(Duration::from_millis(25)).await;
+        assert!(
+            client
+                .inner
+                .get_session(&ProcessId::from("after-handoff"))
+                .is_none()
+        );
+        assert!(client.inner.http_body_streams.load().is_empty());
+        process_task.abort();
+        http_task.abort();
+        let (process_result, http_result) = tokio::join!(process_task, http_task);
+        assert!(matches!(process_result, Err(error) if error.is_cancelled()));
+        assert!(matches!(http_result, Err(error) if error.is_cancelled()));
+
+        let state = Arc::new(SessionState::new());
+        client
+            .inner
+            .insert_session(&ProcessId::from("cancelled"), Arc::clone(&state))
+            .expect("cancelled session should register");
+        drop(SessionRegistration {
+            client: client.clone(),
+            process_id: ProcessId::from("cancelled"),
+            state,
+            active: true,
+        });
+        assert!(
+            client
+                .inner
+                .get_session(&ProcessId::from("cancelled"))
+                .is_none()
+        );
+
+        drop(handoff);
+        terminate_seen_rx
+            .await
+            .expect("cancelled registration should terminate the remote process");
+        drop(client);
+        release_tx.send(()).expect("server should still be running");
         server.await.expect("server task should finish");
     }
 
@@ -1719,42 +2014,74 @@ mod tests {
                 )
                 .await;
 
-                let read = read_jsonrpc_websocket(&mut second).await;
-                let read = match read {
-                    JSONRPCMessage::Request(request) if request.method == EXEC_READ_METHOD => {
-                        request
-                    }
-                    other => panic!("expected recovery read request, got {other:?}"),
-                };
-                let params: ReadParams = serde_json::from_value(
-                    read.params
-                        .clone()
-                        .expect("recovery read params should exist"),
-                )
-                .expect("recovery read params should deserialize");
-                assert_eq!(params.after_seq, Some(1));
-                write_jsonrpc_websocket(
-                    &mut second,
-                    JSONRPCMessage::Response(JSONRPCResponse {
-                        id: read.id,
-                        result: serde_json::to_value(ReadResponse {
-                            chunks: vec![ProcessOutputChunk {
-                                seq: 2,
-                                stream: ExecOutputStream::Stdout,
-                                chunk: b"during\n".to_vec().into(),
-                            }],
-                            next_seq: 3,
-                            exited: false,
-                            exit_code: None,
-                            exit_seq: None,
-                            closed: false,
-                            closed_seq: None,
-                            failure: None,
-                        })
-                        .expect("recovery read response should serialize"),
-                    }),
-                )
-                .await;
+                for _ in 0..3 {
+                    let read = match read_jsonrpc_websocket(&mut second).await {
+                        JSONRPCMessage::Request(request) if request.method == EXEC_READ_METHOD => {
+                            request
+                        }
+                        other => panic!("expected recovery read request, got {other:?}"),
+                    };
+                    let params: ReadParams = serde_json::from_value(
+                        read.params
+                            .clone()
+                            .expect("recovery read params should exist"),
+                    )
+                    .expect("recovery read params should deserialize");
+                    let message = match params.process_id.as_ref() {
+                        "resumed-process" => {
+                            assert_eq!(params.after_seq, Some(1));
+                            JSONRPCMessage::Response(JSONRPCResponse {
+                                id: read.id,
+                                result: serde_json::to_value(ReadResponse {
+                                    chunks: vec![ProcessOutputChunk {
+                                        seq: 2,
+                                        stream: ExecOutputStream::Stdout,
+                                        chunk: b"during\n".to_vec().into(),
+                                    }],
+                                    next_seq: 3,
+                                    exited: false,
+                                    exit_code: None,
+                                    exit_seq: None,
+                                    closed: false,
+                                    closed_seq: None,
+                                    failure: None,
+                                })
+                                .expect("recovery read response should serialize"),
+                            })
+                        }
+                        "terminal-process" => {
+                            assert_eq!(params.after_seq, Some(0));
+                            JSONRPCMessage::Response(JSONRPCResponse {
+                                id: read.id,
+                                result: serde_json::to_value(ReadResponse {
+                                    chunks: vec![ProcessOutputChunk {
+                                        seq: 1,
+                                        stream: ExecOutputStream::Stdout,
+                                        chunk: b"tail\n".to_vec().into(),
+                                    }],
+                                    next_seq: 4,
+                                    exited: true,
+                                    exit_code: Some(0),
+                                    exit_seq: Some(2),
+                                    closed: true,
+                                    closed_seq: Some(3),
+                                    failure: None,
+                                })
+                                .expect("terminal recovery response should serialize"),
+                            })
+                        }
+                        "missing-process" => JSONRPCMessage::Error(JSONRPCError {
+                            id: read.id,
+                            error: JSONRPCErrorError {
+                                code: -32600,
+                                message: "unknown process".to_string(),
+                                data: None,
+                            },
+                        }),
+                        process_id => panic!("unexpected recovery process {process_id}"),
+                    };
+                    write_jsonrpc_websocket(&mut second, message).await;
+                }
 
                 let write = read_jsonrpc_websocket(&mut second).await;
                 let write = match write {
@@ -1785,10 +2112,17 @@ mod tests {
         });
         let first = client.get().await.expect("first client should connect");
         let session = first
-            .register_session(&ProcessId::from("resumed-process"))
-            .await
+            .create_session(&ProcessId::from("resumed-process"))
             .expect("process session should register");
         let mut events = session.subscribe_events();
+        let terminal_session = first
+            .create_session(&ProcessId::from("terminal-process"))
+            .expect("terminal process session should register");
+        let mut terminal_events = terminal_session.subscribe_events();
+        let missing_session = first
+            .create_session(&ProcessId::from("missing-process"))
+            .expect("missing process session should register");
+        let mut missing_events = missing_session.subscribe_events();
         registered_tx.send(()).expect("registration should signal");
         assert_eq!(
             timeout(Duration::from_secs(1), events.recv())
@@ -1813,6 +2147,40 @@ mod tests {
                 stream: ExecOutputStream::Stdout,
                 chunk: b"during\n".to_vec().into(),
             })
+        );
+        let mut recovered_terminal_events = Vec::new();
+        for _ in 0..3 {
+            recovered_terminal_events.push(
+                timeout(Duration::from_secs(1), terminal_events.recv())
+                    .await
+                    .expect("terminal recovery should not time out")
+                    .expect("terminal event stream should stay open"),
+            );
+        }
+        assert_eq!(
+            recovered_terminal_events,
+            vec![
+                ExecProcessEvent::Output(ProcessOutputChunk {
+                    seq: 1,
+                    stream: ExecOutputStream::Stdout,
+                    chunk: b"tail\n".to_vec().into(),
+                }),
+                ExecProcessEvent::Exited {
+                    seq: 2,
+                    exit_code: 0,
+                },
+                ExecProcessEvent::Closed { seq: 3 },
+            ]
+        );
+        assert_eq!(
+            timeout(Duration::from_secs(1), missing_events.recv())
+                .await
+                .expect("missing process recovery should not time out")
+                .expect("missing process event stream should stay open"),
+            ExecProcessEvent::Failed(
+                "failed to recover process missing-process: exec-server rejected request (-32600): unknown process"
+                    .to_string()
+            )
         );
         assert_eq!(
             session
@@ -1886,12 +2254,10 @@ mod tests {
         let noisy_process_id = ProcessId::from("noisy");
         let quiet_process_id = ProcessId::from("quiet");
         let _noisy_session = client
-            .register_session(&noisy_process_id)
-            .await
+            .create_session(&noisy_process_id)
             .expect("noisy session should register");
         let quiet_session = client
-            .register_session(&quiet_process_id)
-            .await
+            .create_session(&quiet_process_id)
             .expect("quiet session should register");
         let mut quiet_wake_rx = quiet_session.subscribe_wake();
 

--- a/codex-rs/exec-server/src/client.rs
+++ b/codex-rs/exec-server/src/client.rs
@@ -89,6 +89,8 @@ use crate::rpc::RpcClient;
 use crate::rpc::RpcClientEvent;
 
 pub(crate) mod http_client;
+#[path = "client_recovery.rs"]
+mod recovery;
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const INITIALIZE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -161,7 +163,7 @@ pub(crate) struct Session {
 }
 
 struct Inner {
-    client: RpcClient,
+    client: ArcSwap<ClientGeneration>,
     // The remote transport delivers one shared notification stream for every
     // process on the connection. Keep a local process_id -> session registry so
     // we can turn those connection-global notifications into process wakeups
@@ -171,9 +173,8 @@ struct Inner {
     // need serialization so concurrent register/remove operations do not
     // overwrite each other's copy-on-write updates.
     sessions_write_lock: Mutex<()>,
-    // Once the transport closes, every environment operation should fail quickly
-    // with the same canonical message. This client never reconnects, so the
-    // latch only moves from unset to set once.
+    // Once recovery is exhausted, every environment operation should fail
+    // quickly with the same canonical message.
     disconnected: OnceLock<String>,
     // Streaming HTTP responses are keyed by a client-generated request id
     // because they share the same connection-global notification channel as
@@ -184,13 +185,22 @@ struct Inner {
     http_body_streams_write_lock: Mutex<()>,
     http_body_stream_next_id: AtomicU64,
     session_id: std::sync::RwLock<Option<String>>,
-    reader_task: tokio::task::JoinHandle<()>,
+    remote_connect_args: Option<RemoteExecServerConnectArgs>,
+    recovery_lock: Mutex<()>,
+    connection_state_tx: watch::Sender<ConnectionState>,
+    next_generation_id: AtomicU64,
 }
 
-impl Drop for Inner {
-    fn drop(&mut self) {
-        self.reader_task.abort();
-    }
+struct ClientGeneration {
+    id: u64,
+    client: RpcClient,
+}
+
+#[derive(Clone, Debug)]
+enum ConnectionState {
+    Connected(u64),
+    Recovering,
+    Failed(String),
 }
 
 #[derive(Clone)]
@@ -330,6 +340,23 @@ impl ExecServerClient {
         &self,
         options: ExecServerClientConnectOptions,
     ) -> Result<InitializeResponse, ExecServerError> {
+        let generation = self.inner.client.load_full();
+        let response = Self::initialize_generation(&generation, options).await?;
+        {
+            let mut session_id = self
+                .inner
+                .session_id
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            *session_id = Some(response.session_id.clone());
+        }
+        Ok(response)
+    }
+
+    async fn initialize_generation(
+        generation: &ClientGeneration,
+        options: ExecServerClientConnectOptions,
+    ) -> Result<InitializeResponse, ExecServerError> {
         let ExecServerClientConnectOptions {
             client_name,
             initialize_timeout,
@@ -337,8 +364,7 @@ impl ExecServerClient {
         } = options;
 
         timeout(initialize_timeout, async {
-            let response: InitializeResponse = self
-                .inner
+            let response: InitializeResponse = generation
                 .client
                 .call(
                     INITIALIZE_METHOD,
@@ -348,15 +374,7 @@ impl ExecServerClient {
                     },
                 )
                 .await?;
-            {
-                let mut session_id = self
-                    .inner
-                    .session_id
-                    .write()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                *session_id = Some(response.session_id.clone());
-            }
-            self.notify_initialized().await?;
+            Self::notify_initialized(generation).await?;
             Ok(response)
         })
         .await
@@ -503,67 +521,87 @@ impl ExecServerClient {
     }
 
     fn is_disconnected(&self) -> bool {
-        self.inner.disconnected.get().is_some() || self.inner.client.is_disconnected()
+        self.inner.disconnected.get().is_some()
     }
 
     pub(crate) async fn connect(
         connection: JsonRpcConnection,
         options: ExecServerClientConnectOptions,
     ) -> Result<Self, ExecServerError> {
-        let (rpc_client, mut events_rx) = RpcClient::new(connection);
-        let inner = Arc::new_cyclic(|weak| {
-            let weak = weak.clone();
-            let reader_task = tokio::spawn(async move {
-                while let Some(event) = events_rx.recv().await {
-                    match event {
-                        RpcClientEvent::Notification(notification) => {
-                            if let Some(inner) = weak.upgrade()
-                                && let Err(err) =
-                                    handle_server_notification(&inner, notification).await
-                            {
-                                let message = record_disconnected(
-                                    &inner,
-                                    format!("exec-server notification handling failed: {err}"),
-                                );
-                                fail_all_in_flight_work(&inner, message).await;
-                                return;
-                            }
-                        }
-                        RpcClientEvent::Disconnected { reason } => {
-                            if let Some(inner) = weak.upgrade() {
-                                let message = record_disconnected(
-                                    &inner,
-                                    disconnected_message(reason.as_deref()),
-                                );
-                                fail_all_in_flight_work(&inner, message).await;
-                            }
-                            return;
-                        }
-                    }
-                }
-            });
+        Self::connect_with_recovery(connection, options, /*remote_connect_args*/ None).await
+    }
 
-            Inner {
-                client: rpc_client,
-                sessions: ArcSwap::from_pointee(HashMap::new()),
-                sessions_write_lock: Mutex::new(()),
-                disconnected: OnceLock::new(),
-                http_body_streams: ArcSwap::from_pointee(HashMap::new()),
-                http_body_stream_failures: ArcSwap::from_pointee(HashMap::new()),
-                http_body_streams_write_lock: Mutex::new(()),
-                http_body_stream_next_id: AtomicU64::new(1),
-                session_id: std::sync::RwLock::new(None),
-                reader_task,
-            }
+    pub(crate) async fn connect_with_recovery(
+        connection: JsonRpcConnection,
+        options: ExecServerClientConnectOptions,
+        remote_connect_args: Option<RemoteExecServerConnectArgs>,
+    ) -> Result<Self, ExecServerError> {
+        let (rpc_client, events_rx) = RpcClient::new(connection);
+        let generation_id = 1;
+        let generation = Arc::new(ClientGeneration {
+            id: generation_id,
+            client: rpc_client,
+        });
+        let (connection_state_tx, _connection_state_rx) =
+            watch::channel(ConnectionState::Connected(generation_id));
+        let inner = Arc::new(Inner {
+            client: ArcSwap::from(generation),
+            sessions: ArcSwap::from_pointee(HashMap::new()),
+            sessions_write_lock: Mutex::new(()),
+            disconnected: OnceLock::new(),
+            http_body_streams: ArcSwap::from_pointee(HashMap::new()),
+            http_body_stream_failures: ArcSwap::from_pointee(HashMap::new()),
+            http_body_streams_write_lock: Mutex::new(()),
+            http_body_stream_next_id: AtomicU64::new(1),
+            session_id: std::sync::RwLock::new(None),
+            remote_connect_args,
+            recovery_lock: Mutex::new(()),
+            connection_state_tx,
+            next_generation_id: AtomicU64::new(generation_id + 1),
         });
 
         let client = Self { inner };
+        client.spawn_generation_reader(generation_id, events_rx);
         client.initialize(options).await?;
         Ok(client)
     }
 
-    async fn notify_initialized(&self) -> Result<(), ExecServerError> {
-        self.inner
+    fn spawn_generation_reader(
+        &self,
+        generation_id: u64,
+        mut events_rx: mpsc::Receiver<RpcClientEvent>,
+    ) {
+        let weak = Arc::downgrade(&self.inner);
+        tokio::spawn(async move {
+            while let Some(event) = events_rx.recv().await {
+                match event {
+                    RpcClientEvent::Notification(notification) => {
+                        if let Some(inner) = weak.upgrade()
+                            && let Err(err) = handle_server_notification(&inner, notification).await
+                        {
+                            inner.handle_generation_disconnect(
+                                generation_id,
+                                format!("exec-server notification handling failed: {err}"),
+                            );
+                            return;
+                        }
+                    }
+                    RpcClientEvent::Disconnected { reason } => {
+                        if let Some(inner) = weak.upgrade() {
+                            inner.handle_generation_disconnect(
+                                generation_id,
+                                disconnected_message(reason.as_deref()),
+                            );
+                        }
+                        return;
+                    }
+                }
+            }
+        });
+    }
+
+    async fn notify_initialized(generation: &ClientGeneration) -> Result<(), ExecServerError> {
+        generation
             .client
             .notify(INITIALIZED_METHOD, &serde_json::json!({}))
             .await
@@ -575,24 +613,16 @@ impl ExecServerClient {
         P: serde::Serialize,
         T: serde::de::DeserializeOwned,
     {
-        // Reject new work before allocating a JSON-RPC request id. MCP tool
-        // calls, process writes, and fs operations all pass through here, so
-        // this is the shared low-level failure path after environment disconnect.
-        if let Some(error) = self.inner.disconnected_error() {
-            return Err(error);
-        }
+        let generation = self.inner.connected_generation().await?;
 
-        match self.inner.client.call(method, params).await {
+        match generation.client.call(method, params).await {
             Ok(response) => Ok(response),
             Err(error) => {
                 let error = ExecServerError::from(error);
                 if is_transport_closed_error(&error) {
-                    // A call can race with disconnect after the preflight
-                    // check. Only the reader task drains sessions so queued
-                    // process notifications stay ordered before disconnect.
-                    let message = disconnected_message(/*reason*/ None);
-                    let message = record_disconnected(&self.inner, message);
-                    Err(ExecServerError::Disconnected(message))
+                    Err(ExecServerError::Disconnected(disconnected_message(
+                        /*reason*/ None,
+                    )))
                 } else {
                     Err(error)
                 }
@@ -654,35 +684,103 @@ impl SessionState {
             return false;
         };
 
-        let mut ready = Vec::new();
-        {
-            let mut ordered_events = self
-                .ordered_events
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            // We have already delivered this sequence number or moved past it,
-            // so accepting it again would duplicate output or lifecycle events.
-            if seq <= ordered_events.last_published_seq {
-                return false;
-            }
-
-            ordered_events.pending.entry(seq).or_insert(event);
-            loop {
-                let next_seq = ordered_events.last_published_seq + 1;
-                let Some(event) = ordered_events.pending.remove(&next_seq) else {
-                    break;
-                };
-                ordered_events.last_published_seq += 1;
-                ready.push(event);
-            }
+        let mut ordered_events = self
+            .ordered_events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // We have already delivered this sequence number or moved past it,
+        // so accepting it again would duplicate output or lifecycle events.
+        if seq <= ordered_events.last_published_seq {
+            return false;
         }
 
+        ordered_events.pending.entry(seq).or_insert(event);
+        self.publish_ready_events(&mut ordered_events)
+    }
+
+    fn publish_ready_events(&self, ordered_events: &mut OrderedSessionEvents) -> bool {
         let mut published_closed = false;
-        for event in ready {
+        loop {
+            let next_seq = ordered_events.last_published_seq + 1;
+            let Some(event) = ordered_events.pending.remove(&next_seq) else {
+                break;
+            };
+            ordered_events.last_published_seq = next_seq;
             published_closed |= matches!(&event, ExecProcessEvent::Closed { .. });
             self.events.publish(event);
         }
         published_closed
+    }
+
+    fn last_published_seq(&self) -> u64 {
+        self.ordered_events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .last_published_seq
+    }
+
+    fn recover_events(&self, response: ReadResponse) -> Result<bool, ExecServerError> {
+        let ReadResponse {
+            chunks,
+            next_seq,
+            exited,
+            exit_code,
+            exit_seq,
+            closed,
+            closed_seq,
+            failure,
+        } = response;
+        if let Some(message) = failure {
+            return Err(ExecServerError::Protocol(format!(
+                "process failed while recovering: {message}"
+            )));
+        }
+
+        let mut recovered = BTreeMap::new();
+        for chunk in chunks {
+            recovered.insert(chunk.seq, ExecProcessEvent::Output(chunk));
+        }
+        if exited {
+            let seq = exit_seq.ok_or_else(|| {
+                ExecServerError::Protocol(
+                    "recovering exited process did not include its exit sequence".to_string(),
+                )
+            })?;
+            let exit_code = exit_code.ok_or_else(|| {
+                ExecServerError::Protocol(
+                    "recovering exited process did not include its exit code".to_string(),
+                )
+            })?;
+            recovered.insert(seq, ExecProcessEvent::Exited { seq, exit_code });
+        }
+        if closed {
+            let seq = closed_seq.ok_or_else(|| {
+                ExecServerError::Protocol(
+                    "recovering closed process did not include its close sequence".to_string(),
+                )
+            })?;
+            recovered.insert(seq, ExecProcessEvent::Closed { seq });
+        }
+
+        let mut ordered_events = self
+            .ordered_events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let target_seq = next_seq.saturating_sub(1);
+        for seq in ordered_events.last_published_seq.saturating_add(1)..=target_seq {
+            if !ordered_events.pending.contains_key(&seq) && !recovered.contains_key(&seq) {
+                return Err(ExecServerError::Protocol(format!(
+                    "process event {seq} is no longer retained while recovering through sequence {target_seq}"
+                )));
+            }
+        }
+        for (seq, event) in recovered {
+            if seq > ordered_events.last_published_seq {
+                ordered_events.pending.entry(seq).or_insert(event);
+            }
+        }
+        self.note_change(target_seq);
+        Ok(self.publish_ready_events(&mut ordered_events))
     }
 
     async fn set_failure(&self, message: String) {
@@ -714,7 +812,9 @@ impl SessionState {
             next_seq,
             exited: true,
             exit_code: None,
+            exit_seq: None,
             closed: true,
+            closed_seq: None,
             failure: Some(message),
         }
     }
@@ -743,23 +843,35 @@ impl Session {
             return Ok(response);
         }
 
-        match self
-            .client
-            .read(ReadParams {
-                process_id: self.process_id.clone(),
-                after_seq,
-                max_bytes,
-                wait_ms,
-            })
-            .await
-        {
-            Ok(response) => Ok(response),
-            Err(err) if is_transport_closed_error(&err) => {
-                let message = disconnected_message(/*reason*/ None);
-                self.state.set_failure(message.clone()).await;
-                Ok(self.state.synthesized_failure(message))
+        loop {
+            let generation_id = self.client.inner.client.load().id;
+            match self
+                .client
+                .read(ReadParams {
+                    process_id: self.process_id.clone(),
+                    after_seq,
+                    max_bytes,
+                    wait_ms,
+                })
+                .await
+            {
+                Ok(response) => return Ok(response),
+                Err(err)
+                    if is_transport_closed_error(&err)
+                        && self.client.inner.remote_connect_args.is_some() =>
+                {
+                    self.client
+                        .inner
+                        .wait_for_generation_recovery(generation_id)
+                        .await?;
+                }
+                Err(err) if is_transport_closed_error(&err) => {
+                    let message = disconnected_message(/*reason*/ None);
+                    self.state.set_failure(message.clone()).await;
+                    return Ok(self.state.synthesized_failure(message));
+                }
+                Err(err) => return Err(err),
             }
-            Err(err) => Err(err),
         }
     }
 
@@ -999,6 +1111,8 @@ mod tests {
     use crate::protocol::EXEC_CLOSED_METHOD;
     use crate::protocol::EXEC_EXITED_METHOD;
     use crate::protocol::EXEC_OUTPUT_DELTA_METHOD;
+    use crate::protocol::EXEC_READ_METHOD;
+    use crate::protocol::EXEC_WRITE_METHOD;
     use crate::protocol::ExecClosedNotification;
     use crate::protocol::ExecExitedNotification;
     use crate::protocol::ExecOutputDeltaNotification;
@@ -1007,6 +1121,10 @@ mod tests {
     use crate::protocol::INITIALIZED_METHOD;
     use crate::protocol::InitializeResponse;
     use crate::protocol::ProcessOutputChunk;
+    use crate::protocol::ReadParams;
+    use crate::protocol::ReadResponse;
+    use crate::protocol::WriteResponse;
+    use crate::protocol::WriteStatus;
 
     async fn read_jsonrpc_line<R>(lines: &mut tokio::io::Lines<BufReader<R>>) -> JSONRPCMessage
     where
@@ -1108,17 +1226,27 @@ mod tests {
         }
     }
 
-    async fn wait_for_disconnect(client: &ExecServerClient) {
-        timeout(Duration::from_secs(1), async {
+    async fn wait_for_generation(client: &ExecServerClient, generation_id: u64) {
+        let result = timeout(Duration::from_secs(1), async {
             loop {
-                if client.is_disconnected() {
+                if matches!(
+                    client.inner.connection_state_tx.borrow().clone(),
+                    super::ConnectionState::Connected(current_generation_id)
+                        if current_generation_id == generation_id
+                ) {
                     return;
                 }
                 tokio::task::yield_now().await;
             }
         })
-        .await
-        .expect("client should observe disconnect");
+        .await;
+        assert!(
+            result.is_ok(),
+            "client should connect generation {generation_id}; state: {:?}, current generation: {}, disconnected: {:?}",
+            client.inner.connection_state_tx.borrow().clone(),
+            client.inner.client.load().id,
+            client.inner.disconnected.get(),
+        );
     }
 
     #[cfg(not(windows))]
@@ -1539,7 +1667,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn remote_websocket_client_replaces_disconnected_client_with_fresh_session() {
+    async fn remote_websocket_client_resumes_disconnected_session() {
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("listener should bind");
@@ -1547,6 +1675,9 @@ mod tests {
             "ws://{}",
             listener.local_addr().expect("listener should have address")
         );
+        let (registered_tx, registered_rx) = oneshot::channel();
+        let (disconnect_tx, disconnect_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
         let server = tokio::spawn({
             async move {
                 let mut first = accept_websocket(&listener).await;
@@ -1556,18 +1687,94 @@ mod tests {
                     /*expected_resume_session_id*/ None,
                 )
                 .await;
+                let _ = registered_rx.await;
+                write_jsonrpc_websocket(
+                    &mut first,
+                    JSONRPCMessage::Notification(JSONRPCNotification {
+                        method: EXEC_OUTPUT_DELTA_METHOD.to_string(),
+                        params: Some(
+                            serde_json::to_value(ExecOutputDeltaNotification {
+                                process_id: ProcessId::from("resumed-process"),
+                                seq: 1,
+                                stream: ExecOutputStream::Stdout,
+                                chunk: b"before\n".to_vec().into(),
+                            })
+                            .expect("output notification should serialize"),
+                        ),
+                    }),
+                )
+                .await;
+                let _ = disconnect_rx.await;
                 first
                     .close(None)
                     .await
                     .expect("first websocket should close");
+                drop(first);
 
                 let mut second = accept_websocket(&listener).await;
                 complete_websocket_initialize(
                     &mut second,
-                    "session-2",
-                    /*expected_resume_session_id*/ None,
+                    "session-1",
+                    /*expected_resume_session_id*/ Some("session-1"),
                 )
                 .await;
+
+                let read = read_jsonrpc_websocket(&mut second).await;
+                let read = match read {
+                    JSONRPCMessage::Request(request) if request.method == EXEC_READ_METHOD => {
+                        request
+                    }
+                    other => panic!("expected recovery read request, got {other:?}"),
+                };
+                let params: ReadParams = serde_json::from_value(
+                    read.params
+                        .clone()
+                        .expect("recovery read params should exist"),
+                )
+                .expect("recovery read params should deserialize");
+                assert_eq!(params.after_seq, Some(1));
+                write_jsonrpc_websocket(
+                    &mut second,
+                    JSONRPCMessage::Response(JSONRPCResponse {
+                        id: read.id,
+                        result: serde_json::to_value(ReadResponse {
+                            chunks: vec![ProcessOutputChunk {
+                                seq: 2,
+                                stream: ExecOutputStream::Stdout,
+                                chunk: b"during\n".to_vec().into(),
+                            }],
+                            next_seq: 3,
+                            exited: false,
+                            exit_code: None,
+                            exit_seq: None,
+                            closed: false,
+                            closed_seq: None,
+                            failure: None,
+                        })
+                        .expect("recovery read response should serialize"),
+                    }),
+                )
+                .await;
+
+                let write = read_jsonrpc_websocket(&mut second).await;
+                let write = match write {
+                    JSONRPCMessage::Request(request) if request.method == EXEC_WRITE_METHOD => {
+                        request
+                    }
+                    other => panic!("expected process write request, got {other:?}"),
+                };
+                write_jsonrpc_websocket(
+                    &mut second,
+                    JSONRPCMessage::Response(JSONRPCResponse {
+                        id: write.id,
+                        result: serde_json::to_value(WriteResponse {
+                            status: WriteStatus::Accepted,
+                        })
+                        .expect("write response should serialize"),
+                    }),
+                )
+                .await;
+                let _ = release_rx.await;
             }
         });
 
@@ -1577,15 +1784,55 @@ mod tests {
             initialize_timeout: Duration::from_secs(1),
         });
         let first = client.get().await.expect("first client should connect");
-        wait_for_disconnect(&first).await;
+        let session = first
+            .register_session(&ProcessId::from("resumed-process"))
+            .await
+            .expect("process session should register");
+        let mut events = session.subscribe_events();
+        registered_tx.send(()).expect("registration should signal");
+        assert_eq!(
+            timeout(Duration::from_secs(1), events.recv())
+                .await
+                .expect("initial output should not time out")
+                .expect("event stream should stay open"),
+            ExecProcessEvent::Output(ProcessOutputChunk {
+                seq: 1,
+                stream: ExecOutputStream::Stdout,
+                chunk: b"before\n".to_vec().into(),
+            })
+        );
+        disconnect_tx.send(()).expect("disconnect should signal");
+        wait_for_generation(&first, /*generation_id*/ 2).await;
+        assert_eq!(
+            timeout(Duration::from_secs(1), events.recv())
+                .await
+                .expect("recovered output should not time out")
+                .expect("event stream should stay open"),
+            ExecProcessEvent::Output(ProcessOutputChunk {
+                seq: 2,
+                stream: ExecOutputStream::Stdout,
+                chunk: b"during\n".to_vec().into(),
+            })
+        );
+        assert_eq!(
+            session
+                .write(b"hello\n".to_vec())
+                .await
+                .expect("write should use resumed session"),
+            WriteResponse {
+                status: WriteStatus::Accepted,
+            }
+        );
 
         let (replacement_a, replacement_b) = tokio::join!(client.get(), client.get());
         let replacement_a = replacement_a.expect("first replacement should connect");
         let replacement_b = replacement_b.expect("second replacement should reuse client");
-        assert_eq!(replacement_a.session_id().as_deref(), Some("session-2"));
-        assert_eq!(replacement_b.session_id().as_deref(), Some("session-2"));
+        assert_eq!(replacement_a.session_id().as_deref(), Some("session-1"));
+        assert_eq!(replacement_b.session_id().as_deref(), Some("session-1"));
+        assert!(Arc::ptr_eq(&first.inner, &replacement_a.inner));
         assert!(Arc::ptr_eq(&replacement_a.inner, &replacement_b.inner));
 
+        release_tx.send(()).expect("server should release");
         server.await.expect("server task should finish");
     }
 

--- a/codex-rs/exec-server/src/client/rpc_http_client.rs
+++ b/codex-rs/exec-server/src/client/rpc_http_client.rs
@@ -42,6 +42,7 @@ impl ExecServerClient {
         &self,
         mut params: HttpRequestParams,
     ) -> Result<(HttpRequestResponse, HttpResponseBodyStream), ExecServerError> {
+        let generation = self.inner.generation().await?;
         params.stream_response = true;
         let request_id = self.inner.next_http_body_stream_request_id();
         params.request_id = request_id.clone();
@@ -51,7 +52,10 @@ impl ExecServerClient {
             .await?;
         let mut registration =
             HttpBodyStreamRegistration::new(Arc::clone(&self.inner), request_id.clone());
-        let response = match self.call(HTTP_REQUEST_METHOD, &params).await {
+        let response = match self
+            .call_generation(&generation.generation, HTTP_REQUEST_METHOD, &params)
+            .await
+        {
             Ok(response) => response,
             Err(error) => {
                 self.inner.remove_http_body_stream(&request_id).await;

--- a/codex-rs/exec-server/src/client_recovery.rs
+++ b/codex-rs/exec-server/src/client_recovery.rs
@@ -7,14 +7,12 @@ use tokio::time::sleep;
 use tokio::time::timeout_at;
 
 use super::ClientGeneration;
-use super::ConnectionState;
 use super::ExecServerClient;
 use super::ExecServerError;
 use super::Inner;
-use super::disconnected_message;
+use super::TransportState;
 use super::fail_all_in_flight_work;
 use super::is_transport_closed_error;
-use super::record_disconnected;
 use crate::client_api::ExecServerClientConnectOptions;
 use crate::protocol::EXEC_READ_METHOD;
 use crate::protocol::ReadParams;
@@ -25,142 +23,66 @@ const SESSION_RECOVERY_TIMEOUT: Duration = Duration::from_secs(25);
 const SESSION_RECOVERY_RETRY_INTERVAL: Duration = Duration::from_millis(50);
 
 impl Inner {
-    pub(super) async fn connected_generation(
-        &self,
-    ) -> Result<Arc<ClientGeneration>, ExecServerError> {
-        let mut state_rx = self.connection_state_tx.subscribe();
-        loop {
-            if let Some(error) = self.disconnected_error() {
-                return Err(error);
-            }
-
-            match state_rx.borrow().clone() {
-                ConnectionState::Connected(generation_id) => {
-                    let generation = self.client.load_full();
-                    if generation.id == generation_id && !generation.client.is_disconnected() {
-                        return Ok(generation);
-                    }
-                }
-                ConnectionState::Recovering => {}
-                ConnectionState::Failed(message) => {
-                    return Err(ExecServerError::Disconnected(message));
-                }
-            }
-
-            state_rx.changed().await.map_err(|_| {
-                ExecServerError::Disconnected(disconnected_message(/*reason*/ None))
-            })?;
-        }
-    }
-
     pub(super) fn handle_generation_disconnect(
         self: &Arc<Self>,
-        generation_id: u64,
+        generation: Arc<ClientGeneration>,
         message: String,
     ) {
-        let generation = self.client.load_full();
-        if generation.id != generation_id {
+        if !generation.mark_terminal() {
             return;
         }
 
-        if self.remote_connect_args.is_none() {
-            let message = record_disconnected(self, message);
-            self.connection_state_tx
-                .send_replace(ConnectionState::Failed(message.clone()));
-            let inner = Arc::clone(self);
-            tokio::spawn(async move {
-                fail_all_in_flight_work(&inner, message).await;
-            });
-            return;
-        }
-
-        let should_recover = matches!(
-            self.connection_state_tx.borrow().clone(),
-            ConnectionState::Connected(current_generation_id)
-                if current_generation_id == generation_id
-        );
-        if !should_recover {
-            return;
-        }
-
-        self.connection_state_tx
-            .send_replace(ConnectionState::Recovering);
+        generation.client.close_transport();
         let inner = Arc::clone(self);
         tokio::spawn(async move {
-            inner.fail_all_http_body_streams(message.clone()).await;
-            inner.recover_remote_session(generation_id, message).await;
+            generation.client.close().await;
+            if inner.remote_connect_args.is_some() {
+                inner.recover_remote_session(generation, message).await;
+            } else {
+                inner.fail_generation(generation.id, message).await;
+            }
         });
     }
 
-    pub(super) async fn wait_for_generation_recovery(
-        &self,
-        failed_generation_id: u64,
-    ) -> Result<(), ExecServerError> {
-        let mut state_rx = self.connection_state_tx.subscribe();
-        loop {
-            match state_rx.borrow().clone() {
-                ConnectionState::Connected(generation_id)
-                    if generation_id != failed_generation_id =>
-                {
-                    return Ok(());
-                }
-                ConnectionState::Failed(message) => {
-                    return Err(ExecServerError::Disconnected(message));
-                }
-                ConnectionState::Connected(_) | ConnectionState::Recovering => {}
-            }
-            state_rx.changed().await.map_err(|_| {
-                ExecServerError::Disconnected(disconnected_message(/*reason*/ None))
-            })?;
+    async fn fail_generation(&self, generation_id: u64, message: String) {
+        let mut state = self.transport.write().await;
+        if !is_current_generation(&state, generation_id) {
+            return;
         }
+
+        *state = TransportState::Failed(message.clone());
+        fail_all_in_flight_work(self, message).await;
     }
 
     async fn recover_remote_session(
         self: Arc<Self>,
-        failed_generation_id: u64,
+        failed_generation: Arc<ClientGeneration>,
         disconnect_message: String,
     ) {
-        let _recovery_guard = self.recovery_lock.lock().await;
-        if self.disconnected.get().is_some() {
+        let mut state = self.transport.write().await;
+        if !is_current_generation(&state, failed_generation.id) {
             return;
         }
 
-        let current = self.client.load_full();
-        if current.id != failed_generation_id
-            && matches!(
-                self.connection_state_tx.borrow().clone(),
-                ConnectionState::Connected(current_generation_id)
-                    if current_generation_id == current.id
-            )
-        {
-            return;
-        }
-
-        let Some(session_id) = self
-            .session_id
-            .read()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .clone()
-        else {
-            self.fail_session_recovery(
-                disconnect_message,
-                "the disconnected client had no initialized session id".to_string(),
-            )
+        // The write lease starts after all operations using the failed
+        // generation have finished. It also prevents new process and HTTP
+        // routes from being registered until promotion completes.
+        self.fail_all_http_body_streams(disconnect_message.clone())
             .await;
-            return;
-        };
 
+        let session_id = self.session_id.clone();
         let deadline = Instant::now() + SESSION_RECOVERY_TIMEOUT;
         let last_error = loop {
             match timeout_at(deadline, self.resume_once(&session_id)).await {
-                Ok(Ok(generation_id)) => {
-                    self.connection_state_tx
-                        .send_replace(ConnectionState::Connected(generation_id));
+                Ok(Ok(generation)) if !generation.is_terminal() => {
+                    *state = TransportState::Connected(generation);
                     return;
                 }
+                Ok(Ok(generation)) => {
+                    generation.client.close().await;
+                }
                 Ok(Err(error)) => {
-                    let retry = is_retryable_recovery_error(&error);
-                    if !retry {
+                    if !is_retryable_recovery_error(&error) {
                         break error.to_string();
                     }
                 }
@@ -176,11 +98,16 @@ impl Inner {
             sleep(SESSION_RECOVERY_RETRY_INTERVAL.min(deadline - now)).await;
         };
 
-        self.fail_session_recovery(disconnect_message, last_error)
-            .await;
+        let message =
+            format!("{disconnect_message}; failed to resume exec-server session: {last_error}");
+        *state = TransportState::Failed(message.clone());
+        fail_all_in_flight_work(&self, message).await;
     }
 
-    async fn resume_once(self: &Arc<Self>, session_id: &str) -> Result<u64, ExecServerError> {
+    async fn resume_once(
+        self: &Arc<Self>,
+        session_id: &str,
+    ) -> Result<Arc<ClientGeneration>, ExecServerError> {
         let mut connect_args = self
             .remote_connect_args
             .clone()
@@ -188,46 +115,44 @@ impl Inner {
         connect_args.resume_session_id = Some(session_id.to_string());
         let connection = ExecServerClient::open_websocket_connection(&connect_args).await?;
         let (rpc_client, events_rx) = RpcClient::new(connection);
-        let generation_id = self.next_generation_id.fetch_add(1, Ordering::SeqCst);
-        let generation = Arc::new(ClientGeneration {
-            id: generation_id,
-            client: rpc_client,
-        });
+        let generation = Arc::new(ClientGeneration::new(
+            self.next_generation_id.fetch_add(1, Ordering::SeqCst),
+            rpc_client,
+        ));
         let stable_client = ExecServerClient {
             inner: Arc::clone(self),
         };
-        stable_client.spawn_generation_reader(generation_id, events_rx);
-        let response = ExecServerClient::initialize_generation(
-            &generation,
-            ExecServerClientConnectOptions {
-                client_name: connect_args.client_name,
-                initialize_timeout: connect_args.initialize_timeout,
-                resume_session_id: connect_args.resume_session_id,
-            },
-        )
-        .await?;
-        if response.session_id != session_id {
-            return Err(ExecServerError::Protocol(format!(
-                "exec-server resumed session {session_id} as unexpected session {}",
-                response.session_id
-            )));
-        }
+        stable_client.spawn_generation_reader(Arc::clone(&generation), events_rx);
 
-        stable_client.recover_process_sessions(&generation).await?;
-        if generation.client.is_disconnected() {
-            return Err(ExecServerError::Closed);
-        }
-        self.client.store(generation);
-        Ok(generation_id)
-    }
+        let result = async {
+            let response = ExecServerClient::initialize_generation(
+                &generation,
+                ExecServerClientConnectOptions {
+                    client_name: connect_args.client_name,
+                    initialize_timeout: connect_args.initialize_timeout,
+                    resume_session_id: connect_args.resume_session_id,
+                },
+            )
+            .await?;
+            if response.session_id != session_id {
+                return Err(ExecServerError::Protocol(format!(
+                    "exec-server resumed session {session_id} as unexpected session {}",
+                    response.session_id
+                )));
+            }
 
-    async fn fail_session_recovery(self: &Arc<Self>, disconnect_message: String, error: String) {
-        let message =
-            format!("{disconnect_message}; failed to resume exec-server session: {error}");
-        let message = record_disconnected(self, message);
-        self.connection_state_tx
-            .send_replace(ConnectionState::Failed(message.clone()));
-        fail_all_in_flight_work(self, message).await;
+            stable_client.recover_process_sessions(&generation).await
+        }
+        .await;
+
+        let error = match result {
+            Ok(()) if !generation.is_terminal() => return Ok(generation),
+            Ok(()) => ExecServerError::Closed,
+            Err(error) => error,
+        };
+        generation.mark_terminal();
+        generation.client.close().await;
+        Err(error)
     }
 }
 
@@ -236,11 +161,23 @@ impl ExecServerClient {
         &self,
         generation: &ClientGeneration,
     ) -> Result<(), ExecServerError> {
-        let sessions = self.inner.sessions.load_full();
+        let sessions = self
+            .inner
+            .sessions
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
         for (process_id, session) in sessions.iter() {
-            let response: ReadResponse = generation
+            let Some(current_session) = self.inner.get_session(process_id) else {
+                continue;
+            };
+            if !Arc::ptr_eq(session, &current_session) {
+                continue;
+            }
+
+            let response = generation
                 .client
-                .call(
+                .call::<_, ReadResponse>(
                     EXEC_READ_METHOD,
                     &ReadParams {
                         process_id: process_id.clone(),
@@ -249,18 +186,35 @@ impl ExecServerClient {
                         wait_ms: Some(0),
                     },
                 )
-                .await?;
-            let published_closed = session.recover_events(response).map_err(|error| {
-                ExecServerError::Protocol(format!(
-                    "failed to recover process {process_id}: {error}"
-                ))
-            })?;
-            if published_closed {
-                self.inner.remove_session(process_id).await;
+                .await
+                .map_err(ExecServerError::from);
+            let recovered = match response {
+                Ok(response) => session.recover_events(response),
+                Err(error) if is_transport_closed_error(&error) => return Err(error),
+                Err(error) => Err(error),
+            };
+            match recovered {
+                Ok(published_closed) => {
+                    if published_closed {
+                        self.inner.remove_session(process_id);
+                    }
+                }
+                Err(error) => {
+                    let message = format!("failed to recover process {process_id}: {error}");
+                    self.inner.remove_session(process_id);
+                    session.set_failure(message).await;
+                }
             }
         }
         Ok(())
     }
+}
+
+fn is_current_generation(state: &TransportState, generation_id: u64) -> bool {
+    matches!(
+        state,
+        TransportState::Connected(generation) if generation.id == generation_id
+    )
 }
 
 fn is_retryable_recovery_error(error: &ExecServerError) -> bool {

--- a/codex-rs/exec-server/src/client_recovery.rs
+++ b/codex-rs/exec-server/src/client_recovery.rs
@@ -1,0 +1,279 @@
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use tokio::time::Instant;
+use tokio::time::sleep;
+use tokio::time::timeout_at;
+
+use super::ClientGeneration;
+use super::ConnectionState;
+use super::ExecServerClient;
+use super::ExecServerError;
+use super::Inner;
+use super::disconnected_message;
+use super::fail_all_in_flight_work;
+use super::is_transport_closed_error;
+use super::record_disconnected;
+use crate::client_api::ExecServerClientConnectOptions;
+use crate::protocol::EXEC_READ_METHOD;
+use crate::protocol::ReadParams;
+use crate::protocol::ReadResponse;
+use crate::rpc::RpcClient;
+
+const SESSION_RECOVERY_TIMEOUT: Duration = Duration::from_secs(25);
+const SESSION_RECOVERY_RETRY_INTERVAL: Duration = Duration::from_millis(50);
+
+impl Inner {
+    pub(super) async fn connected_generation(
+        &self,
+    ) -> Result<Arc<ClientGeneration>, ExecServerError> {
+        let mut state_rx = self.connection_state_tx.subscribe();
+        loop {
+            if let Some(error) = self.disconnected_error() {
+                return Err(error);
+            }
+
+            match state_rx.borrow().clone() {
+                ConnectionState::Connected(generation_id) => {
+                    let generation = self.client.load_full();
+                    if generation.id == generation_id && !generation.client.is_disconnected() {
+                        return Ok(generation);
+                    }
+                }
+                ConnectionState::Recovering => {}
+                ConnectionState::Failed(message) => {
+                    return Err(ExecServerError::Disconnected(message));
+                }
+            }
+
+            state_rx.changed().await.map_err(|_| {
+                ExecServerError::Disconnected(disconnected_message(/*reason*/ None))
+            })?;
+        }
+    }
+
+    pub(super) fn handle_generation_disconnect(
+        self: &Arc<Self>,
+        generation_id: u64,
+        message: String,
+    ) {
+        let generation = self.client.load_full();
+        if generation.id != generation_id {
+            return;
+        }
+
+        if self.remote_connect_args.is_none() {
+            let message = record_disconnected(self, message);
+            self.connection_state_tx
+                .send_replace(ConnectionState::Failed(message.clone()));
+            let inner = Arc::clone(self);
+            tokio::spawn(async move {
+                fail_all_in_flight_work(&inner, message).await;
+            });
+            return;
+        }
+
+        let should_recover = matches!(
+            self.connection_state_tx.borrow().clone(),
+            ConnectionState::Connected(current_generation_id)
+                if current_generation_id == generation_id
+        );
+        if !should_recover {
+            return;
+        }
+
+        self.connection_state_tx
+            .send_replace(ConnectionState::Recovering);
+        let inner = Arc::clone(self);
+        tokio::spawn(async move {
+            inner.fail_all_http_body_streams(message.clone()).await;
+            inner.recover_remote_session(generation_id, message).await;
+        });
+    }
+
+    pub(super) async fn wait_for_generation_recovery(
+        &self,
+        failed_generation_id: u64,
+    ) -> Result<(), ExecServerError> {
+        let mut state_rx = self.connection_state_tx.subscribe();
+        loop {
+            match state_rx.borrow().clone() {
+                ConnectionState::Connected(generation_id)
+                    if generation_id != failed_generation_id =>
+                {
+                    return Ok(());
+                }
+                ConnectionState::Failed(message) => {
+                    return Err(ExecServerError::Disconnected(message));
+                }
+                ConnectionState::Connected(_) | ConnectionState::Recovering => {}
+            }
+            state_rx.changed().await.map_err(|_| {
+                ExecServerError::Disconnected(disconnected_message(/*reason*/ None))
+            })?;
+        }
+    }
+
+    async fn recover_remote_session(
+        self: Arc<Self>,
+        failed_generation_id: u64,
+        disconnect_message: String,
+    ) {
+        let _recovery_guard = self.recovery_lock.lock().await;
+        if self.disconnected.get().is_some() {
+            return;
+        }
+
+        let current = self.client.load_full();
+        if current.id != failed_generation_id
+            && matches!(
+                self.connection_state_tx.borrow().clone(),
+                ConnectionState::Connected(current_generation_id)
+                    if current_generation_id == current.id
+            )
+        {
+            return;
+        }
+
+        let Some(session_id) = self
+            .session_id
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+        else {
+            self.fail_session_recovery(
+                disconnect_message,
+                "the disconnected client had no initialized session id".to_string(),
+            )
+            .await;
+            return;
+        };
+
+        let deadline = Instant::now() + SESSION_RECOVERY_TIMEOUT;
+        let last_error = loop {
+            match timeout_at(deadline, self.resume_once(&session_id)).await {
+                Ok(Ok(generation_id)) => {
+                    self.connection_state_tx
+                        .send_replace(ConnectionState::Connected(generation_id));
+                    return;
+                }
+                Ok(Err(error)) => {
+                    let retry = is_retryable_recovery_error(&error);
+                    if !retry {
+                        break error.to_string();
+                    }
+                }
+                Err(_) => {
+                    break format!("recovery timed out after {SESSION_RECOVERY_TIMEOUT:?}");
+                }
+            }
+
+            let now = Instant::now();
+            if now >= deadline {
+                break format!("recovery timed out after {SESSION_RECOVERY_TIMEOUT:?}");
+            }
+            sleep(SESSION_RECOVERY_RETRY_INTERVAL.min(deadline - now)).await;
+        };
+
+        self.fail_session_recovery(disconnect_message, last_error)
+            .await;
+    }
+
+    async fn resume_once(self: &Arc<Self>, session_id: &str) -> Result<u64, ExecServerError> {
+        let mut connect_args = self
+            .remote_connect_args
+            .clone()
+            .ok_or_else(|| ExecServerError::Protocol("missing reconnect arguments".to_string()))?;
+        connect_args.resume_session_id = Some(session_id.to_string());
+        let connection = ExecServerClient::open_websocket_connection(&connect_args).await?;
+        let (rpc_client, events_rx) = RpcClient::new(connection);
+        let generation_id = self.next_generation_id.fetch_add(1, Ordering::SeqCst);
+        let generation = Arc::new(ClientGeneration {
+            id: generation_id,
+            client: rpc_client,
+        });
+        let stable_client = ExecServerClient {
+            inner: Arc::clone(self),
+        };
+        stable_client.spawn_generation_reader(generation_id, events_rx);
+        let response = ExecServerClient::initialize_generation(
+            &generation,
+            ExecServerClientConnectOptions {
+                client_name: connect_args.client_name,
+                initialize_timeout: connect_args.initialize_timeout,
+                resume_session_id: connect_args.resume_session_id,
+            },
+        )
+        .await?;
+        if response.session_id != session_id {
+            return Err(ExecServerError::Protocol(format!(
+                "exec-server resumed session {session_id} as unexpected session {}",
+                response.session_id
+            )));
+        }
+
+        stable_client.recover_process_sessions(&generation).await?;
+        if generation.client.is_disconnected() {
+            return Err(ExecServerError::Closed);
+        }
+        self.client.store(generation);
+        Ok(generation_id)
+    }
+
+    async fn fail_session_recovery(self: &Arc<Self>, disconnect_message: String, error: String) {
+        let message =
+            format!("{disconnect_message}; failed to resume exec-server session: {error}");
+        let message = record_disconnected(self, message);
+        self.connection_state_tx
+            .send_replace(ConnectionState::Failed(message.clone()));
+        fail_all_in_flight_work(self, message).await;
+    }
+}
+
+impl ExecServerClient {
+    async fn recover_process_sessions(
+        &self,
+        generation: &ClientGeneration,
+    ) -> Result<(), ExecServerError> {
+        let sessions = self.inner.sessions.load_full();
+        for (process_id, session) in sessions.iter() {
+            let response: ReadResponse = generation
+                .client
+                .call(
+                    EXEC_READ_METHOD,
+                    &ReadParams {
+                        process_id: process_id.clone(),
+                        after_seq: Some(session.last_published_seq()),
+                        max_bytes: None,
+                        wait_ms: Some(0),
+                    },
+                )
+                .await?;
+            let published_closed = session.recover_events(response).map_err(|error| {
+                ExecServerError::Protocol(format!(
+                    "failed to recover process {process_id}: {error}"
+                ))
+            })?;
+            if published_closed {
+                self.inner.remove_session(process_id).await;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn is_retryable_recovery_error(error: &ExecServerError) -> bool {
+    is_transport_closed_error(error)
+        || matches!(
+            error,
+            ExecServerError::WebSocketConnectTimeout { .. }
+                | ExecServerError::WebSocketConnect { .. }
+                | ExecServerError::InitializeTimedOut { .. }
+        )
+        || matches!(
+            error,
+            ExecServerError::Server { message, .. }
+                if message.contains("is already attached to another connection")
+        )
+}

--- a/codex-rs/exec-server/src/client_transport.rs
+++ b/codex-rs/exec-server/src/client_transport.rs
@@ -56,6 +56,14 @@ impl ExecServerClient {
     pub async fn connect_websocket(
         args: RemoteExecServerConnectArgs,
     ) -> Result<Self, ExecServerError> {
+        let connection = Self::open_websocket_connection(&args).await?;
+        let options = args.clone().into();
+        Self::connect_with_recovery(connection, options, Some(args)).await
+    }
+
+    pub(crate) async fn open_websocket_connection(
+        args: &RemoteExecServerConnectArgs,
+    ) -> Result<JsonRpcConnection, ExecServerError> {
         ensure_rustls_crypto_provider();
         let websocket_url = args.websocket_url.clone();
         let connect_timeout = args.connect_timeout;
@@ -76,7 +84,7 @@ impl ExecServerClient {
         } else {
             JsonRpcConnection::from_websocket(stream, connection_label)
         };
-        Self::connect(connection, args.into()).await
+        Ok(connection)
     }
 
     pub(crate) async fn connect_stdio_command(

--- a/codex-rs/exec-server/src/local_process.rs
+++ b/codex-rs/exec-server/src/local_process.rs
@@ -74,11 +74,13 @@ struct RunningProcess {
     retained_bytes: usize,
     next_seq: u64,
     exit_code: Option<i32>,
+    exit_seq: Option<u64>,
     wake_tx: watch::Sender<u64>,
     events: ExecProcessEventLog,
     output_notify: Arc<Notify>,
     open_streams: usize,
     closed: bool,
+    closed_seq: Option<u64>,
 }
 
 enum ProcessEntry {
@@ -232,11 +234,13 @@ impl LocalProcess {
                     retained_bytes: 0,
                     next_seq: 1,
                     exit_code: None,
+                    exit_seq: None,
                     wake_tx: wake_tx.clone(),
                     events: events.clone(),
                     output_notify: Arc::clone(&output_notify),
                     open_streams: 2,
                     closed: false,
+                    closed_seq: None,
                 })),
             );
         }
@@ -307,6 +311,9 @@ impl LocalProcess {
                 for retained in process.output.iter().filter(|chunk| chunk.seq > after_seq) {
                     let chunk_len = retained.chunk.len();
                     if !chunks.is_empty() && total_bytes + chunk_len > max_bytes {
+                        next_seq = chunks
+                            .last()
+                            .map_or(process.next_seq, |chunk: &ProcessOutputChunk| chunk.seq + 1);
                         break;
                     }
                     total_bytes += chunk_len;
@@ -315,8 +322,8 @@ impl LocalProcess {
                         stream: retained.stream,
                         chunk: retained.chunk.clone().into(),
                     });
-                    next_seq = retained.seq + 1;
                     if total_bytes >= max_bytes {
+                        next_seq = retained.seq + 1;
                         break;
                     }
                 }
@@ -327,7 +334,9 @@ impl LocalProcess {
                         next_seq,
                         exited: process.exit_code.is_some(),
                         exit_code: process.exit_code,
+                        exit_seq: process.exit_seq,
                         closed: process.closed,
+                        closed_seq: process.closed_seq,
                         failure: None,
                     },
                     Arc::clone(&process.output_notify),
@@ -689,6 +698,7 @@ async fn watch_exit(
             let seq = process.next_seq;
             process.next_seq += 1;
             process.exit_code = Some(exit_code);
+            process.exit_seq = Some(seq);
             let _ = process.wake_tx.send(seq);
             process
                 .events
@@ -743,6 +753,7 @@ async fn maybe_emit_closed(process_id: ProcessId, inner: Arc<Inner>) {
         process.closed = true;
         let seq = process.next_seq;
         process.next_seq += 1;
+        process.closed_seq = Some(seq);
         let _ = process.wake_tx.send(seq);
         process.events.publish(ExecProcessEvent::Closed { seq });
         (
@@ -882,7 +893,9 @@ mod tests {
                 next_seq: 2,
                 exited: true,
                 exit_code: Some(0),
+                exit_seq: Some(1),
                 closed: false,
+                closed_seq: None,
                 failure: None,
             }
         );
@@ -992,11 +1005,13 @@ mod tests {
                 retained_bytes: 0,
                 next_seq: 1,
                 exit_code: None,
+                exit_seq: None,
                 wake_tx: wake_tx.clone(),
                 events: events.clone(),
                 output_notify: Arc::clone(&output_notify),
                 open_streams: 2,
                 closed: false,
+                closed_seq: None,
             })),
         );
         assert!(previous.is_none());

--- a/codex-rs/exec-server/src/local_process.rs
+++ b/codex-rs/exec-server/src/local_process.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::collections::hash_map::Entry;
 use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::MutexGuard;
 use std::time::Duration;
 
 use codex_app_server_protocol::JSONRPCErrorError;
@@ -11,7 +13,6 @@ use codex_protocol::shell_environment;
 use codex_utils_pty::ExecCommandSession;
 use codex_utils_pty::ProcessSignal as PtyProcessSignal;
 use codex_utils_pty::TerminalSize;
-use tokio::sync::Mutex;
 use tokio::sync::Notify;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
@@ -90,12 +91,41 @@ enum ProcessEntry {
 
 struct Inner {
     notifications: std::sync::RwLock<Option<RpcNotificationSender>>,
-    processes: Mutex<HashMap<ProcessId, ProcessEntry>>,
+    processes: StdMutex<HashMap<ProcessId, ProcessEntry>>,
+}
+
+struct ProcessStartReservation {
+    inner: Arc<Inner>,
+    process_id: ProcessId,
+    active: bool,
 }
 
 #[derive(Clone)]
 pub(crate) struct LocalProcess {
     inner: Arc<Inner>,
+}
+
+impl Inner {
+    fn lock_processes(&self) -> MutexGuard<'_, HashMap<ProcessId, ProcessEntry>> {
+        self.processes
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+impl Drop for ProcessStartReservation {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+        let mut processes = self.inner.lock_processes();
+        if matches!(
+            processes.get(&self.process_id),
+            Some(ProcessEntry::Starting)
+        ) {
+            processes.remove(&self.process_id);
+        }
+    }
 }
 
 struct LocalExecProcess {
@@ -119,14 +149,14 @@ impl LocalProcess {
         Self {
             inner: Arc::new(Inner {
                 notifications: std::sync::RwLock::new(Some(notifications)),
-                processes: Mutex::new(HashMap::new()),
+                processes: StdMutex::new(HashMap::new()),
             }),
         }
     }
 
     pub(crate) async fn shutdown(&self) {
         let remaining = {
-            let mut processes = self.inner.processes.lock().await;
+            let mut processes = self.inner.lock_processes();
             processes
                 .drain()
                 .filter_map(|(_, process)| match process {
@@ -166,7 +196,7 @@ impl LocalProcess {
         })?;
 
         {
-            let mut process_map = self.inner.processes.lock().await;
+            let mut process_map = self.inner.lock_processes();
             if process_map.contains_key(&process_id) {
                 return Err(invalid_request(format!(
                     "process {process_id} already exists"
@@ -174,6 +204,11 @@ impl LocalProcess {
             }
             process_map.insert(process_id.clone(), ProcessEntry::Starting);
         }
+        let mut reservation = ProcessStartReservation {
+            inner: Arc::clone(&self.inner),
+            process_id: process_id.clone(),
+            active: true,
+        };
 
         let env = child_env(&params);
         let spawned_result = if params.tty {
@@ -205,16 +240,7 @@ impl LocalProcess {
             )
             .await
         };
-        let spawned = match spawned_result {
-            Ok(spawned) => spawned,
-            Err(err) => {
-                let mut process_map = self.inner.processes.lock().await;
-                if matches!(process_map.get(&process_id), Some(ProcessEntry::Starting)) {
-                    process_map.remove(&process_id);
-                }
-                return Err(internal_error(err.to_string()));
-            }
-        };
+        let spawned = spawned_result.map_err(|err| internal_error(err.to_string()))?;
 
         let output_notify = Arc::new(Notify::new());
         let (wake_tx, _wake_rx) = watch::channel(0);
@@ -223,7 +249,13 @@ impl LocalProcess {
             RETAINED_OUTPUT_BYTES_PER_PROCESS,
         );
         {
-            let mut process_map = self.inner.processes.lock().await;
+            let mut process_map = self.inner.lock_processes();
+            if !matches!(process_map.get(&process_id), Some(ProcessEntry::Starting)) {
+                spawned.session.terminate();
+                return Err(internal_error(format!(
+                    "process {process_id} start was cancelled"
+                )));
+            }
             process_map.insert(
                 process_id.clone(),
                 ProcessEntry::Running(Box::new(RunningProcess {
@@ -243,6 +275,7 @@ impl LocalProcess {
                     closed_seq: None,
                 })),
             );
+            reservation.active = false;
         }
 
         tokio::spawn(stream_output(
@@ -294,7 +327,7 @@ impl LocalProcess {
 
         loop {
             let (response, output_notify) = {
-                let process_map = self.inner.processes.lock().await;
+                let process_map = self.inner.lock_processes();
                 let process = process_map.get(&params.process_id).ok_or_else(|| {
                     invalid_request(format!("unknown process id {}", params.process_id))
                 })?;
@@ -372,7 +405,7 @@ impl LocalProcess {
     ) -> Result<WriteResponse, JSONRPCErrorError> {
         let _input_bytes = params.chunk.0.len();
         let writer_tx = {
-            let process_map = self.inner.processes.lock().await;
+            let process_map = self.inner.lock_processes();
             let Some(process) = process_map.get(&params.process_id) else {
                 return Ok(WriteResponse {
                     status: WriteStatus::UnknownProcess,
@@ -406,7 +439,7 @@ impl LocalProcess {
         params: SignalParams,
     ) -> Result<SignalResponse, JSONRPCErrorError> {
         {
-            let process_map = self.inner.processes.lock().await;
+            let process_map = self.inner.lock_processes();
             match process_map.get(&params.process_id) {
                 Some(ProcessEntry::Running(process)) => {
                     if process.exit_code.is_some() {
@@ -429,7 +462,7 @@ impl LocalProcess {
         params: TerminateParams,
     ) -> Result<TerminateResponse, JSONRPCErrorError> {
         let running = {
-            let process_map = self.inner.processes.lock().await;
+            let process_map = self.inner.lock_processes();
             match process_map.get(&params.process_id) {
                 Some(ProcessEntry::Running(process)) => {
                     if process.exit_code.is_some() {
@@ -637,7 +670,7 @@ async fn stream_output(
     while let Some(chunk) = receiver.recv().await {
         let _chunk_len = chunk.len();
         let notification = {
-            let mut processes = inner.processes.lock().await;
+            let mut processes = inner.lock_processes();
             let Some(entry) = processes.get_mut(&process_id) else {
                 break;
             };
@@ -693,7 +726,7 @@ async fn watch_exit(
 ) {
     let exit_code = exit_rx.await.unwrap_or(-1);
     let notification = {
-        let mut processes = inner.processes.lock().await;
+        let mut processes = inner.lock_processes();
         if let Some(ProcessEntry::Running(process)) = processes.get_mut(&process_id) {
             let seq = process.next_seq;
             process.next_seq += 1;
@@ -726,7 +759,7 @@ async fn watch_exit(
 
 async fn finish_output_stream(process_id: ProcessId, inner: Arc<Inner>) {
     {
-        let mut processes = inner.processes.lock().await;
+        let mut processes = inner.lock_processes();
         let Some(ProcessEntry::Running(process)) = processes.get_mut(&process_id) else {
             return;
         };
@@ -741,7 +774,7 @@ async fn finish_output_stream(process_id: ProcessId, inner: Arc<Inner>) {
 
 async fn maybe_emit_closed(process_id: ProcessId, inner: Arc<Inner>) {
     let (notification, output_notify) = {
-        let mut processes = inner.processes.lock().await;
+        let mut processes = inner.lock_processes();
         let Some(ProcessEntry::Running(process)) = processes.get_mut(&process_id) else {
             return;
         };
@@ -770,7 +803,7 @@ async fn maybe_emit_closed(process_id: ProcessId, inner: Arc<Inner>) {
     let cleanup_inner = Arc::clone(&inner);
     tokio::spawn(async move {
         tokio::time::sleep(EXITED_PROCESS_RETENTION).await;
-        let mut processes = cleanup_inner.processes.lock().await;
+        let mut processes = cleanup_inner.lock_processes();
         match processes.entry(cleanup_process_id) {
             Entry::Occupied(entry) => {
                 if matches!(entry.get(), ProcessEntry::Running(process) if process.closed) {
@@ -817,6 +850,24 @@ mod tests {
             pipe_stdin: false,
             arg0: None,
         }
+    }
+
+    #[tokio::test]
+    async fn dropped_start_reservation_releases_process_id() {
+        let backend = LocalProcess::default();
+        let process_id = ProcessId::from("cancelled-start");
+        backend
+            .inner
+            .lock_processes()
+            .insert(process_id.clone(), ProcessEntry::Starting);
+
+        drop(ProcessStartReservation {
+            inner: Arc::clone(&backend.inner),
+            process_id,
+            active: true,
+        });
+
+        assert!(backend.inner.lock_processes().is_empty());
     }
 
     #[tokio::test]
@@ -952,7 +1003,7 @@ mod tests {
         timeout(Duration::from_secs(1), async {
             loop {
                 {
-                    let processes = backend.inner.processes.lock().await;
+                    let processes = backend.inner.lock_processes();
                     if !processes.contains_key(&process_id) {
                         break;
                     }
@@ -994,7 +1045,7 @@ mod tests {
             RETAINED_OUTPUT_BYTES_PER_PROCESS,
         );
 
-        let mut processes = backend.inner.processes.lock().await;
+        let mut processes = backend.inner.lock_processes();
         let previous = processes.insert(
             process_id.clone(),
             ProcessEntry::Running(Box::new(RunningProcess {

--- a/codex-rs/exec-server/src/protocol.rs
+++ b/codex-rs/exec-server/src/protocol.rs
@@ -142,10 +142,8 @@ pub struct ReadResponse {
     pub next_seq: u64,
     pub exited: bool,
     pub exit_code: Option<i32>,
-    #[serde(default)]
     pub exit_seq: Option<u64>,
     pub closed: bool,
-    #[serde(default)]
     pub closed_seq: Option<u64>,
     pub failure: Option<String>,
 }

--- a/codex-rs/exec-server/src/protocol.rs
+++ b/codex-rs/exec-server/src/protocol.rs
@@ -142,7 +142,11 @@ pub struct ReadResponse {
     pub next_seq: u64,
     pub exited: bool,
     pub exit_code: Option<i32>,
+    #[serde(default)]
+    pub exit_seq: Option<u64>,
     pub closed: bool,
+    #[serde(default)]
+    pub closed_seq: Option<u64>,
     pub failure: Option<String>,
 }
 

--- a/codex-rs/exec-server/src/remote_process.rs
+++ b/codex-rs/exec-server/src/remote_process.rs
@@ -35,13 +35,8 @@ impl RemoteProcess {
         &self,
         params: ExecParams,
     ) -> Result<StartedExecProcess, crate::ExecServerError> {
-        let process_id = params.process_id.clone();
         let client = self.client.get().await?;
-        let session = client.register_session(&process_id).await?;
-        if let Err(err) = client.exec(params).await {
-            session.unregister().await;
-            return Err(err);
-        }
+        let session = client.start_process(params).await?;
 
         Ok(StartedExecProcess {
             process: Arc::new(RemoteExecProcess { session }),
@@ -118,9 +113,6 @@ impl ExecProcess for RemoteExecProcess {
 
 impl Drop for RemoteExecProcess {
     fn drop(&mut self) {
-        let session = self.session.clone();
-        tokio::spawn(async move {
-            session.unregister().await;
-        });
+        self.session.unregister();
     }
 }

--- a/codex-rs/exec-server/src/rpc.rs
+++ b/codex-rs/exec-server/src/rpc.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI64;
 use std::sync::atomic::Ordering;
 
@@ -225,6 +226,7 @@ pub(crate) struct RpcClient {
     // immediately when the socket closes, even if no JSON-RPC error response
     // can be delivered for their request id.
     disconnected_rx: watch::Receiver<bool>,
+    closed: Arc<AtomicBool>,
     next_request_id: AtomicI64,
     transport_tasks: Vec<JoinHandle<()>>,
     transport: JsonRpcTransport,
@@ -241,9 +243,11 @@ impl RpcClient {
             transport,
         } = connection;
         let pending = Arc::new(Mutex::new(HashMap::<RequestId, PendingRequest>::new()));
+        let closed = Arc::new(AtomicBool::new(false));
         let (event_tx, event_rx) = mpsc::channel(128);
 
         let pending_for_reader = Arc::clone(&pending);
+        let closed_for_reader = Arc::clone(&closed);
         let transport_for_reader = transport.clone();
         let reader_task = tokio::spawn(async move {
             let disconnect_reason = loop {
@@ -274,7 +278,7 @@ impl RpcClient {
                     reason: disconnect_reason,
                 })
                 .await;
-            drain_pending(&pending_for_reader).await;
+            close_pending(&pending_for_reader, &closed_for_reader).await;
             transport_for_reader.terminate();
         });
 
@@ -283,6 +287,7 @@ impl RpcClient {
                 write_tx,
                 pending,
                 disconnected_rx,
+                closed,
                 next_request_id: AtomicI64::new(1),
                 transport_tasks,
                 transport,
@@ -296,24 +301,36 @@ impl RpcClient {
         &self,
         method: &str,
         params: &P,
-    ) -> Result<(), serde_json::Error> {
-        let params = serde_json::to_value(params)?;
+    ) -> Result<(), RpcCallError> {
+        let params = serde_json::to_value(params).map_err(RpcCallError::Json)?;
+        if self.closed.load(Ordering::Acquire) || *self.disconnected_rx.borrow() {
+            return Err(RpcCallError::Closed);
+        }
         self.write_tx
             .send(JSONRPCMessage::Notification(JSONRPCNotification {
                 method: method.to_string(),
                 params: Some(params),
             }))
             .await
-            .map_err(|_| {
-                serde_json::Error::io(std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    "JSON-RPC transport closed",
-                ))
-            })
+            .map_err(|_| RpcCallError::Closed)
     }
 
     pub(crate) fn is_disconnected(&self) -> bool {
-        *self.disconnected_rx.borrow()
+        self.closed.load(Ordering::Acquire) || *self.disconnected_rx.borrow()
+    }
+
+    pub(crate) fn close_transport(&self) {
+        self.closed.store(true, Ordering::Release);
+        self.transport.terminate();
+        for task in &self.transport_tasks {
+            task.abort();
+        }
+        self.reader_task.abort();
+    }
+
+    pub(crate) async fn close(&self) {
+        self.close_transport();
+        close_pending(&self.pending, &self.closed).await;
     }
 
     pub(crate) async fn call<P, T>(&self, method: &str, params: &P) -> Result<T, RpcCallError>
@@ -328,7 +345,7 @@ impl RpcClient {
             // Registering the pending request and checking disconnect must be
             // atomic with the reader's drain_pending path. Otherwise a call
             // can sneak in after the drain and wait forever.
-            if *self.disconnected_rx.borrow() {
+            if self.closed.load(Ordering::Acquire) || *self.disconnected_rx.borrow() {
                 return Err(RpcCallError::Closed);
             }
             pending.insert(request_id.clone(), response_tx);
@@ -379,11 +396,7 @@ impl RpcClient {
 
 impl Drop for RpcClient {
     fn drop(&mut self) {
-        self.transport.terminate();
-        for task in &self.transport_tasks {
-            task.abort();
-        }
-        self.reader_task.abort();
+        self.close_transport();
     }
 }
 
@@ -512,9 +525,10 @@ async fn handle_server_message(
     Ok(())
 }
 
-async fn drain_pending(pending: &Mutex<HashMap<RequestId, PendingRequest>>) {
+async fn close_pending(pending: &Mutex<HashMap<RequestId, PendingRequest>>, closed: &AtomicBool) {
     let pending = {
         let mut pending = pending.lock().await;
+        closed.store(true, Ordering::Release);
         pending
             .drain()
             .map(|(_, pending)| pending)

--- a/codex-rs/exec-server/src/server/processor.rs
+++ b/codex-rs/exec-server/src/server/processor.rs
@@ -187,7 +187,6 @@ async fn run_connection(
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
-    use std::sync::Arc;
     use std::time::Duration;
 
     use codex_app_server_protocol::JSONRPCMessage;
@@ -207,13 +206,15 @@ mod tests {
     use tokio::task::JoinHandle;
     use tokio::time::timeout;
 
-    use super::run_connection;
+    use super::ConnectionProcessor;
     use crate::ExecServerRuntimePaths;
     use crate::ProcessId;
     use crate::connection::JsonRpcConnection;
     use crate::protocol::EXEC_METHOD;
+    use crate::protocol::EXEC_OUTPUT_DELTA_METHOD;
     use crate::protocol::EXEC_READ_METHOD;
-    use crate::protocol::EXEC_TERMINATE_METHOD;
+    use crate::protocol::EXEC_WRITE_METHOD;
+    use crate::protocol::ExecOutputDeltaNotification;
     use crate::protocol::ExecParams;
     use crate::protocol::ExecResponse;
     use crate::protocol::INITIALIZE_METHOD;
@@ -221,15 +222,13 @@ mod tests {
     use crate::protocol::InitializeParams;
     use crate::protocol::InitializeResponse;
     use crate::protocol::ReadParams;
-    use crate::protocol::TerminateParams;
-    use crate::protocol::TerminateResponse;
-    use crate::server::session_registry::SessionRegistry;
+    use crate::protocol::WriteParams;
 
-    #[tokio::test]
-    async fn transport_disconnect_detaches_session_during_in_flight_read() {
-        let registry = SessionRegistry::new();
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn resumed_connection_routes_process_notifications_to_replacement() {
+        let processor = ConnectionProcessor::new(test_runtime_paths());
         let (mut first_writer, mut first_lines, first_task) =
-            spawn_test_connection(Arc::clone(&registry), "first");
+            spawn_test_connection(processor.clone(), "first");
 
         send_request(
             &mut first_writer,
@@ -268,10 +267,13 @@ mod tests {
         )
         .await;
         drop(first_writer);
-        tokio::time::sleep(Duration::from_millis(25)).await;
+        timeout(Duration::from_secs(1), first_task)
+            .await
+            .expect("first processor should exit")
+            .expect("first processor should join");
 
         let (mut second_writer, mut second_lines, second_task) =
-            spawn_test_connection(Arc::clone(&registry), "second");
+            spawn_test_connection(processor, "second");
         send_request(
             &mut second_writer,
             /*id*/ 1,
@@ -287,25 +289,33 @@ mod tests {
             read_response::<InitializeResponse>(&mut second_lines, /*expected_id*/ 1),
         )
         .await
-        .expect("resume initialize should not wait for the old read to finish");
+        .expect("resume initialize should complete");
         assert_eq!(
             second_initialize_response.session_id,
             initialize_response.session_id
         );
-        timeout(Duration::from_secs(1), first_task)
-            .await
-            .expect("first processor should exit")
-            .expect("first processor should join");
         send_notification(&mut second_writer, INITIALIZED_METHOD, &()).await;
-
         send_request(
             &mut second_writer,
             /*id*/ 2,
-            EXEC_TERMINATE_METHOD,
-            &TerminateParams { process_id },
+            EXEC_WRITE_METHOD,
+            &WriteParams {
+                process_id: process_id.clone(),
+                chunk: b"go\n".to_vec().into(),
+            },
         )
         .await;
-        let _: TerminateResponse = read_response(&mut second_lines, /*expected_id*/ 2).await;
+        let output = timeout(
+            Duration::from_secs(1),
+            read_notification::<ExecOutputDeltaNotification>(
+                &mut second_lines,
+                EXEC_OUTPUT_DELTA_METHOD,
+            ),
+        )
+        .await
+        .expect("resumed connection should receive process output");
+        assert_eq!(output.process_id, process_id);
+        assert_eq!(output.chunk.into_inner(), b"late");
 
         drop(second_writer);
         drop(second_lines);
@@ -316,14 +326,16 @@ mod tests {
     }
 
     fn spawn_test_connection(
-        registry: Arc<SessionRegistry>,
+        processor: ConnectionProcessor,
         label: &str,
     ) -> (DuplexStream, Lines<BufReader<DuplexStream>>, JoinHandle<()>) {
         let (client_writer, server_reader) = duplex(1 << 20);
         let (server_writer, client_reader) = duplex(1 << 20);
         let connection =
             JsonRpcConnection::from_stdio(server_reader, server_writer, label.to_string());
-        let task = tokio::spawn(run_connection(connection, registry, test_runtime_paths()));
+        let task = tokio::spawn(async move {
+            processor.run_connection(connection).await;
+        });
         (client_writer, BufReader::new(client_reader).lines(), task)
     }
 
@@ -389,6 +401,33 @@ mod tests {
         }
     }
 
+    async fn read_notification<T: DeserializeOwned>(
+        lines: &mut Lines<BufReader<DuplexStream>>,
+        expected_method: &str,
+    ) -> T {
+        loop {
+            let line = lines
+                .next_line()
+                .await
+                .expect("read notification")
+                .expect("notification line");
+            match serde_json::from_str::<JSONRPCMessage>(&line)
+                .expect("decode JSON-RPC notification")
+            {
+                JSONRPCMessage::Notification(notification)
+                    if notification.method == expected_method =>
+                {
+                    return serde_json::from_value(
+                        notification.params.expect("notification params"),
+                    )
+                    .expect("decode notification params");
+                }
+                JSONRPCMessage::Notification(_) | JSONRPCMessage::Response(_) => {}
+                other => panic!("expected JSON-RPC notification, got {other:?}"),
+            }
+        }
+    }
+
     fn exec_params(process_id: ProcessId) -> ExecParams {
         let mut env = HashMap::new();
         if let Some(path) = std::env::var_os("PATH") {
@@ -396,28 +435,29 @@ mod tests {
         }
         ExecParams {
             process_id,
-            argv: sleep_then_print_argv(),
+            argv: wait_for_stdin_then_print_argv(),
             cwd: PathUri::from_path(std::env::current_dir().expect("cwd")).expect("cwd URI"),
             env_policy: None,
             env,
             tty: false,
-            pipe_stdin: false,
+            pipe_stdin: true,
             arg0: None,
         }
     }
 
-    fn sleep_then_print_argv() -> Vec<String> {
+    fn wait_for_stdin_then_print_argv() -> Vec<String> {
         if cfg!(windows) {
             vec![
-                std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string()),
-                "/C".to_string(),
-                "ping -n 3 127.0.0.1 >NUL && echo late".to_string(),
+                "powershell.exe".to_string(),
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                "$null = [Console]::In.ReadLine(); [Console]::Out.Write('late')".to_string(),
             ]
         } else {
             vec![
                 "/bin/sh".to_string(),
                 "-c".to_string(),
-                "sleep 1; printf late".to_string(),
+                "read _line; printf late".to_string(),
             ]
         }
     }

--- a/codex-rs/exec-server/src/server/session_registry.rs
+++ b/codex-rs/exec-server/src/server/session_registry.rs
@@ -32,6 +32,12 @@ struct AttachmentState {
     detached_expires_at: Option<tokio::time::Instant>,
 }
 
+enum AttachResult {
+    Attached,
+    AlreadyAttached,
+    Expired,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct ConnectionId(Uuid);
 
@@ -76,19 +82,17 @@ impl SessionRegistry {
                     .get(&session_id)
                     .cloned()
                     .ok_or_else(|| invalid_request(format!("unknown session id {session_id}")))?;
-                if entry.is_expired(tokio::time::Instant::now()) {
-                    let entry = sessions.remove(&session_id).ok_or_else(|| {
-                        invalid_request(format!("unknown session id {session_id}"))
-                    })?;
-                    Ok(AttachOutcome::Expired { session_id, entry })
-                } else if entry.has_active_connection() {
-                    Err(invalid_request(format!(
+                match entry.attach(connection_id, notifications, tokio::time::Instant::now()) {
+                    AttachResult::Attached => Ok(AttachOutcome::Attached(entry)),
+                    AttachResult::AlreadyAttached => Err(invalid_request(format!(
                         "session {session_id} is already attached to another connection"
-                    )))
-                } else {
-                    entry.process.set_notification_sender(Some(notifications));
-                    entry.attach(connection_id);
-                    Ok(AttachOutcome::Attached(entry))
+                    ))),
+                    AttachResult::Expired => {
+                        let entry = sessions.remove(&session_id).ok_or_else(|| {
+                            invalid_request(format!("unknown session id {session_id}"))
+                        })?;
+                        Ok(AttachOutcome::Expired { session_id, entry })
+                    }
                 }
             } else {
                 let session_id = Uuid::new_v4().to_string();
@@ -157,14 +161,31 @@ impl SessionEntry {
         }
     }
 
-    fn attach(&self, connection_id: ConnectionId) {
+    fn attach(
+        &self,
+        connection_id: ConnectionId,
+        notifications: RpcNotificationSender,
+        now: tokio::time::Instant,
+    ) -> AttachResult {
         let mut attachment = self
             .attachment
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if attachment
+            .detached_expires_at
+            .is_some_and(|deadline| now >= deadline)
+        {
+            return AttachResult::Expired;
+        }
+        if attachment.current_connection_id.is_some() {
+            return AttachResult::AlreadyAttached;
+        }
+
+        self.process.set_notification_sender(Some(notifications));
         attachment.current_connection_id = Some(connection_id);
         attachment.detached_connection_id = None;
         attachment.detached_expires_at = None;
+        AttachResult::Attached
     }
 
     fn detach(&self, connection_id: ConnectionId) -> bool {
@@ -176,18 +197,11 @@ impl SessionEntry {
             return false;
         }
 
+        self.process.set_notification_sender(/*notifications*/ None);
         attachment.current_connection_id = None;
         attachment.detached_connection_id = Some(connection_id);
         attachment.detached_expires_at = Some(tokio::time::Instant::now() + DETACHED_SESSION_TTL);
         true
-    }
-
-    fn has_active_connection(&self) -> bool {
-        self.attachment
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .current_connection_id
-            .is_some()
     }
 
     fn is_attached_to(&self, connection_id: ConnectionId) -> bool {
@@ -196,14 +210,6 @@ impl SessionEntry {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .current_connection_id
             == Some(connection_id)
-    }
-
-    fn is_expired(&self, now: tokio::time::Instant) -> bool {
-        self.attachment
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .detached_expires_at
-            .is_some_and(|deadline| now >= deadline)
     }
 
     fn is_detached_connection_expired(
@@ -244,10 +250,6 @@ impl SessionHandle {
         if !self.entry.detach(self.connection_id) {
             return;
         }
-
-        self.entry
-            .process
-            .set_notification_sender(/*notifications*/ None);
 
         let registry = Arc::clone(&self.registry);
         let session_id = self.entry.session_id.clone();

--- a/codex-rs/exec-server/src/server/session_registry.rs
+++ b/codex-rs/exec-server/src/server/session_registry.rs
@@ -14,7 +14,7 @@ use crate::server::process_handler::ProcessHandler;
 #[cfg(test)]
 const DETACHED_SESSION_TTL: Duration = Duration::from_millis(200);
 #[cfg(not(test))]
-const DETACHED_SESSION_TTL: Duration = Duration::from_secs(10);
+const DETACHED_SESSION_TTL: Duration = Duration::from_secs(30);
 
 pub(crate) struct SessionRegistry {
     sessions: Mutex<HashMap<String, Arc<SessionEntry>>>,


### PR DESCRIPTION
## Why

The previous reconnect path opened a fresh exec-server session and permanently failed every process attached to the disconnected client. Executor-backed stdio MCP servers therefore surfaced `Transport closed` after a transient WebSocket interruption even though the server still retained their processes for possible resumption.

This change keeps recovery below RMCP, so existing process and MCP transports remain usable after the same exec-server session is reattached.

In-flight mutating RPCs whose responses are lost are intentionally not replayed because their delivery is ambiguous. Operations started while recovery is already known to be pending wait for the replacement generation.

## What

- keep one stable logical exec-server client while replacing disconnected WebSocket generations
- proactively resume the same server session, retrying the detach race within a bounded recovery window
- preserve existing process handles and replay retained output, exit, and close events in sequence
- fail explicitly on retention gaps and only close process event streams after recovery is exhausted
- extend detached-session retention from 10 seconds to 30 seconds so it exceeds the 25-second client recovery window
