### PR TITLE
[codex] Fix missing response item metadata in tests

### DIFF
--- a/codex-rs/codex-api/tests/clients.rs
+++ b/codex-rs/codex-api/tests/clients.rs
@@ -312,6 +312,7 @@ async fn responses_client_stream_request_preserves_exact_json_body() -> Result<(
             role: "user".into(),
             content: vec![ContentItem::InputText { text: "hi".into() }],
             phase: None,
+            metadata: None,
         }],
         tools: Vec::new(),
         tool_choice: "auto".into(),

--- a/codex-rs/core/src/guardian/tests.rs
+++ b/codex-rs/core/src/guardian/tests.rs
@@ -1696,6 +1696,7 @@ async fn guardian_review_request_layout_matches_model_visible_request_snapshot()
                     ),
                 }],
                 phase: None,
+                metadata: None,
             }],
         )
         .await;


### PR DESCRIPTION
Summary
- Add the two missing `metadata: None` initializers after #28355 made response-item metadata required.
- Restore test compilation for `codex-core` and `codex-api` on main.

Validation
- `git diff --check`
- `just fmt` (Rust formatting passed; unrelated Python formatter steps could not use the sandboxed shared `uv` cache)
- `just test -p codex-core guardian_review_request_layout_matches_model_visible_request_snapshot`
- `just test -p codex-api responses_client_stream_request_preserves_exact_json_body`
