### PR TITLE
core: preserve selected environment workspace paths

### DIFF
--- a/codex-rs/analytics/src/analytics_client_tests.rs
+++ b/codex-rs/analytics/src/analytics_client_tests.rs
@@ -208,7 +208,7 @@ fn sample_thread_start_response(
         model: model.to_string(),
         model_provider: "openai".to_string(),
         service_tier: None,
-        cwd: test_path_buf("/tmp").abs(),
+        cwd: test_path_buf("/tmp").abs().into(),
         runtime_workspace_roots: Vec::new(),
         instruction_sources: Vec::new(),
         approval_policy: AppServerAskForApproval::OnFailure,

--- a/codex-rs/analytics/src/client_tests.rs
+++ b/codex-rs/analytics/src/client_tests.rs
@@ -305,7 +305,7 @@ fn sample_thread_start_response() -> ClientResponsePayload {
         model: "gpt-5".to_string(),
         model_provider: "openai".to_string(),
         service_tier: None,
-        cwd: test_path_buf("/tmp").abs(),
+        cwd: test_path_buf("/tmp").abs().into(),
         runtime_workspace_roots: Vec::new(),
         instruction_sources: Vec::new(),
         approval_policy: AppServerAskForApproval::OnFailure,


### PR DESCRIPTION
app-server may run on a different OS from the selected execution environment. Thread metadata and model context therefore need to preserve environment-native workspace paths instead of projecting them onto the app-server host.

This returns the selected environment cwd and runtime roots as API path strings, carries model-visible roots as `PathUri` through turn context, and reports the implicit active permission profile. The TUI still converts paths only at its host-native config boundary and rejects foreign roots there.

Stacked on #28152.

Validation:
- `just test -p codex-app-server-protocol`
- focused app-server, core, exec, and TUI tests for selected-environment paths
- `bazel test //codex-rs/core/tests/remote_env_windows:smoke-test --test_output=errors`
- `just bazel-lock-check`
