### PR TITLE
Skip local project trust for remote threads

### DIFF
--- a/codex-rs/app-server/src/request_processors/thread_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor.rs
@@ -1035,6 +1035,20 @@ impl ThreadRequestProcessor {
             .load_with_overrides(config_overrides.clone(), typesafe_overrides.clone())
             .await
             .map_err(|err| config_load_error(&err))?;
+        let environments = environments.unwrap_or_else(|| {
+            listener_task_context
+                .thread_manager
+                .default_environment_selections(&config.cwd)
+        });
+        let primary_environment_is_remote = environments
+            .first()
+            .and_then(|selection| {
+                listener_task_context
+                    .thread_manager
+                    .environment_manager()
+                    .get_environment(&selection.environment_id)
+            })
+            .is_some_and(|environment| environment.is_remote());
 
         // The user may have requested WorkspaceWrite or DangerFullAccess via
         // the command line, though in the process of deriving the Config, it
@@ -1048,7 +1062,8 @@ impl ThreadRequestProcessor {
             config.cwd.as_path(),
         );
 
-        if requested_cwd.is_some()
+        if !primary_environment_is_remote
+            && requested_cwd.is_some()
             && config.active_project.trust_level.is_none()
             && (requested_permissions_trust_project || effective_permissions_trust_project)
         {
@@ -1101,11 +1116,6 @@ impl ThreadRequestProcessor {
                 .map_err(|err| config_load_error(&err))?;
         }
 
-        let environments = environments.unwrap_or_else(|| {
-            listener_task_context
-                .thread_manager
-                .default_environment_selections(&config.cwd)
-        });
         let dynamic_tools = dynamic_tools.unwrap_or_default();
         if !dynamic_tools.is_empty() {
             validate_dynamic_tools(&dynamic_tools).map_err(invalid_request)?;

--- a/codex-rs/app-server/tests/suite/v2/thread_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_start.rs
@@ -1029,6 +1029,59 @@ model_reasoning_effort = "high"
 }
 
 #[tokio::test]
+async fn thread_start_with_remote_primary_environment_does_not_persist_project_trust() -> Result<()>
+{
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+
+    let codex_home = TempDir::new()?;
+    create_config_toml_without_approval_policy(codex_home.path(), &server.uri())?;
+    std::fs::write(
+        codex_home.path().join("environments.toml"),
+        r#"
+default = "remote"
+include_local = true
+
+[[environments]]
+id = "remote"
+url = "ws://127.0.0.1:1"
+"#,
+    )?;
+    let config_path = codex_home.path().join("config.toml");
+    let config_before = std::fs::read_to_string(&config_path)?;
+    let workspace = TempDir::new()?;
+
+    let mut mcp = TestAppServer::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    for environments in [
+        None,
+        Some(vec![TurnEnvironmentParams {
+            environment_id: "remote".to_string(),
+            cwd: workspace.path().to_path_buf().abs().into(),
+        }]),
+    ] {
+        let request_id = mcp
+            .send_thread_start_request(ThreadStartParams {
+                cwd: Some(workspace.path().display().to_string()),
+                sandbox: Some(SandboxMode::WorkspaceWrite),
+                environments,
+                ..Default::default()
+            })
+            .await?;
+        timeout(
+            DEFAULT_READ_TIMEOUT,
+            mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+        )
+        .await??;
+
+        let config_after = std::fs::read_to_string(&config_path)?;
+        assert_eq!(config_after, config_before);
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn thread_start_with_nested_git_cwd_trusts_repo_root() -> Result<()> {
     let server = create_mock_responses_server_repeating_assistant("Done").await;
 


### PR DESCRIPTION
## Summary

When a remote environment is primary, its working directory does not belong to the local app-server process. Skip the app-server auto-trust step so it does not use local Git state to choose a trust root or write that local path to config.

Local threads keep the existing project trust behavior. This covers both explicit remote selection and a remote default environment.