### PR TITLE
[codex] cache normalized MCP tool inventories

### DIFF
--- a/codex-rs/codex-mcp/src/connection_manager.rs
+++ b/codex-rs/codex-mcp/src/connection_manager.rs
@@ -75,6 +75,10 @@ use tracing::trace;
 use tracing::trace_span;
 use tracing::warn;
 
+mod tool_inventory_cache;
+
+use tool_inventory_cache::ToolInventoryCache;
+
 const MCP_UI_META_KEY: &str = "ui";
 const MCP_UI_VISIBILITY_META_KEY: &str = "visibility";
 const MCP_UI_MODEL_VISIBILITY: &str = "model";
@@ -113,6 +117,7 @@ pub struct McpConnectionManager {
     prefix_mcp_tool_names: bool,
     elicitation_requests: ElicitationRequestManager,
     startup_cancellation_token: CancellationToken,
+    tool_inventory_cache: ToolInventoryCache,
 }
 
 impl McpConnectionManager {
@@ -156,6 +161,14 @@ impl McpConnectionManager {
         let codex_apps_auth_provider = auth
             .filter(|auth| auth.uses_codex_backend())
             .map(codex_model_provider::auth_provider_from_auth);
+        let codex_apps_tools_cache_path = mcp_servers
+            .get(CODEX_APPS_MCP_SERVER_NAME)
+            .filter(|server| server.enabled())
+            .map(|_| CodexAppsToolsCacheContext {
+                codex_home: codex_home.clone(),
+                user_key: codex_apps_tools_cache_key.clone(),
+            })
+            .map(|context| context.tools_cache_path());
         let mcp_servers = mcp_servers.clone();
         for (server_name, server) in mcp_servers
             .into_iter()
@@ -254,6 +267,7 @@ impl McpConnectionManager {
             prefix_mcp_tool_names,
             elicitation_requests: elicitation_requests.clone(),
             startup_cancellation_token: startup_cancellation_token.clone(),
+            tool_inventory_cache: ToolInventoryCache::new(codex_apps_tools_cache_path),
         };
         tokio::spawn(async move {
             let outcomes = join_set.join_all().await;
@@ -344,6 +358,7 @@ impl McpConnectionManager {
                 /*reviewer*/ None,
             ),
             startup_cancellation_token: CancellationToken::new(),
+            tool_inventory_cache: ToolInventoryCache::new(/*codex_apps_cache_path*/ None),
         }
     }
 
@@ -446,6 +461,13 @@ impl McpConnectionManager {
     /// Returns all tools with model-visible names normalized.
     #[instrument(level = "trace", skip_all, fields(mcp_server_count = self.clients.len()))]
     pub async fn list_all_tools(&self) -> Vec<ToolInfo> {
+        let revision_before = self.tool_inventory_cache.revision(&self.clients);
+        if let Some(revision) = revision_before.as_ref()
+            && let Some(tools) = self.tool_inventory_cache.get(revision)
+        {
+            return tools;
+        }
+
         let mut tools = Vec::new();
         for (server_name, managed_client) in &self.clients {
             let has_cached_tool_info_snapshot = managed_client.cached_tool_info_snapshot.is_some();
@@ -481,7 +503,10 @@ impl McpConnectionManager {
                     .map(|tool| self.with_server_metadata(tool)),
             );
         }
-        normalize_tools_for_model_with_prefix(tools, self.prefix_mcp_tool_names)
+        let tools = normalize_tools_for_model_with_prefix(tools, self.prefix_mcp_tool_names);
+        self.tool_inventory_cache
+            .insert_if_unchanged(revision_before, &self.clients, &tools);
+        tools
     }
 
     /// Force-refresh codex apps tools by bypassing the in-process cache.
@@ -522,6 +547,7 @@ impl McpConnectionManager {
             &managed_client.server_info,
             &tools,
         );
+        self.tool_inventory_cache.clear();
         emit_duration(
             MCP_TOOLS_LIST_DURATION_METRIC,
             list_start.elapsed(),

--- a/codex-rs/codex-mcp/src/connection_manager/tool_inventory_cache.rs
+++ b/codex-rs/codex-mcp/src/connection_manager/tool_inventory_cache.rs
@@ -1,0 +1,114 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::sync::atomic::Ordering;
+use std::time::SystemTime;
+
+use crate::rmcp_client::AsyncManagedClient;
+use crate::tools::ToolInfo;
+
+pub(super) struct ToolInventoryCache {
+    codex_apps_cache_path: Option<PathBuf>,
+    cached: Mutex<Option<CachedToolInventory>>,
+}
+
+#[derive(Clone)]
+struct CachedToolInventory {
+    revision: ToolInventoryRevision,
+    tools: Vec<ToolInfo>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) struct ToolInventoryRevision {
+    server_startup: Vec<(String, bool)>,
+    codex_apps_cache_file: Option<CodexAppsCacheFileRevision>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum CodexAppsCacheFileRevision {
+    Missing,
+    Present { len: u64, modified: SystemTime },
+}
+
+impl ToolInventoryCache {
+    pub(super) fn new(codex_apps_cache_path: Option<PathBuf>) -> Self {
+        Self {
+            codex_apps_cache_path,
+            cached: Mutex::new(None),
+        }
+    }
+
+    pub(super) fn get(&self, revision: &ToolInventoryRevision) -> Option<Vec<ToolInfo>> {
+        self.cached
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .as_ref()
+            .filter(|cached| &cached.revision == revision)
+            .map(|cached| cached.tools.clone())
+    }
+
+    pub(super) fn insert_if_unchanged(
+        &self,
+        revision_before: Option<ToolInventoryRevision>,
+        clients: &HashMap<String, AsyncManagedClient>,
+        tools: &[ToolInfo],
+    ) {
+        let revision_after = self.revision(clients);
+        if let (Some(revision_before), Some(revision_after)) = (revision_before, revision_after)
+            && revision_before == revision_after
+        {
+            self.cached
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .replace(CachedToolInventory {
+                    revision: revision_after,
+                    tools: tools.to_vec(),
+                });
+        }
+    }
+
+    pub(super) fn clear(&self) {
+        self.cached
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+    }
+
+    pub(super) fn revision(
+        &self,
+        clients: &HashMap<String, AsyncManagedClient>,
+    ) -> Option<ToolInventoryRevision> {
+        let mut server_startup = clients
+            .iter()
+            .map(|(server_name, client)| {
+                (
+                    server_name.clone(),
+                    client.startup_complete.load(Ordering::Acquire),
+                )
+            })
+            .collect::<Vec<_>>();
+        server_startup.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+
+        let codex_apps_cache_file = match self.codex_apps_cache_path.as_ref() {
+            Some(path) => Some(match std::fs::metadata(path) {
+                Ok(metadata) => metadata
+                    .modified()
+                    .map(|modified| CodexAppsCacheFileRevision::Present {
+                        len: metadata.len(),
+                        modified,
+                    })
+                    .ok(),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    Some(CodexAppsCacheFileRevision::Missing)
+                }
+                Err(_) => None,
+            }?),
+            None => None,
+        };
+
+        Some(ToolInventoryRevision {
+            server_startup,
+            codex_apps_cache_file,
+        })
+    }
+}

--- a/codex-rs/codex-mcp/src/connection_manager_tests.rs
+++ b/codex-rs/codex-mcp/src/connection_manager_tests.rs
@@ -101,6 +101,39 @@ fn create_test_server_info(title: &str) -> McpServerInfo {
     }
 }
 
+#[test]
+fn tool_inventory_revision_tracks_cross_process_apps_cache_updates() {
+    let codex_home = tempdir().expect("create tempdir");
+    let cache_context = create_codex_apps_tools_cache_context(
+        codex_home.path().to_path_buf(),
+        Some("account"),
+        Some("user"),
+    );
+    let approval_policy = Constrained::allow_any(AskForApproval::OnFailure);
+    let permission_profile = PermissionProfile::default();
+    let mut manager = McpConnectionManager::new_uninitialized_with_permission_profile(
+        &approval_policy,
+        &permission_profile,
+        /*prefix_mcp_tool_names*/ true,
+    );
+    manager.tool_inventory_cache = ToolInventoryCache::new(Some(cache_context.tools_cache_path()));
+
+    let missing_revision = manager
+        .tool_inventory_cache
+        .revision(&manager.clients)
+        .expect("missing cache file has a stable revision");
+    write_cached_codex_apps_tools(
+        &cache_context,
+        &[create_test_tool(CODEX_APPS_MCP_SERVER_NAME, "search")],
+    );
+    let populated_revision = manager
+        .tool_inventory_cache
+        .revision(&manager.clients)
+        .expect("populated cache file has a stable revision");
+
+    assert_ne!(missing_revision, populated_revision);
+}
+
 fn model_tool_names(tools: &[ToolInfo]) -> HashSet<ToolName> {
     tools
         .iter()


### PR DESCRIPTION
## Summary

- cache the fully normalized MCP tool inventory inside each connection manager
- invalidate the cache when server startup state changes or the Codex Apps disk cache is updated
- clear the inventory cache after a successful hard refresh

## Why

Apps-enabled turns can request the same MCP inventory multiple times. Each call reread and decoded the Apps disk cache, reapplied server metadata, and renormalized the full tool set.

## Impact

Stable inventories now pay only a cheap startup/file revision check plus a clone of the normalized result. Cross-process Apps cache updates remain visible through the file revision, and in-process hard refreshes invalidate immediately.

## Validation

- `just test -p codex-mcp` (88 passed)
- `just fmt`
