### PR TITLE
Require approval for generic Git commands

### DIFF
--- a/codex-rs/core/src/exec_policy.rs
+++ b/codex-rs/core/src/exec_policy.rs
@@ -337,15 +337,17 @@ impl ExecPolicyManager {
                     },
                     None => ExecApprovalRequirement::NeedsApproval {
                         reason: derive_prompt_reason(command, &evaluation),
-                        proposed_execpolicy_amendment: requested_amendment.or_else(|| {
-                            if auto_amendment_allowed {
-                                try_derive_execpolicy_amendment_for_prompt_rules(
-                                    &evaluation.matched_rules,
-                                )
-                            } else {
-                                None
-                            }
-                        }),
+                        proposed_execpolicy_amendment: suppress_repo_sensitive_git_amendment(
+                            requested_amendment.or_else(|| {
+                                if auto_amendment_allowed {
+                                    try_derive_execpolicy_amendment_for_prompt_rules(
+                                        &evaluation.matched_rules,
+                                    )
+                                } else {
+                                    None
+                                }
+                            }),
+                        ),
                     },
                 }
             }
@@ -364,11 +366,13 @@ impl ExecPolicyManager {
                             is_policy_match(rule_match) && rule_match.decision() == Decision::Allow
                         })
                 }),
-                proposed_execpolicy_amendment: if auto_amendment_allowed {
-                    try_derive_execpolicy_amendment_for_allow_rules(&evaluation.matched_rules)
-                } else {
-                    None
-                },
+                proposed_execpolicy_amendment: suppress_repo_sensitive_git_amendment(
+                    if auto_amendment_allowed {
+                        try_derive_execpolicy_amendment_for_allow_rules(&evaluation.matched_rules)
+                    } else {
+                        None
+                    },
+                ),
             },
         }
     }
@@ -846,6 +850,33 @@ fn try_derive_execpolicy_amendment_for_allow_rules(
             } => Some(ExecPolicyAmendment::from(command.clone())),
             _ => None,
         })
