### PR TITLE
[codex] resolve provider auth once per request setup

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -118,6 +118,7 @@ use codex_feedback::FeedbackRequestTags;
 use codex_feedback::emit_feedback_request_tags_with_auth_env;
 use codex_login::auth_env_telemetry::AuthEnvTelemetry;
 use codex_login::auth_env_telemetry::collect_auth_env_telemetry;
+use codex_model_provider::ProviderClientSetup;
 use codex_model_provider::SharedModelProvider;
 use codex_model_provider::create_model_provider;
 #[cfg(test)]
@@ -182,16 +183,6 @@ struct ModelClientState {
     attestation_provider: Option<Arc<dyn AttestationProvider>>,
     disable_websockets: AtomicBool,
     cached_websocket_session: StdMutex<WebsocketSession>,
-}
-
-/// Resolved API client setup for a single request attempt.
-///
-/// Keeping this as a single bundle ensures prewarm and normal request paths
-/// share the same auth/provider setup flow.
-struct CurrentClientSetup {
-    auth: Option<CodexAuth>,
-    api_provider: ApiProvider,
-    api_auth: SharedAuthProvider,
 }
 
 #[derive(Clone, Copy)]
@@ -790,15 +781,8 @@ impl ModelClient {
     ///
     /// This centralizes setup used by both prewarm and normal request paths so they stay in
     /// lockstep when auth/provider resolution changes.
-    async fn current_client_setup(&self) -> Result<CurrentClientSetup> {
-        let auth = self.state.provider.auth().await;
-        let api_provider = self.state.provider.api_provider().await?;
-        let api_auth = self.state.provider.api_auth().await?;
-        Ok(CurrentClientSetup {
-            auth,
-            api_provider,
-            api_auth,
-        })
+    async fn current_client_setup(&self) -> Result<ProviderClientSetup> {
+        self.state.provider.client_setup().await
     }
 
     /// Opens a websocket connection using the same header and telemetry wiring as normal turns.

--- a/codex-rs/model-provider/src/amazon_bedrock/mod.rs
+++ b/codex-rs/model-provider/src/amazon_bedrock/mod.rs
@@ -24,6 +24,7 @@ use crate::provider::ModelProviderFuture;
 use crate::provider::ProviderAccountResult;
 use crate::provider::ProviderAccountState;
 use crate::provider::ProviderCapabilities;
+use crate::provider::ProviderClientSetup;
 use auth::resolve_provider_auth;
 pub(crate) use catalog::static_model_catalog;
 use catalog::with_default_only_service_tier;
@@ -133,6 +134,22 @@ impl ModelProvider for AmazonBedrockModelProvider {
         Ok(ProviderAccountState {
             account: Some(ProviderAccount::AmazonBedrock),
             requires_openai_auth: false,
+        })
+    }
+
+    fn client_setup(&self) -> ModelProviderFuture<'_, Result<ProviderClientSetup>> {
+        Box::pin(async move {
+            let managed_auth = self.managed_auth();
+            let mut api_provider_info = self.info.clone();
+            api_provider_info.base_url =
+                Some(runtime_base_url(managed_auth.as_ref(), &self.aws).await?);
+            let api_provider = api_provider_info.to_api_provider(/*auth_mode*/ None)?;
+            let api_auth = resolve_provider_auth(managed_auth.as_ref(), &self.aws).await?;
+            Ok(ProviderClientSetup {
+                auth: managed_auth.map(CodexAuth::BedrockApiKey),
+                api_provider,
+                api_auth,
+            })
         })
     }
 

--- a/codex-rs/model-provider/src/lib.rs
+++ b/codex-rs/model-provider/src/lib.rs
@@ -15,5 +15,6 @@ pub use provider::ProviderAccountError;
 pub use provider::ProviderAccountResult;
 pub use provider::ProviderAccountState;
 pub use provider::ProviderCapabilities;
+pub use provider::ProviderClientSetup;
 pub use provider::SharedModelProvider;
 pub use provider::create_model_provider;

--- a/codex-rs/model-provider/src/provider.rs
+++ b/codex-rs/model-provider/src/provider.rs
@@ -79,6 +79,13 @@ impl std::error::Error for ProviderAccountError {}
 
 pub type ProviderAccountResult = std::result::Result<ProviderAccountState, ProviderAccountError>;
 
+/// API client configuration derived from one provider-auth snapshot.
+pub struct ProviderClientSetup {
+    pub auth: Option<CodexAuth>,
+    pub api_provider: Provider,
+    pub api_auth: SharedAuthProvider,
+}
+
 /// Default model used for automatic approval review when a provider does not
 /// require a backend-specific model ID.
 pub const DEFAULT_APPROVAL_REVIEW_PREFERRED_MODEL: &str = "codex-auto-review";
@@ -144,6 +151,27 @@ pub trait ModelProvider: fmt::Debug + Send + Sync {
 
     /// Returns the current app-visible account state for this provider.
     fn account_state(&self) -> ProviderAccountResult;
+
+    /// Resolves the API client configuration for one request attempt.
+    ///
+    /// Implementations must derive every field from the same authentication
+    /// snapshot so credentials and provider routing cannot disagree.
+    fn client_setup(
+        &self,
+    ) -> ModelProviderFuture<'_, codex_protocol::error::Result<ProviderClientSetup>> {
+        Box::pin(async move {
+            let auth = self.auth().await;
+            let api_provider = self
+                .info()
+                .to_api_provider(auth.as_ref().map(CodexAuth::auth_mode))?;
+            let api_auth = resolve_provider_auth(auth.as_ref(), self.info())?;
+            Ok(ProviderClientSetup {
+                auth,
+                api_provider,
+                api_auth,
+            })
+        })
+    }
 
     /// Returns provider configuration adapted for the API client.
     fn api_provider(&self) -> ModelProviderFuture<'_, codex_protocol::error::Result<Provider>> {


### PR DESCRIPTION
## Summary

- add a provider-owned client setup snapshot that derives API routing and credentials from one auth resolution
- use that snapshot for every core request setup
- preserve provider-specific Bedrock routing while resolving managed auth once

## Why

`current_client_setup` previously resolved provider auth three times: once directly, then once each while building the API provider and API auth. Besides redundant work, an auth refresh between those calls could produce inconsistent routing and credentials for one request attempt.

## Impact

Each request setup now performs one provider-auth resolution and uses a coherent snapshot for telemetry, routing, and request authentication.

## Validation

- `just test -p codex-model-provider`
- `cargo check -p codex-core`
- `just fmt`
