### PR TITLE
[codex] remove stale PathExt import

### DIFF
--- a/codex-rs/core/src/tools/runtimes/mod_tests.rs
+++ b/codex-rs/core/src/tools/runtimes/mod_tests.rs
@@ -26,7 +26,6 @@ use codex_sandboxing::SandboxType;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_path_uri::PathUri;
 use core_test_support::PathBufExt;
-use core_test_support::PathExt;
 use pretty_assertions::assert_eq;
 use std::path::PathBuf;
 use std::process::Command;


### PR DESCRIPTION
## Why

`main` fails dev-profile Cargo and Bazel Clippy builds because `core/src/tools/runtimes/mod_tests.rs` imports `PathExt` after its last use was removed. With warnings denied, that stale import prevents `codex-core` test targets from compiling across platforms.

## What changed

Remove the unused `PathExt` import. Remaining `.abs()` calls in the module operate on `PathBuf` and continue to use `PathBufExt`.

## Validation

- `just fmt`
- Focused `codex-core` test compile attempted; blocked locally by disk exhaustion before compilation completed. The CI failure itself is the unused-import diagnostic this change removes.