### PR TITLE
[codex] add CDP runtime default example

### DIFF
--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -236,6 +236,37 @@ Example with notification opt-out:
 - `config/batchWrite` — apply multiple config edits atomically to the user's config.toml on disk, with optional `reloadUserConfig: true` to hot-reload loaded threads, including multiple `desktop.*` edits.
 - `configRequirements/read` — fetch loaded requirements constraints from `requirements.toml` and/or MDM (or `null` if none are configured), including allow-lists (`allowedApprovalPolicies`, `allowedSandboxModes`, `allowedWebSearchModes`), the layered permission-profile allow map (`allowedPermissionProfiles`), the managed permission-profile default (`defaultPermissions`), lifecycle hook lockdown (`allowManagedHooksOnly`), computer use policy (`computerUse`), pinned feature values (`featureRequirements`), managed lifecycle hooks (`hooks`), `enforceResidency`, and `network` constraints such as canonical domain/socket permissions plus `managedAllowedDomainsOnly` and `dangerFullAccessDenylistOnly`.
 
+### Example: Supply an account-scoped feature default
+
+The Codex App can evaluate a Statsig gate and pass the resulting default to Rust without adding a
+Statsig client to `codex-rs`. For example, the App can target personal accounts with `cdp = true`
+and workspace accounts with `cdp = false`, then send the selected value after app-server
+initialization:
+
+```json
+{
+  "method": "experimentalFeature/enablement/set",
+  "id": 20,
+  "params": {
+    "enablement": {
+      "cdp": true
+    }
+  }
+}
+```
+
+This value is an in-memory default, not an administrator policy. An explicit `features.cdp` value
+in `config.toml` takes precedence, and a cloud-delivered requirement can pin the value for managed
+accounts:
+
+```toml
+[features]
+cdp = false
+```
+
+The persistent personal-account opt-in/opt-out experience is intentionally outside this example;
+it needs a separate product decision about where that account preference is stored and synchronized.
+
 ### Example: Start or resume a thread
 
 Start a fresh thread when you need a new Codex conversation.

--- a/codex-rs/app-server/src/request_processors/config_processor.rs
+++ b/codex-rs/app-server/src/request_processors/config_processor.rs
@@ -47,6 +47,7 @@ use std::path::PathBuf;
 
 const SUPPORTED_EXPERIMENTAL_FEATURE_ENABLEMENT: &[&str] = &[
     "auth_elicitation",
+    "cdp",
     "memories",
     "mentions_v2",
     "remote_control",

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -127,6 +127,11 @@ pub enum Feature {
     LocalThreadStoreCompression,
     /// Enable the Chronicle sidecar for passive screen-context memories.
     Chronicle,
+    /// Enable CDP.
+    ///
+    /// The Codex App supplies the account-scoped rollout default at runtime.
+    /// Explicit config and managed requirements retain higher precedence.
+    Cdp,
     /// Append additional AGENTS.md guidance to user instructions.
     ChildAgentsMd,
     /// Compress request bodies (zstd) when sending streaming requests to codex-backend.
@@ -868,6 +873,15 @@ pub const FEATURES: &[FeatureSpec] = &[
         id: Feature::Chronicle,
         key: "chronicle",
         stage: Stage::UnderDevelopment,
+        default_enabled: false,
+    },
+    FeatureSpec {
+        id: Feature::Cdp,
+        key: "cdp",
+        stage: Stage::UnderDevelopment,
+        // The App supplies the account-scoped default through
+        // `experimentalFeature/enablement/set`. Keep the Rust fallback off for
+        // clients that do not evaluate the rollout.
         default_enabled: false,
     },
     FeatureSpec {


### PR DESCRIPTION
## Summary

- add `cdp` as a canonical, default-off Rust feature
- allow the Codex App to provide its account-scoped default through `experimentalFeature/enablement/set`
- document an illustrative Statsig-to-app-server handoff and managed-requirement override

## Motivation

The Codex Rust client does not evaluate Statsig gates directly. This demonstrates how the App can evaluate an account-scoped rollout—such as personal accounts defaulting on and workspace accounts defaulting off—and pass the resulting default into Rust while preserving explicit config and enterprise requirement precedence.

The companion App implementation is [openai/openai#1032880](https://github.com/openai/openai/pull/1032880). It maps `codex_rollout_cdp` to the canonical `cdp` key and forwards the resulting override through the existing per-host runtime enablement bridge.

This is intentionally illustrative. It does not implement a persistent personal-account opt-in/opt-out preference; that storage and synchronization model still needs a separate product decision.

## Validation

- `just fmt`
- `just test -p codex-features` (49 passed)
- `just test -p codex-app-server` (840 passed, 2 skipped)
