### PR TITLE
[codex] Split plugin and skill warmup tracing

### DIFF
--- a/codex-rs/core-plugins/src/manager.rs
+++ b/codex-rs/core-plugins/src/manager.rs
@@ -466,9 +466,14 @@ impl PluginsManager {
     }
 
     #[instrument(
-        level = "trace",
+        name = "plugins_for_config",
+        level = "info",
         skip_all,
-        fields(force_reload, plugins_enabled = config.plugins_enabled)
+        fields(
+            otel.name = "plugins_for_config",
+            force_reload,
+            plugins_enabled = config.plugins_enabled
+        )
     )]
     pub(crate) async fn plugins_for_config_with_force_reload(
         &self,

--- a/codex-rs/core-skills/src/service.rs
+++ b/codex-rs/core-skills/src/service.rs
@@ -105,7 +105,12 @@ impl SkillsService {
     /// This path uses a cache keyed by the effective skill-relevant config state rather than just
     /// cwd so role-local and session-local skill overrides cannot bleed across sessions that happen
     /// to share a directory.
-    #[instrument(level = "trace", skip_all)]
+    #[instrument(
+        name = "skills_for_config",
+        level = "info",
+        skip_all,
+        fields(otel.name = "skills_for_config")
+    )]
     pub async fn snapshot_for_config(
         &self,
         input: &SkillsLoadInput,


### PR DESCRIPTION
## What changed

- promote plugin config loading to an info-level `plugins_for_config` span
- promote skill config loading to an info-level `skills_for_config` span
- attach stable OpenTelemetry names to both spans

## Why

`session_init.plugin_skill_warmup` currently combines plugin loading and skill loading, which makes cold-start traces unable to identify which phase dominates. These child spans preserve the existing aggregate while making the two costs independently visible.

Context: https://openai.slack.com/archives/C0ARA9GF5D4/p1781639496496439?thread_ts=1781202444.891669&cid=C0ARA9GF5D4

## Impact

This is observability-only. It does not change plugin or skill loading behavior.

## Validation

- `just test -p codex-core-skills -p codex-core-plugins` (347 passed)
- `just fmt`