### PR TITLE
[core] Expose rollout-history turn boundaries

### DIFF
--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -5,6 +5,7 @@ use crate::context_manager::normalize;
 use crate::event_mapping::has_non_contextual_dev_message_content;
 use crate::event_mapping::is_contextual_dev_message_content;
 use crate::event_mapping::is_contextual_user_message_content;
+use crate::rollout_history::is_user_turn_boundary;
 use crate::session::turn_context::TurnContext;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
@@ -16,7 +17,6 @@ use codex_protocol::models::FunctionCallOutputPayload;
 use codex_protocol::models::ImageDetail;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::openai_models::InputModality;
-use codex_protocol::protocol::InterAgentCommunication;
 use codex_protocol::protocol::TokenUsage;
 use codex_protocol::protocol::TokenUsageInfo;
 use codex_protocol::protocol::TurnContextItem;
@@ -745,22 +745,6 @@ fn is_model_generated_item(item: &ResponseItem) -> bool {
         | ResponseItem::AgentMessage { .. }
         | ResponseItem::Other => false,
     }
-}
-
-pub(crate) fn is_user_turn_boundary(item: &ResponseItem) -> bool {
-    if matches!(item, ResponseItem::AgentMessage { .. }) {
-        return true;
-    }
-    let ResponseItem::Message { role, content, .. } = item else {
-        return false;
-    };
-
-    (role == "user" && !is_contextual_user_message_content(content))
-        || (role == "assistant" && is_inter_agent_instruction_content(content))
-}
-
-fn is_inter_agent_instruction_content(content: &[ContentItem]) -> bool {
-    InterAgentCommunication::is_message_content(content)
 }
 
 fn user_message_positions(items: &[ResponseItem]) -> Vec<usize> {

--- a/codex-rs/core/src/context_manager/mod.rs
+++ b/codex-rs/core/src/context_manager/mod.rs
@@ -3,5 +3,4 @@ mod normalize;
 pub(crate) mod updates;
 
 pub(crate) use history::ContextManager;
-pub(crate) use history::is_user_turn_boundary;
 pub(crate) use history::truncate_function_output_payload;

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -136,6 +136,7 @@ pub use agents_md::LOCAL_AGENTS_MD_FILENAME;
 pub use agents_md::LoadedAgentsMd;
 mod rollout;
 mod rollout_budget;
+pub mod rollout_history;
 pub(crate) mod safety;
 mod session_rollout_init_error;
 pub mod shell;

--- a/codex-rs/core/src/rollout_history.rs
+++ b/codex-rs/core/src/rollout_history.rs
@@ -1,0 +1,23 @@
+use crate::event_mapping::is_contextual_user_message_content;
+use codex_protocol::models::ResponseItem;
+use codex_protocol::protocol::InterAgentCommunication;
+
+/// Returns whether a response item starts a user-directed turn in stored history.
+///
+/// Context-only user messages do not start turns. Agent messages and structured
+/// assistant instructions do, since they represent input that expects a response.
+pub fn is_user_turn_boundary(item: &ResponseItem) -> bool {
+    if matches!(item, ResponseItem::AgentMessage { .. }) {
+        return true;
+    }
+    let ResponseItem::Message { role, content, .. } = item else {
+        return false;
+    };
+
+    (role == "user" && !is_contextual_user_message_content(content))
+        || (role == "assistant" && InterAgentCommunication::is_message_content(content))
+}
+
+#[cfg(test)]
+#[path = "rollout_history_tests.rs"]
+mod tests;

--- a/codex-rs/core/src/rollout_history_tests.rs
+++ b/codex-rs/core/src/rollout_history_tests.rs
@@ -1,0 +1,66 @@
+use super::is_user_turn_boundary;
+use codex_protocol::AgentPath;
+use codex_protocol::models::ContentItem;
+use codex_protocol::models::ResponseItem;
+use codex_protocol::protocol::InterAgentCommunication;
+
+fn message(role: &str, content: ContentItem) -> ResponseItem {
+    ResponseItem::Message {
+        id: None,
+        role: role.to_string(),
+        content: vec![content],
+        phase: None,
+    }
+}
+
+#[test]
+fn classifies_user_directed_turn_boundaries() {
+    let user_message = message(
+        "user",
+        ContentItem::InputText {
+            text: "hello".to_string(),
+        },
+    );
+    let agent_message = ResponseItem::AgentMessage {
+        author: "/root".to_string(),
+        recipient: "/root/worker".to_string(),
+        content: Vec::new(),
+    };
+    let instruction = InterAgentCommunication::new(
+        AgentPath::root(),
+        AgentPath::root().join("worker").expect("valid agent path"),
+        Vec::new(),
+        "continue".to_string(),
+        /*trigger_turn*/ true,
+    );
+    let assistant_instruction = message(
+        "assistant",
+        ContentItem::OutputText {
+            text: serde_json::to_string(&instruction).expect("instruction should serialize"),
+        },
+    );
+
+    assert!(is_user_turn_boundary(&user_message));
+    assert!(is_user_turn_boundary(&agent_message));
+    assert!(is_user_turn_boundary(&assistant_instruction));
+}
+
+#[test]
+fn excludes_context_and_non_input_items() {
+    let context_message = message(
+        "user",
+        ContentItem::InputText {
+            text: "<environment_context><cwd>/tmp</cwd></environment_context>".to_string(),
+        },
+    );
+    let assistant_message = message(
+        "assistant",
+        ContentItem::OutputText {
+            text: "done".to_string(),
+        },
+    );
+
+    assert!(!is_user_turn_boundary(&context_message));
+    assert!(!is_user_turn_boundary(&assistant_message));
+    assert!(!is_user_turn_boundary(&ResponseItem::Other));
+}

--- a/codex-rs/core/src/rollout_history_tests.rs
+++ b/codex-rs/core/src/rollout_history_tests.rs
@@ -5,13 +5,12 @@ use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::InterAgentCommunication;
 
 fn message(role: &str, content: ContentItem) -> ResponseItem {
-    ResponseItem::Message {
-        id: None,
-        role: role.to_string(),
-        content: vec![content],
-        phase: None,
-        metadata: None,
-    }
+    serde_json::from_value(serde_json::json!({
+        "type": "message",
+        "role": role,
+        "content": [content],
+    }))
+    .expect("message response item should deserialize")
 }
 
 #[test]
@@ -22,13 +21,13 @@ fn classifies_user_directed_turn_boundaries() {
             text: "hello".to_string(),
         },
     );
