### PR TITLE
[do not merge] Run shell commands in remote environments

### DIFF
--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -301,13 +301,6 @@ impl TurnContext {
         }
     }
 
-    #[deprecated(note = "resolve paths from the selected turn environment cwd instead")]
-    pub(crate) fn resolve_path(&self, path: Option<String>) -> AbsolutePathBuf {
-        #[allow(deprecated)]
-        path.as_ref()
-            .map_or_else(|| self.cwd.clone(), |path| self.cwd.join(path))
-    }
-
     pub(crate) fn file_system_sandbox_context(
         &self,
         additional_permissions: Option<AdditionalPermissionProfile>,

--- a/codex-rs/core/src/tools/handlers/shell/shell_command.rs
+++ b/codex-rs/core/src/tools/handlers/shell/shell_command.rs
@@ -84,16 +84,14 @@ impl ShellCommandHandler {
 
     pub(super) fn to_exec_params(
         params: &ShellCommandToolCallParams,
-        session: &crate::session::session::Session,
+        shell: &Shell,
         turn_context: &TurnContext,
         thread_id: ThreadId,
+        cwd: codex_utils_absolute_path::AbsolutePathBuf,
         allow_login_shell: bool,
     ) -> Result<ExecParams, FunctionCallError> {
-        let shell = session.user_shell();
         let use_login_shell = Self::resolve_use_login_shell(params.login, allow_login_shell)?;
-        let command = Self::base_command(shell.as_ref(), &params.command, use_login_shell);
-        #[allow(deprecated)]
-        let cwd = turn_context.resolve_path(params.workdir.clone());
+        let command = Self::base_command(shell, &params.command, use_login_shell);
 
         Ok(ExecParams {
             command,
@@ -170,27 +168,41 @@ impl ShellCommandHandler {
             )));
         };
 
-        #[allow(deprecated)]
-        let cwd = resolve_workdir_base_path(&arguments, &turn.cwd)?;
+        let Some(turn_environment) = turn.environments.primary() else {
+            return Err(FunctionCallError::RespondToModel(
+                "shell is unavailable in this session".to_string(),
+            ));
+        };
+        let environment_cwd = turn_environment.cwd().to_abs_path().map_err(|err| {
+            FunctionCallError::RespondToModel(format!(
+                "environment cwd `{}` is not native to the Codex host: {err}",
+                turn_environment.cwd()
+            ))
+        })?;
+        let cwd = resolve_workdir_base_path(&arguments, &environment_cwd)?;
         let params: ShellCommandToolCallParams = parse_arguments_with_base_path(&arguments, &cwd)?;
-        #[allow(deprecated)]
-        let workdir = turn.resolve_path(params.workdir.clone());
         maybe_emit_implicit_skill_invocation(
             session.as_ref(),
             turn.as_ref(),
             &params.command,
-            &workdir,
+            &cwd,
         )
         .await;
         let prefix_rule = params.prefix_rule.clone();
+        let session_shell = session.user_shell();
+        let shell = turn_environment
+            .shell
+            .as_ref()
+            .unwrap_or(session_shell.as_ref());
         let exec_params = Self::to_exec_params(
             &params,
-            session.as_ref(),
+            shell,
             turn.as_ref(),
             session.thread_id,
+            cwd,
             turn.config.permissions.allow_login_shell,
         )?;
-        let shell_type = Some(session.user_shell().shell_type);
+        let shell_type = Some(shell.shell_type);
         run_exec_like(RunExecLikeArgs {
             tool_name,
             exec_params,

--- a/codex-rs/core/src/tools/handlers/shell_tests.rs
+++ b/codex-rs/core/src/tools/handlers/shell_tests.rs
@@ -67,7 +67,7 @@ fn assert_safe(shell: &Shell, command: &str) {
 }
 
 #[tokio::test]
-async fn shell_command_handler_to_exec_params_uses_session_shell_and_turn_context() {
+async fn shell_command_handler_to_exec_params_uses_shell_and_cwd() {
     let (session, turn_context) = make_session_and_context().await;
 
     let command = "echo hello".to_string();
@@ -80,8 +80,7 @@ async fn shell_command_handler_to_exec_params_uses_session_shell_and_turn_contex
     let expected_command = session
         .user_shell()
         .derive_exec_args(&command, /*use_login_shell*/ true);
-    #[allow(deprecated)]
-    let expected_cwd = turn_context.resolve_path(workdir.clone());
+    let expected_cwd = turn_context.config.cwd.join("subdir");
     let expected_env = create_env(
         &turn_context.config.permissions.shell_environment_policy,
         Some(session.thread_id),
@@ -100,9 +99,10 @@ async fn shell_command_handler_to_exec_params_uses_session_shell_and_turn_contex
 
     let exec_params = ShellCommandHandler::to_exec_params(
         &params,
-        &session,
+        session.user_shell().as_ref(),
         &turn_context,
         session.thread_id,
+        expected_cwd.clone(),
         /*allow_login_shell*/ true,
     )
     .expect("login shells should be allowed");
@@ -162,9 +162,16 @@ async fn shell_command_handler_defaults_to_non_login_when_disallowed() {
 
     let exec_params = ShellCommandHandler::to_exec_params(
         &params,
-        &session,
+        session.user_shell().as_ref(),
         &turn_context,
         session.thread_id,
+        turn_context
+            .environments
+            .primary()
+            .expect("turn environment")
+            .cwd()
+            .to_abs_path()
+            .expect("native cwd"),
         /*allow_login_shell*/ false,
     )
     .expect("non-login shells should still be allowed");

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -10,10 +10,12 @@ pub(crate) mod zsh_fork_backend;
 
 use crate::command_canonicalization::canonicalize_command_for_approval;
 use crate::exec::ExecCapturePolicy;
+use crate::exec_env::create_env;
 use crate::guardian::GuardianApprovalRequest;
 use crate::guardian::GuardianNetworkAccessTrigger;
 use crate::guardian::review_approval_request;
 use crate::sandboxing::ExecOptions;
+use crate::sandboxing::ExecServerEnvConfig;
 use crate::sandboxing::SandboxPermissions;
 use crate::sandboxing::execute_env;
 use crate::session::turn_context::TurnEnvironment;
@@ -40,6 +42,8 @@ use crate::tools::sandboxing::ToolRuntime;
 use crate::tools::sandboxing::managed_network_for_sandbox_permissions;
 use crate::tools::sandboxing::sandbox_permissions_preserving_denied_reads;
 use crate::tools::sandboxing::with_cached_approval;
+use crate::unified_exec::UnifiedExecContext;
+use crate::unified_exec::exec_env_policy_from_shell_policy;
 use codex_network_proxy::NetworkProxy;
 use codex_protocol::exec_output::ExecToolCallOutput;
 use codex_protocol::models::AdditionalPermissionProfile;
@@ -49,6 +53,7 @@ use codex_shell_command::powershell::prefix_powershell_script_with_utf8;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use futures::future::BoxFuture;
 use std::collections::HashMap;
+use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 #[derive(Clone, Debug)]
@@ -242,6 +247,7 @@ impl ToolRuntime<ShellRequest, ExecToolCallOutput> for ShellRuntime {
         ctx: &ToolCtx,
     ) -> Result<ExecToolCallOutput, ToolError> {
         let session_shell = ctx.session.user_shell();
+        let environment_is_remote = req.turn_environment.environment.is_remote();
         let shell = req
             .turn_environment
             .shell
@@ -261,11 +267,14 @@ impl ToolRuntime<ShellRequest, ExecToolCallOutput> for ShellRuntime {
         let (env, runtime_path_prepends) = {
             let mut env = env;
             let mut runtime_path_prepends = RuntimePathPrepends::default();
-            crate::tools::runtimes::apply_package_path_prepend(
-                &mut env,
-                &mut runtime_path_prepends,
-            );
-            if self.backend == ShellRuntimeBackend::ShellCommandZshFork
+            if !environment_is_remote {
+                crate::tools::runtimes::apply_package_path_prepend(
+                    &mut env,
+                    &mut runtime_path_prepends,
+                );
+            }
+            if !environment_is_remote
+                && self.backend == ShellRuntimeBackend::ShellCommandZshFork
                 && let Some(shell_zsh_path) = ctx.session.services.shell_zsh_path.as_deref()
             {
                 apply_zsh_fork_path_prepend(&mut env, &mut runtime_path_prepends, shell_zsh_path);
@@ -274,14 +283,18 @@ impl ToolRuntime<ShellRequest, ExecToolCallOutput> for ShellRuntime {
         };
         #[cfg(not(unix))]
         let runtime_path_prepends = RuntimePathPrepends::default();
-        let command = maybe_wrap_shell_lc_with_snapshot(
-            &req.command,
-            shell,
-            shell_snapshot_location.as_ref(),
-            &explicit_env_overrides,
-            &env,
-            &runtime_path_prepends,
-        );
+        let command = if environment_is_remote {
+            req.command.clone()
+        } else {
+            maybe_wrap_shell_lc_with_snapshot(
+                &req.command,
+                shell,
+                shell_snapshot_location.as_ref(),
+                &explicit_env_overrides,
+                &env,
+                &runtime_path_prepends,
+            )
+        };
         let command = disable_powershell_profile_for_elevated_windows_sandbox(
             &command,
             req.shell_type.as_ref(),
@@ -293,6 +306,12 @@ impl ToolRuntime<ShellRequest, ExecToolCallOutput> for ShellRuntime {
         } else {
             command
         };
+
+        if self.backend == ShellRuntimeBackend::ShellCommandZshFork && environment_is_remote {
+            return Err(ToolError::Rejected(
+                "shell_command zsh-fork is not supported for remote environments".to_string(),
+            ));
+        }
 
         if self.backend == ShellRuntimeBackend::ShellCommandZshFork {
             match zsh_fork_backend::maybe_run_shell_command(req, attempt, ctx, &command).await? {
@@ -316,12 +335,37 @@ impl ToolRuntime<ShellRequest, ExecToolCallOutput> for ShellRuntime {
             expiration,
             capture_policy: ExecCapturePolicy::ShellTool,
         };
-        let env = attempt
+        let mut exec_env = attempt
             .env_for(command, options, managed_network)
             .map_err(ToolError::Codex)?;
-        let out = execute_env(env, Self::stdout_stream(ctx))
-            .await
-            .map_err(ToolError::Codex)?;
+        if environment_is_remote {
+            let shell_environment_policy = &ctx.turn.config.permissions.shell_environment_policy;
+            exec_env.exec_server_env_config = Some(ExecServerEnvConfig {
+                policy: exec_env_policy_from_shell_policy(shell_environment_policy),
+                local_policy_env: create_env(shell_environment_policy, /*thread_id*/ None),
+            });
+        }
+        let out = if environment_is_remote {
+            let context = UnifiedExecContext::new(
+                Arc::clone(&ctx.session),
+                Arc::clone(&ctx.turn),
+                ctx.call_id.clone(),
+            );
+            ctx.session
+                .services
+                .unified_exec_manager
+                .execute_remote_shell(
+                    exec_env,
+                    req.turn_environment.environment.as_ref(),
+                    &context,
+                )
+                .await
+                .map_err(ToolError::Codex)?
+        } else {
+            execute_env(exec_env, Self::stdout_stream(ctx))
+                .await
+                .map_err(ToolError::Codex)?
+        };
         Ok(out)
     }
 }

--- a/codex-rs/core/src/unified_exec/mod.rs
+++ b/codex-rs/core/src/unified_exec/mod.rs
@@ -49,6 +49,7 @@ mod head_tail_buffer;
 mod process;
 mod process_manager;
 mod process_state;
+mod remote_shell;
 
 pub(crate) fn set_deterministic_process_ids_for_tests(enabled: bool) {
     process_manager::set_deterministic_process_ids_for_tests(enabled);
@@ -60,6 +61,7 @@ pub(crate) use process::NoopSpawnLifecycle;
 pub(crate) use process::SpawnLifecycle;
 pub(crate) use process::SpawnLifecycleHandle;
 pub(crate) use process::UnifiedExecProcess;
+pub(crate) use process_manager::exec_env_policy_from_shell_policy;
 
 pub(crate) const MIN_YIELD_TIME_MS: u64 = 250;
 pub(crate) const WINDOWS_INITIAL_EXEC_YIELD_TIME_FLOOR_MS: u64 = 2_000;

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -101,7 +101,7 @@ fn apply_unified_exec_env(mut env: HashMap<String, String>) -> HashMap<String, S
     env
 }
 
-fn exec_env_policy_from_shell_policy(
+pub(crate) fn exec_env_policy_from_shell_policy(
     policy: &ShellEnvironmentPolicy,
 ) -> codex_exec_server::ExecEnvPolicy {
     codex_exec_server::ExecEnvPolicy {

--- a/codex-rs/core/src/unified_exec/remote_shell.rs
+++ b/codex-rs/core/src/unified_exec/remote_shell.rs
@@ -1,0 +1,128 @@
+//! Runs remote shell commands through the existing unified-exec process lifecycle.
+//!
+//! This adapter intentionally keeps unified exec's combined output and process lifecycle
+//! semantics. It only waits for completion and converts the result for `shell_command`.
+
+use std::io;
+use std::sync::Arc;
+
+use codex_exec_server::Environment;
+use codex_protocol::error::CodexErr;
+use codex_protocol::error::SandboxErr;
+use codex_protocol::exec_output::ExecToolCallOutput;
+use codex_protocol::exec_output::StreamOutput;
+use tokio::sync::Mutex;
+use tokio::time::Instant;
+
+use super::NoopSpawnLifecycle;
+use super::UnifiedExecContext;
+use super::UnifiedExecError;
+use super::UnifiedExecProcessManager;
+use super::async_watcher::start_streaming_output;
+use super::head_tail_buffer::HeadTailBuffer;
+use crate::exec::ExecExpirationOutcome;
+use crate::exec::is_likely_sandbox_denied;
+use crate::sandboxing::ExecRequest;
+
+impl UnifiedExecProcessManager {
+    pub(crate) async fn execute_remote_shell(
+        &self,
+        mut request: ExecRequest,
+        environment: &Environment,
+        context: &UnifiedExecContext,
+    ) -> Result<ExecToolCallOutput, CodexErr> {
+        if let Some(network) = request.network.as_ref() {
+            network.apply_to_env(&mut request.env);
+        }
+
+        let expiration = request.expiration.clone();
+        let sandbox = request.sandbox;
+        let process_id = self.allocate_process_id().await;
+        let started_at = Instant::now();
+        let process = match self
+            .open_session_with_exec_env(
+                process_id,
+                &request,
+                /*tty*/ false,
+                Box::new(NoopSpawnLifecycle),
+                environment,
+            )
+            .await
+        {
+            Ok(process) => process,
+            Err(error) => {
+                self.release_process_id(process_id).await;
+                return Err(match error {
+                    UnifiedExecError::SandboxDenied { output, .. } => {
+                        CodexErr::Sandbox(SandboxErr::Denied {
+                            output: Box::new(output),
+                            network_policy_decision: None,
+                        })
+                    }
+                    error => CodexErr::Io(io::Error::other(error.to_string())),
+                });
+            }
+        };
+
+        start_streaming_output(
+            &process,
+            context,
+            Arc::new(Mutex::new(HeadTailBuffer::default())),
+        );
+        let output_handles = process.output_handles();
+        let output_drained = process.output_drained_notify();
+        // Match unified exec by establishing the remote process before waiting for completion.
+        let expiration_wait = expiration.wait_with_outcome();
+        tokio::pin!(expiration_wait);
+        let expiration_outcome = tokio::select! {
+            _ = output_handles.cancellation_token.cancelled() => None,
+            outcome = &mut expiration_wait => Some(outcome),
+        };
+        // Keep unified exec's existing termination behavior rather than adding a second drain path.
+        if expiration_outcome.is_some() && process.terminate_confirmed().await.is_err() {
+            process.terminate();
+        }
+        output_drained.notified().await;
+
+        let bytes = output_handles.output_buffer.lock().await.to_bytes();
+        // Unified exec exposes remote process output as one combined stream.
+        let stdout = StreamOutput {
+            text: bytes,
+            truncated_after_lines: None,
+        }
+        .from_utf8_lossy();
+        let timed_out = expiration_outcome == Some(ExecExpirationOutcome::TimedOut);
+        let exit_code = match expiration_outcome {
+            Some(ExecExpirationOutcome::TimedOut) => 124,
+            Some(ExecExpirationOutcome::Cancelled) => 1,
+            None => process.exit_code().unwrap_or(-1),
+        };
+        let output = ExecToolCallOutput {
+            exit_code,
+            stdout: stdout.clone(),
+            stderr: StreamOutput::new(String::new()),
+            aggregated_output: stdout,
+            duration: started_at.elapsed(),
+            timed_out,
+        };
+        let failure_message = process.failure_message();
+        self.release_process_id(process_id).await;
+
+        if timed_out {
+            return Err(CodexErr::Sandbox(SandboxErr::Timeout {
+                output: Box::new(output),
+            }));
+        }
+        if let Some(message) = failure_message {
+            return Err(CodexErr::Io(io::Error::other(message)));
+        }
+        if is_likely_sandbox_denied(sandbox, &output) {
+            return Err(CodexErr::Sandbox(SandboxErr::Denied {
+                output: Box::new(output),
+                network_policy_decision: None,
+            }));
+        }
+
+        Ok(output)
+    }
+}

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -294,10 +294,11 @@ fn remote_exec(script: &str) -> Result<()> {
     Ok(())
 }
 
-async fn exec_command_routing_output(
+async fn command_routing_output(
     test: &TestCodex,
     server: &wiremock::MockServer,
     call_id: &str,
+    tool_name: &str,
     arguments: Value,
     environments: Option<Vec<TurnEnvironmentSelection>>,
 ) -> Result<String> {
@@ -306,7 +307,7 @@ async fn exec_command_routing_output(
         vec![
             sse(vec![
                 ev_response_created("resp-1"),
-                ev_function_call(call_id, "exec_command", &serde_json::to_string(&arguments)?),
+                ev_function_call(call_id, tool_name, &serde_json::to_string(&arguments)?),
                 ev_completed("resp-1"),
             ]),
             sse(vec![
@@ -318,7 +319,7 @@ async fn exec_command_routing_output(
     )
     .await;
 
-    test.submit_turn_with_environments("route exec command", environments)
+    test.submit_turn_with_environments("route command", environments)
         .await?;
 
     response_mock
@@ -366,10 +367,11 @@ async fn exec_command_routes_to_selected_remote_environment() -> Result<()> {
         environment_id: REMOTE_ENVIRONMENT_ID.to_string(),
         cwd: PathUri::from_abs_path(&remote_cwd),
     };
-    let multi_env_output = exec_command_routing_output(
+    let multi_env_output = command_routing_output(
         &test,
         &server,
         "call-multi-env",
+        "exec_command",
         json!({
             "shell": "/bin/sh",
             "cmd": format!("cat {remote_marker_name}"),
@@ -387,6 +389,84 @@ async fn exec_command_routes_to_selected_remote_environment() -> Result<()> {
     assert!(
         !multi_env_output.contains("local-routing"),
         "multi-env command should not route to local: {multi_env_output}",
+    );
+
+    test.fs()
+        .remove(
+            &remote_cwd_uri,
+            RemoveOptions {
+                recursive: true,
+                force: true,
+            },
+            /*sandbox*/ None,
+        )
+        .await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn shell_command_routes_to_primary_remote_environment() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+    skip_if_wine_exec!(Ok(()), "requires the Docker-backed POSIX executor");
+    let Some(_remote_env) = get_remote_test_env() else {
+        return Ok(());
+    };
+
+    let server = start_mock_server().await;
+    let test = test_codex()
+        .with_model("gpt-5.4")
+        .build_with_remote_and_local_env(&server)
+        .await?;
+    let local_cwd = TempDir::new()?;
+    fs::write(local_cwd.path().join("marker.txt"), "local-routing")?;
+    let remote_cwd = PathBuf::from(format!(
+        "/tmp/codex-shell-remote-routing-{}",
+        SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis()
+    ))
+    .abs();
+    let remote_cwd_uri = PathUri::from_abs_path(&remote_cwd);
+    test.fs()
+        .create_directory(
+            &remote_cwd_uri,
+            CreateDirectoryOptions { recursive: true },
+            /*sandbox*/ None,
+        )
+        .await?;
+    test.fs()
+        .write_file(
+            &PathUri::from_path(remote_cwd.join("marker.txt"))?,
+            b"remote-routing".to_vec(),
+            /*sandbox*/ None,
+        )
+        .await?;
+
+    let output = command_routing_output(
+        &test,
+        &server,
+        "call-shell-remote",
+        "shell_command",
+        json!({
+            "command": "cat marker.txt",
+            "login": false,
+            "timeout_ms": 10_000,
+        }),
+        Some(vec![
+            TurnEnvironmentSelection {
+                environment_id: REMOTE_ENVIRONMENT_ID.to_string(),
+                cwd: remote_cwd_uri.clone(),
+            },
+            local(local_cwd.path().abs()),
+        ]),
+    )
+    .await?;
+    assert!(
+        output.contains("remote-routing"),
+        "unexpected shell_command output: {output}",
+    );
+    assert!(
+        !output.contains("local-routing"),
+        "shell_command should not route to local: {output}",
     );
 
     test.fs()


### PR DESCRIPTION
## Why

`shell_command` still assumes that the Codex orchestrator owns the selected working directory and can spawn the command locally. In a split environment, the primary working directory and shell belong to the remote executor, so the command can run against the wrong filesystem or fail before reaching the executor.

Unified exec already routes commands through the selected environment. This change gives `shell_command` the same split execution boundary without changing its local execution path.

## What this achieves

- Resolves the command working directory and shell from the primary turn environment.
- Keeps the existing `shell_command` approval and sandbox transformation flow.
- Sends remote commands through the existing unified-exec process lifecycle and environment exec backend.
- Avoids applying orchestrator-local shell snapshots and runtime path changes to remote commands.
- Leaves local `shell_command` execution unchanged.
- Adds an integration test proving that a remote primary environment reads the remote working directory instead of the local one.

## Known limitations

Remote `shell_command` intentionally supports no more than unified exec currently supports on the split:

- Remote stdout and stderr are exposed as unified exec's combined output stream; stderr identity is not preserved separately.
- Timeout and cancellation begin after the remote process is established, and termination uses unified exec's existing output-drain behavior.
- Sandboxing and platform support are the same as unified exec today. This PR does not improve split sandboxing or Windows support.
- Remote shell snapshots and the zsh-fork execution path are not supported.
- Remote paths must currently be representable using the orchestrator's native path convention.
