### PR TITLE
[codex] Revive process and workdir invariant coverage

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/process_exec.rs
+++ b/codex-rs/app-server/tests/suite/v2/process_exec.rs
@@ -185,6 +185,54 @@ async fn process_spawn_failure_releases_process_handle() -> Result<()> {
 }
 
 #[tokio::test]
+async fn process_handle_can_be_reused_after_process_exit() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    let (_server, mut mcp) = initialized_mcp(codex_home.path()).await?;
+
+    let process_handle = "reusable-after-exit-1".to_string();
+    for output in ["first-out", "second-out"] {
+        let command = if cfg!(windows) {
+            vec![
+                "powershell.exe".to_string(),
+                "-NoProfile".to_string(),
+                "-NonInteractive".to_string(),
+                "-Command".to_string(),
+                format!("[Console]::Out.Write('{output}')"),
+            ]
+        } else {
+            vec![
+                "sh".to_string(),
+                "-lc".to_string(),
+                format!("printf {output}"),
+            ]
+        };
+        let request_id = mcp
+            .send_process_spawn_request(process_spawn_params(
+                process_handle.clone(),
+                codex_home.path(),
+                command,
+            )?)
+            .await?;
+        let response = mcp
+            .read_stream_until_response_message(RequestId::Integer(request_id))
+            .await?;
+        assert_eq!(response.result, serde_json::json!({}));
+        assert_eq!(
+            read_process_exited(&mut mcp).await?,
+            ProcessExitedNotification {
+                process_handle: process_handle.clone(),
+                exit_code: 0,
+                stdout: output.to_string(),
+                stdout_cap_reached: false,
+                stderr: String::new(),
+                stderr_cap_reached: false,
+            }
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
 async fn process_spawn_returns_error_when_local_environment_is_disabled() -> Result<()> {
     let codex_home = TempDir::new()?;
     let server = create_mock_responses_server_sequence_unchecked(Vec::new()).await;

--- a/codex-rs/app-server/tests/suite/v2/process_exec.rs
+++ b/codex-rs/app-server/tests/suite/v2/process_exec.rs
@@ -121,6 +121,70 @@ async fn process_spawn_rejects_duplicate_active_handle_without_replacing_origina
 }
 
 #[tokio::test]
+async fn process_spawn_failure_releases_process_handle() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    let (_server, mut mcp) = initialized_mcp(codex_home.path()).await?;
+
+    let process_handle = "spawn-failure-1".to_string();
+    let missing_program = codex_home.path().join("missing-process-executable");
+    let failed_request_id = mcp
+        .send_process_spawn_request(process_spawn_params(
+            process_handle.clone(),
+            codex_home.path(),
+            vec![missing_program.display().to_string()],
+        )?)
+        .await?;
+    let error = mcp
+        .read_stream_until_error_message(RequestId::Integer(failed_request_id))
+        .await?;
+    assert_eq!(error.error.code, -32603);
+    assert!(
+        error.error.message.starts_with("failed to spawn process:"),
+        "unexpected spawn error: {}",
+        error.error.message
+    );
+
+    let command = if cfg!(windows) {
+        vec![
+            "powershell.exe".to_string(),
+            "-NoProfile".to_string(),
+            "-NonInteractive".to_string(),
+            "-Command".to_string(),
+            "[Console]::Out.Write('retry-out')".to_string(),
+        ]
+    } else {
+        vec![
+            "sh".to_string(),
+            "-lc".to_string(),
+            "printf retry-out".to_string(),
+        ]
+    };
+    let retry_request_id = mcp
+        .send_process_spawn_request(process_spawn_params(
+            process_handle.clone(),
+            codex_home.path(),
+            command,
+        )?)
+        .await?;
+    let response = mcp
+        .read_stream_until_response_message(RequestId::Integer(retry_request_id))
+        .await?;
+    assert_eq!(response.result, serde_json::json!({}));
+    assert_eq!(
+        read_process_exited(&mut mcp).await?,
+        ProcessExitedNotification {
+            process_handle,
+            exit_code: 0,
+            stdout: "retry-out".to_string(),
+            stdout_cap_reached: false,
+            stderr: String::new(),
+            stderr_cap_reached: false,
+        }
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn process_spawn_returns_error_when_local_environment_is_disabled() -> Result<()> {
     let codex_home = TempDir::new()?;
     let server = create_mock_responses_server_sequence_unchecked(Vec::new()).await;

--- a/codex-rs/app-server/tests/suite/v2/process_exec.rs
+++ b/codex-rs/app-server/tests/suite/v2/process_exec.rs
@@ -31,45 +31,7 @@ async fn process_spawn_returns_before_exit_and_emits_exit_notification() -> Resu
     // Use a probe/release handshake instead of asserting on wall-clock timing:
     // the child proves it started by writing the probe file, then waits for the
     // test to create the release file before it can emit output and exit.
-    let command = if cfg!(windows) {
-        vec![
-            "powershell.exe".to_string(),
-            "-NoProfile".to_string(),
-            "-NonInteractive".to_string(),
-            "-Command".to_string(),
-            concat!(
-                "[IO.File]::WriteAllText($env:CODEX_PROCESS_EXEC_PROBE_FILE, 'process'); ",
-                "while (!(Test-Path -LiteralPath $env:CODEX_PROCESS_EXEC_RELEASE_FILE)) { ",
-                "Start-Sleep -Milliseconds 20 ",
-                "}; ",
-                "[Console]::Out.Write('process-out'); ",
-                "[Console]::Error.Write('process-err')",
-            )
-            .to_string(),
-        ]
-    } else {
-        vec![
-            "sh".to_string(),
-            "-c".to_string(),
-            concat!(
-                "printf process > \"$CODEX_PROCESS_EXEC_PROBE_FILE\"; ",
-                "while [ ! -e \"$CODEX_PROCESS_EXEC_RELEASE_FILE\" ]; do sleep 0.05; done; ",
-                "printf process-out; ",
-                "printf process-err >&2",
-            )
-            .to_string(),
-        ]
-    };
-    let env = HashMap::from([
-        (
-            "CODEX_PROCESS_EXEC_PROBE_FILE".to_string(),
-            Some(probe_file.display().to_string()),
-        ),
-        (
-            "CODEX_PROCESS_EXEC_RELEASE_FILE".to_string(),
-            Some(release_file.display().to_string()),
-        ),
-    ]);
+    let (command, env) = probe_release_process(&probe_file, &release_file);
     let spawn_request_id = mcp
         .send_process_spawn_request(ProcessSpawnParams {
             env: Some(env),
@@ -88,6 +50,61 @@ async fn process_spawn_returns_before_exit_and_emits_exit_notification() -> Resu
     assert_eq!(std::fs::read_to_string(&probe_file)?, "process");
     std::fs::write(&release_file, "release")?;
 
+    let exited = read_process_exited(&mut mcp).await?;
+    assert_eq!(
+        exited,
+        ProcessExitedNotification {
+            process_handle,
+            exit_code: 0,
+            stdout: "process-out".to_string(),
+            stdout_cap_reached: false,
+            stderr: "process-err".to_string(),
+            stderr_cap_reached: false,
+        }
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn process_spawn_rejects_duplicate_active_handle_without_replacing_original() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    let (_server, mut mcp) = initialized_mcp(codex_home.path()).await?;
+
+    let process_handle = "duplicate-active-1".to_string();
+    let probe_file = codex_home.path().join("duplicate-process-created");
+    let release_file = codex_home.path().join("duplicate-process-release");
+    let (command, env) = probe_release_process(&probe_file, &release_file);
+    let spawn_request_id = mcp
+        .send_process_spawn_request(ProcessSpawnParams {
+            env: Some(env),
+            output_bytes_cap: Some(None),
+            timeout_ms: Some(None),
+            ..process_spawn_params(process_handle.clone(), codex_home.path(), command)?
+        })
+        .await?;
+    let response = mcp
+        .read_stream_until_response_message(RequestId::Integer(spawn_request_id))
+        .await?;
+    assert_eq!(response.result, serde_json::json!({}));
+    wait_for_file(&probe_file).await?;
+    assert_eq!(std::fs::read_to_string(&probe_file)?, "process");
+
+    let duplicate_request_id = mcp
+        .send_process_spawn_request(process_spawn_params(
+            process_handle.clone(),
+            codex_home.path(),
+            vec!["codex-process-exec-duplicate-must-not-start".to_string()],
+        )?)
+        .await?;
+    let error = mcp
+        .read_stream_until_error_message(RequestId::Integer(duplicate_request_id))
+        .await?;
+    assert_eq!(
+        error.error.message,
+        format!("duplicate active process handle: {process_handle:?}")
+    );
+
+    std::fs::write(&release_file, "release")?;
     let exited = read_process_exited(&mut mcp).await?;
     assert_eq!(
         exited,
@@ -228,6 +245,52 @@ async fn process_kill_terminates_running_process() -> Result<()> {
     assert!(!exited.stderr_cap_reached);
 
     Ok(())
+}
+
+fn probe_release_process(
+    probe_file: &Path,
+    release_file: &Path,
+) -> (Vec<String>, HashMap<String, Option<String>>) {
+    let command = if cfg!(windows) {
+        vec![
+            "powershell.exe".to_string(),
+            "-NoProfile".to_string(),
+            "-NonInteractive".to_string(),
+            "-Command".to_string(),
+            concat!(
+                "[IO.File]::WriteAllText($env:CODEX_PROCESS_EXEC_PROBE_FILE, 'process'); ",
+                "while (!(Test-Path -LiteralPath $env:CODEX_PROCESS_EXEC_RELEASE_FILE)) { ",
+                "Start-Sleep -Milliseconds 20 ",
+                "}; ",
+                "[Console]::Out.Write('process-out'); ",
+                "[Console]::Error.Write('process-err')",
+            )
+            .to_string(),
+        ]
+    } else {
+        vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            concat!(
+                "printf process > \"$CODEX_PROCESS_EXEC_PROBE_FILE\"; ",
+                "while [ ! -e \"$CODEX_PROCESS_EXEC_RELEASE_FILE\" ]; do sleep 0.05; done; ",
+                "printf process-out; ",
+                "printf process-err >&2",
+            )
+            .to_string(),
+        ]
+    };
+    let env = HashMap::from([
+        (
+            "CODEX_PROCESS_EXEC_PROBE_FILE".to_string(),
+            Some(probe_file.display().to_string()),
+        ),
+        (
+            "CODEX_PROCESS_EXEC_RELEASE_FILE".to_string(),
+            Some(release_file.display().to_string()),
+        ),
+    ]);
+    (command, env)
 }
 
 async fn initialized_mcp(codex_home: &Path) -> Result<(MockServer, TestAppServer)> {

--- a/codex-rs/app-server/tests/suite/v2/process_exec.rs
+++ b/codex-rs/app-server/tests/suite/v2/process_exec.rs
@@ -66,6 +66,57 @@ async fn process_spawn_returns_before_exit_and_emits_exit_notification() -> Resu
 }
 
 #[tokio::test]
+async fn process_spawn_uses_requested_cwd() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    let process_cwd = TempDir::new()?;
+    std::fs::write(
+        process_cwd.path().join("cwd-marker.txt"),
+        "app-server-process-cwd",
+    )?;
+    let (_server, mut mcp) = initialized_mcp(codex_home.path()).await?;
+
+    let process_handle = "requested-cwd-1".to_string();
+    let command = if cfg!(windows) {
+        vec![
+            "powershell.exe".to_string(),
+            "-NoProfile".to_string(),
+            "-NonInteractive".to_string(),
+            "-Command".to_string(),
+            "[Console]::Out.Write([IO.File]::ReadAllText('cwd-marker.txt'))".to_string(),
+        ]
+    } else {
+        vec![
+            "sh".to_string(),
+            "-lc".to_string(),
+            "cat cwd-marker.txt".to_string(),
+        ]
+    };
+    let request_id = mcp
+        .send_process_spawn_request(process_spawn_params(
+            process_handle.clone(),
+            process_cwd.path(),
+            command,
+        )?)
+        .await?;
+    let response = mcp
+        .read_stream_until_response_message(RequestId::Integer(request_id))
+        .await?;
+    assert_eq!(response.result, serde_json::json!({}));
+    assert_eq!(
+        read_process_exited(&mut mcp).await?,
+        ProcessExitedNotification {
+            process_handle,
+            exit_code: 0,
+            stdout: "app-server-process-cwd".to_string(),
+            stdout_cap_reached: false,
+            stderr: String::new(),
+            stderr_cap_reached: false,
+        }
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn process_spawn_rejects_duplicate_active_handle_without_replacing_original() -> Result<()> {
     let codex_home = TempDir::new()?;
     let (_server, mut mcp) = initialized_mcp(codex_home.path()).await?;

--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -471,11 +471,18 @@ async fn unified_exec_resolves_relative_workdir() -> Result<()> {
 
     let workdir_rel = std::path::PathBuf::from("uexec_relative_workdir");
     let workdir = create_workspace_directory(&test, &workdir_rel).await?;
+    let marker_uri = PathUri::from_path(workdir.join("cwd-marker.txt"))?;
+    test.fs()
+        .write_file(
+            &marker_uri,
+            b"resolved-relative-workdir".to_vec(),
+            /*sandbox*/ None,
+        )
+        .await?;
 
     let call_id = "uexec-workdir-relative";
     let args = json!({
-        "cmd": "pwd",
-        "yield_time_ms": 250,
+        "cmd": "cat cwd-marker.txt",
         "workdir": workdir_rel.to_string_lossy().to_string(),
     });
 
@@ -491,7 +498,7 @@ async fn unified_exec_resolves_relative_workdir() -> Result<()> {
             ev_completed("resp-2"),
         ]),
     ];
-    mount_sse_sequence(&server, responses).await;
+    let request_log = mount_sse_sequence(&server, responses).await;
 
     submit_unified_exec_turn(
         &test,
@@ -516,6 +523,15 @@ async fn unified_exec_resolves_relative_workdir() -> Result<()> {
         matches!(event, EventMsg::TurnComplete(_))
     })
     .await;
+
+    let output = request_log
+        .function_call_output_text(call_id)
+        .expect("missing relative workdir exec output");
+    let output = parse_unified_exec_output(&output)?;
+    assert_eq!(
+        (output.exit_code, output.output),
+        (Some(0), "resolved-relative-workdir".to_string())
+    );
 
     Ok(())
 }

--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -554,11 +554,18 @@ async fn unified_exec_respects_workdir_override() -> Result<()> {
     let test = builder.build_with_remote_env(&server).await?;
 
     let workdir = create_workspace_directory(&test, "uexec_workdir_test").await?;
+    let marker_uri = PathUri::from_path(workdir.join("cwd-marker.txt"))?;
+    test.fs()
+        .write_file(
+            &marker_uri,
+            b"resolved-absolute-workdir".to_vec(),
+            /*sandbox*/ None,
+        )
+        .await?;
 
     let call_id = "uexec-workdir";
     let args = json!({
-        "cmd": "pwd",
-        "yield_time_ms": 250,
+        "cmd": "cat cwd-marker.txt",
         "workdir": workdir.to_string_lossy().to_string(),
     });
 
@@ -595,8 +602,14 @@ async fn unified_exec_respects_workdir_override() -> Result<()> {
     })
     .await;
 
-    let requests = request_log.requests();
-    assert!(!requests.is_empty(), "expected at least one POST request");
+    let output = request_log
+        .function_call_output_text(call_id)
+        .expect("missing absolute workdir exec output");
+    let output = parse_unified_exec_output(&output)?;
+    assert_eq!(
+        (output.exit_code, output.output),
+        (Some(0), "resolved-absolute-workdir".to_string())
+    );
 
     Ok(())
 }

--- a/codex-rs/exec-server/tests/exec_process.rs
+++ b/codex-rs/exec-server/tests/exec_process.rs
@@ -733,6 +733,52 @@ async fn exec_process_starts_and_exits(use_remote: bool) -> Result<()> {
 
 #[test_case(false ; "local")]
 #[test_case(true ; "remote")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+// Serialize tests that launch a real exec-server process through the full CLI.
+#[serial_test::serial(remote_exec_server)]
+async fn exec_process_uses_requested_cwd(use_remote: bool) -> Result<()> {
+    let context = create_process_context(use_remote).await?;
+    let cwd = TempDir::new()?;
+    let expected_cwd = std::fs::canonicalize(cwd.path())?;
+    let argv = if cfg!(windows) {
+        vec![
+            std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string()),
+            "/C".to_string(),
+            "cd".to_string(),
+        ]
+    } else {
+        vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            "pwd -P".to_string(),
+        ]
+    };
+    let session = context
+        .backend
+        .start(ExecParams {
+            process_id: ProcessId::from("proc-cwd"),
+            argv,
+            cwd: PathUri::from_path(expected_cwd.clone())?,
+            env_policy: /*env_policy*/ None,
+            env: Default::default(),
+            tty: false,
+            pipe_stdin: false,
+            arg0: None,
+        })
+        .await?;
+    let wake_rx = session.process.subscribe_wake();
+    let (output, exit_code, closed) =
+        collect_process_output_from_reads(session.process, wake_rx).await?;
+
+    assert_eq!(
+        (std::fs::canonicalize(output.trim())?, exit_code, closed),
+        (expected_cwd, Some(0), true)
+    );
+    Ok(())
+}
+
+#[test_case(false ; "local")]
+#[test_case(true ; "remote")]
 #[cfg_attr(not(unix), ignore = "Unix-only exec-server process test")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 // Serialize tests that launch a real exec-server process through the full CLI.

--- a/codex-rs/exec-server/tests/exec_process.rs
+++ b/codex-rs/exec-server/tests/exec_process.rs
@@ -855,6 +855,73 @@ async fn exec_process_rejects_non_native_cwd_without_reserving_process_id(
 
 #[test_case(false ; "local")]
 #[test_case(true ; "remote")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+// Serialize tests that launch a real exec-server process through the full CLI.
+#[serial_test::serial(remote_exec_server)]
+async fn exec_process_reuses_id_after_spawn_failure(use_remote: bool) -> Result<()> {
+    let context = create_process_context(use_remote).await?;
+    let process_id = ProcessId::from("proc-spawn-failure");
+    let cwd = PathUri::from_path(std::env::current_dir()?)?;
+    let missing_executable = if cfg!(windows) {
+        r"C:\codex-exec-server-test\definitely-missing.exe"
+    } else {
+        "/codex-exec-server-test/definitely-missing"
+    };
+    let error = match context
+        .backend
+        .start(ExecParams {
+            process_id: process_id.clone(),
+            argv: vec![missing_executable.to_string()],
+            cwd: cwd.clone(),
+            env_policy: /*env_policy*/ None,
+            env: Default::default(),
+            tty: false,
+            pipe_stdin: false,
+            arg0: None,
+        })
+        .await
+    {
+        Ok(_) => anyhow::bail!("missing executable should fail during process launch"),
+        Err(error) => error,
+    };
+    let ExecServerError::Server { code, .. } = error else {
+        anyhow::bail!("unexpected process launch error: {error}");
+    };
+    assert_eq!(code, -32603);
+
+    let success_argv = if cfg!(windows) {
+        vec![
+            "cmd.exe".to_string(),
+            "/D".to_string(),
+            "/C".to_string(),
+            "exit 0".to_string(),
+        ]
+    } else {
+        vec!["true".to_string()]
+    };
+    let session = context
+        .backend
+        .start(ExecParams {
+            process_id,
+            argv: success_argv,
+            cwd,
+            env_policy: /*env_policy*/ None,
+            env: Default::default(),
+            tty: false,
+            pipe_stdin: false,
+            arg0: None,
+        })
+        .await?;
+    let wake_rx = session.process.subscribe_wake();
+    assert_eq!(
+        collect_process_output_from_reads(session.process, wake_rx).await?,
+        (String::new(), Some(0), true)
+    );
+    Ok(())
+}
+
+#[test_case(false ; "local")]
+#[test_case(true ; "remote")]
 #[cfg_attr(not(unix), ignore = "Unix-only exec-server process test")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 // Serialize tests that launch a real exec-server process through the full CLI.

--- a/codex-rs/exec-server/tests/exec_process.rs
+++ b/codex-rs/exec-server/tests/exec_process.rs
@@ -10,6 +10,7 @@ use codex_exec_server::ExecOutputStream;
 use codex_exec_server::ExecParams;
 use codex_exec_server::ExecProcess;
 use codex_exec_server::ExecProcessEvent;
+use codex_exec_server::ExecServerError;
 use codex_exec_server::ProcessId;
 use codex_exec_server::ProcessSignal;
 use codex_exec_server::ReadResponse;
@@ -774,6 +775,81 @@ async fn exec_process_uses_requested_cwd(use_remote: bool) -> Result<()> {
         (std::fs::canonicalize(output.trim())?, exit_code, closed),
         (expected_cwd, Some(0), true)
     );
+    Ok(())
+}
+
+#[test_case(false ; "local")]
+#[test_case(true ; "remote")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+// Serialize tests that launch a real exec-server process through the full CLI.
+#[serial_test::serial(remote_exec_server)]
+async fn exec_process_rejects_non_native_cwd_without_reserving_process_id(
+    use_remote: bool,
+) -> Result<()> {
+    let context = create_process_context(use_remote).await?;
+    let process_id = ProcessId::from("proc-non-native-cwd");
+    let cwd = PathUri::parse(if cfg!(windows) {
+        "file:///usr/local/checkout"
+    } else {
+        "file://server/share/checkout"
+    })?;
+    let source = match cwd.to_abs_path() {
+        Ok(path) => anyhow::bail!(
+            "cwd should not be native on this host: {}",
+            path.as_path().display()
+        ),
+        Err(source) => source,
+    };
+    let current_exe = std::env::current_exe()?;
+    let argv = vec![
+        current_exe.to_string_lossy().into_owned(),
+        "--list".to_string(),
+    ];
+    let error = match context
+        .backend
+        .start(ExecParams {
+            process_id: process_id.clone(),
+            argv: argv.clone(),
+            cwd: cwd.clone(),
+            env_policy: /*env_policy*/ None,
+            env: Default::default(),
+            tty: false,
+            pipe_stdin: false,
+            arg0: None,
+        })
+        .await
+    {
+        Ok(_) => anyhow::bail!("non-native cwd should fail before process launch"),
+        Err(error) => error,
+    };
+    let ExecServerError::Server { code, message } = error else {
+        anyhow::bail!("unexpected non-native cwd error: {error}");
+    };
+    assert_eq!(
+        (code, message),
+        (
+            -32602,
+            format!("cwd URI `{cwd}` is not valid on this exec-server host: {source}")
+        )
+    );
+
+    let session = context
+        .backend
+        .start(ExecParams {
+            process_id,
+            argv,
+            cwd: PathUri::from_path(std::env::current_dir()?)?,
+            env_policy: /*env_policy*/ None,
+            env: Default::default(),
+            tty: false,
+            pipe_stdin: false,
+            arg0: None,
+        })
+        .await?;
+    let wake_rx = session.process.subscribe_wake();
+    let (_, exit_code, closed) =
+        collect_process_output_from_reads(session.process, wake_rx).await?;
+    assert_eq!((exit_code, closed), (Some(0), true));
     Ok(())
 }
 


### PR DESCRIPTION
Revives nine focused integration-test changes covering process working-directory and lifecycle invariants across exec-server, unified exec, and app-server.

Each source PR is preserved as one commit. The cases that look similar exercise different boundaries: exec-server vs app-server handle registries, local vs websocket backends, spawn rejection vs spawn failure vs exit cleanup, and relative vs absolute workdir resolution. All nine add coverage that was missing at their specific boundary.

Impact: test-only; no runtime behavior changes.

Validation:
- `just test -p codex-exec-server` — 260 passed, 2 skipped
- changed app-server process tests passed
- changed codex-core unified-exec tests passed
- both workdir tests passed together 20/20 after removing an artificial 250 ms early-yield race
- process-handle reuse passed 20/20
- `just fix`
- `just fmt`
- workspace `just test` — 11,060 passed, 41 unrelated local/environment failures, 25 skipped; all revived cases completed, with the workdir race subsequently hardened as above