+}
+
+/// Generic Git safety depends on the repository discovered at execution time,
+/// so an approval for one checkout must not become a durable allow rule that
+/// silently applies to another checkout. Explicit user-authored policy rules
+/// still take precedence during evaluation; this only removes amendments that
+/// Codex would otherwise offer to persist from a runtime approval.
+fn suppress_repo_sensitive_git_amendment(
+    amendment: Option<ExecPolicyAmendment>,
+) -> Option<ExecPolicyAmendment> {
+    amendment.filter(|amendment| !starts_with_git_executable(&amendment.command))
+}
+
+fn starts_with_git_executable(command: &[String]) -> bool {
+    let Some(executable_name) = command
+        .first()
+        .and_then(|executable| Path::new(executable).file_name())
+        .and_then(|name| name.to_str())
+    else {
+        return false;
+    };
+    let executable_name = executable_name.to_ascii_lowercase();
+    let executable_name = [".exe", ".cmd", ".bat", ".com"]
+        .into_iter()
+        .find_map(|suffix| executable_name.strip_suffix(suffix))
+        .unwrap_or(&executable_name);
+    executable_name == "git"
 }
 
 fn derive_requested_execpolicy_amendment_from_prefix_rule(

--- a/codex-rs/core/src/exec_policy.rs
+++ b/codex-rs/core/src/exec_policy.rs
@@ -806,6 +806,7 @@ fn commands_for_exec_policy(command: &[String]) -> ExecPolicyCommands {
 /// Zsh-fork uses this to scope a parent approval to the exact intercepted Git
 /// child. Multiple commands, complex parsing, wrappers such as `env`, and
 /// PowerShell-flavored commands deliberately do not qualify.
+#[cfg(any(unix, test))]
 pub(crate) fn single_plain_git_command(command: &[String]) -> Option<Vec<String>> {
     let parsed = commands_for_exec_policy(command);
     if parsed.used_complex_parsing
@@ -884,6 +885,7 @@ fn suppress_non_durable_execpolicy_amendment(
     amendment.filter(|amendment| !starts_with_non_durable_executable(&amendment.command))
 }
 
+#[cfg(any(unix, test))]
 fn starts_with_git_executable(command: &[String]) -> bool {
     starts_with_executable_named(command, "git")
 }
@@ -893,6 +895,7 @@ fn starts_with_non_durable_executable(command: &[String]) -> bool {
         .is_some_and(|name| matches!(name.as_str(), "git" | "env" | "sudo" | "command" | "nice"))
 }
 
+#[cfg(any(unix, test))]
 fn starts_with_executable_named(command: &[String], expected: &str) -> bool {
     normalized_executable_name(command).is_some_and(|name| name == expected)
 }

--- a/codex-rs/core/src/exec_policy.rs
+++ b/codex-rs/core/src/exec_policy.rs
@@ -866,11 +866,15 @@ fn suppress_repo_sensitive_git_amendment(
 fn starts_with_git_executable(command: &[String]) -> bool {
     let Some(executable_name) = command
         .first()
-        .and_then(|executable| Path::new(executable).file_name())
-        .and_then(|name| name.to_str())
+        .and_then(|executable| executable.rsplit(['/', '\\']).next())
     else {
         return false;
     };
+    let executable_name = executable_name
+        .as_bytes()
+        .get(..2)
+        .filter(|prefix| prefix[0].is_ascii_alphabetic() && prefix[1] == b':')
+        .map_or(executable_name, |_| &executable_name[2..]);
     let executable_name = executable_name.to_ascii_lowercase();
     let executable_name = [".exe", ".cmd", ".bat", ".com"]
         .into_iter()

--- a/codex-rs/core/src/exec_policy.rs
+++ b/codex-rs/core/src/exec_policy.rs
@@ -337,7 +337,7 @@ impl ExecPolicyManager {
                     },
                     None => ExecApprovalRequirement::NeedsApproval {
                         reason: derive_prompt_reason(command, &evaluation),
-                        proposed_execpolicy_amendment: suppress_repo_sensitive_git_amendment(
+                        proposed_execpolicy_amendment: suppress_non_durable_execpolicy_amendment(
                             requested_amendment.or_else(|| {
                                 if auto_amendment_allowed {
                                     try_derive_execpolicy_amendment_for_prompt_rules(
@@ -366,7 +366,7 @@ impl ExecPolicyManager {
                             is_policy_match(rule_match) && rule_match.decision() == Decision::Allow
                         })
                 }),
-                proposed_execpolicy_amendment: suppress_repo_sensitive_git_amendment(
+                proposed_execpolicy_amendment: suppress_non_durable_execpolicy_amendment(
                     if auto_amendment_allowed {
                         try_derive_execpolicy_amendment_for_allow_rules(&evaluation.matched_rules)
                     } else {
@@ -800,6 +800,25 @@ fn commands_for_exec_policy(command: &[String]) -> ExecPolicyCommands {
     }
 }
 
+/// Return one plain generic Git command when the request can be lowered
+/// without ambiguity.
+///
+/// Zsh-fork uses this to scope a parent approval to the exact intercepted Git
+/// child. Multiple commands, complex parsing, wrappers such as `env`, and
+/// PowerShell-flavored commands deliberately do not qualify.
+pub(crate) fn single_plain_git_command(command: &[String]) -> Option<Vec<String>> {
+    let parsed = commands_for_exec_policy(command);
+    if parsed.used_complex_parsing
+        || parsed.command_origin != ExecPolicyCommandOrigin::Generic
+        || parsed.commands.len() != 1
+    {
+        return None;
+    }
+
+    let command = parsed.commands.into_iter().next()?;
+    starts_with_git_executable(&command).then_some(command)
+}
+
 /// Derive a proposed execpolicy amendment when a command requires user approval
 /// - If any execpolicy rule prompts, return None, because an amendment would not skip that policy requirement.
 /// - Otherwise return the first heuristics Prompt.
@@ -854,22 +873,32 @@ fn try_derive_execpolicy_amendment_for_allow_rules(
 
 /// Generic Git safety depends on the repository discovered at execution time,
 /// so an approval for one checkout must not become a durable allow rule that
-/// silently applies to another checkout. Explicit user-authored policy rules
-/// still take precedence during evaluation; this only removes amendments that
-/// Codex would otherwise offer to persist from a runtime approval.
-fn suppress_repo_sensitive_git_amendment(
+/// silently applies to another checkout. Generic command delegators are also
+/// context-sensitive and can hide Git or another executable behind the same
+/// persisted prefix. Explicit user-authored policy rules still take precedence
+/// during evaluation; this only removes amendments that Codex would otherwise
+/// offer to persist from a runtime approval.
+fn suppress_non_durable_execpolicy_amendment(
     amendment: Option<ExecPolicyAmendment>,
 ) -> Option<ExecPolicyAmendment> {
-    amendment.filter(|amendment| !starts_with_git_executable(&amendment.command))
+    amendment.filter(|amendment| !starts_with_non_durable_executable(&amendment.command))
 }
 
 fn starts_with_git_executable(command: &[String]) -> bool {
-    let Some(executable_name) = command
-        .first()
-        .and_then(|executable| executable.rsplit(['/', '\\']).next())
-    else {
-        return false;
-    };
+    starts_with_executable_named(command, "git")
+}
+
+fn starts_with_non_durable_executable(command: &[String]) -> bool {
+    normalized_executable_name(command)
+        .is_some_and(|name| matches!(name.as_str(), "git" | "env" | "sudo" | "command" | "nice"))
+}
+
+fn starts_with_executable_named(command: &[String], expected: &str) -> bool {
+    normalized_executable_name(command).is_some_and(|name| name == expected)
+}
+
+fn normalized_executable_name(command: &[String]) -> Option<String> {
+    let executable_name = command.first()?.rsplit(['/', '\\']).next()?;
     let executable_name = executable_name
         .as_bytes()
         .get(..2)
@@ -880,7 +909,7 @@ fn starts_with_git_executable(command: &[String]) -> bool {
         .into_iter()
         .find_map(|suffix| executable_name.strip_suffix(suffix))
         .unwrap_or(&executable_name);
-    executable_name == "git"
+    Some(executable_name.to_string())
 }
 
 fn derive_requested_execpolicy_amendment_from_prefix_rule(

--- a/codex-rs/core/src/exec_policy_tests.rs
+++ b/codex-rs/core/src/exec_policy_tests.rs
@@ -1179,6 +1179,27 @@ fn git_branch_requires_approval_for_untrusted_projects() {
 }
 
 #[test]
+fn path_qualified_safe_basename_requires_approval_for_untrusted_projects() {
+    let executable = if cfg!(windows) { r".\cat.exe" } else { "./cat" };
+    let command = vec![executable.to_string(), "Cargo.toml".to_string()];
+
+    assert_eq!(
+        Decision::Prompt,
+        render_decision_for_unmatched_command(
+            &command,
+            UnmatchedCommandContext {
+                approval_policy: AskForApproval::UnlessTrusted,
+                permission_profile: &PermissionProfile::workspace_write(),
+                windows_sandbox_level: WindowsSandboxLevel::Disabled,
+                sandbox_permissions: SandboxPermissions::UseDefault,
+                used_complex_parsing: false,
+                command_origin: ExecPolicyCommandOrigin::Generic,
+            },
+        )
+    );
+}
+
+#[test]
 fn managed_cwd_write_profile_has_filesystem_restrictions() {
     let file_system_sandbox_policy = FileSystemSandboxPolicy::restricted(vec![
         FileSystemSandboxEntry {

--- a/codex-rs/core/src/exec_policy_tests.rs
+++ b/codex-rs/core/src/exec_policy_tests.rs
@@ -1017,8 +1017,8 @@ prefix_rule(pattern=["git"], decision="prompt")
             sandbox_permissions: SandboxPermissions::UseDefault,
             prefix_rule: None,
         },
-        ExecApprovalRequirement::Skip {
-            bypass_sandbox: false,
+        ExecApprovalRequirement::NeedsApproval {
+            reason: None,
             proposed_execpolicy_amendment: Some(ExecPolicyAmendment::new(vec![
                 disallowed_git_path,
                 "status".to_string(),
@@ -1131,6 +1131,46 @@ fn known_safe_on_request_still_prompts_for_restricted_sandbox_escalation() {
                 permission_profile: &PermissionProfile::workspace_write(),
                 windows_sandbox_level: WindowsSandboxLevel::RestrictedToken,
                 sandbox_permissions: SandboxPermissions::RequireEscalated,
+                used_complex_parsing: false,
+                command_origin: ExecPolicyCommandOrigin::Generic,
+            },
+        )
+    );
+}
+
+#[test]
+fn git_status_requires_approval_for_untrusted_projects() {
+    let command = vec!["git".to_string(), "status".to_string()];
+
+    assert_eq!(
+        Decision::Prompt,
+        render_decision_for_unmatched_command(
+            &command,
+            UnmatchedCommandContext {
+                approval_policy: AskForApproval::UnlessTrusted,
+                permission_profile: &PermissionProfile::workspace_write(),
+                windows_sandbox_level: WindowsSandboxLevel::Disabled,
+                sandbox_permissions: SandboxPermissions::UseDefault,
+                used_complex_parsing: false,
+                command_origin: ExecPolicyCommandOrigin::Generic,
+            },
+        )
+    );
+}
+
+#[test]
+fn git_branch_requires_approval_for_untrusted_projects() {
+    let command = vec!["git".to_string(), "branch".to_string()];
+
+    assert_eq!(
+        Decision::Prompt,
+        render_decision_for_unmatched_command(
+            &command,
+            UnmatchedCommandContext {
+                approval_policy: AskForApproval::UnlessTrusted,
+                permission_profile: &PermissionProfile::workspace_write(),
+                windows_sandbox_level: WindowsSandboxLevel::Disabled,
+                sandbox_permissions: SandboxPermissions::UseDefault,
                 used_complex_parsing: false,
                 command_origin: ExecPolicyCommandOrigin::Generic,
             },

--- a/codex-rs/core/src/exec_policy_tests.rs
+++ b/codex-rs/core/src/exec_policy_tests.rs
@@ -1019,10 +1019,7 @@ prefix_rule(pattern=["git"], decision="prompt")
         },
         ExecApprovalRequirement::NeedsApproval {
             reason: None,
-            proposed_execpolicy_amendment: Some(ExecPolicyAmendment::new(vec![
-                disallowed_git_path,
-                "status".to_string(),
-            ])),
+            proposed_execpolicy_amendment: None,
         },
     )
     .await;
@@ -1197,6 +1194,180 @@ fn path_qualified_safe_basename_requires_approval_for_untrusted_projects() {
             },
         )
     );
+}
+
+#[tokio::test]
+async fn generic_git_policy_matrix_preserves_sandbox_and_escalation_semantics() {
+    let command = vec!["git".to_string(), "status".to_string()];
+
+    for approval_policy in [
+        AskForApproval::OnRequest,
+        AskForApproval::Granular(GranularApprovalConfig {
+            sandbox_approval: true,
+            rules: true,
+            skill_approval: true,
+            request_permissions: true,
+            mcp_elicitations: true,
+        }),
+    ] {
+        assert_exec_approval_requirement_for_command(
+            ExecApprovalRequirementScenario {
+                policy_src: None,
+                command: command.clone(),
+                approval_policy,
+                permission_profile: PermissionProfile::workspace_write(),
+                sandbox_permissions: SandboxPermissions::UseDefault,
+                prefix_rule: None,
+            },
+            ExecApprovalRequirement::Skip {
+                bypass_sandbox: false,
+                proposed_execpolicy_amendment: None,
+            },
+        )
+        .await;
+
+        assert_exec_approval_requirement_for_command(
+            ExecApprovalRequirementScenario {
+                policy_src: None,
+                command: command.clone(),
+                approval_policy,
+                permission_profile: PermissionProfile::workspace_write(),
+                sandbox_permissions: SandboxPermissions::RequireEscalated,
+                prefix_rule: None,
+            },
+            ExecApprovalRequirement::NeedsApproval {
+                reason: None,
+                proposed_execpolicy_amendment: None,
+            },
+        )
+        .await;
+    }
+
+    assert_exec_approval_requirement_for_command(
+        ExecApprovalRequirementScenario {
+            policy_src: None,
+            command,
+            approval_policy: AskForApproval::UnlessTrusted,
+            permission_profile: PermissionProfile::workspace_write(),
+            sandbox_permissions: SandboxPermissions::UseDefault,
+            prefix_rule: None,
+        },
+        ExecApprovalRequirement::NeedsApproval {
+            reason: None,
+            proposed_execpolicy_amendment: None,
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn generic_git_one_shot_approval_does_not_create_cross_repo_cache() {
+    let manager = ExecPolicyManager::default();
+    let command = vec!["git".to_string(), "status".to_string()];
+
+    // A one-shot approval does not mutate the policy manager. Because Codex no
+    // longer offers a durable amendment for repository-sensitive Git, the same
+    // argv in a second checkout must prompt again.
+    for checkout in ["first checkout", "second checkout"] {
+        let requirement = manager
+            .create_exec_approval_requirement_for_command(ExecApprovalRequest {
+                command: &command,
+                approval_policy: AskForApproval::UnlessTrusted,
+                permission_profile: PermissionProfile::workspace_write(),
+                windows_sandbox_level: WindowsSandboxLevel::RestrictedToken,
+                sandbox_permissions: SandboxPermissions::UseDefault,
+                prefix_rule: None,
+            })
+            .await;
+
+        assert_eq!(
+            requirement,
+            ExecApprovalRequirement::NeedsApproval {
+                reason: None,
+                proposed_execpolicy_amendment: None,
+            },
+            "{checkout} must require its own approval",
+        );
+    }
+}
+
+#[tokio::test]
+async fn generic_git_never_offers_requested_or_shell_lowered_durable_amendments() {
+    for (command, prefix_rule) in [
+        (
+            vec!["git".to_string(), "status".to_string()],
+            Some(vec!["git".to_string(), "status".to_string()]),
+        ),
+        (
+            vec![
+                "bash".to_string(),
+                "-lc".to_string(),
+                "git status".to_string(),
+            ],
+            None,
+        ),
+        (
+            vec![
+                if cfg!(windows) {
+                    r"C:\Program Files\Git\cmd\git.exe".to_string()
+                } else {
+                    "/usr/bin/git".to_string()
+                },
+                "status".to_string(),
+            ],
+            None,
+        ),
+    ] {
+        assert_exec_approval_requirement_for_command(
+            ExecApprovalRequirementScenario {
+                policy_src: None,
+                command,
+                approval_policy: AskForApproval::UnlessTrusted,
+                permission_profile: PermissionProfile::workspace_write(),
+                sandbox_permissions: SandboxPermissions::UseDefault,
+                prefix_rule,
+            },
+            ExecApprovalRequirement::NeedsApproval {
+                reason: None,
+                proposed_execpolicy_amendment: None,
+            },
+        )
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn explicit_user_authored_git_policy_rule_still_allows_matching_commands() {
+    for command in [
+        vec![
+            "git".to_string(),
+            "status".to_string(),
+            "--short".to_string(),
+        ],
+        vec![
+            "bash".to_string(),
+            "-lc".to_string(),
+            "git status --short".to_string(),
+        ],
+    ] {
+        assert_exec_approval_requirement_for_command(
+            ExecApprovalRequirementScenario {
+                policy_src: Some(
+                    r#"prefix_rule(pattern=["git", "status"], decision="allow")"#.to_string(),
+                ),
+                command,
+                approval_policy: AskForApproval::UnlessTrusted,
+                permission_profile: PermissionProfile::workspace_write(),
+                sandbox_permissions: SandboxPermissions::UseDefault,
+                prefix_rule: None,
+            },
+            ExecApprovalRequirement::Skip {
+                bypass_sandbox: true,
+                proposed_execpolicy_amendment: None,
+            },
+        )
+        .await;
+    }
 }
 
 #[test]

--- a/codex-rs/core/src/exec_policy_tests.rs
+++ b/codex-rs/core/src/exec_policy_tests.rs
@@ -1231,6 +1231,54 @@ fn git_executable_detection_is_platform_independent() {
     }
 }
 
+#[test]
+fn non_durable_wrapper_detection_is_platform_independent() {
+    for executable in [
+        "env",
+        "/usr/bin/env",
+        r"C:\Windows\System32\ENV.EXE",
+        r"C:env.cmd",
+        "/usr/bin/sudo",
+        r"C:\tools\COMMAND.BAT",
+        "/usr/bin/nice",
+    ] {
+        assert!(
+            starts_with_non_durable_executable(&[executable.to_string()]),
+            "expected {executable:?} to be non-durable"
+        );
+    }
+
+    for executable in [
+        "envy",
+        "/tmp/env.exe.old",
+        "/usr/bin/env/",
+        r"C:notenv.exe",
+        "commander",
+        "nicety",
+    ] {
+        assert!(
+            !starts_with_non_durable_executable(&[executable.to_string()]),
+            "expected {executable:?} to remain eligible for normal amendment handling"
+        );
+    }
+}
+
+#[test]
+fn single_plain_git_command_rejects_wrappers_and_multiple_commands() {
+    assert_eq!(
+        single_plain_git_command(&vec_str(&["/bin/zsh", "-lc", "git status --short"])),
+        Some(vec_str(&["git", "status", "--short"]))
+    );
+    assert_eq!(
+        single_plain_git_command(&vec_str(&["/bin/zsh", "-lc", "env git status"])),
+        None
+    );
+    assert_eq!(
+        single_plain_git_command(&vec_str(&["/bin/zsh", "-lc", "git status && git diff",])),
+        None
+    );
+}
+
 #[tokio::test]
 async fn generic_git_policy_matrix_preserves_sandbox_and_escalation_semantics() {
     let command = vec!["git".to_string(), "status".to_string()];
@@ -1327,28 +1375,42 @@ async fn generic_git_one_shot_approval_does_not_create_cross_repo_cache() {
 }
 
 #[tokio::test]
-async fn generic_git_never_offers_requested_or_shell_lowered_durable_amendments() {
+async fn non_durable_commands_never_offer_generated_durable_amendments() {
     for (command, prefix_rule) in [
         (
-            vec!["git".to_string(), "status".to_string()],
-            Some(vec!["git".to_string(), "status".to_string()]),
+            vec_str(&["git", "status"]),
+            Some(vec_str(&["git", "status"])),
         ),
+        (vec_str(&["bash", "-lc", "git status"]), None),
+        (vec_str(&["/usr/bin/git", "status"]), None),
         (
-            vec![
-                "bash".to_string(),
-                "-lc".to_string(),
-                "git status".to_string(),
-            ],
+            vec_str(&[r"C:\Program Files\Git\cmd\GIT.EXE", "status"]),
             None,
         ),
-        (vec!["/usr/bin/git".to_string(), "status".to_string()], None),
+        (vec_str(&["env", "git", "status"]), None),
+        (vec_str(&["/usr/bin/env", "-i", "git", "status"]), None),
+        (vec_str(&["env", "--", "git", "status"]), None),
         (
-            vec![
-                r"C:\Program Files\Git\cmd\GIT.EXE".to_string(),
-                "status".to_string(),
-            ],
+            vec_str(&["env", "-u", "GIT_CONFIG_SYSTEM", "git", "status"]),
             None,
         ),
+        (
+            vec_str(&["env", "GIT_OPTIONAL_LOCKS=0", "git", "status"]),
+            Some(vec_str(&["env", "GIT_OPTIONAL_LOCKS=0"])),
+        ),
+        (vec_str(&["env", "-S", "git status"]), None),
+        (vec_str(&["env", "FOO=1", "cargo", "check"]), None),
+        (
+            vec_str(&[
+                r"C:\Windows\System32\ENV.EXE",
+                r"C:\Program Files\Git\cmd\git.exe",
+                "status",
+            ]),
+            None,
+        ),
+        (vec_str(&["sudo", "git", "status"]), None),
+        (vec_str(&["command", "git", "status"]), None),
+        (vec_str(&["nice", "git", "status"]), None),
     ] {
         assert_exec_approval_requirement_for_command(
             ExecApprovalRequirementScenario {
@@ -1366,6 +1428,60 @@ async fn generic_git_never_offers_requested_or_shell_lowered_durable_amendments(
         )
         .await;
     }
+}
+
+#[tokio::test]
+async fn env_wrappers_suppress_sandbox_fallback_amendments() {
+    for (sandbox_permissions, expected) in [
+        (
+            SandboxPermissions::UseDefault,
+            ExecApprovalRequirement::Skip {
+                bypass_sandbox: false,
+                proposed_execpolicy_amendment: None,
+            },
+        ),
+        (
+            SandboxPermissions::RequireEscalated,
+            ExecApprovalRequirement::NeedsApproval {
+                reason: None,
+                proposed_execpolicy_amendment: None,
+            },
+        ),
+    ] {
+        assert_exec_approval_requirement_for_command(
+            ExecApprovalRequirementScenario {
+                policy_src: None,
+                command: vec_str(&["/usr/bin/env", "GIT_OPTIONAL_LOCKS=0", "git", "status"]),
+                approval_policy: AskForApproval::OnRequest,
+                permission_profile: PermissionProfile::workspace_write(),
+                sandbox_permissions,
+                prefix_rule: None,
+            },
+            expected,
+        )
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn explicit_user_authored_env_git_rule_still_allows_matching_commands() {
+    assert_exec_approval_requirement_for_command(
+        ExecApprovalRequirementScenario {
+            policy_src: Some(
+                r#"prefix_rule(pattern=["env", "git", "status"], decision="allow")"#.to_string(),
+            ),
+            command: vec_str(&["env", "git", "status"]),
+            approval_policy: AskForApproval::UnlessTrusted,
+            permission_profile: PermissionProfile::workspace_write(),
+            sandbox_permissions: SandboxPermissions::UseDefault,
+            prefix_rule: None,
+        },
+        ExecApprovalRequirement::Skip {
+            bypass_sandbox: true,
+            proposed_execpolicy_amendment: None,
+        },
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/exec_policy_tests.rs
+++ b/codex-rs/core/src/exec_policy_tests.rs
@@ -1196,6 +1196,41 @@ fn path_qualified_safe_basename_requires_approval_for_untrusted_projects() {
     );
 }
 
+#[test]
+fn git_executable_detection_is_platform_independent() {
+    for executable in [
+        "git",
+        "GIT",
+        "/usr/bin/git",
+        "/opt/tools/GiT.ExE",
+        r"C:\Program Files\Git\cmd\git.exe",
+        r"C:/Program Files/Git/cmd/GIT.CMD",
+        r"C:git.exe",
+        r"d:GIT.CmD",
+        r"..\bin\git.BaT",
+        r".\git.CoM",
+    ] {
+        assert!(
+            starts_with_git_executable(&[executable.to_string()]),
+            "expected {executable:?} to be recognized as Git"
+        );
+    }
+
+    for executable in [
+        "git-lfs",
+        "legit",
+        "git.exe.old",
+        "/usr/bin/git/",
+        r"C:\tools\git.exe\helper",
+        r"C:notgit.exe",
+    ] {
+        assert!(
+            !starts_with_git_executable(&[executable.to_string()]),
+            "expected {executable:?} not to be recognized as Git"
+        );
+    }
+}
+
 #[tokio::test]
 async fn generic_git_policy_matrix_preserves_sandbox_and_escalation_semantics() {
     let command = vec!["git".to_string(), "status".to_string()];
@@ -1306,13 +1341,10 @@ async fn generic_git_never_offers_requested_or_shell_lowered_durable_amendments(
             ],
             None,
         ),
+        (vec!["/usr/bin/git".to_string(), "status".to_string()], None),
         (
             vec![
-                if cfg!(windows) {
-                    r"C:\Program Files\Git\cmd\git.exe".to_string()
-                } else {
-                    "/usr/bin/git".to_string()
-                },
+                r"C:\Program Files\Git\cmd\GIT.EXE".to_string(),
                 "status".to_string(),
             ],
             None,

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -5,6 +5,8 @@ Executes shell requests under the orchestrator: asks for approval when needed,
 builds sandbox transform inputs, and runs them under the current SandboxAttempt.
 */
 #[cfg(unix)]
+mod trusted_executable;
+#[cfg(unix)]
 pub(crate) mod unix_escalation;
 pub(crate) mod zsh_fork_backend;
 

--- a/codex-rs/core/src/tools/runtimes/shell/trusted_executable.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/trusted_executable.rs
@@ -1,0 +1,198 @@
+//! Trust checks for executable paths reported by the zsh execve interceptor.
+//!
+//! Policy matching, reporting, and execution keep the resolved absolute path.
+//! These helpers only recover a bare executable name for unmatched-command
+//! classification after proving that the original request used that bare name
+//! and the resolved host path cannot be replaced by the agent.
+
+use crate::sandboxing::SandboxPermissions;
+use crate::tools::sandboxing::ExecApprovalRequirement;
+use codex_protocol::models::AdditionalPermissionProfile;
+use codex_protocol::permissions::FileSystemSandboxPolicy;
+use codex_protocol::protocol::AskForApproval;
+use codex_utils_absolute_path::AbsolutePathBuf;
+use std::collections::HashMap;
+use std::ffi::CString;
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct TrustedExecutableDir {
+    path: PathBuf,
+    canonical_path: PathBuf,
+}
+
+/// One parent-approved command that may suppress one redundant intercepted
+/// child prompt in the same tool invocation.
+///
+/// Matching re-runs the trusted-path proof and compares the complete normalized
+/// argv. The value is consumed on success and is never persisted or reused.
+#[derive(Debug)]
+pub(super) struct ParentApprovedIntercept {
+    command: Mutex<Option<Vec<String>>>,
+}
+
+impl ParentApprovedIntercept {
+    fn new(command: Vec<String>) -> Self {
+        Self {
+            command: Mutex::new(Some(command)),
+        }
+    }
+
+    pub(super) fn for_parent_git_approval(
+        command: &[String],
+        exec_approval_requirement: &ExecApprovalRequirement,
+        approval_policy: AskForApproval,
+        sandbox_permissions: SandboxPermissions,
+        additional_permissions: Option<&AdditionalPermissionProfile>,
+    ) -> Option<Self> {
+        if approval_policy != AskForApproval::UnlessTrusted
+            || sandbox_permissions != SandboxPermissions::UseDefault
+            || additional_permissions.is_some()
+            || !matches!(
+                exec_approval_requirement,
+                ExecApprovalRequirement::NeedsApproval { reason: None, .. }
+            )
+        {
+            return None;
+        }
+
+        crate::exec_policy::single_plain_git_command(command).map(Self::new)
+    }
+
+    pub(super) fn consume_if_matches(
+        &self,
+        program: &AbsolutePathBuf,
+        argv: &[String],
+        trusted_executable_dirs: &[TrustedExecutableDir],
+        file_system_sandbox_policy: &FileSystemSandboxPolicy,
+        cwd: &AbsolutePathBuf,
+    ) -> bool {
+        let Some(intercepted_command) = trusted_intercepted_command(
+            program,
+            argv,
+            trusted_executable_dirs,
+            file_system_sandbox_policy,
+            cwd,
+        ) else {
+            return false;
+        };
+        let Ok(mut approved_command) = self.command.lock() else {
+            return false;
+        };
+        if approved_command.as_deref() != Some(intercepted_command.as_slice()) {
+            return false;
+        }
+        approved_command.take();
+        true
+    }
+}
+
+pub(super) fn trusted_executable_dirs(
+    env: &HashMap<String, String>,
+    file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    cwd: &AbsolutePathBuf,
+) -> Vec<TrustedExecutableDir> {
+    env.get("PATH")
+        .into_iter()
+        .flat_map(std::env::split_paths)
+        .filter(|path| path.is_absolute())
+        .filter_map(|path| {
+            if agent_can_write_path(file_system_sandbox_policy, cwd, &path) {
+                return None;
+            }
+            let canonical_path = std::fs::canonicalize(&path).ok()?;
+            if agent_can_write_path(file_system_sandbox_policy, cwd, &canonical_path) {
+                return None;
+            }
+            Some(TrustedExecutableDir {
+                path,
+                canonical_path,
+            })
+        })
+        .collect()
+}
+
+pub(super) fn trusted_intercepted_executable_name(
+    program: &AbsolutePathBuf,
+    argv: &[String],
+    trusted_executable_dirs: &[TrustedExecutableDir],
+    file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    cwd: &AbsolutePathBuf,
+) -> Option<String> {
+    let argv_zero = argv.first()?;
+    let argv_zero_path = Path::new(argv_zero);
+    let is_bare_name = argv_zero_path.components().count() == 1;
+    let resolved_name_matches = program.as_path().file_name() == Some(argv_zero_path.as_os_str());
+    let resolved_from_trusted_path = program.as_path().parent().is_some_and(|parent| {
+        trusted_executable_dirs.iter().any(|directory| {
+            directory.path == parent
+                && std::fs::canonicalize(&directory.path)
+                    .is_ok_and(|canonical_path| canonical_path == directory.canonical_path)
+        })
+    });
+    let resolved_target_is_read_only =
+        std::fs::canonicalize(program.as_path())
+            .ok()
+            .is_some_and(|canonical_program| {
+                !agent_can_write_path(file_system_sandbox_policy, cwd, &canonical_program)
+            });
+
+    if is_bare_name
+        && resolved_name_matches
+        && resolved_from_trusted_path
+        && resolved_target_is_read_only
+    {
+        Some(argv_zero.clone())
+    } else {
+        None
+    }
+}
+
+fn trusted_intercepted_command(
+    program: &AbsolutePathBuf,
+    argv: &[String],
+    trusted_executable_dirs: &[TrustedExecutableDir],
+    file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    cwd: &AbsolutePathBuf,
+) -> Option<Vec<String>> {
+    let executable_name = trusted_intercepted_executable_name(
+        program,
+        argv,
+        trusted_executable_dirs,
+        file_system_sandbox_policy,
+        cwd,
+    )?;
+    Some(
+        std::iter::once(executable_name)
+            .chain(argv.iter().skip(1).cloned())
+            .collect(),
+    )
+}
+
+fn agent_can_write_path(
+    file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    cwd: &AbsolutePathBuf,
+    path: &Path,
+) -> bool {
+    if !file_system_sandbox_policy.has_full_disk_write_access() {
+        return path.ancestors().any(|ancestor| {
+            file_system_sandbox_policy.can_write_path_with_cwd(ancestor, cwd.as_path())
+        });
+    }
+
+    path.ancestors().any(|ancestor| {
+        let Ok(ancestor) = CString::new(ancestor.as_os_str().as_bytes()) else {
+            return true;
+        };
+        // SAFETY: `ancestor` is a NUL-terminated C string that remains alive
+        // for the duration of this read-only access check.
+        unsafe { libc::access(ancestor.as_ptr(), libc::W_OK) == 0 }
+    })
+}
+
+#[cfg(test)]
+#[path = "trusted_executable_tests.rs"]
+mod tests;

--- a/codex-rs/core/src/tools/runtimes/shell/trusted_executable_tests.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/trusted_executable_tests.rs
@@ -1,0 +1,193 @@
+use super::ParentApprovedIntercept;
+use super::trusted_executable_dirs;
+use crate::sandboxing::SandboxPermissions;
+use crate::tools::sandboxing::ExecApprovalRequirement;
+use codex_protocol::models::AdditionalPermissionProfile;
+use codex_protocol::models::PermissionProfile;
+use codex_protocol::protocol::AskForApproval;
+use codex_utils_absolute_path::AbsolutePathBuf;
+use std::collections::HashMap;
+use std::path::Path;
+
+fn host_git() -> &'static Path {
+    ["/usr/bin/git", "/bin/git", "/opt/homebrew/bin/git"]
+        .into_iter()
+        .map(Path::new)
+        .find(|path| path.is_file())
+        .expect("test host should provide git")
+}
+
+fn trusted_git_fixture() -> (
+    AbsolutePathBuf,
+    AbsolutePathBuf,
+    PermissionProfile,
+    Vec<super::TrustedExecutableDir>,
+) {
+    let program = AbsolutePathBuf::from_absolute_path(host_git()).unwrap();
+    let cwd = AbsolutePathBuf::try_from(std::env::current_dir().unwrap()).unwrap();
+    let permission_profile = PermissionProfile::workspace_write();
+    let mut env = HashMap::new();
+    env.insert(
+        "PATH".to_string(),
+        program
+            .as_path()
+            .parent()
+            .expect("git should have a parent")
+            .display()
+            .to_string(),
+    );
+    let trusted_dirs =
+        trusted_executable_dirs(&env, &permission_profile.file_system_sandbox_policy(), &cwd);
+    assert!(!trusted_dirs.is_empty());
+    (program, cwd, permission_profile, trusted_dirs)
+}
+
+#[test]
+fn parent_approved_git_intercept_is_narrowly_scoped() {
+    let command = vec![
+        "/bin/zsh".to_string(),
+        "-lc".to_string(),
+        "git status --short".to_string(),
+    ];
+    let heuristic_prompt = ExecApprovalRequirement::NeedsApproval {
+        reason: None,
+        proposed_execpolicy_amendment: None,
+    };
+    assert!(
+        ParentApprovedIntercept::for_parent_git_approval(
+            &command,
+            &heuristic_prompt,
+            AskForApproval::UnlessTrusted,
+            SandboxPermissions::UseDefault,
+            /*additional_permissions*/ None,
+        )
+        .is_some()
+    );
+
+    let policy_prompt = ExecApprovalRequirement::NeedsApproval {
+        reason: Some("required by policy".to_string()),
+        proposed_execpolicy_amendment: None,
+    };
+    assert!(
+        ParentApprovedIntercept::for_parent_git_approval(
+            &command,
+            &policy_prompt,
+            AskForApproval::UnlessTrusted,
+            SandboxPermissions::UseDefault,
+            /*additional_permissions*/ None,
+        )
+        .is_none()
+    );
+    assert!(
+        ParentApprovedIntercept::for_parent_git_approval(
+            &command,
+            &heuristic_prompt,
+            AskForApproval::UnlessTrusted,
+            SandboxPermissions::RequireEscalated,
+            /*additional_permissions*/ None,
+        )
+        .is_none()
+    );
+    assert!(
+        ParentApprovedIntercept::for_parent_git_approval(
+            &command,
+            &heuristic_prompt,
+            AskForApproval::UnlessTrusted,
+            SandboxPermissions::UseDefault,
+            Some(&AdditionalPermissionProfile::default()),
+        )
+        .is_none()
+    );
+    assert!(
+        ParentApprovedIntercept::for_parent_git_approval(
+            &["/bin/zsh".into(), "-lc".into(), "env git status".into()],
+            &heuristic_prompt,
+            AskForApproval::UnlessTrusted,
+            SandboxPermissions::UseDefault,
+            /*additional_permissions*/ None,
+        )
+        .is_none()
+    );
+}
+
+#[test]
+fn parent_approval_matches_one_exact_trusted_intercept() {
+    let (program, cwd, permission_profile, trusted_dirs) = trusted_git_fixture();
+    let approved = ParentApprovedIntercept::new(vec![
+        "git".to_string(),
+        "status".to_string(),
+        "--short".to_string(),
+    ]);
+    let argv = [
+        "git".to_string(),
+        "status".to_string(),
+        "--short".to_string(),
+    ];
+
+    assert!(approved.consume_if_matches(
+        &program,
+        &argv,
+        &trusted_dirs,
+        &permission_profile.file_system_sandbox_policy(),
+        &cwd,
+    ));
+    assert!(!approved.consume_if_matches(
+        &program,
+        &argv,
+        &trusted_dirs,
+        &permission_profile.file_system_sandbox_policy(),
+        &cwd,
+    ));
+}
+
+#[test]
+fn parent_approval_rejects_changed_or_path_qualified_argv() {
+    let (program, cwd, permission_profile, trusted_dirs) = trusted_git_fixture();
+    for argv in [
+        vec!["git".to_string(), "diff".to_string()],
+        vec![
+            program.to_string_lossy().to_string(),
+            "status".to_string(),
+            "--short".to_string(),
+        ],
+    ] {
+        let approved = ParentApprovedIntercept::new(vec![
+            "git".to_string(),
+            "status".to_string(),
+            "--short".to_string(),
+        ]);
+        assert!(!approved.consume_if_matches(
+            &program,
+            &argv,
+            &trusted_dirs,
+            &permission_profile.file_system_sandbox_policy(),
+            &cwd,
+        ));
+    }
+}
+
+#[test]
+fn parent_approval_rejects_writable_path_shadow() {
+    let writable_dir = tempfile::tempdir().unwrap();
+    let shadow_git = writable_dir.path().join("git");
+    std::fs::write(&shadow_git, "not a trusted host executable").unwrap();
+    let cwd = AbsolutePathBuf::from_absolute_path(writable_dir.path()).unwrap();
+    let permission_profile = PermissionProfile::workspace_write();
+    let mut env = HashMap::new();
+    env.insert(
+        "PATH".to_string(),
+        writable_dir.path().display().to_string(),
+    );
+    let trusted_dirs =
+        trusted_executable_dirs(&env, &permission_profile.file_system_sandbox_policy(), &cwd);
+    let approved = ParentApprovedIntercept::new(vec!["git".into(), "status".into()]);
+
+    assert!(trusted_dirs.is_empty());
+    assert!(!approved.consume_if_matches(
+        &AbsolutePathBuf::from_absolute_path(&shadow_git).unwrap(),
+        &["git".into(), "status".into()],
+        &trusted_dirs,
+        &permission_profile.file_system_sandbox_policy(),
+        &cwd,
+    ));
+}

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
@@ -1,4 +1,8 @@
 use super::ShellRequest;
+use super::trusted_executable::ParentApprovedIntercept;
+use super::trusted_executable::TrustedExecutableDir;
+use super::trusted_executable::trusted_executable_dirs;
+use super::trusted_executable::trusted_intercepted_executable_name;
 use crate::exec::ExecCapturePolicy;
 use crate::exec::ExecExpiration;
 use crate::exec::cancel_when_either;
@@ -68,10 +72,7 @@ use codex_shell_escalation::Stopwatch;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_path_uri::PathUri;
 use std::collections::HashMap;
-use std::ffi::CString;
 use std::io;
-use std::os::unix::ffi::OsStrExt;
-use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -253,6 +254,13 @@ pub(super) async fn try_run_zsh_fork(
             &command_executor.file_system_sandbox_policy,
             &command_executor.cwd,
         ),
+        parent_approved_intercept: ParentApprovedIntercept::for_parent_git_approval(
+            &req.command,
+            &req.exec_approval_requirement,
+            ctx.turn.approval_policy.value(),
+            req.sandbox_permissions,
+            req.additional_permissions.as_ref(),
+        ),
         stopwatch: stopwatch.clone(),
     };
 
@@ -345,6 +353,13 @@ pub(crate) async fn prepare_unified_exec_zsh_fork(
             &command_executor.file_system_sandbox_policy,
             &command_executor.cwd,
         ),
+        parent_approved_intercept: ParentApprovedIntercept::for_parent_git_approval(
+            &req.command,
+            &req.exec_approval_requirement,
+            ctx.turn.approval_policy.value(),
+            req.sandbox_permissions,
+            req.additional_permissions.as_ref(),
+        ),
         stopwatch: Stopwatch::unlimited(),
     };
 
@@ -378,6 +393,7 @@ struct CoreShellActionProvider {
     approval_sandbox_permissions: SandboxPermissions,
     prompt_permissions: Option<AdditionalPermissionProfile>,
     trusted_executable_dirs: Vec<TrustedExecutableDir>,
+    parent_approved_intercept: Option<ParentApprovedIntercept>,
     stopwatch: Stopwatch,
 }
 
@@ -684,6 +700,28 @@ impl CoreShellActionProvider {
             SandboxPermissions::RequireEscalated => unsandboxed_allowed,
             SandboxPermissions::WithAdditionalPermissions => true,
         };
+        let decision = if evaluation.decision == Decision::Prompt
+            && !decision_driven_by_policy
+            && !needs_escalation
+            && self
+                .parent_approved_intercept
+                .as_ref()
+                .is_some_and(|approved| {
+                    approved.consume_if_matches(
+                        program,
+                        argv,
+                        &self.trusted_executable_dirs,
+                        &self.file_system_sandbox_policy,
+                        workdir,
+                    )
+                }) {
+            tracing::debug!(
+                "reusing exact parent approval for trusted intercepted command {program:?}"
+            );
+            Decision::Allow
+        } else {
+            evaluation.decision
+        };
 
         let decision_source = if decision_driven_by_policy {
             DecisionSource::PrefixRule
@@ -701,7 +739,7 @@ impl CoreShellActionProvider {
             ),
         };
         self.process_decision(
-            evaluation.decision,
+            decision,
             needs_escalation,
             program,
             argv,
@@ -821,12 +859,6 @@ struct CandidateCommands {
     trusted_executable_name: Option<String>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-struct TrustedExecutableDir {
-    path: PathBuf,
-    canonical_path: PathBuf,
-}
-
 fn commands_for_intercepted_exec_policy(
     program: &AbsolutePathBuf,
     argv: &[String],
@@ -867,88 +899,6 @@ fn commands_for_intercepted_exec_policy(
             cwd,
         ),
     }
-}
-
-fn trusted_executable_dirs(
-    env: &HashMap<String, String>,
-    file_system_sandbox_policy: &FileSystemSandboxPolicy,
-    cwd: &AbsolutePathBuf,
-) -> Vec<TrustedExecutableDir> {
-    env.get("PATH")
-        .into_iter()
-        .flat_map(std::env::split_paths)
-        .filter(|path| path.is_absolute())
-        .filter_map(|path| {
-            if agent_can_write_path(file_system_sandbox_policy, cwd, &path) {
-                return None;
-            }
-            let canonical_path = std::fs::canonicalize(&path).ok()?;
-            if agent_can_write_path(file_system_sandbox_policy, cwd, &canonical_path) {
-                return None;
-            }
-            Some(TrustedExecutableDir {
-                path,
-                canonical_path,
-            })
-        })
-        .collect()
-}
-
-fn trusted_intercepted_executable_name(
-    program: &AbsolutePathBuf,
-    argv: &[String],
-    trusted_executable_dirs: &[TrustedExecutableDir],
-    file_system_sandbox_policy: &FileSystemSandboxPolicy,
-    cwd: &AbsolutePathBuf,
-) -> Option<String> {
-    let argv_zero = argv.first()?;
-    let argv_zero_path = Path::new(argv_zero);
-    let is_bare_name = argv_zero_path.components().count() == 1;
-    let resolved_name_matches = program.as_path().file_name() == Some(argv_zero_path.as_os_str());
-    let resolved_from_trusted_path = program.as_path().parent().is_some_and(|parent| {
-        trusted_executable_dirs.iter().any(|directory| {
-            directory.path == parent
-                && std::fs::canonicalize(&directory.path)
-                    .is_ok_and(|canonical_path| canonical_path == directory.canonical_path)
-        })
-    });
-    let resolved_target_is_read_only =
-        std::fs::canonicalize(program.as_path())
-            .ok()
-            .is_some_and(|canonical_program| {
-                !agent_can_write_path(file_system_sandbox_policy, cwd, &canonical_program)
-            });
-
-    if is_bare_name
-        && resolved_name_matches
-        && resolved_from_trusted_path
-        && resolved_target_is_read_only
-    {
-        Some(argv_zero.clone())
-    } else {
-        None
-    }
-}
-
-fn agent_can_write_path(
-    file_system_sandbox_policy: &FileSystemSandboxPolicy,
-    cwd: &AbsolutePathBuf,
-    path: &Path,
-) -> bool {
-    if !file_system_sandbox_policy.has_full_disk_write_access() {
-        return path.ancestors().any(|ancestor| {
-            file_system_sandbox_policy.can_write_path_with_cwd(ancestor, cwd.as_path())
-        });
-    }
-
-    path.ancestors().any(|ancestor| {
-        let Ok(ancestor) = CString::new(ancestor.as_os_str().as_bytes()) else {
-            return true;
-        };
-        // SAFETY: `ancestor` is a NUL-terminated C string that remains alive
-        // for the duration of this read-only access check.
-        unsafe { libc::access(ancestor.as_ptr(), libc::W_OK) == 0 }
-    })
 }
 
 struct CoreShellCommandExecutor {

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
@@ -68,7 +68,10 @@ use codex_shell_escalation::Stopwatch;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_path_uri::PathUri;
 use std::collections::HashMap;
+use std::ffi::CString;
 use std::io;
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -245,6 +248,11 @@ pub(super) async fn try_run_zsh_fork(
         sandbox_permissions: req.sandbox_permissions,
         approval_sandbox_permissions,
         prompt_permissions: req.additional_permissions.clone(),
+        trusted_executable_dirs: trusted_executable_dirs(
+            &command_executor.env,
+            &command_executor.file_system_sandbox_policy,
+            &command_executor.cwd,
+        ),
         stopwatch: stopwatch.clone(),
     };
 
@@ -332,6 +340,11 @@ pub(crate) async fn prepare_unified_exec_zsh_fork(
             req.additional_permissions_preapproved,
         ),
         prompt_permissions: req.additional_permissions.clone(),
+        trusted_executable_dirs: trusted_executable_dirs(
+            &command_executor.env,
+            &command_executor.file_system_sandbox_policy,
+            &command_executor.cwd,
+        ),
         stopwatch: Stopwatch::unlimited(),
     };
 
@@ -364,6 +377,7 @@ struct CoreShellActionProvider {
     sandbox_permissions: SandboxPermissions,
     approval_sandbox_permissions: SandboxPermissions,
     prompt_permissions: Option<AdditionalPermissionProfile>,
+    trusted_executable_dirs: Vec<TrustedExecutableDir>,
     stopwatch: Stopwatch,
 }
 
@@ -655,6 +669,8 @@ impl CoreShellActionProvider {
                     sandbox_permissions: self.approval_sandbox_permissions,
                     enable_shell_wrapper_parsing:
                         ENABLE_INTERCEPTED_EXEC_POLICY_SHELL_WRAPPER_PARSING,
+                    trusted_executable_dirs: self.trusted_executable_dirs.clone(),
+                    cwd: workdir.clone(),
                 },
             )
         };
@@ -723,27 +739,51 @@ fn evaluate_intercepted_exec_policy(
         windows_sandbox_level,
         sandbox_permissions,
         enable_shell_wrapper_parsing,
+        trusted_executable_dirs,
+        cwd,
     } = context;
+    let file_system_sandbox_policy = permission_profile.file_system_sandbox_policy();
     let CandidateCommands {
         commands,
         used_complex_parsing,
+        trusted_executable_name,
     } = if enable_shell_wrapper_parsing {
         // In this codepath, the first argument in `commands` could be a bare
         // name like `find` instead of an absolute path like `/usr/bin/find`.
         // It could also be a shell built-in like `echo`.
-        commands_for_intercepted_exec_policy(program, argv)
+        commands_for_intercepted_exec_policy(
+            program,
+            argv,
+            &trusted_executable_dirs,
+            &file_system_sandbox_policy,
+            &cwd,
+        )
     } else {
         // In this codepath, `commands` has a single entry where the program
         // is always an absolute path.
         CandidateCommands {
             commands: vec![join_program_and_argv(program, argv)],
             used_complex_parsing: false,
+            trusted_executable_name: trusted_intercepted_executable_name(
+                program,
+                argv,
+                &trusted_executable_dirs,
+                &file_system_sandbox_policy,
+                &cwd,
+            ),
         }
     };
 
     let fallback = |cmd: &[String]| {
+        let normalized_fallback_command = trusted_executable_name.as_ref().map(|name| {
+            let mut normalized = cmd.to_vec();
+            if let Some(executable) = normalized.first_mut() {
+                *executable = name.clone();
+            }
+            normalized
+        });
         crate::exec_policy::render_decision_for_unmatched_command(
-            cmd,
+            normalized_fallback_command.as_deref().unwrap_or(cmd),
             crate::exec_policy::UnmatchedCommandContext {
                 approval_policy,
                 permission_profile: &permission_profile,
@@ -771,16 +811,28 @@ struct InterceptedExecPolicyContext {
     windows_sandbox_level: WindowsSandboxLevel,
     sandbox_permissions: SandboxPermissions,
     enable_shell_wrapper_parsing: bool,
+    trusted_executable_dirs: Vec<TrustedExecutableDir>,
+    cwd: AbsolutePathBuf,
 }
 
 struct CandidateCommands {
     commands: Vec<Vec<String>>,
     used_complex_parsing: bool,
+    trusted_executable_name: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TrustedExecutableDir {
+    path: PathBuf,
+    canonical_path: PathBuf,
 }
 
 fn commands_for_intercepted_exec_policy(
     program: &AbsolutePathBuf,
     argv: &[String],
+    trusted_executable_dirs: &[TrustedExecutableDir],
+    file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    cwd: &AbsolutePathBuf,
 ) -> CandidateCommands {
     if let [_, flag, script] = argv {
         let shell_command = [
@@ -792,12 +844,14 @@ fn commands_for_intercepted_exec_policy(
             return CandidateCommands {
                 commands,
                 used_complex_parsing: false,
+                trusted_executable_name: None,
             };
         }
         if let Some(single_command) = parse_shell_lc_single_command_prefix(&shell_command) {
             return CandidateCommands {
                 commands: vec![single_command],
                 used_complex_parsing: true,
+                trusted_executable_name: None,
             };
         }
     }
@@ -805,7 +859,96 @@ fn commands_for_intercepted_exec_policy(
     CandidateCommands {
         commands: vec![join_program_and_argv(program, argv)],
         used_complex_parsing: false,
+        trusted_executable_name: trusted_intercepted_executable_name(
+            program,
+            argv,
+            trusted_executable_dirs,
+            file_system_sandbox_policy,
+            cwd,
+        ),
     }
+}
+
+fn trusted_executable_dirs(
+    env: &HashMap<String, String>,
+    file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    cwd: &AbsolutePathBuf,
+) -> Vec<TrustedExecutableDir> {
+    env.get("PATH")
+        .into_iter()
+        .flat_map(std::env::split_paths)
+        .filter(|path| path.is_absolute())
+        .filter_map(|path| {
+            if agent_can_write_path(file_system_sandbox_policy, cwd, &path) {
+                return None;
+            }
+            let canonical_path = std::fs::canonicalize(&path).ok()?;
+            if agent_can_write_path(file_system_sandbox_policy, cwd, &canonical_path) {
+                return None;
+            }
+            Some(TrustedExecutableDir {
+                path,
+                canonical_path,
+            })
+        })
+        .collect()
+}
+
+fn trusted_intercepted_executable_name(
+    program: &AbsolutePathBuf,
+    argv: &[String],
+    trusted_executable_dirs: &[TrustedExecutableDir],
+    file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    cwd: &AbsolutePathBuf,
+) -> Option<String> {
+    let argv_zero = argv.first()?;
+    let argv_zero_path = Path::new(argv_zero);
+    let is_bare_name = argv_zero_path.components().count() == 1;
+    let resolved_name_matches = program.as_path().file_name() == Some(argv_zero_path.as_os_str());
+    let resolved_from_trusted_path = program.as_path().parent().is_some_and(|parent| {
+        trusted_executable_dirs.iter().any(|directory| {
+            directory.path == parent
+                && std::fs::canonicalize(&directory.path)
+                    .is_ok_and(|canonical_path| canonical_path == directory.canonical_path)
+        })
+    });
+    let resolved_target_is_read_only =
+        std::fs::canonicalize(program.as_path())
+            .ok()
+            .is_some_and(|canonical_program| {
+                !agent_can_write_path(file_system_sandbox_policy, cwd, &canonical_program)
+            });
+
+    if is_bare_name
+        && resolved_name_matches
+        && resolved_from_trusted_path
+        && resolved_target_is_read_only
+    {
+        Some(argv_zero.clone())
+    } else {
+        None
+    }
+}
+
+fn agent_can_write_path(
+    file_system_sandbox_policy: &FileSystemSandboxPolicy,
+    cwd: &AbsolutePathBuf,
+    path: &Path,
+) -> bool {
+    if !file_system_sandbox_policy.has_full_disk_write_access() {
+        return path.ancestors().any(|ancestor| {
+            file_system_sandbox_policy.can_write_path_with_cwd(ancestor, cwd.as_path())
+        });
+    }
+
+    path.ancestors().any(|ancestor| {
+        let Ok(ancestor) = CString::new(ancestor.as_os_str().as_bytes()) else {
+            return true;
+        };
+        // SAFETY: `ancestor` is a NUL-terminated C string that remains alive
+        // for the duration of this read-only access check.
+        unsafe { libc::access(ancestor.as_ptr(), libc::W_OK) == 0 }
+    })
 }
 
 struct CoreShellCommandExecutor {

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation_tests.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation_tests.rs
@@ -607,6 +607,7 @@ async fn preapproved_additional_permissions_escalate_intercepted_exec() -> anyho
         approval_sandbox_permissions: SandboxPermissions::UseDefault,
         prompt_permissions: Some(requested_permissions),
         trusted_executable_dirs: Vec::new(),
+        parent_approved_intercept: None,
         stopwatch: codex_shell_escalation::Stopwatch::new(Duration::from_secs(1)),
     };
 
@@ -744,6 +745,7 @@ async fn execve_permission_request_hook_short_circuits_prompt() -> anyhow::Resul
         approval_sandbox_permissions: SandboxPermissions::RequireEscalated,
         prompt_permissions: None,
         trusted_executable_dirs: Vec::new(),
+        parent_approved_intercept: None,
         stopwatch: codex_shell_escalation::Stopwatch::new(Duration::from_secs(1)),
     };
 
@@ -962,6 +964,7 @@ prefix_rule(pattern = ["{cat_path_literal}"], decision = "allow")
         approval_sandbox_permissions: SandboxPermissions::UseDefault,
         prompt_permissions: None,
         trusted_executable_dirs: Vec::new(),
+        parent_approved_intercept: None,
         stopwatch: codex_shell_escalation::Stopwatch::new(Duration::from_secs(1)),
     };
 
@@ -1006,6 +1009,7 @@ async fn denied_reads_keep_granular_sandbox_rejection_for_escalation() -> anyhow
         approval_sandbox_permissions: SandboxPermissions::RequireEscalated,
         prompt_permissions: None,
         trusted_executable_dirs: Vec::new(),
+        parent_approved_intercept: None,
         stopwatch: codex_shell_escalation::Stopwatch::new(Duration::from_secs(1)),
     };
 

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation_tests.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation_tests.rs
@@ -7,6 +7,7 @@ use super::evaluate_intercepted_exec_policy;
 use super::extract_shell_script;
 use super::join_program_and_argv;
 use super::map_exec_result;
+use super::trusted_executable_dirs;
 use crate::config::Constrained;
 use crate::sandboxing::SandboxPermissions;
 use crate::session::tests::make_session_and_context;
@@ -42,6 +43,8 @@ use codex_utils_absolute_path::AbsolutePathBuf;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 use std::collections::HashMap;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -250,6 +253,9 @@ fn commands_for_intercepted_exec_policy_parses_plain_shell_wrappers() {
     let candidate_commands = commands_for_intercepted_exec_policy(
         &program,
         &["not-bash".into(), "-lc".into(), "git status && pwd".into()],
+        &[],
+        &read_only_file_system_sandbox_policy(),
+        &test_sandbox_cwd(),
     );
 
     assert_eq!(
@@ -260,6 +266,172 @@ fn commands_for_intercepted_exec_policy_parses_plain_shell_wrappers() {
         ]
     );
     assert!(!candidate_commands.used_complex_parsing);
+    assert_eq!(candidate_commands.trusted_executable_name, None);
+}
+
+fn intercepted_unless_trusted_decision(
+    program: &Path,
+    argv: &[&str],
+    permission_profile: PermissionProfile,
+    cwd: &Path,
+    path_dirs: &[&Path],
+) -> Decision {
+    let cwd = AbsolutePathBuf::from_absolute_path(cwd).unwrap();
+    let mut env = HashMap::new();
+    env.insert(
+        "PATH".to_string(),
+        std::env::join_paths(path_dirs)
+            .unwrap()
+            .into_string()
+            .unwrap(),
+    );
+    let trusted_executable_dirs =
+        trusted_executable_dirs(&env, &permission_profile.file_system_sandbox_policy(), &cwd);
+    evaluate_intercepted_exec_policy(
+        &PolicyParser::new().build(),
+        &AbsolutePathBuf::from_absolute_path(program).unwrap(),
+        &argv
+            .iter()
+            .map(|arg| (*arg).to_string())
+            .collect::<Vec<_>>(),
+        InterceptedExecPolicyContext {
+            approval_policy: AskForApproval::UnlessTrusted,
+            permission_profile,
+            windows_sandbox_level: WindowsSandboxLevel::Disabled,
+            sandbox_permissions: SandboxPermissions::UseDefault,
+            enable_shell_wrapper_parsing: false,
+            trusted_executable_dirs,
+            cwd,
+        },
+    )
+    .decision
+}
+
+#[test]
+fn trusted_executable_dirs_exclude_sandbox_writable_ancestor() {
+    let workspace = tempfile::tempdir().unwrap();
+    let locked = workspace.path().join("locked");
+    let bin = locked.join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o555)).unwrap();
+    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o555)).unwrap();
+    let cwd = AbsolutePathBuf::from_absolute_path(workspace.path()).unwrap();
+    let permission_profile = PermissionProfile::workspace_write();
+    let mut env = HashMap::new();
+    env.insert("PATH".to_string(), bin.display().to_string());
+
+    assert!(
+        trusted_executable_dirs(&env, &permission_profile.file_system_sandbox_policy(), &cwd)
+            .is_empty()
+    );
+
+    std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755)).unwrap();
+    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+#[test]
+fn intercepted_exec_policy_normalizes_only_trusted_bare_path_resolution() {
+    let trusted_program_path = ["/bin/ls", "/usr/bin/ls"]
+        .into_iter()
+        .find(|path| Path::new(path).is_file())
+        .expect("test host should provide ls");
+    let trusted_program = Path::new(trusted_program_path);
+    let trusted_dir = trusted_program.parent().expect("ls should have a parent");
+
+    for profile in [
+        PermissionProfile::workspace_write(),
+        PermissionProfile::Disabled,
+    ] {
+        assert_eq!(
+            intercepted_unless_trusted_decision(
+                trusted_program,
+                &["ls", "."],
+                profile,
+                Path::new("/workspace"),
+                &[trusted_dir],
+            ),
+            Decision::Allow
+        );
+    }
+
+    for argv in [
+        ["./ls"].as_slice(),
+        [trusted_program_path].as_slice(),
+        ["not-ls"].as_slice(),
+    ] {
+        assert_eq!(
+            intercepted_unless_trusted_decision(
+                trusted_program,
+                argv,
+                PermissionProfile::workspace_write(),
+                Path::new("/workspace"),
+                &[trusted_dir],
+            ),
+            Decision::Prompt
+        );
+    }
+
+    let writable_path = tempfile::tempdir().unwrap();
+    let shadow_program_path = writable_path.path().join("ls");
+    std::fs::write(&shadow_program_path, "not a trusted host executable").unwrap();
+    for profile in [
+        PermissionProfile::workspace_write(),
+        PermissionProfile::Disabled,
+    ] {
+        assert_eq!(
+            intercepted_unless_trusted_decision(
+                &shadow_program_path,
+                &["ls"],
+                profile,
+                writable_path.path(),
+                &[writable_path.path()],
+            ),
+            Decision::Prompt
+        );
+    }
+}
+
+#[test]
+fn intercepted_exec_policy_rejects_symlink_into_writable_target() {
+    let root = tempfile::tempdir().unwrap();
+    let trusted_bin = root.path().join("trusted-bin");
+    let writable_dir = root.path().join("writable");
+    std::fs::create_dir_all(&trusted_bin).unwrap();
+    std::fs::create_dir_all(&writable_dir).unwrap();
+    let trusted_bin = std::fs::canonicalize(trusted_bin).unwrap();
+    let writable_dir = std::fs::canonicalize(writable_dir).unwrap();
+    let writable_target = writable_dir.join("ls");
+    std::fs::write(&writable_target, "attacker controlled").unwrap();
+    let linked_program = trusted_bin.join("ls");
+    std::os::unix::fs::symlink(&writable_target, &linked_program).unwrap();
+
+    let cwd = AbsolutePathBuf::from_absolute_path(&writable_dir).unwrap();
+    let file_system_sandbox_policy = FileSystemSandboxPolicy::restricted(vec![
+        FileSystemSandboxEntry {
+            path: FileSystemPath::Special {
+                value: FileSystemSpecialPath::Root,
+            },
+            access: FileSystemAccessMode::Read,
+        },
+        FileSystemSandboxEntry {
+            path: FileSystemPath::Path { path: cwd.clone() },
+            access: FileSystemAccessMode::Write,
+        },
+    ]);
+    let permission_profile = PermissionProfile::from_runtime_permissions(
+        &file_system_sandbox_policy,
+        NetworkSandboxPolicy::Restricted,
+    );
+    assert_eq!(
+        intercepted_unless_trusted_decision(
+            &linked_program,
+            &["ls"],
+            permission_profile,
+            cwd.as_path(),
+            &[&trusted_bin],
+        ),
+        Decision::Prompt
+    );
 }
 
 #[test]
@@ -434,6 +606,7 @@ async fn preapproved_additional_permissions_escalate_intercepted_exec() -> anyho
         sandbox_permissions: SandboxPermissions::WithAdditionalPermissions,
         approval_sandbox_permissions: SandboxPermissions::UseDefault,
         prompt_permissions: Some(requested_permissions),
+        trusted_executable_dirs: Vec::new(),
         stopwatch: codex_shell_escalation::Stopwatch::new(Duration::from_secs(1)),
     };
 
@@ -570,6 +743,7 @@ async fn execve_permission_request_hook_short_circuits_prompt() -> anyhow::Resul
         sandbox_permissions: SandboxPermissions::RequireEscalated,
         approval_sandbox_permissions: SandboxPermissions::RequireEscalated,
         prompt_permissions: None,
+        trusted_executable_dirs: Vec::new(),
         stopwatch: codex_shell_escalation::Stopwatch::new(Duration::from_secs(1)),
     };
 
@@ -634,6 +808,8 @@ fn evaluate_intercepted_exec_policy_uses_wrapper_command_when_shell_wrapper_pars
             windows_sandbox_level: WindowsSandboxLevel::Disabled,
             sandbox_permissions: SandboxPermissions::UseDefault,
             enable_shell_wrapper_parsing: enable_intercepted_exec_policy_shell_wrapper_parsing,
+            trusted_executable_dirs: Vec::new(),
+            cwd: test_sandbox_cwd(),
         },
     );
 
@@ -685,6 +861,8 @@ fn evaluate_intercepted_exec_policy_matches_inner_shell_commands_when_enabled() 
             windows_sandbox_level: WindowsSandboxLevel::Disabled,
             sandbox_permissions: SandboxPermissions::UseDefault,
             enable_shell_wrapper_parsing: enable_intercepted_exec_policy_shell_wrapper_parsing,
+            trusted_executable_dirs: Vec::new(),
+            cwd: test_sandbox_cwd(),
         },
     );
 
@@ -727,6 +905,8 @@ host_executable(name = "git", paths = ["{git_path_literal}"])
             windows_sandbox_level: WindowsSandboxLevel::Disabled,
             sandbox_permissions: SandboxPermissions::UseDefault,
             enable_shell_wrapper_parsing: false,
+            trusted_executable_dirs: Vec::new(),
+            cwd: test_sandbox_cwd(),
         },
     );
 
@@ -781,6 +961,7 @@ prefix_rule(pattern = ["{cat_path_literal}"], decision = "allow")
         sandbox_permissions: SandboxPermissions::UseDefault,
         approval_sandbox_permissions: SandboxPermissions::UseDefault,
         prompt_permissions: None,
+        trusted_executable_dirs: Vec::new(),
         stopwatch: codex_shell_escalation::Stopwatch::new(Duration::from_secs(1)),
     };
 
@@ -824,6 +1005,7 @@ async fn denied_reads_keep_granular_sandbox_rejection_for_escalation() -> anyhow
         sandbox_permissions: SandboxPermissions::RequireEscalated,
         approval_sandbox_permissions: SandboxPermissions::RequireEscalated,
         prompt_permissions: None,
+        trusted_executable_dirs: Vec::new(),
         stopwatch: codex_shell_escalation::Stopwatch::new(Duration::from_secs(1)),
     };
 
@@ -865,6 +1047,8 @@ fn intercepted_exec_policy_treats_preapproved_additional_permissions_as_default(
                 /*additional_permissions_preapproved*/ true,
             ),
             enable_shell_wrapper_parsing: false,
+            trusted_executable_dirs: Vec::new(),
+            cwd: test_sandbox_cwd(),
         },
     );
     let fresh_request = evaluate_intercepted_exec_policy(
@@ -877,6 +1061,8 @@ fn intercepted_exec_policy_treats_preapproved_additional_permissions_as_default(
             windows_sandbox_level: WindowsSandboxLevel::Disabled,
             sandbox_permissions: SandboxPermissions::WithAdditionalPermissions,
             enable_shell_wrapper_parsing: false,
+            trusted_executable_dirs: Vec::new(),
+            cwd: test_sandbox_cwd(),
         },
     );
 
@@ -910,6 +1096,8 @@ host_executable(name = "git", paths = ["{allowed_git_literal}"])
             windows_sandbox_level: WindowsSandboxLevel::Disabled,
             sandbox_permissions: SandboxPermissions::UseDefault,
             enable_shell_wrapper_parsing: false,
+            trusted_executable_dirs: Vec::new(),
+            cwd: test_sandbox_cwd(),
         },
     );
 

--- a/codex-rs/core/tests/suite/exec_policy.rs
+++ b/codex-rs/core/tests/suite/exec_policy.rs
@@ -149,7 +149,7 @@ async fn assert_generic_git_prompts_without_amendment(tool: AgentExecTool) -> Re
         "run repository-sensitive git status",
         AskForApproval::UnlessTrusted,
         PermissionProfile::Disabled,
-        None,
+        /*collaboration_mode*/ None,
     )
     .await?;
 

--- a/codex-rs/core/tests/suite/exec_policy.rs
+++ b/codex-rs/core/tests/suite/exec_policy.rs
@@ -96,7 +96,10 @@ enum AgentExecTool {
     UnifiedExec,
 }
 
-async fn assert_generic_git_prompts_without_amendment(tool: AgentExecTool) -> Result<()> {
+async fn assert_generic_git_prompts_without_amendment(
+    tool: AgentExecTool,
+    command: &str,
+) -> Result<()> {
     let server = start_mock_server().await;
     let mut builder = test_codex().with_config(move |config| {
         if matches!(tool, AgentExecTool::UnifiedExec) {
@@ -112,7 +115,7 @@ async fn assert_generic_git_prompts_without_amendment(tool: AgentExecTool) -> Re
             "git-approval-shell",
             "shell_command",
             json!({
-                "command": "git status --short",
+                "command": command,
                 "timeout_ms": 1_000,
             }),
         ),
@@ -120,7 +123,7 @@ async fn assert_generic_git_prompts_without_amendment(tool: AgentExecTool) -> Re
             "git-approval-unified-exec",
             "exec_command",
             json!({
-                "cmd": "git status --short",
+                "cmd": command,
                 "yield_time_ms": 1_000,
             }),
         ),
@@ -168,7 +171,7 @@ async fn assert_generic_git_prompts_without_amendment(tool: AgentExecTool) -> Re
         approval
             .command
             .iter()
-            .any(|argument| argument.contains("git status --short")),
+            .any(|argument| argument.contains(command)),
         "unexpected {tool:?} approval command: {:?}",
         approval.command
     );
@@ -200,12 +203,31 @@ async fn assert_generic_git_prompts_without_amendment(tool: AgentExecTool) -> Re
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn generic_git_shell_command_prompts_without_amendment() -> Result<()> {
-    assert_generic_git_prompts_without_amendment(AgentExecTool::Shell).await
+    assert_generic_git_prompts_without_amendment(AgentExecTool::Shell, "git status --short").await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn generic_git_unified_exec_prompts_without_amendment() -> Result<()> {
-    assert_generic_git_prompts_without_amendment(AgentExecTool::UnifiedExec).await
+    assert_generic_git_prompts_without_amendment(AgentExecTool::UnifiedExec, "git status --short")
+        .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn env_wrapped_git_shell_command_prompts_without_amendment() -> Result<()> {
+    assert_generic_git_prompts_without_amendment(
+        AgentExecTool::Shell,
+        "env GIT_OPTIONAL_LOCKS=0 git status --short",
+    )
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn env_wrapped_git_unified_exec_prompts_without_amendment() -> Result<()> {
+    assert_generic_git_prompts_without_amendment(
+        AgentExecTool::UnifiedExec,
+        "env GIT_OPTIONAL_LOCKS=0 git status --short",
+    )
+    .await
 }
 
 #[cfg(windows)]

--- a/codex-rs/core/tests/suite/exec_policy.rs
+++ b/codex-rs/core/tests/suite/exec_policy.rs
@@ -9,6 +9,7 @@ use codex_protocol::models::PermissionProfile;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::Op;
+use codex_protocol::protocol::ReviewDecision;
 use codex_protocol::user_input::UserInput;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
@@ -21,6 +22,7 @@ use core_test_support::test_codex::local_selections;
 use core_test_support::test_codex::test_codex;
 use core_test_support::test_codex::turn_permission_fields;
 use core_test_support::wait_for_event;
+use pretty_assertions::assert_eq;
 use serde_json::Value;
 use serde_json::json;
 use std::fs;
@@ -86,6 +88,124 @@ fn assert_no_matched_rules_invariant(output_item: &Value) {
         !output.contains("invariant failed: matched_rules must be non-empty"),
         "unexpected invariant panic surfaced in output: {output}"
     );
+}
+
+#[derive(Clone, Copy, Debug)]
+enum AgentExecTool {
+    Shell,
+    UnifiedExec,
+}
+
+async fn assert_generic_git_prompts_without_amendment(tool: AgentExecTool) -> Result<()> {
+    let server = start_mock_server().await;
+    let mut builder = test_codex().with_config(move |config| {
+        if matches!(tool, AgentExecTool::UnifiedExec) {
+            config
+                .features
+                .enable(Feature::UnifiedExec)
+                .expect("test config should allow feature update");
+        }
+    });
+    let test = builder.build(&server).await?;
+    let (call_id, tool_name, args) = match tool {
+        AgentExecTool::Shell => (
+            "git-approval-shell",
+            "shell_command",
+            json!({
+                "command": "git status --short",
+                "timeout_ms": 1_000,
+            }),
+        ),
+        AgentExecTool::UnifiedExec => (
+            "git-approval-unified-exec",
+            "exec_command",
+            json!({
+                "cmd": "git status --short",
+                "yield_time_ms": 1_000,
+            }),
+        ),
+    };
+
+    mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-git-approval-1"),
+            ev_function_call(call_id, tool_name, &serde_json::to_string(&args)?),
+            ev_completed("resp-git-approval-1"),
+        ]),
+    )
+    .await;
+    let results_mock = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_assistant_message("msg-git-approval-1", "done"),
+            ev_completed("resp-git-approval-2"),
+        ]),
+    )
+    .await;
+
+    submit_user_turn(
+        &test,
+        "run repository-sensitive git status",
+        AskForApproval::UnlessTrusted,
+        PermissionProfile::Disabled,
+        None,
+    )
+    .await?;
+
+    let approval_event = wait_for_event(&test.codex, |event| {
+        matches!(
+            event,
+            EventMsg::ExecApprovalRequest(_) | EventMsg::TurnComplete(_)
+        )
+    })
+    .await;
+    let EventMsg::ExecApprovalRequest(approval) = approval_event else {
+        panic!("{tool:?} git command completed without requesting approval");
+    };
+    assert_eq!(approval.proposed_execpolicy_amendment, None);
+    assert!(
+        approval
+            .command
+            .iter()
+            .any(|argument| argument.contains("git status --short")),
+        "unexpected {tool:?} approval command: {:?}",
+        approval.command
+    );
+
+    test.codex
+        .submit(Op::ExecApproval {
+            id: approval.effective_approval_id(),
+            turn_id: None,
+            decision: ReviewDecision::Denied,
+        })
+        .await?;
+    wait_for_event(&test.codex, |event| {
+        matches!(event, EventMsg::TurnComplete(_))
+    })
+    .await;
+
+    let output_item = results_mock.single_request().function_call_output(call_id);
+    let output = output_item
+        .get("output")
+        .and_then(Value::as_str)
+        .expect("function call output should include a string output payload");
+    assert!(
+        output.contains("rejected by user"),
+        "unexpected {tool:?} denial output: {output}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn generic_git_shell_command_prompts_without_amendment() -> Result<()> {
+    assert_generic_git_prompts_without_amendment(AgentExecTool::Shell).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn generic_git_unified_exec_prompts_without_amendment() -> Result<()> {
+    assert_generic_git_prompts_without_amendment(AgentExecTool::UnifiedExec).await
 }
 
 #[cfg(windows)]

--- a/codex-rs/core/tests/suite/generic_git_zsh_fork.rs
+++ b/codex-rs/core/tests/suite/generic_git_zsh_fork.rs
@@ -1,0 +1,197 @@
+use anyhow::Result;
+use codex_config::types::ApprovalsReviewer;
+use codex_protocol::config_types::CollaborationMode;
+use codex_protocol::config_types::ModeKind;
+use codex_protocol::config_types::Settings;
+use codex_protocol::models::PermissionProfile;
+use codex_protocol::protocol::AskForApproval;
+use codex_protocol::protocol::EventMsg;
+use codex_protocol::protocol::Op;
+use codex_protocol::protocol::ReviewDecision;
+use codex_protocol::protocol::ThreadSettingsOverrides;
+use codex_protocol::user_input::UserInput;
+use core_test_support::responses::ev_assistant_message;
+use core_test_support::responses::ev_completed;
+use core_test_support::responses::ev_function_call;
+use core_test_support::responses::ev_response_created;
+use core_test_support::responses::mount_sse_once;
+use core_test_support::responses::sse;
+use core_test_support::responses::start_mock_server;
+use core_test_support::skip_if_no_network;
+use core_test_support::test_codex::TestCodex;
+use core_test_support::test_codex::local_selections;
+use core_test_support::test_codex::turn_permission_fields;
+use core_test_support::wait_for_event;
+use core_test_support::zsh_fork::build_unified_exec_zsh_fork_test;
+use core_test_support::zsh_fork::build_zsh_fork_test;
+use core_test_support::zsh_fork::zsh_fork_runtime;
+use serde_json::json;
+
+#[derive(Clone, Copy, Debug)]
+enum AgentExecTool {
+    Shell,
+    UnifiedExec,
+}
+
+async fn assert_generic_git_uses_one_parent_approval(tool: AgentExecTool) -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let Some(runtime) = zsh_fork_runtime("generic Git single approval test")? else {
+        return Ok(());
+    };
+    let server = start_mock_server().await;
+    let approval_policy = AskForApproval::UnlessTrusted;
+    let permission_profile = PermissionProfile::workspace_write();
+    let test = match tool {
+        AgentExecTool::Shell => {
+            build_zsh_fork_test(
+                &server,
+                runtime,
+                approval_policy,
+                permission_profile,
+                |_home| {},
+            )
+            .await?
+        }
+        AgentExecTool::UnifiedExec => {
+            build_unified_exec_zsh_fork_test(
+                &server,
+                runtime,
+                approval_policy,
+                permission_profile,
+                |_home| {},
+            )
+            .await?
+        }
+    };
+    let call_id = match tool {
+        AgentExecTool::Shell => "generic-git-zsh-fork-shell",
+        AgentExecTool::UnifiedExec => "generic-git-zsh-fork-unified-exec",
+    };
+    let (tool_name, args) = match tool {
+        AgentExecTool::Shell => (
+            "shell_command",
+            json!({
+                "command": "git status --short",
+                "timeout_ms": 30_000,
+            }),
+        ),
+        AgentExecTool::UnifiedExec => (
+            "exec_command",
+            json!({
+                "cmd": "git status --short",
+                "yield_time_ms": 30_000,
+            }),
+        ),
+    };
+    let _first_response = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-generic-git-zsh-fork-1"),
+            ev_function_call(call_id, tool_name, &serde_json::to_string(&args)?),
+            ev_completed("resp-generic-git-zsh-fork-1"),
+        ]),
+    )
+    .await;
+    let _results = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_assistant_message("msg-generic-git-zsh-fork-1", "done"),
+            ev_completed("resp-generic-git-zsh-fork-2"),
+        ]),
+    )
+    .await;
+
+    submit_turn(&test, approval_policy).await?;
+    let approval = expect_approval_or_completion(&test).await;
+    let EventMsg::ExecApprovalRequest(approval) = approval else {
+        panic!("{tool:?} generic Git completed without parent approval");
+    };
+    assert_eq!(
+        approval.approval_id, None,
+        "{tool:?} first approval must be the parent tool command"
+    );
+    assert_eq!(approval.proposed_execpolicy_amendment, None);
+    assert!(
+        approval
+            .command
+            .iter()
+            .any(|argument| argument.contains("git status --short")),
+        "unexpected {tool:?} parent approval command: {:?}",
+        approval.command
+    );
+    test.codex
+        .submit(Op::ExecApproval {
+            id: approval.effective_approval_id(),
+            turn_id: None,
+            decision: ReviewDecision::Approved,
+        })
+        .await?;
+
+    match expect_approval_or_completion(&test).await {
+        EventMsg::TurnComplete(_) => {}
+        EventMsg::ExecApprovalRequest(approval) => panic!(
+            "{tool:?} emitted a redundant child approval after parent approval: {:?}",
+            approval.command
+        ),
+        event => panic!("unexpected {tool:?} event: {event:?}"),
+    }
+
+    Ok(())
+}
+
+async fn submit_turn(test: &TestCodex, approval_policy: AskForApproval) -> Result<()> {
+    let session_model = test.session_configured.model.clone();
+    let (sandbox_policy, permission_profile) = turn_permission_fields(
+        test.session_configured.permission_profile.clone(),
+        test.cwd.path(),
+    );
+    test.codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "run repository-sensitive Git through zsh fork".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: ThreadSettingsOverrides {
+                environments: Some(local_selections(test.config.cwd.clone())),
+                approval_policy: Some(approval_policy),
+                approvals_reviewer: Some(ApprovalsReviewer::User),
+                sandbox_policy: Some(sandbox_policy),
+                permission_profile,
+                collaboration_mode: Some(CollaborationMode {
+                    mode: ModeKind::Default,
+                    settings: Settings {
+                        model: session_model,
+                        reasoning_effort: None,
+                        developer_instructions: None,
+                    },
+                }),
+                ..Default::default()
+            },
+        })
+        .await?;
+    Ok(())
+}
+
+async fn expect_approval_or_completion(test: &TestCodex) -> EventMsg {
+    wait_for_event(&test.codex, |event| {
+        matches!(
+            event,
+            EventMsg::ExecApprovalRequest(_) | EventMsg::TurnComplete(_)
+        )
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shell_zsh_fork_generic_git_uses_one_parent_approval() -> Result<()> {
+    assert_generic_git_uses_one_parent_approval(AgentExecTool::Shell).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unified_exec_zsh_fork_generic_git_uses_one_parent_approval() -> Result<()> {
+    assert_generic_git_uses_one_parent_approval(AgentExecTool::UnifiedExec).await
+}

--- a/codex-rs/core/tests/suite/mod.rs
+++ b/codex-rs/core/tests/suite/mod.rs
@@ -55,6 +55,8 @@ mod exec_policy;
 #[cfg(not(target_os = "windows"))]
 mod extension_sandbox;
 mod fork_thread;
+#[cfg(unix)]
+mod generic_git_zsh_fork;
 #[cfg(not(target_os = "windows"))]
 mod guardian_review;
 #[cfg(not(target_os = "windows"))]

--- a/codex-rs/shell-command/src/command_safety/is_dangerous_command.rs
+++ b/codex-rs/shell-command/src/command_safety/is_dangerous_command.rs
@@ -43,31 +43,6 @@ pub fn is_dangerous_powershell_words(command: &[String]) -> bool {
     }
 }
 
-fn is_git_global_option_with_value(arg: &str) -> bool {
-    matches!(
-        arg,
-        "-C" | "-c"
-            | "--config-env"
-            | "--exec-path"
-            | "--git-dir"
-            | "--namespace"
-            | "--super-prefix"
-            | "--work-tree"
-    )
-}
-
-fn is_git_global_option_with_inline_value(arg: &str) -> bool {
-    matches!(
-        arg,
-        s if s.starts_with("--config-env=")
-            || s.starts_with("--exec-path=")
-            || s.starts_with("--git-dir=")
-            || s.starts_with("--namespace=")
-            || s.starts_with("--super-prefix=")
-            || s.starts_with("--work-tree=")
-    ) || ((arg.starts_with("-C") || arg.starts_with("-c")) && arg.len() > 2)
-}
-
 pub(crate) fn executable_name_lookup_key(raw: &str) -> Option<String> {
     #[cfg(windows)]
     {
@@ -92,54 +67,6 @@ pub(crate) fn executable_name_lookup_key(raw: &str) -> Option<String> {
             .and_then(|name| name.to_str())
             .map(std::borrow::ToOwned::to_owned)
     }
-}
-
-/// Find the first matching git subcommand, skipping known global options that
-/// may appear before it (e.g., `-C`, `-c`, `--git-dir`).
-///
-/// Shared with `is_safe_command` to avoid git-global-option bypasses.
-pub(crate) fn find_git_subcommand<'a>(
-    command: &'a [String],
-    subcommands: &[&str],
-) -> Option<(usize, &'a str)> {
-    let cmd0 = command.first().map(String::as_str)?;
-    if executable_name_lookup_key(cmd0).as_deref() != Some("git") {
-        return None;
-    }
-
-    let mut skip_next = false;
-    for (idx, arg) in command.iter().enumerate().skip(1) {
-        if skip_next {
-            skip_next = false;
-            continue;
-        }
-
-        let arg = arg.as_str();
-
-        if is_git_global_option_with_inline_value(arg) {
-            continue;
-        }
-
-        if is_git_global_option_with_value(arg) {
-            skip_next = true;
-            continue;
-        }
-
-        if arg == "--" || arg.starts_with('-') {
-            continue;
-        }
-
-        if subcommands.contains(&arg) {
-            return Some((idx, arg));
-        }
-
-        // In git, the first non-option token is the subcommand. If it isn't
-        // one of the subcommands we're looking for, we must stop scanning to
-        // avoid misclassifying later positional args (e.g., branch names).
-        return None;
-    }
-
-    None
 }
 
 fn is_dangerous_to_call_with_exec(command: &[String]) -> bool {

--- a/codex-rs/shell-command/src/command_safety/is_safe_command.rs
+++ b/codex-rs/shell-command/src/command_safety/is_safe_command.rs
@@ -64,6 +64,12 @@ fn is_safe_to_call_with_exec(command: &[String]) -> bool {
     let Some(cmd0) = command.first().map(String::as_str) else {
         return false;
     };
+    if std::path::Path::new(cmd0).components().count() != 1 {
+        // A workspace executable can impersonate an allowlisted utility by
+        // reusing its basename. Only bare names resolved through the trusted
+        // process PATH are eligible for generic safe-command classification.
+        return false;
+    }
 
     match executable_name_lookup_key(cmd0).as_deref() {
         Some(cmd) if cfg!(target_os = "linux") && matches!(cmd, "numfmt" | "tac") => true,
@@ -248,6 +254,35 @@ mod tests {
             assert!(!is_safe_to_call_with_exec(&vec_str(&["numfmt", "1000"])));
             assert!(!is_safe_to_call_with_exec(&vec_str(&["tac", "Cargo.toml"])));
         }
+    }
+
+    #[test]
+    fn path_qualified_safe_command_names_require_approval() {
+        let absolute_cat = if cfg!(windows) {
+            r"C:\workspace\cat.exe"
+        } else {
+            "/tmp/workspace/cat"
+        };
+        let parent_relative_cat = if cfg!(windows) {
+            r"..\cat.exe"
+        } else {
+            "../cat"
+        };
+
+        for args in [
+            vec_str(&["./cat", "Cargo.toml"]),
+            vec_str(&[parent_relative_cat, "Cargo.toml"]),
+            vec_str(&[absolute_cat, "Cargo.toml"]),
+            vec_str(&["bash", "-lc", "./cat Cargo.toml"]),
+        ] {
+            assert!(
+                !is_known_safe_command(&args),
+                "expected path-qualified executable {args:?} to require approval",
+            );
+        }
+
+        let bare_cat = if cfg!(windows) { "cat.exe" } else { "cat" };
+        assert!(is_known_safe_command(&vec_str(&[bare_cat, "Cargo.toml"])));
     }
 
     #[test]

--- a/codex-rs/shell-command/src/command_safety/is_safe_command.rs
+++ b/codex-rs/shell-command/src/command_safety/is_safe_command.rs
@@ -1,9 +1,5 @@
 use crate::bash::parse_shell_lc_plain_commands;
 use crate::command_safety::is_dangerous_command::executable_name_lookup_key;
-// Find the first matching git subcommand, skipping known global options that
-// may appear before it (e.g., `-C`, `-c`, `--git-dir`).
-// Implemented in `is_dangerous_command` and shared here.
-use crate::command_safety::is_dangerous_command::find_git_subcommand;
 #[cfg(windows)]
 use crate::command_safety::windows_safe_commands::is_safe_command_windows;
 #[cfg(windows)]
@@ -172,131 +168,11 @@ fn is_safe_to_call_with_exec(command: &[String]) -> bool {
     }
 }
 
-pub(crate) fn is_safe_git_command(command: &[String]) -> bool {
-    let Some((subcommand_idx, subcommand)) =
-        find_git_subcommand(command, &["status", "log", "diff", "show", "branch"])
-    else {
-        return false;
-    };
-
-    let global_args = &command[1..subcommand_idx];
-    if git_has_unsafe_global_option(global_args) {
-        return false;
-    }
-
-    let subcommand_args = &command[subcommand_idx + 1..];
-
-    match subcommand {
-        "status" | "log" | "diff" | "show" => {
-            // These subcommands can consult repository-controlled configuration
-            // for external helpers, so argv-only classification is not enough to
-            // auto-approve them.
-            false
-        }
-        "branch" => {
-            git_subcommand_args_are_read_only(subcommand_args)
-                && git_branch_is_read_only(subcommand_args)
-        }
-        other => {
-            debug_assert!(false, "unexpected git subcommand from matcher: {other}");
-            false
-        }
-    }
-}
-
-// Treat `git branch` as safe only when the arguments clearly indicate
-// a read-only query, not a branch mutation (create/rename/delete).
-fn git_branch_is_read_only(branch_args: &[String]) -> bool {
-    if branch_args.is_empty() {
-        // `git branch` with no additional args lists branches.
-        return true;
-    }
-
-    let mut saw_read_only_flag = false;
-    for arg in branch_args.iter().map(String::as_str) {
-        match arg {
-            "--list" | "-l" | "--show-current" | "-a" | "--all" | "-r" | "--remotes" | "-v"
-            | "-vv" | "--verbose" => {
-                saw_read_only_flag = true;
-            }
-            _ if arg.starts_with("--format=") => {
-                saw_read_only_flag = true;
-            }
-            _ => {
-                // Any other flag or positional argument may create, rename, or delete branches.
-                return false;
-            }
-        }
-    }
-
-    saw_read_only_flag
-}
-
-#[derive(Clone, Copy)]
-enum GitOptionPattern {
-    Exact(&'static str),
-    ShortWithInlineValue(&'static str),
-    Prefix(&'static str),
-}
-
-const UNSAFE_GIT_GLOBAL_OPTIONS: &[GitOptionPattern] = &[
-    GitOptionPattern::Exact("-C"),
-    GitOptionPattern::ShortWithInlineValue("-C"),
-    GitOptionPattern::Exact("-c"),
-    GitOptionPattern::ShortWithInlineValue("-c"),
-    GitOptionPattern::Exact("-p"),
-    GitOptionPattern::Exact("--config-env"),
-    GitOptionPattern::Prefix("--config-env="),
-    GitOptionPattern::Exact("--exec-path"),
-    GitOptionPattern::Prefix("--exec-path="),
-    GitOptionPattern::Exact("--git-dir"),
-    GitOptionPattern::Prefix("--git-dir="),
-    GitOptionPattern::Exact("--namespace"),
-    GitOptionPattern::Prefix("--namespace="),
-    GitOptionPattern::Exact("--paginate"),
-    GitOptionPattern::Exact("--super-prefix"),
-    GitOptionPattern::Prefix("--super-prefix="),
-    GitOptionPattern::Exact("--work-tree"),
-    GitOptionPattern::Prefix("--work-tree="),
-];
-
-const UNSAFE_GIT_SUBCOMMAND_OPTIONS: &[GitOptionPattern] = &[
-    GitOptionPattern::Exact("--output"),
-    GitOptionPattern::Prefix("--output="),
-    GitOptionPattern::Exact("--ext-diff"),
-    GitOptionPattern::Exact("--textconv"),
-    GitOptionPattern::Exact("--exec"),
-    GitOptionPattern::Prefix("--exec="),
-];
-
-impl GitOptionPattern {
-    fn matches(self, arg: &str) -> bool {
-        match self {
-            GitOptionPattern::Exact(option) => arg == option,
-            GitOptionPattern::ShortWithInlineValue(option) => {
-                arg.starts_with(option) && arg.len() > option.len()
-            }
-            GitOptionPattern::Prefix(prefix) => arg.starts_with(prefix),
-        }
-    }
-}
-
-fn git_matches_option_pattern(arg: &str, patterns: &[GitOptionPattern]) -> bool {
-    patterns.iter().any(|pattern| pattern.matches(arg))
-}
-
-fn git_has_unsafe_global_option(global_args: &[String]) -> bool {
-    global_args
-        .iter()
-        .map(String::as_str)
-        .any(|arg| git_matches_option_pattern(arg, UNSAFE_GIT_GLOBAL_OPTIONS))
-}
-
-fn git_subcommand_args_are_read_only(args: &[String]) -> bool {
-    !args
-        .iter()
-        .map(String::as_str)
-        .any(|arg| git_matches_option_pattern(arg, UNSAFE_GIT_SUBCOMMAND_OPTIONS))
+pub(crate) fn is_safe_git_command(_command: &[String]) -> bool {
+    // Git behavior depends on repository config, attributes, the discovered
+    // repository, environment, and TTY state. This argv-only classifier cannot
+    // prove that any Git command avoids repository-selected executables.
+    false
 }
 
 // (bash parsing helpers implemented in crate::bash)
@@ -350,12 +226,6 @@ mod tests {
     #[test]
     fn known_safe_examples() {
         assert!(is_safe_to_call_with_exec(&vec_str(&["ls"])));
-        assert!(is_safe_to_call_with_exec(&vec_str(&["git", "branch"])));
-        assert!(is_safe_to_call_with_exec(&vec_str(&[
-            "git",
-            "branch",
-            "--show-current"
-        ])));
         assert!(is_safe_to_call_with_exec(&vec_str(&["base64"])));
         assert!(is_safe_to_call_with_exec(&vec_str(&[
             "sed", "-n", "1,5p", "file.txt"
@@ -381,20 +251,23 @@ mod tests {
     }
 
     #[test]
-    fn git_config_sensitive_subcommands_require_approval() {
+    fn git_commands_require_approval() {
         for args in [
             vec_str(&["git", "status"]),
             vec_str(&["git", "log", "-1"]),
             vec_str(&["git", "diff"]),
             vec_str(&["git", "show", "HEAD"]),
+            vec_str(&["git", "branch"]),
+            vec_str(&["git", "branch", "--show-current"]),
             vec_str(&["bash", "-lc", "git status"]),
             vec_str(&["bash", "-lc", "git log -1"]),
             vec_str(&["bash", "-lc", "git diff"]),
             vec_str(&["bash", "-lc", "git show HEAD"]),
+            vec_str(&["bash", "-lc", "git branch"]),
         ] {
             assert!(
                 !is_known_safe_command(&args),
-                "expected {args:?} to require approval because git may invoke repository-configured helpers",
+                "expected {args:?} to require approval because Git may invoke repository-configured helpers",
             );
         }
     }
@@ -412,8 +285,8 @@ mod tests {
     }
 
     #[test]
-    fn git_branch_global_options_respect_safety_rules() {
-        assert!(is_known_safe_command(&vec_str(&[
+    fn git_branch_read_only_flags_still_require_approval() {
+        assert!(!is_known_safe_command(&vec_str(&[
             "git",
             "branch",
             "--show-current",
@@ -661,12 +534,12 @@ mod tests {
     }
 
     #[test]
-    fn windows_git_full_path_is_safe() {
+    fn windows_git_full_path_requires_approval() {
         if !cfg!(windows) {
             return;
         }
 
-        assert!(is_known_safe_command(&vec_str(&[
+        assert!(!is_known_safe_command(&vec_str(&[
             r"C:\Program Files\Git\cmd\git.exe",
             "status",
         ])));

--- a/codex-rs/shell-command/src/command_safety/is_safe_command.rs
+++ b/codex-rs/shell-command/src/command_safety/is_safe_command.rs
@@ -308,6 +308,60 @@ mod tests {
     }
 
     #[test]
+    fn git_repo_selected_helper_and_transport_variants_require_approval() {
+        for args in [
+            // `status` can invoke a repository-selected fsmonitor.
+            vec_str(&["git", "status", "--short"]),
+            // Diff-producing commands can invoke external diff and textconv helpers.
+            vec_str(&["git", "diff", "--ext-diff", "HEAD"]),
+            vec_str(&["git", "log", "--textconv", "-1"]),
+            vec_str(&["git", "show", "--textconv", "HEAD"]),
+            // Filters and transport were not in the old safelist, but keep them
+            // in the regression matrix so future safelist expansion fails closed.
+            vec_str(&["git", "cat-file", "--filters", "HEAD:file.txt"]),
+            vec_str(&["git", "remote", "show", "origin"]),
+            vec_str(&["git", "fetch", "origin"]),
+            // Shell lowering must preserve the same decision.
+            vec_str(&["bash", "-lc", "git status --short"]),
+            vec_str(&["bash", "-lc", "git diff --ext-diff HEAD"]),
+            vec_str(&["bash", "-lc", "git log --textconv -1"]),
+            vec_str(&["bash", "-lc", "git show --textconv HEAD"]),
+            vec_str(&["bash", "-lc", "git branch --show-current"]),
+        ] {
+            assert!(
+                !is_known_safe_command(&args),
+                "expected repository-sensitive Git variant {args:?} to require approval",
+            );
+        }
+    }
+
+    #[test]
+    fn path_qualified_git_variants_require_approval() {
+        let absolute_git = if cfg!(windows) {
+            r"C:\Program Files\Git\cmd\git.exe"
+        } else {
+            "/usr/bin/git"
+        };
+        let current_relative_git = if cfg!(windows) { r".\git.exe" } else { "./git" };
+        let parent_relative_git = if cfg!(windows) {
+            r"..\git.exe"
+        } else {
+            "../git"
+        };
+
+        for args in [
+            vec_str(&[absolute_git, "status"]),
+            vec_str(&[current_relative_git, "status"]),
+            vec_str(&[parent_relative_git, "status"]),
+        ] {
+            assert!(
+                !is_known_safe_command(&args),
+                "expected path-qualified Git executable {args:?} to require approval",
+            );
+        }
+    }
+
+    #[test]
     fn git_branch_mutating_flags_are_not_safe() {
         assert!(!is_known_safe_command(&vec_str(&[
             "git", "branch", "-d", "feature"

--- a/codex-rs/shell-command/src/command_safety/is_safe_command.rs
+++ b/codex-rs/shell-command/src/command_safety/is_safe_command.rs
@@ -187,7 +187,12 @@ pub(crate) fn is_safe_git_command(command: &[String]) -> bool {
     let subcommand_args = &command[subcommand_idx + 1..];
 
     match subcommand {
-        "status" | "log" | "diff" | "show" => git_subcommand_args_are_read_only(subcommand_args),
+        "status" | "log" | "diff" | "show" => {
+            // These subcommands can consult repository-controlled configuration
+            // for external helpers, so argv-only classification is not enough to
+            // auto-approve them.
+            false
+        }
         "branch" => {
             git_subcommand_args_are_read_only(subcommand_args)
                 && git_branch_is_read_only(subcommand_args)
@@ -345,7 +350,6 @@ mod tests {
     #[test]
     fn known_safe_examples() {
         assert!(is_safe_to_call_with_exec(&vec_str(&["ls"])));
-        assert!(is_safe_to_call_with_exec(&vec_str(&["git", "status"])));
         assert!(is_safe_to_call_with_exec(&vec_str(&["git", "branch"])));
         assert!(is_safe_to_call_with_exec(&vec_str(&[
             "git",
@@ -373,6 +377,25 @@ mod tests {
         } else {
             assert!(!is_safe_to_call_with_exec(&vec_str(&["numfmt", "1000"])));
             assert!(!is_safe_to_call_with_exec(&vec_str(&["tac", "Cargo.toml"])));
+        }
+    }
+
+    #[test]
+    fn git_config_sensitive_subcommands_require_approval() {
+        for args in [
+            vec_str(&["git", "status"]),
+            vec_str(&["git", "log", "-1"]),
+            vec_str(&["git", "diff"]),
+            vec_str(&["git", "show", "HEAD"]),
+            vec_str(&["bash", "-lc", "git status"]),
+            vec_str(&["bash", "-lc", "git log -1"]),
+            vec_str(&["bash", "-lc", "git diff"]),
+            vec_str(&["bash", "-lc", "git show HEAD"]),
+        ] {
+            assert!(
+                !is_known_safe_command(&args),
+                "expected {args:?} to require approval because git may invoke repository-configured helpers",
+            );
         }
     }
 
@@ -461,13 +484,15 @@ mod tests {
     }
 
     #[test]
-    fn git_subcommand_patch_flags_remain_safe() {
-        assert!(is_known_safe_command(&vec_str(&["git", "log", "-p", "-1"])));
-        assert!(is_known_safe_command(&vec_str(&["git", "diff", "-p"])));
-        assert!(is_known_safe_command(&vec_str(&[
+    fn git_patch_display_subcommands_require_approval() {
+        assert!(!is_known_safe_command(&vec_str(&[
+            "git", "log", "-p", "-1"
+        ])));
+        assert!(!is_known_safe_command(&vec_str(&["git", "diff", "-p"])));
+        assert!(!is_known_safe_command(&vec_str(&[
             "git", "show", "-p", "HEAD",
         ])));
-        assert!(is_known_safe_command(&vec_str(&[
+        assert!(!is_known_safe_command(&vec_str(&[
             "bash",
             "-lc",
             "git log -p -1",
@@ -651,11 +676,6 @@ mod tests {
     fn bash_lc_safe_examples() {
         assert!(is_known_safe_command(&vec_str(&["bash", "-lc", "ls"])));
         assert!(is_known_safe_command(&vec_str(&["bash", "-lc", "ls -1"])));
-        assert!(is_known_safe_command(&vec_str(&[
-            "bash",
-            "-lc",
-            "git status"
-        ])));
         assert!(is_known_safe_command(&vec_str(&[
             "bash",
             "-lc",

--- a/codex-rs/shell-command/src/command_safety/windows_safe_commands.rs
+++ b/codex-rs/shell-command/src/command_safety/windows_safe_commands.rs
@@ -283,7 +283,7 @@ mod tests {
     }
 
     #[test]
-    fn allows_read_only_pipelines_and_git_branch_usage() {
+    fn allows_read_only_pipelines() {
         let Some(pwsh) = try_find_pwsh_executable_blocking() else {
             return;
         };
@@ -309,12 +309,6 @@ mod tests {
         assert!(is_safe_command_windows(&[
             pwsh.clone(),
             "-Command".to_string(),
-            "git branch --show-current".to_string()
-        ]));
-
-        assert!(is_safe_command_windows(&[
-            pwsh.clone(),
-            "-Command".to_string(),
             "(Get-Content foo.rs -Raw)".to_string()
         ]));
 
@@ -327,20 +321,27 @@ mod tests {
 
     #[test]
     fn rejects_git_config_sensitive_subcommands() {
-        let results: Vec<(&str, bool)> = ["git status", "git log -1", "git diff", "git show HEAD"]
-            .into_iter()
-            .map(|script| {
-                (
-                    script,
-                    is_safe_command_windows(&[
-                        "powershell.exe".to_string(),
-                        "-NoProfile".to_string(),
-                        "-Command".to_string(),
-                        script.to_string(),
-                    ]),
-                )
-            })
-            .collect();
+        let results: Vec<(&str, bool)> = [
+            "git status",
+            "git log -1",
+            "git diff",
+            "git show HEAD",
+            "git branch",
+            "git branch --show-current",
+        ]
+        .into_iter()
+        .map(|script| {
+            (
+                script,
+                is_safe_command_windows(&[
+                    "powershell.exe".to_string(),
+                    "-NoProfile".to_string(),
+                    "-Command".to_string(),
+                    script.to_string(),
+                ]),
+            )
+        })
+        .collect();
 
         assert_eq!(
             vec![
@@ -348,6 +349,8 @@ mod tests {
                 ("git log -1", false),
                 ("git diff", false),
                 ("git show HEAD", false),
+                ("git branch", false),
+                ("git branch --show-current", false),
             ],
             results
         );

--- a/codex-rs/shell-command/src/command_safety/windows_safe_commands.rs
+++ b/codex-rs/shell-command/src/command_safety/windows_safe_commands.rs
@@ -244,13 +244,6 @@ mod tests {
 
         assert!(is_safe_command_windows(&vec_str(&[
             "powershell.exe",
-            "-NoProfile",
-            "-Command",
-            "git status",
-        ])));
-
-        assert!(is_safe_command_windows(&vec_str(&[
-            "powershell.exe",
             "Get-Content",
             "Cargo.toml",
         ])));
@@ -290,7 +283,7 @@ mod tests {
     }
 
     #[test]
-    fn allows_read_only_pipelines_and_git_usage() {
+    fn allows_read_only_pipelines_and_git_branch_usage() {
         let Some(pwsh) = try_find_pwsh_executable_blocking() else {
             return;
         };
@@ -316,7 +309,7 @@ mod tests {
         assert!(is_safe_command_windows(&[
             pwsh.clone(),
             "-Command".to_string(),
-            "git show HEAD:foo.rs".to_string()
+            "git branch --show-current".to_string()
         ]));
 
         assert!(is_safe_command_windows(&[
@@ -330,6 +323,34 @@ mod tests {
             "-Command".to_string(),
             "Get-Item foo.rs | Select-Object Length".to_string()
         ]));
+    }
+
+    #[test]
+    fn rejects_git_config_sensitive_subcommands() {
+        let results: Vec<(&str, bool)> = ["git status", "git log -1", "git diff", "git show HEAD"]
+            .into_iter()
+            .map(|script| {
+                (
+                    script,
+                    is_safe_command_windows(&[
+                        "powershell.exe".to_string(),
+                        "-NoProfile".to_string(),
+                        "-Command".to_string(),
+                        script.to_string(),
+                    ]),
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            vec![
+                ("git status", false),
+                ("git log -1", false),
+                ("git diff", false),
+                ("git show HEAD", false),
+            ],
+            results
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Why

Git is more programmable than it looks. Even a command such as `git status` or `git diff` can read repository configuration and start helper programs. Treating these commands as automatically safe based only on their command line is therefore unsafe.

A one-time approval is also tied to the current repository. It should not silently become a permanent rule that applies in every checkout.

## Approach

Require approval for agent-issued Git commands under `UnlessTrusted`. Normal `OnRequest` and `Granular` commands remain sandboxed, and explicit sandbox expansion still requires approval.

Do not propose permanent approval rules for Git or generic wrappers such as `env`, `sudo`, `command`, and `nice`. Only preserve safe-command treatment for bare executables resolved from a stable entry in the original host PATH.

For zsh-fork, reuse an accepted parent approval once when the child is the exact Git command that was approved. This avoids asking twice without broadening the approval.

This PR covers approval behavior. Internal Git helpers and transport isolation are handled by the other PRs in this series. It should land after #30628 and #30631.

## Testing

Focused shell, policy, trusted-executable, escalation, integration, cross-checkout, and real zsh-fork tests passed. Formatting and fix checks also passed.