### PR TITLE
automations: dispatch scheduled heartbeats

### DIFF
--- a/codex-rs/app-server/src/request_processors/automation_dispatch.rs
+++ b/codex-rs/app-server/src/request_processors/automation_dispatch.rs
@@ -9,6 +9,8 @@ use crate::request_processors::thread_processor::ThreadRequestProcessor;
 use crate::request_processors::thread_processor::build_thread_from_snapshot;
 use crate::request_processors::thread_summary::thread_started_notification;
 use crate::thread_status::resolve_thread_status;
+use chrono::Duration as ChronoDuration;
+use chrono::Utc;
 use codex_app_server_protocol::AutomationRunNowParams;
 use codex_app_server_protocol::AutomationRunNowResponse;
 use codex_app_server_protocol::ClientResponsePayload;
@@ -27,8 +29,10 @@ use codex_protocol::protocol::ThreadSettingsOverrides;
 use codex_protocol::protocol::ThreadSource;
 use codex_protocol::user_input::UserInput;
 use codex_rollout::StateDbHandle;
+use codex_state::AUTOMATION_HEARTBEAT_BLOCKED_RETRY_SECS;
 use codex_state::Automation;
 use codex_state::AutomationDispatchClaim;
+use codex_state::AutomationDispatchMode;
 use codex_state::AutomationDispatchOutcome;
 use codex_state::AutomationDispatchSettings;
 use codex_state::AutomationTarget;
