### PR TITLE
[codex] parallelize Codex Apps file uploads

### DIFF
--- a/codex-rs/config/src/config_toml.rs
+++ b/codex-rs/config/src/config_toml.rs
@@ -360,6 +360,11 @@ pub struct ConfigToml {
     /// Optional product SKU forwarded on host-owned Codex Apps MCP requests.
     pub apps_mcp_product_sku: Option<String>,
 
+    /// Maximum number of Codex Apps file bridge uploads that may run concurrently for one
+    /// array-valued tool argument.
+    #[schemars(range(min = 1))]
+    pub apps_file_upload_concurrency: Option<usize>,
+
     /// Base URL override for the built-in `openai` model provider.
     pub openai_base_url: Option<String>,
 

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -4432,6 +4432,12 @@
       "default": null,
       "description": "Settings for app-specific controls."
     },
+    "apps_file_upload_concurrency": {
+      "description": "Maximum number of Codex Apps file bridge uploads that may run concurrently for one array-valued tool argument.",
+      "format": "uint",
+      "minimum": 1.0,
+      "type": "integer"
+    },
     "apps_mcp_product_sku": {
       "description": "Optional product SKU forwarded on host-owned Codex Apps MCP requests.",
       "type": "string"

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -8953,6 +8953,52 @@ apps_mcp_product_sku = "tpp"
 }
 
 #[tokio::test]
