### PR TITLE
fix(tui): restore TUI after suspend

### DIFF
--- a/codex-rs/tui/src/terminal_probe.rs
+++ b/codex-rs/tui/src/terminal_probe.rs
@@ -1,16 +1,16 @@
 //! Short, best-effort terminal response probes for TUI startup and resume.
 //!
 //! Crossterm's public helpers wait up to two seconds for terminal responses. That is too long for
-//! TUI startup, where unsupported terminals should simply fall back to conservative defaults.
+//! TUI startup and resume, where unsupported terminals should simply fall back to conservative
+//! defaults.
 //! This module sends the same kinds of optional terminal queries with a caller-provided deadline,
 //! prefers duplicated stdio handles, falls back to the controlling terminal path when stdio is
 //! unavailable, and reports `None` when a response is unavailable.
 //!
-//! The probes run before the crossterm event stream is created, so they do not share crossterm's
-//! internal skipped-event queue. Bytes read while looking for probe responses are consumed from the
-//! terminal; keeping the timeout short is part of the contract that makes this acceptable for
-//! startup. A future input-preservation layer would need to replay unrelated bytes through the same
-//! parser that normal TUI input uses.
+//! Probes run only while the crossterm event stream is absent or paused, so they do not share
+//! crossterm's internal skipped-event queue. Bytes read while looking for probe responses are
+//! consumed from the terminal; callers must therefore own terminal input for the duration of the
+//! short timeout and accept that unrelated buffered input will be discarded.
 
 use std::time::Duration;
 
@@ -58,7 +58,7 @@ mod imp {
         Skip,
     }
 
-    /// Temporary terminal handle used while a startup probe owns terminal input.
+    /// Temporary terminal handle used while a probe owns terminal input.
     ///
     /// The preferred path is duplicated stdin/stdout, because terminal replies are delivered to the
     /// same input stream crossterm reads from. Some embedded or redirected environments expose a
