### PR TITLE
[codex] add path-types skill

### DIFF
--- a/.codex/skills/codex-path-types/SKILL.md
+++ b/.codex/skills/codex-path-types/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: codex-path-types
+description: Choose Rust path types that meet Codex's compatibility requirements. Use when defining new path-bearing Rust types or when explicitly asked to migrate existing types in app-server, exec-server, or dependencies shared by them.
+---
+
+# Codex Path Types
+
+Apply this guidance when defining new types. Change existing code only when explicitly requested,
+and keep edits minimal and proportional. Treat these rules as the target state of an ongoing
+migration; if compliance is difficult, ask the user how to proceed.
+
+- In app-server protocol types, use `ApiPathString` for backwards compatibility during the URI
+  migration. At the protocol boundary, convert it to `PathUri` and use `PathUri` internally. For
+  host-local logic, such as some config values, use `AbsolutePathBuf` or `PathBuf` instead.
+- In exec-server protocol types, use `PathUri`. Internally, use `PathUri` or `AbsolutePathBuf` as
+  appropriate.
+- In dependencies shared by both servers, use `PathUri` or separate APIs that decouple their use
+  cases.

--- a/.codex/skills/path-types/SKILL.md
+++ b/.codex/skills/path-types/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: codex-path-types
-description: Choose Rust path types that meet Codex's compatibility requirements. Use when defining new path-bearing Rust types or when explicitly asked to migrate existing types in app-server, exec-server, or dependencies shared by them.
+name: path-types
+description: Choose Rust types for operating system paths across the Codex repository. Use when defining new path-bearing types or explicitly migrating existing ones.
 ---
 
-# Codex Path Types
+# Path Types
 
 Apply this guidance when defining new types. Change existing code only when explicitly requested,
 and keep edits minimal and proportional. Treat these rules as the target state of an ongoing


### PR DESCRIPTION
## Why

Codex contributors and agents need repository-scoped guidance for choosing compatible Rust types
for operating system paths during the ongoing URI migration. Keeping the guidance in the repository
makes the app-server and exec-server rules available consistently without relying on a personal
skill installation.

## What

- Add the `path-types` skill at `.codex/skills/path-types/SKILL.md`.
- Document the intended uses of `ApiPathString`, `PathUri`, `AbsolutePathBuf`, and `PathBuf` across
  protocol, internal, and shared dependency boundaries.
- Keep migrations of existing types limited to explicit requests and proportional edits.

## Validation

- Validated the skill structure with skill-creator's `quick_validate.py`.
