### PR TITLE
[codex] Enforce managed shell environment policy

### DIFF
--- a/codex-rs/config/src/config_requirements.rs
+++ b/codex-rs/config/src/config_requirements.rs
@@ -1,7 +1,7 @@
 use codex_protocol::config_types::ApprovalsReviewer;
 use codex_protocol::config_types::SandboxMode;
+use codex_protocol::config_types::ShellEnvironmentPolicyFilter;
 use codex_protocol::config_types::ShellEnvironmentPolicyInherit;
-use codex_protocol::config_types::ShellEnvironmentPolicyRule;
 use codex_protocol::config_types::WebSearchMode;
 use codex_protocol::models::PermissionProfile;
 use codex_protocol::protocol::AskForApproval;
@@ -895,7 +895,7 @@ pub struct ConfigRequirementsToml {
 /// Managed shell environment policy fields accepted by `requirements.toml`.
 ///
 /// Unlike ordinary `config.toml`, requirements intentionally accept only the
-/// keyed `rules` form. This makes include/exclude actions compose by pattern,
+/// keyed `filters` form. This makes include/exclude actions compose by pattern,
 /// while config arrays remain a migration-only compatibility path that can be
 /// deprecated independently later.
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
@@ -904,8 +904,7 @@ pub struct ShellEnvironmentPolicyRequirementsToml {
     pub inherit: Option<ShellEnvironmentPolicyInherit>,
     pub ignore_default_excludes: Option<bool>,
     pub r#set: Option<HashMap<String, String>>,
-    pub rules: Option<BTreeMap<String, ShellEnvironmentPolicyRule>>,
-    pub experimental_use_profile: Option<bool>,
+    pub filters: Option<BTreeMap<String, ShellEnvironmentPolicyFilter>>,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
@@ -3817,10 +3816,10 @@ command = "python3 /enterprise/hooks/pre.py"
     }
 
     #[test]
-    fn shell_environment_policy_requires_rules_for_list_fields() -> Result<()> {
+    fn shell_environment_policy_requires_filters_for_list_fields() -> Result<()> {
         let requirements: ConfigRequirementsToml = from_str(
             r#"
-[shell_environment_policy.rules]
+[shell_environment_policy.filters]
 "HOME" = "include"
 "SECRET_*" = "exclude"
 "#,
@@ -3829,9 +3828,12 @@ command = "python3 /enterprise/hooks/pre.py"
         assert_eq!(
             requirements.shell_environment_policy,
             Some(ShellEnvironmentPolicyRequirementsToml {
-                rules: Some(BTreeMap::from([
-                    ("HOME".to_string(), ShellEnvironmentPolicyRule::Include,),
-                    ("SECRET_*".to_string(), ShellEnvironmentPolicyRule::Exclude,),
+                filters: Some(BTreeMap::from([
+                    ("HOME".to_string(), ShellEnvironmentPolicyFilter::Include,),
+                    (
+                        "SECRET_*".to_string(),
+                        ShellEnvironmentPolicyFilter::Exclude,
+                    ),
                 ])),
                 ..Default::default()
             })
@@ -3845,7 +3847,7 @@ command = "python3 /enterprise/hooks/pre.py"
             assert!(error.to_string().contains(field));
         }
         let error = from_str::<ConfigRequirementsToml>(
-            "[shell_environment_policy.rules]\n\"PATH\" = \"keep\"\n",
+            "[shell_environment_policy.filters]\n\"PATH\" = \"keep\"\n",
         )
         .expect_err("unknown rule actions should be rejected");
         assert!(error.to_string().contains("keep"));

--- a/codex-rs/config/src/config_requirements.rs
+++ b/codex-rs/config/src/config_requirements.rs
@@ -1,5 +1,7 @@
 use codex_protocol::config_types::ApprovalsReviewer;
 use codex_protocol::config_types::SandboxMode;
+use codex_protocol::config_types::ShellEnvironmentPolicyInherit;
+use codex_protocol::config_types::ShellEnvironmentPolicyRule;
 use codex_protocol::config_types::WebSearchMode;
 use codex_protocol::models::PermissionProfile;
 use codex_protocol::protocol::AskForApproval;
@@ -10,6 +12,7 @@ use serde::de::Error as _;
 use serde::de::value::Error as ValueDeserializerError;
 use serde::de::value::StrDeserializer;
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::fmt;
 use wildmatch::WildMatchPattern;
 
@@ -155,6 +158,7 @@ pub struct ConfigRequirements {
     pub check_for_update_on_startup: Option<Sourced<bool>>,
     pub otel: Option<Sourced<OtelConfigToml>>,
     pub allow_login_shell: Option<Sourced<bool>>,
+    pub shell_environment_policy: Option<Sourced<ShellEnvironmentPolicyRequirementsToml>>,
     pub feedback: Option<Sourced<FeedbackConfigToml>>,
     pub approval_policy: ConstrainedWithSource<AskForApproval>,
     pub approvals_reviewer: ConstrainedWithSource<ApprovalsReviewer>,
@@ -193,6 +197,7 @@ impl Default for ConfigRequirements {
             check_for_update_on_startup: None,
             otel: None,
             allow_login_shell: None,
+            shell_environment_policy: None,
             feedback: None,
             approval_policy: ConstrainedWithSource::new(
                 Constrained::allow_any_from_default(),
@@ -859,6 +864,7 @@ pub struct ConfigRequirementsToml {
     pub check_for_update_on_startup: Option<bool>,
     pub otel: Option<OtelConfigToml>,
     pub allow_login_shell: Option<bool>,
+    pub shell_environment_policy: Option<ShellEnvironmentPolicyRequirementsToml>,
     pub feedback: Option<FeedbackConfigToml>,
     pub allowed_approval_policies: Option<Vec<AskForApproval>>,
     pub allowed_approvals_reviewers: Option<Vec<ApprovalsReviewer>>,
@@ -884,6 +890,22 @@ pub struct ConfigRequirementsToml {
     pub network: Option<NetworkRequirementsToml>,
     pub permissions: Option<PermissionsRequirementsToml>,
     pub guardian_policy_config: Option<String>,
+}
+
+/// Managed shell environment policy fields accepted by `requirements.toml`.
+///
+/// Unlike ordinary `config.toml`, requirements intentionally accept only the
+/// keyed `rules` form. This makes include/exclude actions compose by pattern,
+/// while config arrays remain a migration-only compatibility path that can be
+/// deprecated independently later.
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ShellEnvironmentPolicyRequirementsToml {
+    pub inherit: Option<ShellEnvironmentPolicyInherit>,
+    pub ignore_default_excludes: Option<bool>,
+    pub r#set: Option<HashMap<String, String>>,
+    pub rules: Option<BTreeMap<String, ShellEnvironmentPolicyRule>>,
+    pub experimental_use_profile: Option<bool>,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
@@ -926,6 +948,7 @@ pub struct ConfigRequirementsWithSources {
     pub check_for_update_on_startup: Option<Sourced<bool>>,
     pub otel: Option<Sourced<OtelConfigToml>>,
     pub allow_login_shell: Option<Sourced<bool>>,
+    pub shell_environment_policy: Option<Sourced<ShellEnvironmentPolicyRequirementsToml>>,
     pub feedback: Option<Sourced<FeedbackConfigToml>>,
     pub allowed_approval_policies: Option<Sourced<Vec<AskForApproval>>>,
     pub allowed_approvals_reviewers: Option<Sourced<Vec<ApprovalsReviewer>>>,
@@ -979,6 +1002,7 @@ impl ConfigRequirementsWithSources {
             check_for_update_on_startup: _,
             otel: _,
             allow_login_shell: _,
+            shell_environment_policy: _,
             feedback: _,
             allowed_approval_policies: _,
             allowed_approvals_reviewers: _,
@@ -1027,6 +1051,7 @@ impl ConfigRequirementsWithSources {
                 check_for_update_on_startup,
                 otel,
                 allow_login_shell,
+                shell_environment_policy,
                 feedback,
                 allowed_approval_policies,
                 allowed_approvals_reviewers,
@@ -1072,6 +1097,7 @@ impl ConfigRequirementsWithSources {
             check_for_update_on_startup,
             otel,
             allow_login_shell,
+            shell_environment_policy,
             feedback,
             allowed_approval_policies,
             allowed_approvals_reviewers,
@@ -1106,6 +1132,7 @@ impl ConfigRequirementsWithSources {
             check_for_update_on_startup: check_for_update_on_startup.map(|sourced| sourced.value),
             otel: otel.map(|sourced| sourced.value),
             allow_login_shell: allow_login_shell.map(|sourced| sourced.value),
+            shell_environment_policy: shell_environment_policy.map(|sourced| sourced.value),
             feedback: feedback.map(|sourced| sourced.value),
             allowed_approval_policies: allowed_approval_policies.map(|sourced| sourced.value),
             allowed_approvals_reviewers: allowed_approvals_reviewers.map(|sourced| sourced.value),
@@ -1211,6 +1238,10 @@ impl ConfigRequirementsToml {
                 .is_none_or(|otel| otel == &OtelConfigToml::default())
             && self.allow_login_shell.is_none()
             && self
+                .shell_environment_policy
+                .as_ref()
+                .is_none_or(|policy| policy == &ShellEnvironmentPolicyRequirementsToml::default())
+            && self
                 .feedback
                 .as_ref()
                 .is_none_or(|feedback| feedback == &FeedbackConfigToml::default())
@@ -1278,6 +1309,7 @@ impl TryFrom<ConfigRequirementsWithSources> for ConfigRequirements {
             check_for_update_on_startup,
             otel,
             allow_login_shell,
+            shell_environment_policy,
             feedback,
             allowed_approval_policies,
             allowed_approvals_reviewers,
@@ -1618,6 +1650,7 @@ impl TryFrom<ConfigRequirementsWithSources> for ConfigRequirements {
             check_for_update_on_startup,
             otel,
             allow_login_shell,
+            shell_environment_policy,
             feedback,
             approval_policy,
             approvals_reviewer,
@@ -1720,6 +1753,7 @@ mod tests {
             check_for_update_on_startup,
             otel,
             allow_login_shell,
+            shell_environment_policy,
             feedback,
             allowed_approval_policies,
             allowed_approvals_reviewers,
@@ -1761,6 +1795,8 @@ mod tests {
                 .map(|value| Sourced::new(value, RequirementSource::Unknown)),
             otel: otel.map(|value| Sourced::new(value, RequirementSource::Unknown)),
             allow_login_shell: allow_login_shell
+                .map(|value| Sourced::new(value, RequirementSource::Unknown)),
+            shell_environment_policy: shell_environment_policy
                 .map(|value| Sourced::new(value, RequirementSource::Unknown)),
             feedback: feedback.map(|value| Sourced::new(value, RequirementSource::Unknown)),
             allowed_approval_policies: allowed_approval_policies
@@ -3777,6 +3813,42 @@ command = "python3 /enterprise/hooks/pre.py"
                 requirement_source: source,
             })
         );
+        Ok(())
+    }
+
+    #[test]
+    fn shell_environment_policy_requires_rules_for_list_fields() -> Result<()> {
+        let requirements: ConfigRequirementsToml = from_str(
+            r#"
+[shell_environment_policy.rules]
+"HOME" = "include"
+"SECRET_*" = "exclude"
+"#,
+        )?;
+
+        assert_eq!(
+            requirements.shell_environment_policy,
+            Some(ShellEnvironmentPolicyRequirementsToml {
+                rules: Some(BTreeMap::from([
+                    ("HOME".to_string(), ShellEnvironmentPolicyRule::Include,),
+                    ("SECRET_*".to_string(), ShellEnvironmentPolicyRule::Exclude,),
+                ])),
+                ..Default::default()
+            })
+        );
+
+        for field in ["exclude", "include_only"] {
+            let error = from_str::<ConfigRequirementsToml>(&format!(
+                "[shell_environment_policy]\n{field} = [\"LEGACY_*\"]\n"
+            ))
+            .expect_err("legacy requirements.toml arrays should be rejected");
+            assert!(error.to_string().contains(field));
+        }
+        let error = from_str::<ConfigRequirementsToml>(
+            "[shell_environment_policy.rules]\n\"PATH\" = \"keep\"\n",
+        )
+        .expect_err("unknown rule actions should be rejected");
+        assert!(error.to_string().contains("keep"));
         Ok(())
     }
 }

--- a/codex-rs/config/src/lib.rs
+++ b/codex-rs/config/src/lib.rs
@@ -74,6 +74,7 @@ pub use config_requirements::RemoteSandboxConfigToml;
 pub use config_requirements::RequirementSource;
 pub use config_requirements::ResidencyRequirement;
 pub use config_requirements::SandboxModeRequirement;
+pub use config_requirements::ShellEnvironmentPolicyRequirementsToml;
 pub use config_requirements::Sourced;
 pub use config_requirements::WebSearchModeRequirement;
 pub use config_requirements::WindowsRequirementsToml;

--- a/codex-rs/config/src/merge.rs
+++ b/codex-rs/config/src/merge.rs
@@ -21,7 +21,9 @@ fn merge_toml_values_at_path(base: &mut TomlValue, overlay: &TomlValue, path: &m
             normalize_network_domain_keys(base_table);
             normalize_network_domain_keys(&mut overlay_table);
         }
-        if is_shell_environment_filters_path(path) {
+        if is_shell_environment_filters_path(path)
+            || cfg!(target_os = "windows") && is_shell_environment_set_path(path)
+        {
             normalize_case_insensitive_keys(base_table);
             normalize_case_insensitive_keys(&mut overlay_table);
         }
@@ -31,12 +33,12 @@ fn merge_toml_values_at_path(base: &mut TomlValue, overlay: &TomlValue, path: &m
             if let Some(existing) = base_table.get_mut(&key) {
                 merge_toml_values_at_path(existing, &value, path);
             } else {
-                base_table.insert(key, normalized_with_key_aliases(&value, path));
+                base_table.insert(key, normalized_for_merge(&value, path));
             }
             path.pop();
         }
     } else {
-        *base = normalized_with_key_aliases(overlay, path);
+        *base = normalized_for_merge(overlay, path);
     }
 }
 
@@ -176,6 +178,13 @@ fn is_shell_environment_filters_path(path: &[String]) -> bool {
     )
 }
 
+fn is_shell_environment_set_path(path: &[String]) -> bool {
+    matches!(
+        path,
+        [policy, set] if policy == "shell_environment_policy" && set == "set"
+    )
+}
+
 fn is_permission_network_domains_path(path: &[String]) -> bool {
     matches!(
         path,
@@ -195,6 +204,35 @@ fn normalize_case_insensitive_keys(table: &mut toml::map::Map<String, TomlValue>
     let entries = std::mem::take(table);
     for (key, value) in entries {
         table.insert(key.to_ascii_lowercase(), value);
+    }
+}
+
+fn normalized_for_merge(value: &TomlValue, path: &[String]) -> TomlValue {
+    let mut normalized = normalized_with_key_aliases(value, path);
+    normalize_nested_case_insensitive_keys(&mut normalized, &mut path.to_vec());
+    normalized
+}
+
+fn normalize_nested_case_insensitive_keys(value: &mut TomlValue, path: &mut Vec<String>) {
+    match value {
+        TomlValue::Table(table) => {
+            if is_shell_environment_filters_path(path)
+                || cfg!(target_os = "windows") && is_shell_environment_set_path(path)
+            {
+                normalize_case_insensitive_keys(table);
+            }
+            for (key, value) in table {
+                path.push(key.clone());
+                normalize_nested_case_insensitive_keys(value, path);
+                path.pop();
+            }
+        }
+        TomlValue::Array(items) => {
+            for item in items {
+                normalize_nested_case_insensitive_keys(item, path);
+            }
+        }
+        _ => {}
     }
 }
 

--- a/codex-rs/config/src/merge_tests.rs
+++ b/codex-rs/config/src/merge_tests.rs
@@ -179,6 +179,58 @@ fn shell_environment_policy_filters_overlay_merges_by_key_case_insensitively() {
 }
 
 #[test]
+fn shell_environment_policy_filters_are_normalized_in_the_first_layer() {
+    let mut base = parse_toml("");
+    let overlay = parse_toml(
+        r#"
+[shell_environment_policy.filters]
+"UPPER_*" = "exclude"
+"#,
+    );
+
+    merge_toml_values(&mut base, &overlay);
+
+    assert_eq!(
+        base,
+        parse_toml(
+            r#"
+[shell_environment_policy.filters]
+"upper_*" = "exclude"
+"#,
+        )
+    );
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn shell_environment_policy_set_keys_merge_case_insensitively_on_windows() {
+    let mut base = parse_toml(
+        r#"
+[shell_environment_policy.set]
+Path = "low"
+"#,
+    );
+    let overlay = parse_toml(
+        r#"
+[shell_environment_policy.set]
+PATH = "high"
+"#,
+    );
+
+    merge_toml_values(&mut base, &overlay);
+
+    assert_eq!(
+        base,
+        parse_toml(
+            r#"
+[shell_environment_policy.set]
+path = "high"
+"#,
+        )
+    );
+}
+
+#[test]
 fn shell_environment_policy_filters_override_lower_legacy_arrays_by_pattern() {
     let mut base = parse_toml(
         r#"

--- a/codex-rs/config/src/requirements_layers/stack.rs
+++ b/codex-rs/config/src/requirements_layers/stack.rs
@@ -184,6 +184,7 @@ fn populate_merged_regular_fields_with_sources(
         check_for_update_on_startup,
         otel: _,
         allow_login_shell,
+        shell_environment_policy,
         feedback,
         allowed_approval_policies,
         allowed_approvals_reviewers,
@@ -221,6 +222,7 @@ fn populate_merged_regular_fields_with_sources(
         &["check_for_update_on_startup"]
     );
     set_sourced!(allow_login_shell, &["allow_login_shell"]);
+    set_sourced!(shell_environment_policy, &["shell_environment_policy"]);
     set_sourced!(feedback, &["feedback"]);
     set_sourced!(allowed_approval_policies, &["allowed_approval_policies"]);
     set_sourced!(

--- a/codex-rs/config/src/requirements_layers/stack_tests.rs
+++ b/codex-rs/config/src/requirements_layers/stack_tests.rs
@@ -8,7 +8,7 @@ use crate::ConfigRequirementsWithSources;
 use crate::RequirementSource;
 use crate::ShellEnvironmentPolicyRequirementsToml;
 use crate::Sourced;
-use codex_protocol::config_types::ShellEnvironmentPolicyRule;
+use codex_protocol::config_types::ShellEnvironmentPolicyFilter;
 use codex_protocol::protocol::AskForApproval;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use pretty_assertions::assert_eq;
@@ -1078,7 +1078,7 @@ shared = "high"
 }
 
 #[test]
-fn shell_environment_rules_compose_by_pattern() {
+fn shell_environment_filters_compose_by_pattern() {
     let high_source = RequirementSource::EnterpriseManaged {
         id: "req_high".to_string(),
         name: "High".to_string(),
@@ -1092,7 +1092,7 @@ fn shell_environment_rules_compose_by_pattern() {
             RequirementsLayerEntry::from_toml(
                 low_source.clone(),
                 r#"
-[shell_environment_policy.rules]
+[shell_environment_policy.filters]
 "FLIP_*" = "exclude"
 "KEEP_*" = "include"
 "#,
@@ -1100,7 +1100,7 @@ fn shell_environment_rules_compose_by_pattern() {
             RequirementsLayerEntry::from_toml(
                 high_source.clone(),
                 r#"
-[shell_environment_policy.rules]
+[shell_environment_policy.filters]
 "ADD_*" = "exclude"
 "FLIP_*" = "include"
 "#,
@@ -1115,10 +1115,10 @@ fn shell_environment_rules_compose_by_pattern() {
         composed.shell_environment_policy,
         Some(Sourced::new(
             ShellEnvironmentPolicyRequirementsToml {
-                rules: Some(BTreeMap::from([
-                    ("ADD_*".to_string(), ShellEnvironmentPolicyRule::Exclude,),
-                    ("FLIP_*".to_string(), ShellEnvironmentPolicyRule::Include,),
-                    ("KEEP_*".to_string(), ShellEnvironmentPolicyRule::Include,),
+                filters: Some(BTreeMap::from([
+                    ("add_*".to_string(), ShellEnvironmentPolicyFilter::Exclude,),
+                    ("flip_*".to_string(), ShellEnvironmentPolicyFilter::Include,),
+                    ("keep_*".to_string(), ShellEnvironmentPolicyFilter::Include,),
                 ])),
                 ..Default::default()
             },

--- a/codex-rs/config/src/requirements_layers/stack_tests.rs
+++ b/codex-rs/config/src/requirements_layers/stack_tests.rs
@@ -6,7 +6,9 @@ use super::compose_requirements_for_hostname_and_hook_directory;
 use crate::ConfigRequirementsToml;
 use crate::ConfigRequirementsWithSources;
 use crate::RequirementSource;
+use crate::ShellEnvironmentPolicyRequirementsToml;
 use crate::Sourced;
+use codex_protocol::config_types::ShellEnvironmentPolicyRule;
 use codex_protocol::protocol::AskForApproval;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use pretty_assertions::assert_eq;
@@ -1070,6 +1072,56 @@ shared = "high"
             )
             .otel
             .expect("expected OTEL requirements"),
+            RequirementSource::composite([high_source, low_source]),
+        ))
+    );
+}
+
+#[test]
+fn shell_environment_rules_compose_by_pattern() {
+    let high_source = RequirementSource::EnterpriseManaged {
+        id: "req_high".to_string(),
+        name: "High".to_string(),
+    };
+    let low_source = RequirementSource::EnterpriseManaged {
+        id: "req_low".to_string(),
+        name: "Low".to_string(),
+    };
+    let composed = compose_requirements_for_hostname(
+        vec![
+            RequirementsLayerEntry::from_toml(
+                low_source.clone(),
+                r#"
+[shell_environment_policy.rules]
+"FLIP_*" = "exclude"
+"KEEP_*" = "include"
+"#,
+            ),
+            RequirementsLayerEntry::from_toml(
+                high_source.clone(),
+                r#"
+[shell_environment_policy.rules]
+"ADD_*" = "exclude"
+"FLIP_*" = "include"
+"#,
+            ),
+        ],
+        /*hostname*/ None,
+    )
+    .expect("compose requirements")
+    .expect("requirements present");
+
+    assert_eq!(
+        composed.shell_environment_policy,
+        Some(Sourced::new(
+            ShellEnvironmentPolicyRequirementsToml {
+                rules: Some(BTreeMap::from([
+                    ("ADD_*".to_string(), ShellEnvironmentPolicyRule::Exclude,),
+                    ("FLIP_*".to_string(), ShellEnvironmentPolicyRule::Include,),
+                    ("KEEP_*".to_string(), ShellEnvironmentPolicyRule::Include,),
+                ])),
+                ..Default::default()
+            },
             RequirementSource::composite([high_source, low_source]),
         ))
     );

--- a/codex-rs/config/src/types.rs
+++ b/codex-rs/config/src/types.rs
@@ -936,8 +936,6 @@ pub struct ShellEnvironmentPolicyToml {
     /// migration. Requirements accept only this keyed form, keeping array
     /// compatibility isolated so the legacy fields can be deprecated later.
     pub filters: Option<BTreeMap<String, ShellEnvironmentPolicyFilter>>,
-
-    pub experimental_use_profile: Option<bool>,
 }
 
 #[derive(Deserialize)]
@@ -949,7 +947,6 @@ struct ShellEnvironmentPolicyTomlRaw {
     r#set: Option<HashMap<String, String>>,
     include_only: Option<Vec<String>>,
     filters: Option<BTreeMap<String, ShellEnvironmentPolicyFilter>>,
-    experimental_use_profile: Option<bool>,
 }
 
 impl<'de> Deserialize<'de> for ShellEnvironmentPolicyToml {
@@ -970,7 +967,6 @@ impl<'de> Deserialize<'de> for ShellEnvironmentPolicyToml {
             r#set: raw.r#set,
             include_only: raw.include_only,
             filters: raw.filters,
-            experimental_use_profile: raw.experimental_use_profile,
         })
     }
 }
@@ -999,15 +995,12 @@ impl From<ShellEnvironmentPolicyToml> for ShellEnvironmentPolicy {
             .into_iter()
             .map(|s| EnvironmentVariablePattern::new_case_insensitive(&s))
             .collect();
-        let use_profile = toml.experimental_use_profile.unwrap_or(false);
-
         Self {
             inherit,
             ignore_default_excludes,
             exclude,
             r#set,
             include_only,
-            use_profile,
         }
     }
 }

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -2639,9 +2639,6 @@
           },
           "type": "array"
         },
-        "experimental_use_profile": {
-          "type": "boolean"
-        },
         "filters": {
           "additionalProperties": {
             "$ref": "#/definitions/ShellEnvironmentPolicyFilter"
@@ -5213,7 +5210,6 @@
       ],
       "default": {
         "exclude": null,
-        "experimental_use_profile": null,
         "filters": null,
         "ignore_default_excludes": null,
         "include_only": null,

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -11208,6 +11208,16 @@ MANAGED_SECRET_ALLOWED = "required"
     )
     .await?;
 
+    let expected_set = HashMap::from([
+        ("CONFIGURED".to_string(), "kept".to_string()),
+        ("MANAGED".to_string(), "required".to_string()),
+        ("MANAGED_SECRET_ALLOWED".to_string(), "required".to_string()),
+    ]);
+    #[cfg(target_os = "windows")]
+    let expected_set = expected_set
+        .into_iter()
+        .map(|(key, value)| (key.to_ascii_lowercase(), value))
+        .collect();
     let expected: codex_protocol::config_types::ShellEnvironmentPolicy =
         codex_config::types::ShellEnvironmentPolicyToml {
             ignore_default_excludes: Some(false),
@@ -11217,11 +11227,7 @@ MANAGED_SECRET_ALLOWED = "required"
                 "managed_*".to_string(),
             ]),
             include_only: Some(vec!["HOME".to_string(), "flip_to_include".to_string()]),
-            r#set: Some(HashMap::from([
-                ("CONFIGURED".to_string(), "kept".to_string()),
-                ("MANAGED".to_string(), "required".to_string()),
-                ("MANAGED_SECRET_ALLOWED".to_string(), "required".to_string()),
-            ])),
+            r#set: Some(expected_set),
             ..Default::default()
         }
         .into();

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -11185,7 +11185,9 @@ include_only = ["HOME", "FLIP_TO_EXCLUDE"]
 
 [shell_environment_policy.set]
 CONFIGURED = "kept"
+CONFIGURED_SECRET = "removed"
 MANAGED = "old"
+MANAGED_BLOCKED = "removed"
 "#,
     )?;
     let config = load_with_enterprise_requirement(
@@ -11193,15 +11195,15 @@ MANAGED = "old"
         r#"
 [shell_environment_policy]
 ignore_default_excludes = false
-experimental_use_profile = true
 
-[shell_environment_policy.rules]
+[shell_environment_policy.filters]
 "FLIP_TO_EXCLUDE" = "exclude"
 "FLIP_TO_INCLUDE" = "include"
 "MANAGED_*" = "exclude"
 
 [shell_environment_policy.set]
 MANAGED = "required"
+MANAGED_SECRET_ALLOWED = "required"
 "#,
     )
     .await?;
@@ -11211,14 +11213,14 @@ MANAGED = "required"
             ignore_default_excludes: Some(false),
             exclude: Some(vec![
                 "USER_*".to_string(),
-                "FLIP_TO_EXCLUDE".to_string(),
-                "MANAGED_*".to_string(),
+                "flip_to_exclude".to_string(),
+                "managed_*".to_string(),
             ]),
-            include_only: Some(vec!["HOME".to_string(), "FLIP_TO_INCLUDE".to_string()]),
-            experimental_use_profile: Some(true),
+            include_only: Some(vec!["HOME".to_string(), "flip_to_include".to_string()]),
             r#set: Some(HashMap::from([
                 ("CONFIGURED".to_string(), "kept".to_string()),
                 ("MANAGED".to_string(), "required".to_string()),
+                ("MANAGED_SECRET_ALLOWED".to_string(), "required".to_string()),
             ])),
             ..Default::default()
         }

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -8340,6 +8340,7 @@ async fn test_requirements_web_search_mode_allowlist_does_not_warn_when_unset() 
         check_for_update_on_startup: None,
         otel: None,
         allow_login_shell: None,
+        shell_environment_policy: None,
         feedback: None,
         allowed_approval_policies: None,
         allowed_approvals_reviewers: None,
@@ -11167,6 +11168,64 @@ zz_overflow = {configured_overflow:?}
     assert!(config.startup_warnings.iter().any(|warning| {
         warning.contains("otel.tracestate.vendor.zz_overflow")
             && warning.contains("would invalidate tracestate required by")
+    }));
+    Ok(())
+}
+
+#[tokio::test]
+async fn managed_shell_environment_policy_overrides_matching_patterns() -> std::io::Result<()> {
+    let codex_home = TempDir::new()?;
+    std::fs::write(
+        codex_home.path().join(CONFIG_TOML_FILE),
+        r#"
+[shell_environment_policy]
+ignore_default_excludes = true
+exclude = ["USER_*", "FLIP_TO_INCLUDE"]
+include_only = ["HOME", "FLIP_TO_EXCLUDE"]
+
+[shell_environment_policy.set]
+CONFIGURED = "kept"
+MANAGED = "old"
+"#,
+    )?;
+    let config = load_with_enterprise_requirement(
+        &codex_home,
+        r#"
+[shell_environment_policy]
+ignore_default_excludes = false
+experimental_use_profile = true
+
+[shell_environment_policy.rules]
+"FLIP_TO_EXCLUDE" = "exclude"
+"FLIP_TO_INCLUDE" = "include"
+"MANAGED_*" = "exclude"
+
+[shell_environment_policy.set]
+MANAGED = "required"
+"#,
+    )
+    .await?;
+
+    let expected: codex_protocol::config_types::ShellEnvironmentPolicy =
+        codex_config::types::ShellEnvironmentPolicyToml {
+            ignore_default_excludes: Some(false),
+            exclude: Some(vec![
+                "USER_*".to_string(),
+                "FLIP_TO_EXCLUDE".to_string(),
+                "MANAGED_*".to_string(),
+            ]),
+            include_only: Some(vec!["HOME".to_string(), "FLIP_TO_INCLUDE".to_string()]),
+            experimental_use_profile: Some(true),
+            r#set: Some(HashMap::from([
+                ("CONFIGURED".to_string(), "kept".to_string()),
+                ("MANAGED".to_string(), "required".to_string()),
+            ])),
+            ..Default::default()
+        }
+        .into();
+    assert_eq!(config.permissions.shell_environment_policy, expected);
+    assert!(config.startup_warnings.iter().any(|warning| {
+        warning.contains("Configured values under `shell_environment_policy` are overridden")
     }));
     Ok(())
 }

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -2716,6 +2716,7 @@ impl Config {
             check_for_update_on_startup: _,
             otel: _,
             allow_login_shell: _,
+            shell_environment_policy: _,
             feedback: _,
             approval_policy: mut constrained_approval_policy,
             approvals_reviewer: mut constrained_approvals_reviewer,

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -2706,6 +2706,11 @@ impl Config {
         // Destructure every field to ensure ConfigRequirements additions are
         // either applied above or handled while constructing the final Config.
         let ConfigRequirements {
+            approval_policy: mut constrained_approval_policy,
+            approvals_reviewer: mut constrained_approvals_reviewer,
+            permission_profile: mut constrained_permission_profile,
+            windows_sandbox_mode: mut constrained_windows_sandbox_mode,
+            web_search_mode: mut constrained_web_search_mode,
             allowed_login_methods: _,
             allowed_chatgpt_workspaces: _,
             cli_auth_credentials_store: _,
@@ -2718,12 +2723,7 @@ impl Config {
             allow_login_shell: _,
             shell_environment_policy: _,
             feedback: _,
-            approval_policy: mut constrained_approval_policy,
-            approvals_reviewer: mut constrained_approvals_reviewer,
-            permission_profile: mut constrained_permission_profile,
-            windows_sandbox_mode: mut constrained_windows_sandbox_mode,
             windows_sandbox_private_desktop: _,
-            web_search_mode: mut constrained_web_search_mode,
             allow_managed_hooks_only: _,
             allow_appshots: _,
             allow_remote_control: _,

--- a/codex-rs/core/src/config/requirements.rs
+++ b/codex-rs/core/src/config/requirements.rs
@@ -6,8 +6,9 @@ use codex_config::config_toml::ConfigToml;
 use codex_config::types::AuthCredentialsStoreMode;
 use codex_config::types::FeedbackConfigToml;
 use codex_config::types::ShellEnvironmentPolicyToml;
+use codex_protocol::config_types::EnvironmentVariablePattern;
 use codex_protocol::config_types::ForcedLoginMethod;
-use codex_protocol::config_types::ShellEnvironmentPolicyRule;
+use codex_protocol::config_types::ShellEnvironmentPolicyFilter;
 use std::collections::BTreeMap;
 
 use super::otel;
@@ -149,8 +150,7 @@ fn apply_shell_environment_policy_requirement(
         inherit,
         ignore_default_excludes,
         r#set: required_set,
-        rules,
-        experimental_use_profile,
+        filters,
     } = value;
     let mut conflict = false;
 
@@ -159,20 +159,40 @@ fn apply_shell_environment_policy_requirement(
         &mut configured.ignore_default_excludes,
         ignore_default_excludes,
     );
-    conflict |= apply_required_pattern_rules(configured, rules);
-    conflict |= replace_required_leaf(
-        &mut configured.experimental_use_profile,
-        experimental_use_profile,
-    );
+    conflict |= apply_required_pattern_filters(configured, filters);
+
+    if let Some(configured_set) = configured.r#set.as_mut() {
+        let mut required_excludes = filters
+            .iter()
+            .flatten()
+            .filter(|(_, action)| **action == ShellEnvironmentPolicyFilter::Exclude)
+            .map(|(pattern, _)| EnvironmentVariablePattern::new_case_insensitive(pattern))
+            .collect::<Vec<_>>();
+        if ignore_default_excludes == &Some(false) {
+            required_excludes.extend(
+                ["*KEY*", "*SECRET*", "*TOKEN*"]
+                    .map(EnvironmentVariablePattern::new_case_insensitive),
+            );
+        }
+        let previous_len = configured_set.len();
+        configured_set
+            .retain(|key, _| !required_excludes.iter().any(|pattern| pattern.matches(key)));
+        conflict |= configured_set.len() != previous_len;
+    }
 
     if let Some(required) = required_set.as_ref() {
         let configured_set = configured.r#set.get_or_insert_default();
         conflict |= required.iter().any(|(key, value)| {
             configured_set
-                .get(key)
+                .iter()
+                .find(|(configured_key, _)| environment_keys_equal(configured_key, key))
+                .map(|(_, current)| current)
                 .is_some_and(|current| current != value)
         });
-        configured_set.extend(required.clone());
+        for (key, value) in required {
+            configured_set.retain(|configured_key, _| !environment_keys_equal(configured_key, key));
+            configured_set.insert(key.clone(), value.clone());
+        }
     }
 
     push_structured_requirement_override_warning(
@@ -183,49 +203,74 @@ fn apply_shell_environment_policy_requirement(
     );
 }
 
-fn apply_required_pattern_rules(
+fn apply_required_pattern_filters(
     configured: &mut ShellEnvironmentPolicyToml,
-    required: &Option<BTreeMap<String, ShellEnvironmentPolicyRule>>,
+    required: &Option<BTreeMap<String, ShellEnvironmentPolicyFilter>>,
 ) -> bool {
     let Some(required) = required else {
         return false;
     };
     let conflict = required.iter().any(|(pattern, required_action)| {
         let configured_action = configured
-            .rules
+            .filters
             .as_ref()
-            .and_then(|rules| rules.get(pattern).copied())
+            .and_then(|filters| {
+                filters
+                    .iter()
+                    .find(|(configured_pattern, _)| {
+                        configured_pattern.eq_ignore_ascii_case(pattern)
+                    })
+                    .map(|(_, action)| *action)
+            })
             .or_else(|| {
                 configured
                     .exclude
                     .as_ref()
-                    .is_some_and(|patterns| patterns.contains(pattern))
-                    .then_some(ShellEnvironmentPolicyRule::Exclude)
+                    .is_some_and(|patterns| {
+                        patterns
+                            .iter()
+                            .any(|candidate| candidate.eq_ignore_ascii_case(pattern))
+                    })
+                    .then_some(ShellEnvironmentPolicyFilter::Exclude)
             })
             .or_else(|| {
                 configured
                     .include_only
                     .as_ref()
-                    .is_some_and(|patterns| patterns.contains(pattern))
-                    .then_some(ShellEnvironmentPolicyRule::Include)
+                    .is_some_and(|patterns| {
+                        patterns
+                            .iter()
+                            .any(|candidate| candidate.eq_ignore_ascii_case(pattern))
+                    })
+                    .then_some(ShellEnvironmentPolicyFilter::Include)
             });
         configured_action.is_some_and(|action| action != *required_action)
     });
 
     for pattern in required.keys() {
         if let Some(exclude) = configured.exclude.as_mut() {
-            exclude.retain(|candidate| candidate != pattern);
+            exclude.retain(|candidate| !candidate.eq_ignore_ascii_case(pattern));
         }
         if let Some(include_only) = configured.include_only.as_mut() {
-            include_only.retain(|candidate| candidate != pattern);
+            include_only.retain(|candidate| !candidate.eq_ignore_ascii_case(pattern));
         }
     }
-    configured
-        .rules
-        .get_or_insert_default()
-        .extend(required.clone());
+    let configured_filters = configured.filters.get_or_insert_default();
+    for (pattern, action) in required {
+        configured_filters
+            .retain(|configured_pattern, _| !configured_pattern.eq_ignore_ascii_case(pattern));
+        configured_filters.insert(pattern.clone(), *action);
+    }
 
     conflict
+}
+
+fn environment_keys_equal(left: &str, right: &str) -> bool {
+    if cfg!(target_os = "windows") {
+        left.eq_ignore_ascii_case(right)
+    } else {
+        left == right
+    }
 }
 
 fn apply_feedback_requirement(

--- a/codex-rs/core/src/config/requirements.rs
+++ b/codex-rs/core/src/config/requirements.rs
@@ -1,10 +1,14 @@
 use codex_config::ConfigRequirements;
 use codex_config::RequirementSource;
+use codex_config::ShellEnvironmentPolicyRequirementsToml;
 use codex_config::Sourced;
 use codex_config::config_toml::ConfigToml;
 use codex_config::types::AuthCredentialsStoreMode;
 use codex_config::types::FeedbackConfigToml;
+use codex_config::types::ShellEnvironmentPolicyToml;
 use codex_protocol::config_types::ForcedLoginMethod;
+use codex_protocol::config_types::ShellEnvironmentPolicyRule;
+use std::collections::BTreeMap;
 
 use super::otel;
 
@@ -42,6 +46,11 @@ pub(super) fn apply_to_config(
     apply_exact!(model_catalog_json);
     apply_exact!(check_for_update_on_startup);
     apply_exact!(allow_login_shell);
+    apply_shell_environment_policy_requirement(
+        &mut config.shell_environment_policy,
+        requirements.shell_environment_policy.as_ref(),
+        startup_warnings,
+    );
     if let Some(requirement) = requirements.otel.as_ref() {
         otel::apply_requirement(&mut config.otel, requirement, startup_warnings)?;
     }
@@ -119,6 +128,97 @@ pub(super) fn replace_required_leaf<T: Clone + PartialEq>(
         .as_ref()
         .is_some_and(|configured| configured != required);
     *configured = Some(required.clone());
+    conflict
+}
+
+fn apply_shell_environment_policy_requirement(
+    configured: &mut ShellEnvironmentPolicyToml,
+    requirement: Option<&Sourced<ShellEnvironmentPolicyRequirementsToml>>,
+    startup_warnings: &mut Vec<String>,
+) {
+    let Some(Sourced { value, source }) = requirement else {
+        return;
+    };
+    let ShellEnvironmentPolicyRequirementsToml {
+        inherit,
+        ignore_default_excludes,
+        r#set: required_set,
+        rules,
+        experimental_use_profile,
+    } = value;
+    let mut conflict = false;
+
+    conflict |= replace_required_leaf(&mut configured.inherit, inherit);
+    conflict |= replace_required_leaf(
+        &mut configured.ignore_default_excludes,
+        ignore_default_excludes,
+    );
+    conflict |= apply_required_pattern_rules(configured, rules);
+    conflict |= replace_required_leaf(
+        &mut configured.experimental_use_profile,
+        experimental_use_profile,
+    );
+
+    if let Some(required) = required_set.as_ref() {
+        let configured_set = configured.r#set.get_or_insert_default();
+        conflict |= required.iter().any(|(key, value)| {
+            configured_set
+                .get(key)
+                .is_some_and(|current| current != value)
+        });
+        configured_set.extend(required.clone());
+    }
+
+    push_structured_requirement_override_warning(
+        "shell_environment_policy",
+        conflict,
+        source,
+        startup_warnings,
+    );
+}
+
+fn apply_required_pattern_rules(
+    configured: &mut ShellEnvironmentPolicyToml,
+    required: &Option<BTreeMap<String, ShellEnvironmentPolicyRule>>,
+) -> bool {
+    let Some(required) = required else {
+        return false;
+    };
+    let conflict = required.iter().any(|(pattern, required_action)| {
+        let configured_action = configured
+            .rules
+            .as_ref()
+            .and_then(|rules| rules.get(pattern).copied())
+            .or_else(|| {
+                configured
+                    .exclude
+                    .as_ref()
+                    .is_some_and(|patterns| patterns.contains(pattern))
+                    .then_some(ShellEnvironmentPolicyRule::Exclude)
+            })
+            .or_else(|| {
+                configured
+                    .include_only
+                    .as_ref()
+                    .is_some_and(|patterns| patterns.contains(pattern))
+                    .then_some(ShellEnvironmentPolicyRule::Include)
+            });
+        configured_action.is_some_and(|action| action != *required_action)
+    });
+
+    for pattern in required.keys() {
+        if let Some(exclude) = configured.exclude.as_mut() {
+            exclude.retain(|candidate| candidate != pattern);
+        }
+        if let Some(include_only) = configured.include_only.as_mut() {
+            include_only.retain(|candidate| candidate != pattern);
+        }
+    }
+    configured
+        .rules
+        .get_or_insert_default()
+        .extend(required.clone());
+
     conflict
 }
 

--- a/codex-rs/core/src/config/requirements.rs
+++ b/codex-rs/core/src/config/requirements.rs
@@ -13,6 +13,10 @@ use std::collections::BTreeMap;
 use super::otel;
 
 /// Runtime values that cannot be applied by mutating [`ConfigToml`] alone.
+///
+/// Other managed settings are written back into `ConfigToml`. These values need
+/// additional credential-store compatibility handling or intersection with the
+/// configured authentication restrictions before constructing the final config.
 pub(super) struct AppliedConfigRequirements {
     pub cli_auth_credentials_store_mode: AuthCredentialsStoreMode,
     pub forced_login_method: Option<ForcedLoginMethod>,
@@ -21,8 +25,10 @@ pub(super) struct AppliedConfigRequirements {
 
 /// Applies managed requirements to regular config before final config construction.
 ///
-/// Managed values replace their configured counterparts, and conflicts produce
-/// source-aware startup warnings.
+/// Managed values replace or merge with their configured counterparts, and
+/// conflicts produce source-aware startup warnings. Effective authentication
+/// values that need additional resolution are returned separately. Invalid or
+/// conflicting requirements return an error.
 pub(super) fn apply_to_config(
     config: &mut ConfigToml,
     requirements: &ConfigRequirements,

--- a/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
@@ -4465,7 +4465,7 @@ async fn build_agent_spawn_config_uses_turn_context_values() {
     turn.developer_instructions = Some("dev".to_string());
     turn.compact_prompt = Some("compact".to_string());
     turn.shell_environment_policy = ShellEnvironmentPolicy {
-        use_profile: true,
+        ignore_default_excludes: false,
         ..ShellEnvironmentPolicy::default()
     };
     let temp_dir = tempfile::tempdir().expect("temp dir");

--- a/codex-rs/exec-server/src/local_process.rs
+++ b/codex-rs/exec-server/src/local_process.rs
@@ -463,7 +463,6 @@ fn shell_environment_policy(env_policy: &ExecEnvPolicy) -> ShellEnvironmentPolic
             .iter()
             .map(|pattern| EnvironmentVariablePattern::new_case_insensitive(pattern))
             .collect(),
-        use_profile: false,
     }
 }
 

--- a/codex-rs/protocol/src/config_types.rs
+++ b/codex-rs/protocol/src/config_types.rs
@@ -252,9 +252,6 @@ pub struct ShellEnvironmentPolicy {
 
     /// Environment variable names to retain in the environment.
     pub include_only: Vec<EnvironmentVariablePattern>,
-
-    /// If true, the shell profile will be used to run the command.
-    pub use_profile: bool,
 }
 
 impl Default for ShellEnvironmentPolicy {
@@ -265,7 +262,6 @@ impl Default for ShellEnvironmentPolicy {
             exclude: Vec::new(),
             r#set: HashMap::new(),
             include_only: Vec::new(),
-            use_profile: false,
         }
     }
 }

--- a/codex-rs/rmcp-client/src/stdio_server_launcher.rs
+++ b/codex-rs/rmcp-client/src/stdio_server_launcher.rs
@@ -628,7 +628,6 @@ mod tests {
                 .iter()
                 .map(|pattern| EnvironmentVariablePattern::new_case_insensitive(pattern))
                 .collect(),
-            use_profile: false,
         };
 
         let env = shell_environment::create_env_from_vars(


### PR DESCRIPTION
## Summary

Adds `shell_environment_policy` enforcement to `requirements.toml` using the keyed `filters` representation introduced at the bottom of this stack.

```toml
[shell_environment_policy]
inherit = "all"
ignore_default_excludes = false

[shell_environment_policy.filters]
"CORP_*" = "include"
"*SECRET*" = "exclude"
```

## Why

Managed shell policy must compose safely across requirement sources. Legacy arrays cannot compose per pattern because each higher layer replaces the entire array.

Ordinary `config.toml` continues accepting either representation to ease migration. `requirements.toml` accepts only keyed filters, isolating compatibility and making future array deprecation simpler.

## Semantics

- Requirements accept `filters` and reject legacy `exclude`/`include_only` arrays.
- `inherit` and `ignore_default_excludes` use the highest-priority specified value.
- `set` composes by environment-variable name; keys compose case-insensitively on Windows.
- `filters` composes by pattern; the highest-priority action wins for the same pattern.
- Required scalar leaves replace matching configured leaves.
- Required excludes and required default excludes remove configured `set` entries that would reintroduce a blocked variable.
- Required `set` entries are applied afterward and may deliberately re-add a variable.
- Required filters replace the configured action for the same pattern.
- Matching legacy-array entries are removed before installing a required action.
- Unrelated configured settings and patterns remain.
- Conflicts produce one source-aware warning for the structured shell policy.

This PR does not make shell snapshots policy-aware.

## `experimental_use_profile`

Review traced the runtime behavior to [#5278](https://github.com/openai/codex/pull/5278), which silently removed the execution plumbing for shell-profile loading while leaving the config field behind. No usage regressions were reported after that removal, so this stack removes the inert `experimental_use_profile` / `use_profile` field rather than reviving it or exposing it through managed requirements.

## Stack

PRs: #28411 → #28409 → #28410 → #28412 → **#28414** → #28413

| Position | PR | Branch |
| --- | --- | --- |
| 1 | Keyed shell filters | `abhinav/requirements-shell-rules` |
| 2 | Exact managed values | `abhinav/requirements-exact-values` |
| 3 | Managed auth/bootstrap | `abhinav/requirements-auth-bootstrap` |
| 4 | Managed OTEL | `abhinav/requirements-otel` |
| 5 | **Managed shell policy — this PR** | `abhinav/requirements-shell-policy` |
| 6 | App-server API/schemas | `abhinav/requirements-app-server-api` |
