### PR TITLE
[codex] Compress cold active rollouts

### DIFF
--- a/codex-rs/rollout/src/compression.rs
+++ b/codex-rs/rollout/src/compression.rs
@@ -362,9 +362,14 @@ mod worker {
         let result = async {
             cleanup_stale_temps(codex_home.as_path()).await?;
             let mut stats = CompressionStats::default();
-            if started_at.elapsed() < WORKER_MAX_RUNTIME {
-                let archived_root = codex_home.join(ARCHIVED_SESSIONS_SUBDIR);
-                compress_rollouts_in_root(archived_root.as_path(), started_at, &mut stats).await?;
+            for root in [
+                codex_home.join(ARCHIVED_SESSIONS_SUBDIR),
+                codex_home.join(SESSIONS_SUBDIR),
+            ] {
+                if started_at.elapsed() >= WORKER_MAX_RUNTIME {
+                    break;
+                }
+                compress_rollouts_in_root(root.as_path(), started_at, &mut stats).await?;
             }
             Ok::<_, io::Error>(stats)
         }

--- a/codex-rs/rollout/src/compression_tests.rs
+++ b/codex-rs/rollout/src/compression_tests.rs
@@ -130,7 +130,7 @@ async fn search_rollout_matches_uses_logical_path_for_compressed_rollout() -> an
 }
 
 #[tokio::test]
-async fn worker_compresses_old_archived_rollouts_only() -> anyhow::Result<()> {
+async fn worker_compresses_old_active_and_archived_rollouts() -> anyhow::Result<()> {
     let home = TempDir::new()?;
     let active_uuid = Uuid::from_u128(3);
     let active_id = ThreadId::from_string(&active_uuid.to_string())?;
@@ -158,8 +158,8 @@ async fn worker_compresses_old_archived_rollouts_only() -> anyhow::Result<()> {
 
     worker::run(home.path().to_path_buf()).await?;
 
-    assert!(active_path.exists());
-    assert!(!compressed_rollout_path(&active_path).exists());
+    assert!(!active_path.exists());
+    assert!(compressed_rollout_path(&active_path).exists());
     assert!(!archived_path.exists());
     assert!(compressed_rollout_path(&archived_path).exists());
     assert!(fresh_path.exists());


### PR DESCRIPTION
## Why

The local rollout compression worker currently scans only `archived_sessions`, so cold unarchived thread history remains expanded indefinitely.

## What changed

- Scan `sessions` after `archived_sessions` within the existing worker runtime budget.
- Update rollout compression coverage to require both cold active and archived rollouts to be compressed while fresh active rollouts remain plain.

The worker remains behind the disabled-by-default `local_thread_store_compression` feature, and the existing seven-day cold-file threshold is unchanged.

## Validation

- `just test -p codex-rollout` (69 passed)
- `just fmt`
- `git diff --check`