+async fn config_loads_apps_file_upload_concurrency_from_toml() -> std::io::Result<()> {
+    let codex_home = TempDir::new()?;
+    let toml = r#"
+model = "gpt-5.4"
+apps_file_upload_concurrency = 7
+"#;
+    let cfg: ConfigToml = toml::from_str(toml)
+        .expect("TOML deserialization should succeed for apps file upload concurrency");
+
+    let config = Config::load_from_base_config_with_overrides(
+        cfg,
+        ConfigOverrides::default(),
+        codex_home.abs(),
+    )
+    .await?;
+
+    assert_eq!(config.apps_file_upload_concurrency, 7);
+    Ok(())
+}
+
+#[tokio::test]
+async fn config_rejects_zero_apps_file_upload_concurrency() -> std::io::Result<()> {
+    let codex_home = TempDir::new()?;
+    let toml = r#"
+model = "gpt-5.4"
+apps_file_upload_concurrency = 0
+"#;
+    let cfg: ConfigToml = toml::from_str(toml)
+        .expect("TOML deserialization should succeed for apps file upload concurrency");
+
+    let error = Config::load_from_base_config_with_overrides(
+        cfg,
+        ConfigOverrides::default(),
+        codex_home.abs(),
+    )
+    .await
+    .expect_err("zero apps file upload concurrency should be rejected");
+
+    assert_eq!(
+        error.to_string(),
+        "apps_file_upload_concurrency must be at least 1"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn config_loads_mcp_oauth_callback_url_from_toml() -> std::io::Result<()> {
     let codex_home = TempDir::new()?;
     let toml = r#"

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -194,6 +194,7 @@ impl Default for GhostSnapshotConfig {
 pub(crate) const AGENTS_MD_MAX_BYTES: usize = DEFAULT_PROJECT_DOC_MAX_BYTES; // 32 KiB
 pub(crate) const DEFAULT_AGENT_MAX_THREADS: Option<usize> = Some(6);
 pub(crate) const DEFAULT_MULTI_AGENT_V2_MAX_CONCURRENT_THREADS_PER_SESSION: usize = 4;
+pub(crate) const DEFAULT_APPS_FILE_UPLOAD_CONCURRENCY: usize = 4;
 pub(crate) const DEFAULT_MULTI_AGENT_V2_MIN_WAIT_TIMEOUT_MS: i64 = 10_000;
 pub(crate) const DEFAULT_MULTI_AGENT_V2_MAX_WAIT_TIMEOUT_MS: i64 = 3600 * 1000;
 pub(crate) const DEFAULT_MULTI_AGENT_V2_DEFAULT_WAIT_TIMEOUT_MS: i64 = 30_000;
@@ -952,6 +953,10 @@ pub struct Config {
 
     /// Optional product SKU forwarded to the host-owned apps MCP server.
     pub apps_mcp_product_sku: Option<String>,
+
+    /// Maximum number of Codex Apps file bridge uploads that may run concurrently for one
+    /// array-valued tool argument.
+    pub apps_file_upload_concurrency: usize,
 
     /// Machine-local realtime audio device preferences used by realtime voice.
     pub realtime_audio: RealtimeAudioConfig,
@@ -3182,6 +3187,12 @@ impl Config {
                 "features.multi_agent_v2.max_concurrent_threads_per_session must be at least 1",
             ));
         }
+        if cfg.apps_file_upload_concurrency == Some(0) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "apps_file_upload_concurrency must be at least 1",
+            ));
+        }
         validate_multi_agent_v2_wait_timeout(
             "features.multi_agent_v2.min_wait_timeout_ms",
             multi_agent_v2.min_wait_timeout_ms,
@@ -3644,6 +3655,9 @@ impl Config {
                 .unwrap_or("https://chatgpt.com/backend-api/".to_string()),
             respect_system_proxy,
             apps_mcp_product_sku: cfg.apps_mcp_product_sku.clone(),
+            apps_file_upload_concurrency: cfg
+                .apps_file_upload_concurrency
+                .unwrap_or(DEFAULT_APPS_FILE_UPLOAD_CONCURRENCY),
             realtime_audio: cfg
                 .audio
                 .map_or_else(RealtimeAudioConfig::default, |audio| RealtimeAudioConfig {

--- a/codex-rs/core/src/mcp_openai_file.rs
+++ b/codex-rs/core/src/mcp_openai_file.rs
@@ -17,6 +17,9 @@ use codex_api::OPENAI_FILE_UPLOAD_LIMIT_BYTES;
 use codex_api::upload_openai_file;
 use codex_login::CodexAuth;
 use codex_utils_path_uri::PathUri;
+use futures::StreamExt;
+use futures::TryStreamExt;
+use futures::stream;
 use serde_json::Value as JsonValue;
 
 pub(crate) async fn rewrite_mcp_tool_arguments_for_openai_files(
@@ -77,22 +80,38 @@ async fn rewrite_argument_value_for_openai_files(
             Ok(Some(rewritten))
         }
         JsonValue::Array(values) => {
-            let mut rewritten_values = Vec::with_capacity(values.len());
-            for (index, item) in values.iter().enumerate() {
-                let Some(file_path) = item.as_str() else {
-                    return Ok(None);
-                };
-                let rewritten = build_uploaded_argument_value(
-                    turn_context,
-                    auth,
-                    field_name,
-                    Some(index),
-                    file_path,
-                )
+            let Some(upload_futures) = values
+                .iter()
+                .enumerate()
+                .map(|(index, item)| {
+                    let file_path = item.as_str()?;
+                    Some(async move {
+                        build_uploaded_argument_value(
+                            turn_context,
+                            auth,
+                            field_name,
+                            Some(index),
+                            file_path,
+                        )
+                        .await
+                        .map(|rewritten| (index, rewritten))
+                    })
+                })
+                .collect::<Option<Vec<_>>>()
+            else {
+                return Ok(None);
+            };
+            let mut rewritten_values = stream::iter(upload_futures)
+                .buffer_unordered(turn_context.config.apps_file_upload_concurrency)
+                .try_collect::<Vec<_>>()
                 .await?;
-                rewritten_values.push(rewritten);
-            }
-            Ok(Some(JsonValue::Array(rewritten_values)))
+            rewritten_values.sort_unstable_by_key(|(index, _)| *index);
+            Ok(Some(JsonValue::Array(
+                rewritten_values
+                    .into_iter()
+                    .map(|(_, rewritten)| rewritten)
+                    .collect(),
+            )))
         }
         _ => Ok(None),
     }
@@ -531,6 +550,120 @@ mod tests {
                     "file_size_bytes": 3,
                 }
             ]))
+        );
+    }
+
+    #[tokio::test]
+    async fn rewrite_argument_value_for_openai_files_uploads_arrays_in_parallel() {
+        use std::time::Duration;
+        use std::time::Instant;
+        use wiremock::Mock;
+        use wiremock::MockServer;
+        use wiremock::ResponseTemplate;
+        use wiremock::matchers::body_json;
+        use wiremock::matchers::header;
+        use wiremock::matchers::method;
+        use wiremock::matchers::path;
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/backend-api/files"))
+            .and(header("chatgpt-account-id", "account_id"))
+            .and(body_json(serde_json::json!({
+                "file_name": "one.csv",
+                "file_size": 3,
+                "use_case": "codex",
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "file_id": "file_1",
+                "upload_url": format!("{}/upload/file_1", server.uri()),
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/backend-api/files"))
+            .and(header("chatgpt-account-id", "account_id"))
+            .and(body_json(serde_json::json!({
+                "file_name": "two.csv",
+                "file_size": 3,
+                "use_case": "codex",
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "file_id": "file_2",
+                "upload_url": format!("{}/upload/file_2", server.uri()),
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let upload_delay = Duration::from_millis(200);
+        Mock::given(method("PUT"))
+            .and(path("/upload/file_1"))
+            .respond_with(ResponseTemplate::new(200).set_delay(upload_delay))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path("/upload/file_2"))
+            .respond_with(ResponseTemplate::new(200).set_delay(upload_delay))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/backend-api/files/file_1/uploaded"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "status": "success",
+                "download_url": format!("{}/download/file_1", server.uri()),
+                "file_name": "one.csv",
+                "mime_type": "text/csv",
+                "file_size_bytes": 3,
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/backend-api/files/file_2/uploaded"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "status": "success",
+                "download_url": format!("{}/download/file_2", server.uri()),
+                "file_name": "two.csv",
+                "mime_type": "text/csv",
+                "file_size_bytes": 3,
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (_, mut turn_context) = make_session_and_context().await;
+        let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
+        let dir = tempdir().expect("temp dir");
+        tokio::fs::write(dir.path().join("one.csv"), b"one")
+            .await
+            .expect("write first local file");
+        tokio::fs::write(dir.path().join("two.csv"), b"two")
+            .await
+            .expect("write second local file");
+        set_primary_environment_cwd(&mut turn_context, dir.path());
+
+        let mut config = (*turn_context.config).clone();
+        config.chatgpt_base_url = format!("{}/backend-api", server.uri());
+        config.apps_file_upload_concurrency = 2;
+        turn_context.config = Arc::new(config);
+
+        let started = Instant::now();
+        rewrite_argument_value_for_openai_files(
+            &turn_context,
+            Some(&auth),
+            "files",
+            &serde_json::json!(["one.csv", "two.csv"]),
+        )
+        .await
+        .expect("rewrite should succeed");
+
+        assert!(
+            started.elapsed() < Duration::from_millis(350),
+            "expected array uploads to overlap, elapsed {:?}",
+            started.elapsed()
         );
     }
 


### PR DESCRIPTION
## Why
Array-valued `openai/fileParams` bridge uploads currently serialize each file, making multi-file Codex Apps calls wait on independent uploads one by one.

## What
- Upload array-valued Codex Apps file bridge arguments with bounded concurrency while preserving array order.
- Add `apps_file_upload_concurrency` config, default `4`, validated at `>= 1`.
- Add config coverage and a focused upload overlap test.

## Testing
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/lt/.cache/codex-target-cf1853 cargo check -p codex-core --tests`
- Attempted focused `cargo test -p codex-core rewrite_argument_value_for_openai_files_uploads_arrays_in_parallel -- --nocapture`, but local disk pressure prevented completing the linked unit-test build.