### PR TITLE
ci: run code-mode unit tests on all bazel targets

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -21,8 +21,8 @@ jobs:
     # PRs use the sharded Windows cross-compiled test jobs below. Post-merge
     # pushes to main also run the native Windows test job for broader Windows
     # signal without putting PR latency back on the critical path. When
-    # authenticated RBE is available, the Windows-cross shards exercise the
-    # source-built V8/code-mode targets.
+    # Code-mode unit tests run on every Bazel target. When authenticated RBE
+    # is available, the Windows-cross shards exercise the source-built V8 path.
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -95,10 +95,6 @@ jobs:
             # path. V8 consumers under `//codex-rs/...` still participate
             # transitively through `//...`.
             -//third_party/v8:all
-            # Keep V8-backed code-mode tests out of the ordinary macOS/Linux
-            # legs; authenticated Windows-cross shards below exercise the
-            # source-built gnullvm V8 path.
-            -//codex-rs/code-mode:code-mode-unit-tests
             -//codex-rs/v8-poc:v8-poc-unit-tests
           )
 
@@ -299,9 +295,6 @@ jobs:
             # path. V8 consumers under `//codex-rs/...` still participate
             # transitively through `//...`.
             -//third_party/v8:all
-            # Keep this job broad and cheap; authenticated Windows-cross jobs
-            # add source-built V8-backed code-mode coverage.
-            -//codex-rs/code-mode:code-mode-unit-tests
             -//codex-rs/v8-poc:v8-poc-unit-tests
           )
 


### PR DESCRIPTION
## Why

V8 should be stable under Bazel, so the `codex-code-mode` unit tests should run across the Bazel platform matrix. If these tests prove unstable, we should fix the tests rather than exclude them from CI.

## What changed

- Remove the explicit `//codex-rs/code-mode:code-mode-unit-tests` exclusion from the macOS and Linux Bazel test jobs.
- Remove the same exclusion from the native Windows post-merge job.
- Keep the existing Windows gnullvm shard coverage.

## Bazel test coverage

The target contains 26 unit tests. A fresh uncached local Bazel execution ran all 26 with 0 failures, 0 ignored tests, and 0 filtered tests.

PR Bazel CI selected the target on every enabled platform and reported a cached pass:

| Platform | Passing CI job |
| --- | --- |
| macOS aarch64 | [Bazel test passed](https://github.com/openai/codex/actions/runs/27636617545/job/81725447804) |
| macOS x86_64 | [Bazel test passed in 2.2s](https://github.com/openai/codex/actions/runs/27636617545/job/81725448008) |
| Linux GNU | [Bazel test passed in 0.4s](https://github.com/openai/codex/actions/runs/27636617545/job/81725447898) |
| Linux musl | [Bazel test passed in 0.4s](https://github.com/openai/codex/actions/runs/27636617545/job/81725448117) |
| Windows gnullvm | [Bazel test passed in shard 4/4 in 1.6s](https://github.com/openai/codex/actions/runs/27636617545/job/81725448166) |
