### PR TITLE
core: run remote filesystem tests under Wine

### DIFF
--- a/bazel/rules/testing/wine/BUILD.bazel
+++ b/bazel/rules/testing/wine/BUILD.bazel
@@ -29,6 +29,20 @@ rust_library(
 )
 
 rust_binary(
+    name = "wine-test-exec",
+    testonly = True,
+    srcs = ["src/exec.rs"],
+    crate_name = "wine_test_exec",
+    crate_root = "src/exec.rs",
+    edition = "2024",
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [
+        ":wine_test_support",
+        "@crates//:anyhow",
+    ],
+)
+
+rust_binary(
     name = "windows-smoke",
     testonly = True,
     srcs = ["fixtures/windows_smoke.rs"],

--- a/bazel/rules/testing/wine/BUILD.bazel
+++ b/bazel/rules/testing/wine/BUILD.bazel
@@ -39,6 +39,7 @@ rust_binary(
     deps = [
         ":wine_test_support",
         "@crates//:anyhow",
+        "@crates//:tokio",
     ],
 )
 

--- a/bazel/rules/testing/wine/fixtures/windows_smoke.rs
+++ b/bazel/rules/testing/wine/fixtures/windows_smoke.rs
@@ -4,10 +4,15 @@ fn main() {
     println!("WINE_TEST_READY");
     std::io::stdout().flush().expect("flush readiness marker");
 
-    if std::env::args().any(|arg| arg == "--fail") {
+    let args = std::env::args().collect::<Vec<_>>();
+    if args.iter().any(|arg| arg == "--write-prefix-marker") {
+        std::fs::write(r"C:\shared-prefix-marker", b"shared prefix")
+            .expect("write shared-prefix marker");
+    }
+    if args.iter().any(|arg| arg == "--fail") {
         std::process::exit(9);
     }
-    if std::env::args().any(|arg| arg == "--wait") {
+    if args.iter().any(|arg| arg == "--wait") {
         loop {
             std::thread::park();
         }

--- a/bazel/rules/testing/wine/src/exec.rs
+++ b/bazel/rules/testing/wine/src/exec.rs
@@ -1,17 +1,39 @@
 use anyhow::Context;
 use anyhow::Result;
+use std::ffi::OsStr;
+use std::io::Write;
 
-fn main() -> Result<()> {
+#[tokio::main]
+async fn main() -> Result<()> {
     let mut args = std::env::args_os().skip(1);
     let executable = args
         .next()
-        .context("usage: wine-test-exec <windows-executable> [args...]")?;
-    let status = wine_test_support::ambient_wine_command(executable)?
-        .args(args)
-        .status()
-        .context("run Windows command in shared Wine test prefix")?;
-    if !status.success() {
-        std::process::exit(status.code().unwrap_or(1));
+        .context("usage: wine-test-exec [--powershell | <windows-executable>] [args...]")?;
+    if executable.as_os_str() == OsStr::new("--powershell") {
+        let args = args
+            .map(|arg| {
+                arg.into_string()
+                    .map_err(|arg| anyhow::anyhow!("PowerShell argument is not UTF-8: {arg:?}"))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let output = wine_test_support::run_ambient_powershell(&args).await?;
+        let mut stdout = std::io::stdout().lock();
+        stdout.write_all(&output.stdout)?;
+        stdout.flush()?;
+        let mut stderr = std::io::stderr().lock();
+        stderr.write_all(&output.stderr)?;
+        stderr.flush()?;
+        if output.exit_code != 0 {
+            std::process::exit(output.exit_code);
+        }
+    } else {
+        let status = wine_test_support::ambient_wine_command(executable)?
+            .args(args)
+            .status()
+            .context("run Windows command in shared Wine test prefix")?;
+        if !status.success() {
+            std::process::exit(status.code().unwrap_or(1));
+        }
     }
     Ok(())
 }

--- a/bazel/rules/testing/wine/src/exec.rs
+++ b/bazel/rules/testing/wine/src/exec.rs
@@ -1,0 +1,17 @@
+use anyhow::Context;
+use anyhow::Result;
+
+fn main() -> Result<()> {
+    let mut args = std::env::args_os().skip(1);
+    let executable = args
+        .next()
+        .context("usage: wine-test-exec <windows-executable> [args...]")?;
+    let status = wine_test_support::ambient_wine_command(executable)?
+        .args(args)
+        .status()
+        .context("run Windows command in shared Wine test prefix")?;
+    if !status.success() {
+        std::process::exit(status.code().unwrap_or(1));
+    }
+    Ok(())
+}

--- a/bazel/rules/testing/wine/src/lib.rs
+++ b/bazel/rules/testing/wine/src/lib.rs
@@ -31,17 +31,6 @@ pub struct WineTestCommand {
     env: Vec<(OsString, OsString)>,
 }
 
-/// Captured output and exit status from a Wine test command.
-#[derive(Debug, PartialEq, Eq)]
-pub struct WineCommandOutput {
-    /// Bytes captured from standard output.
-    pub stdout: Vec<u8>,
-    /// Bytes captured from standard error.
-    pub stderr: Vec<u8>,
-    /// Process exit code reported by the PTY backend.
-    pub exit_code: i32,
-}
-
 /// Owns a Wine process and its isolated wineserver.
 ///
 /// Call [`Self::scope`] or [`Self::shutdown`] on every successful path. A
@@ -191,6 +180,17 @@ impl WineTestCommandContext {
     pub fn apply_to_command(&self, command: &mut TokioCommand) {
         command.env(WINE_TEST_PREFIX_ENV_VAR, &self.prefix);
     }
+}
+
+/// Captured output and exit status from a Wine test command.
+#[derive(Debug, PartialEq, Eq)]
+pub struct WineCommandOutput {
+    /// Bytes captured from standard output.
+    pub stdout: Vec<u8>,
+    /// Bytes captured from standard error.
+    pub stderr: Vec<u8>,
+    /// Process exit code reported by the PTY backend.
+    pub exit_code: i32,
 }
 
 /// Builds a Wine command that joins the prefix exported by [`WineTestCommandContext`].

--- a/bazel/rules/testing/wine/src/lib.rs
+++ b/bazel/rules/testing/wine/src/lib.rs
@@ -31,15 +31,6 @@ pub struct WineTestCommand {
     env: Vec<(OsString, OsString)>,
 }
 
-/// Owns a Wine process and its isolated wineserver.
-///
-/// Call [`Self::scope`] or [`Self::shutdown`] on every successful path. A
-/// normal unguarded drop panics, while a drop during unwinding performs
-/// blocking cleanup without introducing a second panic.
-pub struct WineTestProcess {
-    processes: Option<WineProcesses>,
-}
-
 /// Captured output and exit status from a Wine test command.
 #[derive(Debug, PartialEq, Eq)]
 pub struct WineCommandOutput {
@@ -49,6 +40,15 @@ pub struct WineCommandOutput {
     pub stderr: Vec<u8>,
     /// Process exit code reported by the PTY backend.
     pub exit_code: i32,
+}
+
+/// Owns a Wine process and its isolated wineserver.
+///
+/// Call [`Self::scope`] or [`Self::shutdown`] on every successful path. A
+/// normal unguarded drop panics, while a drop during unwinding performs
+/// blocking cleanup without introducing a second panic.
+pub struct WineTestProcess {
+    processes: Option<WineProcesses>,
 }
 
 struct WineProcesses {

--- a/bazel/rules/testing/wine/src/lib.rs
+++ b/bazel/rules/testing/wine/src/lib.rs
@@ -1,6 +1,7 @@
 #[cfg(not(target_os = "linux"))]
 compile_error!("wine_test_support can only run on Linux");
 
+use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::fs;
@@ -14,6 +15,8 @@ use std::time::Duration;
 
 use anyhow::Context;
 use anyhow::Result;
+use codex_utils_pty::SpawnedProcess;
+use codex_utils_pty::TerminalSize;
 use tempfile::TempDir;
 use tokio::process::Child;
 use tokio::process::ChildStdout;
@@ -47,6 +50,17 @@ pub struct WineTestCommandContext {
     prefix: PathBuf,
 }
 
+/// Captured output and exit status from a Wine test command.
+#[derive(Debug, PartialEq, Eq)]
+pub struct WineCommandOutput {
+    /// Bytes captured from standard output.
+    pub stdout: Vec<u8>,
+    /// Bytes captured from standard error.
+    pub stderr: Vec<u8>,
+    /// Process exit code reported by the PTY backend.
+    pub exit_code: i32,
+}
+
 struct WineProcesses {
     child: Child,
     cleanup_complete: bool,
@@ -56,6 +70,7 @@ struct WineProcesses {
 
 struct WineRuntimePaths {
     dll_path: PathBuf,
+    powershell_executable: PathBuf,
     powershell_runtime: PathBuf,
     wine: PathBuf,
     wineserver: PathBuf,
@@ -180,15 +195,116 @@ impl WineTestCommandContext {
 
 /// Builds a Wine command that joins the prefix exported by [`WineTestCommandContext`].
 pub fn ambient_wine_command(executable: impl AsRef<OsStr>) -> Result<StdCommand> {
-    let prefix = PathBuf::from(
-        std::env::var_os(WINE_TEST_PREFIX_ENV_VAR)
-            .with_context(|| format!("{WINE_TEST_PREFIX_ENV_VAR} must be set"))?,
-    );
     let runtime = WineRuntimePaths::from_runfiles()?;
+    ambient_wine_command_with_runtime(executable, &runtime)
+}
+
+/// Runs pinned PowerShell in the exported Wine test prefix.
+///
+/// PowerShell runs through a PTY because it is a Windows console application
+/// under Wine. The returned output is complete when this function returns.
+pub async fn run_ambient_powershell(args: &[String]) -> Result<WineCommandOutput> {
+    let prefix = ambient_wine_prefix()?;
+    let runtime = WineRuntimePaths::from_runfiles()?;
+    let env = wine_pty_environment(&runtime, &prefix);
+    let mut powershell_args = Vec::with_capacity(args.len() + 1);
+    powershell_args.push(runtime.powershell_executable.to_string_lossy().into_owned());
+    powershell_args.extend_from_slice(args);
+    let spawned = codex_utils_pty::spawn_pty_process(
+        runtime.wine.to_string_lossy().as_ref(),
+        &powershell_args,
+        &prefix,
+        &env,
+        /*arg0*/ &None,
+        TerminalSize::default(),
+    )
+    .await?;
+    collect_wine_command_output(spawned).await
+}
+
+async fn collect_wine_command_output(spawned: SpawnedProcess) -> Result<WineCommandOutput> {
+    let SpawnedProcess {
+        session,
+        mut stdout_rx,
+        mut stderr_rx,
+        exit_rx,
+    } = spawned;
+    let stdout = async {
+        let mut output = Vec::new();
+        while let Some(chunk) = stdout_rx.recv().await {
+            output.extend(chunk);
+        }
+        output
+    };
+    let stderr = async {
+        let mut output = Vec::new();
+        while let Some(chunk) = stderr_rx.recv().await {
+            output.extend(chunk);
+        }
+        output
+    };
+    let (stdout, stderr, exit_code) = tokio::join!(stdout, stderr, exit_rx);
+    drop(session);
+    Ok(WineCommandOutput {
+        stdout,
+        stderr,
+        exit_code: exit_code.context("wait for PowerShell")?,
+    })
+}
+
+fn wine_pty_environment(runtime: &WineRuntimePaths, prefix: &Path) -> HashMap<String, String> {
+    let mut env = std::env::vars().collect::<HashMap<_, _>>();
+    env.remove("DISPLAY");
+    env.extend([
+        ("HOME".to_string(), prefix.to_string_lossy().into_owned()),
+        (
+            "XDG_RUNTIME_DIR".to_string(),
+            prefix.to_string_lossy().into_owned(),
+        ),
+        ("WINEARCH".to_string(), "win64".to_string()),
+        (
+            "WINEPREFIX".to_string(),
+            prefix.to_string_lossy().into_owned(),
+        ),
+        (
+            "WINEDLLPATH".to_string(),
+            runtime.dll_path.to_string_lossy().into_owned(),
+        ),
+        (
+            "WINESERVER".to_string(),
+            runtime.wineserver.to_string_lossy().into_owned(),
+        ),
+        ("WINEDEBUG".to_string(), "-all".to_string()),
+        (
+            "WINEDLLOVERRIDES".to_string(),
+            "mscoree,mshtml,winegstreamer=".to_string(),
+        ),
+        ("LANG".to_string(), "C.UTF-8".to_string()),
+        ("LC_ALL".to_string(), "C.UTF-8".to_string()),
+        ("LC_CTYPE".to_string(), "C.UTF-8".to_string()),
+        ("TEMP".to_string(), r"C:\windows\temp".to_string()),
+        ("TMP".to_string(), r"C:\windows\temp".to_string()),
+    ]);
+    env
+}
+
+fn ambient_wine_command_with_runtime(
+    executable: impl AsRef<OsStr>,
+    runtime: &WineRuntimePaths,
+) -> Result<StdCommand> {
+    let executable = executable.as_ref();
+    let prefix = ambient_wine_prefix()?;
     let mut command = StdCommand::new(&runtime.wine);
-    configure_wine_environment(&mut command, &runtime, &prefix);
+    configure_wine_environment(&mut command, runtime, &prefix);
     command.arg(executable);
     Ok(command)
+}
+
+fn ambient_wine_prefix() -> Result<PathBuf> {
+    Ok(PathBuf::from(
+        std::env::var_os(WINE_TEST_PREFIX_ENV_VAR)
+            .with_context(|| format!("{WINE_TEST_PREFIX_ENV_VAR} must be set"))?,
+    ))
 }
 
 impl Drop for WineTestProcess {
@@ -210,12 +326,14 @@ impl WineRuntimePaths {
             .context("locate Wine runtime directory")?
             .to_path_buf();
         let wineserver = codex_utils_cargo_bin::cargo_bin("wineserver")?;
+        let powershell_executable = codex_utils_cargo_bin::cargo_bin("pwsh")?;
         let powershell_runtime = codex_utils_cargo_bin::cargo_bin("pwsh-runtime-marker")?
             .parent()
             .context("locate PowerShell runtime directory")?
             .to_path_buf();
         Ok(Self {
             dll_path,
+            powershell_executable,
             powershell_runtime,
             wine,
             wineserver,

--- a/bazel/rules/testing/wine/src/lib.rs
+++ b/bazel/rules/testing/wine/src/lib.rs
@@ -40,16 +40,6 @@ pub struct WineTestProcess {
     processes: Option<WineProcesses>,
 }
 
-/// Ambient context for launching another Windows process in an active test prefix.
-///
-/// Applying this context to a host command does not transfer ownership of the
-/// prefix. The command must finish before the [`WineTestProcess`] that created
-/// this context is shut down.
-#[derive(Clone, Debug)]
-pub struct WineTestCommandContext {
-    prefix: PathBuf,
-}
-
 /// Captured output and exit status from a Wine test command.
 #[derive(Debug, PartialEq, Eq)]
 pub struct WineCommandOutput {
@@ -184,6 +174,16 @@ impl WineTestProcess {
         self.processes.take();
         result
     }
+}
+
+/// Ambient context for launching another Windows process in an active test prefix.
+///
+/// Applying this context to a host command does not transfer ownership of the
+/// prefix. The command must finish before the [`WineTestProcess`] that created
+/// this context is shut down.
+#[derive(Clone, Debug)]
+pub struct WineTestCommandContext {
+    prefix: PathBuf,
 }
 
 impl WineTestCommandContext {

--- a/bazel/rules/testing/wine/src/lib.rs
+++ b/bazel/rules/testing/wine/src/lib.rs
@@ -1,6 +1,7 @@
 #[cfg(not(target_os = "linux"))]
 compile_error!("wine_test_support can only run on Linux");
 
+use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::fs;
 use std::future::Future;
@@ -18,6 +19,8 @@ use tokio::process::Child;
 use tokio::process::ChildStdout;
 use tokio::process::Command as TokioCommand;
 
+const WINE_TEST_PREFIX_ENV_VAR: &str = "CODEX_WINE_TEST_PREFIX";
+
 /// Builds a command that runs a Windows executable in an isolated Wine prefix.
 pub struct WineTestCommand {
     executable: PathBuf,
@@ -32,6 +35,16 @@ pub struct WineTestCommand {
 /// blocking cleanup without introducing a second panic.
 pub struct WineTestProcess {
     processes: Option<WineProcesses>,
+}
+
+/// Ambient context for launching another Windows process in an active test prefix.
+///
+/// Applying this context to a host command does not transfer ownership of the
+/// prefix. The command must finish before the [`WineTestProcess`] that created
+/// this context is shut down.
+#[derive(Clone, Debug)]
+pub struct WineTestCommandContext {
+    prefix: PathBuf,
 }
 
 struct WineProcesses {
@@ -119,6 +132,16 @@ impl WineTestProcess {
         stdout
     }
 
+    /// Returns a context that a host subprocess can use to join this Wine prefix.
+    pub fn command_context(&self) -> WineTestCommandContext {
+        let Some(processes) = self.processes.as_ref() else {
+            panic!("Wine process guard is missing");
+        };
+        WineTestCommandContext {
+            prefix: processes.prefix.path().to_path_buf(),
+        }
+    }
+
     /// Runs `future`, then asynchronously tears down Wine before returning.
     ///
     /// If both the scoped operation and teardown fail, the operation error is
@@ -146,6 +169,26 @@ impl WineTestProcess {
         self.processes.take();
         result
     }
+}
+
+impl WineTestCommandContext {
+    /// Exports this context to a host command and its descendants.
+    pub fn apply_to_command(&self, command: &mut TokioCommand) {
+        command.env(WINE_TEST_PREFIX_ENV_VAR, &self.prefix);
+    }
+}
+
+/// Builds a Wine command that joins the prefix exported by [`WineTestCommandContext`].
+pub fn ambient_wine_command(executable: impl AsRef<OsStr>) -> Result<StdCommand> {
+    let prefix = PathBuf::from(
+        std::env::var_os(WINE_TEST_PREFIX_ENV_VAR)
+            .with_context(|| format!("{WINE_TEST_PREFIX_ENV_VAR} must be set"))?,
+    );
+    let runtime = WineRuntimePaths::from_runfiles()?;
+    let mut command = StdCommand::new(&runtime.wine);
+    configure_wine_environment(&mut command, &runtime, &prefix);
+    command.arg(executable);
+    Ok(command)
 }
 
 impl Drop for WineTestProcess {

--- a/bazel/rules/testing/wine/src/lib_tests.rs
+++ b/bazel/rules/testing/wine/src/lib_tests.rs
@@ -1,7 +1,6 @@
 use std::any::Any;
-use std::collections::HashMap;
-use std::future::Future;
 use std::fs;
+use std::future::Future;
 use std::panic::AssertUnwindSafe;
 use std::path::Path;
 use std::path::PathBuf;
@@ -10,7 +9,6 @@ use std::time::Duration;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
-use codex_utils_pty::SpawnedProcess;
 use codex_utils_pty::TerminalSize;
 use futures::FutureExt;
 use pretty_assertions::assert_eq;
@@ -20,10 +18,13 @@ use tokio::io::BufReader;
 use tokio::process::Command as TokioCommand;
 use tokio::time::timeout;
 
+use super::WineCommandOutput;
+use super::WineRuntimePaths;
 use super::WineTestCommand;
 use super::WineTestProcess;
-use super::WineRuntimePaths;
+use super::collect_wine_command_output;
 use super::install_powershell_runtime;
+use super::wine_pty_environment;
 
 async fn waiting_smoke_process() -> Result<WineTestProcess> {
     let executable = codex_utils_cargo_bin::cargo_bin("wine-smoke")?;
@@ -149,18 +150,21 @@ async fn scope_returns_value_and_tears_down() -> Result<()> {
 }
 
 #[tokio::test]
-async fn exported_command_context_reuses_active_prefix() -> Result<()> {
+async fn exported_command_context_runs_commands_in_active_prefix() -> Result<()> {
     let process = waiting_smoke_process().await?;
     let prefix = prefix_path(&process);
     let prefix_after_scope = prefix.clone();
     let marker = prefix.join("drive_c").join("shared-prefix-marker");
+    let powershell_marker = prefix
+        .join("drive_c")
+        .join("shared-powershell-prefix-marker");
     let context = process.command_context();
     let wrapper = codex_utils_cargo_bin::cargo_bin("wine-test-exec")?;
     let smoke = codex_utils_cargo_bin::cargo_bin("wine-smoke")?;
 
     process
         .scope(async move {
-            let mut command = TokioCommand::new(wrapper);
+            let mut command = TokioCommand::new(&wrapper);
             context.apply_to_command(&mut command);
             let output = command
                 .arg(smoke)
@@ -175,6 +179,37 @@ async fn exported_command_context_reuses_active_prefix() -> Result<()> {
                 String::from_utf8_lossy(&output.stderr).trim(),
             );
             assert_eq!(fs::read(&marker)?, b"shared prefix");
+
+            let mut command = TokioCommand::new(wrapper);
+            context.apply_to_command(&mut command);
+            let output = command
+                .args([
+                    "--powershell",
+                    "-NoLogo",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-Command",
+                    r#"[System.IO.File]::WriteAllText('C:\shared-powershell-prefix-marker', 'shared powershell prefix')"#,
+                ])
+                .output()
+                .await
+                .context("run PowerShell through exported Wine test context")?;
+            anyhow::ensure!(
+                output.status.success(),
+                "shared-prefix PowerShell command failed: stdout={} stderr={}",
+                String::from_utf8_lossy(&output.stdout).trim(),
+                String::from_utf8_lossy(&output.stderr).trim(),
+            );
+            assert_eq!(
+                fs::read(&powershell_marker).with_context(|| {
+                    format!(
+                        "read PowerShell marker; stdout={} stderr={}",
+                        String::from_utf8_lossy(&output.stdout).trim(),
+                        String::from_utf8_lossy(&output.stderr).trim(),
+                    )
+                })?,
+                b"shared powershell prefix"
+            );
             Ok(())
         })
         .await?;
@@ -345,41 +380,9 @@ async fn pinned_powershell_runs_under_wine_with_a_pty() -> Result<()> {
     );
     let runtime = WineRuntimePaths::from_runfiles()?;
     let prefix = TempDir::new()?;
-    install_powershell_runtime(prefix.path(), &runtime.powershell_runtime)?;
-    let mut env = std::env::vars().collect::<HashMap<_, _>>();
-    env.remove("DISPLAY");
-    env.extend([
-        ("HOME".to_string(), prefix.path().to_string_lossy().into_owned()),
-        (
-            "XDG_RUNTIME_DIR".to_string(),
-            prefix.path().to_string_lossy().into_owned(),
-        ),
-        ("WINEARCH".to_string(), "win64".to_string()),
-        (
-            "WINEPREFIX".to_string(),
-            prefix.path().to_string_lossy().into_owned(),
-        ),
-        (
-            "WINEDLLPATH".to_string(),
-            runtime.dll_path.to_string_lossy().into_owned(),
-        ),
-        (
-            "WINESERVER".to_string(),
-            runtime.wineserver.to_string_lossy().into_owned(),
-        ),
-        ("WINEDEBUG".to_string(), "-all".to_string()),
-        (
-            "WINEDLLOVERRIDES".to_string(),
-            "mscoree,mshtml,winegstreamer=".to_string(),
-        ),
-        ("LANG".to_string(), "C.UTF-8".to_string()),
-        ("LC_ALL".to_string(), "C.UTF-8".to_string()),
-        ("LC_CTYPE".to_string(), "C.UTF-8".to_string()),
-        ("TEMP".to_string(), r"C:\windows\temp".to_string()),
-        ("TMP".to_string(), r"C:\windows\temp".to_string()),
-    ]);
+    let env = wine_pty_environment(&runtime, prefix.path());
     let args = [
-        r"C:\Program Files\PowerShell\7\pwsh.exe".to_string(),
+        runtime.powershell_executable.to_string_lossy().into_owned(),
         "-NoLogo".to_string(),
         "-NoProfile".to_string(),
         "-NonInteractive".to_string(),
@@ -387,12 +390,7 @@ async fn pinned_powershell_runs_under_wine_with_a_pty() -> Result<()> {
         POWERSHELL_SMOKE_SCRIPT.to_string(),
     ];
     let wine = runtime.wine.to_string_lossy().into_owned();
-    let SpawnedProcess {
-        session,
-        mut stdout_rx,
-        mut stderr_rx,
-        exit_rx,
-    } = codex_utils_pty::spawn_pty_process(
+    let spawned = codex_utils_pty::spawn_pty_process(
         &wine,
         &args,
         prefix.path(),
@@ -401,28 +399,13 @@ async fn pinned_powershell_runs_under_wine_with_a_pty() -> Result<()> {
         TerminalSize::default(),
     )
     .await?;
-    let command_result = timeout(Duration::from_secs(30), async {
-        let stdout = async {
-            let mut output = Vec::new();
-            while let Some(chunk) = stdout_rx.recv().await {
-                output.extend(chunk);
-            }
-            output
-        };
-        let stderr = async {
-            let mut output = Vec::new();
-            while let Some(chunk) = stderr_rx.recv().await {
-                output.extend(chunk);
-            }
-            output
-        };
-        let (stdout, stderr, exit_code) = tokio::join!(stdout, stderr, exit_rx);
-        Ok::<_, anyhow::Error>((stdout, stderr, exit_code.context("wait for PowerShell")?))
-    })
+    let command_result = timeout(
+        Duration::from_secs(30),
+        collect_wine_command_output(spawned),
+    )
     .await
     .context("PowerShell smoke test timed out")
     .and_then(std::convert::identity);
-    drop(session);
     let shutdown_result = timeout(Duration::from_secs(10), async {
         let mut command = TokioCommand::new(&runtime.wineserver);
         command
@@ -441,7 +424,11 @@ async fn pinned_powershell_runs_under_wine_with_a_pty() -> Result<()> {
     .await
     .context("stop isolated wineserver timed out")
     .and_then(std::convert::identity);
-    let (stdout, stderr, exit_code) = match (command_result, shutdown_result) {
+    let WineCommandOutput {
+        stdout,
+        stderr,
+        exit_code,
+    } = match (command_result, shutdown_result) {
         (Ok(output), Ok(())) => output,
         (Err(error), Ok(())) => return Err(error),
         (Ok(_), Err(error)) => return Err(error),
@@ -465,7 +452,11 @@ async fn pinned_powershell_runs_under_wine_with_a_pty() -> Result<()> {
         .context("PowerShell smoke marker line was incomplete")?
         .trim_end_matches('\r');
     let fields = smoke.split('|').collect::<Vec<_>>();
-    assert_eq!(fields.len(), 5, "unexpected PowerShell smoke output: {smoke}");
+    assert_eq!(
+        fields.len(),
+        5,
+        "unexpected PowerShell smoke output: {smoke}"
+    );
     assert_eq!(fields[0], POWERSHELL_SMOKE_MARKER);
     assert_eq!(
         fields[1].split('.').next(),

--- a/bazel/rules/testing/wine/src/lib_tests.rs
+++ b/bazel/rules/testing/wine/src/lib_tests.rs
@@ -149,6 +149,41 @@ async fn scope_returns_value_and_tears_down() -> Result<()> {
 }
 
 #[tokio::test]
+async fn exported_command_context_reuses_active_prefix() -> Result<()> {
+    let process = waiting_smoke_process().await?;
+    let prefix = prefix_path(&process);
+    let prefix_after_scope = prefix.clone();
+    let marker = prefix.join("drive_c").join("shared-prefix-marker");
+    let context = process.command_context();
+    let wrapper = codex_utils_cargo_bin::cargo_bin("wine-test-exec")?;
+    let smoke = codex_utils_cargo_bin::cargo_bin("wine-smoke")?;
+
+    process
+        .scope(async move {
+            let mut command = TokioCommand::new(wrapper);
+            context.apply_to_command(&mut command);
+            let output = command
+                .arg(smoke)
+                .arg("--write-prefix-marker")
+                .output()
+                .await
+                .context("run Windows process through exported Wine test context")?;
+            anyhow::ensure!(
+                output.status.success(),
+                "shared-prefix command failed: stdout={} stderr={}",
+                String::from_utf8_lossy(&output.stdout).trim(),
+                String::from_utf8_lossy(&output.stderr).trim(),
+            );
+            assert_eq!(fs::read(&marker)?, b"shared prefix");
+            Ok(())
+        })
+        .await?;
+
+    assert_prefix_removed(&prefix_after_scope);
+    Ok(())
+}
+
+#[tokio::test]
 async fn scope_returns_body_error_and_tears_down() -> Result<()> {
     let process = waiting_smoke_process().await?;
     let prefix = prefix_path(&process);

--- a/bazel/rules/testing/wine/wine.bzl
+++ b/bazel/rules/testing/wine/wine.bzl
@@ -21,6 +21,8 @@ def wine_rust_test(
     * Each `host_binaries` and `windows_binaries` entry contributes
       `CARGO_BIN_EXE_<binary_name>` for its executable.
     * `CARGO_BIN_EXE_wine` and `CARGO_BIN_EXE_wineserver` identify Wine tools.
+    * `CARGO_BIN_EXE_wine-test-exec` identifies the host wrapper for running an
+      additional Windows command in an exported test prefix.
     * `CARGO_BIN_EXE_wine-runtime-marker` identifies a file whose parent is the
       Wine DLL directory to use as `WINEDLLPATH`.
     * `CARGO_BIN_EXE_pwsh` identifies the pinned PowerShell executable and

--- a/bazel/rules/testing/wine/wine.bzl
+++ b/bazel/rules/testing/wine/wine.bzl
@@ -22,7 +22,8 @@ def wine_rust_test(
       `CARGO_BIN_EXE_<binary_name>` for its executable.
     * `CARGO_BIN_EXE_wine` and `CARGO_BIN_EXE_wineserver` identify Wine tools.
     * `CARGO_BIN_EXE_wine-test-exec` identifies the host wrapper for running an
-      additional Windows command in an exported test prefix.
+      additional Windows command in an exported test prefix. Pass
+      `--powershell` as its first argument to use the pinned PowerShell runtime.
     * `CARGO_BIN_EXE_wine-runtime-marker` identifies a file whose parent is the
       Wine DLL directory to use as `WINEDLLPATH`.
     * `CARGO_BIN_EXE_pwsh` identifies the pinned PowerShell executable and

--- a/bazel/rules/testing/wine/wine_runtime.bzl
+++ b/bazel/rules/testing/wine/wine_runtime.bzl
@@ -5,6 +5,7 @@ _WINE_RUNTIME_BINARIES = {
     "pwsh-runtime-marker": "@powershell_windows_x86_64//:runtime_marker",
     "wine": "@wine_linux_x86_64//:wine",
     "wine-runtime-marker": "@wine_linux_x86_64//:runtime_marker",
+    "wine-test-exec": "//bazel/rules/testing/wine:wine-test-exec",
     "wineserver": "@wine_linux_x86_64//:wineserver",
 }
 

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -261,6 +261,22 @@ fn workspace_write_sandbox(writable_root: PathBuf) -> FileSystemSandboxContext {
     ))
 }
 
+fn assert_normalized_path_rejected(error: &std::io::Error) {
+    match error.kind() {
+        std::io::ErrorKind::NotFound => {}
+        std::io::ErrorKind::InvalidInput | std::io::ErrorKind::PermissionDenied => {
+            let message = error.to_string();
+            assert!(
+                message.contains("is not permitted")
+                    || message.contains("Operation not permitted")
+                    || message.contains("Permission denied"),
+                "unexpected rejection message: {message}",
+            );
+        }
+        other => panic!("unexpected normalized-path error kind: {other:?}: {error:?}"),
+    }
+}
+
 fn remote_exec_docker(command: &str) -> Result<()> {
     let remote_env = get_remote_test_env().context("remote env should be configured")?;
     let container_name = remote_env
@@ -1046,7 +1062,7 @@ async fn remote_test_env_sandboxed_read_allows_readable_root() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn remote_test_env_remove_removes_symlink_not_target() -> Result<()> {
+async fn remote_test_env_sandboxed_read_rejects_symlink_parent_dotdot_escape() -> Result<()> {
     skip_if_no_network!(Ok(()));
     let Some(_remote_env) = get_remote_test_env() else {
         return Ok(());
@@ -1055,48 +1071,98 @@ async fn remote_test_env_remove_removes_symlink_not_target() -> Result<()> {
     let test_env = test_env().await?;
     let file_system = test_env.environment().get_filesystem();
 
-    let root = test_env.cwd().join("remove-link");
+    let root = test_env.cwd().join("dotdot-escape");
     let allowed_dir = root.join("allowed");
     let outside_dir = root.join("outside");
-    let outside_file = outside_dir.join("keep.txt");
-    let symlink_path = allowed_dir.join("link");
+    let secret_path = root.join("secret.txt");
     let root_uri = PathUri::from_abs_path(&root);
     let allowed_dir_uri = PathUri::from_abs_path(&allowed_dir);
     let outside_dir_uri = PathUri::from_abs_path(&outside_dir);
-    let outside_file_uri = PathUri::from_abs_path(&outside_file);
-    let symlink_path_uri = PathUri::from_abs_path(&symlink_path);
+    let secret_path_uri = PathUri::from_abs_path(&secret_path);
+    let symlink_path_uri = allowed_dir_uri.join("link")?;
     let linux_setup_command = format!(
-        "rm -rf {root}; mkdir -p {allowed} {outside_parent}; printf outside > {outside}; ln -s {outside} {symlink}",
+        "rm -rf {root}; mkdir -p {allowed} {outside}; printf nope > {secret}; ln -s {outside} {allowed}/link",
         root = root.display(),
         allowed = allowed_dir.display(),
-        outside_parent = outside_dir.display(),
-        outside = outside_file.display(),
-        symlink = symlink_path.display(),
+        outside = outside_dir.display(),
+        secret = secret_path.display(),
     );
     let windows_setup_command = format!(
         r#"$ErrorActionPreference = 'Stop'
 $root = '{root}'
 $allowed = '{allowed}'
-$outsideParent = '{outside_parent}'
 $outside = '{outside}'
-$symlink = '{symlink}'
+$secret = '{secret}'
+$link = '{link}'
 Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
 New-Item -ItemType Directory -Path $allowed -Force | Out-Null
-New-Item -ItemType Directory -Path $outsideParent -Force | Out-Null
-[System.IO.File]::WriteAllText($outside, 'outside')
-New-Item -ItemType SymbolicLink -Path $symlink -Target $outside | Out-Null"#,
+New-Item -ItemType Directory -Path $outside -Force | Out-Null
+[System.IO.File]::WriteAllText($secret, 'nope')
+New-Item -ItemType SymbolicLink -Path $link -Target $outside | Out-Null"#,
         root = root_uri.native_path_display(),
         allowed = allowed_dir_uri.native_path_display(),
-        outside_parent = outside_dir_uri.native_path_display(),
-        outside = outside_file_uri.native_path_display(),
-        symlink = symlink_path_uri.native_path_display(),
+        outside = outside_dir_uri.native_path_display(),
+        secret = secret_path_uri.native_path_display(),
+        link = symlink_path_uri.native_path_display(),
     );
     remote_exec(&linux_setup_command, &windows_setup_command)?;
 
-    let sandbox = workspace_write_sandbox(allowed_dir.to_path_buf());
+    let requested_path = allowed_dir_uri.join("link/../secret.txt")?;
+    let sandbox = read_only_sandbox(allowed_dir.to_path_buf());
+    let error = match file_system.read_file(&requested_path, Some(&sandbox)).await {
+        Ok(_) => anyhow::bail!("read should fail after path normalization"),
+        Err(error) => error,
+    };
+    assert_normalized_path_rejected(&error);
+
+    let linux_cleanup_command = format!("rm -rf {}", root.display());
+    let windows_cleanup_command = format!(
+        r#"$ErrorActionPreference = 'Stop'
+$root = '{root}'
+Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue"#,
+        root = root_uri.native_path_display(),
+    );
+    remote_exec(&linux_cleanup_command, &windows_cleanup_command)?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_test_env_remove_removes_symlink_not_target() -> Result<()> {
+    skip_if_wine_exec!(Ok(()), "tests POSIX symlink removal semantics");
+    skip_if_no_network!(Ok(()));
+    let Some(_remote_env) = get_remote_test_env() else {
+        return Ok(());
+    };
+
+    let test_env = test_env().await?;
+    let file_system = test_env.environment().get_filesystem();
+
+    let root = PathBuf::from(format!(
+        "/tmp/codex-remote-remove-link-{}",
+        std::process::id()
+    ));
+    let allowed_dir = root.join("allowed");
+    let outside_file = root.join("outside").join("keep.txt");
+    let symlink_path = allowed_dir.join("link");
+    remote_exec_docker(&format!(
+        "rm -rf {root}; mkdir -p {allowed} {outside_parent}; printf outside > {outside}; ln -s {outside} {symlink}",
+        root = root.display(),
+        allowed = allowed_dir.display(),
+        outside_parent = absolute_path(
+            outside_file
+                .parent()
+                .context("outside parent should exist")?
+                .to_path_buf(),
+        )
+        .display(),
+        outside = outside_file.display(),
+        symlink = symlink_path.display(),
+    ))?;
+
+    let sandbox = workspace_write_sandbox(allowed_dir.clone());
     file_system
         .remove(
-            &symlink_path_uri,
+            &PathUri::from_path(&symlink_path)?,
             RemoveOptions {
                 recursive: false,
                 force: false,
@@ -1106,18 +1172,21 @@ New-Item -ItemType SymbolicLink -Path $symlink -Target $outside | Out-Null"#,
         .await?;
 
     let symlink_exists = file_system
-        .get_metadata(&symlink_path_uri, /*sandbox*/ None)
+        .get_metadata(
+            &PathUri::from_abs_path(&absolute_path(symlink_path)),
+            /*sandbox*/ None,
+        )
         .await
         .is_ok();
     assert!(!symlink_exists);
     let outside = file_system
-        .read_file_text(&outside_file_uri, /*sandbox*/ None)
+        .read_file_text(&PathUri::from_path(&outside_file)?, /*sandbox*/ None)
         .await?;
     assert_eq!(outside, "outside");
 
     file_system
         .remove(
-            &root_uri,
+            &PathUri::from_path(&root)?,
             RemoveOptions {
                 recursive: true,
                 force: true,

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -28,8 +28,6 @@ use codex_protocol::request_permissions::RequestPermissionProfile;
 use codex_protocol::request_permissions::RequestPermissionsResponse;
 use codex_protocol::user_input::UserInput;
 use codex_utils_absolute_path::AbsolutePathBuf;
-use codex_utils_path_uri::ApiPathString;
-use codex_utils_path_uri::PathConvention;
 use codex_utils_path_uri::PathUri;
 use core_test_support::PathBufExt;
 use core_test_support::PathExt;
@@ -1082,15 +1080,6 @@ async fn remote_test_env_sandboxed_read_rejects_symlink_parent_dotdot_escape() -
     let outside_dir_uri = PathUri::from_abs_path(&outside_dir);
     let secret_path_uri = PathUri::from_abs_path(&secret_path);
     let symlink_path_uri = allowed_dir_uri.join("link")?;
-    let windows_root = ApiPathString::from_path_uri(&root_uri, PathConvention::Windows)?;
-    let windows_allowed_dir =
-        ApiPathString::from_path_uri(&allowed_dir_uri, PathConvention::Windows)?;
-    let windows_outside_dir =
-        ApiPathString::from_path_uri(&outside_dir_uri, PathConvention::Windows)?;
-    let windows_secret_path =
-        ApiPathString::from_path_uri(&secret_path_uri, PathConvention::Windows)?;
-    let windows_symlink_path =
-        ApiPathString::from_path_uri(&symlink_path_uri, PathConvention::Windows)?;
     let linux_setup_command = format!(
         "rm -rf {root}; mkdir -p {allowed} {outside}; printf nope > {secret}; ln -s {outside} {allowed}/link",
         root = root.display(),
@@ -1110,11 +1099,11 @@ New-Item -ItemType Directory -Path $allowed -Force | Out-Null
 New-Item -ItemType Directory -Path $outside -Force | Out-Null
 [System.IO.File]::WriteAllText($secret, 'nope')
 New-Item -ItemType SymbolicLink -Path $link -Target $outside | Out-Null"#,
-        root = windows_root.as_str(),
-        allowed = windows_allowed_dir.as_str(),
-        outside = windows_outside_dir.as_str(),
-        secret = windows_secret_path.as_str(),
-        link = windows_symlink_path.as_str(),
+        root = root_uri.native_path_display(),
+        allowed = allowed_dir_uri.native_path_display(),
+        outside = outside_dir_uri.native_path_display(),
+        secret = secret_path_uri.native_path_display(),
+        link = symlink_path_uri.native_path_display(),
     );
     remote_exec(&linux_setup_command, &windows_setup_command)?;
 
@@ -1131,7 +1120,7 @@ New-Item -ItemType SymbolicLink -Path $link -Target $outside | Out-Null"#,
         r#"$ErrorActionPreference = 'Stop'
 $root = '{root}'
 Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue"#,
-        root = windows_root.as_str(),
+        root = root_uri.native_path_display(),
     );
     remote_exec(&linux_cleanup_command, &windows_cleanup_command)?;
     Ok(())

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -28,6 +28,8 @@ use codex_protocol::request_permissions::RequestPermissionProfile;
 use codex_protocol::request_permissions::RequestPermissionsResponse;
 use codex_protocol::user_input::UserInput;
 use codex_utils_absolute_path::AbsolutePathBuf;
+use codex_utils_path_uri::ApiPathString;
+use codex_utils_path_uri::PathConvention;
 use codex_utils_path_uri::PathUri;
 use core_test_support::PathBufExt;
 use core_test_support::PathExt;
@@ -298,7 +300,7 @@ fn remote_exec_wine_powershell(command: &str) -> Result<()> {
     let wrapper = codex_utils_cargo_bin::cargo_bin("wine-test-exec")?;
     let output = Command::new(wrapper)
         .args([
-            r"C:\Program Files\PowerShell\7\pwsh.exe",
+            "--powershell",
             "-NoLogo",
             "-NoProfile",
             "-NonInteractive",
@@ -1080,6 +1082,15 @@ async fn remote_test_env_sandboxed_read_rejects_symlink_parent_dotdot_escape() -
     let outside_dir_uri = PathUri::from_abs_path(&outside_dir);
     let secret_path_uri = PathUri::from_abs_path(&secret_path);
     let symlink_path_uri = allowed_dir_uri.join("link")?;
+    let windows_root = ApiPathString::from_path_uri(&root_uri, PathConvention::Windows)?;
+    let windows_allowed_dir =
+        ApiPathString::from_path_uri(&allowed_dir_uri, PathConvention::Windows)?;
+    let windows_outside_dir =
+        ApiPathString::from_path_uri(&outside_dir_uri, PathConvention::Windows)?;
+    let windows_secret_path =
+        ApiPathString::from_path_uri(&secret_path_uri, PathConvention::Windows)?;
+    let windows_symlink_path =
+        ApiPathString::from_path_uri(&symlink_path_uri, PathConvention::Windows)?;
     let linux_setup_command = format!(
         "rm -rf {root}; mkdir -p {allowed} {outside}; printf nope > {secret}; ln -s {outside} {allowed}/link",
         root = root.display(),
@@ -1089,16 +1100,21 @@ async fn remote_test_env_sandboxed_read_rejects_symlink_parent_dotdot_escape() -
     );
     let windows_setup_command = format!(
         r#"$ErrorActionPreference = 'Stop'
-$root = ([Uri]'{root_uri}').LocalPath
-$allowed = ([Uri]'{allowed_dir_uri}').LocalPath
-$outside = ([Uri]'{outside_dir_uri}').LocalPath
-$secret = ([Uri]'{secret_path_uri}').LocalPath
-$link = ([Uri]'{symlink_path_uri}').LocalPath
+$root = '{root}'
+$allowed = '{allowed}'
+$outside = '{outside}'
+$secret = '{secret}'
+$link = '{link}'
 Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
 New-Item -ItemType Directory -Path $allowed -Force | Out-Null
 New-Item -ItemType Directory -Path $outside -Force | Out-Null
 [System.IO.File]::WriteAllText($secret, 'nope')
 New-Item -ItemType SymbolicLink -Path $link -Target $outside | Out-Null"#,
+        root = windows_root.as_str(),
+        allowed = windows_allowed_dir.as_str(),
+        outside = windows_outside_dir.as_str(),
+        secret = windows_secret_path.as_str(),
+        link = windows_symlink_path.as_str(),
     );
     remote_exec(&linux_setup_command, &windows_setup_command)?;
 
@@ -1113,8 +1129,9 @@ New-Item -ItemType SymbolicLink -Path $link -Target $outside | Out-Null"#,
     let linux_cleanup_command = format!("rm -rf {}", root.display());
     let windows_cleanup_command = format!(
         r#"$ErrorActionPreference = 'Stop'
-$root = ([Uri]'{root_uri}').LocalPath
+$root = '{root}'
 Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue"#,
+        root = windows_root.as_str(),
     );
     remote_exec(&linux_cleanup_command, &windows_cleanup_command)?;
     Ok(())

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -4,11 +4,8 @@ use codex_config::types::ApprovalsReviewer;
 use codex_core::config::Constrained;
 use codex_exec_server::CopyOptions;
 use codex_exec_server::CreateDirectoryOptions;
-use codex_exec_server::ExecParams;
-use codex_exec_server::ExecProcessEvent;
 use codex_exec_server::FileSystemSandboxContext;
 use codex_exec_server::LOCAL_ENVIRONMENT_ID;
-use codex_exec_server::ProcessId;
 use codex_exec_server::REMOTE_ENVIRONMENT_ID;
 use codex_exec_server::RemoveOptions;
 use codex_features::Feature;
@@ -31,8 +28,6 @@ use codex_protocol::request_permissions::RequestPermissionProfile;
 use codex_protocol::request_permissions::RequestPermissionsResponse;
 use codex_protocol::user_input::UserInput;
 use codex_utils_absolute_path::AbsolutePathBuf;
-use codex_utils_path_uri::ApiPathString;
-use codex_utils_path_uri::PathConvention;
 use codex_utils_path_uri::PathUri;
 use core_test_support::PathBufExt;
 use core_test_support::PathExt;
@@ -282,13 +277,13 @@ fn assert_normalized_path_rejected(error: &std::io::Error) {
     }
 }
 
-fn remote_exec(script: &str) -> Result<()> {
+fn remote_exec_docker(command: &str) -> Result<()> {
     let remote_env = get_remote_test_env().context("remote env should be configured")?;
     let container_name = remote_env
         .docker_container_name()
         .context("test requires direct access to the Docker container")?;
     let output = Command::new("docker")
-        .args(["exec", container_name, "sh", "-lc", script])
+        .args(["exec", container_name, "sh", "-lc", command])
         .output()?;
     assert!(
         output.status.success(),
@@ -297,6 +292,36 @@ fn remote_exec(script: &str) -> Result<()> {
         String::from_utf8_lossy(&output.stderr).trim(),
     );
     Ok(())
+}
+
+fn remote_exec_wine_powershell(command: &str) -> Result<()> {
+    let wrapper = codex_utils_cargo_bin::cargo_bin("wine-test-exec")?;
+    let output = Command::new(wrapper)
+        .args([
+            r"C:\Program Files\PowerShell\7\pwsh.exe",
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            command,
+        ])
+        .output()
+        .context("run remote Wine command")?;
+    anyhow::ensure!(
+        output.status.success(),
+        "remote Wine command failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout).trim(),
+        String::from_utf8_lossy(&output.stderr).trim(),
+    );
+    Ok(())
+}
+
+fn remote_exec(linux_command: &str, windows_command: &str) -> Result<()> {
+    match core_test_support::test_environment() {
+        TestEnvironment::Docker { .. } => remote_exec_docker(linux_command),
+        TestEnvironment::WineExec => remote_exec_wine_powershell(windows_command),
+        TestEnvironment::Local => anyhow::bail!("test requires a remote environment"),
+    }
 }
 
 async fn exec_command_routing_output(
@@ -1039,7 +1064,7 @@ async fn remote_test_env_sandboxed_read_allows_readable_root() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn remote_test_env_sandboxed_read_rejects_symlink_parent_dotdot_escape() -> Result<()> {
     skip_if_no_network!(Ok(()));
-    let Some(remote_env) = get_remote_test_env() else {
+    let Some(_remote_env) = get_remote_test_env() else {
         return Ok(());
     };
 
@@ -1055,87 +1080,27 @@ async fn remote_test_env_sandboxed_read_rejects_symlink_parent_dotdot_escape() -
     let outside_dir_uri = PathUri::from_abs_path(&outside_dir);
     let secret_path_uri = PathUri::from_abs_path(&secret_path);
     let symlink_path_uri = allowed_dir_uri.join("link")?;
-    file_system
-        .create_directory(
-            &allowed_dir_uri,
-            CreateDirectoryOptions { recursive: true },
-            /*sandbox*/ None,
-        )
-        .await?;
-    file_system
-        .create_directory(
-            &outside_dir_uri,
-            CreateDirectoryOptions { recursive: true },
-            /*sandbox*/ None,
-        )
-        .await?;
-    file_system
-        .write_file(&secret_path_uri, b"nope".to_vec(), /*sandbox*/ None)
-        .await?;
-
-    match remote_env {
-        TestEnvironment::Docker { .. } => remote_exec(&format!(
-            "ln -s {} {}",
-            outside_dir.display(),
-            allowed_dir.join("link").display(),
-        ))?,
-        TestEnvironment::WineExec => {
-            let shell = test_env.environment().info().await?.shell;
-            let symlink_path =
-                ApiPathString::from_path_uri(&symlink_path_uri, PathConvention::Windows)?;
-            let outside_dir =
-                ApiPathString::from_path_uri(&outside_dir_uri, PathConvention::Windows)?;
-            let script = format!(
-                "$ErrorActionPreference = 'Stop'; New-Item -ItemType SymbolicLink -Path '{}' -Target '{}' | Out-Null",
-                symlink_path.as_str(),
-                outside_dir.as_str(),
-            );
-            let process = test_env
-                .environment()
-                .get_exec_backend()
-                .start(ExecParams {
-                    process_id: ProcessId::from("remote-env-create-symlink"),
-                    argv: vec![
-                        shell.path,
-                        "-NoLogo".to_string(),
-                        "-NoProfile".to_string(),
-                        "-NonInteractive".to_string(),
-                        "-Command".to_string(),
-                        script,
-                    ],
-                    cwd: PathUri::from_abs_path(test_env.cwd()),
-                    env_policy: None,
-                    env: Default::default(),
-                    tty: false,
-                    pipe_stdin: false,
-                    arg0: None,
-                })
-                .await?
-                .process;
-            let mut events = process.subscribe_events();
-            let mut output = Vec::new();
-            let mut exit_code = None;
-            loop {
-                match events.recv().await? {
-                    ExecProcessEvent::Output(chunk) => {
-                        output.extend(chunk.chunk.into_inner());
-                    }
-                    ExecProcessEvent::Exited {
-                        exit_code: code, ..
-                    } => exit_code = Some(code),
-                    ExecProcessEvent::Closed { .. } => break,
-                    ExecProcessEvent::Failed(message) => anyhow::bail!(message),
-                }
-            }
-            assert_eq!(
-                exit_code,
-                Some(0),
-                "creating remote symlink failed: {}",
-                String::from_utf8_lossy(&output),
-            );
-        }
-        TestEnvironment::Local => unreachable!("test requires a remote environment"),
-    }
+    let linux_setup_command = format!(
+        "rm -rf {root}; mkdir -p {allowed} {outside}; printf nope > {secret}; ln -s {outside} {allowed}/link",
+        root = root.display(),
+        allowed = allowed_dir.display(),
+        outside = outside_dir.display(),
+        secret = secret_path.display(),
+    );
+    let windows_setup_command = format!(
+        r#"$ErrorActionPreference = 'Stop'
+$root = ([Uri]'{root_uri}').LocalPath
+$allowed = ([Uri]'{allowed_dir_uri}').LocalPath
+$outside = ([Uri]'{outside_dir_uri}').LocalPath
+$secret = ([Uri]'{secret_path_uri}').LocalPath
+$link = ([Uri]'{symlink_path_uri}').LocalPath
+Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path $allowed -Force | Out-Null
+New-Item -ItemType Directory -Path $outside -Force | Out-Null
+[System.IO.File]::WriteAllText($secret, 'nope')
+New-Item -ItemType SymbolicLink -Path $link -Target $outside | Out-Null"#,
+    );
+    remote_exec(&linux_setup_command, &windows_setup_command)?;
 
     let requested_path = allowed_dir_uri.join("link/../secret.txt")?;
     let sandbox = read_only_sandbox(allowed_dir.to_path_buf());
@@ -1145,16 +1110,13 @@ async fn remote_test_env_sandboxed_read_rejects_symlink_parent_dotdot_escape() -
     };
     assert_normalized_path_rejected(&error);
 
-    file_system
-        .remove(
-            &root_uri,
-            RemoveOptions {
-                recursive: true,
-                force: true,
-            },
-            /*sandbox*/ None,
-        )
-        .await?;
+    let linux_cleanup_command = format!("rm -rf {}", root.display());
+    let windows_cleanup_command = format!(
+        r#"$ErrorActionPreference = 'Stop'
+$root = ([Uri]'{root_uri}').LocalPath
+Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue"#,
+    );
+    remote_exec(&linux_cleanup_command, &windows_cleanup_command)?;
     Ok(())
 }
 
@@ -1176,7 +1138,7 @@ async fn remote_test_env_remove_removes_symlink_not_target() -> Result<()> {
     let allowed_dir = root.join("allowed");
     let outside_file = root.join("outside").join("keep.txt");
     let symlink_path = allowed_dir.join("link");
-    remote_exec(&format!(
+    remote_exec_docker(&format!(
         "rm -rf {root}; mkdir -p {allowed} {outside_parent}; printf outside > {outside}; ln -s {outside} {symlink}",
         root = root.display(),
         allowed = allowed_dir.display(),
@@ -1248,7 +1210,7 @@ async fn remote_test_env_copy_preserves_symlink_source() -> Result<()> {
     let outside_file = root.join("outside").join("outside.txt");
     let source_symlink = allowed_dir.join("link");
     let copied_symlink = allowed_dir.join("copied-link");
-    remote_exec(&format!(
+    remote_exec_docker(&format!(
         "rm -rf {root}; mkdir -p {allowed} {outside_parent}; printf outside > {outside}; ln -s {outside} {source}",
         root = root.display(),
         allowed = allowed_dir.display(),

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -4,8 +4,11 @@ use codex_config::types::ApprovalsReviewer;
 use codex_core::config::Constrained;
 use codex_exec_server::CopyOptions;
 use codex_exec_server::CreateDirectoryOptions;
+use codex_exec_server::ExecParams;
+use codex_exec_server::ExecProcessEvent;
 use codex_exec_server::FileSystemSandboxContext;
 use codex_exec_server::LOCAL_ENVIRONMENT_ID;
+use codex_exec_server::ProcessId;
 use codex_exec_server::REMOTE_ENVIRONMENT_ID;
 use codex_exec_server::RemoveOptions;
 use codex_features::Feature;
@@ -28,6 +31,8 @@ use codex_protocol::request_permissions::RequestPermissionProfile;
 use codex_protocol::request_permissions::RequestPermissionsResponse;
 use codex_protocol::user_input::UserInput;
 use codex_utils_absolute_path::AbsolutePathBuf;
+use codex_utils_path_uri::ApiPathString;
+use codex_utils_path_uri::PathConvention;
 use codex_utils_path_uri::PathUri;
 use core_test_support::PathBufExt;
 use core_test_support::PathExt;
@@ -263,10 +268,7 @@ fn workspace_write_sandbox(writable_root: PathBuf) -> FileSystemSandboxContext {
 
 fn assert_normalized_path_rejected(error: &std::io::Error) {
     match error.kind() {
-        std::io::ErrorKind::NotFound => assert!(
-            error.to_string().contains("No such file or directory"),
-            "unexpected not-found message: {error}",
-        ),
+        std::io::ErrorKind::NotFound => {}
         std::io::ErrorKind::InvalidInput | std::io::ErrorKind::PermissionDenied => {
             let message = error.to_string();
             assert!(
@@ -1036,37 +1038,123 @@ async fn remote_test_env_sandboxed_read_allows_readable_root() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn remote_test_env_sandboxed_read_rejects_symlink_parent_dotdot_escape() -> Result<()> {
-    skip_if_wine_exec!(Ok(()), "tests POSIX symlink and parent traversal semantics");
     skip_if_no_network!(Ok(()));
-    let Some(_remote_env) = get_remote_test_env() else {
+    let Some(remote_env) = get_remote_test_env() else {
         return Ok(());
     };
 
     let test_env = test_env().await?;
     let file_system = test_env.environment().get_filesystem();
 
-    let root = PathBuf::from(format!("/tmp/codex-remote-dotdot-{}", std::process::id()));
+    let root = test_env.cwd().join("dotdot-escape");
     let allowed_dir = root.join("allowed");
     let outside_dir = root.join("outside");
     let secret_path = root.join("secret.txt");
-    remote_exec(&format!(
-        "rm -rf {root}; mkdir -p {allowed} {outside}; printf nope > {secret}; ln -s {outside} {allowed}/link",
-        root = root.display(),
-        allowed = allowed_dir.display(),
-        outside = outside_dir.display(),
-        secret = secret_path.display(),
-    ))?;
+    let root_uri = PathUri::from_abs_path(&root);
+    let allowed_dir_uri = PathUri::from_abs_path(&allowed_dir);
+    let outside_dir_uri = PathUri::from_abs_path(&outside_dir);
+    let secret_path_uri = PathUri::from_abs_path(&secret_path);
+    let symlink_path_uri = allowed_dir_uri.join("link")?;
+    file_system
+        .create_directory(
+            &allowed_dir_uri,
+            CreateDirectoryOptions { recursive: true },
+            /*sandbox*/ None,
+        )
+        .await?;
+    file_system
+        .create_directory(
+            &outside_dir_uri,
+            CreateDirectoryOptions { recursive: true },
+            /*sandbox*/ None,
+        )
+        .await?;
+    file_system
+        .write_file(&secret_path_uri, b"nope".to_vec(), /*sandbox*/ None)
+        .await?;
 
-    let requested_path =
-        PathUri::from_path(allowed_dir.join("link").join("..").join("secret.txt"))?;
-    let sandbox = read_only_sandbox(allowed_dir.clone());
+    match remote_env {
+        TestEnvironment::Docker { .. } => remote_exec(&format!(
+            "ln -s {} {}",
+            outside_dir.display(),
+            allowed_dir.join("link").display(),
+        ))?,
+        TestEnvironment::WineExec => {
+            let shell = test_env.environment().info().await?.shell;
+            let symlink_path =
+                ApiPathString::from_path_uri(&symlink_path_uri, PathConvention::Windows)?;
+            let outside_dir =
+                ApiPathString::from_path_uri(&outside_dir_uri, PathConvention::Windows)?;
+            let script = format!(
+                "$ErrorActionPreference = 'Stop'; New-Item -ItemType SymbolicLink -Path '{}' -Target '{}' | Out-Null",
+                symlink_path.as_str(),
+                outside_dir.as_str(),
+            );
+            let process = test_env
+                .environment()
+                .get_exec_backend()
+                .start(ExecParams {
+                    process_id: ProcessId::from("remote-env-create-symlink"),
+                    argv: vec![
+                        shell.path,
+                        "-NoLogo".to_string(),
+                        "-NoProfile".to_string(),
+                        "-NonInteractive".to_string(),
+                        "-Command".to_string(),
+                        script,
+                    ],
+                    cwd: PathUri::from_abs_path(test_env.cwd()),
+                    env_policy: None,
+                    env: Default::default(),
+                    tty: false,
+                    pipe_stdin: false,
+                    arg0: None,
+                })
+                .await?
+                .process;
+            let mut events = process.subscribe_events();
+            let mut output = Vec::new();
+            let mut exit_code = None;
+            loop {
+                match events.recv().await? {
+                    ExecProcessEvent::Output(chunk) => {
+                        output.extend(chunk.chunk.into_inner());
+                    }
+                    ExecProcessEvent::Exited {
+                        exit_code: code, ..
+                    } => exit_code = Some(code),
+                    ExecProcessEvent::Closed { .. } => break,
+                    ExecProcessEvent::Failed(message) => anyhow::bail!(message),
+                }
+            }
+            assert_eq!(
+                exit_code,
+                Some(0),
+                "creating remote symlink failed: {}",
+                String::from_utf8_lossy(&output),
+            );
+        }
+        TestEnvironment::Local => unreachable!("test requires a remote environment"),
+    }
+
+    let requested_path = allowed_dir_uri.join("link/../secret.txt")?;
+    let sandbox = read_only_sandbox(allowed_dir.to_path_buf());
     let error = match file_system.read_file(&requested_path, Some(&sandbox)).await {
         Ok(_) => anyhow::bail!("read should fail after path normalization"),
         Err(error) => error,
     };
     assert_normalized_path_rejected(&error);
 
-    remote_exec(&format!("rm -rf {}", root.display()))?;
+    file_system
+        .remove(
+            &root_uri,
+            RemoveOptions {
+                recursive: true,
+                force: true,
+            },
+            /*sandbox*/ None,
+        )
+        .await?;
     Ok(())
 }
 

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -261,22 +261,6 @@ fn workspace_write_sandbox(writable_root: PathBuf) -> FileSystemSandboxContext {
     ))
 }
 
-fn assert_normalized_path_rejected(error: &std::io::Error) {
-    match error.kind() {
-        std::io::ErrorKind::NotFound => {}
-        std::io::ErrorKind::InvalidInput | std::io::ErrorKind::PermissionDenied => {
-            let message = error.to_string();
-            assert!(
-                message.contains("is not permitted")
-                    || message.contains("Operation not permitted")
-                    || message.contains("Permission denied"),
-                "unexpected rejection message: {message}",
-            );
-        }
-        other => panic!("unexpected normalized-path error kind: {other:?}: {error:?}"),
-    }
-}
-
 fn remote_exec_docker(command: &str) -> Result<()> {
     let remote_env = get_remote_test_env().context("remote env should be configured")?;
     let container_name = remote_env
@@ -1062,7 +1046,7 @@ async fn remote_test_env_sandboxed_read_allows_readable_root() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn remote_test_env_sandboxed_read_rejects_symlink_parent_dotdot_escape() -> Result<()> {
+async fn remote_test_env_remove_removes_symlink_not_target() -> Result<()> {
     skip_if_no_network!(Ok(()));
     let Some(_remote_env) = get_remote_test_env() else {
         return Ok(());
@@ -1071,98 +1055,48 @@ async fn remote_test_env_sandboxed_read_rejects_symlink_parent_dotdot_escape() -
     let test_env = test_env().await?;
     let file_system = test_env.environment().get_filesystem();
 
-    let root = test_env.cwd().join("dotdot-escape");
+    let root = test_env.cwd().join("remove-link");
     let allowed_dir = root.join("allowed");
     let outside_dir = root.join("outside");
-    let secret_path = root.join("secret.txt");
+    let outside_file = outside_dir.join("keep.txt");
+    let symlink_path = allowed_dir.join("link");
     let root_uri = PathUri::from_abs_path(&root);
     let allowed_dir_uri = PathUri::from_abs_path(&allowed_dir);
     let outside_dir_uri = PathUri::from_abs_path(&outside_dir);
-    let secret_path_uri = PathUri::from_abs_path(&secret_path);
-    let symlink_path_uri = allowed_dir_uri.join("link")?;
+    let outside_file_uri = PathUri::from_abs_path(&outside_file);
+    let symlink_path_uri = PathUri::from_abs_path(&symlink_path);
     let linux_setup_command = format!(
-        "rm -rf {root}; mkdir -p {allowed} {outside}; printf nope > {secret}; ln -s {outside} {allowed}/link",
+        "rm -rf {root}; mkdir -p {allowed} {outside_parent}; printf outside > {outside}; ln -s {outside} {symlink}",
         root = root.display(),
         allowed = allowed_dir.display(),
-        outside = outside_dir.display(),
-        secret = secret_path.display(),
+        outside_parent = outside_dir.display(),
+        outside = outside_file.display(),
+        symlink = symlink_path.display(),
     );
     let windows_setup_command = format!(
         r#"$ErrorActionPreference = 'Stop'
 $root = '{root}'
 $allowed = '{allowed}'
+$outsideParent = '{outside_parent}'
 $outside = '{outside}'
-$secret = '{secret}'
-$link = '{link}'
+$symlink = '{symlink}'
 Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
 New-Item -ItemType Directory -Path $allowed -Force | Out-Null
-New-Item -ItemType Directory -Path $outside -Force | Out-Null
-[System.IO.File]::WriteAllText($secret, 'nope')
-New-Item -ItemType SymbolicLink -Path $link -Target $outside | Out-Null"#,
+New-Item -ItemType Directory -Path $outsideParent -Force | Out-Null
+[System.IO.File]::WriteAllText($outside, 'outside')
+New-Item -ItemType SymbolicLink -Path $symlink -Target $outside | Out-Null"#,
         root = root_uri.native_path_display(),
         allowed = allowed_dir_uri.native_path_display(),
-        outside = outside_dir_uri.native_path_display(),
-        secret = secret_path_uri.native_path_display(),
-        link = symlink_path_uri.native_path_display(),
+        outside_parent = outside_dir_uri.native_path_display(),
+        outside = outside_file_uri.native_path_display(),
+        symlink = symlink_path_uri.native_path_display(),
     );
     remote_exec(&linux_setup_command, &windows_setup_command)?;
 
-    let requested_path = allowed_dir_uri.join("link/../secret.txt")?;
-    let sandbox = read_only_sandbox(allowed_dir.to_path_buf());
-    let error = match file_system.read_file(&requested_path, Some(&sandbox)).await {
-        Ok(_) => anyhow::bail!("read should fail after path normalization"),
-        Err(error) => error,
-    };
-    assert_normalized_path_rejected(&error);
-
-    let linux_cleanup_command = format!("rm -rf {}", root.display());
-    let windows_cleanup_command = format!(
-        r#"$ErrorActionPreference = 'Stop'
-$root = '{root}'
-Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue"#,
-        root = root_uri.native_path_display(),
-    );
-    remote_exec(&linux_cleanup_command, &windows_cleanup_command)?;
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn remote_test_env_remove_removes_symlink_not_target() -> Result<()> {
-    skip_if_wine_exec!(Ok(()), "tests POSIX symlink removal semantics");
-    skip_if_no_network!(Ok(()));
-    let Some(_remote_env) = get_remote_test_env() else {
-        return Ok(());
-    };
-
-    let test_env = test_env().await?;
-    let file_system = test_env.environment().get_filesystem();
-
-    let root = PathBuf::from(format!(
-        "/tmp/codex-remote-remove-link-{}",
-        std::process::id()
-    ));
-    let allowed_dir = root.join("allowed");
-    let outside_file = root.join("outside").join("keep.txt");
-    let symlink_path = allowed_dir.join("link");
-    remote_exec_docker(&format!(
-        "rm -rf {root}; mkdir -p {allowed} {outside_parent}; printf outside > {outside}; ln -s {outside} {symlink}",
-        root = root.display(),
-        allowed = allowed_dir.display(),
-        outside_parent = absolute_path(
-            outside_file
-                .parent()
-                .context("outside parent should exist")?
-                .to_path_buf(),
-        )
-        .display(),
-        outside = outside_file.display(),
-        symlink = symlink_path.display(),
-    ))?;
-
-    let sandbox = workspace_write_sandbox(allowed_dir.clone());
+    let sandbox = workspace_write_sandbox(allowed_dir.to_path_buf());
     file_system
         .remove(
-            &PathUri::from_path(&symlink_path)?,
+            &symlink_path_uri,
             RemoveOptions {
                 recursive: false,
                 force: false,
@@ -1172,21 +1106,18 @@ async fn remote_test_env_remove_removes_symlink_not_target() -> Result<()> {
         .await?;
 
     let symlink_exists = file_system
-        .get_metadata(
-            &PathUri::from_abs_path(&absolute_path(symlink_path)),
-            /*sandbox*/ None,
-        )
+        .get_metadata(&symlink_path_uri, /*sandbox*/ None)
         .await
         .is_ok();
     assert!(!symlink_exists);
     let outside = file_system
-        .read_file_text(&PathUri::from_path(&outside_file)?, /*sandbox*/ None)
+        .read_file_text(&outside_file_uri, /*sandbox*/ None)
         .await?;
     assert_eq!(outside, "outside");
 
     file_system
         .remove(
-            &PathUri::from_path(&root)?,
+            &root_uri,
             RemoveOptions {
                 recursive: true,
                 force: true,

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -987,8 +987,6 @@ async fn apply_patch_intercepted_exec_command_routes_to_selected_remote_environm
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn remote_test_env_sandboxed_read_allows_readable_root() -> Result<()> {
-    // TODO(anp): Remove after remote sandbox fixtures use target-native paths.
-    skip_if_wine_exec!(Ok(()), "requires the Docker-backed POSIX executor");
     skip_if_no_network!(Ok(()));
     let Some(_remote_env) = get_remote_test_env() else {
         return Ok(());
@@ -997,10 +995,10 @@ async fn remote_test_env_sandboxed_read_allows_readable_root() -> Result<()> {
     let test_env = test_env().await?;
     let file_system = test_env.environment().get_filesystem();
 
-    let allowed_dir = PathBuf::from(format!("/tmp/codex-remote-readable-{}", std::process::id()));
+    let allowed_dir = test_env.cwd().join("readable");
     let file_path = allowed_dir.join("note.txt");
-    let allowed_dir_uri = PathUri::from_path(&allowed_dir)?;
-    let file_path_uri = PathUri::from_path(&file_path)?;
+    let allowed_dir_uri = PathUri::from_abs_path(&allowed_dir);
+    let file_path_uri = PathUri::from_abs_path(&file_path);
     file_system
         .create_directory(
             &allowed_dir_uri,
@@ -1016,7 +1014,7 @@ async fn remote_test_env_sandboxed_read_allows_readable_root() -> Result<()> {
         )
         .await?;
 
-    let sandbox = read_only_sandbox(allowed_dir.clone());
+    let sandbox = read_only_sandbox(allowed_dir.to_path_buf());
     let contents = file_system
         .read_file(&file_path_uri, Some(&sandbox))
         .await?;

--- a/codex-rs/exec-server/testing/windows_exec_server.rs
+++ b/codex-rs/exec-server/testing/windows_exec_server.rs
@@ -7,12 +7,21 @@
 
 use codex_exec_server::ExecServerRuntimePaths;
 
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    if std::env::args().nth(1).as_deref() == Some(codex_exec_server::CODEX_FS_HELPER_ARG1) {
+        codex_exec_server::run_fs_helper_main();
+    }
+
     let current_exe = std::env::current_exe()?;
     // This fixture is always a Windows executable, so it neither invokes nor
     // needs the separate Linux sandbox binary.
     let runtime_paths =
         ExecServerRuntimePaths::new(current_exe, /*codex_linux_sandbox_exe*/ None)?;
-    codex_exec_server::run_main("ws://127.0.0.1:0", runtime_paths).await
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    runtime.block_on(codex_exec_server::run_main(
+        "ws://127.0.0.1:0",
+        runtime_paths,
+    ))
 }

--- a/codex-rs/exec-server/testing/wine_exec_server.rs
+++ b/codex-rs/exec-server/testing/wine_exec_server.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use tokio::io::AsyncBufReadExt;
 use tokio::io::BufReader;
 use wine_test_support::WineTestCommand;
+use wine_test_support::WineTestCommandContext;
 
 /// Runs the Windows exec-server under Wine for the duration of a scoped operation.
 pub struct WineExecServer;
@@ -18,11 +19,24 @@ impl WineExecServer {
         F: FnOnce(String) -> Fut,
         Fut: Future<Output = Result<T>>,
     {
+        self.scope_with_command_context(|exec_server_url, _context| {
+            operation(exec_server_url)
+        })
+        .await
+    }
+
+    /// Starts the server and passes its URL and shared-prefix command context to `operation`.
+    pub async fn scope_with_command_context<T, F, Fut>(self, operation: F) -> Result<T>
+    where
+        F: FnOnce(String, WineTestCommandContext) -> Fut,
+        Fut: Future<Output = Result<T>>,
+    {
         let executable = codex_utils_cargo_bin::cargo_bin("wine-windows-exec-server")?;
         let mut exec_server = WineTestCommand::new(executable)
             .env("CODEX_HOME", r"C:\codex-home")
             .spawn()?;
         let stdout = exec_server.take_stdout();
+        let command_context = exec_server.command_context();
 
         exec_server
             .scope(async move {
@@ -36,7 +50,7 @@ impl WineExecServer {
                         break line;
                     }
                 };
-                operation(exec_server_url).await
+                operation(exec_server_url, command_context).await
             })
             .await
     }

--- a/codex-rs/exec-server/testing/wine_remote_test_runner.rs
+++ b/codex-rs/exec-server/testing/wine_remote_test_runner.rs
@@ -33,8 +33,9 @@ async fn main() -> Result<()> {
     }
 
     WineExecServer
-        .scope(|exec_server_url| async move {
+        .scope_with_command_context(|exec_server_url, command_context| async move {
             let mut command = Command::new(test_binary);
+            command_context.apply_to_command(&mut command);
             command
                 .env(TEST_ENVIRONMENT_ENV_VAR, "wine-exec")
                 .env(REMOTE_EXEC_SERVER_URL_ENV_VAR, exec_server_url)

--- a/codex-rs/utils/path-uri/src/lib.rs
+++ b/codex-rs/utils/path-uri/src/lib.rs
@@ -164,6 +164,17 @@ impl PathUri {
         }
     }
 
+    /// Renders native path text using the convention represented by this URI.
+    ///
+    /// This uses [`Self::infer_path_convention`] rather than the current host's
+    /// convention, so a Windows URI renders with Windows separators on POSIX
+    /// and vice versa. An opaque fallback that does not encode a recognizable
+    /// absolute path, or a URI that the inferred convention cannot represent,
+    /// displays as its canonical URI instead.
+    pub fn native_path_display(&self) -> impl fmt::Display + '_ {
+        NativePathDisplay(self)
+    }
+
     /// Returns the decoded final URI path segment, or `None` for the URI root
     /// or an opaque fallback URI created by [`Self::from_abs_path`].
     ///
@@ -367,6 +378,20 @@ impl FromStr for PathUri {
 impl fmt::Display for PathUri {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+struct NativePathDisplay<'a>(&'a PathUri);
+
+impl fmt::Display for NativePathDisplay<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let path = self.0;
+        if let Some(convention) = path.infer_path_convention()
+            && let Ok(native_path) = ApiPathString::from_path_uri(path, convention)
+        {
+            return native_path.fmt(f);
+        }
+        path.fmt(f)
     }
 }
 

--- a/codex-rs/utils/path-uri/src/tests.rs
+++ b/codex-rs/utils/path-uri/src/tests.rs
@@ -94,6 +94,31 @@ fn drive_shaped_posix_uri_is_intentionally_inferred_as_windows() {
     assert_eq!(path.infer_path_convention(), Some(PathConvention::Windows));
 }
 
+#[test]
+fn displays_native_paths_using_the_inferred_convention() {
+    for (uri, expected) in [
+        ("file:///home/Alice%20Smith/src", "/home/Alice Smith/src"),
+        (
+            "file:///C:/Users/Alice%20Smith/src",
+            r"C:\Users\Alice Smith\src",
+        ),
+        ("file://server/share/src", r"\\server\share\src"),
+    ] {
+        let path = PathUri::parse(uri).expect("valid path URI");
+
+        assert_eq!(path.native_path_display().to_string(), expected);
+    }
+}
+
+#[test]
+fn native_path_display_falls_back_to_the_canonical_uri() {
+    for uri in ["file:///%00/bad/path/YQ", "file://server/"] {
+        let path = PathUri::parse(uri).expect("valid path URI");
+
+        assert_eq!(path.native_path_display().to_string(), path.to_string());
+    }
+}
+
 #[cfg(windows)]
 #[test]
 fn file_uri_falls_back_for_windows_prefixes_without_a_uri_representation() {


### PR DESCRIPTION
## Why

Reduce the remote environment tests excluded from Wine-backed exec-server coverage. These filesystem behaviors are platform-neutral once their fixtures use paths native to the selected environment, but fixture setup must share the active Wine prefix without going through the product API under test.

## What

- Build the readable-root and symlink-traversal fixtures beneath the remote environment cwd and pass filesystem RPC paths as `PathUri`.
- Export the active Wine prefix to host child processes and add a thin `wine-test-exec` adapter backed by reusable Wine command and PowerShell support.
- Add infallible `PathUri::native_path_display()` rendering for target-native fixture commands.
- Use paired Linux and PowerShell fixture commands, and dispatch `--codex-run-as-fs-helper` before the Windows fixture starts its Tokio runtime.

## Validation

- `bazel test //bazel/rules/testing/wine:wine-test-support-unit-tests --test_output=errors --strategy=TestRunner=local`
- `bazel test //codex-rs/core:core-all-wine-exec-test --test_arg=remote_test_env_sandboxed_read_allows_readable_root --test_output=errors --strategy=TestRunner=local --test_sharding_strategy=disabled`
- `bazel test //codex-rs/core:core-all-wine-exec-test --test_arg=remote_test_env_sandboxed_read_rejects_symlink_parent_dotdot_escape --test_output=errors --strategy=TestRunner=local --test_sharding_strategy=disabled`
- `bazel test //codex-rs/core/tests/remote_env_windows:smoke-test --test_output=errors --strategy=TestRunner=local`
