### PR TITLE
Force offline standalone web search after connector use

### DIFF
--- a/codex-rs/core/src/compact_tests.rs
+++ b/codex-rs/core/src/compact_tests.rs
@@ -484,6 +484,7 @@ async fn process_compacted_history_reinjects_model_switch_message() {
     let previous_turn_settings = PreviousTurnSettings {
         model: "previous-regular-model".to_string(),
         realtime_active: None,
+        connector_used: false,
     };
 
     let (refreshed, initial_context) = process_compacted_history_with_test_session(

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -115,6 +115,7 @@ pub use thread_manager::ThreadManager;
 pub use thread_manager::ThreadShutdownReport;
 pub use thread_manager::build_models_manager;
 pub use thread_manager::thread_store_from_config;
+pub use web_search::WebSearchRuntimePolicy;
 pub use web_search::web_search_action_detail;
 pub use web_search::web_search_detail;
 pub use windows_sandbox_read_grants::grant_read_root_non_elevated;

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -139,6 +139,12 @@ pub(crate) async fn handle_mcp_tool_call(
 
     let metadata =
         lookup_mcp_tool_metadata(sess.as_ref(), turn_context.as_ref(), &server, &tool_name).await;
+    if metadata
+        .as_ref()
+        .is_some_and(|metadata| metadata.connector_id.is_some())
+    {
+        sess.mark_previous_turn_used_connector().await;
+    }
     let item_metadata = McpToolCallItemMetadata {
         mcp_app_resource_uri: metadata
             .as_ref()

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -278,6 +278,7 @@ impl SteerInputError {
 pub(crate) struct PreviousTurnSettings {
     pub(crate) model: String,
     pub(crate) realtime_active: Option<bool>,
+    pub(crate) connector_used: bool,
 }
 
 #[cfg(test)]
@@ -1364,6 +1365,14 @@ impl Session {
     ) {
         let mut state = self.state.lock().await;
         state.set_previous_turn_settings(previous_turn_settings);
+    }
+
+    pub(crate) async fn mark_previous_turn_used_connector(&self) {
+        let mut state = self.state.lock().await;
+        if let Some(mut previous_turn_settings) = state.previous_turn_settings() {
+            previous_turn_settings.connector_used = true;
+            state.set_previous_turn_settings(Some(previous_turn_settings));
+        }
     }
 
     fn maybe_refresh_shell_snapshot_for_cwd(

--- a/codex-rs/core/src/session/rollout_reconstruction.rs
+++ b/codex-rs/core/src/session/rollout_reconstruction.rs
@@ -185,6 +185,7 @@ impl Session {
                         active_segment.previous_turn_settings = Some(PreviousTurnSettings {
                             model: ctx.model.clone(),
                             realtime_active: ctx.realtime_active,
+                            connector_used: false,
                         });
                         if matches!(
                             active_segment.reference_context_item,

--- a/codex-rs/core/src/session/rollout_reconstruction_tests.rs
+++ b/codex-rs/core/src/session/rollout_reconstruction_tests.rs
@@ -167,6 +167,7 @@ async fn record_initial_history_resumed_hydrates_previous_turn_settings_from_lif
         Some(PreviousTurnSettings {
             model: previous_model.to_string(),
             realtime_active: Some(turn_context.realtime_active),
+            connector_used: false,
         })
     );
 }
@@ -272,6 +273,7 @@ async fn reconstruct_history_rollback_keeps_history_and_metadata_in_sync_for_com
         Some(PreviousTurnSettings {
             model: turn_context.model_info.slug.clone(),
             realtime_active: Some(turn_context.realtime_active),
+            connector_used: false,
         })
     );
     assert_eq!(
@@ -365,6 +367,7 @@ async fn reconstruct_history_rollback_keeps_history_and_metadata_in_sync_for_inc
         Some(PreviousTurnSettings {
             model: turn_context.model_info.slug.clone(),
             realtime_active: Some(turn_context.realtime_active),
+            connector_used: false,
         })
     );
     assert_eq!(
@@ -490,6 +493,7 @@ async fn reconstruct_history_rollback_skips_non_user_turns_for_history_and_metad
         Some(PreviousTurnSettings {
             model: turn_context.model_info.slug.clone(),
             realtime_active: Some(turn_context.realtime_active),
+            connector_used: false,
         })
     );
     assert_eq!(
@@ -590,6 +594,7 @@ async fn reconstruct_history_rollback_counts_inter_agent_assistant_turns() {
         Some(PreviousTurnSettings {
             model: turn_context.model_info.slug.clone(),
             realtime_active: Some(turn_context.realtime_active),
+            connector_used: false,
         })
     );
     assert_eq!(
@@ -811,6 +816,7 @@ async fn record_initial_history_resumed_rollback_drops_incomplete_user_turn_comp
         Some(PreviousTurnSettings {
             model: turn_context.model_info.slug.clone(),
             realtime_active: Some(turn_context.realtime_active),
+            connector_used: false,
         })
     );
     assert_eq!(
@@ -1025,6 +1031,7 @@ async fn record_initial_history_resumed_turn_context_after_compaction_reestablis
         Some(PreviousTurnSettings {
             model: previous_model.to_string(),
             realtime_active: Some(turn_context.realtime_active),
+            connector_used: false,
         })
     );
     assert_eq!(
@@ -1162,6 +1169,7 @@ async fn record_initial_history_resumed_aborted_turn_without_id_clears_active_tu
         Some(PreviousTurnSettings {
             model: previous_model.to_string(),
             realtime_active: Some(turn_context.realtime_active),
+            connector_used: false,
         })
     );
     assert!(session.reference_context_item().await.is_none());
@@ -1282,6 +1290,7 @@ async fn record_initial_history_resumed_unmatched_abort_preserves_active_turn_fo
         Some(PreviousTurnSettings {
             model: current_model.to_string(),
             realtime_active: Some(turn_context.realtime_active),
+            connector_used: false,
         })
     );
     assert_eq!(
@@ -1392,6 +1401,7 @@ async fn record_initial_history_resumed_trailing_incomplete_turn_compaction_clea
         Some(PreviousTurnSettings {
             model: previous_model.to_string(),
             realtime_active: Some(turn_context.realtime_active),
+            connector_used: false,
         })
     );
     assert!(session.reference_context_item().await.is_none());
@@ -1442,6 +1452,7 @@ async fn record_initial_history_resumed_trailing_incomplete_turn_preserves_turn_
         Some(PreviousTurnSettings {
             model: turn_context.model_info.slug.clone(),
             realtime_active: Some(turn_context.realtime_active),
+            connector_used: false,
         })
     );
     assert_eq!(
@@ -1564,6 +1575,7 @@ async fn record_initial_history_resumed_replaced_incomplete_compacted_turn_clear
         Some(PreviousTurnSettings {
             model: previous_model.to_string(),
             realtime_active: Some(turn_context.realtime_active),
+            connector_used: false,
         })
     );
     assert!(session.reference_context_item().await.is_none());

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -2612,6 +2612,7 @@ async fn record_initial_history_forked_hydrates_previous_turn_settings() {
         Some(PreviousTurnSettings {
             model: previous_model.to_string(),
             realtime_active: Some(turn_context.realtime_active),
+            connector_used: false,
         })
     );
     assert_eq!(history.raw_items(), &[]);
@@ -2654,6 +2655,7 @@ async fn thread_rollback_drops_last_turn_from_history() {
     sess.set_previous_turn_settings(Some(PreviousTurnSettings {
         model: "stale-model".to_string(),
         realtime_active: Some(tc.realtime_active),
+        connector_used: false,
     }))
     .await;
     {
@@ -2836,6 +2838,7 @@ async fn thread_rollback_recomputes_previous_turn_settings_and_reference_context
     sess.set_previous_turn_settings(Some(PreviousTurnSettings {
         model: "stale-model".to_string(),
         realtime_active: None,
+        connector_used: false,
     }))
     .await;
 
@@ -2852,6 +2855,7 @@ async fn thread_rollback_recomputes_previous_turn_settings_and_reference_context
         Some(PreviousTurnSettings {
             model: tc.model_info.slug.clone(),
             realtime_active: Some(tc.realtime_active),
+            connector_used: false,
         })
     );
     assert_eq!(
@@ -7348,6 +7352,7 @@ async fn build_settings_update_items_uses_previous_turn_settings_for_realtime_en
     let previous_turn_settings = PreviousTurnSettings {
         model: previous_context.model_info.slug.clone(),
         realtime_active: Some(true),
+        connector_used: false,
     };
     let mut current_context = previous_context
         .with_model(
@@ -7941,6 +7946,7 @@ async fn build_initial_context_uses_previous_turn_settings_for_realtime_end() {
     let previous_turn_settings = PreviousTurnSettings {
         model: turn_context.model_info.slug.clone(),
         realtime_active: Some(true),
+        connector_used: false,
     };
 
     session
@@ -7963,6 +7969,7 @@ async fn build_initial_context_restates_realtime_start_when_reference_context_is
     let previous_turn_settings = PreviousTurnSettings {
         model: turn_context.model_info.slug.clone(),
         realtime_active: Some(true),
+        connector_used: false,
     };
 
     session
@@ -8187,6 +8194,7 @@ async fn build_initial_context_prepends_model_switch_message() {
     let previous_turn_settings = PreviousTurnSettings {
         model: "previous-regular-model".to_string(),
         realtime_active: None,
+        connector_used: false,
     };
 
     session
@@ -8239,6 +8247,7 @@ async fn record_context_updates_and_set_reference_context_item_persists_full_rei
         .set_previous_turn_settings(Some(PreviousTurnSettings {
             model: previous_context.model_info.slug.clone(),
             realtime_active: Some(previous_context.realtime_active),
+            connector_used: false,
         }))
         .await;
     session

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use crate::SkillInjections;
+use crate::WebSearchRuntimePolicy;
 use crate::build_skill_injections;
 use crate::client::ModelClientSession;
 use crate::client_common::Prompt;
@@ -157,6 +158,23 @@ pub(crate) async fn run_turn(
     sess.record_context_updates_and_set_reference_context_item(turn_context.as_ref())
         .await;
 
+    let mut force_cached_after_connector_use = sess
+        .services
+        .thread_extension_data
+        .get::<WebSearchRuntimePolicy>()
+        .is_some_and(|policy| policy.force_cached_after_connector_use);
+    if !force_cached_after_connector_use {
+        force_cached_after_connector_use = sess
+            .previous_turn_settings()
+            .await
+            .is_some_and(|settings| settings.connector_used);
+    }
+    sess.services
+        .thread_extension_data
+        .insert(WebSearchRuntimePolicy {
+            force_cached_after_connector_use,
+        });
+
     let (injection_items, explicitly_enabled_connectors) =
         build_skills_and_plugins(&sess, turn_context.as_ref(), &input, &cancellation_token).await?;
 
@@ -173,6 +191,9 @@ pub(crate) async fn run_turn(
     sess.set_previous_turn_settings(Some(PreviousTurnSettings {
         model: turn_context.model_info.slug.clone(),
         realtime_active: Some(turn_context.realtime_active),
+        // Carry the flag forward so later standalone web searches stay cached
+        // after any connector-backed MCP use in the thread.
+        connector_used: force_cached_after_connector_use,
     }))
     .await;
     for response_item in injection_items {

--- a/codex-rs/core/src/web_search.rs
+++ b/codex-rs/core/src/web_search.rs
@@ -1,5 +1,11 @@
 use codex_protocol::models::WebSearchAction;
 
+/// Per-turn runtime policy for standalone web search.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct WebSearchRuntimePolicy {
+    pub force_cached_after_connector_use: bool,
+}
+
 fn search_action_detail(query: &Option<String>, queries: &Option<Vec<String>>) -> String {
     query.clone().filter(|q| !q.is_empty()).unwrap_or_else(|| {
         let items = queries.as_ref();

--- a/codex-rs/ext/web-search/src/extension.rs
+++ b/codex-rs/ext/web-search/src/extension.rs
@@ -6,6 +6,7 @@ use codex_api::LocationType;
 use codex_api::SearchContextSize;
 use codex_api::SearchFilters;
 use codex_api::SearchSettings;
+use codex_core::WebSearchRuntimePolicy;
 use codex_core::config::Config;
 use codex_extension_api::ConfigContributor;
 use codex_extension_api::ExtensionData;
@@ -81,6 +82,20 @@ fn search_settings(config: &Config, web_search_mode: WebSearchMode) -> SearchSet
     }
 }
 
+fn settings_for_tool(
+    config: &WebSearchExtensionConfig,
+    thread_store: &ExtensionData,
+) -> SearchSettings {
+    let mut settings = config.settings.clone();
+    if thread_store
+        .get::<WebSearchRuntimePolicy>()
+        .is_some_and(|policy| policy.force_cached_after_connector_use)
+    {
+        settings.external_web_access = Some(false);
+    }
+    settings
+}
+
 impl ThreadLifecycleContributor<Config> for WebSearchExtension {
     fn on_thread_start<'a>(
         &'a self,
@@ -118,6 +133,7 @@ impl ToolContributor for WebSearchExtension {
         if !config.available {
             return Vec::new();
         }
+        let settings = settings_for_tool(&config, thread_store);
 
         vec![Arc::new(WebSearchTool {
             session_id: session_store.level_id().to_string(),
@@ -125,7 +141,7 @@ impl ToolContributor for WebSearchExtension {
                 config.provider.clone(),
                 Some(self.auth_manager.clone()),
             ),
-            settings: config.settings.clone(),
+            settings,
         })]
     }
 }
@@ -139,6 +155,8 @@ pub fn install(registry: &mut ExtensionRegistryBuilder<Config>, auth_manager: Ar
 
 #[cfg(test)]
 mod tests {
+    use codex_api::SearchSettings;
+    use codex_core::WebSearchRuntimePolicy;
     use codex_extension_api::ExtensionData;
     use codex_extension_api::ExtensionRegistryBuilder;
     use codex_extension_api::ToolName;
@@ -150,6 +168,7 @@ mod tests {
     use super::Config;
     use super::WebSearchExtensionConfig;
     use super::install;
+    use super::settings_for_tool;
     use crate::tool::RUN_TOOL_NAME;
     use crate::tool::WEB_NAMESPACE;
 
@@ -179,6 +198,30 @@ mod tests {
         assert_eq!(
             tool_names,
             vec![(ToolName::namespaced(WEB_NAMESPACE, RUN_TOOL_NAME), true)]
+        );
+    }
+
+    #[test]
+    fn runtime_policy_forces_cached_search() {
+        let thread_store = ExtensionData::new("11111111-1111-4111-8111-111111111111");
+        thread_store.insert(WebSearchRuntimePolicy {
+            force_cached_after_connector_use: true,
+        });
+        let config = WebSearchExtensionConfig {
+            available: true,
+            provider: ModelProviderInfo::create_openai_provider(/*base_url*/ None),
+            settings: SearchSettings {
+                external_web_access: Some(true),
+                ..Default::default()
+            },
+        };
+
+        assert_eq!(
+            settings_for_tool(&config, &thread_store),
+            SearchSettings {
+                external_web_access: Some(false),
+                ..Default::default()
+            }
         );
     }
 }


### PR DESCRIPTION
## Summary

- Track connector-backed MCP usage in turn state and carry it forward once set.
- Derive a per-turn standalone web-search runtime policy from that sticky connector-use state.
- Keep the thread web-search policy sticky too, so once this Codex thread is forced offline, later standalone web.run construction short-circuits from the existing offline policy.
- Force standalone web.run to send external_web_access=false after any prior connector use in the thread.

## Tests

- just fix -p codex-api
- just fix -p codex-web-search-extension
- just fix -p codex-core
- just test -p codex-api search_posts_typed_request_and_parses_output
- just test -p codex-web-search-extension
- just test -p codex-core code_mode_can_call_standalone_web_search
- just test -p codex-core standalone_web_search_marks_thread_memory_mode_polluted_when_configured
- just test -p codex-core (local sandbox: compiled; 2621 passed, 8 flaky, 65 failed, 17 skipped; failures appear unrelated to this change)
- just fmt (Rust formatted; overall command exits 1 because sdk/python is absent in this checkout)