@@ -72,7 +72,7 @@ mod imp {
     }
 
     impl Tty {
-        /// Opens an isolated reader and writer for startup probes.
+        /// Opens an isolated reader and writer for terminal probes.
         ///
         /// The reader and writer must be separate file descriptions so switching the reader into
         /// nonblocking mode does not also make writes fail with `WouldBlock` under terminal
@@ -266,8 +266,8 @@ mod imp {
     /// Reads available terminal bytes until `parse` recognizes a probe response or time expires.
     ///
     /// The accumulated buffer may include unrelated terminal input. This helper intentionally does
-    /// not try to replay those bytes, so it must stay limited to short startup probes that run
-    /// before normal crossterm input polling begins.
+    /// not try to replay those bytes, so callers must use it only during short, exclusive probe
+    /// windows before normal crossterm input polling begins or while that polling is paused.
     fn read_until<T>(
         tty: &mut Tty,
         timeout: Duration,

--- a/codex-rs/tui/src/terminal_probe.rs
+++ b/codex-rs/tui/src/terminal_probe.rs
@@ -1,4 +1,4 @@
-//! Short, best-effort terminal response probes for TUI startup.
+//! Short, best-effort terminal response probes for TUI startup and resume.
 //!
 //! Crossterm's public helpers wait up to two seconds for terminal responses. That is too long for
 //! TUI startup, where unsupported terminals should simply fall back to conservative defaults.
@@ -230,6 +230,17 @@ mod imp {
             return Ok(None);
         };
         Ok(Some(colors))
+    }
+
+    /// Queries the terminal cursor position while normal input polling is paused.
+    ///
+    /// Resume can emit a focus report immediately before the cursor-position response. Reusing
+    /// the startup parser lets the probe find the response without leaking either sequence into
+    /// the composer.
+    pub(crate) fn cursor_position(timeout: Duration) -> io::Result<Option<Position>> {
+        let mut tty = Tty::open()?;
+        tty.write_all(b"\x1B[6n")?;
+        read_until(&mut tty, timeout, parse_cursor_position)
     }
 
     /// Runs the optional terminal queries needed during TUI startup under one shared deadline.

--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -239,7 +239,7 @@ enum RawModeRestore {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum KeyboardRestore {
     PopStack,
-    ResetAfterExit,
+    ResetReporting,
 }
 
 fn restore_common(
@@ -250,7 +250,7 @@ fn restore_common(
 
     match keyboard_restore {
         KeyboardRestore::PopStack => keyboard_modes::restore_keyboard_enhancement_stack(),
-        KeyboardRestore::ResetAfterExit => keyboard_modes::reset_keyboard_reporting_after_exit(),
+        KeyboardRestore::ResetReporting => keyboard_modes::reset_keyboard_reporting(),
     }
 
     if let Err(err) = execute!(stdout(), DisableBracketedPaste) {
@@ -283,10 +283,11 @@ pub fn restore() -> Result<()> {
 
 /// Restore the terminal before yielding control to the parent process during suspend.
 ///
-/// This must preserve keyboard enhancement stack entries owned by the parent, so it only pops
-/// the entry pushed by [`set_modes`] rather than using the exit-only keyboard reset.
+/// Uses a stronger keyboard reset than [`restore`] so the parent shell recovers even if a
+/// terminal missed the stack pop that normally pairs with [`set_modes`]. After `fg`, suspend
+/// handling calls [`set_modes`] again to re-enable the TUI's keyboard reporting.
 pub(super) fn restore_for_suspend() -> Result<()> {
-    restore_common(RawModeRestore::Disable, KeyboardRestore::PopStack)
+    restore_common(RawModeRestore::Disable, KeyboardRestore::ResetReporting)
 }
 
 /// Restore the terminal after Codex is exiting.
@@ -295,7 +296,7 @@ pub(super) fn restore_for_suspend() -> Result<()> {
 /// terminal missed the stack pop that normally pairs with [`set_modes`].
 pub fn restore_after_exit() -> Result<()> {
     let mut first_error =
-        restore_common(RawModeRestore::Disable, KeyboardRestore::ResetAfterExit).err();
+        restore_common(RawModeRestore::Disable, KeyboardRestore::ResetReporting).err();
     if let Err(err) = terminal_stderr::finish() {
         first_error.get_or_insert(err);
     }

--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -239,7 +239,7 @@ enum RawModeRestore {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum KeyboardRestore {
     PopStack,
-    ResetReporting,
+    ResetAfterExit,
 }
 
 fn restore_common(
@@ -250,7 +250,7 @@ fn restore_common(
 
     match keyboard_restore {
         KeyboardRestore::PopStack => keyboard_modes::restore_keyboard_enhancement_stack(),
-        KeyboardRestore::ResetReporting => keyboard_modes::reset_keyboard_reporting(),
+        KeyboardRestore::ResetAfterExit => keyboard_modes::reset_keyboard_reporting_after_exit(),
     }
 
     if let Err(err) = execute!(stdout(), DisableBracketedPaste) {
@@ -281,14 +281,6 @@ pub fn restore() -> Result<()> {
     restore_common(RawModeRestore::Disable, KeyboardRestore::PopStack)
 }
 
-/// Restore the terminal before yielding control to the parent process during suspend.
-///
-/// This must preserve keyboard enhancement stack entries owned by the parent, so it only pops
-/// the entry pushed by [`set_modes`] rather than using the exit-only keyboard reset.
-pub(super) fn restore_for_suspend() -> Result<()> {
-    restore_common(RawModeRestore::Disable, KeyboardRestore::PopStack)
-}
-
 /// Force crossterm's cached raw-mode state back in sync with the terminal after `fg`.
 ///
 /// A shell may restore the job's saved termios after the process receives `SIGCONT`. When that
@@ -306,7 +298,7 @@ pub(super) fn reapply_raw_mode_after_resume() -> Result<()> {
 /// terminal missed the stack pop that normally pairs with [`set_modes`].
 pub fn restore_after_exit() -> Result<()> {
     let mut first_error =
-        restore_common(RawModeRestore::Disable, KeyboardRestore::ResetReporting).err();
+        restore_common(RawModeRestore::Disable, KeyboardRestore::ResetAfterExit).err();
     if let Err(err) = terminal_stderr::finish() {
         first_error.get_or_insert(err);
     }

--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -287,6 +287,7 @@ pub fn restore() -> Result<()> {
 /// races with [`set_modes`], crossterm still believes raw mode is enabled even though the terminal
 /// has returned to canonical, echoing mode. Clearing crossterm's saved state before enabling raw
 /// mode again makes the kernel state authoritative once the shell has completed its handoff.
+#[cfg(unix)]
 pub(super) fn reapply_raw_mode_after_resume() -> Result<()> {
     disable_raw_mode()?;
     enable_raw_mode()

--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -281,6 +281,14 @@ pub fn restore() -> Result<()> {
     restore_common(RawModeRestore::Disable, KeyboardRestore::PopStack)
 }
 
+/// Restore the terminal before yielding control to the parent process during suspend.
+///
+/// This must preserve keyboard enhancement stack entries owned by the parent, so it only pops
+/// the entry pushed by [`set_modes`] rather than using the exit-only keyboard reset.
+pub(super) fn restore_for_suspend() -> Result<()> {
+    restore_common(RawModeRestore::Disable, KeyboardRestore::PopStack)
+}
+
 /// Restore the terminal after Codex is exiting.
 ///
 /// Uses a stronger keyboard reset than [`restore`] so the parent shell recovers even if a

--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -882,7 +882,7 @@ impl Tui {
         #[cfg(unix)]
         let mut prepared_resume = self
             .suspend_context
-            .prepare_resume_action(&mut self.terminal, &mut self.alt_saved_viewport);
+            .prepare_resume_action(&mut self.alt_saved_viewport);
 
         // Precompute any viewport updates that need a cursor-position query before entering
         // the synchronized update, to avoid racing with the event reader.
@@ -1018,7 +1018,7 @@ impl Tui {
         #[cfg(unix)]
         let mut prepared_resume = self
             .suspend_context
-            .prepare_resume_action(&mut self.terminal, &mut self.alt_saved_viewport);
+            .prepare_resume_action(&mut self.alt_saved_viewport);
 
         ensure_virtual_terminal_processing()?;
 

--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -283,11 +283,21 @@ pub fn restore() -> Result<()> {
 
 /// Restore the terminal before yielding control to the parent process during suspend.
 ///
-/// Uses a stronger keyboard reset than [`restore`] so the parent shell recovers even if a
-/// terminal missed the stack pop that normally pairs with [`set_modes`]. After `fg`, suspend
-/// handling calls [`set_modes`] again to re-enable the TUI's keyboard reporting.
+/// This must preserve keyboard enhancement stack entries owned by the parent, so it only pops
+/// the entry pushed by [`set_modes`] rather than using the exit-only keyboard reset.
 pub(super) fn restore_for_suspend() -> Result<()> {
-    restore_common(RawModeRestore::Disable, KeyboardRestore::ResetReporting)
+    restore_common(RawModeRestore::Disable, KeyboardRestore::PopStack)
+}
+
+/// Force crossterm's cached raw-mode state back in sync with the terminal after `fg`.
+///
+/// A shell may restore the job's saved termios after the process receives `SIGCONT`. When that
+/// races with [`set_modes`], crossterm still believes raw mode is enabled even though the terminal
+/// has returned to canonical, echoing mode. Clearing crossterm's saved state before enabling raw
+/// mode again makes the kernel state authoritative once the shell has completed its handoff.
+pub(super) fn reapply_raw_mode_after_resume() -> Result<()> {
+    disable_raw_mode()?;
+    enable_raw_mode()
 }
 
 /// Restore the terminal after Codex is exiting.

--- a/codex-rs/tui/src/tui/event_stream.rs
+++ b/codex-rs/tui/src/tui/event_stream.rs
@@ -24,16 +24,8 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::task::Context;
 use std::task::Poll;
-#[cfg(unix)]
-use std::time::Duration;
-#[cfg(unix)]
-use std::time::Instant;
 
 use crossterm::event::Event;
-#[cfg(unix)]
-use crossterm::event::KeyCode;
-#[cfg(unix)]
-use crossterm::event::KeyEventKind;
 use tokio::sync::broadcast;
 use tokio::sync::watch;
 use tokio_stream::Stream;
@@ -154,143 +146,6 @@ pub struct TuiEventStream<S: EventSource + Default + Unpin = CrosstermEventSourc
     suspend_context: crate::tui::job_control::SuspendContext,
     #[cfg(unix)]
     alt_screen_active: Arc<AtomicBool>,
-    #[cfg(unix)]
-    post_resume_input_guard: PostResumeInputGuard,
-}
-
-#[cfg(unix)]
-const POST_RESUME_INPUT_GUARD_DURATION: Duration = Duration::from_millis(/*millis*/ 500);
-
-#[cfg(unix)]
-#[derive(Debug, Default)]
-struct PostResumeInputGuard {
-    expires_at: Option<Instant>,
-    focus_sequence_index: u8,
-}
-
-#[cfg(unix)]
-impl PostResumeInputGuard {
-    fn arm(&mut self, now: Instant) {
-        self.expires_at = now.checked_add(POST_RESUME_INPUT_GUARD_DURATION);
-        self.focus_sequence_index = 0;
-        tracing::trace!(
-            event = "tui_post_resume_input_guard_armed",
-            duration_ms = %POST_RESUME_INPUT_GUARD_DURATION.as_millis(),
-            "armed post-resume terminal input guard"
-        );
-    }
-
-    fn should_drop(&mut self, event: &Event, now: Instant) -> bool {
-        if !self.expires_at.is_some_and(|expires_at| now <= expires_at) {
-            self.disarm();
-            return false;
-        }
-
-        self.trace_event(event);
-
-        match event {
-            Event::Paste(pasted) => {
-                let should_drop = pasted.as_bytes() == b"\x1b[I";
-                if should_drop {
-                    tracing::debug!(
-                        event = "tui_post_resume_focus_report_suppressed",
-                        delivery = "paste",
-                        "suppressed literal focus report after resume"
-                    );
-                }
-                self.disarm();
-                should_drop
-            }
-            Event::FocusGained => {
-                self.disarm();
-                false
-            }
-            Event::Key(key_event)
-                if matches!(key_event.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
-            {
-                let matches_focus_sequence = match self.focus_sequence_index {
-                    0 => matches!(key_event.code, KeyCode::Esc | KeyCode::Char('\x1b')),
-                    1 => matches!(key_event.code, KeyCode::Char('[')),
-                    2 => matches!(key_event.code, KeyCode::Char('I')),
-                    _ => false,
-                };
-                if !matches_focus_sequence {
-                    self.disarm();
-                    return false;
-                }
-
-                self.focus_sequence_index += 1;
-                if self.focus_sequence_index == 3 {
-                    tracing::debug!(
-                        event = "tui_post_resume_focus_report_suppressed",
-                        delivery = "split_key_events",
-                        "suppressed split focus report after resume"
-                    );
-                    self.disarm();
-                }
-                true
-            }
-            Event::Key(_) => false,
-            _ => false,
-        }
-    }
-
-    fn trace_event(&self, event: &Event) {
-        let event_kind = match event {
-            Event::Key(key_event) => match key_event.code {
-                KeyCode::Esc => "key_escape",
-                KeyCode::Char('\x1b') => "key_escape_char",
-                KeyCode::Char('^') => "key_caret",
-                KeyCode::Char('[') => "key_left_bracket",
-                KeyCode::Char('I') => "key_upper_i",
-                KeyCode::Char(_) => "key_char_other",
-                _ => "key_other",
-            },
-            Event::Paste(pasted) if pasted.as_bytes() == b"\x1b[I" => "paste_focus_report",
-            Event::Paste(_) => "paste_other",
-            Event::FocusGained => "focus_gained",
-            Event::FocusLost => "focus_lost",
-            Event::Resize(_, _) => "resize",
-            _ => "other",
-        };
-        let paste_byte_len = match event {
-            Event::Paste(pasted) => Some(pasted.len()),
-            _ => None,
-        };
-        let paste_contains_escape = match event {
-            Event::Paste(pasted) => Some(pasted.contains('\x1b')),
-            _ => None,
-        };
-        let paste_matches_visible_focus_report = match event {
-            Event::Paste(pasted) => Some(pasted == "^[[I"),
-            _ => None,
-        };
-        let key_kind = match event {
-            Event::Key(key_event) => Some(key_event.kind),
-            _ => None,
-        };
-        let key_modifiers = match event {
-            Event::Key(key_event) => Some(key_event.modifiers),
-            _ => None,
-        };
-
-        tracing::trace!(
-            event = "tui_post_resume_input_observed",
-            event_kind,
-            focus_sequence_index = self.focus_sequence_index,
-            ?paste_byte_len,
-            ?paste_contains_escape,
-            ?paste_matches_visible_focus_report,
-            ?key_kind,
-            ?key_modifiers,
-            "observed terminal input after resume"
-        );
-    }
-
-    fn disarm(&mut self) {
-        self.expires_at = None;
-        self.focus_sequence_index = 0;
-    }
 }
 
 impl<S: EventSource + Default + Unpin> TuiEventStream<S> {
@@ -312,8 +167,6 @@ impl<S: EventSource + Default + Unpin> TuiEventStream<S> {
             suspend_context,
             #[cfg(unix)]
             alt_screen_active,
-            #[cfg(unix)]
-            post_resume_input_guard: PostResumeInputGuard::default(),
         }
     }
 
@@ -382,14 +235,6 @@ impl<S: EventSource + Default + Unpin> TuiEventStream<S> {
 
     /// Map a crossterm event to a [`TuiEvent`], skipping events we don't use (mouse events, etc.).
     fn map_crossterm_event(&mut self, event: Event) -> Option<TuiEvent> {
-        #[cfg(unix)]
-        if self
-            .post_resume_input_guard
-            .should_drop(&event, Instant::now())
-        {
-            return None;
-        }
-
         match event {
             Event::Key(key_event) => {
                 #[cfg(unix)]
@@ -397,13 +242,12 @@ impl<S: EventSource + Default + Unpin> TuiEventStream<S> {
                     self.broker.pause_events();
                     let suspend_result = self.suspend_context.suspend(&self.alt_screen_active);
                     self.broker.resume_events();
-                    match suspend_result {
-                        Ok(()) => self.post_resume_input_guard.arm(Instant::now()),
-                        Err(err) => tracing::warn!(
+                    if let Err(err) = suspend_result {
+                        tracing::warn!(
                             event = "tui_suspend_failed",
                             error = %err,
                             "failed to suspend TUI process"
-                        ),
+                        );
                     }
                     return Some(TuiEvent::Draw);
                 }
@@ -466,7 +310,6 @@ mod tests {
     use std::task::Context;
     use std::task::Poll;
     use std::time::Duration;
-    use std::time::Instant;
     use tokio::sync::broadcast;
     use tokio::sync::mpsc;
     use tokio::time::timeout;
@@ -552,56 +395,6 @@ mod tests {
         let (draw_tx, draw_rx) = broadcast::channel(1);
         let terminal_focused = Arc::new(AtomicBool::new(true));
         (broker, handle, draw_tx, draw_rx, terminal_focused)
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn post_resume_guard_suppresses_literal_focus_report_paste() {
-        let now = Instant::now();
-        let mut guard = PostResumeInputGuard::default();
-        guard.arm(now);
-
-        assert!(guard.should_drop(&Event::Paste("\x1b[I".to_string()), now));
-        assert!(!guard.should_drop(
-            &Event::Key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)),
-            now
-        ));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn post_resume_guard_suppresses_split_focus_report_keys() {
-        let now = Instant::now();
-        let mut guard = PostResumeInputGuard::default();
-        guard.arm(now);
-
-        assert!(guard.should_drop(
-            &Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
-            now
-        ));
-        assert!(guard.should_drop(
-            &Event::Key(KeyEvent::new(KeyCode::Char('['), KeyModifiers::NONE)),
-            now
-        ));
-        assert!(guard.should_drop(
-            &Event::Key(KeyEvent::new(KeyCode::Char('I'), KeyModifiers::SHIFT)),
-            now
-        ));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn post_resume_guard_expires_before_filtering_user_input() {
-        let now = Instant::now();
-        let mut guard = PostResumeInputGuard::default();
-        guard.arm(now);
-        let after_guard =
-            now + POST_RESUME_INPUT_GUARD_DURATION + Duration::from_millis(/*millis*/ 1);
-
-        assert!(!guard.should_drop(
-            &Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
-            after_guard
-        ));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/codex-rs/tui/src/tui/event_stream.rs
+++ b/codex-rs/tui/src/tui/event_stream.rs
@@ -239,7 +239,9 @@ impl<S: EventSource + Default + Unpin> TuiEventStream<S> {
             Event::Key(key_event) => {
                 #[cfg(unix)]
                 if crate::tui::job_control::SUSPEND_KEY.is_press(key_event) {
+                    self.broker.pause_events();
                     let _ = self.suspend_context.suspend(&self.alt_screen_active);
+                    self.broker.resume_events();
                     return Some(TuiEvent::Draw);
                 }
                 Some(TuiEvent::Key(key_event))

--- a/codex-rs/tui/src/tui/event_stream.rs
+++ b/codex-rs/tui/src/tui/event_stream.rs
@@ -24,8 +24,16 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::task::Context;
 use std::task::Poll;
+#[cfg(unix)]
+use std::time::Duration;
+#[cfg(unix)]
+use std::time::Instant;
 
 use crossterm::event::Event;
+#[cfg(unix)]
+use crossterm::event::KeyCode;
+#[cfg(unix)]
+use crossterm::event::KeyEventKind;
 use tokio::sync::broadcast;
 use tokio::sync::watch;
 use tokio_stream::Stream;
@@ -146,6 +154,143 @@ pub struct TuiEventStream<S: EventSource + Default + Unpin = CrosstermEventSourc
     suspend_context: crate::tui::job_control::SuspendContext,
     #[cfg(unix)]
     alt_screen_active: Arc<AtomicBool>,
+    #[cfg(unix)]
+    post_resume_input_guard: PostResumeInputGuard,
+}
+
+#[cfg(unix)]
+const POST_RESUME_INPUT_GUARD_DURATION: Duration = Duration::from_millis(/*millis*/ 500);
+
+#[cfg(unix)]
+#[derive(Debug, Default)]
+struct PostResumeInputGuard {
+    expires_at: Option<Instant>,
+    focus_sequence_index: u8,
+}
+
+#[cfg(unix)]
+impl PostResumeInputGuard {
+    fn arm(&mut self, now: Instant) {
+        self.expires_at = now.checked_add(POST_RESUME_INPUT_GUARD_DURATION);
+        self.focus_sequence_index = 0;
+        tracing::trace!(
+            event = "tui_post_resume_input_guard_armed",
+            duration_ms = %POST_RESUME_INPUT_GUARD_DURATION.as_millis(),
+            "armed post-resume terminal input guard"
+        );
+    }
+
+    fn should_drop(&mut self, event: &Event, now: Instant) -> bool {
+        if !self.expires_at.is_some_and(|expires_at| now <= expires_at) {
+            self.disarm();
+            return false;
+        }
+
+        self.trace_event(event);
+
+        match event {
+            Event::Paste(pasted) => {
+                let should_drop = pasted.as_bytes() == b"\x1b[I";
+                if should_drop {
+                    tracing::debug!(
+                        event = "tui_post_resume_focus_report_suppressed",
+                        delivery = "paste",
+                        "suppressed literal focus report after resume"
+                    );
+                }
+                self.disarm();
+                should_drop
+            }
+            Event::FocusGained => {
+                self.disarm();
+                false
+            }
+            Event::Key(key_event)
+                if matches!(key_event.kind, KeyEventKind::Press | KeyEventKind::Repeat) =>
+            {
+                let matches_focus_sequence = match self.focus_sequence_index {
+                    0 => matches!(key_event.code, KeyCode::Esc | KeyCode::Char('\x1b')),
+                    1 => matches!(key_event.code, KeyCode::Char('[')),
+                    2 => matches!(key_event.code, KeyCode::Char('I')),
+                    _ => false,
+                };
+                if !matches_focus_sequence {
+                    self.disarm();
+                    return false;
+                }
+
+                self.focus_sequence_index += 1;
+                if self.focus_sequence_index == 3 {
+                    tracing::debug!(
+                        event = "tui_post_resume_focus_report_suppressed",
+                        delivery = "split_key_events",
+                        "suppressed split focus report after resume"
+                    );
+                    self.disarm();
+                }
+                true
+            }
+            Event::Key(_) => false,
+            _ => false,
+        }
+    }
+
+    fn trace_event(&self, event: &Event) {
+        let event_kind = match event {
+            Event::Key(key_event) => match key_event.code {
+                KeyCode::Esc => "key_escape",
+                KeyCode::Char('\x1b') => "key_escape_char",
+                KeyCode::Char('^') => "key_caret",
+                KeyCode::Char('[') => "key_left_bracket",
+                KeyCode::Char('I') => "key_upper_i",
+                KeyCode::Char(_) => "key_char_other",
+                _ => "key_other",
+            },
+            Event::Paste(pasted) if pasted.as_bytes() == b"\x1b[I" => "paste_focus_report",
+            Event::Paste(_) => "paste_other",
+            Event::FocusGained => "focus_gained",
+            Event::FocusLost => "focus_lost",
+            Event::Resize(_, _) => "resize",
+            _ => "other",
+        };
+        let paste_byte_len = match event {
+            Event::Paste(pasted) => Some(pasted.len()),
+            _ => None,
+        };
+        let paste_contains_escape = match event {
+            Event::Paste(pasted) => Some(pasted.contains('\x1b')),
+            _ => None,
+        };
+        let paste_matches_visible_focus_report = match event {
+            Event::Paste(pasted) => Some(pasted == "^[[I"),
+            _ => None,
+        };
+        let key_kind = match event {
+            Event::Key(key_event) => Some(key_event.kind),
+            _ => None,
+        };
+        let key_modifiers = match event {
+            Event::Key(key_event) => Some(key_event.modifiers),
+            _ => None,
+        };
+
+        tracing::trace!(
+            event = "tui_post_resume_input_observed",
+            event_kind,
+            focus_sequence_index = self.focus_sequence_index,
+            ?paste_byte_len,
+            ?paste_contains_escape,
+            ?paste_matches_visible_focus_report,
+            ?key_kind,
+            ?key_modifiers,
+            "observed terminal input after resume"
+        );
+    }
+
+    fn disarm(&mut self) {
+        self.expires_at = None;
+        self.focus_sequence_index = 0;
+    }
 }
 
 impl<S: EventSource + Default + Unpin> TuiEventStream<S> {
@@ -167,6 +312,8 @@ impl<S: EventSource + Default + Unpin> TuiEventStream<S> {
             suspend_context,
             #[cfg(unix)]
             alt_screen_active,
+            #[cfg(unix)]
+            post_resume_input_guard: PostResumeInputGuard::default(),
         }
     }
 
@@ -235,13 +382,29 @@ impl<S: EventSource + Default + Unpin> TuiEventStream<S> {
 
     /// Map a crossterm event to a [`TuiEvent`], skipping events we don't use (mouse events, etc.).
     fn map_crossterm_event(&mut self, event: Event) -> Option<TuiEvent> {
+        #[cfg(unix)]
+        if self
+            .post_resume_input_guard
+            .should_drop(&event, Instant::now())
+        {
+            return None;
+        }
+
         match event {
             Event::Key(key_event) => {
                 #[cfg(unix)]
                 if crate::tui::job_control::SUSPEND_KEY.is_press(key_event) {
                     self.broker.pause_events();
-                    let _ = self.suspend_context.suspend(&self.alt_screen_active);
+                    let suspend_result = self.suspend_context.suspend(&self.alt_screen_active);
                     self.broker.resume_events();
+                    match suspend_result {
+                        Ok(()) => self.post_resume_input_guard.arm(Instant::now()),
+                        Err(err) => tracing::warn!(
+                            event = "tui_suspend_failed",
+                            error = %err,
+                            "failed to suspend TUI process"
+                        ),
+                    }
                     return Some(TuiEvent::Draw);
                 }
                 Some(TuiEvent::Key(key_event))
@@ -303,6 +466,7 @@ mod tests {
     use std::task::Context;
     use std::task::Poll;
     use std::time::Duration;
+    use std::time::Instant;
     use tokio::sync::broadcast;
     use tokio::sync::mpsc;
     use tokio::time::timeout;
@@ -388,6 +552,56 @@ mod tests {
         let (draw_tx, draw_rx) = broadcast::channel(1);
         let terminal_focused = Arc::new(AtomicBool::new(true));
         (broker, handle, draw_tx, draw_rx, terminal_focused)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn post_resume_guard_suppresses_literal_focus_report_paste() {
+        let now = Instant::now();
+        let mut guard = PostResumeInputGuard::default();
+        guard.arm(now);
+
+        assert!(guard.should_drop(&Event::Paste("\x1b[I".to_string()), now));
+        assert!(!guard.should_drop(
+            &Event::Key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE)),
+            now
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn post_resume_guard_suppresses_split_focus_report_keys() {
+        let now = Instant::now();
+        let mut guard = PostResumeInputGuard::default();
+        guard.arm(now);
+
+        assert!(guard.should_drop(
+            &Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+            now
+        ));
+        assert!(guard.should_drop(
+            &Event::Key(KeyEvent::new(KeyCode::Char('['), KeyModifiers::NONE)),
+            now
+        ));
+        assert!(guard.should_drop(
+            &Event::Key(KeyEvent::new(KeyCode::Char('I'), KeyModifiers::SHIFT)),
+            now
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn post_resume_guard_expires_before_filtering_user_input() {
+        let now = Instant::now();
+        let mut guard = PostResumeInputGuard::default();
+        guard.arm(now);
+        let after_guard =
+            now + POST_RESUME_INPUT_GUARD_DURATION + Duration::from_millis(/*millis*/ 1);
+
+        assert!(!guard.should_drop(
+            &Event::Key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+            after_guard
+        ));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/codex-rs/tui/src/tui/job_control.rs
+++ b/codex-rs/tui/src/tui/job_control.rs
@@ -176,14 +176,39 @@ impl PreparedResumeAction {
 
 /// Deliver SIGTSTP after restoring terminal state, then re-applies terminal modes once resumed.
 fn suspend_process() -> Result<()> {
+    tracing::trace!(
+        event = "tui_suspend_stage_changed",
+        stage = "restoring_terminal",
+        "restoring terminal before suspend"
+    );
     super::restore_for_suspend()?;
     super::terminal_stderr::pause()?;
+    tracing::trace!(
+        event = "tui_suspend_stage_changed",
+        stage = "sending_sigtstp",
+        "sending SIGTSTP to process group"
+    );
     unsafe {
         libc::kill(/*pid*/ 0, libc::SIGTSTP)
     };
+    tracing::trace!(
+        event = "tui_suspend_stage_changed",
+        stage = "resumed",
+        "process resumed after SIGTSTP"
+    );
     // After the process resumes, reapply terminal modes so drawing can continue.
     super::terminal_stderr::resume()?;
     super::set_modes()?;
+    tracing::trace!(
+        event = "tui_suspend_stage_changed",
+        stage = "terminal_modes_reenabled",
+        "re-enabled terminal modes after resume"
+    );
     super::flush_terminal_input_buffer();
+    tracing::trace!(
+        event = "tui_suspend_stage_changed",
+        stage = "terminal_input_flushed",
+        "flushed terminal input after resume"
+    );
     Ok(())
 }

--- a/codex-rs/tui/src/tui/job_control.rs
+++ b/codex-rs/tui/src/tui/job_control.rs
@@ -71,7 +71,29 @@ impl SuspendContext {
         }
         let y = self.suspend_cursor_y.load(Ordering::Relaxed);
         let _ = execute!(stdout(), MoveTo(0, y), Show);
-        suspend_process()
+        suspend_process()?;
+
+        // The shell writes its job-control status and the resumed command after `fg`, so the
+        // cursor may no longer be on the row cached before suspending. The event stream remains
+        // paused until this method returns, which makes it safe for the probe to consume both an
+        // interleaved focus report and the cursor-position response without racing the background
+        // input reader.
+        match crate::terminal_probe::cursor_position(crate::terminal_probe::DEFAULT_TIMEOUT) {
+            Ok(Some(position)) => self.set_cursor_y(position.y),
+            Ok(None) => tracing::debug!("terminal cursor position unavailable after resume"),
+            Err(err) => tracing::debug!(
+                error = %err,
+                "failed to read terminal cursor position after resume"
+            ),
+        }
+        super::flush_terminal_input_buffer();
+        tracing::trace!(
+            event = "tui_suspend_stage_changed",
+            stage = "terminal_input_flushed",
+            "flushed terminal input after resume"
+        );
+
+        Ok(())
     }
 
     /// Consume the pending resume intent and precompute any viewport changes needed post-resume.
@@ -203,12 +225,6 @@ fn suspend_process() -> Result<()> {
         event = "tui_suspend_stage_changed",
         stage = "terminal_modes_reenabled",
         "re-enabled terminal modes after resume"
-    );
-    super::flush_terminal_input_buffer();
-    tracing::trace!(
-        event = "tui_suspend_stage_changed",
-        stage = "terminal_input_flushed",
-        "flushed terminal input after resume"
     );
     Ok(())
 }

--- a/codex-rs/tui/src/tui/job_control.rs
+++ b/codex-rs/tui/src/tui/job_control.rs
@@ -72,6 +72,7 @@ impl SuspendContext {
         let y = self.suspend_cursor_y.load(Ordering::Relaxed);
         let _ = execute!(stdout(), MoveTo(0, y), Show);
         suspend_process()?;
+        super::reapply_raw_mode_after_resume()?;
 
         // The shell writes its job-control status and the resumed command after `fg`, so the
         // cursor may no longer be on the row cached before suspending. The event stream remains
@@ -87,7 +88,6 @@ impl SuspendContext {
             ),
         }
         super::flush_terminal_input_buffer();
-        super::reapply_raw_mode_after_resume()?;
         tracing::trace!(
             event = "tui_suspend_resumed",
             cursor_y = self.cursor_y(),

--- a/codex-rs/tui/src/tui/job_control.rs
+++ b/codex-rs/tui/src/tui/job_control.rs
@@ -89,9 +89,9 @@ impl SuspendContext {
         super::flush_terminal_input_buffer();
         super::reapply_raw_mode_after_resume()?;
         tracing::trace!(
-            event = "tui_suspend_stage_changed",
-            stage = "terminal_input_flushed_and_raw_mode_reapplied",
-            "flushed terminal input and reapplied raw mode after resume"
+            event = "tui_suspend_resumed",
+            cursor_y = self.cursor_y(),
+            "restored terminal state after resume"
         );
 
         Ok(())
@@ -199,33 +199,13 @@ impl PreparedResumeAction {
 
 /// Deliver SIGTSTP after restoring terminal state, then re-applies terminal modes once resumed.
 fn suspend_process() -> Result<()> {
-    tracing::trace!(
-        event = "tui_suspend_stage_changed",
-        stage = "restoring_terminal",
-        "restoring terminal before suspend"
-    );
-    super::restore_for_suspend()?;
+    super::restore()?;
     super::terminal_stderr::pause()?;
-    tracing::trace!(
-        event = "tui_suspend_stage_changed",
-        stage = "sending_sigtstp",
-        "sending SIGTSTP to process group"
-    );
     unsafe {
         libc::kill(/*pid*/ 0, libc::SIGTSTP)
     };
-    tracing::trace!(
-        event = "tui_suspend_stage_changed",
-        stage = "resumed",
-        "process resumed after SIGTSTP"
-    );
     // After the process resumes, reapply terminal modes so drawing can continue.
     super::terminal_stderr::resume()?;
     super::set_modes()?;
-    tracing::trace!(
-        event = "tui_suspend_stage_changed",
-        stage = "terminal_modes_reenabled",
-        "re-enabled terminal modes after resume"
-    );
     Ok(())
 }

--- a/codex-rs/tui/src/tui/job_control.rs
+++ b/codex-rs/tui/src/tui/job_control.rs
@@ -87,10 +87,11 @@ impl SuspendContext {
             ),
         }
         super::flush_terminal_input_buffer();
+        super::reapply_raw_mode_after_resume()?;
         tracing::trace!(
             event = "tui_suspend_stage_changed",
-            stage = "terminal_input_flushed",
-            "flushed terminal input after resume"
+            stage = "terminal_input_flushed_and_raw_mode_reapplied",
+            "flushed terminal input and reapplied raw mode after resume"
         );
 
         Ok(())

--- a/codex-rs/tui/src/tui/job_control.rs
+++ b/codex-rs/tui/src/tui/job_control.rs
@@ -13,7 +13,6 @@ use crossterm::event::KeyCode;
 use crossterm::terminal::EnterAlternateScreen;
 use crossterm::terminal::LeaveAlternateScreen;
 use ratatui::crossterm::execute;
-use ratatui::layout::Position;
 use ratatui::layout::Rect;
 
 use crate::key_hint;
@@ -81,23 +80,22 @@ impl SuspendContext {
     /// resumes; returns `None` when there was no pending suspend intent.
     pub(crate) fn prepare_resume_action(
         &self,
-        terminal: &mut Terminal,
         alt_saved_viewport: &mut Option<Rect>,
     ) -> Option<PreparedResumeAction> {
         let action = self.take_resume_action()?;
         match action {
             ResumeAction::RealignInline => {
-                let cursor_pos = terminal
-                    .get_cursor_position()
-                    .unwrap_or(terminal.last_known_cursor_pos);
-                let viewport = Rect::new(0, cursor_pos.y, 0, 0);
+                let viewport = Rect::new(
+                    /*x*/ 0,
+                    self.cursor_y(),
+                    /*width*/ 0,
+                    /*height*/ 0,
+                );
                 Some(PreparedResumeAction::RealignViewport(viewport))
             }
             ResumeAction::RestoreAlt => {
-                if let Ok(Position { y, .. }) = terminal.get_cursor_position()
-                    && let Some(saved) = alt_saved_viewport.as_mut()
-                {
-                    saved.y = y;
+                if let Some(saved) = alt_saved_viewport.as_mut() {
+                    saved.y = self.cursor_y();
                 }
                 Some(PreparedResumeAction::RestoreAltScreen)
             }
@@ -110,6 +108,10 @@ impl SuspendContext {
     /// position to restore before yielding.
     pub(crate) fn set_cursor_y(&self, value: u16) {
         self.suspend_cursor_y.store(value, Ordering::Relaxed);
+    }
+
+    fn cursor_y(&self) -> u16 {
+        self.suspend_cursor_y.load(Ordering::Relaxed)
     }
 
     /// Record a pending resume action to apply after SIGTSTP returns control.
@@ -182,5 +184,6 @@ fn suspend_process() -> Result<()> {
     // After the process resumes, reapply terminal modes so drawing can continue.
     super::terminal_stderr::resume()?;
     super::set_modes()?;
+    super::flush_terminal_input_buffer();
     Ok(())
 }

--- a/codex-rs/tui/src/tui/job_control.rs
+++ b/codex-rs/tui/src/tui/job_control.rs
@@ -174,7 +174,7 @@ impl PreparedResumeAction {
 
 /// Deliver SIGTSTP after restoring terminal state, then re-applies terminal modes once resumed.
 fn suspend_process() -> Result<()> {
-    super::restore()?;
+    super::restore_for_suspend()?;
     super::terminal_stderr::pause()?;
     unsafe {
         libc::kill(/*pid*/ 0, libc::SIGTSTP)

--- a/codex-rs/tui/src/tui/keyboard_modes.rs
+++ b/codex-rs/tui/src/tui/keyboard_modes.rs
@@ -1,8 +1,8 @@
 //! Terminal keyboard enhancement setup and teardown helpers.
 //!
 //! The TUI uses crossterm's keyboard enhancement stack while it owns the terminal, but
-//! suspend and process exit get a stronger reset so the parent shell does not inherit
-//! enhanced key reporting if a terminal misses the normal stack pop.
+//! process exit gets a stronger reset so the parent shell does not inherit enhanced key
+//! reporting if a terminal misses the normal stack pop.
 
 use std::fmt;
 use std::io::stdout;
@@ -202,7 +202,7 @@ pub(super) fn restore_keyboard_enhancement_stack() {
     );
 }
 
-pub(super) fn reset_keyboard_reporting() {
+pub(super) fn reset_keyboard_reporting_after_exit() {
     let _ = execute!(
         stdout(),
         PopKeyboardEnhancementFlags,

--- a/codex-rs/tui/src/tui/keyboard_modes.rs
+++ b/codex-rs/tui/src/tui/keyboard_modes.rs
@@ -1,8 +1,8 @@
 //! Terminal keyboard enhancement setup and teardown helpers.
 //!
 //! The TUI uses crossterm's keyboard enhancement stack while it owns the terminal, but
-//! process exit gets a stronger reset so the parent shell does not inherit enhanced key
-//! reporting if a terminal misses the normal stack pop.
+//! suspend and process exit get a stronger reset so the parent shell does not inherit
+//! enhanced key reporting if a terminal misses the normal stack pop.
 
 use std::fmt;
 use std::io::stdout;
@@ -202,7 +202,7 @@ pub(super) fn restore_keyboard_enhancement_stack() {
     );
 }
 
-pub(super) fn reset_keyboard_reporting_after_exit() {
+pub(super) fn reset_keyboard_reporting() {
     let _ = execute!(
         stdout(),
         PopKeyboardEnhancementFlags,


### PR DESCRIPTION
## Why

On Linux, suspending Codex with `Ctrl+Z` and returning with `fg` can leave the composer misaligned or inject terminal response bytes such as focus reports into the prompt. Shell job-control output moves the cursor while Codex is suspended, and terminal input polling can race with the responses used to restore the inline viewport.

Fixes #26564.

## What changed

- preserve and restore keyboard reporting without disturbing the parent terminal stack
- pause terminal event polling while Codex is suspended and flush buffered input before resuming it
- force crossterm's cached raw-mode state back in sync after the shell completes its `fg` handoff
- probe the actual post-`fg` cursor position with the tolerant terminal-response parser, then realign the inline viewport before redrawing

## How to Test

1. On Linux, start the development TUI with `just c`.
2. Type text into the composer without submitting it.
3. Press `Ctrl+Z`, run any harmless shell command, then run `fg`.
4. Confirm the composer redraws below the shell output, the draft text is preserved, and no raw escape sequences appear.
5. Repeat the suspend/resume cycle and confirm normal typing still works.

Targeted tests:

- `cargo test -p codex-tui --lib parses_cursor_position_as_zero_based -j 1`
- `cargo test -p codex-tui --lib tui::event_stream::tests -j 1`
