### PR TITLE
thread-store: fix response fixture compilation

### DIFF
--- a/codex-rs/thread-store/src/local/mod.rs
+++ b/codex-rs/thread-store/src/local/mod.rs
@@ -512,6 +512,7 @@ mod tests {
                 RolloutItem::ResponseItem(ResponseItem::FunctionCallOutput {
                     call_id: "call-1".to_string(),
                     output: FunctionCallOutputPayload::from_text("tool output".to_string()),
+                    metadata: None,
                 }),
                 RolloutItem::EventMsg(EventMsg::TokenCount(
                     codex_protocol::protocol::TokenCountEvent {


### PR DESCRIPTION
## Why

A `codex-thread-store` test fixture still constructs `ResponseItem::FunctionCallOutput` without its required `metadata` field, preventing the crate's test targets from compiling on `main`.

## What changed

- Set the fixture's response-item metadata to `None`.

## Testing

- `cargo check -p codex-thread-store --tests`