-    let agent_message = ResponseItem::AgentMessage {
-        id: None,
-        author: "/root".to_string(),
-        recipient: "/root/worker".to_string(),
-        content: Vec::new(),
-        metadata: None,
-    };
+    let agent_message = serde_json::from_value(serde_json::json!({
+        "type": "agent_message",
+        "author": "/root",
+        "recipient": "/root/worker",
+        "content": [],
+    }))
+    .expect("agent message response item should deserialize");
     let instruction = InterAgentCommunication::new(
         AgentPath::root(),
         AgentPath::root().join("worker").expect("valid agent path"),

--- a/codex-rs/core/src/rollout_history_tests.rs
+++ b/codex-rs/core/src/rollout_history_tests.rs
@@ -10,6 +10,7 @@ fn message(role: &str, content: ContentItem) -> ResponseItem {
         role: role.to_string(),
         content: vec![content],
         phase: None,
+        metadata: None,
     }
 }
 
@@ -22,9 +23,11 @@ fn classifies_user_directed_turn_boundaries() {
         },
     );
     let agent_message = ResponseItem::AgentMessage {
+        id: None,
         author: "/root".to_string(),
         recipient: "/root/worker".to_string(),
         content: Vec::new(),
+        metadata: None,
     };
     let instruction = InterAgentCommunication::new(
         AgentPath::root(),

--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -49,7 +49,7 @@ use codex_protocol::protocol::WarningEvent;
 use codex_protocol::request_permissions::RequestPermissionsResponse;
 use codex_protocol::request_user_input::RequestUserInputResponse;
 
-use crate::context_manager::is_user_turn_boundary;
+use crate::rollout_history::is_user_turn_boundary;
 use codex_protocol::dynamic_tools::DynamicToolResponse;
 use codex_protocol::mcp::RequestId as ProtocolRequestId;
 use codex_rmcp_client::ElicitationAction;

--- a/codex-rs/core/src/session/rollout_reconstruction.rs
+++ b/codex-rs/core/src/session/rollout_reconstruction.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::context::world_state::WorldStateSnapshot;
-use crate::context_manager::is_user_turn_boundary;
+use crate::rollout_history::is_user_turn_boundary;
 use codex_protocol::protocol::SessionContextWindow;
 use uuid::Uuid;
 

--- a/codex-rs/core/src/thread_rollout_truncation.rs
+++ b/codex-rs/core/src/thread_rollout_truncation.rs
@@ -3,8 +3,8 @@
 //! In core, "user turns" are detected by scanning `ResponseItem::Message` items and
 //! interpreting them via `event_mapping::parse_turn_item(...)`.
 
-use crate::context_manager::is_user_turn_boundary;
 use crate::event_mapping;
+use crate::rollout_history::is_user_turn_boundary;
 use codex_protocol::items::TurnItem;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::EventMsg;


### PR DESCRIPTION
## Overview

This is the fourth change in a five-PR stack that improves reusable Rust APIs around the in-process app server and stored rollout history. It moves user-turn boundary classification out of context-manager internals so other history consumers can apply the same rule.

## What

- add `codex_core::rollout_history`
- expose `is_user_turn_boundary()` for persisted response items
- move existing core callers to the neutral module
- cover user input, contextual fragments, agent messages, and assistant instructions with focused classification tests

## Why

User-turn boundary classification describes persisted rollout history, but its implementation previously lived inside the context manager. Consumers reconstructing stored history should not depend on a context-manager implementation detail to apply the same classification.

Keeping the helper in `codex-core` also avoids moving contextual-fragment knowledge into `codex-rollout`, which would require a broader dependency change.

## Stack

Each PR is based on the preceding branch:

1. [#28459 — custom in-process thread stores](https://github.com/openai/codex/pull/28459)
2. [#28460 — lossless in-process event delivery](https://github.com/openai/codex/pull/28460)
3. [#28461 — stored-thread view helpers](https://github.com/openai/codex/pull/28461)
4. **[#28462 — rollout-history turn boundaries](https://github.com/openai/codex/pull/28462) (this PR)**
5. [#30369 — durable external thread goals](https://github.com/openai/codex/pull/30369)

## Validation

Validation for the final stacked commits:

- focused `codex-core` rollout-history tests
- `just test -p codex-app-server`: 886 passed; one timing retry passed on its second attempt
- `just test -p codex-core`: 2,717 passed; eight timing-sensitive failures passed in focused reruns, while five high-output code-mode failures remained
- `just test --test-threads=8`: 10,944 of 10,958 passed; the remaining failures were the same five high-output tests, three timing-sensitive tests that pass in focused reruns, and six tests in untouched exec/TUI code affected by this host's managed permission policy
- a representative high-output failure reproduces on the exact `upstream/main` commit
- `just fix -p codex-app-server`, `just fix -p codex-core`, and `just fmt`; final worktree clean