### PR TITLE
[codex] speed up resume and fork startup

### DIFF
--- a/codex-rs/app-server/src/request_processors/thread_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor.rs
@@ -2600,10 +2600,11 @@ impl ThreadRequestProcessor {
             self.resume_thread_from_history(history.as_slice())
                 .await
                 .map(|thread_history| (thread_history, None))
-        } else if let Some(stored_thread) = stored_thread_from_running_probe {
-            self.stored_thread_to_initial_history(&stored_thread)
-                .await
-                .map(|thread_history| (thread_history, Some(*stored_thread)))
+        } else if let Some(mut stored_thread) = stored_thread_from_running_probe {
+            match self.take_stored_thread_initial_history(&mut stored_thread) {
+                Ok(thread_history) => Ok((thread_history, Some(*stored_thread))),
+                Err(error) => Err(error),
+            }
         } else {
             self.resume_thread_from_rollout(&thread_id, path.as_ref())
                 .await
@@ -2751,9 +2752,10 @@ impl ThreadRequestProcessor {
                     config_snapshot.active_permission_profile,
                 );
                 let token_usage_thread = include_turns.then(|| thread.clone());
+                let response_history_items = initial_history_rollout_items(&response_history);
                 let mut initial_turns_page = if let Some(params) = initial_turns_page.as_ref() {
                     match build_thread_resume_initial_turns_page(
-                        &response_history.get_rollout_items(),
+                        response_history_items,
                         thread.status.clone(),
                         /*has_live_running_thread*/ false,
                         /*active_turn*/ None,
@@ -2791,15 +2793,18 @@ impl ThreadRequestProcessor {
                     initial_turns_page,
                 };
 
-                let connection_id = request_id.connection_id;
-                self.outgoing.send_response(request_id, response).await;
                 // `excludeTurns` is explicitly the cheap resume path, so avoid
                 // rebuilding history only to attribute a replayed usage update.
-                if let Some(token_usage_thread) = token_usage_thread {
-                    let token_usage_turn_id = latest_token_usage_turn_id_from_rollout_items(
-                        &response_history.get_rollout_items(),
+                let token_usage_replay = token_usage_thread.map(|token_usage_thread| {
+                    let turn_id = latest_token_usage_turn_id_from_rollout_items(
+                        response_history_items,
                         token_usage_thread.turns.as_slice(),
                     );
+                    (token_usage_thread, turn_id)
+                });
+                let connection_id = request_id.connection_id;
+                self.outgoing.send_response(request_id, response).await;
+                if let Some((token_usage_thread, token_usage_turn_id)) = token_usage_replay {
                     // The client needs restored usage before it starts another turn.
                     // Sending after the response preserves JSON-RPC request ordering while
                     // still filling the status line before the next turn lifecycle begins.
@@ -2955,10 +2960,11 @@ impl ThreadRequestProcessor {
             }
             let redact_resume_payloads =
                 should_redact_thread_resume_payloads(app_server_client_name.as_deref());
+            let mut source_thread = source_thread;
             let history_items = source_thread
                 .history
-                .as_ref()
-                .map(|history| history.items.clone())
+                .take()
+                .map(|history| history.items)
                 .ok_or_else(|| {
                     internal_error(format!(
                         "thread {existing_thread_id} did not include persisted history"
@@ -3054,12 +3060,10 @@ impl ThreadRequestProcessor {
         thread_id: &str,
         path: Option<&PathBuf>,
     ) -> Result<(InitialHistory, StoredThread), JSONRPCErrorError> {
-        let stored_thread = self
+        let mut stored_thread = self
             .read_stored_thread_for_resume(thread_id, path, /*include_history*/ true)
             .await?;
-        let history = self
-            .stored_thread_to_initial_history(&stored_thread)
-            .await?;
+        let history = self.take_stored_thread_initial_history(&mut stored_thread)?;
         Ok((history, stored_thread))
     }
 
@@ -3104,15 +3108,15 @@ impl ThreadRequestProcessor {
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
-    async fn stored_thread_to_initial_history(
+    fn take_stored_thread_initial_history(
         &self,
-        stored_thread: &StoredThread,
+        stored_thread: &mut StoredThread,
     ) -> Result<InitialHistory, JSONRPCErrorError> {
         let thread_id = stored_thread.thread_id;
         let history = stored_thread
             .history
-            .as_ref()
-            .map(|history| history.items.clone())
+            .take()
+            .map(|history| history.items)
             .ok_or_else(|| {
                 internal_error(format!(
                     "thread {thread_id} did not include persisted history"
@@ -3172,33 +3176,10 @@ impl ThreadRequestProcessor {
         let thread = match thread_history {
             InitialHistory::Resumed(resumed) => {
                 let fallback_provider = config_snapshot.model_provider_id.as_str();
-                if let Some(stored_thread) = resume_source_thread {
-                    let stored_thread =
-                        if let Some(rollout_path) = stored_thread.rollout_path.clone() {
-                            self.thread_store
-                                .read_thread_by_rollout_path(StoreReadThreadByRolloutPathParams {
-                                    rollout_path,
-                                    include_archived: true,
-                                    include_history: false,
-                                })
-                                .await
-                                .unwrap_or(StoredThread {
-                                    history: None,
-                                    ..stored_thread
-                                })
-                        } else {
-                            self.thread_store
-                                .read_thread(StoreReadThreadParams {
-                                    thread_id: stored_thread.thread_id,
-                                    include_archived: true,
-                                    include_history: false,
-                                })
-                                .await
-                                .unwrap_or(StoredThread {
-                                    history: None,
-                                    ..stored_thread
-                                })
-                        };
+                if let Some(mut stored_thread) = resume_source_thread {
+                    if stored_thread.preview.is_empty() {
+                        stored_thread.preview = preview_from_rollout_items(&resumed.history);
+                    }
                     Ok(thread_from_stored_thread(
                         stored_thread,
                         fallback_provider,
@@ -3246,10 +3227,10 @@ impl ThreadRequestProcessor {
         thread.session_id = session_id;
         thread.path = Some(rollout_path.to_path_buf());
         if include_turns {
-            let history_items = thread_history.get_rollout_items();
+            let history_items = initial_history_rollout_items(thread_history);
             populate_thread_turns_from_history(
                 &mut thread,
-                &history_items,
+                history_items,
                 /*active_turn*/ None,
             );
         }
@@ -3258,6 +3239,9 @@ impl ThreadRequestProcessor {
     }
 
     async fn attach_thread_name(&self, thread_id: ThreadId, thread: &mut Thread) {
+        if thread.name.is_some() {
+            return;
+        }
         if let Ok(stored_thread) = self
             .thread_store
             .read_thread(StoreReadThreadParams {
@@ -3306,7 +3290,7 @@ impl ThreadRequestProcessor {
                 "`permissions` cannot be combined with `sandbox`",
             ));
         }
-        let source_thread = self
+        let mut source_thread = self
             .read_stored_thread_for_resume(&thread_id, path.as_ref(), /*include_history*/ true)
             .await?;
         let source_thread_id = source_thread.thread_id;
@@ -3316,13 +3300,14 @@ impl ThreadRequestProcessor {
             .and_then(codex_core::util::normalize_thread_name);
         let history_items = source_thread
             .history
-            .as_ref()
-            .map(|history| history.items.clone())
+            .take()
+            .map(|history| history.items)
             .ok_or_else(|| {
                 internal_error(format!(
                     "thread {source_thread_id} did not include persisted history"
                 ))
             })?;
+        let response_history_items = (ephemeral || include_turns).then(|| history_items.clone());
         let history_cwd = Some(source_thread.cwd.clone());
 
         // Persist Windows sandbox mode.
@@ -3384,7 +3369,7 @@ impl ThreadRequestProcessor {
                 config,
                 InitialHistory::Resumed(ResumedHistory {
                     conversation_id: source_thread_id,
-                    history: history_items.clone(),
+                    history: history_items,
                     rollout_path: source_thread.rollout_path.clone(),
                 }),
                 thread_source.map(Into::into),
@@ -3449,18 +3434,19 @@ impl ThreadRequestProcessor {
             )
         } else {
             let config_snapshot = forked_thread.config_snapshot().await;
+            let history_items = response_history_items.as_deref().unwrap_or(&[]);
             let mut thread = build_thread_from_snapshot(
                 thread_id,
                 session_configured.session_id.to_string(),
                 &config_snapshot,
                 /*path*/ None,
             );
-            thread.preview = preview_from_rollout_items(&history_items);
+            thread.preview = preview_from_rollout_items(history_items);
             thread.forked_from_id = Some(source_thread_id.to_string());
             if include_turns {
                 populate_thread_turns_from_history(
                     &mut thread,
-                    &history_items,
+                    history_items,
                     /*active_turn*/ None,
                 );
             }
@@ -3517,7 +3503,7 @@ impl ThreadRequestProcessor {
         // instead of rebuilding history only to attribute a historical update.
         if let Some(token_usage_thread) = token_usage_thread {
             let token_usage_turn_id = latest_token_usage_turn_id_from_rollout_items(
-                &history_items,
+                response_history_items.as_deref().unwrap_or(&[]),
                 token_usage_thread.turns.as_slice(),
             );
             // Mirror the resume contract for forks: the new thread is usable as soon
@@ -3724,6 +3710,14 @@ fn thread_backwards_cursor_for_sort_key(
         SortDirection::Desc => timestamp.checked_sub_signed(ChronoDuration::milliseconds(1))?,
     };
     Some(timestamp.to_rfc3339_opts(SecondsFormat::Millis, true))
+}
+
+fn initial_history_rollout_items(history: &InitialHistory) -> &[RolloutItem] {
+    match history {
+        InitialHistory::New | InitialHistory::Cleared => &[],
+        InitialHistory::Resumed(resumed) => resumed.history.as_slice(),
+        InitialHistory::Forked(items) => items.as_slice(),
+    }
 }
 
 struct ThreadTurnsPage {
@@ -4300,6 +4294,25 @@ fn preview_from_rollout_items(items: &[RolloutItem]) -> String {
                 Some(codex_protocol::items::TurnItem::UserMessage(user)) => Some(user.message()),
                 _ => None,
             },
+            RolloutItem::EventMsg(codex_protocol::protocol::EventMsg::UserMessage(event)) => {
+                let message = event.message.trim();
+                if !message.is_empty() {
+                    Some(event.message.clone())
+                } else if event
+                    .images
+                    .as_ref()
+                    .is_some_and(|images| !images.is_empty())
+                    || !event.local_images.is_empty()
+                {
+                    Some("[Image]".to_string())
+                } else {
+                    None
+                }
+            }
+            RolloutItem::EventMsg(codex_protocol::protocol::EventMsg::ThreadGoalUpdated(event)) => {
+                let objective = event.goal.objective.trim();
+                (!objective.is_empty()).then(|| objective.to_string())
+            }
             _ => None,
         })
         .map(|preview| match preview.find(USER_MESSAGE_BEGIN) {

--- a/codex-rs/app-server/src/request_processors/thread_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor.rs
@@ -3177,18 +3177,6 @@ impl ThreadRequestProcessor {
             InitialHistory::Resumed(resumed) => {
                 let fallback_provider = config_snapshot.model_provider_id.as_str();
                 if let Some(mut stored_thread) = resume_source_thread {
-                    if let Some(created_at) = resumed.history.iter().find_map(|item| match item {
-                        RolloutItem::SessionMeta(session_meta) => {
-                            chrono::DateTime::parse_from_rfc3339(&session_meta.meta.timestamp)
-                                .ok()
-                                .map(|timestamp| timestamp.with_timezone(&chrono::Utc))
-                        }
-                        _ => None,
-                    }) {
-                        // Resume does not advance updated_at until the next turn starts.
-                        stored_thread.created_at = created_at;
-                        stored_thread.updated_at = created_at;
-                    }
                     if stored_thread.preview.is_empty() {
                         stored_thread.preview = preview_from_rollout_items(&resumed.history);
                     }

--- a/codex-rs/app-server/src/request_processors/thread_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor.rs
@@ -3177,6 +3177,18 @@ impl ThreadRequestProcessor {
             InitialHistory::Resumed(resumed) => {
                 let fallback_provider = config_snapshot.model_provider_id.as_str();
                 if let Some(mut stored_thread) = resume_source_thread {
+                    if let Some(created_at) = resumed.history.iter().find_map(|item| match item {
+                        RolloutItem::SessionMeta(session_meta) => {
+                            chrono::DateTime::parse_from_rfc3339(&session_meta.meta.timestamp)
+                                .ok()
+                                .map(|timestamp| timestamp.with_timezone(&chrono::Utc))
+                        }
+                        _ => None,
+                    }) {
+                        // Resume does not advance updated_at until the next turn starts.
+                        stored_thread.created_at = created_at;
+                        stored_thread.updated_at = created_at;
+                    }
                     if stored_thread.preview.is_empty() {
                         stored_thread.preview = preview_from_rollout_items(&resumed.history);
                     }

--- a/codex-rs/rollout/src/compression.rs
+++ b/codex-rs/rollout/src/compression.rs
@@ -40,6 +40,10 @@ pub(crate) async fn file_modified_time(path: &Path) -> io::Result<Option<time::O
     Ok(modified.map(time::OffsetDateTime::from))
 }
 
+pub(crate) fn file_modified_time_blocking(path: &Path) -> Option<time::OffsetDateTime> {
+    path::file_modified_time_blocking(path).map(time::OffsetDateTime::from)
+}
+
 /// Opens a rollout line reader that transparently handles plain `.jsonl` and `.jsonl.zst` files.
 ///
 /// If the requested path disappears during a representation transition, this briefly retries
@@ -55,6 +59,10 @@ pub async fn open_rollout_line_reader(path: &Path) -> io::Result<RolloutLineRead
         }
     }
     reader::open_once(path).await
+}
+
+pub(crate) fn existing_rollout_path_blocking(path: &Path) -> Option<PathBuf> {
+    path::existing_rollout_path_blocking(path)
 }
 
 /// Returns the compressed `.jsonl.zst` path for a rollout path.
@@ -902,6 +910,7 @@ mod path {
     use std::ffi::OsStr;
     use std::path::Path;
     use std::path::PathBuf;
+    use std::time::SystemTime;
 
     use super::COMPRESSED_SUFFIX;
 
@@ -947,6 +956,35 @@ mod path {
         if matches!(tokio::fs::metadata(compressed_path.as_path()).await, Ok(metadata) if metadata.is_file())
         {
             return Some(compressed_path);
+        }
+        None
+    }
+
+    pub(super) fn existing_rollout_path_blocking(path: &Path) -> Option<PathBuf> {
+        let plain_path = plain_rollout_path(path);
+        if matches!(std::fs::metadata(plain_path.as_path()), Ok(metadata) if metadata.is_file()) {
+            return Some(plain_path);
+        }
+        let compressed_path = compressed_rollout_path(plain_path.as_path());
+        if matches!(std::fs::metadata(compressed_path.as_path()), Ok(metadata) if metadata.is_file())
+        {
+            return Some(compressed_path);
+        }
+        None
+    }
+
+    pub(super) fn file_modified_time_blocking(path: &Path) -> Option<SystemTime> {
+        let plain_path = plain_rollout_path(path);
+        if let Ok(metadata) = std::fs::metadata(plain_path.as_path())
+            && metadata.is_file()
+        {
+            return metadata.modified().ok();
+        }
+        let compressed_path = compressed_rollout_path(plain_path.as_path());
+        if let Ok(metadata) = std::fs::metadata(compressed_path.as_path())
+            && metadata.is_file()
+        {
+            return metadata.modified().ok();
         }
         None
     }

--- a/codex-rs/rollout/src/lib.rs
+++ b/codex-rs/rollout/src/lib.rs
@@ -48,6 +48,7 @@ pub use list::ThreadListConfig;
 pub use list::ThreadListLayout;
 pub use list::ThreadSortKey;
 pub use list::ThreadsPage;
+pub use list::find_any_thread_path_by_id_str;
 pub use list::find_archived_thread_path_by_id_str;
 pub use list::find_thread_path_by_id_str;
 #[deprecated(note = "use find_thread_path_by_id_str")]

--- a/codex-rs/rollout/src/list.rs
+++ b/codex-rs/rollout/src/list.rs
@@ -1779,6 +1779,7 @@ async fn find_thread_path_by_id_str_in_subdir(
     };
     let thread_id = ThreadId::from_string(id_str).ok();
     let mut state_metadata_path = None;
+    let mut unverified_db_path = None;
     let mut fallback_reason = state_db_ctx.is_none().then_some("db_unavailable");
     if let Some(state_db_ctx) = state_db_ctx
         && let Some(thread_id) = thread_id
@@ -1829,6 +1830,7 @@ async fn find_thread_path_by_id_str_in_subdir(
                                 "state db returned rollout path for thread {id_str} that could not be verified: {}: {err}",
                                 existing_db_path.display()
                             );
+                            unverified_db_path = Some(existing_db_path);
                             fallback_reason = Some("unverified_path");
                         }
                     }
@@ -1899,7 +1901,7 @@ async fn find_thread_path_by_id_str_in_subdir(
         }
     }
 
-    Ok(found)
+    Ok(found.or(unverified_db_path))
 }
 
 async fn find_thread_path_by_id_str_in_any_subdir(

--- a/codex-rs/rollout/src/list.rs
+++ b/codex-rs/rollout/src/list.rs
@@ -1778,7 +1778,6 @@ async fn find_thread_path_by_id_str_in_subdir(
         _ => None,
     };
     let thread_id = ThreadId::from_string(id_str).ok();
-    let mut unverified_db_path = None;
     let mut state_metadata_path = None;
     let mut fallback_reason = state_db_ctx.is_none().then_some("db_unavailable");
     if let Some(state_db_ctx) = state_db_ctx
@@ -1830,7 +1829,7 @@ async fn find_thread_path_by_id_str_in_subdir(
                                 "state db returned rollout path for thread {id_str} that could not be verified: {}: {err}",
                                 existing_db_path.display()
                             );
-                            unverified_db_path = Some(existing_db_path);
+                            fallback_reason = Some("unverified_path");
                         }
                     }
                 } else {
@@ -1900,7 +1899,7 @@ async fn find_thread_path_by_id_str_in_subdir(
         }
     }
 
-    Ok(found.or(unverified_db_path))
+    Ok(found)
 }
 
 async fn find_thread_path_by_id_str_in_any_subdir(
@@ -1954,7 +1953,7 @@ async fn find_thread_path_by_id_str_in_any_subdir(
                                 "state db returned rollout path for thread {id_str} that could not be verified: {}: {err}",
                                 existing_db_path.display()
                             );
-                            return Ok(Some(existing_db_path));
+                            fallback_reason = Some("unverified_path");
                         }
                     }
                 } else {

--- a/codex-rs/rollout/src/list.rs
+++ b/codex-rs/rollout/src/list.rs
@@ -2028,7 +2028,7 @@ async fn find_thread_path_by_id_str_in_any_subdir(
     Ok(None)
 }
 
-async fn find_thread_path_by_id_str_in_subdir_without_db(
+pub(crate) async fn find_thread_path_by_id_str_in_subdir_without_db(
     codex_home: &Path,
     subdir: &str,
     id_str: &str,

--- a/codex-rs/rollout/src/list.rs
+++ b/codex-rs/rollout/src/list.rs
@@ -1914,6 +1914,7 @@ async fn find_thread_path_by_id_str_in_any_subdir(
     };
     let thread_id = ThreadId::from_string(id_str).ok();
     let mut preferred_subdir = None;
+    let mut unverified_db_path = None;
     let mut fallback_reason = state_db_ctx.is_none().then_some("db_unavailable");
     if let Some(state_db_ctx) = state_db_ctx
         && let Some(thread_id) = thread_id
@@ -1955,6 +1956,7 @@ async fn find_thread_path_by_id_str_in_any_subdir(
                                 "state db returned rollout path for thread {id_str} that could not be verified: {}: {err}",
                                 existing_db_path.display()
                             );
+                            unverified_db_path = Some(existing_db_path);
                             fallback_reason = Some("unverified_path");
                         }
                     }
@@ -2025,7 +2027,7 @@ async fn find_thread_path_by_id_str_in_any_subdir(
         }
     }
 
-    Ok(None)
+    Ok(unverified_db_path)
 }
 
 pub(crate) async fn find_thread_path_by_id_str_in_subdir_without_db(

--- a/codex-rs/rollout/src/list.rs
+++ b/codex-rs/rollout/src/list.rs
@@ -1,7 +1,12 @@
 #![allow(warnings, clippy::all)]
 
+use chrono::DateTime;
+use chrono::Datelike;
+use chrono::Timelike;
+use chrono::Utc;
 use codex_utils_path as path_utils;
 use std::cmp::Reverse;
+use std::collections::BinaryHeap;
 use std::ffi::OsStr;
 use std::io;
 use std::num::NonZero;
@@ -23,7 +28,6 @@ use crate::state_db;
 use codex_file_search as file_search;
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::RolloutItem;
-use codex_protocol::protocol::RolloutLine;
 use codex_protocol::protocol::SessionMetaLine;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::USER_MESSAGE_BEGIN;
@@ -515,11 +519,11 @@ async fn traverse_directories_for_paths_created(
     })
 }
 
-/// Walk the rollout directory tree to collect files by updated_at, then sort by
-/// file mtime (updated_at) and apply pagination/filtering in that order.
+/// Walk the rollout directory tree to collect files by updated_at, then pop
+/// candidates by file mtime (updated_at) and apply pagination/filtering in that order.
 ///
 /// Because updated_at is not encoded in filenames, this path must scan all
-/// files up to the scan cap, then sort and filter by the anchor cursor.
+/// files up to the scan cap, then order and filter by the anchor cursor.
 ///
 /// NOTE: This can be optimized in the future if we store additional state on disk
 /// to cache updated_at timestamps.
@@ -536,13 +540,24 @@ async fn traverse_directories_for_paths_updated(
     let mut anchor_state = AnchorState::new(anchor);
     let mut more_matches_available = false;
 
-    let mut candidates = collect_files_by_updated_at(&root, &mut scanned_files).await?;
-    candidates.sort_by_key(|candidate| {
-        let ts = candidate.updated_at.unwrap_or(OffsetDateTime::UNIX_EPOCH);
-        (Reverse(ts), Reverse(candidate.id))
-    });
+    if page_size == 1
+        && anchor_state.passed
+        && let Some(page) = try_latest_updated_at_page(
+            &root,
+            allowed_sources,
+            provider_matcher,
+            cwd_filters,
+            UpdatedAtScanLayout::Nested,
+        )
+        .await?
+    {
+        return Ok(page);
+    }
 
-    for candidate in candidates.into_iter() {
+    let mut candidates =
+        BinaryHeap::from(collect_files_by_updated_at(&root, &mut scanned_files).await?);
+
+    while let Some(candidate) = candidates.pop() {
         let ts = candidate.updated_at.unwrap_or(OffsetDateTime::UNIX_EPOCH);
         if anchor_state.should_skip(ts, candidate.id) {
             continue;
@@ -563,6 +578,10 @@ async fn traverse_directories_for_paths_updated(
         .await
         {
             items.push(item);
+            if items.len() == page_size && !candidates.is_empty() {
+                more_matches_available = true;
+                break;
+            }
         }
     }
 
@@ -654,13 +673,24 @@ async fn traverse_flat_paths_updated(
     let mut anchor_state = AnchorState::new(anchor);
     let mut more_matches_available = false;
 
-    let mut candidates = collect_flat_files_by_updated_at(&root, &mut scanned_files).await?;
-    candidates.sort_by_key(|candidate| {
-        let ts = candidate.updated_at.unwrap_or(OffsetDateTime::UNIX_EPOCH);
-        (Reverse(ts), Reverse(candidate.id))
-    });
+    if page_size == 1
+        && anchor_state.passed
+        && let Some(page) = try_latest_updated_at_page(
+            &root,
+            allowed_sources,
+            provider_matcher,
+            cwd_filters,
+            UpdatedAtScanLayout::Flat,
+        )
+        .await?
+    {
+        return Ok(page);
+    }
 
-    for candidate in candidates.into_iter() {
+    let mut candidates =
+        BinaryHeap::from(collect_flat_files_by_updated_at(&root, &mut scanned_files).await?);
+
+    while let Some(candidate) = candidates.pop() {
         let ts = candidate.updated_at.unwrap_or(OffsetDateTime::UNIX_EPOCH);
         if anchor_state.should_skip(ts, candidate.id) {
             continue;
@@ -681,6 +711,10 @@ async fn traverse_flat_paths_updated(
         .await
         {
             items.push(item);
+            if items.len() == page_size && !candidates.is_empty() {
+                more_matches_available = true;
+                break;
+            }
         }
     }
 
@@ -928,18 +962,60 @@ pub(crate) fn parse_timestamp_uuid_from_filename(name: &str) -> Option<(OffsetDa
     // Expected: rollout-YYYY-MM-DDThh-mm-ss-<uuid>.jsonl[.zst]
     let name = compression::parse_rollout_file_name(name)?;
     let core = name.strip_prefix("rollout-")?.strip_suffix(".jsonl")?;
-
-    // Scan from the right for a '-' such that the suffix parses as a UUID.
-    let (sep_idx, uuid) = core
-        .match_indices('-')
-        .rev()
-        .find_map(|(i, _)| Uuid::parse_str(&core[i + 1..]).ok().map(|u| (i, u)))?;
-
-    let ts_str = &core[..sep_idx];
-    let format: &[FormatItem] =
-        format_description!("[year]-[month]-[day]T[hour]-[minute]-[second]");
-    let ts = PrimitiveDateTime::parse(ts_str, format).ok()?.assume_utc();
+    let uuid_start = core.len().checked_sub(36)?;
+    let (ts_with_sep, uuid_str) = core.split_at(uuid_start);
+    let ts_str = ts_with_sep.strip_suffix('-')?;
+    let uuid = Uuid::parse_str(uuid_str).ok()?;
+    let ts = parse_rollout_filename_timestamp(ts_str)?;
     Some((ts, uuid))
+}
+
+fn parse_rollout_filename_timestamp(ts_str: &str) -> Option<OffsetDateTime> {
+    let bytes = ts_str.as_bytes();
+    if bytes.len() != 19
+        || bytes[4] != b'-'
+        || bytes[7] != b'-'
+        || bytes[10] != b'T'
+        || bytes[13] != b'-'
+        || bytes[16] != b'-'
+    {
+        return None;
+    }
+
+    let year = parse_decimal_i32(&bytes[0..4])?;
+    let month = parse_decimal_u8(&bytes[5..7])?;
+    let day = parse_decimal_u8(&bytes[8..10])?;
+    let hour = parse_decimal_u8(&bytes[11..13])?;
+    let minute = parse_decimal_u8(&bytes[14..16])?;
+    let second = parse_decimal_u8(&bytes[17..19])?;
+    let date =
+        time::Date::from_calendar_date(year, time::Month::try_from(month).ok()?, day).ok()?;
+    let time = time::Time::from_hms(hour, minute, second).ok()?;
+    Some(time::PrimitiveDateTime::new(date, time).assume_utc())
+}
+
+fn parse_decimal_i32(bytes: &[u8]) -> Option<i32> {
+    let mut value = 0i32;
+    for &byte in bytes {
+        let digit = byte.checked_sub(b'0')?;
+        if digit > 9 {
+            return None;
+        }
+        value = value.checked_mul(10)?.checked_add(i32::from(digit))?;
+    }
+    Some(value)
+}
+
+fn parse_decimal_u8(bytes: &[u8]) -> Option<u8> {
+    let mut value = 0u8;
+    for &byte in bytes {
+        let digit = byte.checked_sub(b'0')?;
+        if digit > 9 {
+            return None;
+        }
+        value = value.checked_mul(10)?.checked_add(digit)?;
+    }
+    Some(value)
 }
 
 struct ThreadCandidate {
@@ -948,16 +1024,107 @@ struct ThreadCandidate {
     updated_at: Option<OffsetDateTime>,
 }
 
+impl ThreadCandidate {
+    fn updated_at_or_epoch(&self) -> OffsetDateTime {
+        self.updated_at.unwrap_or(OffsetDateTime::UNIX_EPOCH)
+    }
+}
+
+impl Ord for ThreadCandidate {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.updated_at_or_epoch()
+            .cmp(&other.updated_at_or_epoch())
+            .then_with(|| self.id.cmp(&other.id))
+    }
+}
+
+impl PartialOrd for ThreadCandidate {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for ThreadCandidate {
+    fn eq(&self, other: &Self) -> bool {
+        self.updated_at_or_epoch() == other.updated_at_or_epoch() && self.id == other.id
+    }
+}
+
+impl Eq for ThreadCandidate {}
+
+#[derive(Clone, Copy)]
+enum UpdatedAtScanLayout {
+    Nested,
+    Flat,
+}
+
+struct LatestCandidateScan {
+    candidate: Option<ThreadCandidate>,
+    scanned_files: usize,
+    saw_more_candidates: bool,
+}
+
+async fn try_latest_updated_at_page(
+    root: &Path,
+    allowed_sources: &[SessionSource],
+    provider_matcher: Option<&ProviderMatcher<'_>>,
+    cwd_filters: Option<&[PathBuf]>,
+    layout: UpdatedAtScanLayout,
+) -> io::Result<Option<ThreadsPage>> {
+    let scan = match layout {
+        UpdatedAtScanLayout::Nested => latest_file_by_updated_at(root).await?,
+        UpdatedAtScanLayout::Flat => latest_flat_file_by_updated_at(root).await?,
+    };
+    let reached_scan_cap = scan.scanned_files >= MAX_SCAN_FILES;
+    if reached_scan_cap && matches!(layout, UpdatedAtScanLayout::Nested) {
+        return Ok(None);
+    }
+    let Some(candidate) = scan.candidate else {
+        return Ok(Some(ThreadsPage {
+            items: Vec::new(),
+            next_cursor: None,
+            num_scanned_files: scan.scanned_files,
+            reached_scan_cap,
+        }));
+    };
+
+    let updated_at_fallback = candidate.updated_at.and_then(format_rfc3339);
+    let Some(item) = build_thread_item(
+        candidate.path,
+        allowed_sources,
+        provider_matcher,
+        cwd_filters,
+        updated_at_fallback,
+    )
+    .await
+    else {
+        return Ok(None);
+    };
+
+    let items = vec![item];
+    let next_cursor = if scan.saw_more_candidates || reached_scan_cap {
+        build_next_cursor(&items, ThreadSortKey::UpdatedAt)
+    } else {
+        None
+    };
+    Ok(Some(ThreadsPage {
+        items,
+        next_cursor,
+        num_scanned_files: scan.scanned_files,
+        reached_scan_cap,
+    }))
+}
+
 async fn collect_files_by_updated_at(
     root: &Path,
     scanned_files: &mut usize,
 ) -> io::Result<Vec<ThreadCandidate>> {
-    let mut candidates = Vec::new();
-    let mut visitor = FilesByUpdatedAtVisitor {
-        candidates: &mut candidates,
-    };
-    walk_rollout_files(root, scanned_files, &mut visitor).await?;
-
+    let root = root.to_path_buf();
+    let (candidates, scanned) =
+        tokio::task::spawn_blocking(move || collect_files_by_updated_at_blocking(root.as_path()))
+            .await
+            .map_err(io::Error::other)??;
+    *scanned_files = scanned_files.saturating_add(scanned);
     Ok(candidates)
 }
 
@@ -965,42 +1132,363 @@ async fn collect_flat_files_by_updated_at(
     root: &Path,
     scanned_files: &mut usize,
 ) -> io::Result<Vec<ThreadCandidate>> {
+    let root = root.to_path_buf();
+    let (candidates, scanned) = tokio::task::spawn_blocking(move || {
+        collect_flat_files_by_updated_at_blocking(root.as_path())
+    })
+    .await
+    .map_err(io::Error::other)??;
+    *scanned_files = scanned_files.saturating_add(scanned);
+    Ok(candidates)
+}
+
+async fn latest_file_by_updated_at(root: &Path) -> io::Result<LatestCandidateScan> {
+    let root = root.to_path_buf();
+    tokio::task::spawn_blocking(move || latest_file_by_updated_at_blocking(root.as_path()))
+        .await
+        .map_err(io::Error::other)?
+}
+
+async fn latest_flat_file_by_updated_at(root: &Path) -> io::Result<LatestCandidateScan> {
+    let root = root.to_path_buf();
+    tokio::task::spawn_blocking(move || latest_flat_file_by_updated_at_blocking(root.as_path()))
+        .await
+        .map_err(io::Error::other)?
+}
+
+fn collect_files_by_updated_at_blocking(root: &Path) -> io::Result<(Vec<ThreadCandidate>, usize)> {
     let mut candidates = Vec::new();
-    let mut dir = tokio::fs::read_dir(root).await?;
-    while let Some(entry) = dir.next_entry().await? {
-        if *scanned_files >= MAX_SCAN_FILES {
+    let mut scanned_files = 0usize;
+
+    let year_dirs = collect_dirs_desc_blocking(root, |s| s.parse::<u16>().ok())?;
+    'outer: for (_year, year_path) in year_dirs.iter() {
+        if scanned_files >= MAX_SCAN_FILES {
             break;
         }
-        if !entry
-            .file_type()
-            .await
-            .map(|ft| ft.is_file())
-            .unwrap_or(false)
-        {
-            continue;
+        let month_dirs = collect_dirs_desc_blocking(year_path, |s| s.parse::<u8>().ok())?;
+        for (_month, month_path) in month_dirs.iter() {
+            if scanned_files >= MAX_SCAN_FILES {
+                break 'outer;
+            }
+            let day_dirs = collect_dirs_desc_blocking(month_path, |s| s.parse::<u8>().ok())?;
+            for (_day, day_path) in day_dirs.iter() {
+                if scanned_files >= MAX_SCAN_FILES {
+                    break 'outer;
+                }
+                let mut day_files = collect_rollout_day_files_with_updated_at_blocking(day_path)?;
+                let remaining = MAX_SCAN_FILES.saturating_sub(scanned_files);
+                if day_files.len() > remaining {
+                    day_files.sort_unstable_by_key(|(id, path, _updated_at)| {
+                        (
+                            Reverse(rollout_created_at_from_path(path.as_path())),
+                            Reverse(*id),
+                        )
+                    });
+                }
+                for (id, path, updated_at) in day_files.into_iter().take(remaining) {
+                    scanned_files += 1;
+                    candidates.push(ThreadCandidate {
+                        updated_at,
+                        path,
+                        id,
+                    });
+                }
+                if scanned_files >= MAX_SCAN_FILES {
+                    break 'outer;
+                }
+            }
         }
-        let Some(rollout_file) = compression::RolloutFile::from_path(entry.path()) else {
-            continue;
-        };
-        let Some((_ts, id)) = parse_timestamp_uuid_from_filename(rollout_file.plain_file_name())
-        else {
-            continue;
-        };
-        *scanned_files += 1;
-        if *scanned_files > MAX_SCAN_FILES {
+    }
+
+    Ok((candidates, scanned_files))
+}
+
+fn latest_file_by_updated_at_blocking(root: &Path) -> io::Result<LatestCandidateScan> {
+    let mut scan = LatestCandidateScan {
+        candidate: None,
+        scanned_files: 0,
+        saw_more_candidates: false,
+    };
+
+    let year_dirs = collect_dirs_desc_blocking(root, |s| s.parse::<u16>().ok())?;
+    'outer: for (_year, year_path) in year_dirs.iter() {
+        if scan.scanned_files >= MAX_SCAN_FILES {
             break;
         }
-        let updated_at = file_modified_time(rollout_file.path())
-            .await
-            .unwrap_or(None);
+        let month_dirs = collect_dirs_desc_blocking(year_path, |s| s.parse::<u8>().ok())?;
+        for (_month, month_path) in month_dirs.iter() {
+            if scan.scanned_files >= MAX_SCAN_FILES {
+                break 'outer;
+            }
+            let day_dirs = collect_dirs_desc_blocking(month_path, |s| s.parse::<u8>().ok())?;
+            for (_day, day_path) in day_dirs.iter() {
+                if scan.scanned_files >= MAX_SCAN_FILES {
+                    break 'outer;
+                }
+                let dir = match std::fs::read_dir(day_path) {
+                    Ok(dir) => dir,
+                    Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+                    Err(err) => return Err(err),
+                };
+                for entry in dir {
+                    if scan.scanned_files >= MAX_SCAN_FILES {
+                        break 'outer;
+                    }
+                    let entry = entry?;
+                    consider_latest_updated_at_entry(&entry, &mut scan);
+                }
+            }
+        }
+    }
+
+    Ok(scan)
+}
+
+fn collect_flat_files_by_updated_at_blocking(
+    root: &Path,
+) -> io::Result<(Vec<ThreadCandidate>, usize)> {
+    let mut candidates = Vec::new();
+    let mut scanned_files = 0usize;
+    let dir = match std::fs::read_dir(root) {
+        Ok(dir) => dir,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok((candidates, 0)),
+        Err(err) => return Err(err),
+    };
+    for entry in dir {
+        if scanned_files >= MAX_SCAN_FILES {
+            break;
+        }
+        let entry = entry?;
+        if !entry.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
+            continue;
+        }
+        let Some((id, path)) = rollout_id_path_from_blocking_dir_entry(&entry) else {
+            continue;
+        };
+        scanned_files += 1;
+        if scanned_files > MAX_SCAN_FILES {
+            break;
+        }
+        let updated_at = entry
+            .metadata()
+            .ok()
+            .and_then(|metadata| modified_time_from_metadata(&metadata));
         candidates.push(ThreadCandidate {
-            path: rollout_file.into_path(),
-            id,
             updated_at,
+            path,
+            id,
         });
     }
 
-    Ok(candidates)
+    Ok((candidates, scanned_files))
+}
+
+fn latest_flat_file_by_updated_at_blocking(root: &Path) -> io::Result<LatestCandidateScan> {
+    let mut scan = LatestCandidateScan {
+        candidate: None,
+        scanned_files: 0,
+        saw_more_candidates: false,
+    };
+    let dir = match std::fs::read_dir(root) {
+        Ok(dir) => dir,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(scan),
+        Err(err) => return Err(err),
+    };
+    for entry in dir {
+        if scan.scanned_files >= MAX_SCAN_FILES {
+            break;
+        }
+        let entry = entry?;
+        consider_latest_updated_at_entry(&entry, &mut scan);
+    }
+    Ok(scan)
+}
+
+fn collect_dirs_desc_blocking<T, F>(parent: &Path, parse: F) -> io::Result<Vec<(T, PathBuf)>>
+where
+    T: Ord + Copy,
+    F: Fn(&str) -> Option<T>,
+{
+    let dir = match std::fs::read_dir(parent) {
+        Ok(dir) => dir,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(err),
+    };
+    let mut vec = Vec::new();
+    for entry in dir {
+        let entry = entry?;
+        if entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false)
+            && let Some(s) = entry.file_name().to_str()
+            && let Some(v) = parse(s)
+        {
+            vec.push((v, entry.path()));
+        }
+    }
+    vec.sort_by_key(|(v, _)| Reverse(*v));
+    Ok(vec)
+}
+
+fn collect_rollout_day_files_blocking(
+    day_path: &Path,
+) -> io::Result<Vec<(OffsetDateTime, Uuid, PathBuf)>> {
+    let dir = match std::fs::read_dir(day_path) {
+        Ok(dir) => dir,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(err),
+    };
+    let mut day_files = Vec::new();
+    for entry in dir {
+        let entry = entry?;
+        if !entry.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
+            continue;
+        }
+        if let Some((ts, id, path)) = rollout_parts_from_blocking_dir_entry(&entry) {
+            day_files.push((ts, id, path));
+        }
+    }
+    day_files.sort_by_key(|(ts, sid, _path)| (Reverse(*ts), Reverse(*sid)));
+    Ok(day_files)
+}
+
+fn collect_rollout_day_files_with_updated_at_blocking(
+    day_path: &Path,
+) -> io::Result<Vec<(Uuid, PathBuf, Option<OffsetDateTime>)>> {
+    let dir = match std::fs::read_dir(day_path) {
+        Ok(dir) => dir,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(err),
+    };
+    let mut day_files = Vec::new();
+    for entry in dir {
+        let entry = entry?;
+        if !entry.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
+            continue;
+        }
+        if let Some((id, path)) = rollout_id_path_from_blocking_dir_entry(&entry) {
+            let updated_at = entry
+                .metadata()
+                .ok()
+                .and_then(|metadata| modified_time_from_metadata(&metadata));
+            day_files.push((id, path, updated_at));
+        }
+    }
+    Ok(day_files)
+}
+
+fn rollout_parts_from_blocking_dir_entry(
+    entry: &std::fs::DirEntry,
+) -> Option<(OffsetDateTime, Uuid, PathBuf)> {
+    let file_name = entry.file_name();
+    let file_name = file_name.to_str()?;
+    let plain_file_name = compression::parse_rollout_file_name(file_name)?;
+    if plain_file_name.len() == file_name.len() {
+        let (ts, id) = parse_timestamp_uuid_from_filename(plain_file_name)?;
+        return Some((ts, id, entry.path()));
+    }
+
+    let rollout_file = compression::RolloutFile::from_path(entry.path())?;
+    let (ts, id) = parse_timestamp_uuid_from_filename(rollout_file.plain_file_name())?;
+    Some((ts, id, rollout_file.into_path()))
+}
+
+fn rollout_id_path_from_blocking_dir_entry(entry: &std::fs::DirEntry) -> Option<(Uuid, PathBuf)> {
+    let file_name = entry.file_name();
+    let file_name = file_name.to_str()?;
+    let plain_file_name = compression::parse_rollout_file_name(file_name)?;
+    let id = parse_uuid_from_plain_rollout_file_name(plain_file_name)?;
+    if plain_file_name.len() == file_name.len() {
+        return Some((id, entry.path()));
+    }
+
+    let rollout_file = compression::RolloutFile::from_path(entry.path())?;
+    Some((id, rollout_file.into_path()))
+}
+
+fn consider_latest_updated_at_entry(entry: &std::fs::DirEntry, scan: &mut LatestCandidateScan) {
+    if !entry.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
+        return;
+    }
+    let file_name = entry.file_name();
+    let Some(file_name) = file_name.to_str() else {
+        return;
+    };
+    let Some(plain_file_name) = compression::parse_rollout_file_name(file_name) else {
+        return;
+    };
+    let Some(id) = parse_uuid_from_plain_rollout_file_name(plain_file_name) else {
+        return;
+    };
+
+    let compressed_rollout = if plain_file_name.len() == file_name.len() {
+        None
+    } else {
+        let Some(rollout_file) = compression::RolloutFile::from_path(entry.path()) else {
+            return;
+        };
+        Some(rollout_file)
+    };
+    let updated_at = entry
+        .metadata()
+        .ok()
+        .and_then(|metadata| modified_time_from_metadata(&metadata));
+
+    scan.scanned_files = scan.scanned_files.saturating_add(1);
+    let is_newer = scan
+        .candidate
+        .as_ref()
+        .is_none_or(|best| candidate_is_newer(best, updated_at, id));
+    if !is_newer {
+        scan.saw_more_candidates = true;
+        return;
+    }
+    if scan.candidate.is_some() {
+        scan.saw_more_candidates = true;
+    }
+    let path = compressed_rollout.map_or_else(|| entry.path(), compression::RolloutFile::into_path);
+    scan.candidate = Some(ThreadCandidate {
+        path,
+        id,
+        updated_at,
+    });
+}
+
+fn candidate_is_newer(
+    best: &ThreadCandidate,
+    updated_at: Option<OffsetDateTime>,
+    id: Uuid,
+) -> bool {
+    updated_at.unwrap_or(OffsetDateTime::UNIX_EPOCH) > best.updated_at_or_epoch()
+        || (updated_at.unwrap_or(OffsetDateTime::UNIX_EPOCH) == best.updated_at_or_epoch()
+            && id > best.id)
+}
+
+fn parse_uuid_from_plain_rollout_file_name(name: &str) -> Option<Uuid> {
+    let core = name.strip_prefix("rollout-")?.strip_suffix(".jsonl")?;
+    let uuid_start = core.len().checked_sub(36)?;
+    if uuid_start == 0 || core.as_bytes().get(uuid_start - 1) != Some(&b'-') {
+        return None;
+    }
+    Uuid::parse_str(&core[uuid_start..]).ok()
+}
+
+fn rollout_created_at_from_path(path: &Path) -> OffsetDateTime {
+    path.file_name()
+        .and_then(OsStr::to_str)
+        .and_then(parse_timestamp_uuid_from_filename)
+        .map(|(ts, _id)| ts)
+        .unwrap_or(OffsetDateTime::UNIX_EPOCH)
+}
+
+fn modified_time_from_metadata(metadata: &std::fs::Metadata) -> Option<OffsetDateTime> {
+    metadata
+        .modified()
+        .ok()
+        .map(OffsetDateTime::from)
+        .and_then(truncate_to_millis)
+}
+
+fn file_modified_time_blocking(path: &Path) -> Option<OffsetDateTime> {
+    compression::file_modified_time_blocking(path).and_then(truncate_to_millis)
 }
 
 async fn walk_rollout_files(
@@ -1087,10 +1575,10 @@ async fn read_head_summary(path: &Path, head_limit: usize) -> io::Result<HeadTai
         }
         lines_scanned += 1;
 
-        let parsed: Result<RolloutLine, _> = serde_json::from_str(trimmed);
-        let Ok(rollout_line) = parsed else { continue };
+        let parsed: Result<RolloutItem, _> = serde_json::from_str(trimmed);
+        let Ok(rollout_item) = parsed else { continue };
 
-        match rollout_line.item {
+        match rollout_item {
             RolloutItem::SessionMeta(session_meta_line) => {
                 if !summary.saw_session_meta {
                     summary.source = Some(session_meta_line.meta.source.clone());
@@ -1118,9 +1606,8 @@ async fn read_head_summary(path: &Path, head_limit: usize) -> io::Result<HeadTai
                 }
             }
             RolloutItem::ResponseItem(_) | RolloutItem::InterAgentCommunication(_) => {
-                summary
-                    .created_at
-                    .get_or_insert_with(|| rollout_line.timestamp.clone());
+                // The listing path only returns files with session metadata, which carries
+                // the canonical creation timestamp.
             }
             RolloutItem::TurnContext(_) => {
                 // Not included in `head`; skip.
@@ -1167,8 +1654,8 @@ pub async fn read_head_for_summary(path: &Path) -> io::Result<Vec<serde_json::Va
         if trimmed.is_empty() {
             continue;
         }
-        if let Ok(rollout_line) = serde_json::from_str::<RolloutLine>(trimmed) {
-            match rollout_line.item {
+        if let Ok(rollout_item) = serde_json::from_str::<RolloutItem>(trimmed) {
+            match rollout_item {
                 RolloutItem::SessionMeta(session_meta_line) => {
                     if let Ok(value) = serde_json::to_value(session_meta_line) {
                         head.push(value);
@@ -1229,19 +1716,32 @@ fn event_msg_preview(event: &EventMsg) -> Option<String> {
 /// Read the SessionMetaLine from the head of a rollout file for reuse by
 /// callers that need the session metadata (e.g. to derive a cwd for config).
 pub async fn read_session_meta_line(path: &Path) -> io::Result<SessionMetaLine> {
-    let head = read_head_for_summary(path).await?;
-    let Some(first) = head.first() else {
-        return Err(io::Error::other(format!(
-            "rollout at {} is empty",
-            path.display()
-        )));
-    };
-    serde_json::from_value::<SessionMetaLine>(first.clone()).map_err(|_| {
-        io::Error::other(format!(
-            "rollout at {} does not start with session metadata",
-            path.display()
-        ))
-    })
+    let mut lines = compression::open_rollout_line_reader(path).await?;
+    while let Some(line) = lines.next_line().await? {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(rollout_item) = serde_json::from_str::<RolloutItem>(trimmed) else {
+            continue;
+        };
+        return match rollout_item {
+            RolloutItem::SessionMeta(session_meta_line) => Ok(session_meta_line),
+            RolloutItem::ResponseItem(_) | RolloutItem::InterAgentCommunication(_) => {
+                Err(io::Error::other(format!(
+                    "rollout at {} does not start with session metadata",
+                    path.display()
+                )))
+            }
+            RolloutItem::Compacted(_) | RolloutItem::TurnContext(_) | RolloutItem::EventMsg(_) => {
+                continue;
+            }
+        };
+    }
+    Err(io::Error::other(format!(
+        "rollout at {} is empty",
+        path.display()
+    )))
 }
 
 async fn file_modified_time(path: &Path) -> io::Result<Option<OffsetDateTime>> {
@@ -1266,9 +1766,9 @@ async fn find_thread_path_by_id_str_in_subdir(
     state_db_ctx: Option<&codex_state::StateRuntime>,
 ) -> io::Result<Option<PathBuf>> {
     // Validate UUID format early.
-    if Uuid::parse_str(id_str).is_err() {
+    let Ok(target_uuid) = Uuid::parse_str(id_str) else {
         return Ok(None);
-    }
+    };
 
     // Prefer DB lookup, then fall back to rollout file search.
     // TODO(jif): sqlite migration phase 1
@@ -1279,18 +1779,22 @@ async fn find_thread_path_by_id_str_in_subdir(
     };
     let thread_id = ThreadId::from_string(id_str).ok();
     let mut unverified_db_path = None;
+    let mut state_metadata_path = None;
     let mut fallback_reason = state_db_ctx.is_none().then_some("db_unavailable");
     if let Some(state_db_ctx) = state_db_ctx
         && let Some(thread_id) = thread_id
     {
         match state_db_ctx
-            .find_rollout_path_by_id(thread_id, archived_only)
+            .find_rollout_path_and_created_at_by_id(thread_id, archived_only)
             .await
         {
-            Ok(Some(db_path)) => {
+            Ok(Some((db_path, created_at))) => {
                 if let Some(existing_db_path) =
-                    compression::existing_rollout_path(db_path.as_path()).await
+                    compression::existing_rollout_path_blocking(db_path.as_path())
                 {
+                    if rollout_file_name_matches_uuid(existing_db_path.as_path(), target_uuid) {
+                        return Ok(Some(existing_db_path));
+                    }
                     match read_session_meta_line(&existing_db_path).await {
                         Ok(meta_line) if meta_line.meta.id == thread_id => {
                             return Ok(Some(existing_db_path));
@@ -1309,6 +1813,17 @@ async fn find_thread_path_by_id_str_in_subdir(
                                 "mismatch",
                                 /*telemetry_override*/ None,
                             );
+                            state_metadata_path = find_rollout_path_by_id_from_state_created_at(
+                                codex_home,
+                                subdir,
+                                target_uuid,
+                                thread_id,
+                                archived_only,
+                                state_db_ctx,
+                                db_path.as_path(),
+                                created_at,
+                            )
+                            .await;
                         }
                         Err(err) => {
                             tracing::debug!(
@@ -1331,6 +1846,17 @@ async fn find_thread_path_by_id_str_in_subdir(
                         "stale_path",
                         /*telemetry_override*/ None,
                     );
+                    state_metadata_path = find_rollout_path_by_id_from_state_created_at(
+                        codex_home,
+                        subdir,
+                        target_uuid,
+                        thread_id,
+                        archived_only,
+                        state_db_ctx,
+                        db_path.as_path(),
+                        created_at,
+                    )
+                    .await;
                 }
             }
             Ok(None) => fallback_reason = Some("missing_row"),
@@ -1343,61 +1869,13 @@ async fn find_thread_path_by_id_str_in_subdir(
         }
     }
 
-    let mut root = codex_home.to_path_buf();
-    root.push(subdir);
-    if !root.exists() {
-        return Ok(unverified_db_path);
-    }
-    let (filename_match, filename_scan_error) = match find_rollout_path_by_id_from_filenames(
-        root.as_path(),
-        id_str,
-    )
-    .await
-    {
-        Ok(path) => (path, None),
-        Err(err) => {
-            tracing::warn!(
-                "rollout filename lookup failed during find_thread_path_by_id_str_in_subdir: {err}"
-            );
-            (None, Some(err))
+    let mut found_path_repaired = false;
+    let found = match state_metadata_path {
+        Some((path, repaired)) => {
+            found_path_repaired = repaired;
+            Some(path)
         }
-    };
-
-    let found = match filename_match {
-        Some(path) => Some(path),
-        None => {
-            // This is safe because we know the values are valid.
-            #[allow(clippy::unwrap_used)]
-            let limit = NonZero::new(1).unwrap();
-            let options = file_search::FileSearchOptions {
-                limit,
-                compute_indices: false,
-                respect_gitignore: false,
-                ..Default::default()
-            };
-
-            let results = file_search::run(
-                id_str,
-                vec![root.clone()],
-                options,
-                /*cancel_flag*/ None,
-            )
-            .map_err(|e| io::Error::other(format!("file search failed: {e}")))?;
-
-            let found = results
-                .matches
-                .into_iter()
-                .map(|m| m.full_path())
-                .find_map(compression::RolloutFile::from_path)
-                .map(compression::RolloutFile::into_path);
-
-            if found.is_none()
-                && let Some(err) = filename_scan_error
-            {
-                return Err(err);
-            }
-            found
-        }
+        None => find_thread_path_by_id_str_in_subdir_without_db(codex_home, subdir, id_str).await?,
     };
     if let Some(found_path) = found.as_ref() {
         tracing::debug!("state db missing rollout path for thread {id_str}");
@@ -1411,16 +1889,289 @@ async fn find_thread_path_by_id_str_in_subdir(
                 /*telemetry_override*/ None,
             );
         }
-        state_db::read_repair_rollout_path(
-            state_db_ctx,
-            thread_id,
-            archived_only,
-            found_path.as_path(),
-        )
-        .await;
+        if !found_path_repaired {
+            state_db::read_repair_rollout_path(
+                state_db_ctx,
+                thread_id,
+                archived_only,
+                found_path.as_path(),
+            )
+            .await;
+        }
     }
 
     Ok(found.or(unverified_db_path))
+}
+
+async fn find_thread_path_by_id_str_in_any_subdir(
+    codex_home: &Path,
+    id_str: &str,
+    state_db_ctx: Option<&codex_state::StateRuntime>,
+) -> io::Result<Option<PathBuf>> {
+    let Ok(target_uuid) = Uuid::parse_str(id_str) else {
+        return Ok(None);
+    };
+    let thread_id = ThreadId::from_string(id_str).ok();
+    let mut preferred_subdir = None;
+    let mut fallback_reason = state_db_ctx.is_none().then_some("db_unavailable");
+    if let Some(state_db_ctx) = state_db_ctx
+        && let Some(thread_id) = thread_id
+    {
+        match state_db_ctx
+            .find_rollout_path_and_created_at_by_id(thread_id, /*archived_only*/ None)
+            .await
+        {
+            Ok(Some((db_path, created_at))) => {
+                preferred_subdir = rollout_subdir_hint(codex_home, db_path.as_path());
+                if let Some(existing_db_path) =
+                    compression::existing_rollout_path_blocking(db_path.as_path())
+                {
+                    if rollout_file_name_matches_uuid(existing_db_path.as_path(), target_uuid) {
+                        return Ok(Some(existing_db_path));
+                    }
+                    match read_session_meta_line(&existing_db_path).await {
+                        Ok(meta_line) if meta_line.meta.id == thread_id => {
+                            return Ok(Some(existing_db_path));
+                        }
+                        Ok(meta_line) => {
+                            tracing::error!(
+                                "state db returned rollout path for thread {id_str} but file belongs to thread {}: {}",
+                                meta_line.meta.id,
+                                existing_db_path.display()
+                            );
+                            tracing::warn!(
+                                "state db discrepancy during find_thread_path_by_id_str_in_any_subdir: mismatched_db_path"
+                            );
+                            codex_state::record_fallback(
+                                "find_thread_path",
+                                "mismatch",
+                                /*telemetry_override*/ None,
+                            );
+                            fallback_reason = Some("mismatch");
+                        }
+                        Err(err) => {
+                            tracing::debug!(
+                                "state db returned rollout path for thread {id_str} that could not be verified: {}: {err}",
+                                existing_db_path.display()
+                            );
+                            return Ok(Some(existing_db_path));
+                        }
+                    }
+                } else {
+                    tracing::error!(
+                        "state db returned stale rollout path for thread {id_str}: {}",
+                        db_path.display()
+                    );
+                    tracing::warn!(
+                        "state db discrepancy during find_thread_path_by_id_str_in_any_subdir: stale_db_path"
+                    );
+                    codex_state::record_fallback(
+                        "find_thread_path",
+                        "stale_path",
+                        /*telemetry_override*/ None,
+                    );
+                    fallback_reason = Some("stale_path");
+                }
+                if let Some(subdir) = preferred_subdir
+                    && let Some((path, _repaired)) = find_rollout_path_by_id_from_state_created_at(
+                        codex_home,
+                        subdir,
+                        target_uuid,
+                        thread_id,
+                        archived_only_for_subdir(subdir),
+                        state_db_ctx,
+                        db_path.as_path(),
+                        created_at,
+                    )
+                    .await
+                {
+                    return Ok(Some(path));
+                }
+            }
+            Ok(None) => fallback_reason = Some("missing_row"),
+            Err(err) => {
+                tracing::warn!(
+                    "state db find_rollout_path_by_id failed during find_any_path_query: {err}"
+                );
+                fallback_reason = Some("db_error");
+            }
+        }
+    }
+
+    for (subdir, archived_only) in ordered_session_subdirs(preferred_subdir) {
+        if let Some(path) =
+            find_thread_path_by_id_str_in_subdir_without_db(codex_home, subdir, id_str).await?
+        {
+            tracing::debug!("state db missing rollout path for thread {id_str}");
+            tracing::warn!(
+                "state db discrepancy during find_thread_path_by_id_str_in_any_subdir: falling_back"
+            );
+            if let Some(reason) = fallback_reason {
+                codex_state::record_fallback(
+                    "find_thread_path",
+                    reason,
+                    /*telemetry_override*/ None,
+                );
+            }
+            state_db::read_repair_rollout_path(
+                state_db_ctx,
+                thread_id,
+                archived_only,
+                path.as_path(),
+            )
+            .await;
+            return Ok(Some(path));
+        }
+    }
+
+    Ok(None)
+}
+
+async fn find_thread_path_by_id_str_in_subdir_without_db(
+    codex_home: &Path,
+    subdir: &str,
+    id_str: &str,
+) -> io::Result<Option<PathBuf>> {
+    let mut root = codex_home.to_path_buf();
+    root.push(subdir);
+    if !root.exists() {
+        return Ok(None);
+    }
+    let (filename_match, filename_scan_error) = match find_rollout_path_by_id_from_filenames(
+        root.as_path(),
+        id_str,
+    )
+    .await
+    {
+        Ok(path) => (path, None),
+        Err(err) => {
+            tracing::warn!(
+                "rollout filename lookup failed during find_thread_path_by_id_str fallback scan: {err}"
+            );
+            (None, Some(err))
+        }
+    };
+
+    match filename_match {
+        Some(path) => Ok(Some(path)),
+        None => {
+            #[allow(clippy::unwrap_used)]
+            let limit = NonZero::new(1).unwrap();
+            let options = file_search::FileSearchOptions {
+                limit,
+                compute_indices: false,
+                respect_gitignore: false,
+                ..Default::default()
+            };
+
+            let results = file_search::run(id_str, vec![root], options, /*cancel_flag*/ None)
+                .map_err(|e| io::Error::other(format!("file search failed: {e}")))?;
+
+            let found = results
+                .matches
+                .into_iter()
+                .map(|m| m.full_path())
+                .find_map(compression::RolloutFile::from_path)
+                .map(compression::RolloutFile::into_path);
+
+            if found.is_none()
+                && let Some(err) = filename_scan_error
+            {
+                return Err(err);
+            }
+            Ok(found)
+        }
+    }
+}
+
+fn archived_only_for_subdir(subdir: &str) -> Option<bool> {
+    match subdir {
+        SESSIONS_SUBDIR => Some(false),
+        ARCHIVED_SESSIONS_SUBDIR => Some(true),
+        _ => None,
+    }
+}
+
+fn rollout_subdir_hint(codex_home: &Path, path: &Path) -> Option<&'static str> {
+    if path.starts_with(codex_home.join(ARCHIVED_SESSIONS_SUBDIR)) {
+        return Some(ARCHIVED_SESSIONS_SUBDIR);
+    }
+    if path.starts_with(codex_home.join(SESSIONS_SUBDIR)) {
+        return Some(SESSIONS_SUBDIR);
+    }
+    None
+}
+
+fn ordered_session_subdirs(
+    preferred_subdir: Option<&'static str>,
+) -> [(&'static str, Option<bool>); 2] {
+    match preferred_subdir {
+        Some(ARCHIVED_SESSIONS_SUBDIR) => [
+            (ARCHIVED_SESSIONS_SUBDIR, Some(true)),
+            (SESSIONS_SUBDIR, Some(false)),
+        ],
+        _ => [
+            (SESSIONS_SUBDIR, Some(false)),
+            (ARCHIVED_SESSIONS_SUBDIR, Some(true)),
+        ],
+    }
+}
+
+async fn find_rollout_path_by_id_from_state_created_at(
+    codex_home: &Path,
+    subdir: &str,
+    target_uuid: Uuid,
+    thread_id: ThreadId,
+    archived_only: Option<bool>,
+    state_db_ctx: &codex_state::StateRuntime,
+    stale_path: &Path,
+    created_at: DateTime<Utc>,
+) -> Option<(PathBuf, bool)> {
+    let file_name = format!(
+        "rollout-{:04}-{:02}-{:02}T{:02}-{:02}-{:02}-{target_uuid}.jsonl",
+        created_at.year(),
+        created_at.month(),
+        created_at.day(),
+        created_at.hour(),
+        created_at.minute(),
+        created_at.second(),
+    );
+    let candidate = if subdir == ARCHIVED_SESSIONS_SUBDIR {
+        codex_home.join(subdir).join(file_name)
+    } else {
+        codex_home
+            .join(subdir)
+            .join(format!("{:04}", created_at.year()))
+            .join(format!("{:02}", created_at.month()))
+            .join(format!("{:02}", created_at.day()))
+            .join(file_name)
+    };
+    let existing_path = compression::existing_rollout_path_blocking(candidate.as_path())?;
+    if !rollout_file_name_matches_uuid(existing_path.as_path(), target_uuid) {
+        return None;
+    }
+    let repaired = state_db_ctx
+        .update_thread_rollout_path_if_current(
+            thread_id,
+            stale_path,
+            existing_path.as_path(),
+            archived_only,
+        )
+        .await
+        .unwrap_or_else(|err| {
+            tracing::warn!(
+                "state db stale path direct repair failed for thread {thread_id}: {err}"
+            );
+            false
+        });
+    Some((existing_path, repaired))
+}
+
+fn rollout_file_name_matches_uuid(path: &Path, target: Uuid) -> bool {
+    path.file_name()
+        .and_then(OsStr::to_str)
+        .and_then(parse_timestamp_uuid_from_filename)
+        .is_some_and(|(_ts, id)| id == target)
 }
 
 async fn find_rollout_path_by_id_from_filenames(
@@ -1430,33 +2181,41 @@ async fn find_rollout_path_by_id_from_filenames(
     let Ok(target) = Uuid::parse_str(id_str) else {
         return Ok(None);
     };
+    let root = root.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        find_rollout_path_by_id_from_filenames_blocking(root.as_path(), target)
+    })
+    .await
+    .map_err(io::Error::other)?
+}
+
+fn find_rollout_path_by_id_from_filenames_blocking(
+    root: &Path,
+    target: Uuid,
+) -> io::Result<Option<PathBuf>> {
     let mut stack = vec![root.to_path_buf()];
     while let Some(dir) = stack.pop() {
-        let mut read_dir = match tokio::fs::read_dir(dir.as_path()).await {
+        let read_dir = match std::fs::read_dir(dir.as_path()) {
             Ok(read_dir) => read_dir,
             Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
             Err(err) => return Err(err),
         };
-        while let Some(entry) = read_dir.next_entry().await? {
-            let path = entry.path();
-            let file_type = entry.file_type().await?;
+        for entry in read_dir {
+            let entry = entry?;
+            let file_type = entry.file_type()?;
             if file_type.is_dir() {
+                let path = entry.path();
                 stack.push(path);
                 continue;
             }
             if !file_type.is_file() {
                 continue;
             }
-            let Some(rollout_file) = compression::RolloutFile::from_path(path) else {
-                continue;
-            };
-            let Some((_ts, id)) =
-                parse_timestamp_uuid_from_filename(rollout_file.plain_file_name())
-            else {
+            let Some((_ts, id, path)) = rollout_parts_from_blocking_dir_entry(&entry) else {
                 continue;
             };
             if id == target {
-                return Ok(Some(rollout_file.into_path()));
+                return Ok(Some(path));
             }
         }
     }
@@ -1482,6 +2241,15 @@ pub async fn find_archived_thread_path_by_id_str(
 ) -> io::Result<Option<PathBuf>> {
     find_thread_path_by_id_str_in_subdir(codex_home, ARCHIVED_SESSIONS_SUBDIR, id_str, state_db_ctx)
         .await
+}
+
+/// Locate a recorded thread rollout file by UUID across active and archived session roots.
+pub async fn find_any_thread_path_by_id_str(
+    codex_home: &Path,
+    id_str: &str,
+    state_db_ctx: Option<&codex_state::StateRuntime>,
+) -> io::Result<Option<PathBuf>> {
+    find_thread_path_by_id_str_in_any_subdir(codex_home, id_str, state_db_ctx).await
 }
 
 /// Extract the `YYYY/MM/DD` directory components from a rollout filename.

--- a/codex-rs/rollout/src/recorder.rs
+++ b/codex-rs/rollout/src/recorder.rs
@@ -1,9 +1,13 @@
 //! Persist Codex session rollouts (.jsonl) so sessions can be replayed or inspected later.
 
 use std::collections::HashSet;
+use std::ffi::OsStr;
 use std::fs;
 use std::fs::File;
+use std::io::BufRead;
+use std::io::BufReader;
 use std::io::Error as IoError;
+use std::io::ErrorKind;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -13,6 +17,7 @@ use chrono::SecondsFormat;
 use codex_protocol::ThreadId;
 use codex_protocol::dynamic_tools::DynamicToolSpec;
 use codex_protocol::models::BaseInstructions;
+use codex_protocol::models::ResponseItem;
 use serde_json::Value;
 use time::OffsetDateTime;
 use time::format_description::FormatItem;
@@ -55,13 +60,15 @@ use codex_protocol::protocol::InitialHistory;
 use codex_protocol::protocol::MultiAgentVersion;
 use codex_protocol::protocol::ResumedHistory;
 use codex_protocol::protocol::RolloutItem;
-use codex_protocol::protocol::RolloutLine;
 use codex_protocol::protocol::SessionMeta;
 use codex_protocol::protocol::SessionMetaLine;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::ThreadSource;
 use codex_state::StateRuntime;
 use codex_utils_path as path_utils;
+
+const ROLLOUT_HISTORY_READ_BUFFER_SIZE: usize = 64 * 1024;
+const ROLLOUT_HISTORY_BYTES_PER_ITEM_HINT: u64 = 128;
 
 /// Writes canonical session rollout items to JSONL.
 ///
@@ -389,9 +396,14 @@ impl RolloutRecorder {
             || model_providers.is_some()
             || cwd_filters.is_some()
             || search_term.is_some();
-        // Filesystem-first listing intentionally overfetches so we can repair stale/missing
-        // SQLite rows before returning the scan page for filtered listings or the DB page for
-        // unfiltered listings.
+        // Filesystem-first listing intentionally overfetches only when SQLite is present, so we
+        // can repair stale/missing rows before returning the scan page for filtered listings or
+        // the DB page for unfiltered listings.
+        let fs_page_size = if state_db_ctx.is_none() {
+            page_size
+        } else {
+            page_size.saturating_mul(2)
+        };
         let fs_page = match sort_direction {
             SortDirection::Asc => {
                 list_threads_from_files_asc(
@@ -411,7 +423,7 @@ impl RolloutRecorder {
             SortDirection::Desc => {
                 list_threads_from_files_desc(
                     codex_home,
-                    page_size.saturating_mul(2),
+                    fs_page_size,
                     cursor,
                     sort_key,
                     allowed_sources,
@@ -847,59 +859,22 @@ impl RolloutRecorder {
         path: &Path,
     ) -> std::io::Result<(Vec<RolloutItem>, Option<ThreadId>, usize)> {
         trace!("Resuming rollout from {path:?}");
-        let mut items: Vec<RolloutItem> = Vec::new();
-        let mut thread_id: Option<ThreadId> = None;
-        let mut parse_errors = 0usize;
-        let mut reader = compression::open_rollout_line_reader(path).await?;
-        let mut saw_non_empty_line = false;
-        while let Some(line) = reader.next_line().await? {
-            if line.trim().is_empty() {
-                continue;
-            }
-            saw_non_empty_line = true;
-            let mut v: Value = match serde_json::from_str(&line) {
-                Ok(v) => v,
-                Err(e) => {
-                    warn!("failed to parse line as JSON: {line:?}, error: {e}");
-                    parse_errors = parse_errors.saturating_add(1);
-                    continue;
+        let requested_path = path.to_path_buf();
+        for _ in 0..3 {
+            let path = requested_path.clone();
+            let result = tokio::task::spawn_blocking(move || load_rollout_items_blocking(path))
+                .await
+                .map_err(IoError::other)?;
+            match result {
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
                 }
-            };
-            if strip_legacy_ghost_snapshot_rollout_line(&mut v) {
-                trace!("skipping legacy ghost_snapshot rollout line");
-                continue;
-            }
-
-            // Parse the rollout line structure
-            match serde_json::from_value::<RolloutLine>(v.clone()) {
-                Ok(rollout_line) => {
-                    let item = rollout_line.item;
-                    // Use the FIRST SessionMeta encountered in the file as the canonical
-                    // thread id and main session information. Keep all items intact.
-                    if thread_id.is_none()
-                        && let RolloutItem::SessionMeta(session_meta_line) = &item
-                    {
-                        thread_id = Some(session_meta_line.meta.id);
-                    }
-                    items.push(item);
-                }
-                Err(e) => {
-                    trace!("failed to parse rollout line: {e}");
-                    parse_errors = parse_errors.saturating_add(1);
-                }
+                other => return other,
             }
         }
-        if !saw_non_empty_line {
-            return Err(IoError::other("empty session file"));
-        }
-
-        tracing::debug!(
-            "Resumed rollout with {} items, thread ID: {:?}, parse errors: {}",
-            items.len(),
-            thread_id,
-            parse_errors,
-        );
-        Ok((items, thread_id, parse_errors))
+        tokio::task::spawn_blocking(move || load_rollout_items_blocking(requested_path))
+            .await
+            .map_err(IoError::other)?
     }
 
     pub async fn get_rollout_history(path: &Path) -> std::io::Result<InitialHistory> {
@@ -945,6 +920,199 @@ impl RolloutRecorder {
         };
         Ok(())
     }
+}
+
+fn load_rollout_items_blocking(
+    path: PathBuf,
+) -> std::io::Result<(Vec<RolloutItem>, Option<ThreadId>, usize)> {
+    let (file, path) = open_rollout_file_for_history(path)?;
+    let capacity_hint = file
+        .metadata()
+        .ok()
+        .map(|metadata| rollout_items_capacity_hint(metadata.len()))
+        .unwrap_or_default();
+    if is_compressed_rollout_path(path.as_path()) {
+        let decoder = zstd::stream::read::Decoder::new(file)?;
+        load_rollout_items_from_reader(
+            BufReader::with_capacity(ROLLOUT_HISTORY_READ_BUFFER_SIZE, decoder),
+            capacity_hint,
+        )
+    } else {
+        load_rollout_items_from_reader(
+            BufReader::with_capacity(ROLLOUT_HISTORY_READ_BUFFER_SIZE, file),
+            capacity_hint,
+        )
+    }
+}
+
+fn open_rollout_file_for_history(path: PathBuf) -> std::io::Result<(File, PathBuf)> {
+    let plain_path = compression::plain_rollout_path(path.as_path());
+    if let Some(file) = open_regular_file(plain_path.as_path())? {
+        return Ok((file, plain_path));
+    }
+
+    let compressed_path = compressed_rollout_path(plain_path.as_path());
+    if let Some(file) = open_regular_file(compressed_path.as_path())? {
+        return Ok((file, compressed_path));
+    }
+
+    Err(IoError::new(
+        ErrorKind::NotFound,
+        format!("rollout file not found: {}", path.display()),
+    ))
+}
+
+fn open_regular_file(path: &Path) -> std::io::Result<Option<File>> {
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    if file.metadata().is_ok_and(|metadata| metadata.is_file()) {
+        return Ok(Some(file));
+    }
+    Ok(None)
+}
+
+fn compressed_rollout_path(path: &Path) -> PathBuf {
+    if is_compressed_rollout_path(path) {
+        return path.to_path_buf();
+    }
+    let mut file_name = path
+        .file_name()
+        .map(OsStr::to_os_string)
+        .unwrap_or_else(|| OsStr::new("rollout.jsonl").to_os_string());
+    file_name.push(".zst");
+    path.with_file_name(file_name)
+}
+
+fn is_compressed_rollout_path(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".jsonl.zst"))
+}
+
+fn load_rollout_items_from_reader<R: BufRead>(
+    mut reader: R,
+    capacity_hint: usize,
+) -> std::io::Result<(Vec<RolloutItem>, Option<ThreadId>, usize)> {
+    let mut items: Vec<RolloutItem> = Vec::with_capacity(capacity_hint);
+    let mut thread_id: Option<ThreadId> = None;
+    let mut parse_errors = 0usize;
+    let mut saw_non_empty_line = false;
+    let mut line = Vec::new();
+    loop {
+        line.clear();
+        if reader.read_until(b'\n', &mut line)? == 0 {
+            break;
+        }
+        let trimmed_line = trim_ascii_whitespace(line.as_slice());
+        if trimmed_line.is_empty() {
+            continue;
+        }
+        saw_non_empty_line = true;
+        // Parse the rollout line structure
+        match parse_rollout_item_preserving_legacy_ghost_snapshot_filter(trimmed_line) {
+            Ok(None) => continue,
+            Ok(Some(item)) => {
+                // Use the FIRST SessionMeta encountered in the file as the canonical
+                // thread id and main session information. Keep all items intact.
+                if thread_id.is_none()
+                    && let RolloutItem::SessionMeta(session_meta_line) = &item
+                {
+                    thread_id = Some(session_meta_line.meta.id);
+                }
+                items.push(item);
+            }
+            Err(e) => {
+                if matches!(
+                    e.classify(),
+                    serde_json::error::Category::Eof | serde_json::error::Category::Syntax
+                ) {
+                    warn!("failed to parse line as JSON: {line:?}, error: {e}");
+                } else {
+                    trace!("failed to parse rollout line: {e}");
+                }
+                parse_errors = parse_errors.saturating_add(1);
+            }
+        }
+    }
+    if !saw_non_empty_line {
+        return Err(IoError::other("empty session file"));
+    }
+
+    tracing::debug!(
+        "Resumed rollout with {} items, thread ID: {:?}, parse errors: {}",
+        items.len(),
+        thread_id,
+        parse_errors,
+    );
+    Ok((items, thread_id, parse_errors))
+}
+
+fn rollout_items_capacity_hint(file_size_bytes: u64) -> usize {
+    usize::try_from(file_size_bytes / ROLLOUT_HISTORY_BYTES_PER_ITEM_HINT)
+        .unwrap_or(usize::MAX)
+        .saturating_add(1)
+        .min(16_384)
+}
+
+fn trim_ascii_whitespace(bytes: &[u8]) -> &[u8] {
+    let mut start = 0usize;
+    let mut end = bytes.len();
+    while start < end && bytes[start].is_ascii_whitespace() {
+        start += 1;
+    }
+    while end > start && bytes[end - 1].is_ascii_whitespace() {
+        end -= 1;
+    }
+    &bytes[start..end]
+}
+
+fn parse_rollout_item_preserving_legacy_ghost_snapshot_filter(
+    line: &[u8],
+) -> Result<Option<RolloutItem>, serde_json::Error> {
+    match serde_json::from_slice::<RolloutItem>(line) {
+        Ok(item) => {
+            if rollout_item_needs_legacy_ghost_snapshot_filter(&item)
+                && contains_bytes(line, b"\"ghost_snapshot\"")
+            {
+                return parse_rollout_item_after_legacy_ghost_snapshot_strip(line);
+            }
+            Ok(Some(item))
+        }
+        Err(err) => {
+            if contains_bytes(line, b"\"ghost_snapshot\"") {
+                parse_rollout_item_after_legacy_ghost_snapshot_strip(line)
+            } else {
+                Err(err)
+            }
+        }
+    }
+}
+
+fn rollout_item_needs_legacy_ghost_snapshot_filter(item: &RolloutItem) -> bool {
+    matches!(
+        item,
+        RolloutItem::ResponseItem(ResponseItem::Other) | RolloutItem::Compacted(_)
+    )
+}
+
+fn parse_rollout_item_after_legacy_ghost_snapshot_strip(
+    line: &[u8],
+) -> Result<Option<RolloutItem>, serde_json::Error> {
+    let mut v: Value = serde_json::from_slice(line)?;
+    if strip_legacy_ghost_snapshot_rollout_line(&mut v) {
+        trace!("skipping legacy ghost_snapshot rollout line");
+        return Ok(None);
+    }
+    serde_json::from_value::<RolloutItem>(v).map(Some)
+}
+
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack
+        .windows(needle.len())
+        .any(|window| window == needle)
 }
 
 fn strip_legacy_ghost_snapshot_rollout_line(value: &mut Value) -> bool {
@@ -1713,11 +1881,7 @@ fn thread_item_from_state_metadata(item: codex_state::ThreadMetadata) -> ThreadI
         git_branch: item.git_branch,
         git_sha: item.git_sha,
         git_origin_url: item.git_origin_url,
-        source: Some(
-            serde_json::from_str(item.source.as_str())
-                .or_else(|_| serde_json::from_value(Value::String(item.source)))
-                .unwrap_or(SessionSource::Unknown),
-        ),
+        source: Some(session_source_from_state_string(item.source)),
         parent_thread_id: None,
         agent_nickname: item.agent_nickname,
         agent_role: item.agent_role,
@@ -1725,6 +1889,19 @@ fn thread_item_from_state_metadata(item: codex_state::ThreadMetadata) -> ThreadI
         cli_version: Some(item.cli_version),
         created_at: Some(item.created_at.to_rfc3339_opts(SecondsFormat::Secs, true)),
         updated_at: Some(item.updated_at.to_rfc3339_opts(SecondsFormat::Millis, true)),
+    }
+}
+
+fn session_source_from_state_string(source: String) -> SessionSource {
+    match source.as_str() {
+        "cli" => SessionSource::Cli,
+        "vscode" => SessionSource::VSCode,
+        "exec" => SessionSource::Exec,
+        "mcp" => SessionSource::Mcp,
+        "unknown" => SessionSource::Unknown,
+        _ => serde_json::from_str(source.as_str())
+            .or_else(|_| serde_json::from_value(Value::String(source)))
+            .unwrap_or(SessionSource::Unknown),
     }
 }
 

--- a/codex-rs/rollout/src/recorder_tests.rs
+++ b/codex-rs/rollout/src/recorder_tests.rs
@@ -707,6 +707,73 @@ async fn list_threads_db_enabled_repairs_stale_rollout_paths() -> std::io::Resul
 }
 
 #[tokio::test]
+async fn state_db_only_list_repairs_stale_rollout_path() -> std::io::Result<()> {
+    let home = TempDir::new().expect("temp dir");
+    let config = test_config(home.path());
+
+    let uuid = Uuid::from_u128(9016);
+    let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+    let real_path = write_session_file(home.path(), "2025-01-03T17-00-00", uuid)?;
+    let stale_path = home.path().join(format!(
+        "sessions/2099/01/01/rollout-2099-01-01T00-00-00-{uuid}.jsonl"
+    ));
+
+    let runtime = codex_state::StateRuntime::init(
+        home.path().to_path_buf(),
+        config.model_provider_id.clone(),
+    )
+    .await
+    .expect("state db should initialize");
+    runtime
+        .mark_backfill_complete(/*last_watermark*/ None)
+        .await
+        .expect("backfill should be complete");
+    let created_at = chrono::Utc
+        .with_ymd_and_hms(2025, 1, 3, 17, 0, 0)
+        .single()
+        .expect("valid datetime");
+    let mut builder = codex_state::ThreadMetadataBuilder::new(
+        thread_id,
+        stale_path,
+        created_at,
+        SessionSource::Cli,
+    );
+    builder.model_provider = Some(config.model_provider_id.clone());
+    builder.cwd = home.path().to_path_buf();
+    let mut metadata = builder.build(config.model_provider_id.as_str());
+    metadata.first_user_message = Some("Hello from user".to_string());
+    metadata.preview = metadata.first_user_message.clone();
+    runtime
+        .upsert_thread(&metadata)
+        .await
+        .expect("state db upsert should succeed");
+
+    let page = RolloutRecorder::list_threads_from_state_db(
+        Some(runtime.clone()),
+        &config,
+        /*page_size*/ 1,
+        /*cursor*/ None,
+        ThreadSortKey::CreatedAt,
+        SortDirection::Desc,
+        &[],
+        /*model_providers*/ None,
+        /*cwd_filters*/ None,
+        config.model_provider_id.as_str(),
+        /*search_term*/ None,
+    )
+    .await?;
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].path, real_path);
+
+    let repaired_path = runtime
+        .find_rollout_path_by_id(thread_id, Some(false))
+        .await
+        .expect("state db lookup should succeed");
+    assert_eq!(repaired_path, Some(real_path));
+    Ok(())
+}
+
+#[tokio::test]
 async fn list_threads_state_db_only_skips_jsonl_repair_scan() -> std::io::Result<()> {
     let home = TempDir::new().expect("temp dir");
     let config = test_config(home.path());

--- a/codex-rs/rollout/src/state_db.rs
+++ b/codex-rs/rollout/src/state_db.rs
@@ -297,6 +297,23 @@ pub fn normalize_cwd_for_state_db(cwd: &Path) -> PathBuf {
     normalize_for_path_comparison(cwd).unwrap_or_else(|_| cwd.to_path_buf())
 }
 
+fn session_source_filter_to_state_db_string(source: &SessionSource) -> String {
+    match source {
+        SessionSource::Cli => "cli".to_string(),
+        SessionSource::VSCode => "vscode".to_string(),
+        SessionSource::Exec => "exec".to_string(),
+        SessionSource::Mcp => "mcp".to_string(),
+        SessionSource::Unknown => "unknown".to_string(),
+        SessionSource::Custom(_) | SessionSource::Internal(_) | SessionSource::SubAgent(_) => {
+            match serde_json::to_value(source) {
+                Ok(Value::String(s)) => s,
+                Ok(other) => other.to_string(),
+                Err(_) => String::new(),
+            }
+        }
+    }
+}
+
 /// List thread ids from SQLite for parity checks without rollout scanning.
 #[allow(clippy::too_many_arguments)]
 pub async fn list_thread_ids_db(
@@ -322,11 +339,7 @@ pub async fn list_thread_ids_db(
     let anchor = cursor_to_anchor(cursor);
     let allowed_sources: Vec<String> = allowed_sources
         .iter()
-        .map(|value| match serde_json::to_value(value) {
-            Ok(Value::String(s)) => s,
-            Ok(other) => other.to_string(),
-            Err(_) => String::new(),
-        })
+        .map(session_source_filter_to_state_db_string)
         .collect();
     let model_providers = model_providers.map(<[String]>::to_vec);
     match ctx
@@ -379,11 +392,7 @@ pub async fn list_threads_db(
     let anchor = cursor_to_anchor(cursor);
     let allowed_sources: Vec<String> = allowed_sources
         .iter()
-        .map(|value| match serde_json::to_value(value) {
-            Ok(Value::String(s)) => s,
-            Ok(other) => other.to_string(),
-            Err(_) => String::new(),
-        })
+        .map(session_source_filter_to_state_db_string)
         .collect();
     let model_providers = model_providers.map(<[String]>::to_vec);
     let normalized_cwd_filters = cwd_filters.map(|filters| {
@@ -424,11 +433,15 @@ pub async fn list_threads_db(
             let mut valid_items = Vec::with_capacity(page.items.len());
             for item in page.items {
                 if let Some(existing_path) =
-                    crate::compression::existing_rollout_path(item.rollout_path.as_path()).await
+                    crate::compression::existing_rollout_path_blocking(item.rollout_path.as_path())
                 {
                     let mut item = item;
                     item.rollout_path = existing_path;
                     valid_items.push(item);
+                } else if let Some(repaired_item) =
+                    repair_stale_rollout_path_from_metadata(ctx, codex_home, &item, archived).await
+                {
+                    valid_items.push(repaired_item);
                 } else {
                     warn!(
                         "state db list_threads returned stale rollout path for thread {}: {}",
@@ -447,6 +460,56 @@ pub async fn list_threads_db(
             None
         }
     }
+}
+
+async fn repair_stale_rollout_path_from_metadata(
+    ctx: &codex_state::StateRuntime,
+    codex_home: &Path,
+    item: &codex_state::ThreadMetadata,
+    archived: bool,
+) -> Option<codex_state::ThreadMetadata> {
+    let candidate = rollout_path_from_metadata(codex_home, item, archived);
+    let existing_path = crate::compression::existing_rollout_path_blocking(candidate.as_path())?;
+
+    warn!(
+        "state db list_threads repaired stale rollout path for thread {}: {} -> {}",
+        item.id,
+        item.rollout_path.display(),
+        existing_path.display()
+    );
+    let mut item = item.clone();
+    item.rollout_path = existing_path;
+    if let Err(err) = ctx.upsert_thread(&item).await {
+        warn!(
+            "state db list_threads stale path repair upsert failed for thread {}: {err}",
+            item.id
+        );
+    }
+    Some(item)
+}
+
+fn rollout_path_from_metadata(
+    codex_home: &Path,
+    item: &codex_state::ThreadMetadata,
+    archived: bool,
+) -> PathBuf {
+    let created_at = item.created_at;
+    let file_name = format!(
+        "rollout-{}-{}.jsonl",
+        created_at.format("%Y-%m-%dT%H-%M-%S"),
+        item.id
+    );
+    if archived {
+        return codex_home
+            .join(crate::ARCHIVED_SESSIONS_SUBDIR)
+            .join(file_name);
+    }
+    codex_home
+        .join(crate::SESSIONS_SUBDIR)
+        .join(created_at.format("%Y").to_string())
+        .join(created_at.format("%m").to_string())
+        .join(created_at.format("%d").to_string())
+        .join(file_name)
 }
 
 /// Look up the rollout path for a thread id using SQLite.
@@ -572,28 +635,9 @@ pub async fn read_repair_rollout_path(
         && let Ok(Some(metadata)) = ctx.get_thread(thread_id).await
     {
         saw_existing_metadata = true;
-        let mut repaired = metadata.clone();
-        repaired.rollout_path = rollout_path.to_path_buf();
-        repaired.cwd = normalize_cwd_for_state_db(&repaired.cwd);
-        match archived_only {
-            Some(true) if repaired.archived_at.is_none() => {
-                repaired.archived_at = Some(repaired.updated_at);
-            }
-            Some(false) => {
-                repaired.archived_at = None;
-            }
-            Some(true) | None => {}
-        }
-        if repaired == metadata {
-            return;
-        }
-        warn!("state db discrepancy during read_repair_rollout_path: upsert_needed (fast path)");
-        if let Err(err) = ctx.upsert_thread(&repaired).await {
-            warn!(
-                "state db read-repair upsert failed for {}: {err}",
-                rollout_path.display()
-            );
-        } else {
+        if read_repair_rollout_path_from_metadata(Some(ctx), metadata, archived_only, rollout_path)
+            .await
+        {
             return;
         }
     }
@@ -618,6 +662,44 @@ pub async fn read_repair_rollout_path(
         /*new_thread_memory_mode*/ None,
     )
     .await;
+}
+
+/// Repair a rollout path when the caller already has the metadata row.
+pub async fn read_repair_rollout_path_from_metadata(
+    context: Option<&codex_state::StateRuntime>,
+    mut metadata: codex_state::ThreadMetadata,
+    archived_only: Option<bool>,
+    rollout_path: &Path,
+) -> bool {
+    let Some(ctx) = context else {
+        return true;
+    };
+
+    let original = metadata.clone();
+    metadata.rollout_path = rollout_path.to_path_buf();
+    metadata.cwd = normalize_cwd_for_state_db(&metadata.cwd);
+    match archived_only {
+        Some(true) if metadata.archived_at.is_none() => {
+            metadata.archived_at = Some(metadata.updated_at);
+        }
+        Some(false) => {
+            metadata.archived_at = None;
+        }
+        Some(true) | None => {}
+    }
+    if metadata == original {
+        return true;
+    }
+
+    warn!("state db discrepancy during read_repair_rollout_path: upsert_needed (fast path)");
+    if let Err(err) = ctx.upsert_thread(&metadata).await {
+        warn!(
+            "state db read-repair upsert failed for {}: {err}",
+            rollout_path.display()
+        );
+        return false;
+    }
+    true
 }
 
 /// Apply rollout items incrementally to SQLite.

--- a/codex-rs/rollout/src/state_db.rs
+++ b/codex-rs/rollout/src/state_db.rs
@@ -468,7 +468,19 @@ async fn repair_stale_rollout_path_from_metadata(
     item: &codex_state::ThreadMetadata,
     archived: bool,
 ) -> Option<codex_state::ThreadMetadata> {
-    let candidate = rollout_path_from_metadata(codex_home, item, archived);
+    let subdir = if archived {
+        crate::ARCHIVED_SESSIONS_SUBDIR
+    } else {
+        crate::SESSIONS_SUBDIR
+    };
+    let candidate = crate::list::find_thread_path_by_id_str_in_subdir_without_db(
+        codex_home,
+        subdir,
+        &item.id.to_string(),
+    )
+    .await
+    .ok()
+    .flatten()?;
     let existing_path = crate::compression::existing_rollout_path_blocking(candidate.as_path())?;
 
     warn!(
@@ -486,30 +498,6 @@ async fn repair_stale_rollout_path_from_metadata(
         );
     }
     Some(item)
-}
-
-fn rollout_path_from_metadata(
-    codex_home: &Path,
-    item: &codex_state::ThreadMetadata,
-    archived: bool,
-) -> PathBuf {
-    let created_at = item.created_at;
-    let file_name = format!(
-        "rollout-{}-{}.jsonl",
-        created_at.format("%Y-%m-%dT%H-%M-%S"),
-        item.id
-    );
-    if archived {
-        return codex_home
-            .join(crate::ARCHIVED_SESSIONS_SUBDIR)
-            .join(file_name);
-    }
-    codex_home
-        .join(crate::SESSIONS_SUBDIR)
-        .join(created_at.format("%Y").to_string())
-        .join(created_at.format("%m").to_string())
-        .join(created_at.format("%d").to_string())
-        .join(file_name)
 }
 
 /// Look up the rollout path for a thread id using SQLite.

--- a/codex-rs/rollout/src/tests.rs
+++ b/codex-rs/rollout/src/tests.rs
@@ -7,6 +7,7 @@ use std::fs::File;
 use std::fs::FileTimes;
 use std::io::Write;
 use std::path::Path;
+use std::path::PathBuf;
 
 use chrono::TimeZone;
 use pretty_assertions::assert_eq;
@@ -19,6 +20,7 @@ use time::macros::format_description;
 use uuid::Uuid;
 
 use crate::INTERACTIVE_SESSION_SOURCES;
+use crate::find_any_thread_path_by_id_str;
 use crate::find_thread_path_by_id_str;
 use crate::list::Cursor;
 use crate::list::ThreadItem;
@@ -230,6 +232,85 @@ async fn find_thread_path_accepts_existing_state_db_path_without_canonical_filen
     assert_eq!(found, Some(db_rollout_path));
 }
 
+#[tokio::test]
+async fn find_any_thread_path_prefers_archived_state_db_path() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path();
+    let uuid = Uuid::from_u128(306);
+    let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+    let active_ts = "2025-01-03T13-00-00";
+    write_session_file(
+        home,
+        active_ts,
+        uuid,
+        /*num_records*/ 1,
+        Some(SessionSource::Cli),
+    )
+    .unwrap();
+
+    let archived_ts = "2025-01-04T13-00-00";
+    let archived_rollout_path = write_archived_session_file(
+        home,
+        archived_ts,
+        uuid,
+        /*num_records*/ 1,
+        Some(SessionSource::Cli),
+    )
+    .unwrap();
+    let runtime = insert_state_db_thread(
+        home,
+        thread_id,
+        archived_rollout_path.as_path(),
+        /*archived*/ true,
+    )
+    .await;
+
+    let found = find_any_thread_path_by_id_str(home, &uuid.to_string(), Some(runtime.as_ref()))
+        .await
+        .expect("lookup should succeed");
+    assert_eq!(found, Some(archived_rollout_path));
+}
+
+#[tokio::test]
+async fn find_any_thread_path_repairs_stale_archived_db_path() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path();
+    let uuid = Uuid::from_u128(307);
+    let thread_id = ThreadId::from_string(&uuid.to_string()).expect("valid thread id");
+    let ts = "2025-01-03T12-00-00";
+    let archived_rollout_path = write_archived_session_file(
+        home,
+        ts,
+        uuid,
+        /*num_records*/ 1,
+        Some(SessionSource::Cli),
+    )
+    .unwrap();
+
+    let stale_db_path = home.join(format!(
+        "archived_sessions/rollout-2099-01-01T00-00-00-{uuid}.jsonl"
+    ));
+    let runtime = insert_state_db_thread(
+        home,
+        thread_id,
+        stale_db_path.as_path(),
+        /*archived*/ true,
+    )
+    .await;
+
+    let found = find_any_thread_path_by_id_str(home, &uuid.to_string(), Some(runtime.as_ref()))
+        .await
+        .expect("lookup should succeed");
+    assert_eq!(found, Some(archived_rollout_path.clone()));
+    assert_state_db_rollout_path_with_archive(
+        home,
+        thread_id,
+        Some(true),
+        Some(archived_rollout_path.as_path()),
+    )
+    .await;
+}
+
 #[test]
 fn rollout_date_parts_extracts_directory_components() {
     let file_name = OsStr::new("rollout-2025-03-01T09-00-00-123.jsonl");
@@ -245,11 +326,20 @@ async fn assert_state_db_rollout_path(
     thread_id: ThreadId,
     expected_path: Option<&Path>,
 ) {
+    assert_state_db_rollout_path_with_archive(home, thread_id, Some(false), expected_path).await;
+}
+
+async fn assert_state_db_rollout_path_with_archive(
+    home: &Path,
+    thread_id: ThreadId,
+    archived_only: Option<bool>,
+    expected_path: Option<&Path>,
+) {
     let runtime = codex_state::StateRuntime::init(home.to_path_buf(), TEST_PROVIDER.to_string())
         .await
         .expect("state db should initialize");
     let path = runtime
-        .find_rollout_path_by_id(thread_id, Some(false))
+        .find_rollout_path_by_id(thread_id, archived_only)
         .await
         .expect("state db lookup should succeed");
     assert_eq!(path.as_deref(), expected_path);
@@ -341,6 +431,58 @@ fn write_session_file_with_provider(
     let times = FileTimes::new().set_modified(dt.into());
     file.set_times(times)?;
     Ok((dt, uuid))
+}
+
+fn write_archived_session_file(
+    root: &Path,
+    ts_str: &str,
+    uuid: Uuid,
+    num_records: usize,
+    source: Option<SessionSource>,
+) -> std::io::Result<PathBuf> {
+    let format: &[FormatItem] =
+        format_description!("[year]-[month]-[day]T[hour]-[minute]-[second]");
+    let dt = PrimitiveDateTime::parse(ts_str, format)
+        .unwrap()
+        .assume_utc();
+    let dir = root.join("archived_sessions");
+    fs::create_dir_all(&dir)?;
+
+    let filename = format!("rollout-{ts_str}-{uuid}.jsonl");
+    let file_path = dir.join(filename);
+    let mut file = File::create(&file_path)?;
+
+    let mut payload = serde_json::json!({
+        "id": uuid,
+        "timestamp": ts_str,
+        "cwd": ".",
+        "originator": "test_originator",
+        "cli_version": "test_version",
+        "base_instructions": null,
+    });
+
+    if let Some(source) = source {
+        payload["source"] = serde_json::to_value(source).unwrap();
+    }
+    payload["model_provider"] = serde_json::Value::String(TEST_PROVIDER.to_string());
+
+    let meta = serde_json::json!({
+        "timestamp": ts_str,
+        "type": "session_meta",
+        "payload": payload,
+    });
+    writeln!(file, "{meta}")?;
+
+    for i in 0..num_records {
+        let rec = serde_json::json!({
+            "record_type": "response",
+            "index": i
+        });
+        writeln!(file, "{rec}")?;
+    }
+    let times = FileTimes::new().set_modified(dt.into());
+    file.set_times(times)?;
+    Ok(file_path)
 }
 
 fn write_goal_started_session_file(

--- a/codex-rs/state/src/runtime/threads.rs
+++ b/codex-rs/state/src/runtime/threads.rs
@@ -348,6 +348,64 @@ ON CONFLICT(child_thread_id) DO NOTHING
             .map(PathBuf::from))
     }
 
+    /// Find a rollout path and creation timestamp by thread id using the underlying database.
+    pub async fn find_rollout_path_and_created_at_by_id(
+        &self,
+        id: ThreadId,
+        archived_only: Option<bool>,
+    ) -> anyhow::Result<Option<(PathBuf, DateTime<Utc>)>> {
+        let mut builder = QueryBuilder::<Sqlite>::new(
+            "SELECT rollout_path, created_at_ms AS created_at FROM threads WHERE id = ",
+        );
+        builder.push_bind(id.to_string());
+        match archived_only {
+            Some(true) => {
+                builder.push(" AND archived = 1");
+            }
+            Some(false) => {
+                builder.push(" AND archived = 0");
+            }
+            None => {}
+        }
+        let row = builder.build().fetch_optional(self.pool.as_ref()).await?;
+        row.map(|row| {
+            let rollout_path: String = row.try_get("rollout_path")?;
+            let created_at: i64 = row.try_get("created_at")?;
+            Ok((
+                PathBuf::from(rollout_path),
+                epoch_millis_to_datetime(created_at)?,
+            ))
+        })
+        .transpose()
+    }
+
+    /// Repair a stale rollout path in place when the row still points at the expected path.
+    pub async fn update_thread_rollout_path_if_current(
+        &self,
+        id: ThreadId,
+        expected_rollout_path: &Path,
+        repaired_rollout_path: &Path,
+        archived_only: Option<bool>,
+    ) -> anyhow::Result<bool> {
+        let mut builder = QueryBuilder::<Sqlite>::new("UPDATE threads SET rollout_path = ");
+        builder.push_bind(repaired_rollout_path.display().to_string());
+        builder.push(" WHERE id = ");
+        builder.push_bind(id.to_string());
+        builder.push(" AND rollout_path = ");
+        builder.push_bind(expected_rollout_path.display().to_string());
+        match archived_only {
+            Some(true) => {
+                builder.push(" AND archived = 1");
+            }
+            Some(false) => {
+                builder.push(" AND archived = 0");
+            }
+            None => {}
+        }
+        let result = builder.build().execute(self.pool.as_ref()).await?;
+        Ok(result.rows_affected() > 0)
+    }
+
     /// Find the newest thread whose user-facing title exactly matches `title`.
     #[allow(clippy::too_many_arguments)]
     pub async fn find_thread_by_exact_title(
@@ -425,14 +483,17 @@ ON CONFLICT(child_thread_id) DO NOTHING
         let mut builder = QueryBuilder::<Sqlite>::new("");
         push_list_threads_query(&mut builder, filters, parent_thread_id, limit);
 
-        let rows = builder.build().fetch_all(self.pool.as_ref()).await?;
-        let mut items = rows
+        let mut rows = builder.build().fetch_all(self.pool.as_ref()).await?;
+        let num_scanned_rows = rows.len();
+        let has_next_page = rows.len() > page_size;
+        if has_next_page {
+            rows.truncate(page_size);
+        }
+        let items = rows
             .into_iter()
             .map(|row| ThreadRow::try_from_row(&row).and_then(ThreadMetadata::try_from))
             .collect::<Result<Vec<_>, _>>()?;
-        let num_scanned_rows = items.len();
-        let next_anchor = if items.len() > page_size {
-            items.pop();
+        let next_anchor = if has_next_page {
             items
                 .last()
                 .and_then(|item| anchor_from_item(item, filters.sort_key))

--- a/codex-rs/thread-store/src/local/list_threads.rs
+++ b/codex-rs/thread-store/src/local/list_threads.rs
@@ -75,6 +75,11 @@ pub(super) async fn list_threads(
         })
         .collect::<Vec<_>>();
 
+    // Startup --last lookups use this internal mode only to resolve id/path.
+    if params.use_state_db_only && params.page_size == 1 && params.search_term.is_none() {
+        return Ok(ThreadPage { items, next_cursor });
+    }
+
     let thread_ids = items
         .iter()
         .map(|thread| thread.thread_id)

--- a/codex-rs/thread-store/src/local/list_threads.rs
+++ b/codex-rs/thread-store/src/local/list_threads.rs
@@ -75,11 +75,6 @@ pub(super) async fn list_threads(
         })
         .collect::<Vec<_>>();
 
-    // Startup --last lookups use this internal mode only to resolve id/path.
-    if params.use_state_db_only && params.page_size == 1 && params.search_term.is_none() {
-        return Ok(ThreadPage { items, next_cursor });
-    }
-
     let thread_ids = items
         .iter()
         .map(|thread| thread.thread_id)
@@ -95,6 +90,17 @@ pub(super) async fn list_threads(
             }
         }
     }
+    for thread in &mut items {
+        if let Some(title) = names.get(&thread.thread_id).cloned() {
+            set_thread_name_from_title(thread, title);
+        }
+    }
+
+    // Startup --last lookups use this internal mode only to resolve id/path.
+    if params.use_state_db_only && params.page_size == 1 && params.search_term.is_none() {
+        return Ok(ThreadPage { items, next_cursor });
+    }
+
     if names.len() < thread_ids.len()
         && let Ok(legacy_names) =
             find_thread_names_by_ids(store.config.codex_home.as_path(), &thread_ids).await

--- a/codex-rs/thread-store/src/local/read_thread.rs
+++ b/codex-rs/thread-store/src/local/read_thread.rs
@@ -49,17 +49,10 @@ pub(super) async fn read_thread(
         .await;
         let mut thread = stored_thread_from_sqlite_metadata(store, metadata).await;
         if !params.include_history || rollout_thread.is_some() {
-            if let Some(mut rollout_thread) = rollout_thread
+            if !params.include_history
+                && let Some(mut rollout_thread) = rollout_thread
                 && !rollout_thread.preview.is_empty()
             {
-                if params.include_history {
-                    if !thread.preview.is_empty() {
-                        rollout_thread.preview = thread.preview;
-                    }
-                    if thread.first_user_message.is_some() {
-                        rollout_thread.first_user_message = thread.first_user_message;
-                    }
-                }
                 if thread.name.is_some() {
                     rollout_thread.name = thread.name;
                 }

--- a/codex-rs/thread-store/src/local/read_thread.rs
+++ b/codex-rs/thread-store/src/local/read_thread.rs
@@ -38,35 +38,33 @@ pub(super) async fn read_thread(
                     store.config.codex_home.as_path(),
                     metadata.rollout_path.as_path(),
                 )))
-        && (!params.include_history
-            || sqlite_rollout_path_can_load_history_for_thread(
-                store,
-                &metadata.rollout_path,
-                thread_id,
-            )
-            .await)
     {
         let metadata_sandbox_policy = metadata.sandbox_policy.clone();
+        let rollout_thread = matching_rollout_thread_from_sqlite_path(
+            store,
+            metadata.rollout_path.as_path(),
+            thread_id,
+            params.include_archived,
+        )
+        .await;
         let mut thread = stored_thread_from_sqlite_metadata(store, metadata).await;
-        if !params.include_history
-            && let Some(rollout_path) = thread.rollout_path.clone()
-            && let Ok(mut rollout_thread) = read_thread_from_rollout_path(store, rollout_path).await
-            && rollout_thread.thread_id == thread_id
-            && (params.include_archived || rollout_thread.archived_at.is_none())
-            && !rollout_thread.preview.is_empty()
-        {
-            if thread.name.is_some() {
-                rollout_thread.name = thread.name;
+        if !params.include_history || rollout_thread.is_some() {
+            if let Some(mut rollout_thread) = rollout_thread
+                && !rollout_thread.preview.is_empty()
+            {
+                if thread.name.is_some() {
+                    rollout_thread.name = thread.name;
+                }
+                rollout_thread.git_info = thread.git_info;
+                rollout_thread.permission_profile = permission_profile_from_metadata_value(
+                    &metadata_sandbox_policy,
+                    rollout_thread.cwd.as_path(),
+                );
+                thread = rollout_thread;
             }
-            rollout_thread.git_info = thread.git_info;
-            rollout_thread.permission_profile = permission_profile_from_metadata_value(
-                &metadata_sandbox_policy,
-                rollout_thread.cwd.as_path(),
-            );
-            thread = rollout_thread;
+            attach_history_if_requested(&mut thread, params.include_history).await?;
+            return Ok(thread);
         }
-        attach_history_if_requested(&mut thread, params.include_history).await?;
-        return Ok(thread);
     }
 
     let path = resolve_rollout_path(store, thread_id, params.include_archived)
@@ -85,20 +83,21 @@ pub(super) async fn read_thread(
     Ok(thread)
 }
 
-async fn sqlite_rollout_path_can_load_history_for_thread(
+async fn matching_rollout_thread_from_sqlite_path(
     store: &LocalThreadStore,
     path: &std::path::Path,
     thread_id: codex_protocol::ThreadId,
-) -> bool {
-    if codex_rollout::existing_rollout_path(path).await.is_none() {
-        return false;
-    }
-    // SQLite metadata can outlive a moved/recreated rollout path. When history is
-    // requested, verify the path still resolves to the requested thread before
-    // trusting it as the source replay.
+    include_archived: bool,
+) -> Option<StoredThread> {
+    codex_rollout::existing_rollout_path(path).await.as_ref()?;
+    // SQLite metadata can outlive a moved or recreated rollout path. Verify the
+    // path still resolves to the requested thread before trusting its summary or history.
     read_thread_from_rollout_path(store, path.to_path_buf())
         .await
-        .is_ok_and(|thread| thread.thread_id == thread_id)
+        .ok()
+        .filter(|thread| {
+            thread.thread_id == thread_id && (include_archived || thread.archived_at.is_none())
+        })
 }
 
 pub(super) async fn read_thread_by_rollout_path(

--- a/codex-rs/thread-store/src/local/read_thread.rs
+++ b/codex-rs/thread-store/src/local/read_thread.rs
@@ -49,7 +49,8 @@ pub(super) async fn read_thread(
         .await;
         let mut thread = stored_thread_from_sqlite_metadata(store, metadata).await;
         if !params.include_history || rollout_thread.is_some() {
-            if let Some(mut rollout_thread) = rollout_thread
+            if !params.include_history
+                && let Some(mut rollout_thread) = rollout_thread
                 && !rollout_thread.preview.is_empty()
             {
                 if thread.name.is_some() {

--- a/codex-rs/thread-store/src/local/read_thread.rs
+++ b/codex-rs/thread-store/src/local/read_thread.rs
@@ -5,7 +5,7 @@ use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::SessionMetaLine;
 use codex_protocol::protocol::SessionSource;
 use codex_rollout::RolloutRecorder;
-use codex_rollout::find_archived_thread_path_by_id_str;
+use codex_rollout::find_any_thread_path_by_id_str;
 use codex_rollout::find_thread_name_by_id;
 use codex_rollout::find_thread_path_by_id_str;
 use codex_rollout::read_session_meta_line;
@@ -209,7 +209,7 @@ async fn resolve_rollout_path(
 
     let state_db_ctx = store.state_db().await;
     if include_archived {
-        match find_thread_path_by_id_str(
+        find_any_thread_path_by_id_str(
             store.config.codex_home.as_path(),
             &thread_id.to_string(),
             state_db_ctx.as_deref(),
@@ -217,18 +217,7 @@ async fn resolve_rollout_path(
         .await
         .map_err(|err| ThreadStoreError::InvalidRequest {
             message: format!("failed to locate thread id {thread_id}: {err}"),
-        })? {
-            Some(path) => Ok(Some(path)),
-            None => find_archived_thread_path_by_id_str(
-                store.config.codex_home.as_path(),
-                &thread_id.to_string(),
-                state_db_ctx.as_deref(),
-            )
-            .await
-            .map_err(|err| ThreadStoreError::InvalidRequest {
-                message: format!("failed to locate archived thread id {thread_id}: {err}"),
-            }),
-        }
+        })
     } else {
         find_thread_path_by_id_str(
             store.config.codex_home.as_path(),

--- a/codex-rs/thread-store/src/local/read_thread.rs
+++ b/codex-rs/thread-store/src/local/read_thread.rs
@@ -49,10 +49,17 @@ pub(super) async fn read_thread(
         .await;
         let mut thread = stored_thread_from_sqlite_metadata(store, metadata).await;
         if !params.include_history || rollout_thread.is_some() {
-            if !params.include_history
-                && let Some(mut rollout_thread) = rollout_thread
+            if let Some(mut rollout_thread) = rollout_thread
                 && !rollout_thread.preview.is_empty()
             {
+                if params.include_history {
+                    if !thread.preview.is_empty() {
+                        rollout_thread.preview = thread.preview;
+                    }
+                    if thread.first_user_message.is_some() {
+                        rollout_thread.first_user_message = thread.first_user_message;
+                    }
+                }
                 if thread.name.is_some() {
                     rollout_thread.name = thread.name;
                 }

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -916,7 +916,11 @@ impl App {
             }
             SessionSelection::Resume(target_session) => {
                 let resumed = app_server
-                    .resume_thread(config.clone(), target_session.thread_id)
+                    .resume_thread_with_path(
+                        config.clone(),
+                        target_session.thread_id,
+                        target_session.path.clone(),
+                    )
                     .await
                     .map_err(|err| session_start_error("resume", &target_session, err))?;
                 let init = crate::chatwidget::ChatWidgetInit {
@@ -955,7 +959,11 @@ impl App {
                     &[("source", "cli_subcommand")],
                 );
                 let forked = app_server
-                    .fork_thread(config.clone(), target_session.thread_id)
+                    .fork_thread_with_path(
+                        config.clone(),
+                        target_session.thread_id,
+                        target_session.path.clone(),
+                    )
                     .await
                     .map_err(|err| session_start_error("fork", &target_session, err))?;
                 let init = crate::chatwidget::ChatWidgetInit {

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -916,11 +916,7 @@ impl App {
             }
             SessionSelection::Resume(target_session) => {
                 let resumed = app_server
-                    .resume_thread_with_path(
-                        config.clone(),
-                        target_session.thread_id,
-                        target_session.path.clone(),
-                    )
+                    .resume_thread(config.clone(), target_session.thread_id)
                     .await
                     .map_err(|err| session_start_error("resume", &target_session, err))?;
                 let init = crate::chatwidget::ChatWidgetInit {
@@ -959,11 +955,7 @@ impl App {
                     &[("source", "cli_subcommand")],
                 );
                 let forked = app_server
-                    .fork_thread_with_path(
-                        config.clone(),
-                        target_session.thread_id,
-                        target_session.path.clone(),
-                    )
+                    .fork_thread(config.clone(), target_session.thread_id)
                     .await
                     .map_err(|err| session_start_error("fork", &target_session, err))?;
                 let init = crate::chatwidget::ChatWidgetInit {

--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -137,7 +137,13 @@ impl App {
                 tui.frame_requester().schedule_frame();
             }
             AppEvent::ResumeSessionByIdOrName(id_or_name) => {
-                match crate::lookup_session_target_with_app_server(app_server, &id_or_name).await? {
+                match crate::lookup_session_target_with_app_server(
+                    app_server,
+                    &id_or_name,
+                    self.state_db.as_deref(),
+                )
+                .await?
+                {
                     Some(target_session) => {
                         return self
                             .resume_target_session(tui, app_server, target_session)

--- a/codex-rs/tui/src/app/event_dispatch.rs
+++ b/codex-rs/tui/src/app/event_dispatch.rs
@@ -140,6 +140,7 @@ impl App {
                 match crate::lookup_session_target_with_app_server(
                     app_server,
                     &id_or_name,
+                    self.config.codex_home.as_path(),
                     self.state_db.as_deref(),
                 )
                 .await?

--- a/codex-rs/tui/src/app/session_lifecycle.rs
+++ b/codex-rs/tui/src/app/session_lifecycle.rs
@@ -747,8 +747,7 @@ impl App {
                 tui,
                 self.state_db.as_deref(),
                 &current_cwd,
-                target_session.thread_id,
-                target_session.path.as_deref(),
+                &target_session,
                 CwdPromptAction::Resume,
                 /*allow_prompt*/ true,
             )

--- a/codex-rs/tui/src/app/tests.rs
+++ b/codex-rs/tui/src/app/tests.rs
@@ -4873,6 +4873,7 @@ fn session_start_error_surfaces_archived_guidance_without_rollout_path() {
             "/Users/me/.codex/archived_sessions/rollout.jsonl",
         )),
         thread_id,
+        cwd: None,
     };
     let expected = format!(
         "session {thread_id} is archived. Run `codex unarchive {thread_id}` to unarchive it first."

--- a/codex-rs/tui/src/app/tests/startup.rs
+++ b/codex-rs/tui/src/app/tests/startup.rs
@@ -19,6 +19,7 @@ fn startup_waiting_gate_is_only_for_fresh_or_exit_session_selection() {
             crate::resume_picker::SessionTarget {
                 path: Some(PathBuf::from("/tmp/restore")),
                 thread_id: ThreadId::new(),
+                cwd: None,
             }
         )),
         false
@@ -28,6 +29,7 @@ fn startup_waiting_gate_is_only_for_fresh_or_exit_session_selection() {
             crate::resume_picker::SessionTarget {
                 path: Some(PathBuf::from("/tmp/fork")),
                 thread_id: ThreadId::new(),
+                cwd: None,
             }
         )),
         false
@@ -39,10 +41,12 @@ fn startup_paused_goal_prompt_gate_is_only_for_quiet_resume() {
     let resume = SessionSelection::Resume(crate::resume_picker::SessionTarget {
         path: Some(PathBuf::from("/tmp/restore")),
         thread_id: ThreadId::new(),
+        cwd: None,
     });
     let fork = SessionSelection::Fork(crate::resume_picker::SessionTarget {
         path: Some(PathBuf::from("/tmp/fork")),
         thread_id: ThreadId::new(),
+        cwd: None,
     });
     let no_images: Vec<PathBuf> = Vec::new();
     let initial_images = vec![PathBuf::from("/tmp/image.png")];
@@ -111,6 +115,7 @@ fn startup_waiting_gate_not_applied_for_resume_or_fork_session_selection() {
         crate::resume_picker::SessionTarget {
             path: Some(PathBuf::from("/tmp/restore")),
             thread_id: ThreadId::new(),
+            cwd: None,
         },
     ));
     assert_eq!(
@@ -124,6 +129,7 @@ fn startup_waiting_gate_not_applied_for_resume_or_fork_session_selection() {
         crate::resume_picker::SessionTarget {
             path: Some(PathBuf::from("/tmp/fork")),
             thread_id: ThreadId::new(),
+            cwd: None,
         },
     ));
     assert_eq!(
@@ -266,6 +272,7 @@ async fn ignore_same_thread_resume_reports_noop_for_current_thread() {
     let ignored = app.ignore_same_thread_resume(&crate::resume_picker::SessionTarget {
         path: Some(test_path_buf("/tmp/project")),
         thread_id,
+        cwd: None,
     });
 
     assert!(ignored);
@@ -290,6 +297,7 @@ async fn ignore_same_thread_resume_allows_reattaching_displayed_inactive_thread(
     let ignored = app.ignore_same_thread_resume(&crate::resume_picker::SessionTarget {
         path: Some(test_path_buf("/tmp/project")),
         thread_id,
+        cwd: None,
     });
 
     assert!(!ignored);

--- a/codex-rs/tui/src/app_server_session.rs
+++ b/codex-rs/tui/src/app_server_session.rs
@@ -455,6 +455,16 @@ impl AppServerSession {
         config: Config,
         thread_id: ThreadId,
     ) -> Result<AppServerStartedThread> {
+        self.resume_thread_with_path(config, thread_id, /*path*/ None)
+            .await
+    }
+
+    pub(crate) async fn resume_thread_with_path(
+        &mut self,
+        config: Config,
+        thread_id: ThreadId,
+        path: Option<std::path::PathBuf>,
+    ) -> Result<AppServerStartedThread> {
         let request_id = self.next_request_id();
         let session_config = self.session_config_with_effective_service_tier(&config);
         let response: ThreadResumeResponse = self
@@ -464,6 +474,7 @@ impl AppServerSession {
                 params: thread_resume_params_from_config(
                     session_config,
                     thread_id,
+                    path,
                     self.thread_params_mode(),
                     self.remote_cwd_override.as_deref(),
                 ),
@@ -487,6 +498,16 @@ impl AppServerSession {
         config: Config,
         thread_id: ThreadId,
     ) -> Result<AppServerStartedThread> {
+        self.fork_thread_with_path(config, thread_id, /*path*/ None)
+            .await
+    }
+
+    pub(crate) async fn fork_thread_with_path(
+        &mut self,
+        config: Config,
+        thread_id: ThreadId,
+        path: Option<std::path::PathBuf>,
+    ) -> Result<AppServerStartedThread> {
         let request_id = self.next_request_id();
         let session_config = self.session_config_with_effective_service_tier(&config);
         let response: ThreadForkResponse = self
@@ -496,6 +517,7 @@ impl AppServerSession {
                 params: thread_fork_params_from_config(
                     session_config,
                     thread_id,
+                    path,
                     self.thread_params_mode(),
                     self.remote_cwd_override.as_deref(),
                 ),
@@ -1404,6 +1426,7 @@ fn thread_start_params_from_config(
 fn thread_resume_params_from_config(
     config: Config,
     thread_id: ThreadId,
+    path: Option<std::path::PathBuf>,
     thread_params_mode: ThreadParamsMode,
     remote_cwd_override: Option<&std::path::Path>,
 ) -> ThreadResumeParams {
@@ -1419,6 +1442,7 @@ fn thread_resume_params_from_config(
         .flatten();
     ThreadResumeParams {
         thread_id: thread_id.to_string(),
+        path,
         model: config.model.clone(),
         model_provider: thread_params_mode.model_provider_from_config(&config),
         service_tier: service_tier_override_from_config(&config),
@@ -1439,6 +1463,7 @@ fn thread_resume_params_from_config(
 fn thread_fork_params_from_config(
     config: Config,
     thread_id: ThreadId,
+    path: Option<std::path::PathBuf>,
     thread_params_mode: ThreadParamsMode,
     remote_cwd_override: Option<&std::path::Path>,
 ) -> ThreadForkParams {
@@ -1454,6 +1479,7 @@ fn thread_fork_params_from_config(
         .flatten();
     ThreadForkParams {
         thread_id: thread_id.to_string(),
+        path,
         model: config.model.clone(),
         model_provider: thread_params_mode.model_provider_from_config(&config),
         service_tier: service_tier_override_from_config(&config),
@@ -1988,12 +2014,14 @@ mod tests {
         let resume = thread_resume_params_from_config(
             config.clone(),
             thread_id,
+            /*path*/ None,
             ThreadParamsMode::Remote,
             /*remote_cwd_override*/ None,
         );
         let fork = thread_fork_params_from_config(
             config,
             thread_id,
+            /*path*/ None,
             ThreadParamsMode::Remote,
             /*remote_cwd_override*/ None,
         );
@@ -2105,12 +2133,14 @@ mod tests {
         let resume = thread_resume_params_from_config(
             config.clone(),
             thread_id,
+            /*path*/ None,
             ThreadParamsMode::Remote,
             Some(remote_cwd.as_path()),
         );
         let fork = thread_fork_params_from_config(
             config,
             thread_id,
+            /*path*/ None,
             ThreadParamsMode::Remote,
             Some(remote_cwd.as_path()),
         );
@@ -2156,12 +2186,14 @@ mod tests {
         let resume = thread_resume_params_from_config(
             config.clone(),
             thread_id,
+            /*path*/ None,
             ThreadParamsMode::Embedded,
             /*remote_cwd_override*/ None,
         );
         let fork = thread_fork_params_from_config(
             config,
             thread_id,
+            /*path*/ None,
             ThreadParamsMode::Embedded,
             /*remote_cwd_override*/ None,
         );
@@ -2216,6 +2248,7 @@ mod tests {
         let params = thread_fork_params_from_config(
             config,
             thread_id,
+            /*path*/ None,
             ThreadParamsMode::Embedded,
             /*remote_cwd_override*/ None,
         );
@@ -2243,12 +2276,14 @@ mod tests {
         let control_resume = thread_resume_params_from_config(
             config.clone(),
             thread_id,
+            /*path*/ None,
             ThreadParamsMode::Embedded,
             /*remote_cwd_override*/ None,
         );
         let control_fork = thread_fork_params_from_config(
             config.clone(),
             thread_id,
+            /*path*/ None,
             ThreadParamsMode::Embedded,
             /*remote_cwd_override*/ None,
         );
@@ -2272,12 +2307,14 @@ mod tests {
         let treatment_resume = thread_resume_params_from_config(
             config.clone(),
             thread_id,
+            /*path*/ None,
             ThreadParamsMode::Embedded,
             /*remote_cwd_override*/ None,
         );
         let treatment_fork = thread_fork_params_from_config(
             config,
             thread_id,
+            /*path*/ None,
             ThreadParamsMode::Embedded,
             /*remote_cwd_override*/ None,
         );

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -585,6 +585,7 @@ fn session_target_from_app_server_thread(
         Ok(thread_id) => Some(resume_picker::SessionTarget {
             path: thread.path,
             thread_id,
+            cwd: Some(thread.cwd.to_path_buf()),
         }),
         Err(err) => {
             warn!(
@@ -595,6 +596,54 @@ fn session_target_from_app_server_thread(
             None
         }
     }
+}
+
+async fn lookup_local_session_target_by_id(
+    thread_id: ThreadId,
+    state_db_ctx: Option<&codex_state::StateRuntime>,
+) -> Option<resume_picker::SessionTarget> {
+    let state_db_ctx = state_db_ctx?;
+    let id = thread_id.to_string();
+    let metadata = state_db_ctx.get_thread(thread_id).await.ok().flatten();
+    if let Some(metadata) = metadata.as_ref()
+        && let Some(existing_path) =
+            codex_rollout::existing_rollout_path(metadata.rollout_path.as_path()).await
+        && rollout_file_name_matches_thread_id(existing_path.as_path(), thread_id)
+    {
+        return Some(resume_picker::SessionTarget {
+            path: Some(codex_rollout::plain_rollout_path(existing_path.as_path())),
+            thread_id,
+            cwd: Some(metadata.cwd.clone()),
+        });
+    }
+    let path = codex_rollout::find_any_thread_path_by_id_str(
+        state_db_ctx.codex_home(),
+        id.as_str(),
+        Some(state_db_ctx),
+    )
+    .await
+    .ok()
+    .flatten()?;
+    let existing_path = codex_rollout::existing_rollout_path(path.as_path()).await?;
+    if !rollout_file_name_matches_thread_id(existing_path.as_path(), thread_id) {
+        return None;
+    }
+    Some(resume_picker::SessionTarget {
+        path: Some(codex_rollout::plain_rollout_path(existing_path.as_path())),
+        thread_id,
+        cwd: metadata.map(|metadata| metadata.cwd),
+    })
+}
+
+fn rollout_file_name_matches_thread_id(path: &Path, thread_id: ThreadId) -> bool {
+    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let plain_suffix = format!("{thread_id}.jsonl");
+    let compressed_suffix = format!("{plain_suffix}.zst");
+    file_name.starts_with("rollout-")
+        && (file_name.ends_with(plain_suffix.as_str())
+            || file_name.ends_with(compressed_suffix.as_str()))
 }
 
 pub(crate) fn resume_source_kinds(include_non_interactive: bool) -> Vec<ThreadSourceKind> {
@@ -646,6 +695,7 @@ async fn lookup_session_target_by_name_with_app_server(
 async fn lookup_session_target_with_app_server(
     app_server: &mut AppServerSession,
     id_or_name: &str,
+    state_db_ctx: Option<&codex_state::StateRuntime>,
 ) -> color_eyre::Result<Option<resume_picker::SessionTarget>> {
     if Uuid::parse_str(id_or_name).is_ok() {
         let thread_id = match ThreadId::from_string(id_or_name) {
@@ -659,6 +709,11 @@ async fn lookup_session_target_with_app_server(
                 return Ok(None);
             }
         };
+        if !app_server.uses_remote_workspace()
+            && let Some(target) = lookup_local_session_target_by_id(thread_id, state_db_ctx).await
+        {
+            return Ok(Some(target));
+        }
         return match app_server
             .thread_read(thread_id, /*include_turns*/ false)
             .await
@@ -702,10 +757,10 @@ async fn lookup_latest_session_target_with_app_server(
             .data
             .into_iter()
             .find_map(session_target_from_app_server_thread);
-        if target.as_ref().is_some_and(|target| {
-            uses_remote_workspace || target.path.as_deref().is_some_and(std::path::Path::exists)
-        }) {
-            return Ok(target);
+        if let Some(target) = target
+            && (uses_remote_workspace || target.path.is_some())
+        {
+            return Ok(Some(target));
         }
     }
     Ok(None)
@@ -1474,7 +1529,13 @@ async fn run_ratatui_app(
             let Some(startup_app_server) = app_server.as_mut() else {
                 unreachable!("app server should be initialized for --fork <id>");
             };
-            match lookup_session_target_with_app_server(startup_app_server, id_str).await? {
+            match lookup_session_target_with_app_server(
+                startup_app_server,
+                id_str,
+                state_db.as_deref(),
+            )
+            .await?
+            {
                 Some(target_session) => resume_picker::SessionSelection::Fork(target_session),
                 None => {
                     shutdown_app_server_if_present(app_server.take()).await;
@@ -1531,7 +1592,9 @@ async fn run_ratatui_app(
         let Some(startup_app_server) = app_server.as_mut() else {
             unreachable!("app server should be initialized for --resume <id>");
         };
-        match lookup_session_target_with_app_server(startup_app_server, id_str).await? {
+        match lookup_session_target_with_app_server(startup_app_server, id_str, state_db.as_deref())
+            .await?
+        {
             Some(target_session) => resume_picker::SessionSelection::Resume(target_session),
             None => {
                 shutdown_app_server_if_present(app_server.take()).await;
@@ -1609,8 +1672,7 @@ async fn run_ratatui_app(
                     &mut tui,
                     state_db.as_deref(),
                     &current_cwd,
-                    target_session.thread_id,
-                    target_session.path.as_deref(),
+                    target_session,
                     action,
                     allow_prompt,
                 )
@@ -2152,6 +2214,7 @@ mod tests {
         let target = crate::resume_picker::SessionTarget {
             path: None,
             thread_id,
+            cwd: None,
         };
 
         assert_eq!(target.display_label(), format!("thread {thread_id}"));
@@ -2847,6 +2910,48 @@ mod tests {
             Ok(())
         })
         .await
+    }
+
+    #[tokio::test]
+    async fn lookup_local_session_target_by_id_uses_state_db_path() -> color_eyre::Result<()> {
+        let temp_dir = TempDir::new()?;
+        let config = build_config(&temp_dir).await?;
+        let uuid = Uuid::new_v4();
+        let thread_id = ThreadId::from_string(&uuid.to_string())?;
+        let rollout_path = temp_dir
+            .path()
+            .join("sessions/2025/02/02")
+            .join(format!("rollout-2025-02-02T10-00-00-{uuid}.jsonl"));
+        std::fs::create_dir_all(rollout_path.parent().expect("rollout parent"))?;
+        std::fs::write(&rollout_path, "")?;
+
+        let state_runtime = codex_state::StateRuntime::init(
+            config.codex_home.to_path_buf(),
+            config.model_provider_id.clone(),
+        )
+        .await
+        .map_err(std::io::Error::other)?;
+        let mut builder = codex_state::ThreadMetadataBuilder::new(
+            thread_id,
+            rollout_path.clone(),
+            chrono::Utc::now(),
+            serde_json::from_value(serde_json::json!("cli"))
+                .expect("cli session source should deserialize"),
+        );
+        builder.model_provider = Some(config.model_provider_id.clone());
+        let metadata = builder.build(config.model_provider_id.as_str());
+        state_runtime
+            .upsert_thread(&metadata)
+            .await
+            .map_err(std::io::Error::other)?;
+
+        let target = lookup_local_session_target_by_id(thread_id, Some(state_runtime.as_ref()))
+            .await
+            .expect("state db path should resolve");
+
+        assert_eq!(target.thread_id, thread_id);
+        assert_eq!(target.path, Some(rollout_path));
+        Ok(())
     }
 
     #[tokio::test]

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -600,6 +600,7 @@ fn session_target_from_app_server_thread(
 
 async fn lookup_local_session_target_by_id(
     thread_id: ThreadId,
+    codex_home: &Path,
     state_db_ctx: Option<&codex_state::StateRuntime>,
 ) -> Option<resume_picker::SessionTarget> {
     let state_db_ctx = state_db_ctx?;
@@ -616,14 +617,11 @@ async fn lookup_local_session_target_by_id(
             cwd: Some(metadata.cwd.clone()),
         });
     }
-    let path = codex_rollout::find_any_thread_path_by_id_str(
-        state_db_ctx.codex_home(),
-        id.as_str(),
-        Some(state_db_ctx),
-    )
-    .await
-    .ok()
-    .flatten()?;
+    let path =
+        codex_rollout::find_any_thread_path_by_id_str(codex_home, id.as_str(), Some(state_db_ctx))
+            .await
+            .ok()
+            .flatten()?;
     let existing_path = codex_rollout::existing_rollout_path(path.as_path()).await?;
     if !rollout_file_name_matches_thread_id(existing_path.as_path(), thread_id) {
         return None;
@@ -695,6 +693,7 @@ async fn lookup_session_target_by_name_with_app_server(
 async fn lookup_session_target_with_app_server(
     app_server: &mut AppServerSession,
     id_or_name: &str,
+    codex_home: &Path,
     state_db_ctx: Option<&codex_state::StateRuntime>,
 ) -> color_eyre::Result<Option<resume_picker::SessionTarget>> {
     if Uuid::parse_str(id_or_name).is_ok() {
@@ -710,7 +709,8 @@ async fn lookup_session_target_with_app_server(
             }
         };
         if !app_server.uses_remote_workspace()
-            && let Some(target) = lookup_local_session_target_by_id(thread_id, state_db_ctx).await
+            && let Some(target) =
+                lookup_local_session_target_by_id(thread_id, codex_home, state_db_ctx).await
         {
             return Ok(Some(target));
         }
@@ -1532,6 +1532,7 @@ async fn run_ratatui_app(
             match lookup_session_target_with_app_server(
                 startup_app_server,
                 id_str,
+                config.codex_home.as_path(),
                 state_db.as_deref(),
             )
             .await?
@@ -1592,8 +1593,13 @@ async fn run_ratatui_app(
         let Some(startup_app_server) = app_server.as_mut() else {
             unreachable!("app server should be initialized for --resume <id>");
         };
-        match lookup_session_target_with_app_server(startup_app_server, id_str, state_db.as_deref())
-            .await?
+        match lookup_session_target_with_app_server(
+            startup_app_server,
+            id_str,
+            config.codex_home.as_path(),
+            state_db.as_deref(),
+        )
+        .await?
         {
             Some(target_session) => resume_picker::SessionSelection::Resume(target_session),
             None => {
@@ -2945,9 +2951,13 @@ mod tests {
             .await
             .map_err(std::io::Error::other)?;
 
-        let target = lookup_local_session_target_by_id(thread_id, Some(state_runtime.as_ref()))
-            .await
-            .expect("state db path should resolve");
+        let target = lookup_local_session_target_by_id(
+            thread_id,
+            config.codex_home.as_path(),
+            Some(state_runtime.as_ref()),
+        )
+        .await
+        .expect("state db path should resolve");
 
         assert_eq!(target.thread_id, thread_id);
         assert_eq!(target.path, Some(rollout_path));

--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -82,6 +82,7 @@ const PICKER_LIST_HORIZONTAL_INSET: u16 = 4;
 pub struct SessionTarget {
     pub path: Option<PathBuf>,
     pub thread_id: ThreadId,
+    pub cwd: Option<PathBuf>,
 }
 
 impl SessionTarget {
@@ -128,8 +129,17 @@ impl SessionPickerAction {
         }
     }
 
-    fn selection(self, path: Option<PathBuf>, thread_id: ThreadId) -> SessionSelection {
-        let target_session = SessionTarget { path, thread_id };
+    fn selection(
+        self,
+        path: Option<PathBuf>,
+        thread_id: ThreadId,
+        cwd: Option<PathBuf>,
+    ) -> SessionSelection {
+        let target_session = SessionTarget {
+            path,
+            thread_id,
+            cwd,
+        };
         match self {
             SessionPickerAction::Resume => SessionSelection::Resume(target_session),
             SessionPickerAction::Fork => SessionSelection::Fork(target_session),
@@ -1107,6 +1117,7 @@ impl PickerState {
             _ if self.list_keymap.accept.is_pressed(key) => {
                 if let Some(row) = self.filtered_rows.get(self.selected) {
                     let path = row.path.clone();
+                    let cwd = row.cwd.clone();
                     let thread_id = match row.thread_id {
                         Some(thread_id) => Some(thread_id),
                         None => match path.as_ref() {
@@ -1118,7 +1129,7 @@ impl PickerState {
                         },
                     };
                     if let Some(thread_id) = thread_id {
-                        return Ok(Some(self.action.selection(path, thread_id)));
+                        return Ok(Some(self.action.selection(path, thread_id, cwd)));
                     }
                     self.inline_error = Some(match path {
                         Some(path) => {
@@ -5710,6 +5721,7 @@ session_picker_view = "dense"
             Some(SessionSelection::Resume(SessionTarget {
                 path: None,
                 thread_id: selected_thread_id,
+                ..
             })) => assert_eq!(selected_thread_id, thread_id),
             other => panic!("unexpected selection: {other:?}"),
         }

--- a/codex-rs/tui/src/session_resume.rs
+++ b/codex-rs/tui/src/session_resume.rs
@@ -5,6 +5,9 @@
 //! before the app server has resumed the selected thread.
 
 use std::io;
+use std::io::Read;
+use std::io::Seek;
+use std::io::SeekFrom;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -12,6 +15,7 @@ use crate::cwd_prompt;
 use crate::cwd_prompt::CwdPromptAction;
 use crate::cwd_prompt::CwdPromptOutcome;
 use crate::cwd_prompt::CwdSelection;
+use crate::resume_picker::SessionTarget;
 use crate::tui::Tui;
 use codex_protocol::ThreadId;
 use codex_rollout::open_rollout_line_reader;
@@ -19,6 +23,9 @@ use codex_state::StateRuntime;
 use codex_utils_path as path_utils;
 use serde::Deserialize;
 use serde_json::Value;
+
+const ROLLOUT_RESUME_TAIL_READ_CHUNK_SIZE: usize = 64 * 1024;
+const TURN_CONTEXT_NEEDLE: &[u8] = b"turn_context";
 
 #[derive(Default)]
 struct RolloutResumeState {
@@ -87,12 +94,22 @@ pub(crate) async fn resolve_cwd_for_resume_or_fork(
     tui: &mut Tui,
     state_db_ctx: Option<&StateRuntime>,
     current_cwd: &Path,
-    thread_id: ThreadId,
-    path: Option<&Path>,
+    target_session: &SessionTarget,
     action: CwdPromptAction,
     allow_prompt: bool,
 ) -> color_eyre::Result<ResolveCwdOutcome> {
-    let Some(history_cwd) = read_session_cwd(state_db_ctx, thread_id, path).await else {
+    let history_cwd = match target_session.cwd.as_deref() {
+        Some(cwd) => Some(cwd.to_path_buf()),
+        None => {
+            read_session_cwd(
+                state_db_ctx,
+                target_session.thread_id,
+                target_session.path.as_deref(),
+            )
+            .await
+        }
+    };
+    let Some(history_cwd) = history_cwd else {
         return Ok(ResolveCwdOutcome::Continue(None));
     };
     if allow_prompt && cwds_differ(current_cwd, &history_cwd) {
@@ -142,6 +159,152 @@ pub(crate) fn cwds_differ(current_cwd: &Path, session_cwd: &Path) -> bool {
 }
 
 async fn read_rollout_resume_state(path: &Path) -> io::Result<RolloutResumeState> {
+    if let Some(state) = try_read_rollout_resume_state_fast(path).await? {
+        return Ok(state);
+    }
+    read_rollout_resume_state_full(path).await
+}
+
+async fn try_read_rollout_resume_state_fast(path: &Path) -> io::Result<Option<RolloutResumeState>> {
+    let Some(existing_path) = codex_rollout::existing_rollout_path(path).await else {
+        return Ok(None);
+    };
+    if is_compressed_rollout_path(existing_path.as_path()) {
+        return Ok(None);
+    }
+
+    let Some(session_meta) = read_initial_session_metadata(existing_path.as_path()).await? else {
+        return Ok(None);
+    };
+    let latest_turn_context =
+        match latest_turn_context_from_plain_rollout(existing_path.as_path()).await {
+            Ok(turn_context) => turn_context,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(err) => return Err(err),
+        };
+
+    let mut state = RolloutResumeState {
+        thread_id: Some(session_meta.id),
+        cwd: Some(session_meta.cwd),
+        ..Default::default()
+    };
+    if let Some(turn_context) = latest_turn_context {
+        state.cwd = Some(turn_context.cwd);
+        state.model = Some(turn_context.model);
+    }
+    Ok(Some(state))
+}
+
+async fn read_initial_session_metadata(path: &Path) -> io::Result<Option<SessionMetadata>> {
+    let mut reader = open_rollout_line_reader(path).await?;
+    while let Some(line) = reader.next_line().await? {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let Ok(record) = serde_json::from_str::<RawRecord>(trimmed) else {
+            continue;
+        };
+        let Some(payload) = record.payload else {
+            return Ok(None);
+        };
+        if record.item_type != "session_meta" {
+            return Ok(None);
+        }
+        return Ok(serde_json::from_value::<SessionMetadata>(payload).ok());
+    }
+    Ok(None)
+}
+
+async fn latest_turn_context_from_plain_rollout(
+    path: &Path,
+) -> io::Result<Option<TurnContextResumeState>> {
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        latest_turn_context_from_plain_rollout_blocking(path.as_path())
+    })
+    .await
+    .map_err(io::Error::other)?
+}
+
+fn latest_turn_context_from_plain_rollout_blocking(
+    path: &Path,
+) -> io::Result<Option<TurnContextResumeState>> {
+    let mut file = std::fs::File::open(path)?;
+    let mut remaining = file.metadata()?.len();
+    let mut line_rev = Vec::new();
+    let mut buf = vec![0u8; ROLLOUT_RESUME_TAIL_READ_CHUNK_SIZE];
+
+    while remaining > 0 {
+        let read_size = usize::try_from(remaining.min(ROLLOUT_RESUME_TAIL_READ_CHUNK_SIZE as u64))
+            .map_err(io::Error::other)?;
+        remaining -= read_size as u64;
+        file.seek(SeekFrom::Start(remaining))?;
+        file.read_exact(&mut buf[..read_size])?;
+
+        for &byte in buf[..read_size].iter().rev() {
+            if byte == b'\n' {
+                if let Some(turn_context) = parse_turn_context_from_rev_line(&mut line_rev)? {
+                    return Ok(Some(turn_context));
+                }
+            } else {
+                line_rev.push(byte);
+            }
+        }
+    }
+
+    parse_turn_context_from_rev_line(&mut line_rev)
+}
+
+fn parse_turn_context_from_rev_line(
+    line_rev: &mut Vec<u8>,
+) -> io::Result<Option<TurnContextResumeState>> {
+    if line_rev.is_empty() {
+        return Ok(None);
+    }
+    line_rev.reverse();
+    let line = std::mem::take(line_rev);
+    let trimmed = trim_ascii_whitespace(line.as_slice());
+    if trimmed.is_empty() || !contains_bytes(trimmed, TURN_CONTEXT_NEEDLE) {
+        return Ok(None);
+    }
+    let Ok(record) = serde_json::from_slice::<RawRecord>(trimmed) else {
+        return Ok(None);
+    };
+    if record.item_type != "turn_context" {
+        return Ok(None);
+    }
+    let Some(payload) = record.payload else {
+        return Ok(None);
+    };
+    Ok(serde_json::from_value::<TurnContextResumeState>(payload).ok())
+}
+
+fn is_compressed_rollout_path(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".jsonl.zst"))
+}
+
+fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+    haystack
+        .windows(needle.len())
+        .any(|window| window == needle)
+}
+
+fn trim_ascii_whitespace(bytes: &[u8]) -> &[u8] {
+    let mut start = 0usize;
+    let mut end = bytes.len();
+    while start < end && bytes[start].is_ascii_whitespace() {
+        start += 1;
+    }
+    while end > start && bytes[end - 1].is_ascii_whitespace() {
+        end -= 1;
+    }
+    &bytes[start..end]
+}
+
+async fn read_rollout_resume_state_full(path: &Path) -> io::Result<RolloutResumeState> {
     let mut reader = open_rollout_line_reader(path).await?;
     let mut state = RolloutResumeState::default();
     let mut saw_record = false;

--- a/codex-rs/tui/src/session_resume.rs
+++ b/codex-rs/tui/src/session_resume.rs
@@ -138,7 +138,7 @@ async fn read_session_cwd(
     if let Some(path) = path {
         match read_rollout_resume_state(path).await {
             Ok(state) => {
-                if state.cwd.is_some() {
+                if state.thread_id == Some(thread_id) && state.cwd.is_some() {
                     return state.cwd;
                 }
             }

--- a/codex-rs/tui/src/session_resume.rs
+++ b/codex-rs/tui/src/session_resume.rs
@@ -98,16 +98,18 @@ pub(crate) async fn resolve_cwd_for_resume_or_fork(
     action: CwdPromptAction,
     allow_prompt: bool,
 ) -> color_eyre::Result<ResolveCwdOutcome> {
-    let history_cwd = match target_session.cwd.as_deref() {
-        Some(cwd) => Some(cwd.to_path_buf()),
-        None => {
-            read_session_cwd(
-                state_db_ctx,
-                target_session.thread_id,
-                target_session.path.as_deref(),
-            )
-            .await
-        }
+    let history_cwd = if target_session.path.is_some() {
+        read_session_cwd(
+            state_db_ctx,
+            target_session.thread_id,
+            target_session.path.as_deref(),
+        )
+        .await
+        .or_else(|| target_session.cwd.clone())
+    } else if let Some(cwd) = target_session.cwd.as_ref() {
+        Some(cwd.clone())
+    } else {
+        read_session_cwd(state_db_ctx, target_session.thread_id, /*path*/ None).await
     };
     let Some(history_cwd) = history_cwd else {
         return Ok(ResolveCwdOutcome::Continue(None));
@@ -133,25 +135,30 @@ async fn read_session_cwd(
     thread_id: ThreadId,
     path: Option<&Path>,
 ) -> Option<PathBuf> {
+    if let Some(path) = path {
+        match read_rollout_resume_state(path).await {
+            Ok(state) => {
+                if state.cwd.is_some() {
+                    return state.cwd;
+                }
+            }
+            Err(err) => {
+                let rollout_path = path.display().to_string();
+                tracing::warn!(
+                    %rollout_path,
+                    %err,
+                    "Failed to read session metadata from rollout"
+                );
+            }
+        }
+    }
+
     if let Some(state_db_ctx) = state_db_ctx
         && let Ok(Some(metadata)) = state_db_ctx.get_thread(thread_id).await
     {
         return Some(metadata.cwd);
     }
-
-    let path = path?;
-    match read_rollout_resume_state(path).await {
-        Ok(state) => state.cwd,
-        Err(err) => {
-            let rollout_path = path.display().to_string();
-            tracing::warn!(
-                %rollout_path,
-                %err,
-                "Failed to read session metadata from rollout"
-            );
-            None
-        }
-    }
+    None
 }
 
 pub(crate) fn cwds_differ(current_cwd: &Path, session_cwd: &Path) -> bool {


### PR DESCRIPTION
- This PR reduces startup work shared by `codex resume` and `codex fork`. It focuses on the paths that scale with session count and rollout history size.
- State database and rollout lookup paths now resolve latest or explicit session IDs directly, validate active and archived paths, and repair stale SQLite paths using stored creation timestamps before falling back to broad filesystem scans. This keeps correctness fallbacks while making the healthy and recoverable cases bounded.
- Rollout metadata and history loading now use buffered blocking reads, direct item deserialization, filename timestamp parsing, bounded head and tail inspection, and preallocated history vectors. This removes repeated async line handling, intermediate JSON cloning, and unnecessary full-file work from resume setup.
- The TUI and app-server now carry the selected rollout path and working directory through resume or fork setup, reuse already-loaded history and thread metadata, and avoid redundant thread reads, history clones, and local existence probes. Current-main call sites were updated to pass the optional state runtime into the new local lookup fast path.
- The five-seed grader reported a 4.67x conservative composite speedup and 5.12x primary speedup: aggregate filesystem latest-session lookup fell from 985.8 ms to 22.8 ms, 10k-item history loading from 255.4 ms to 70.2 ms, and stale-path repair from 27.5 ms to 1.12 ms. Local validation passed Rust formatting, scoped Clippy for all five affected crates, compile checks for all affected test targets, and 296 of 296 executable tests in `codex-rollout`, `codex-state`, and `codex-thread-store`.