### PR TITLE
[codex] allow parallel library create tool calls

### DIFF
--- a/codex-rs/codex-mcp/src/connection_manager.rs
+++ b/codex-rs/codex-mcp/src/connection_manager.rs
@@ -75,6 +75,7 @@ use tracing::trace;
 use tracing::trace_span;
 use tracing::warn;
 
+const CODEX_APPS_PARALLEL_TOOL_ALLOWLIST: &[&str] = &["library_create_library_file"];
 const MCP_UI_META_KEY: &str = "ui";
 const MCP_UI_VISIBILITY_META_KEY: &str = "visibility";
 const MCP_UI_MODEL_VISIBILITY: &str = "model";
@@ -797,12 +798,13 @@ impl McpConnectionManager {
 
     fn with_server_metadata(&self, mut tool: ToolInfo) -> ToolInfo {
         let Some(metadata) = self.server_metadata.get(&tool.server_name) else {
-            tool.supports_parallel_tool_calls = false;
+            tool.supports_parallel_tool_calls = codex_apps_tool_supports_parallel_tool_calls(&tool);
             tool.server_origin = None;
             return tool;
         };
 
-        tool.supports_parallel_tool_calls = metadata.supports_parallel_tool_calls;
+        tool.supports_parallel_tool_calls = metadata.supports_parallel_tool_calls
+            || codex_apps_tool_supports_parallel_tool_calls(&tool);
         tool.server_origin = metadata
             .origin
             .as_ref()
@@ -831,6 +833,11 @@ impl McpConnectionManager {
             prefix_mcp_tool_names,
         )
     }
+}
+
+fn codex_apps_tool_supports_parallel_tool_calls(tool: &ToolInfo) -> bool {
+    tool.server_name == CODEX_APPS_MCP_SERVER_NAME
+        && CODEX_APPS_PARALLEL_TOOL_ALLOWLIST.contains(&tool.tool.name.as_ref())
 }
 
 impl Drop for McpConnectionManager {

--- a/codex-rs/codex-mcp/src/connection_manager_tests.rs
+++ b/codex-rs/codex-mcp/src/connection_manager_tests.rs
@@ -1157,6 +1157,31 @@ async fn list_all_tools_adds_server_metadata_to_cached_tools() {
 }
 
 #[test]
+fn codex_apps_parallel_tool_allowlist_uses_raw_tool_name() {
+    let approval_policy = Constrained::allow_any(AskForApproval::OnFailure);
+    let permission_profile = Constrained::allow_any(PermissionProfile::default());
+    let manager = McpConnectionManager::new_uninitialized(
+        &approval_policy,
+        &permission_profile,
+        /*prefix_mcp_tool_names*/ true,
+    );
+
+    let allowlisted_tool = manager.with_server_metadata(create_test_tool(
+        CODEX_APPS_MCP_SERVER_NAME,
+        "library_create_library_file",
+    ));
+    assert!(allowlisted_tool.supports_parallel_tool_calls);
+
+    let other_codex_apps_tool =
+        manager.with_server_metadata(create_test_tool(CODEX_APPS_MCP_SERVER_NAME, "search"));
+    assert!(!other_codex_apps_tool.supports_parallel_tool_calls);
+
+    let same_named_other_server_tool =
+        manager.with_server_metadata(create_test_tool("other", "library_create_library_file"));
+    assert!(!same_named_other_server_tool.supports_parallel_tool_calls);
+}
+
+#[test]
 fn server_metadata_preserves_tool_approval_policy() {
     let mut config = crate::codex_apps_mcp_server_config(
         "https://docs.example",


### PR DESCRIPTION
## Why
`codex_apps` stays server-serial today, but `library_create_library_file` is safe to overlap and is the concrete Codex Apps write tool blocking parallel library file creation.

## What
- Add a raw MCP tool allowlist for `codex_apps` `library_create_library_file`.
- Preserve the server-level `supports_parallel_tool_calls: false` default for all other Codex Apps tools.
- Cover the allowlist with a focused connection-manager test.

## Testing
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/lt/.cache/codex-target-cf1853 cargo test -p codex-mcp codex_apps_parallel_tool_allowlist_uses_raw_tool_name -- --nocapture`