### PR TITLE
[codex] Reuse directory entry metadata in skill scans

### DIFF
--- a/codex-rs/core-skills/src/loader.rs
+++ b/codex-rs/core-skills/src/loader.rs
@@ -558,46 +558,21 @@ async fn discover_skills_under_root(
             }
 
             let path = dir.join(&file_name);
-            let path_uri = PathUri::from_abs_path(&path);
-            let metadata = match fs.get_metadata(&path_uri, /*sandbox*/ None).await {
-                Ok(metadata) => metadata,
-                Err(e) => {
-                    error!("failed to stat skills path {}: {e:#}", path.display());
-                    continue;
-                }
-            };
-
-            if metadata.is_symlink {
-                if !follow_symlinks {
-                    continue;
-                }
-                match fs.read_directory(&path_uri, /*sandbox*/ None).await {
-                    Ok(_) => {
-                        let resolved_dir = canonicalize_for_skill_identity(fs, &path).await;
-                        enqueue_dir(
-                            &mut queue,
-                            &mut visited_dirs,
-                            &mut truncated_by_dir_limit,
-                            resolved_dir,
-                            depth + 1,
-                        );
-                    }
-                    Err(err)
-                        if matches!(
-                            err.kind(),
-                            io::ErrorKind::NotADirectory | io::ErrorKind::NotFound
-                        ) => {}
-                    Err(err) => {
-                        error!(
-                            "failed to read skills symlink dir {}: {err:#}",
-                            path.display()
-                        );
-                    }
+            if entry.is_symlink {
+                if follow_symlinks && entry.is_directory {
+                    let resolved_dir = canonicalize_for_skill_identity(fs, &path).await;
+                    enqueue_dir(
+                        &mut queue,
+                        &mut visited_dirs,
+                        &mut truncated_by_dir_limit,
+                        resolved_dir,
+                        depth + 1,
+                    );
                 }
                 continue;
             }
 
-            if metadata.is_directory {
+            if entry.is_directory {
                 let resolved_dir = canonicalize_for_skill_identity(fs, &path).await;
                 enqueue_dir(
                     &mut queue,
@@ -609,7 +584,7 @@ async fn discover_skills_under_root(
                 continue;
             }
 
-            if metadata.is_file && file_name == SKILLS_FILENAME {
+            if entry.is_file && file_name == SKILLS_FILENAME {
                 match parse_skill_file(fs, &path, scope, plugin_id, plugin_root.as_ref()).await {
                     Ok(skill) => {
                         outcome.skills.push(skill);

--- a/codex-rs/core-skills/src/loader.rs
+++ b/codex-rs/core-skills/src/loader.rs
@@ -558,8 +558,24 @@ async fn discover_skills_under_root(
             }
 
             let path = dir.join(&file_name);
-            if entry.is_symlink {
-                if follow_symlinks && entry.is_directory {
+            let (is_directory, is_file, is_symlink) = match entry.is_symlink {
+                Some(is_symlink) => (entry.is_directory, entry.is_file, is_symlink),
+                None => {
+                    // Older remote exec servers omit symlink identity from directory entries.
+                    let path_uri = PathUri::from_abs_path(&path);
+                    let metadata = match fs.get_metadata(&path_uri, /*sandbox*/ None).await {
+                        Ok(metadata) => metadata,
+                        Err(e) => {
+                            error!("failed to stat skills path {}: {e:#}", path.display());
+                            continue;
+                        }
+                    };
+                    (metadata.is_directory, metadata.is_file, metadata.is_symlink)
+                }
+            };
+
+            if is_symlink {
+                if follow_symlinks && is_directory {
                     let resolved_dir = canonicalize_for_skill_identity(fs, &path).await;
                     enqueue_dir(
                         &mut queue,
@@ -572,7 +588,7 @@ async fn discover_skills_under_root(
                 continue;
             }
 
-            if entry.is_directory {
+            if is_directory {
                 let resolved_dir = canonicalize_for_skill_identity(fs, &path).await;
                 enqueue_dir(
                     &mut queue,
@@ -584,7 +600,7 @@ async fn discover_skills_under_root(
                 continue;
             }
 
-            if entry.is_file && file_name == SKILLS_FILENAME {
+            if is_file && file_name == SKILLS_FILENAME {
                 match parse_skill_file(fs, &path, scope, plugin_id, plugin_root.as_ref()).await {
                     Ok(skill) => {
                         outcome.skills.push(skill);

--- a/codex-rs/exec-server/src/fs_helper.rs
+++ b/codex-rs/exec-server/src/fs_helper.rs
@@ -257,6 +257,7 @@ pub(crate) async fn run_direct_request(
                     file_name: entry.file_name,
                     is_directory: entry.is_directory,
                     is_file: entry.is_file,
+                    is_symlink: entry.is_symlink,
                 })
                 .collect();
             Ok(FsHelperPayload::ReadDirectory(FsReadDirectoryResponse {

--- a/codex-rs/exec-server/src/local_file_system.rs
+++ b/codex-rs/exec-server/src/local_file_system.rs
@@ -613,7 +613,7 @@ impl DirectFileSystem {
                 file_name: entry.file_name().to_string_lossy().into_owned(),
                 is_directory,
                 is_file,
-                is_symlink,
+                is_symlink: Some(is_symlink),
             });
         }
         Ok(entries)

--- a/codex-rs/exec-server/src/local_file_system.rs
+++ b/codex-rs/exec-server/src/local_file_system.rs
@@ -597,13 +597,23 @@ impl DirectFileSystem {
         let mut entries = Vec::new();
         let mut read_dir = tokio::fs::read_dir(path.as_path()).await?;
         while let Some(entry) = read_dir.next_entry().await? {
-            let Ok(metadata) = tokio::fs::metadata(entry.path()).await else {
+            let Ok(file_type) = entry.file_type().await else {
                 continue;
+            };
+            let is_symlink = file_type.is_symlink();
+            let (is_directory, is_file) = if is_symlink {
+                let Ok(metadata) = tokio::fs::metadata(entry.path()).await else {
+                    continue;
+                };
+                (metadata.is_dir(), metadata.is_file())
+            } else {
+                (file_type.is_dir(), file_type.is_file())
             };
             entries.push(ReadDirectoryEntry {
                 file_name: entry.file_name().to_string_lossy().into_owned(),
-                is_directory: metadata.is_dir(),
-                is_file: metadata.is_file(),
+                is_directory,
+                is_file,
+                is_symlink,
             });
         }
         Ok(entries)

--- a/codex-rs/exec-server/src/protocol.rs
+++ b/codex-rs/exec-server/src/protocol.rs
@@ -320,8 +320,8 @@ pub struct FsReadDirectoryEntry {
     pub file_name: String,
     pub is_directory: bool,
     pub is_file: bool,
-    #[serde(default)]
-    pub is_symlink: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_symlink: Option<bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -496,12 +496,48 @@ mod base64_bytes {
 
 #[cfg(test)]
 mod tests {
+    use super::FsReadDirectoryEntry;
     use super::FsReadFileParams;
     use super::HttpRequestParams;
     use codex_file_system::FileSystemSandboxContext;
     use codex_protocol::models::PermissionProfile;
     use codex_utils_path_uri::PathUri;
     use pretty_assertions::assert_eq;
+
+    #[test]
+    fn read_directory_entry_preserves_unknown_legacy_symlink_state() {
+        let entry: FsReadDirectoryEntry = serde_json::from_value(serde_json::json!({
+            "fileName": "skill",
+            "isDirectory": true,
+            "isFile": false,
+        }))
+        .expect("legacy directory entry should deserialize");
+
+        assert_eq!(
+            entry,
+            FsReadDirectoryEntry {
+                file_name: "skill".to_string(),
+                is_directory: true,
+                is_file: false,
+                is_symlink: None,
+            }
+        );
+        assert_eq!(
+            serde_json::to_value(FsReadDirectoryEntry {
+                file_name: "linked-skill".to_string(),
+                is_directory: true,
+                is_file: false,
+                is_symlink: Some(true),
+            })
+            .expect("current directory entry should serialize"),
+            serde_json::json!({
+                "fileName": "linked-skill",
+                "isDirectory": true,
+                "isFile": false,
+                "isSymlink": true,
+            })
+        );
+    }
 
     #[test]
     fn filesystem_protocol_accepts_legacy_absolute_paths_and_serializes_path_uris() {

--- a/codex-rs/exec-server/src/protocol.rs
+++ b/codex-rs/exec-server/src/protocol.rs
@@ -320,6 +320,8 @@ pub struct FsReadDirectoryEntry {
     pub file_name: String,
     pub is_directory: bool,
     pub is_file: bool,
+    #[serde(default)]
+    pub is_symlink: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/codex-rs/exec-server/src/remote_file_system.rs
+++ b/codex-rs/exec-server/src/remote_file_system.rs
@@ -179,6 +179,7 @@ impl RemoteFileSystem {
                 file_name: entry.file_name,
                 is_directory: entry.is_directory,
                 is_file: entry.is_file,
+                is_symlink: entry.is_symlink,
             })
             .collect())
     }

--- a/codex-rs/exec-server/src/sandboxed_file_system.rs
+++ b/codex-rs/exec-server/src/sandboxed_file_system.rs
@@ -196,6 +196,7 @@ impl SandboxedFileSystem {
                 file_name: entry.file_name,
                 is_directory: entry.is_directory,
                 is_file: entry.is_file,
+                is_symlink: entry.is_symlink,
             })
             .collect())
     }

--- a/codex-rs/exec-server/src/server/file_system_handler.rs
+++ b/codex-rs/exec-server/src/server/file_system_handler.rs
@@ -193,6 +193,7 @@ impl FileSystemHandler {
                 file_name: entry.file_name,
                 is_directory: entry.is_directory,
                 is_file: entry.is_file,
+                is_symlink: entry.is_symlink,
             })
             .collect();
         Ok(FsReadDirectoryResponse { entries })

--- a/codex-rs/exec-server/tests/file_system/shared.rs
+++ b/codex-rs/exec-server/tests/file_system/shared.rs
@@ -343,11 +343,13 @@ async fn file_system_read_directory_lists_entries(
                 file_name: "nested".to_string(),
                 is_directory: true,
                 is_file: false,
+                is_symlink: false,
             },
             ReadDirectoryEntry {
                 file_name: "root.txt".to_string(),
                 is_directory: false,
                 is_file: true,
+                is_symlink: false,
             },
         ]
     );

--- a/codex-rs/exec-server/tests/file_system/shared.rs
+++ b/codex-rs/exec-server/tests/file_system/shared.rs
@@ -343,13 +343,13 @@ async fn file_system_read_directory_lists_entries(
                 file_name: "nested".to_string(),
                 is_directory: true,
                 is_file: false,
-                is_symlink: false,
+                is_symlink: Some(false),
             },
             ReadDirectoryEntry {
                 file_name: "root.txt".to_string(),
                 is_directory: false,
                 is_file: true,
-                is_symlink: false,
+                is_symlink: Some(false),
             },
         ]
     );

--- a/codex-rs/exec-server/tests/file_system_unix.rs
+++ b/codex-rs/exec-server/tests/file_system_unix.rs
@@ -111,13 +111,13 @@ async fn file_system_read_directory_reports_symlink_target_kind(
                 file_name: "directory-link".to_string(),
                 is_directory: true,
                 is_file: false,
-                is_symlink: true,
+                is_symlink: Some(true),
             },
             ReadDirectoryEntry {
                 file_name: "file-link".to_string(),
                 is_directory: false,
                 is_file: true,
-                is_symlink: true,
+                is_symlink: Some(true),
             },
         ]
     );

--- a/codex-rs/exec-server/tests/file_system_unix.rs
+++ b/codex-rs/exec-server/tests/file_system_unix.rs
@@ -23,6 +23,7 @@ use codex_exec_server::CreateDirectoryOptions;
 #[cfg(target_os = "linux")]
 use codex_exec_server::Environment;
 use codex_exec_server::FileMetadata;
+use codex_exec_server::ReadDirectoryEntry;
 use codex_exec_server::RemoveOptions;
 use codex_utils_path_uri::PathUri;
 use pretty_assertions::assert_eq;
@@ -77,6 +78,51 @@ fn assert_normalized_path_rejected(error: &std::io::Error) {
         }
         other => panic!("unexpected normalized-path error kind: {other:?}: {error:?}"),
     }
+}
+
+#[test_case(FileSystemImplementation::Local ; "local")]
+#[test_case(FileSystemImplementation::Remote ; "remote")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn file_system_read_directory_reports_symlink_target_kind(
+    implementation: FileSystemImplementation,
+) -> Result<()> {
+    let context = create_file_system_context(implementation).await?;
+    let file_system = context.file_system;
+
+    let tmp = TempDir::new()?;
+    let source_dir = tmp.path().join("source");
+    let target_dir = tmp.path().join("target-dir");
+    let target_file = tmp.path().join("target.txt");
+    std::fs::create_dir_all(&source_dir)?;
+    std::fs::create_dir_all(&target_dir)?;
+    std::fs::write(&target_file, "hello")?;
+    symlink(&target_dir, source_dir.join("directory-link"))?;
+    symlink(&target_file, source_dir.join("file-link"))?;
+
+    let mut entries = file_system
+        .read_directory(&PathUri::from_path(&source_dir)?, /*sandbox*/ None)
+        .await
+        .with_context(|| format!("mode={implementation}"))?;
+    entries.sort_by(|left, right| left.file_name.cmp(&right.file_name));
+    assert_eq!(
+        entries,
+        vec![
+            ReadDirectoryEntry {
+                file_name: "directory-link".to_string(),
+                is_directory: true,
+                is_file: false,
+                is_symlink: true,
+            },
+            ReadDirectoryEntry {
+                file_name: "file-link".to_string(),
+                is_directory: false,
+                is_file: true,
+                is_symlink: true,
+            },
+        ]
+    );
+
+    Ok(())
 }
 
 fn alias_root_candidate() -> Result<Option<PathBuf>> {

--- a/codex-rs/ext/skills/tests/executor_file_system_authority.rs
+++ b/codex-rs/ext/skills/tests/executor_file_system_authority.rs
@@ -33,6 +33,7 @@ static NEXT_TEST_ROOT_ID: AtomicUsize = AtomicUsize::new(0);
 struct SyntheticFileSystem {
     alias_root: AbsolutePathBuf,
     canonical_root: AbsolutePathBuf,
+    entry_is_symlink: Option<bool>,
 }
 
 impl SyntheticFileSystem {
@@ -60,14 +61,14 @@ impl SyntheticFileSystem {
                 file_name: "skill".to_string(),
                 is_directory: true,
                 is_file: false,
-                is_symlink: false,
+                is_symlink: self.entry_is_symlink,
             }])
         } else if path == self.canonical_root.join("skill") {
             Ok(vec![ReadDirectoryEntry {
                 file_name: "SKILL.md".to_string(),
                 is_directory: false,
                 is_file: true,
-                is_symlink: false,
+                is_symlink: self.entry_is_symlink,
             }])
         } else {
             Err(io::Error::new(io::ErrorKind::NotFound, "not found"))
@@ -150,7 +151,7 @@ impl ExecutorFileSystem for SyntheticFileSystem {
     ) -> ExecutorFileSystemFuture<'a, FileMetadata> {
         Box::pin(async move {
             let path = path.to_abs_path()?;
-            if path == self.canonical_root {
+            if path == self.canonical_root || self.entry_is_symlink.is_none() {
                 self.metadata(&path)
             } else {
                 Err(io::Error::new(
@@ -206,6 +207,7 @@ async fn skill_loading_and_reads_use_the_supplied_executor_file_system() {
         file_system: Arc::new(SyntheticFileSystem {
             alias_root,
             canonical_root: canonical_root.clone(),
+            entry_is_symlink: Some(false),
         }),
         plugin_id: None,
         plugin_root: None,
@@ -224,6 +226,41 @@ async fn skill_loading_and_reads_use_the_supplied_executor_file_system() {
     assert_eq!(
         loaded.read_skill_text(&skill).await.expect("skill body"),
         SKILL_CONTENTS
+    );
+}
+
+#[tokio::test]
+async fn skill_loading_falls_back_for_legacy_directory_entries() {
+    let test_root = std::env::temp_dir().join(format!(
+        "codex-legacy-executor-skill-fs-{}",
+        std::process::id()
+    ));
+    let alias_root = AbsolutePathBuf::from_absolute_path_checked(test_root.join("alias"))
+        .expect("absolute path");
+    let canonical_root = AbsolutePathBuf::from_absolute_path_checked(test_root.join("canonical"))
+        .expect("absolute path");
+
+    let outcome = load_skills_from_roots([SkillRoot {
+        path: alias_root.clone(),
+        scope: SkillScope::User,
+        file_system: Arc::new(SyntheticFileSystem {
+            alias_root,
+            canonical_root,
+            entry_is_symlink: None,
+        }),
+        plugin_id: None,
+        plugin_root: None,
+    }])
+    .await;
+
+    assert_eq!(outcome.errors, Vec::new());
+    assert_eq!(
+        outcome
+            .skills
+            .iter()
+            .map(|skill| skill.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["synthetic"]
     );
 }
 

--- a/codex-rs/ext/skills/tests/executor_file_system_authority.rs
+++ b/codex-rs/ext/skills/tests/executor_file_system_authority.rs
@@ -60,12 +60,14 @@ impl SyntheticFileSystem {
                 file_name: "skill".to_string(),
                 is_directory: true,
                 is_file: false,
+                is_symlink: false,
             }])
         } else if path == self.canonical_root.join("skill") {
             Ok(vec![ReadDirectoryEntry {
                 file_name: "SKILL.md".to_string(),
                 is_directory: false,
                 is_file: true,
+                is_symlink: false,
             }])
         } else {
             Err(io::Error::new(io::ErrorKind::NotFound, "not found"))
@@ -146,7 +148,17 @@ impl ExecutorFileSystem for SyntheticFileSystem {
         path: &'a PathUri,
         _sandbox: Option<&'a FileSystemSandboxContext>,
     ) -> ExecutorFileSystemFuture<'a, FileMetadata> {
-        Box::pin(async move { self.metadata(&path.to_abs_path()?) })
+        Box::pin(async move {
+            let path = path.to_abs_path()?;
+            if path == self.canonical_root {
+                self.metadata(&path)
+            } else {
+                Err(io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "synthetic filesystem exposes child entry types through read_directory",
+                ))
+            }
+        })
     }
 
     fn read_directory<'a>(

--- a/codex-rs/file-system/src/lib.rs
+++ b/codex-rs/file-system/src/lib.rs
@@ -54,6 +54,7 @@ pub struct ReadDirectoryEntry {
     pub file_name: String,
     pub is_directory: bool,
     pub is_file: bool,
+    pub is_symlink: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]

--- a/codex-rs/file-system/src/lib.rs
+++ b/codex-rs/file-system/src/lib.rs
@@ -54,7 +54,8 @@ pub struct ReadDirectoryEntry {
     pub file_name: String,
     pub is_directory: bool,
     pub is_file: bool,
-    pub is_symlink: bool,
+    /// `None` when the backing filesystem cannot report symlink identity.
+    pub is_symlink: Option<bool>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]


### PR DESCRIPTION
## Why

Skill discovery already receives file and directory kinds from `read_directory`, but it performs a separate metadata request for every entry. Those extra round trips are especially expensive through a remote exec server.

## What changed

- return resolved file/directory kind plus optional symlink identity from executor `read_directory` entries
- obtain ordinary entry kinds from `DirEntry::file_type`, following metadata only for symlinks
- propagate the field across local, sandboxed, and remote executor filesystem transports
- fall back to `get_metadata` when an older exec server omits symlink identity, preserving legacy traversal behavior
- remove redundant per-entry metadata calls and symlink directory probes from the current protocol path

This PR is independent of the plugin-skill loader stack.

## Validation

- `just test -p codex-skills-extension skill_loading_falls_back_for_legacy_directory_entries`
- `just test -p codex-exec-server read_directory_entry_preserves_unknown_legacy_symlink_state`
- `just test -p codex-exec-server file_system_read_directory_reports_symlink_target_kind` (local and remote)
- Bazel Clippy across the affected file-system, exec-server, core-skills, and skills-extension library/test targets
