### PR TITLE
Map Windows computer use requirement to runtime feature

### DIFF
--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -9325,7 +9325,7 @@ async fn windows_computer_use_requirement_pins_computer_use() -> std::io::Result
         let config = ConfigBuilder::without_managed_config_for_tests()
             .codex_home(codex_home.path().to_path_buf())
             .cloud_config_bundle(
-                CloudConfigBundleFixture::loader_with_enterprise_requirement(&format!(
+                CloudConfigBundleFixture::loader_with_enterprise_requirement(format!(
                     r#"
 [features]
 windows_computer_use = {enabled}

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -9316,6 +9316,39 @@ shell_tool = false
     Ok(())
 }
 
+#[cfg(target_os = "windows")]
+#[tokio::test]
+async fn windows_computer_use_requirement_pins_computer_use() -> std::io::Result<()> {
+    for enabled in [false, true] {
+        let codex_home = TempDir::new()?;
+
+        let config = ConfigBuilder::without_managed_config_for_tests()
+            .codex_home(codex_home.path().to_path_buf())
+            .cloud_config_bundle(
+                CloudConfigBundleFixture::loader_with_enterprise_requirement(&format!(
+                    r#"
+[features]
+windows_computer_use = {enabled}
+"#,
+                )),
+            )
+            .build()
+            .await?;
+
+        assert_eq!(config.features.enabled(Feature::ComputerUse), enabled);
+        assert!(
+            !config
+                .startup_warnings
+                .iter()
+                .any(|warning| warning.contains("windows_computer_use")),
+            "{:?}",
+            config.startup_warnings
+        );
+    }
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn feature_requirements_auto_review_disables_guardian_approval() -> std::io::Result<()> {
     let codex_home = TempDir::new()?;

--- a/codex-rs/core/src/config/managed_features.rs
+++ b/codex-rs/core/src/config/managed_features.rs
@@ -215,6 +215,12 @@ fn parse_feature_requirements(
             continue;
         }
 
+        #[cfg(target_os = "windows")]
+        if key == "windows_computer_use" {
+            pinned_features.insert(Feature::ComputerUse, enabled);
+            continue;
+        }
+
         if let Some(feature) = canonical_feature_for_key(&key) {
             pinned_features.insert(feature, enabled);
             continue;


### PR DESCRIPTION
## Summary
- Map the enterprise/cloud windows_computer_use requirement key to the existing computer_use runtime feature on Windows
- Keep the alias Windows-only so non-Windows runtimes still warn on unknown requirement keys
- Add a Windows-only regression test for both enabled and disabled requirement states

## Validation
- cargo fmt -- --config imports_granularity=Item completed; stable rustfmt emitted the expected nightly-only config warnings
- Focused cargo test -p codex-core windows_computer_use_requirement_pins_computer_use could not complete locally because this Windows ARM64 environment is missing clang for native ing build scripts
- Repo-preferred just fmt / just test are blocked locally because python/pwsh and cargo-nextest are not available on PATH