### PR TITLE
automations: add app-server CRUD handlers

### DIFF
--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -20,6 +20,7 @@ use crate::outgoing_message::OutgoingMessageSender;
 use crate::outgoing_message::RequestContext;
 use crate::request_processors::AccountRequestProcessor;
 use crate::request_processors::AppsRequestProcessor;
+use crate::request_processors::AutomationRequestProcessor;
 use crate::request_processors::CatalogRequestProcessor;
 use crate::request_processors::CommandExecRequestProcessor;
 use crate::request_processors::ConfigRequestProcessor;
@@ -186,6 +187,7 @@ pub(crate) struct MessageProcessor {
     skills_watcher: Arc<SkillsWatcher>,
     account_processor: AccountRequestProcessor,
     apps_processor: AppsRequestProcessor,
+    automation_processor: AutomationRequestProcessor,
     catalog_processor: CatalogRequestProcessor,
     command_exec_processor: CommandExecRequestProcessor,
     process_exec_processor: ProcessExecRequestProcessor,
@@ -464,6 +466,12 @@ impl MessageProcessor {
             state_db.clone(),
             Arc::clone(&goal_service),
         );
+        let automation_processor = AutomationRequestProcessor::new(
+            Arc::clone(&config),
+            state_db.clone(),
+            Arc::clone(&thread_manager),
+            thread_state_manager.clone(),
+        );
         let thread_processor = ThreadRequestProcessor::new(
             auth_manager.clone(),
             Arc::clone(&thread_manager),
@@ -541,6 +549,7 @@ impl MessageProcessor {
             skills_watcher,
             account_processor,
             apps_processor,
+            automation_processor,
             catalog_processor,
             command_exec_processor,
             process_exec_processor,
@@ -1184,20 +1193,30 @@ impl MessageProcessor {
             ClientRequest::ThreadList { params, .. } => {
                 self.thread_processor.thread_list(params).await
             }
-            ClientRequest::AutomationList { .. } => {
-                Err(automation_api_not_implemented("automation/list"))
+            ClientRequest::AutomationList { params, .. } => {
+                self.automation_processor
+                    .automation_list(connection_id, params)
+                    .await
             }
-            ClientRequest::AutomationRead { .. } => {
-                Err(automation_api_not_implemented("automation/read"))
+            ClientRequest::AutomationRead { params, .. } => {
+                self.automation_processor
+                    .automation_read(connection_id, params)
+                    .await
             }
-            ClientRequest::AutomationCreate { .. } => {
-                Err(automation_api_not_implemented("automation/create"))
+            ClientRequest::AutomationCreate { params, .. } => {
+                self.automation_processor
+                    .automation_create(connection_id, params)
+                    .await
             }
-            ClientRequest::AutomationUpdate { .. } => {
-                Err(automation_api_not_implemented("automation/update"))
+            ClientRequest::AutomationUpdate { params, .. } => {
+                self.automation_processor
+                    .automation_update(connection_id, params)
+                    .await
             }
-            ClientRequest::AutomationDelete { .. } => {
-                Err(automation_api_not_implemented("automation/delete"))
+            ClientRequest::AutomationDelete { params, .. } => {
+                self.automation_processor
+                    .automation_delete(connection_id, params)
+                    .await
             }
             ClientRequest::AutomationRunNow { .. } => {
                 Err(automation_api_not_implemented("automation/runNow"))

--- a/codex-rs/app-server/src/request_processors.rs
+++ b/codex-rs/app-server/src/request_processors.rs
@@ -477,6 +477,7 @@ use codex_app_server_protocol::ServerRequest;
 
 mod account_processor;
 mod apps_processor;
+mod automation_processor;
 mod catalog_processor;
 mod command_exec_processor;
 mod config_processor;
@@ -501,6 +502,7 @@ mod windows_sandbox_processor;
 
 pub(crate) use account_processor::AccountRequestProcessor;
 pub(crate) use apps_processor::AppsRequestProcessor;
+pub(crate) use automation_processor::AutomationRequestProcessor;
 pub(crate) use catalog_processor::CatalogRequestProcessor;
 pub(crate) use command_exec_processor::CommandExecRequestProcessor;
 pub(crate) use config_processor::ConfigRequestProcessor;

--- a/codex-rs/app-server/src/request_processors/automation_processor.rs
+++ b/codex-rs/app-server/src/request_processors/automation_processor.rs
@@ -1,0 +1,454 @@
+use crate::error_code::internal_error;
+use crate::error_code::invalid_request;
+use crate::outgoing_message::ConnectionId;
+use crate::thread_state::ThreadStateManager;
+use codex_app_server_protocol::Automation as ApiAutomation;
+use codex_app_server_protocol::AutomationCreateParams as ApiAutomationCreateParams;
+use codex_app_server_protocol::AutomationCreateResponse;
+use codex_app_server_protocol::AutomationDeleteParams;
+use codex_app_server_protocol::AutomationDeleteResponse;
+use codex_app_server_protocol::AutomationListParams;
+use codex_app_server_protocol::AutomationListResponse;
+use codex_app_server_protocol::AutomationReadParams;
+use codex_app_server_protocol::AutomationReadResponse;
+use codex_app_server_protocol::AutomationStatus as ApiAutomationStatus;
+use codex_app_server_protocol::AutomationTarget as ApiAutomationTarget;
+use codex_app_server_protocol::AutomationUpdateParams as ApiAutomationUpdateParams;
+use codex_app_server_protocol::AutomationUpdateResponse;
+use codex_app_server_protocol::ClientResponsePayload;
+use codex_app_server_protocol::JSONRPCErrorError;
+use codex_core::ThreadManager;
+use codex_core::config::Config;
+use codex_features::Feature;
+use codex_protocol::ThreadId;
+use codex_rollout::StateDbHandle;
+use codex_state::Automation as StateAutomation;
+use codex_state::AutomationCreateParams as StateAutomationCreateParams;
+use codex_state::AutomationDispatchSettings as StateAutomationDispatchSettings;
+use codex_state::AutomationStatus as StateAutomationStatus;
+use codex_state::AutomationTarget as StateAutomationTarget;
+use codex_state::AutomationUpdateParams as StateAutomationUpdateParams;
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+const DEFAULT_AUTOMATION_LIST_LIMIT: usize = 50;
+
+#[derive(Clone)]
+pub(crate) struct AutomationRequestProcessor {
+    config: Arc<Config>,
+    state_db: Option<StateDbHandle>,
+    thread_manager: Arc<ThreadManager>,
+    thread_state_manager: ThreadStateManager,
+}
+
+impl AutomationRequestProcessor {
+    pub(crate) fn new(
+        config: Arc<Config>,
+        state_db: Option<StateDbHandle>,
+        thread_manager: Arc<ThreadManager>,
+        thread_state_manager: ThreadStateManager,
+    ) -> Self {
+        Self {
+            config,
+            state_db,
+            thread_manager,
+            thread_state_manager,
+        }
+    }
+
+    pub(crate) async fn automation_list(
+        &self,
+        connection_id: ConnectionId,
+        params: AutomationListParams,
+    ) -> Result<Option<ClientResponsePayload>, JSONRPCErrorError> {
+        self.ensure_enabled()?;
+        let state_db = self.state_db()?;
+        let visible_thread_ids = self.visible_thread_ids(connection_id).await;
+        let automations = state_db
+            .list_automations()
+            .await
+            .map_err(map_automation_storage_error)?
+            .into_iter()
+            .filter(|automation| visible_thread_ids.contains(&automation.owner_thread_id))
+            .collect::<Vec<_>>();
+        let total = automations.len();
+        let start = match params.cursor {
+            Some(cursor) => cursor
+                .parse::<usize>()
+                .map_err(|_| invalid_request(format!("invalid cursor: {cursor}")))?,
+            None => 0,
+        };
+        if start > total {
+            return Err(invalid_request(format!(
+                "cursor {start} exceeds total automations {total}"
+            )));
+        }
+
+        let effective_limit = params
+            .limit
+            .unwrap_or(DEFAULT_AUTOMATION_LIST_LIMIT as u32)
+            .max(1) as usize;
+        let end = start.saturating_add(effective_limit).min(total);
+        let data = automations[start..end]
+            .iter()
+            .map(api_automation_from_state)
+            .collect::<Result<Vec<_>, _>>()?;
+        let next_cursor = (end < total).then(|| end.to_string());
+
+        Ok(Some(AutomationListResponse { data, next_cursor }.into()))
+    }
+
+    pub(crate) async fn automation_read(
+        &self,
+        connection_id: ConnectionId,
+        params: AutomationReadParams,
+    ) -> Result<Option<ClientResponsePayload>, JSONRPCErrorError> {
+        self.ensure_enabled()?;
+        let state_db = self.state_db()?;
+        let visible_thread_ids = self.visible_thread_ids(connection_id).await;
+        let automation = state_db
+            .get_automation(params.automation_id.as_str())
+            .await
+            .map_err(map_automation_storage_error)?
+            .filter(|automation| visible_thread_ids.contains(&automation.owner_thread_id))
+            .map(|automation| api_automation_from_state(&automation))
+            .transpose()?;
+        Ok(Some(AutomationReadResponse { automation }.into()))
+    }
+
+    pub(crate) async fn automation_create(
+        &self,
+        connection_id: ConnectionId,
+        params: ApiAutomationCreateParams,
+    ) -> Result<Option<ClientResponsePayload>, JSONRPCErrorError> {
+        self.ensure_enabled()?;
+        let state_db = self.state_db()?;
+        let visible_thread_ids = self.visible_thread_ids(connection_id).await;
+        let target = state_target_from_api(params.target)?;
+        let (owner_thread_id, dispatch_settings) = self
+            .owner_and_dispatch_settings_for_target(&visible_thread_ids, &target)
+            .await?;
+        let created = state_db
+            .create_automation(&StateAutomationCreateParams {
+                owner_thread_id,
+                name: required_non_empty("name", params.name.as_str())?,
+                prompt: required_non_empty("prompt", params.prompt.as_str())?,
+                status: params
+                    .status
+                    .map(state_status_from_api)
+                    .unwrap_or(StateAutomationStatus::Active),
+                rrule: trim_to_option(params.rrule.as_deref()),
+                model: trim_to_option(params.model.as_deref()),
+                reasoning_effort: params.reasoning_effort,
+                target,
+                dispatch_settings,
+            })
+            .await
+            .map_err(map_automation_mutation_error)?;
+        Ok(Some(
+            AutomationCreateResponse {
+                automation: api_automation_from_state(&created)?,
+            }
+            .into(),
+        ))
+    }
+
+    pub(crate) async fn automation_update(
+        &self,
+        connection_id: ConnectionId,
+        params: ApiAutomationUpdateParams,
+    ) -> Result<Option<ClientResponsePayload>, JSONRPCErrorError> {
+        self.ensure_enabled()?;
+        let state_db = self.state_db()?;
+        let visible_thread_ids = self.visible_thread_ids(connection_id).await;
+        let Some(existing) = state_db
+            .get_automation(params.automation_id.as_str())
+            .await
+            .map_err(map_automation_storage_error)?
+        else {
+            return Ok(Some(AutomationUpdateResponse { automation: None }.into()));
+        };
+        if !visible_thread_ids.contains(&existing.owner_thread_id) {
+            return Ok(Some(AutomationUpdateResponse { automation: None }.into()));
+        }
+
+        let target = match params.target {
+            Some(target) => state_target_from_api(target)?,
+            None => existing.target.clone(),
+        };
+        let (owner_thread_id, dispatch_settings) = self
+            .owner_and_dispatch_settings_for_target(&visible_thread_ids, &target)
+            .await?;
+        let updated = state_db
+            .update_automation_if_owner(
+                &StateAutomationUpdateParams {
+                    id: params.automation_id,
+                    owner_thread_id,
+                    name: match params.name {
+                        Some(name) => required_non_empty("name", name.as_str())?,
+                        None => existing.name.clone(),
+                    },
+                    prompt: match params.prompt {
+                        Some(prompt) => required_non_empty("prompt", prompt.as_str())?,
+                        None => existing.prompt.clone(),
+                    },
+                    status: params
+                        .status
+                        .map(state_status_from_api)
+                        .unwrap_or(existing.status),
+                    rrule: match params.rrule {
+                        None => Some(existing.rrule.clone()),
+                        Some(rrule) => trim_to_option(rrule.as_deref()),
+                    },
+                    model: match params.model {
+                        None => existing.model.clone(),
+                        Some(model) => trim_to_option(model.as_deref()),
+                    },
+                    reasoning_effort: match params.reasoning_effort {
+                        None => existing.reasoning_effort,
+                        Some(reasoning_effort) => reasoning_effort,
+                    },
+                    target,
+                    dispatch_settings,
+                },
+                existing.owner_thread_id,
+            )
+            .await
+            .map_err(map_automation_mutation_error)?
+            .map(|automation| api_automation_from_state(&automation))
+            .transpose()?;
+
+        Ok(Some(
+            AutomationUpdateResponse {
+                automation: updated,
+            }
+            .into(),
+        ))
+    }
+
+    pub(crate) async fn automation_delete(
+        &self,
+        connection_id: ConnectionId,
+        params: AutomationDeleteParams,
+    ) -> Result<Option<ClientResponsePayload>, JSONRPCErrorError> {
+        self.ensure_enabled()?;
+        let state_db = self.state_db()?;
+        let visible_thread_ids = self.visible_thread_ids(connection_id).await;
+        let Some(automation) = state_db
+            .get_automation(params.automation_id.as_str())
+            .await
+            .map_err(map_automation_storage_error)?
+        else {
+            return Ok(Some(AutomationDeleteResponse { deleted: false }.into()));
+        };
+        if !visible_thread_ids.contains(&automation.owner_thread_id) {
+            return Ok(Some(AutomationDeleteResponse { deleted: false }.into()));
+        }
+        let deleted = state_db
+            .delete_automation_if_owner(params.automation_id.as_str(), automation.owner_thread_id)
+            .await
+            .map_err(map_automation_storage_error)?;
+        Ok(Some(AutomationDeleteResponse { deleted }.into()))
+    }
+
+    fn ensure_enabled(&self) -> Result<(), JSONRPCErrorError> {
+        if self.config.features.enabled(Feature::Automations) {
+            Ok(())
+        } else {
+            Err(invalid_request("automations feature is disabled"))
+        }
+    }
+
+    fn state_db(&self) -> Result<&StateDbHandle, JSONRPCErrorError> {
+        self.state_db
+            .as_ref()
+            .ok_or_else(|| internal_error("sqlite state db unavailable for automations"))
+    }
+
+    async fn visible_thread_ids(&self, connection_id: ConnectionId) -> HashSet<ThreadId> {
+        self.thread_state_manager
+            .thread_ids_for_connection(connection_id)
+            .await
+            .into_iter()
+            .collect()
+    }
+
+    async fn owner_and_dispatch_settings_for_target(
+        &self,
+        visible_thread_ids: &HashSet<ThreadId>,
+        target: &StateAutomationTarget,
+    ) -> Result<(ThreadId, Option<StateAutomationDispatchSettings>), JSONRPCErrorError> {
+        match target {
+            StateAutomationTarget::Heartbeat { thread_id } => {
+                if visible_thread_ids.contains(thread_id) {
+                    Ok((*thread_id, None))
+                } else {
+                    Err(invalid_request(
+                        "heartbeat automations must target a subscribed thread",
+                    ))
+                }
+            }
+            StateAutomationTarget::Cron { cwds } => {
+                for thread_id in visible_thread_ids {
+                    let Ok(thread) = self.thread_manager.get_thread(*thread_id).await else {
+                        continue;
+                    };
+                    let snapshot = thread.config_snapshot().await;
+                    if snapshot.ephemeral || snapshot.session_source.is_automation() {
+                        continue;
+                    }
+                    let workspace_roots = if snapshot.workspace_roots.is_empty() {
+                        vec![snapshot.cwd().clone().into_path_buf()]
+                    } else {
+                        snapshot
+                            .workspace_roots
+                            .iter()
+                            .cloned()
+                            .map(codex_utils_absolute_path::AbsolutePathBuf::into_path_buf)
+                            .collect::<Vec<_>>()
+                    };
+                    if cwds_visible_under_roots(cwds, &workspace_roots) {
+                        return Ok((
+                            *thread_id,
+                            Some(StateAutomationDispatchSettings {
+                                workspace_roots,
+                                approval_policy: snapshot.approval_policy,
+                                approvals_reviewer: snapshot.approvals_reviewer,
+                                permission_profile: snapshot.permission_profile,
+                            }),
+                        ));
+                    }
+                }
+                Err(invalid_request(
+                    "cron automations must target cwd paths under a loaded subscribed thread",
+                ))
+            }
+        }
+    }
+}
+
+fn api_automation_from_state(
+    automation: &StateAutomation,
+) -> Result<ApiAutomation, JSONRPCErrorError> {
+    Ok(ApiAutomation {
+        id: automation.id.clone(),
+        name: automation.name.clone(),
+        prompt: automation.prompt.clone(),
+        status: api_status_from_state(automation.status),
+        rrule: automation.rrule.clone(),
+        next_run_at: automation
+            .next_run_at
+            .as_ref()
+            .map(chrono::DateTime::timestamp),
+        last_run_at: automation
+            .last_run_at
+            .as_ref()
+            .map(chrono::DateTime::timestamp),
+        created_at: automation.created_at.timestamp(),
+        updated_at: automation.updated_at.timestamp(),
+        model: automation.model.clone(),
+        reasoning_effort: automation.reasoning_effort.clone(),
+        target: api_target_from_state(&automation.target),
+    })
+}
+
+fn api_target_from_state(target: &StateAutomationTarget) -> ApiAutomationTarget {
+    match target {
+        StateAutomationTarget::Cron { cwds } => ApiAutomationTarget::Cron { cwds: cwds.clone() },
+        StateAutomationTarget::Heartbeat { thread_id } => ApiAutomationTarget::Heartbeat {
+            thread_id: thread_id.to_string(),
+        },
+    }
+}
+
+fn state_target_from_api(
+    target: ApiAutomationTarget,
+) -> Result<StateAutomationTarget, JSONRPCErrorError> {
+    match target {
+        ApiAutomationTarget::Cron { cwds } => Ok(StateAutomationTarget::Cron { cwds }),
+        ApiAutomationTarget::Heartbeat { thread_id } => ThreadId::from_string(&thread_id)
+            .map(|thread_id| StateAutomationTarget::Heartbeat { thread_id })
+            .map_err(|err| invalid_request(format!("invalid thread id: {err}"))),
+    }
+}
+
+fn api_status_from_state(status: StateAutomationStatus) -> ApiAutomationStatus {
+    match status {
+        StateAutomationStatus::Active => ApiAutomationStatus::Active,
+        StateAutomationStatus::Paused => ApiAutomationStatus::Paused,
+    }
+}
+
+fn state_status_from_api(status: ApiAutomationStatus) -> StateAutomationStatus {
+    match status {
+        ApiAutomationStatus::Active => StateAutomationStatus::Active,
+        ApiAutomationStatus::Paused => StateAutomationStatus::Paused,
+    }
+}
+
+fn required_non_empty(field: &str, value: &str) -> Result<String, JSONRPCErrorError> {
+    trim_to_option(Some(value)).ok_or_else(|| invalid_request(format!("{field} must not be empty")))
+}
+
+fn trim_to_option(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn cwds_visible_under_roots(cwds: &[PathBuf], workspace_roots: &[PathBuf]) -> bool {
+    !cwds.is_empty()
+        && cwds
+            .iter()
+            .all(|cwd| workspace_roots.iter().any(|root| cwd.starts_with(root)))
+}
+
+fn map_automation_storage_error(err: anyhow::Error) -> JSONRPCErrorError {
+    internal_error(format!("automation storage failure: {err}"))
+}
+
+fn map_automation_mutation_error(err: anyhow::Error) -> JSONRPCErrorError {
+    let message = err.to_string();
+    if is_automation_user_error(message.as_str()) {
+        invalid_request(message)
+    } else {
+        internal_error(format!("automation mutation failure: {message}"))
+    }
+}
+
+fn is_automation_user_error(message: &str) -> bool {
+    [
+        "changing automation kind is not supported",
+        "active heartbeat already exists for thread",
+        "automation name is required",
+        "automation name is too long",
+        "automation prompt is required",
+        "automation prompt is too long",
+        "cron automations require at least one cwd",
+        "cron automation cwd must not be empty",
+        "cron automation cwd must be absolute",
+        "cron automations require dispatch settings",
+        "cron automations require at least one workspace root",
+        "cron automation dispatch settings must align with target cwds",
+        "cron automation workspace roots must be absolute",
+        "cron automation workspace roots must be frozen resolved paths",
+        "cron automation dispatch settings must contain each target cwd within the approved workspace root and permission scope",
+        "cannot change automation target or dispatch scope while a dispatch is in flight",
+        "heartbeat automations must be owned by their target thread",
+        "heartbeat automations do not use dispatch settings",
+        "rrule ",
+        "invalid rrule",
+        "unsupported rrule frequency:",
+        "MINUTELY rrules only support",
+        "HOURLY rrules only support",
+        "DAILY rrules require",
+        "DAILY rrules do not support",
+        "WEEKLY rrules only support",
+        "WEEKLY rrules require",
+        "failed to compute weekly next run",
+    ]
+    .iter()
+    .any(|prefix| message.starts_with(prefix))
+}

--- a/codex-rs/app-server/src/thread_state.rs
+++ b/codex-rs/app-server/src/thread_state.rs
@@ -338,6 +338,18 @@ impl ThreadStateManager {
             .unwrap_or_default()
     }
 
+    pub(crate) async fn thread_ids_for_connection(
+        &self,
+        connection_id: ConnectionId,
+    ) -> Vec<ThreadId> {
+        let state = self.state.lock().await;
+        state
+            .thread_ids_by_connection
+            .get(&connection_id)
+            .map(|thread_ids| thread_ids.iter().copied().collect())
+            .unwrap_or_default()
+    }
+
     pub(crate) async fn thread_state(&self, thread_id: ThreadId) -> Arc<Mutex<ThreadState>> {
         let mut state = self.state.lock().await;
         state.threads.entry(thread_id).or_default().state.clone()

--- a/codex-rs/app-server/tests/suite/v2/automation.rs
+++ b/codex-rs/app-server/tests/suite/v2/automation.rs
@@ -1,0 +1,227 @@
+use anyhow::Result;
+use app_test_support::TestAppServer;
+use app_test_support::create_mock_responses_server_repeating_assistant;
+use app_test_support::to_response;
+use app_test_support::write_mock_responses_config_toml;
+use codex_app_server_protocol::Automation;
+use codex_app_server_protocol::AutomationCreateParams;
+use codex_app_server_protocol::AutomationCreateResponse;
+use codex_app_server_protocol::AutomationDeleteResponse;
+use codex_app_server_protocol::AutomationListParams;
+use codex_app_server_protocol::AutomationListResponse;
+use codex_app_server_protocol::AutomationReadResponse;
+use codex_app_server_protocol::AutomationStatus;
+use codex_app_server_protocol::AutomationTarget;
+use codex_app_server_protocol::AutomationUpdateResponse;
+use codex_app_server_protocol::JSONRPCError;
+use codex_app_server_protocol::JSONRPCResponse;
+use codex_app_server_protocol::RequestId;
+use codex_app_server_protocol::ThreadStartParams;
+use codex_app_server_protocol::ThreadStartResponse;
+use codex_features::Feature;
+use pretty_assertions::assert_eq;
+use std::collections::BTreeMap;
+use std::path::Path;
+use tempfile::TempDir;
+use tokio::time::timeout;
+
+const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+#[tokio::test]
+async fn automation_api_rejects_disabled_feature() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+    let codex_home = TempDir::new()?;
+    write_config(
+        codex_home.path(),
+        &server.uri(),
+        /*automations_enabled*/ false,
+    )?;
+
+    let mut app_server = init_app_server(codex_home.path()).await?;
+    let request_id = app_server
+        .send_raw_request(
+            "automation/list",
+            Some(serde_json::to_value(AutomationListParams::default())?),
+        )
+        .await?;
+
+    let err: JSONRPCError = timeout(
+        DEFAULT_READ_TIMEOUT,
+        app_server.read_stream_until_error_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    assert_eq!(err.error.code, -32600);
+    assert_eq!(err.error.message, "automations feature is disabled");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn automation_crud_is_scoped_to_subscribed_threads() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+    let codex_home = TempDir::new()?;
+    write_config(
+        codex_home.path(),
+        &server.uri(),
+        /*automations_enabled*/ true,
+    )?;
+    let cwd = codex_home.path().join("workspace");
+    std::fs::create_dir(&cwd)?;
+
+    let mut owner = init_app_server(codex_home.path()).await?;
+    start_thread(&mut owner, &cwd).await?;
+
+    let created = create_cron_automation(&mut owner, &cwd).await?;
+    assert_eq!(created.name, "daily tidy");
+    assert_eq!(created.prompt, "summarize the repo");
+    assert_eq!(created.status, AutomationStatus::Active);
+    assert_eq!(created.model.as_deref(), Some("mock-model"));
+    assert_eq!(
+        created.target,
+        AutomationTarget::Cron {
+            cwds: vec![cwd.clone()],
+        }
+    );
+
+    let listed = list_automations(&mut owner).await?;
+    assert_eq!(listed.data, vec![created.clone()]);
+    assert_eq!(listed.next_cursor, None);
+
+    let updated = update_automation_name(&mut owner, created.id.as_str()).await?;
+    assert_eq!(updated.name, "daily polish");
+    assert_eq!(updated.status, AutomationStatus::Paused);
+
+    let read_back = read_automation(&mut owner, created.id.as_str()).await?;
+    assert_eq!(read_back, Some(updated));
+
+    let mut outsider = init_app_server(codex_home.path()).await?;
+    let outsider_listed = list_automations(&mut outsider).await?;
+    assert_eq!(outsider_listed.data, Vec::<Automation>::new());
+    assert!(!delete_automation(&mut outsider, created.id.as_str()).await?);
+
+    assert!(delete_automation(&mut owner, created.id.as_str()).await?);
+    assert_eq!(
+        read_automation(&mut owner, created.id.as_str()).await?,
+        None
+    );
+
+    Ok(())
+}
+
+async fn init_app_server(codex_home: &Path) -> Result<TestAppServer> {
+    let mut app_server = TestAppServer::new(codex_home).await?;
+    timeout(DEFAULT_READ_TIMEOUT, app_server.initialize()).await??;
+    Ok(app_server)
+}
+
+fn write_config(codex_home: &Path, server_uri: &str, automations_enabled: bool) -> Result<()> {
+    write_mock_responses_config_toml(
+        codex_home,
+        server_uri,
+        &BTreeMap::from([(Feature::Automations, automations_enabled)]),
+        200_000,
+        /*requires_openai_auth*/ None,
+        "mock_provider",
+        "compact",
+    )?;
+    Ok(())
+}
+
+async fn start_thread(app_server: &mut TestAppServer, cwd: &Path) -> Result<ThreadStartResponse> {
+    let request_id = app_server
+        .send_thread_start_request(ThreadStartParams {
+            cwd: Some(cwd.display().to_string()),
+            ..Default::default()
+        })
+        .await?;
+    let resp = response_for(app_server, request_id).await?;
+    to_response::<ThreadStartResponse>(resp)
+}
+
+async fn create_cron_automation(app_server: &mut TestAppServer, cwd: &Path) -> Result<Automation> {
+    let request_id = app_server
+        .send_raw_request(
+            "automation/create",
+            Some(serde_json::to_value(AutomationCreateParams {
+                name: "daily tidy".to_string(),
+                prompt: "summarize the repo".to_string(),
+                rrule: Some("FREQ=DAILY;INTERVAL=1;BYHOUR=9;BYMINUTE=30".to_string()),
+                model: Some("mock-model".to_string()),
+                reasoning_effort: None,
+                status: Some(AutomationStatus::Active),
+                target: AutomationTarget::Cron {
+                    cwds: vec![cwd.to_path_buf()],
+                },
+            })?),
+        )
+        .await?;
+    let resp = response_for(app_server, request_id).await?;
+    Ok(to_response::<AutomationCreateResponse>(resp)?.automation)
+}
+
+async fn list_automations(app_server: &mut TestAppServer) -> Result<AutomationListResponse> {
+    let request_id = app_server
+        .send_raw_request(
+            "automation/list",
+            Some(serde_json::to_value(AutomationListParams {
+                cursor: None,
+                limit: Some(10),
+            })?),
+        )
+        .await?;
+    let resp = response_for(app_server, request_id).await?;
+    to_response::<AutomationListResponse>(resp)
+}
+
+async fn read_automation(
+    app_server: &mut TestAppServer,
+    automation_id: &str,
+) -> Result<Option<Automation>> {
+    let request_id = app_server
+        .send_raw_request(
+            "automation/read",
+            Some(serde_json::json!({ "automationId": automation_id })),
+        )
+        .await?;
+    let resp = response_for(app_server, request_id).await?;
+    Ok(to_response::<AutomationReadResponse>(resp)?.automation)
+}
+
+async fn update_automation_name(
+    app_server: &mut TestAppServer,
+    automation_id: &str,
+) -> Result<Automation> {
+    let request_id = app_server
+        .send_raw_request(
+            "automation/update",
+            Some(serde_json::json!({
+                "automationId": automation_id,
+                "name": "daily polish",
+                "status": "PAUSED"
+            })),
+        )
+        .await?;
+    let resp = response_for(app_server, request_id).await?;
+    to_response::<AutomationUpdateResponse>(resp)?
+        .automation
+        .ok_or_else(|| anyhow::anyhow!("expected updated automation"))
+}
+
+async fn delete_automation(app_server: &mut TestAppServer, automation_id: &str) -> Result<bool> {
+    let request_id = app_server
+        .send_raw_request(
+            "automation/delete",
+            Some(serde_json::json!({ "automationId": automation_id })),
+        )
+        .await?;
+    let resp = response_for(app_server, request_id).await?;
+    Ok(to_response::<AutomationDeleteResponse>(resp)?.deleted)
+}
+
+async fn response_for(app_server: &mut TestAppServer, request_id: i64) -> Result<JSONRPCResponse> {
+    timeout(
+        DEFAULT_READ_TIMEOUT,
+        app_server.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await?
+}

--- a/codex-rs/app-server/tests/suite/v2/mod.rs
+++ b/codex-rs/app-server/tests/suite/v2/mod.rs
@@ -2,6 +2,7 @@ mod account;
 mod analytics;
 mod app_list;
 mod attestation;
+mod automation;
 mod client_metadata;
 mod collaboration_mode_list;
 #[cfg(unix)]


### PR DESCRIPTION
## Stack

1. [#28609](https://github.com/openai/codex/pull/28609) automations: add service groundwork and overview
2. [#28610](https://github.com/openai/codex/pull/28610) automations: add durable state store
3. [#28611](https://github.com/openai/codex/pull/28611) automations: add state CRUD and scheduling
4. [#28612](https://github.com/openai/codex/pull/28612) automations: add dispatch claims and leases
5. [#28613](https://github.com/openai/codex/pull/28613) automations: add app-server protocol
6. **This PR**: automations: add app-server CRUD handlers
7. [#28615](https://github.com/openai/codex/pull/28615) automations: add agent `automation_update` tool
8. [#28616](https://github.com/openai/codex/pull/28616) automations: dispatch `runNow` requests
9. [#28617](https://github.com/openai/codex/pull/28617) automations: add background worker loop
10. [#28618](https://github.com/openai/codex/pull/28618) automations: dispatch scheduled heartbeats
11. [#28619](https://github.com/openai/codex/pull/28619) automations: add dispatch integration coverage
12. [#28620](https://github.com/openai/codex/pull/28620) automations: defer heartbeats for cooldown

## Why

The protocol needs server-side enforcement for feature gating and thread ownership before any background dispatch exists. This keeps the user-visible API usable while still preventing cross-thread automation access.

## What Changed

- Adds `automation/*` request processing in app-server.
- Gates all automation APIs on `Feature::Automations`.
- Scopes automation visibility and mutation to subscribed/owned threads.
- Validates cron targets against loaded thread context and heartbeat targets against subscribed threads.
- Adds app-server integration coverage for disabled-feature rejection and CRUD scoping.

## Verification

- `env -u CODEX_SQLITE_HOME just test -p codex-app-server suite::v2::automation` passed.