### PR TITLE
[app-server] add title to image generation items

### DIFF
--- a/codex-rs/analytics/src/analytics_client_tests.rs
+++ b/codex-rs/analytics/src/analytics_client_tests.rs
@@ -3957,6 +3957,7 @@ async fn turn_event_counts_completed_tool_items() {
         ThreadItem::ImageGeneration {
             id: "image-1".to_string(),
             status: "completed".to_string(),
+            title: None,
             revised_prompt: None,
             result: "ok".to_string(),
             saved_path: None,

--- a/codex-rs/app-server-protocol/schema/json/ServerNotification.json
+++ b/codex-rs/app-server-protocol/schema/json/ServerNotification.json
@@ -4364,6 +4364,13 @@
             "status": {
               "type": "string"
             },
+            "title": {
+              "description": "Short display title for the generated image, when available.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "type": {
               "enum": [
                 "imageGeneration"

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -17686,6 +17686,13 @@
               "status": {
                 "type": "string"
               },
+              "title": {
+                "description": "Short display title for the generated image, when available.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "type": {
                 "enum": [
                   "imageGeneration"

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
@@ -15494,6 +15494,13 @@
             "status": {
               "type": "string"
             },
+            "title": {
+              "description": "Short display title for the generated image, when available.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "type": {
               "enum": [
                 "imageGeneration"

--- a/codex-rs/app-server-protocol/schema/json/v2/ItemCompletedNotification.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ItemCompletedNotification.json
@@ -1114,6 +1114,13 @@
             "status": {
               "type": "string"
             },
+            "title": {
+              "description": "Short display title for the generated image, when available.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "type": {
               "enum": [
                 "imageGeneration"

--- a/codex-rs/app-server-protocol/schema/json/v2/ItemStartedNotification.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ItemStartedNotification.json
@@ -1114,6 +1114,13 @@
             "status": {
               "type": "string"
             },
+            "title": {
+              "description": "Short display title for the generated image, when available.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "type": {
               "enum": [
                 "imageGeneration"

--- a/codex-rs/app-server-protocol/schema/json/v2/ReviewStartResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ReviewStartResponse.json
@@ -1258,6 +1258,13 @@
             "status": {
               "type": "string"
             },
+            "title": {
+              "description": "Short display title for the generated image, when available.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "type": {
               "enum": [
                 "imageGeneration"

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadForkResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadForkResponse.json
@@ -1742,6 +1742,13 @@
             "status": {
               "type": "string"
             },
+            "title": {
+              "description": "Short display title for the generated image, when available.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "type": {
               "enum": [
                 "imageGeneration"

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadListResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadListResponse.json
@@ -1557,6 +1557,13 @@
             "status": {
               "type": "string"
             },
+            "title": {
+              "description": "Short display title for the generated image, when available.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "type": {
               "enum": [
                 "imageGeneration"

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadMetadataUpdateResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadMetadataUpdateResponse.json
@@ -1557,6 +1557,13 @@
             "status": {
               "type": "string"
             },
+            "title": {
+              "description": "Short display title for the generated image, when available.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "type": {
               "enum": [
                 "imageGeneration"

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadReadResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadReadResponse.json
@@ -1557,6 +1557,13 @@
             "status": {
               "type": "string"
             },
+            "title": {
+              "description": "Short display title for the generated image, when available.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "type": {
               "enum": [
                 "imageGeneration"

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadResumeResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadResumeResponse.json
@@ -1742,6 +1742,13 @@
             "status": {
               "type": "string"
             },
+            "title": {
+              "description": "Short display title for the generated image, when available.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "type": {
               "enum": [
                 "imageGeneration"

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadRollbackResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadRollbackResponse.json
@@ -1557,6 +1557,13 @@
             "status": {
               "type": "string"
             },
+            "title": {
+              "description": "Short display title for the generated image, when available.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "type": {
               "enum": [
                 "imageGeneration"

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadStartResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadStartResponse.json
@@ -1742,6 +1742,13 @@
             "status": {
               "type": "string"
             },
+            "title": {
+              "description": "Short display title for the generated image, when available.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "type": {
               "enum": [
                 "imageGeneration"

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadStartedNotification.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadStartedNotification.json
@@ -1557,6 +1557,13 @@
             "status": {
               "type": "string"
             },
+            "title": {
+              "description": "Short display title for the generated image, when available.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "type": {
               "enum": [
                 "imageGeneration"

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadUnarchiveResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadUnarchiveResponse.json
@@ -1557,6 +1557,13 @@
             "status": {
               "type": "string"
             },
+            "title": {
+              "description": "Short display title for the generated image, when available.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "type": {
               "enum": [
                 "imageGeneration"

--- a/codex-rs/app-server-protocol/schema/json/v2/TurnCompletedNotification.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/TurnCompletedNotification.json
@@ -1258,6 +1258,13 @@
             "status": {
               "type": "string"
             },
+            "title": {
+              "description": "Short display title for the generated image, when available.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "type": {
               "enum": [
                 "imageGeneration"

--- a/codex-rs/app-server-protocol/schema/json/v2/TurnStartResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/TurnStartResponse.json
@@ -1258,6 +1258,13 @@
             "status": {
               "type": "string"
             },
+            "title": {
+              "description": "Short display title for the generated image, when available.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "type": {
               "enum": [
                 "imageGeneration"

--- a/codex-rs/app-server-protocol/schema/json/v2/TurnStartedNotification.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/TurnStartedNotification.json
@@ -1258,6 +1258,13 @@
             "status": {
               "type": "string"
             },
+            "title": {
+              "description": "Short display title for the generated image, when available.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
             "type": {
               "enum": [
                 "imageGeneration"

--- a/codex-rs/app-server-protocol/schema/typescript/v2/ThreadItem.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/ThreadItem.ts
@@ -99,4 +99,8 @@ reasoningEffort: ReasoningEffort | null,
 /**
  * Last known status of the target agents, when available.
  */
-agentsStates: { [key in string]?: CollabAgentState }, } | { "type": "subAgentActivity", id: string, kind: SubAgentActivityKind, agentThreadId: string, agentPath: string, } | { "type": "webSearch", id: string, query: string, action: WebSearchAction | null, } | { "type": "imageView", id: string, path: AbsolutePathBuf, } | { "type": "imageGeneration", id: string, status: string, revisedPrompt: string | null, result: string, savedPath?: AbsolutePathBuf, } | { "type": "enteredReviewMode", id: string, review: string, } | { "type": "exitedReviewMode", id: string, review: string, } | { "type": "contextCompaction", id: string, };
+agentsStates: { [key in string]?: CollabAgentState }, } | { "type": "subAgentActivity", id: string, kind: SubAgentActivityKind, agentThreadId: string, agentPath: string, } | { "type": "webSearch", id: string, query: string, action: WebSearchAction | null, } | { "type": "imageView", id: string, path: AbsolutePathBuf, } | { "type": "imageGeneration", id: string, status: string,
+/**
+ * Short display title for the generated image, when available.
+ */
+title: string | null, revisedPrompt: string | null, result: string, savedPath?: AbsolutePathBuf, } | { "type": "enteredReviewMode", id: string, review: string, } | { "type": "exitedReviewMode", id: string, review: string, } | { "type": "contextCompaction", id: string, };

--- a/codex-rs/app-server-protocol/src/protocol/thread_history.rs
+++ b/codex-rs/app-server-protocol/src/protocol/thread_history.rs
@@ -602,6 +602,7 @@ impl ThreadHistoryBuilder {
         let item = ThreadItem::ImageGeneration {
             id: payload.call_id.clone(),
             status: String::new(),
+            title: None,
             revised_prompt: None,
             result: String::new(),
             saved_path: None,
@@ -613,6 +614,7 @@ impl ThreadHistoryBuilder {
         let item = ThreadItem::ImageGeneration {
             id: payload.call_id.clone(),
             status: payload.status.clone(),
+            title: None,
             revised_prompt: payload.revised_prompt.clone(),
             result: payload.result.clone(),
             saved_path: payload.saved_path.clone(),
@@ -1622,6 +1624,7 @@ mod tests {
                     ThreadItem::ImageGeneration {
                         id: "ig_123".into(),
                         status: "completed".into(),
+                        title: None,
                         revised_prompt: Some("final prompt".into()),
                         result: "Zm9v".into(),
                         saved_path: Some(test_path_buf("/tmp/ig_123.png").abs()),

--- a/codex-rs/app-server-protocol/src/protocol/v2/item.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2/item.rs
@@ -358,6 +358,8 @@ pub enum ThreadItem {
     ImageGeneration {
         id: String,
         status: String,
+        /// Short display title for the generated image, when available.
+        title: Option<String>,
         revised_prompt: Option<String>,
         result: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -837,6 +839,7 @@ impl From<CoreTurnItem> for ThreadItem {
             CoreTurnItem::ImageGeneration(image) => ThreadItem::ImageGeneration {
                 id: image.id,
                 status: image.status,
+                title: None,
                 revised_prompt: image.revised_prompt,
                 result: image.result,
                 saved_path: image.saved_path,

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -1354,6 +1354,7 @@ Today both notifications carry an empty `items` array even when item events were
 - `collabToolCall` — `{id, tool, status, senderThreadId, receiverThreadId?, newThreadId?, prompt?, agentStatus?}` describing collab tool calls (`spawn_agent`, `send_input`, `resume_agent`, `wait`, `close_agent`); `status` is `inProgress`, `completed`, or `failed`.
 - `webSearch` — `{id, query, action?}` for a web search request issued by the agent; `action` mirrors the Responses API web_search action payload (`search`, `open_page`, `find_in_page`) and may be omitted until completion.
 - `imageView` — `{id, path}` emitted when the agent invokes the image viewer tool.
+- `imageGeneration` — `{id, status, title, revisedPrompt, result, savedPath?}` emitted when the agent generates an image; `title` is a short display title when available, while `revisedPrompt` contains the full prompt used for generation.
 - `enteredReviewMode` — `{id, review}` sent when the reviewer starts; `review` is a short user-facing label such as `"current changes"` or the requested target description.
 - `exitedReviewMode` — `{id, review}` emitted when the reviewer finishes; `review` is the full plain-text review (usually, overall notes plus bullet point findings).
 - `contextCompaction` — `{id}` emitted when codex compacts the conversation history. This can happen automatically.

--- a/codex-rs/app-server/src/request_processors/thread_resume_redaction.rs
+++ b/codex-rs/app-server/src/request_processors/thread_resume_redaction.rs
@@ -94,6 +94,7 @@ mod tests {
             ThreadItem::ImageGeneration {
                 id: "ig-1".to_string(),
                 status: "completed".to_string(),
+                title: None,
                 revised_prompt: Some("revised".to_string()),
                 result: "base64-result".to_string(),
                 saved_path: Some(test_path_buf("/tmp/ig-1.png").abs()),

--- a/codex-rs/app-server/tests/suite/v2/imagegen_extension.rs
+++ b/codex-rs/app-server/tests/suite/v2/imagegen_extension.rs
@@ -200,6 +200,7 @@ async fn standalone_image_generation_failure_emits_terminal_item() -> Result<()>
         ThreadItem::ImageGeneration {
             id: call_id.to_string(),
             status: "failed".to_string(),
+            title: None,
             revised_prompt: Some("paint a blue whale".to_string()),
             result: String::new(),
             saved_path: None,

--- a/codex-rs/tui/src/chatwidget/tests/helpers.rs
+++ b/codex-rs/tui/src/chatwidget/tests/helpers.rs
@@ -710,6 +710,7 @@ pub(super) fn handle_image_generation_end(
             item: AppServerThreadItem::ImageGeneration {
                 id: call_id.into(),
                 status: status.into(),
+                title: None,
                 revised_prompt,
                 result: String::new(),
                 saved_path,


### PR DESCRIPTION
## What

- add a nullable `title` field to v2 `imageGeneration` thread items
- keep native Codex image-generation items untitled by default
- regenerate the app-server schema fixtures and document how `title` differs from `revisedPrompt`

## Why

App-server backends can receive a concise display title for a generated image separately from the full prompt used for generation. Without a dedicated protocol field, backends must either discard the title or overload `revisedPrompt` with different semantics.

## Validation

- `just write-app-server-schema`
- `just fmt`
- `just fix -p codex-app-server-protocol`
- `just test -p codex-app-server-protocol` (230 passed)