@@ -91,7 +95,12 @@ impl ThreadRequestProcessor {
         };
 
         let dispatch_result = match self.dispatch_claimed_automation(state_db, &claim).await {
-            Ok(dispatch_result) => dispatch_result,
+            Ok(AutomationDispatchResult::Started(dispatch_result)) => dispatch_result,
+            Ok(AutomationDispatchResult::Deferred) => {
+                return Err(internal_error(
+                    "automation runNow was deferred before dispatch",
+                ));
+            }
             Err(err) => {
                 let _ = state_db
                     .mark_automation_dispatch_failed_terminal(
@@ -146,7 +155,7 @@ impl ThreadRequestProcessor {
         &self,
         state_db: &StateDbHandle,
         claim: &AutomationDispatchClaim,
-    ) -> Result<RunNowDispatchResult, JSONRPCErrorError> {
+    ) -> Result<AutomationDispatchResult, JSONRPCErrorError> {
         let started = state_db
             .mark_automation_dispatch_started(
                 claim.automation.id.as_str(),
@@ -165,7 +174,8 @@ impl ThreadRequestProcessor {
                 self.dispatch_cron_automation(state_db, claim, cwds).await
             }
             AutomationTarget::Heartbeat { thread_id } => {
-                self.dispatch_heartbeat_run_now(claim, *thread_id).await
+                self.dispatch_heartbeat_automation(state_db, claim, *thread_id)
+                    .await
             }
         }
     }
@@ -175,7 +185,7 @@ impl ThreadRequestProcessor {
         state_db: &StateDbHandle,
         claim: &AutomationDispatchClaim,
         cwds: &[PathBuf],
-    ) -> Result<RunNowDispatchResult, JSONRPCErrorError> {
+    ) -> Result<AutomationDispatchResult, JSONRPCErrorError> {
         let mut started_count = 0_usize;
         let mut last_error = None;
         for (cwd_index, cwd) in cwds.iter().enumerate().skip(claim.dispatch_cwd_index) {
@@ -214,17 +224,36 @@ impl ThreadRequestProcessor {
         {
             return Err(internal_error(last_error));
         }
-        Ok(RunNowDispatchResult {
-            started_count,
-            last_error,
-        })
+        Ok(AutomationDispatchResult::Started(
+            StartedAutomationDispatch {
+                started_count,
+                last_error,
+            },
+        ))
     }
 
-    async fn dispatch_heartbeat_run_now(
+    async fn dispatch_heartbeat_automation(
+        &self,
+        state_db: &StateDbHandle,
+        claim: &AutomationDispatchClaim,
+        thread_id: ThreadId,
+    ) -> Result<AutomationDispatchResult, JSONRPCErrorError> {
+        match claim.dispatch_mode {
+            AutomationDispatchMode::Manual => {
+                self.dispatch_manual_heartbeat(claim, thread_id).await
+            }
+            AutomationDispatchMode::Scheduled => {
+                self.dispatch_scheduled_heartbeat(state_db, claim, thread_id)
+                    .await
+            }
+        }
+    }
+
+    async fn dispatch_manual_heartbeat(
         &self,
         claim: &AutomationDispatchClaim,
         thread_id: ThreadId,
-    ) -> Result<RunNowDispatchResult, JSONRPCErrorError> {
+    ) -> Result<AutomationDispatchResult, JSONRPCErrorError> {
         let loaded_status = self
             .thread_watch_manager
             .loaded_status_for_thread(&thread_id.to_string())
@@ -243,10 +272,66 @@ impl ThreadRequestProcessor {
             .await?;
         self.submit_automation_prompt(thread.as_ref(), build_heartbeat_prompt(&claim.automation))
             .await?;
-        Ok(RunNowDispatchResult {
-            started_count: 1,
-            last_error: None,
-        })
+        Ok(AutomationDispatchResult::Started(
+            StartedAutomationDispatch {
+                started_count: 1,
+                last_error: None,
+            },
+        ))
+    }
+
+    async fn dispatch_scheduled_heartbeat(
+        &self,
+        state_db: &StateDbHandle,
+        claim: &AutomationDispatchClaim,
+        thread_id: ThreadId,
+    ) -> Result<AutomationDispatchResult, JSONRPCErrorError> {
+        let loaded_status = self
+            .thread_watch_manager
+            .loaded_status_for_thread(&thread_id.to_string())
+            .await;
+        if matches!(loaded_status, ThreadStatus::Active { .. }) {
+            self.defer_scheduled_heartbeat(state_db, claim, "heartbeat target thread is busy")
+                .await?;
+            return Ok(AutomationDispatchResult::Deferred);
+        }
+
+        let thread = match self.thread_manager.get_thread(thread_id).await {
+            Ok(thread) => {
+                let thread_state = self.thread_state_manager.thread_state(thread_id).await;
+                self.ensure_listener_task_running(thread_id, thread.clone(), thread_state)
+                    .await?;
+                thread
+            }
+            Err(_) => self.resume_automation_thread(thread_id).await?,
+        };
+        self.submit_automation_prompt(thread.as_ref(), build_heartbeat_prompt(&claim.automation))
+            .await?;
+        Ok(AutomationDispatchResult::Started(
+            StartedAutomationDispatch {
+                started_count: 1,
+                last_error: None,
+            },
+        ))
+    }
+
+    async fn defer_scheduled_heartbeat(
+        &self,
+        state_db: &StateDbHandle,
+        claim: &AutomationDispatchClaim,
+        reason: &str,
+    ) -> Result<(), JSONRPCErrorError> {
+        let retry_at =
+            Utc::now() + ChronoDuration::seconds(AUTOMATION_HEARTBEAT_BLOCKED_RETRY_SECS.max(0));
+        let deferred = state_db
+            .defer_scheduled_automation_dispatch(claim, retry_at, reason)
+            .await
+            .map_err(|err| internal_error(format!("failed to defer automation: {err}")))?;
+        if deferred {
+            Ok(())
+        } else {
+            Err(internal_error("automation run claim was lost before defer"))
+        }
     }
 
     async fn spawn_and_submit_automation_thread(
@@ -359,9 +444,14 @@ fn run_now_response(found: bool, started_count: u32) -> ClientResponsePayload {
     .into()
 }
 
-pub(super) struct RunNowDispatchResult {
-    started_count: usize,
-    last_error: Option<String>,
+pub(super) enum AutomationDispatchResult {
+    Started(StartedAutomationDispatch),
+    Deferred,
+}
+
+pub(super) struct StartedAutomationDispatch {
+    pub(super) started_count: usize,
+    pub(super) last_error: Option<String>,
 }
 
 fn ensure_cwd_in_dispatch_scope(

--- a/codex-rs/app-server/src/request_processors/automation_worker.rs
+++ b/codex-rs/app-server/src/request_processors/automation_worker.rs
@@ -1,4 +1,5 @@
 use crate::error_code::INVALID_REQUEST_ERROR_CODE;
+use crate::request_processors::automation_dispatch::AutomationDispatchResult;
 use crate::request_processors::thread_processor::ThreadRequestProcessor;
 use codex_rollout::StateDbHandle;
 use codex_state::AUTOMATION_DISPATCH_BATCH_SIZE;
@@ -66,36 +67,58 @@ impl ThreadRequestProcessor {
         state_db: &StateDbHandle,
         claim: &AutomationDispatchClaim,
     ) {
-        if let Err(err) = self.dispatch_claimed_automation(state_db, claim).await {
-            let result = if err.code == INVALID_REQUEST_ERROR_CODE {
-                state_db
-                    .mark_automation_dispatch_failed_terminal(
-                        claim.automation.id.as_str(),
-                        claim.ownership_token.as_str(),
-                        err.message.as_str(),
+        match self.dispatch_claimed_automation(state_db, claim).await {
+            Ok(AutomationDispatchResult::Started(dispatch_result)) => {
+                match state_db
+                    .mark_automation_dispatch_completed(
+                        claim,
+                        dispatch_result.last_error.as_deref(),
                     )
                     .await
-                    .map(|_| ())
-            } else {
-                state_db
-                    .release_automation_dispatch_after_retryable_failure(
-                        claim.automation.id.as_str(),
-                        claim.ownership_token.as_str(),
-                        err.message.as_str(),
-                    )
-                    .await
-                    .map(|_| ())
-            };
-            if let Err(state_err) = result {
+                {
+                    Ok(true) => {}
+                    Ok(false) => warn!(
+                        "automation {} dispatch claim was lost before completion",
+                        claim.automation.id
+                    ),
+                    Err(err) => warn!(
+                        "failed to complete automation {} dispatch: {err:#}",
+                        claim.automation.id
+                    ),
+                }
+            }
+            Ok(AutomationDispatchResult::Deferred) => {}
+            Err(err) => {
+                let result = if err.code == INVALID_REQUEST_ERROR_CODE {
+                    state_db
+                        .mark_automation_dispatch_failed_terminal(
+                            claim.automation.id.as_str(),
+                            claim.ownership_token.as_str(),
+                            err.message.as_str(),
+                        )
+                        .await
+                        .map(|_| ())
+                } else {
+                    state_db
+                        .release_automation_dispatch_after_retryable_failure(
+                            claim.automation.id.as_str(),
+                            claim.ownership_token.as_str(),
+                            err.message.as_str(),
+                        )
+                        .await
+                        .map(|_| ())
+                };
+                if let Err(state_err) = result {
+                    warn!(
+                        "failed to persist automation {} dispatch failure: {state_err:#}",
+                        claim.automation.id
+                    );
+                }
                 warn!(
-                    "failed to persist automation {} dispatch failure: {state_err:#}",
-                    claim.automation.id
+                    "automation {} dispatch failed: {}",
+                    claim.automation.id, err.message
                 );
             }
-            warn!(
-                "automation {} dispatch failed: {}",
-                claim.automation.id, err.message
-            );
         }
     }
 }

--- a/codex-rs/app-server/src/request_processors/thread_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor.rs
@@ -881,6 +881,76 @@ impl ThreadRequestProcessor {
         .await
     }
 
+    pub(super) async fn resume_automation_thread(
+        &self,
+        thread_id: ThreadId,
+    ) -> Result<Arc<CodexThread>, JSONRPCErrorError> {
+        let thread_id_str = thread_id.to_string();
+        let stored_thread = self
+            .read_stored_thread_for_resume(
+                thread_id_str.as_str(),
+                /*path*/ None,
+                /*include_history*/ true,
+            )
+            .await?;
+        let history = self
+            .stored_thread_to_initial_history(&stored_thread)
+            .await?;
+        let mut request_overrides = None;
+        if let Some(reasoning_effort) = stored_thread.reasoning_effort.as_ref() {
+            request_overrides.get_or_insert_with(HashMap::new).insert(
+                "model_reasoning_effort".to_string(),
+                serde_json::Value::String(reasoning_effort.to_string()),
+            );
+        }
+        let cwd = stored_thread.cwd.clone();
+        let config = self
+            .config_manager
+            .load_for_cwd(
+                request_overrides,
+                ConfigOverrides {
+                    cwd: Some(cwd.clone()),
+                    model: stored_thread.model.clone(),
+                    model_provider: Some(stored_thread.model_provider.clone()),
+                    approval_policy: Some(stored_thread.approval_mode),
+                    permission_profile: Some(stored_thread.permission_profile.clone()),
+                    ..ConfigOverrides::default()
+                },
+                Some(cwd),
+            )
+            .await
+            .map_err(|err| config_load_error(&err))?;
+        let NewThread {
+            thread_id: resumed_thread_id,
+            thread,
+            ..
+        } = self
+            .thread_manager
+            .resume_thread_with_history(
+                config,
+                history,
+                Arc::clone(&self.auth_manager),
+                /*parent_trace*/ None,
+            )
+            .await
+            .map_err(|err| match err {
+                CodexErr::ThreadNotFound(thread_id) => {
+                    invalid_request(format!("no rollout found for thread id {thread_id}"))
+                }
+                CodexErr::InvalidRequest(message) => invalid_request(message),
+                err => internal_error(format!("failed to resume automation thread: {err}")),
+            })?;
+        if resumed_thread_id != thread_id {
+            return Err(internal_error(format!(
+                "resumed automation thread id mismatch: requested {thread_id}, got {resumed_thread_id}"
+            )));
+        }
+        let thread_state = self.thread_state_manager.thread_state(thread_id).await;
+        self.ensure_listener_task_running(thread_id, thread.clone(), thread_state)
+            .await?;
+        Ok(thread)
+    }
+
     async fn thread_start_inner(
         &self,
         request_id: ConnectionRequestId,

--- a/codex-rs/state/src/lib.rs
+++ b/codex-rs/state/src/lib.rs
@@ -119,6 +119,7 @@ pub const STATE_DB_FILENAME: &str = "state_5.sqlite";
 pub const DEFAULT_AUTOMATION_RRULE: &str = "FREQ=HOURLY;INTERVAL=24;BYMINUTE=0";
 pub const AUTOMATION_CLAIM_LEASE_SECS: i64 = 120;
 pub const AUTOMATION_DISPATCH_BATCH_SIZE: usize = 8;
+pub const AUTOMATION_HEARTBEAT_BLOCKED_RETRY_SECS: i64 = 60;
 pub const AUTOMATION_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
 pub const AUTOMATION_RETRY_BACKOFF_SECS: i64 = 10;
 pub const AUTOMATION_RETRY_BUDGET: i64 = 3;

--- a/codex-rs/state/src/runtime/automations.rs
+++ b/codex-rs/state/src/runtime/automations.rs
@@ -517,6 +517,51 @@ WHERE id = ?
         })
     }
 
+    pub async fn defer_scheduled_automation_dispatch(
+        &self,
+        claim: &AutomationDispatchClaim,
+        retry_at: chrono::DateTime<Utc>,
+        reason: &str,
+    ) -> anyhow::Result<bool> {
+        anyhow::ensure!(
+            claim.dispatch_mode == AutomationDispatchMode::Scheduled,
+            "only scheduled automation dispatches can be deferred",
+        );
+        let now = Utc::now().timestamp();
+        let retry_at_ts = retry_at.timestamp();
+        let next_run_at = claim
+            .next_run_at_after_claim
+            .map(|value| value.timestamp().min(retry_at_ts))
+            .unwrap_or(retry_at_ts);
+        let result = sqlx::query(
+            r#"
+UPDATE automations
+SET
+    claimed_by = NULL,
+    ownership_token = NULL,
+    lease_until = NULL,
+    in_flight_run_at = NULL,
+    in_flight_dispatch_mode = NULL,
+    dispatch_cwd_index = 0,
+    retry_at = NULL,
+    attempt_count = 0,
+    next_run_at = ?,
+    last_error = ?,
+    updated_at = ?
+WHERE id = ?
+  AND ownership_token = ?
+            "#,
+        )
+        .bind(next_run_at)
+        .bind(reason)
+        .bind(now)
+        .bind(claim.automation.id.as_str())
+        .bind(claim.ownership_token.as_str())
+        .execute(self.automations_pool.as_ref())
+        .await?;
+        Ok(result.rows_affected() == 1)
+    }
+
     pub async fn mark_automation_dispatch_failed_terminal(
         &self,
         automation_id: &str,

--- a/codex-rs/state/src/runtime/automations_tests.rs
+++ b/codex-rs/state/src/runtime/automations_tests.rs
@@ -33,6 +33,20 @@ fn cron_create_params(owner_thread_id: ThreadId, cwd: PathBuf) -> AutomationCrea
     }
 }
 
+fn heartbeat_create_params(thread_id: ThreadId) -> AutomationCreateParams {
+    AutomationCreateParams {
+        owner_thread_id: thread_id,
+        name: "Heartbeat".to_string(),
+        prompt: "Check whether to continue.".to_string(),
+        status: AutomationStatus::Active,
+        rrule: Some("FREQ=MINUTELY;INTERVAL=30".to_string()),
+        model: None,
+        reasoning_effort: None,
+        target: AutomationTarget::Heartbeat { thread_id },
+        dispatch_settings: None,
+    }
+}
+
 #[tokio::test]
 async fn create_update_delete_cron_automation_round_trips() {
     let codex_home = unique_temp_dir();
@@ -286,6 +300,71 @@ async fn retryable_failure_requeues_until_retry_budget_is_exhausted() {
         .expect("automation should exist");
     assert_eq!(reloaded.status, AutomationStatus::Paused);
     assert_eq!(reloaded.next_run_at, None);
+
+    let _ = tokio::fs::remove_dir_all(codex_home).await;
+}
+
+#[tokio::test]
+async fn deferred_scheduled_heartbeat_reopens_next_run_without_consuming() {
+    let codex_home = unique_temp_dir();
+    let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string())
+        .await
+        .expect("state runtime should initialize");
+    let automation = runtime
+        .create_automation(&heartbeat_create_params(thread_id()))
+        .await
+        .expect("create automation");
+    sqlx::query("UPDATE automations SET next_run_at = ? WHERE id = ?")
+        .bind((Utc::now() - Duration::seconds(1)).timestamp())
+        .bind(automation.id.as_str())
+        .execute(runtime.automations_pool.as_ref())
+        .await
+        .expect("force due automation");
+
+    let claim = runtime
+        .claim_due_automation_dispatch("worker-a")
+        .await
+        .expect("claim due automation")
+        .expect("automation should be due");
+    assert_eq!(claim.dispatch_mode, AutomationDispatchMode::Scheduled);
+    assert!(
+        runtime
+            .mark_automation_dispatch_started(
+                claim.automation.id.as_str(),
+                claim.ownership_token.as_str(),
+            )
+            .await
+            .expect("mark started")
+    );
+    let retry_at = Utc::now() + Duration::seconds(60);
+
+    assert!(
+        runtime
+            .defer_scheduled_automation_dispatch(&claim, retry_at, "busy")
+            .await
+            .expect("defer heartbeat")
+    );
+
+    let reloaded = runtime
+        .get_automation(automation.id.as_str())
+        .await
+        .expect("load automation")
+        .expect("automation should exist");
+    assert_eq!(reloaded.last_run_at, None);
+    assert_eq!(
+        reloaded
+            .next_run_at
+            .expect("defer should set next run")
+            .timestamp(),
+        retry_at.timestamp()
+    );
+    assert_eq!(
+        runtime
+            .claim_due_automation_dispatch("worker-b")
+            .await
+            .expect("deferred heartbeat should not be immediately due"),
+        None
+    );
 
     let _ = tokio::fs::remove_dir_all(codex_home).await;
 }


### PR DESCRIPTION
## Stack

1. [#28609](https://github.com/openai/codex/pull/28609) automations: add service groundwork and overview
2. [#28610](https://github.com/openai/codex/pull/28610) automations: add durable state store
3. [#28611](https://github.com/openai/codex/pull/28611) automations: add state CRUD and scheduling
4. [#28612](https://github.com/openai/codex/pull/28612) automations: add dispatch claims and leases
5. [#28613](https://github.com/openai/codex/pull/28613) automations: add app-server protocol
6. [#28614](https://github.com/openai/codex/pull/28614) automations: add app-server CRUD handlers
7. [#28615](https://github.com/openai/codex/pull/28615) automations: add agent `automation_update` tool
8. [#28616](https://github.com/openai/codex/pull/28616) automations: dispatch `runNow` requests
9. [#28617](https://github.com/openai/codex/pull/28617) automations: add background worker loop
10. **This PR**: automations: dispatch scheduled heartbeats
11. [#28619](https://github.com/openai/codex/pull/28619) automations: add dispatch integration coverage
12. [#28620](https://github.com/openai/codex/pull/28620) automations: defer heartbeats for cooldown

## Why

Scheduled heartbeats differ from cron runs because they target existing threads and must avoid interrupting active user/approval flows. They also need a cold-resume path so a dormant thread can receive the heartbeat without an attached client.

## What Changed

- Adds scheduled heartbeat dispatch behavior for loaded and cold-resumed threads.
- Starts/resumes the listener path before submitting heartbeat prompts.
- Defers scheduled heartbeats instead of failing when the target thread is busy.
- Adds cold-claim delay and loaded-thread preference behavior for heartbeat workers.
- Adds state support and tests for deferred scheduled heartbeat retries.

## Verification

- `codex-state` deferred heartbeat tests passed in the focused non-app-server run.
- App-server dispatch paths are covered by the automation integration tests in this stack.