### PR TITLE
[codex] Retry transient models fetch failures

### DIFF
--- a/.github/workflows/rust-release-prepare.yml
+++ b/.github/workflows/rust-release-prepare.yml
@@ -44,7 +44,10 @@ jobs:
           )
 
           url="${base_url%/}/models?client_version=${client_version}"
-          curl --http1.1 --fail --show-error --location "${headers[@]}" "${url}" | jq '.' > codex-rs/models-manager/models.json
+          curl --http1.1 --fail --show-error --location \
+            --retry 2 \
+            --retry-delay 2 \
+            "${headers[@]}" "${url}" | jq '.' > codex-rs/models-manager/models.json
 
       - name: Open pull request (if changed)
         uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0


### PR DESCRIPTION
## Why

The scheduled Rust release preparation workflow intermittently fails while fetching the models catalog. The existing [`curl` invocation](https://github.com/openai/codex/blob/1b81365926670763246bdf791a5758b2b3264a9b/.github/workflows/rust-release-prepare.yml#L47) makes only one attempt, so a transient backend error fails the entire job.

Evidence from a [recent failed run](https://github.com/openai/codex/actions/runs/27564664848) shows an HTTP 500 after roughly six seconds. Correlating that request with backend logs identified a five-second authentication timeout for an internal service; the upstream request subsequently completed successfully in 6.099 seconds. In a [branch-only diagnostic run after the authentication cache had expired](https://github.com/openai/codex/actions/runs/27567643869), the first request succeeded in 4.922 seconds, while warm requests completed in roughly 0.2–0.4 seconds.

This points to transient cold authentication latency rather than a permanently invalid credential. Retrying HTTP 500 responses gives that path another chance while curl's default retry policy continues to treat authentication failures such as HTTP 401 as terminal.

## What changed

- Retry the models catalog request twice after the initial attempt, for at most three attempts total.
- Wait two seconds between retry attempts.

## Verification

- `git diff --check`
- Confirmed with branch-only workflow probes that the same authenticated request succeeds once the authentication path is warm.
