### PR TITLE
[codex] skip persistence work for transient events

### DIFF
--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -133,6 +133,7 @@ use codex_protocol::request_permissions::RequestPermissionsResponse;
 use codex_protocol::request_user_input::RequestUserInputArgs;
 use codex_protocol::request_user_input::RequestUserInputResponse;
 use codex_rmcp_client::ElicitationResponse;
+use codex_rollout::should_persist_event_msg;
 use codex_rollout::state_db;
 use codex_rollout_trace::AgentResultTracePayload;
 use codex_rollout_trace::ThreadStartedTraceMetadata;
@@ -1855,9 +1856,10 @@ impl Session {
     }
 
     pub(crate) async fn send_event_raw(&self, event: Event) {
-        // Persist the event into rollout storage (the store filters as needed).
-        let rollout_items = vec![RolloutItem::EventMsg(event.msg.clone())];
-        self.persist_rollout_items(&rollout_items).await;
+        if should_persist_event_msg(&event.msg) {
+            let rollout_items = vec![RolloutItem::EventMsg(event.msg.clone())];
+            self.persist_rollout_items(&rollout_items).await;
+        }
         self.services
             .rollout_thread_trace
             .record_protocol_event(&event.msg);

--- a/codex-rs/rollout/src/lib.rs
+++ b/codex-rs/rollout/src/lib.rs
@@ -62,6 +62,7 @@ pub use list::rollout_date_parts;
 pub use metadata::builder_from_items;
 pub use policy::is_persisted_rollout_item;
 pub use policy::persisted_rollout_items;
+pub use policy::should_persist_event_msg;
 pub use policy::should_persist_response_item_for_memories;
 pub use recorder::RolloutRecorder;
 pub use recorder::RolloutRecorderParams;

--- a/codex-rs/thread-store/src/live_thread.rs
+++ b/codex-rs/thread-store/src/live_thread.rs
@@ -135,18 +135,15 @@ impl LiveThread {
 
     pub async fn append_items(&self, items: &[RolloutItem]) -> ThreadStoreResult<()> {
         let canonical_items = persisted_rollout_items(items);
-        if items.is_empty() {
+        if canonical_items.is_empty() {
             return Ok(());
         }
         self.thread_store
             .append_items(AppendThreadItemsParams {
                 thread_id: self.thread_id,
-                items: items.to_vec(),
+                items: canonical_items.clone(),
             })
             .await?;
-        if canonical_items.is_empty() {
-            return Ok(());
-        }
         let update = self
             .metadata_sync
             .lock()


### PR DESCRIPTION
## Summary

- check the rollout event policy before constructing and submitting an event item from `send_event_raw`
- return from `LiveThread::append_items` before calling the backing store when filtering produces no canonical items
- pass only canonical items to the backing store while preserving metadata synchronization after a successful append

## Why

High-volume transient events such as command output deltas are intentionally excluded from rollouts. They were still cloned into rollout items, passed through the live thread, cloned again, and filtered by the backing store. This removes that work at the earliest safe boundaries without changing event delivery, tracing, or metadata updates for persisted items.

## Validation

- `just fmt`
- `just test -p codex-thread-store` (80 passed)
- `just test -p codex-core interrupt_persists_turn_aborted_marker_in_next_request` compiled successfully but timed out before the persistence assertion while waiting for `ExecCommandBegin`; this environment cannot create the command PATH aliases (`Operation not permitted`)
- an earlier broad `just test -p codex-core` invocation also compiled successfully, then failed on the same sandbox restrictions and missing workspace test binaries such as `test_stdio_server`
- `git diff --check`
