### PR TITLE
Isolate marketplace Git transport from workspace config

### DIFF
--- a/codex-rs/core-plugins/src/git_transport.rs
+++ b/codex-rs/core-plugins/src/git_transport.rs
@@ -1,6 +1,44 @@
 use std::process::Command;
 use tempfile::TempDir;
 
+/// Environment variables that can redirect Git away from the repository
+/// selected by `current_dir` or `-C`, or inject command-scoped configuration.
+///
+/// This follows `git rev-parse --local-env-vars` and also clears discovery and
+/// namespace controls that affect repository selection. Indexed
+/// `GIT_CONFIG_KEY_*` / `GIT_CONFIG_VALUE_*` entries are inert once both
+/// command-scope entry points are removed.
+const REPOSITORY_LOCAL_GIT_ENVIRONMENT_VARIABLES: &[&str] = &[
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_COMMON_DIR",
+    "GIT_CONFIG",
+    "GIT_CONFIG_COUNT",
+    "GIT_CONFIG_PARAMETERS",
+    "GIT_DIR",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+    "GIT_GRAFT_FILE",
+    "GIT_IMPLICIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_NAMESPACE",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_PREFIX",
+    "GIT_REPLACE_REF_BASE",
+    "GIT_SHALLOW_FILE",
+    "GIT_WORK_TREE",
+];
+
+/// Make an internal Git command honor its explicitly selected repository
+/// instead of ambient repository state inherited by the Codex process.
+///
+/// User-global and system configuration, authentication helpers, and transport
+/// configuration remain available.
+pub(crate) fn sanitize_repository_environment(command: &mut Command) {
+    for name in REPOSITORY_LOCAL_GIT_ENVIRONMENT_VARIABLES {
+        command.env_remove(name);
+    }
+}
+
 /// Runs transport commands from a clean, minimal repository so Git cannot
 /// discover repository-local configuration from the directory where Codex was
 /// launched. User-level Git configuration remains available.
@@ -16,10 +54,9 @@ impl NeutralGitCwd {
     }
 
     pub(crate) fn configure(&self, command: &mut Command) {
+        sanitize_repository_environment(command);
         command
             .current_dir(self.directory.path())
-            .env_remove("GIT_DIR")
-            .env_remove("GIT_WORK_TREE")
             .env("GIT_CEILING_DIRECTORIES", self.directory.path());
     }
 }
@@ -39,6 +76,7 @@ fn initialize_empty_repository(root: &std::path::Path) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::NeutralGitCwd;
+    use super::REPOSITORY_LOCAL_GIT_ENVIRONMENT_VARIABLES;
     #[cfg(unix)]
     use super::initialize_empty_repository;
     use pretty_assertions::assert_eq;
@@ -47,12 +85,19 @@ mod tests {
     use std::fs;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;
+    #[cfg(unix)]
+    use std::path::Path;
+    #[cfg(unix)]
+    use std::path::PathBuf;
     use std::process::Command;
 
     #[test]
     fn configures_an_isolated_repository_discovery_boundary() {
         let neutral_cwd = NeutralGitCwd::new().expect("create neutral Git working directory");
         let mut command = Command::new("git");
+        for name in REPOSITORY_LOCAL_GIT_ENVIRONMENT_VARIABLES {
+            command.env(name, "hostile");
+        }
         neutral_cwd.configure(&mut command);
 
         assert_eq!(
@@ -66,27 +111,166 @@ mod tests {
                 .and_then(|(_, value)| value),
             Some(neutral_cwd.directory.path().as_os_str())
         );
-        assert_eq!(
-            command
-                .get_envs()
-                .find(|(key, _)| *key == OsStr::new("GIT_DIR"))
-                .map(|(_, value)| value),
-            Some(None)
-        );
-        assert_eq!(
-            command
-                .get_envs()
-                .find(|(key, _)| *key == OsStr::new("GIT_WORK_TREE"))
-                .map(|(_, value)| value),
-            Some(None)
-        );
+        for name in REPOSITORY_LOCAL_GIT_ENVIRONMENT_VARIABLES
+            .iter()
+            .filter(|name| **name != "GIT_CEILING_DIRECTORIES")
+        {
+            assert_eq!(
+                command
+                    .get_envs()
+                    .find(|(key, _)| *key == OsStr::new(name))
+                    .map(|(_, value)| value),
+                Some(None),
+                "{name} should be removed"
+            );
+        }
+    }
+
+    #[test]
+    fn preserves_trusted_global_system_and_auth_environment() {
+        let neutral_cwd = NeutralGitCwd::new().expect("create neutral Git working directory");
+        let trusted = [
+            ("GIT_CONFIG_GLOBAL", "/trusted/global.gitconfig"),
+            ("GIT_CONFIG_SYSTEM", "/trusted/system.gitconfig"),
+            ("GIT_SSH_COMMAND", "/trusted/ssh-wrapper"),
+            ("HOME", "/trusted/home"),
+            ("XDG_CONFIG_HOME", "/trusted/config"),
+        ];
+        let mut command = Command::new("git");
+        for (name, value) in trusted {
+            command.env(name, value);
+        }
+        neutral_cwd.configure(&mut command);
+
+        for (name, value) in trusted {
+            assert_eq!(
+                command
+                    .get_envs()
+                    .find(|(key, _)| *key == OsStr::new(name))
+                    .and_then(|(_, value)| value),
+                Some(OsStr::new(value)),
+                "{name} should be preserved"
+            );
+        }
     }
 
     #[cfg(unix)]
     #[test]
     fn nested_neutral_directory_does_not_run_parent_repository_transport_helper() {
         let root = tempfile::tempdir().expect("create test root");
-        let source = root.path().join("source");
+        let fixture = create_transport_fixture(root.path());
+
+        let directory = tempfile::Builder::new()
+            .prefix("neutral-")
+            .tempdir_in(&fixture.hostile_repo)
+            .expect("create nested neutral directory");
+        initialize_empty_repository(directory.path()).expect("initialize neutral repository");
+        let neutral_cwd = NeutralGitCwd { directory };
+        let mut command = Command::new("git");
+        neutral_cwd.configure(&mut command);
+        let output = command
+            .args([
+                "ls-remote",
+                fixture.source.to_string_lossy().as_ref(),
+                "HEAD",
+            ])
+            .output()
+            .expect("run git ls-remote");
+
+        assert!(
+            output.status.success(),
+            "ls-remote should ignore the parent repository's transport rewrite: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(!output.stdout.is_empty());
+        assert!(
+            !fixture.marker.exists(),
+            "repository-selected transport helper must not run"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn neutral_directory_ignores_inherited_git_common_dir() {
+        let root = tempfile::tempdir().expect("create test root");
+        let fixture = create_transport_fixture(root.path());
+        let neutral_cwd = NeutralGitCwd::new().expect("create neutral Git working directory");
+        let mut command = Command::new("git");
+        command.env("GIT_COMMON_DIR", fixture.hostile_repo.join(".git"));
+        neutral_cwd.configure(&mut command);
+
+        let output = command
+            .args([
+                "ls-remote",
+                fixture.source.to_string_lossy().as_ref(),
+                "HEAD",
+            ])
+            .output()
+            .expect("run git ls-remote");
+
+        assert!(
+            output.status.success(),
+            "ls-remote should ignore inherited GIT_COMMON_DIR: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(!output.stdout.is_empty());
+        assert!(
+            !fixture.marker.exists(),
+            "inherited common-dir transport helper must not run"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn neutral_directory_ignores_inherited_command_scope_config() {
+        let root = tempfile::tempdir().expect("create test root");
+        let fixture = create_transport_fixture(root.path());
+        let neutral_cwd = NeutralGitCwd::new().expect("create neutral Git working directory");
+        let rewrite_key = format!("url.ext::{}.insteadOf", fixture.helper.display());
+        let mut command = Command::new("git");
+        command
+            .env("GIT_CONFIG_COUNT", "2")
+            .env("GIT_CONFIG_KEY_0", "protocol.ext.allow")
+            .env("GIT_CONFIG_VALUE_0", "always")
+            .env("GIT_CONFIG_KEY_1", rewrite_key)
+            .env(
+                "GIT_CONFIG_VALUE_1",
+                fixture.source.to_string_lossy().as_ref(),
+            );
+        neutral_cwd.configure(&mut command);
+
+        let output = command
+            .args([
+                "ls-remote",
+                fixture.source.to_string_lossy().as_ref(),
+                "HEAD",
+            ])
+            .output()
+            .expect("run git ls-remote");
+
+        assert!(
+            output.status.success(),
+            "ls-remote should ignore inherited command-scope config: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(!output.stdout.is_empty());
+        assert!(
+            !fixture.marker.exists(),
+            "command-scope transport helper must not run"
+        );
+    }
+
+    #[cfg(unix)]
+    struct TransportFixture {
+        source: PathBuf,
+        hostile_repo: PathBuf,
+        helper: PathBuf,
+        marker: PathBuf,
+    }
+
+    #[cfg(unix)]
+    fn create_transport_fixture(root: &Path) -> TransportFixture {
+        let source = root.join("source");
         fs::create_dir(&source).expect("create source repository");
         run_git(&source, &["init"]);
         run_git(&source, &["config", "user.email", "codex-test@example.com"]);
@@ -95,11 +279,11 @@ mod tests {
         run_git(&source, &["add", "README.md"]);
         run_git(&source, &["commit", "-m", "initial"]);
 
-        let hostile_repo = root.path().join("hostile");
+        let hostile_repo = root.join("hostile");
         fs::create_dir(&hostile_repo).expect("create hostile repository");
         run_git(&hostile_repo, &["init"]);
-        let marker = root.path().join("transport-ran");
-        let helper = root.path().join("transport-helper.sh");
+        let marker = root.join("transport-ran");
+        let helper = root.join("transport-helper.sh");
         fs::write(
             &helper,
             format!("#!/bin/sh\nprintf ran > \"{}\"\nexit 1\n", marker.display()),
@@ -117,29 +301,12 @@ mod tests {
             &["config", &rewrite_key, source.to_string_lossy().as_ref()],
         );
 
-        let directory = tempfile::Builder::new()
-            .prefix("neutral-")
-            .tempdir_in(&hostile_repo)
-            .expect("create nested neutral directory");
-        initialize_empty_repository(directory.path()).expect("initialize neutral repository");
-        let neutral_cwd = NeutralGitCwd { directory };
-        let mut command = Command::new("git");
-        neutral_cwd.configure(&mut command);
-        let output = command
-            .args(["ls-remote", source.to_string_lossy().as_ref(), "HEAD"])
-            .output()
-            .expect("run git ls-remote");
-
-        assert!(
-            output.status.success(),
-            "ls-remote should ignore the parent repository's transport rewrite: {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        assert!(!output.stdout.is_empty());
-        assert!(
-            !marker.exists(),
-            "repository-selected transport helper must not run"
-        );
+        TransportFixture {
+            source,
+            hostile_repo,
+            helper,
+            marker,
+        }
     }
 
     #[cfg(unix)]

--- a/codex-rs/core-plugins/src/git_transport.rs
+++ b/codex-rs/core-plugins/src/git_transport.rs
@@ -39,9 +39,11 @@ fn initialize_empty_repository(root: &std::path::Path) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::NeutralGitCwd;
+    #[cfg(unix)]
     use super::initialize_empty_repository;
     use pretty_assertions::assert_eq;
     use std::ffi::OsStr;
+    #[cfg(unix)]
     use std::fs;
     #[cfg(unix)]
     use std::os::unix::fs::PermissionsExt;

--- a/codex-rs/core-plugins/src/git_transport.rs
+++ b/codex-rs/core-plugins/src/git_transport.rs
@@ -43,6 +43,8 @@ mod tests {
     use pretty_assertions::assert_eq;
     use std::ffi::OsStr;
     use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use std::process::Command;
 
     #[test]
@@ -80,7 +82,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn nested_neutral_directory_does_not_load_parent_repository_config() {
+    fn nested_neutral_directory_does_not_run_parent_repository_transport_helper() {
         let root = tempfile::tempdir().expect("create test root");
         let source = root.path().join("source");
         fs::create_dir(&source).expect("create source repository");
@@ -94,13 +96,23 @@ mod tests {
         let hostile_repo = root.path().join("hostile");
         fs::create_dir(&hostile_repo).expect("create hostile repository");
         run_git(&hostile_repo, &["init"]);
+        let marker = root.path().join("transport-ran");
+        let helper = root.path().join("transport-helper.sh");
+        fs::write(
+            &helper,
+            format!("#!/bin/sh\nprintf ran > \"{}\"\nexit 1\n", marker.display()),
+        )
+        .expect("write transport helper");
+        let mut permissions = fs::metadata(&helper)
+            .expect("read transport helper metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&helper, permissions).expect("mark transport helper executable");
+        run_git(&hostile_repo, &["config", "protocol.ext.allow", "always"]);
+        let rewrite_key = format!("url.ext::{}.insteadOf", helper.display());
         run_git(
             &hostile_repo,
-            &[
-                "config",
-                "url.file:///definitely-not-a-real-codex-test-repo.insteadOf",
-                source.to_string_lossy().as_ref(),
-            ],
+            &["config", &rewrite_key, source.to_string_lossy().as_ref()],
         );
 
         let directory = tempfile::Builder::new()
@@ -118,10 +130,14 @@ mod tests {
 
         assert!(
             output.status.success(),
-            "ls-remote should ignore the parent repository's URL rewrite: {}",
+            "ls-remote should ignore the parent repository's transport rewrite: {}",
             String::from_utf8_lossy(&output.stderr)
         );
         assert!(!output.stdout.is_empty());
+        assert!(
+            !marker.exists(),
+            "repository-selected transport helper must not run"
+        );
     }
 
     #[cfg(unix)]

--- a/codex-rs/core-plugins/src/git_transport.rs
+++ b/codex-rs/core-plugins/src/git_transport.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
 
@@ -39,54 +40,57 @@ pub(crate) fn sanitize_repository_environment(command: &mut Command) {
     }
 }
 
-/// Runs transport commands from a clean, minimal repository so Git cannot
-/// discover repository-local configuration from the directory where Codex was
-/// launched. User-level Git configuration remains available.
+/// Runs initial transport commands from a nested non-repository directory so
+/// Git cannot discover repository-local configuration from the directory where
+/// Codex was launched. User-level Git configuration remains available without
+/// manufacturing branch or repository identity for conditional includes.
 pub(crate) struct NeutralGitCwd {
-    directory: TempDir,
+    boundary: TempDir,
+    cwd: PathBuf,
 }
 
 impl NeutralGitCwd {
     pub(crate) fn new() -> std::io::Result<Self> {
-        let directory = tempfile::tempdir()?;
-        initialize_empty_repository(directory.path())?;
-        Ok(Self { directory })
+        Self::from_boundary(tempfile::tempdir()?)
     }
 
-    #[cfg(all(test, unix))]
-    fn from_prebuilt_directory(directory: TempDir) -> Self {
-        Self { directory }
+    fn from_boundary(boundary: TempDir) -> std::io::Result<Self> {
+        // Git accepts only absolute ceiling entries and parses the environment
+        // value as a platform-specific path list. Reject a boundary that would
+        // split into multiple entries and allow discovery to continue past it.
+        {
+            let path = boundary.path();
+            let mut entries = std::env::split_paths(path.as_os_str());
+            if !path.is_absolute()
+                || entries.next().as_deref() != Some(path)
+                || entries.next().is_some()
+            {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!(
+                        "neutral Git boundary cannot be represented as one GIT_CEILING_DIRECTORIES entry: {}",
+                        path.display()
+                    ),
+                ));
+            }
+        }
+        let cwd = boundary.path().join("cwd");
+        std::fs::create_dir(&cwd)?;
+        Ok(Self { boundary, cwd })
     }
 
     pub(crate) fn configure_transport_command(&self, command: &mut Command) {
         sanitize_repository_environment(command);
         command
-            .current_dir(self.directory.path())
-            .env("GIT_CEILING_DIRECTORIES", self.directory.path());
+            .current_dir(&self.cwd)
+            .env("GIT_CEILING_DIRECTORIES", self.boundary.path());
     }
-}
-
-fn initialize_empty_repository(root: &std::path::Path) -> std::io::Result<()> {
-    // Build the discovery boundary without invoking Git. Running `git init`
-    // before this repository exists could rediscover and honor a hostile
-    // parent repository, which is exactly the behavior this type prevents.
-    let git_dir = root.join(".git");
-    std::fs::create_dir(&git_dir)?;
-    std::fs::create_dir(git_dir.join("objects"))?;
-    std::fs::create_dir_all(git_dir.join("refs/heads"))?;
-    std::fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n")?;
-    std::fs::write(
-        git_dir.join("config"),
-        "[core]\n\trepositoryformatversion = 0\n\tbare = false\n",
-    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::NeutralGitCwd;
     use super::REPOSITORY_LOCAL_GIT_ENVIRONMENT_VARIABLES;
-    #[cfg(unix)]
-    use super::initialize_empty_repository;
     use pretty_assertions::assert_eq;
     use std::ffi::OsStr;
     #[cfg(unix)]
@@ -108,17 +112,15 @@ mod tests {
         }
         neutral_cwd.configure_transport_command(&mut command);
 
-        assert_eq!(
-            command.get_current_dir(),
-            Some(neutral_cwd.directory.path())
-        );
+        assert_eq!(command.get_current_dir(), Some(neutral_cwd.cwd.as_path()));
         assert_eq!(
             command
                 .get_envs()
                 .find(|(key, _)| *key == OsStr::new("GIT_CEILING_DIRECTORIES"))
                 .and_then(|(_, value)| value),
-            Some(neutral_cwd.directory.path().as_os_str())
+            Some(neutral_cwd.boundary.path().as_os_str())
         );
+        assert_eq!(neutral_cwd.cwd.parent(), Some(neutral_cwd.boundary.path()));
         for name in REPOSITORY_LOCAL_GIT_ENVIRONMENT_VARIABLES
             .iter()
             .filter(|name| **name != "GIT_CEILING_DIRECTORIES")
@@ -132,6 +134,49 @@ mod tests {
                 "{name} should be removed"
             );
         }
+    }
+
+    #[test]
+    fn rejects_boundary_with_path_list_separator() {
+        let root = tempfile::tempdir().expect("create test root");
+        #[cfg(windows)]
+        let prefix = "neutral;";
+        #[cfg(not(windows))]
+        let prefix = "neutral:";
+        let boundary = tempfile::Builder::new()
+            .prefix(prefix)
+            .tempdir_in(root.path())
+            .expect("create delimiter-bearing boundary");
+        let boundary_path = boundary.path().to_path_buf();
+
+        let err = match NeutralGitCwd::from_boundary(boundary) {
+            Ok(neutral_cwd) => {
+                drop(neutral_cwd);
+                panic!("delimiter-bearing boundary should be rejected");
+            }
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(
+            !boundary_path.exists(),
+            "rejected temporary boundary should be cleaned up"
+        );
+    }
+
+    #[test]
+    fn neutral_directory_has_no_repository_identity() {
+        let neutral_cwd = NeutralGitCwd::new().expect("create neutral Git working directory");
+        let mut command = Command::new("git");
+        neutral_cwd.configure_transport_command(&mut command);
+
+        let output = command
+            .args(["rev-parse", "--show-toplevel"])
+            .output()
+            .expect("inspect neutral Git working directory");
+
+        assert!(!output.status.success());
+        assert!(output.stdout.is_empty());
     }
 
     #[test]
@@ -171,12 +216,12 @@ mod tests {
         let root = tempfile::tempdir().expect("create test root");
         let fixture = create_transport_fixture(root.path());
 
-        let directory = tempfile::Builder::new()
+        let boundary = tempfile::Builder::new()
             .prefix("neutral-")
             .tempdir_in(&fixture.hostile_repo)
-            .expect("create nested neutral directory");
-        initialize_empty_repository(directory.path()).expect("initialize neutral repository");
-        let neutral_cwd = NeutralGitCwd::from_prebuilt_directory(directory);
+            .expect("create nested neutral boundary");
+        let neutral_cwd =
+            NeutralGitCwd::from_boundary(boundary).expect("create nested neutral directory");
         let empty_config = root.path().join("empty.gitconfig");
         fs::write(&empty_config, "").expect("write empty Git config");
 
@@ -219,6 +264,55 @@ mod tests {
         assert!(
             !fixture.marker.exists(),
             "repository-selected transport helper must not run"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_delimited_boundary_before_hostile_parent_transport_can_run() {
+        let root = tempfile::tempdir().expect("create test root");
+        let fixture = create_transport_fixture(root.path());
+        let boundary = tempfile::Builder::new()
+            .prefix("neutral:")
+            .tempdir_in(&fixture.hostile_repo)
+            .expect("create delimiter-bearing nested boundary");
+        let boundary_path = boundary.path().to_path_buf();
+
+        let err = match NeutralGitCwd::from_boundary(boundary) {
+            Ok(neutral_cwd) => {
+                let empty_config = root.path().join("empty.gitconfig");
+                fs::write(&empty_config, "").expect("write empty Git config");
+                let mut command = Command::new("git");
+                command
+                    .env("GIT_CONFIG_GLOBAL", &empty_config)
+                    .env("GIT_CONFIG_SYSTEM", &empty_config);
+                neutral_cwd.configure_transport_command(&mut command);
+                let _ = command
+                    .args([
+                        "ls-remote",
+                        fixture.source.to_string_lossy().as_ref(),
+                        "HEAD",
+                    ])
+                    .output()
+                    .expect("run git ls-remote");
+                assert!(
+                    !fixture.marker.exists(),
+                    "delimiter-bearing ceiling must not expose parent transport config"
+                );
+                drop(neutral_cwd);
+                panic!("delimiter-bearing boundary should be rejected");
+            }
+            Err(err) => err,
+        };
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+        assert!(
+            !boundary_path.exists(),
+            "rejected temporary boundary should be cleaned up"
+        );
+        assert!(
+            !fixture.marker.exists(),
+            "rejected boundary must not execute parent transport config"
         );
     }
 
@@ -289,6 +383,129 @@ mod tests {
             String::from_utf8_lossy(&output.stderr)
         );
         assert!(!output.stdout.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn neutral_directory_does_not_activate_repository_conditional_global_config() {
+        let root = tempfile::tempdir().expect("create test root");
+        let neutral_cwd = NeutralGitCwd::new().expect("create neutral Git working directory");
+
+        let onbranch_config = root.path().join("onbranch.gitconfig");
+        fs::write(&onbranch_config, "[test]\n\tonbranch = active\n")
+            .expect("write onbranch conditional config");
+        let gitdir_config = root.path().join("gitdir.gitconfig");
+        fs::write(&gitdir_config, "[test]\n\tgitdir = active\n")
+            .expect("write gitdir conditional config");
+        let global_config = root.path().join("global.gitconfig");
+        fs::write(
+            &global_config,
+            format!(
+                "[includeIf \"onbranch:main\"]\n\tpath = {}\n[includeIf \"gitdir:/**\"]\n\tpath = {}\n",
+                onbranch_config.display(),
+                gitdir_config.display()
+            ),
+        )
+        .expect("write conditional global Git config");
+        let system_config = root.path().join("system.gitconfig");
+        fs::write(&system_config, "").expect("write empty system Git config");
+
+        let mut command = Command::new("git");
+        command
+            .env("GIT_CONFIG_GLOBAL", &global_config)
+            .env("GIT_CONFIG_SYSTEM", &system_config);
+        neutral_cwd.configure_transport_command(&mut command);
+        let output = command
+            .args(["config", "--get-regexp", "^test\\."])
+            .output()
+            .expect("inspect repository-conditional Git config");
+
+        assert_eq!(output.status.code(), Some(1));
+        assert!(output.stdout.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn real_destination_repository_conditionals_still_apply() {
+        let root = tempfile::tempdir().expect("create test root");
+        let source = root.path().join("source");
+        fs::create_dir(&source).expect("create source repository");
+        run_git(&source, &["init"]);
+        run_git(&source, &["symbolic-ref", "HEAD", "refs/heads/main"]);
+        run_git(&source, &["config", "user.email", "codex-test@example.com"]);
+        run_git(&source, &["config", "user.name", "Codex Test"]);
+        fs::write(source.join("README.md"), "safe source\n").expect("write source file");
+        run_git(&source, &["add", "README.md"]);
+        run_git(&source, &["commit", "-m", "initial"]);
+
+        let neutral_cwd = NeutralGitCwd::new().expect("create neutral Git working directory");
+        let destination = root.path().join("destination");
+        let mut clone = Command::new("git");
+        neutral_cwd.configure_transport_command(&mut clone);
+        let clone_output = clone
+            .args(["clone"])
+            .arg(&source)
+            .arg(&destination)
+            .output()
+            .expect("clone source repository");
+        assert!(
+            clone_output.status.success(),
+            "clone source repository: {}",
+            String::from_utf8_lossy(&clone_output.stderr)
+        );
+
+        let onbranch_config = root.path().join("real-onbranch.gitconfig");
+        fs::write(&onbranch_config, "[test]\n\tonbranch = active\n")
+            .expect("write real onbranch config");
+        let gitdir_config = root.path().join("real-gitdir.gitconfig");
+        fs::write(&gitdir_config, "[test]\n\tgitdir = active\n").expect("write real gitdir config");
+        let hasconfig_config = root.path().join("real-hasconfig.gitconfig");
+        fs::write(&hasconfig_config, "[test]\n\thasconfig = active\n")
+            .expect("write real hasconfig config");
+        let destination_git_dir =
+            fs::canonicalize(destination.join(".git")).expect("canonicalize destination Git dir");
+        let global_config = root.path().join("real-global.gitconfig");
+        fs::write(
+            &global_config,
+            format!(
+                "[includeIf \"onbranch:main\"]\n\tpath = {}\n[includeIf \"gitdir:{}\"]\n\tpath = {}\n[includeIf \"hasconfig:remote.*.url:{}\"]\n\tpath = {}\n",
+                onbranch_config.display(),
+                destination_git_dir.display(),
+                gitdir_config.display(),
+                source.display(),
+                hasconfig_config.display()
+            ),
+        )
+        .expect("write real destination conditional config");
+        let system_config = root.path().join("real-system.gitconfig");
+        fs::write(&system_config, "").expect("write empty system Git config");
+
+        for use_dash_c in [false, true] {
+            let mut command = Command::new("git");
+            command
+                .env("GIT_CONFIG_GLOBAL", &global_config)
+                .env("GIT_CONFIG_SYSTEM", &system_config);
+            neutral_cwd.configure_transport_command(&mut command);
+            if use_dash_c {
+                command.arg("-C").arg(&destination);
+            } else {
+                command.current_dir(&destination);
+            }
+            let output = command
+                .args(["config", "--get-regexp", "^test\\."])
+                .output()
+                .expect("inspect real destination conditional config");
+
+            assert!(
+                output.status.success(),
+                "read real destination conditionals: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert_eq!(
+                String::from_utf8_lossy(&output.stdout),
+                "test.onbranch active\ntest.gitdir active\ntest.hasconfig active\n"
+            );
+        }
     }
 
     #[cfg(unix)]

--- a/codex-rs/core-plugins/src/git_transport.rs
+++ b/codex-rs/core-plugins/src/git_transport.rs
@@ -53,7 +53,12 @@ impl NeutralGitCwd {
         Ok(Self { directory })
     }
 
-    pub(crate) fn configure(&self, command: &mut Command) {
+    #[cfg(test)]
+    fn from_prebuilt_directory(directory: TempDir) -> Self {
+        Self { directory }
+    }
+
+    pub(crate) fn configure_transport_command(&self, command: &mut Command) {
         sanitize_repository_environment(command);
         command
             .current_dir(self.directory.path())
@@ -62,6 +67,9 @@ impl NeutralGitCwd {
 }
 
 fn initialize_empty_repository(root: &std::path::Path) -> std::io::Result<()> {
+    // Build the discovery boundary without invoking Git. Running `git init`
+    // before this repository exists could rediscover and honor a hostile
+    // parent repository, which is exactly the behavior this type prevents.
     let git_dir = root.join(".git");
     std::fs::create_dir(&git_dir)?;
     std::fs::create_dir(git_dir.join("objects"))?;
@@ -98,7 +106,7 @@ mod tests {
         for name in REPOSITORY_LOCAL_GIT_ENVIRONMENT_VARIABLES {
             command.env(name, "hostile");
         }
-        neutral_cwd.configure(&mut command);
+        neutral_cwd.configure_transport_command(&mut command);
 
         assert_eq!(
             command.get_current_dir(),
@@ -130,17 +138,20 @@ mod tests {
     fn preserves_trusted_global_system_and_auth_environment() {
         let neutral_cwd = NeutralGitCwd::new().expect("create neutral Git working directory");
         let trusted = [
+            ("GIT_ASKPASS", "/trusted/askpass"),
             ("GIT_CONFIG_GLOBAL", "/trusted/global.gitconfig"),
             ("GIT_CONFIG_SYSTEM", "/trusted/system.gitconfig"),
+            ("GIT_SSH", "/trusted/ssh"),
             ("GIT_SSH_COMMAND", "/trusted/ssh-wrapper"),
             ("HOME", "/trusted/home"),
+            ("SSH_AUTH_SOCK", "/trusted/ssh-agent.sock"),
             ("XDG_CONFIG_HOME", "/trusted/config"),
         ];
         let mut command = Command::new("git");
         for (name, value) in trusted {
             command.env(name, value);
         }
-        neutral_cwd.configure(&mut command);
+        neutral_cwd.configure_transport_command(&mut command);
 
         for (name, value) in trusted {
             assert_eq!(
@@ -156,7 +167,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn nested_neutral_directory_does_not_run_parent_repository_transport_helper() {
+    fn nested_neutral_directory_ignores_parent_repository_transport_config() {
         let root = tempfile::tempdir().expect("create test root");
         let fixture = create_transport_fixture(root.path());
 
@@ -165,9 +176,31 @@ mod tests {
             .tempdir_in(&fixture.hostile_repo)
             .expect("create nested neutral directory");
         initialize_empty_repository(directory.path()).expect("initialize neutral repository");
-        let neutral_cwd = NeutralGitCwd { directory };
+        let neutral_cwd = NeutralGitCwd::from_prebuilt_directory(directory);
+        let empty_config = root.path().join("empty.gitconfig");
+        fs::write(&empty_config, "").expect("write empty Git config");
+
+        let mut config_command = Command::new("git");
+        config_command
+            .env("GIT_CONFIG_GLOBAL", &empty_config)
+            .env("GIT_CONFIG_SYSTEM", &empty_config);
+        neutral_cwd.configure_transport_command(&mut config_command);
+        let config_output = config_command
+            .args([
+                "config",
+                "--get-regexp",
+                "^(core\\.sshCommand|credential\\.helper)$",
+            ])
+            .output()
+            .expect("inspect effective transport configuration");
+        assert_eq!(config_output.status.code(), Some(1));
+        assert!(config_output.stdout.is_empty());
+
         let mut command = Command::new("git");
-        neutral_cwd.configure(&mut command);
+        command
+            .env("GIT_CONFIG_GLOBAL", &empty_config)
+            .env("GIT_CONFIG_SYSTEM", &empty_config);
+        neutral_cwd.configure_transport_command(&mut command);
         let output = command
             .args([
                 "ls-remote",
@@ -191,13 +224,82 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn neutral_directory_honors_trusted_global_and_system_transport_config() {
+        let root = tempfile::tempdir().expect("create test root");
+        let fixture = create_transport_fixture(root.path());
+        let global_config = root.path().join("global.gitconfig");
+        let system_config = root.path().join("system.gitconfig");
+        fs::write(
+            &global_config,
+            format!(
+                "[url \"file://{}\"]\n\tinsteadOf = https://trusted.example/repository\n[core]\n\tsshCommand = trusted-ssh-command\n",
+                fixture.source.display()
+            ),
+        )
+        .expect("write trusted global Git config");
+        fs::write(
+            &system_config,
+            "[credential]\n\thelper = trusted-credential-helper\n",
+        )
+        .expect("write trusted system Git config");
+        let neutral_cwd = NeutralGitCwd::new().expect("create neutral Git working directory");
+
+        let mut ssh_config = Command::new("git");
+        ssh_config
+            .env("GIT_CONFIG_GLOBAL", &global_config)
+            .env("GIT_CONFIG_SYSTEM", &system_config);
+        neutral_cwd.configure_transport_command(&mut ssh_config);
+        let ssh_output = ssh_config
+            .args(["config", "--get", "core.sshCommand"])
+            .output()
+            .expect("read trusted SSH configuration");
+        assert!(ssh_output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&ssh_output.stdout).trim(),
+            "trusted-ssh-command"
+        );
+
+        let mut credential_config = Command::new("git");
+        credential_config
+            .env("GIT_CONFIG_GLOBAL", &global_config)
+            .env("GIT_CONFIG_SYSTEM", &system_config);
+        neutral_cwd.configure_transport_command(&mut credential_config);
+        let credential_output = credential_config
+            .args(["config", "--get", "credential.helper"])
+            .output()
+            .expect("read trusted credential configuration");
+        assert!(credential_output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&credential_output.stdout).trim(),
+            "trusted-credential-helper"
+        );
+
+        let mut ls_remote = Command::new("git");
+        ls_remote
+            .env("GIT_CONFIG_GLOBAL", &global_config)
+            .env("GIT_CONFIG_SYSTEM", &system_config);
+        neutral_cwd.configure_transport_command(&mut ls_remote);
+        let output = ls_remote
+            .args(["ls-remote", "https://trusted.example/repository", "HEAD"])
+            .output()
+            .expect("run git ls-remote through trusted global rewrite");
+        assert!(
+            output.status.success(),
+            "trusted global URL rewrite should remain available: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(!output.stdout.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn neutral_directory_ignores_inherited_git_common_dir() {
         let root = tempfile::tempdir().expect("create test root");
         let fixture = create_transport_fixture(root.path());
         let neutral_cwd = NeutralGitCwd::new().expect("create neutral Git working directory");
         let mut command = Command::new("git");
         command.env("GIT_COMMON_DIR", fixture.hostile_repo.join(".git"));
-        neutral_cwd.configure(&mut command);
+        neutral_cwd.configure_transport_command(&mut command);
 
         let output = command
             .args([
@@ -237,7 +339,7 @@ mod tests {
                 "GIT_CONFIG_VALUE_1",
                 fixture.source.to_string_lossy().as_ref(),
             );
-        neutral_cwd.configure(&mut command);
+        neutral_cwd.configure_transport_command(&mut command);
 
         let output = command
             .args([
@@ -295,6 +397,14 @@ mod tests {
         permissions.set_mode(0o755);
         fs::set_permissions(&helper, permissions).expect("mark transport helper executable");
         run_git(&hostile_repo, &["config", "protocol.ext.allow", "always"]);
+        run_git(
+            &hostile_repo,
+            &["config", "core.sshCommand", "hostile-ssh-command"],
+        );
+        run_git(
+            &hostile_repo,
+            &["config", "credential.helper", "!hostile-credential-helper"],
+        );
         let rewrite_key = format!("url.ext::{}.insteadOf", helper.display());
         run_git(
             &hostile_repo,

--- a/codex-rs/core-plugins/src/git_transport.rs
+++ b/codex-rs/core-plugins/src/git_transport.rs
@@ -1,0 +1,141 @@
+use std::process::Command;
+use tempfile::TempDir;
+
+/// Runs transport commands from a clean, minimal repository so Git cannot
+/// discover repository-local configuration from the directory where Codex was
+/// launched. User-level Git configuration remains available.
+pub(crate) struct NeutralGitCwd {
+    directory: TempDir,
+}
+
+impl NeutralGitCwd {
+    pub(crate) fn new() -> std::io::Result<Self> {
+        let directory = tempfile::tempdir()?;
+        initialize_empty_repository(directory.path())?;
+        Ok(Self { directory })
+    }
+
+    pub(crate) fn configure(&self, command: &mut Command) {
+        command
+            .current_dir(self.directory.path())
+            .env_remove("GIT_DIR")
+            .env_remove("GIT_WORK_TREE")
+            .env("GIT_CEILING_DIRECTORIES", self.directory.path());
+    }
+}
+
+fn initialize_empty_repository(root: &std::path::Path) -> std::io::Result<()> {
+    let git_dir = root.join(".git");
+    std::fs::create_dir(&git_dir)?;
+    std::fs::create_dir(git_dir.join("objects"))?;
+    std::fs::create_dir_all(git_dir.join("refs/heads"))?;
+    std::fs::write(git_dir.join("HEAD"), "ref: refs/heads/main\n")?;
+    std::fs::write(
+        git_dir.join("config"),
+        "[core]\n\trepositoryformatversion = 0\n\tbare = false\n",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NeutralGitCwd;
+    use super::initialize_empty_repository;
+    use pretty_assertions::assert_eq;
+    use std::ffi::OsStr;
+    use std::fs;
+    use std::process::Command;
+
+    #[test]
+    fn configures_an_isolated_repository_discovery_boundary() {
+        let neutral_cwd = NeutralGitCwd::new().expect("create neutral Git working directory");
+        let mut command = Command::new("git");
+        neutral_cwd.configure(&mut command);
+
+        assert_eq!(
+            command.get_current_dir(),
+            Some(neutral_cwd.directory.path())
+        );
+        assert_eq!(
+            command
+                .get_envs()
+                .find(|(key, _)| *key == OsStr::new("GIT_CEILING_DIRECTORIES"))
+                .and_then(|(_, value)| value),
+            Some(neutral_cwd.directory.path().as_os_str())
+        );
+        assert_eq!(
+            command
+                .get_envs()
+                .find(|(key, _)| *key == OsStr::new("GIT_DIR"))
+                .map(|(_, value)| value),
+            Some(None)
+        );
+        assert_eq!(
+            command
+                .get_envs()
+                .find(|(key, _)| *key == OsStr::new("GIT_WORK_TREE"))
+                .map(|(_, value)| value),
+            Some(None)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn nested_neutral_directory_does_not_load_parent_repository_config() {
+        let root = tempfile::tempdir().expect("create test root");
+        let source = root.path().join("source");
+        fs::create_dir(&source).expect("create source repository");
+        run_git(&source, &["init"]);
+        run_git(&source, &["config", "user.email", "codex-test@example.com"]);
+        run_git(&source, &["config", "user.name", "Codex Test"]);
+        fs::write(source.join("README.md"), "safe source\n").expect("write source file");
+        run_git(&source, &["add", "README.md"]);
+        run_git(&source, &["commit", "-m", "initial"]);
+
+        let hostile_repo = root.path().join("hostile");
+        fs::create_dir(&hostile_repo).expect("create hostile repository");
+        run_git(&hostile_repo, &["init"]);
+        run_git(
+            &hostile_repo,
+            &[
+                "config",
+                "url.file:///definitely-not-a-real-codex-test-repo.insteadOf",
+                source.to_string_lossy().as_ref(),
+            ],
+        );
+
+        let directory = tempfile::Builder::new()
+            .prefix("neutral-")
+            .tempdir_in(&hostile_repo)
+            .expect("create nested neutral directory");
+        initialize_empty_repository(directory.path()).expect("initialize neutral repository");
+        let neutral_cwd = NeutralGitCwd { directory };
+        let mut command = Command::new("git");
+        neutral_cwd.configure(&mut command);
+        let output = command
+            .args(["ls-remote", source.to_string_lossy().as_ref(), "HEAD"])
+            .output()
+            .expect("run git ls-remote");
+
+        assert!(
+            output.status.success(),
+            "ls-remote should ignore the parent repository's URL rewrite: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(!output.stdout.is_empty());
+    }
+
+    #[cfg(unix)]
+    fn run_git(cwd: &std::path::Path, args: &[&str]) {
+        let output = Command::new("git")
+            .current_dir(cwd)
+            .args(args)
+            .output()
+            .expect("run git");
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}

--- a/codex-rs/core-plugins/src/git_transport.rs
+++ b/codex-rs/core-plugins/src/git_transport.rs
@@ -53,7 +53,7 @@ impl NeutralGitCwd {
         Ok(Self { directory })
     }
 
-    #[cfg(test)]
+    #[cfg(all(test, unix))]
     fn from_prebuilt_directory(directory: TempDir) -> Self {
         Self { directory }
     }

--- a/codex-rs/core-plugins/src/lib.rs
+++ b/codex-rs/core-plugins/src/lib.rs
@@ -1,5 +1,6 @@
 mod app_mcp_routing;
 mod discoverable;
+mod git_transport;
 pub mod installed_marketplaces;
 pub mod loader;
 mod manager;

--- a/codex-rs/core-plugins/src/loader.rs
+++ b/codex-rs/core-plugins/src/loader.rs
@@ -1457,8 +1457,11 @@ fn clone_git_plugin_source(
     sparse_checkout_path: Option<&str>,
     destination: &Path,
 ) -> Result<(), String> {
+    let neutral_cwd = NeutralGitCwd::new()
+        .map_err(|err| format!("failed to create neutral Git working directory: {err}"))?;
     if let Some(sparse_checkout_path) = sparse_checkout_path {
         run_git(
+            &neutral_cwd,
             &[
                 "clone",
                 "--filter=blob:none",
@@ -1470,6 +1473,7 @@ fn clone_git_plugin_source(
             /*cwd*/ None,
         )?;
         run_git(
+            &neutral_cwd,
             &[
                 "sparse-checkout",
                 "set",
@@ -1481,25 +1485,24 @@ fn clone_git_plugin_source(
         )?;
     } else {
         run_git(
+            &neutral_cwd,
             &["clone", url, destination.to_string_lossy().as_ref()],
             /*cwd*/ None,
         )?;
     }
     if let Some(target) = sha.or(ref_name) {
-        run_git(&["checkout", target], Some(destination))?;
+        run_git(&neutral_cwd, &["checkout", target], Some(destination))?;
     } else if sparse_checkout_path.is_some() {
-        run_git(&["checkout"], Some(destination))?;
+        run_git(&neutral_cwd, &["checkout"], Some(destination))?;
     }
     Ok(())
 }
 
-fn run_git(args: &[&str], cwd: Option<&Path>) -> Result<(), String> {
-    let neutral_cwd = NeutralGitCwd::new()
-        .map_err(|err| format!("failed to create neutral Git working directory: {err}"))?;
+fn run_git(neutral_cwd: &NeutralGitCwd, args: &[&str], cwd: Option<&Path>) -> Result<(), String> {
     let mut command = Command::new("git");
     command.args(args);
     command.env("GIT_TERMINAL_PROMPT", "0");
-    neutral_cwd.configure(&mut command);
+    neutral_cwd.configure_transport_command(&mut command);
     if let Some(cwd) = cwd {
         command.current_dir(cwd);
     }

--- a/codex-rs/core-plugins/src/loader.rs
+++ b/codex-rs/core-plugins/src/loader.rs
@@ -1,5 +1,6 @@
 use crate::app_mcp_routing::apply_app_mcp_routing_policy;
 use crate::app_mcp_routing::apps_route_available;
+use crate::git_transport::NeutralGitCwd;
 use crate::is_openai_curated_marketplace_name;
 use crate::manifest::PluginManifest;
 use crate::manifest::PluginManifestHooks;
@@ -1493,9 +1494,12 @@ fn clone_git_plugin_source(
 }
 
 fn run_git(args: &[&str], cwd: Option<&Path>) -> Result<(), String> {
+    let neutral_cwd = NeutralGitCwd::new()
+        .map_err(|err| format!("failed to create neutral Git working directory: {err}"))?;
     let mut command = Command::new("git");
     command.args(args);
     command.env("GIT_TERMINAL_PROMPT", "0");
+    neutral_cwd.configure(&mut command);
     if let Some(cwd) = cwd {
         command.current_dir(cwd);
     }

--- a/codex-rs/core-plugins/src/loader_tests.rs
+++ b/codex-rs/core-plugins/src/loader_tests.rs
@@ -463,15 +463,22 @@ fn materialize_git_subdir_uses_sparse_checkout() {
     fs::write(repo.path().join("plugins/other/marker.txt"), "other").expect("write other marker");
     fs::write(repo.path().join("root.txt"), "root").expect("write root marker");
 
-    run_git(&["init"], Some(repo.path())).expect("init git repo");
+    let neutral_cwd = NeutralGitCwd::new().expect("create neutral Git working directory");
+    run_git(&neutral_cwd, &["init"], Some(repo.path())).expect("init git repo");
     run_git(
+        &neutral_cwd,
         &["config", "user.email", "test@example.com"],
         Some(repo.path()),
     )
     .expect("configure git email");
-    run_git(&["config", "user.name", "Test User"], Some(repo.path())).expect("configure git name");
-    run_git(&["add", "."], Some(repo.path())).expect("stage git repo");
-    run_git(&["commit", "-m", "init"], Some(repo.path())).expect("commit git repo");
+    run_git(
+        &neutral_cwd,
+        &["config", "user.name", "Test User"],
+        Some(repo.path()),
+    )
+    .expect("configure git name");
+    run_git(&neutral_cwd, &["add", "."], Some(repo.path())).expect("stage git repo");
+    run_git(&neutral_cwd, &["commit", "-m", "init"], Some(repo.path())).expect("commit git repo");
 
     let materialized = materialize_marketplace_plugin_source(
         codex_home.path(),

--- a/codex-rs/core-plugins/src/marketplace_add/install.rs
+++ b/codex-rs/core-plugins/src/marketplace_add/install.rs
@@ -1,4 +1,5 @@
 use super::MarketplaceAddError;
+use crate::git_transport::NeutralGitCwd;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
@@ -111,9 +112,15 @@ pub(super) fn marketplace_staging_root(install_root: &Path) -> PathBuf {
 }
 
 fn run_git(args: &[&str], cwd: Option<&Path>) -> Result<(), MarketplaceAddError> {
+    let neutral_cwd = NeutralGitCwd::new().map_err(|err| {
+        MarketplaceAddError::Internal(format!(
+            "failed to create neutral Git working directory: {err}"
+        ))
+    })?;
     let mut command = Command::new("git");
     command.args(args);
     command.env("GIT_TERMINAL_PROMPT", "0");
+    neutral_cwd.configure(&mut command);
     if let Some(cwd) = cwd {
         command.current_dir(cwd);
     }

--- a/codex-rs/core-plugins/src/marketplace_add/install.rs
+++ b/codex-rs/core-plugins/src/marketplace_add/install.rs
@@ -11,14 +11,21 @@ pub(super) fn clone_git_source(
     sparse_paths: &[String],
     destination: &Path,
 ) -> Result<(), MarketplaceAddError> {
+    let neutral_cwd = NeutralGitCwd::new().map_err(|err| {
+        MarketplaceAddError::Internal(format!(
+            "failed to create neutral Git working directory: {err}"
+        ))
+    })?;
     let destination_string = destination.to_string_lossy().to_string();
     if sparse_paths.is_empty() {
         run_git(
+            &neutral_cwd,
             &["clone", url, destination_string.as_str()],
             /*cwd*/ None,
         )?;
         if let Some(ref_name) = ref_name {
             run_git(
+                &neutral_cwd,
                 &["checkout", ref_name],
                 Some(Path::new(&destination_string)),
             )?;
@@ -27,6 +34,7 @@ pub(super) fn clone_git_source(
     }
 
     run_git(
+        &neutral_cwd,
         &[
             "clone",
             "--filter=blob:none",
@@ -38,8 +46,12 @@ pub(super) fn clone_git_source(
     )?;
     let mut sparse_args = vec!["sparse-checkout", "set"];
     sparse_args.extend(sparse_paths.iter().map(String::as_str));
-    run_git(&sparse_args, Some(destination))?;
-    run_git(&["checkout", ref_name.unwrap_or("HEAD")], Some(destination))?;
+    run_git(&neutral_cwd, &sparse_args, Some(destination))?;
+    run_git(
+        &neutral_cwd,
+        &["checkout", ref_name.unwrap_or("HEAD")],
+        Some(destination),
+    )?;
     Ok(())
 }
 
@@ -111,16 +123,15 @@ pub(super) fn marketplace_staging_root(install_root: &Path) -> PathBuf {
     install_root.join(".staging")
 }
 
-fn run_git(args: &[&str], cwd: Option<&Path>) -> Result<(), MarketplaceAddError> {
-    let neutral_cwd = NeutralGitCwd::new().map_err(|err| {
-        MarketplaceAddError::Internal(format!(
-            "failed to create neutral Git working directory: {err}"
-        ))
-    })?;
+fn run_git(
+    neutral_cwd: &NeutralGitCwd,
+    args: &[&str],
+    cwd: Option<&Path>,
+) -> Result<(), MarketplaceAddError> {
     let mut command = Command::new("git");
     command.args(args);
     command.env("GIT_TERMINAL_PROMPT", "0");
-    neutral_cwd.configure(&mut command);
+    neutral_cwd.configure_transport_command(&mut command);
     if let Some(cwd) = cwd {
         command.current_dir(cwd);
     }

--- a/codex-rs/core-plugins/src/marketplace_upgrade/git.rs
+++ b/codex-rs/core-plugins/src/marketplace_upgrade/git.rs
@@ -153,7 +153,7 @@ fn git_command(neutral_cwd: &NeutralGitCwd) -> Command {
     command
         .env("GIT_OPTIONAL_LOCKS", "0")
         .env("GIT_TERMINAL_PROMPT", "0");
-    neutral_cwd.configure(&mut command);
+    neutral_cwd.configure_transport_command(&mut command);
     command
 }
 

--- a/codex-rs/core-plugins/src/marketplace_upgrade/git.rs
+++ b/codex-rs/core-plugins/src/marketplace_upgrade/git.rs
@@ -1,3 +1,4 @@
+use crate::git_transport::NeutralGitCwd;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
@@ -17,8 +18,13 @@ pub(super) fn git_remote_revision(
     }
 
     let ref_name = ref_name.unwrap_or("HEAD");
+    let neutral_cwd = NeutralGitCwd::new()
+        .map_err(|err| format!("failed to create neutral Git working directory: {err}"))?;
     let output = run_git_command_with_timeout(
-        git_command().arg("ls-remote").arg(source).arg(ref_name),
+        git_command(&neutral_cwd)
+            .arg("ls-remote")
+            .arg(source)
+            .arg(ref_name),
         "git ls-remote marketplace source",
         timeout,
     )?;
@@ -47,17 +53,22 @@ pub(super) fn clone_git_source(
     destination: &Path,
     timeout: Duration,
 ) -> Result<String, String> {
+    let neutral_cwd = NeutralGitCwd::new()
+        .map_err(|err| format!("failed to create neutral Git working directory: {err}"))?;
     let git_destination = git_path_arg(destination);
     if sparse_paths.is_empty() {
         let output = run_git_command_with_timeout(
-            git_command().arg("clone").arg(source).arg(&git_destination),
+            git_command(&neutral_cwd)
+                .arg("clone")
+                .arg(source)
+                .arg(&git_destination),
             "git clone marketplace source",
             timeout,
         )?;
         ensure_git_success(&output, "git clone marketplace source")?;
         if let Some(ref_name) = ref_name {
             let output = run_git_command_with_timeout(
-                git_command()
+                git_command(&neutral_cwd)
                     .arg("-C")
                     .arg(&git_destination)
                     .arg("checkout")
@@ -67,11 +78,11 @@ pub(super) fn clone_git_source(
             )?;
             ensure_git_success(&output, "git checkout marketplace ref")?;
         }
-        return git_worktree_revision(&git_destination, timeout);
+        return git_worktree_revision(&git_destination, timeout, &neutral_cwd);
     }
 
     let output = run_git_command_with_timeout(
-        git_command()
+        git_command(&neutral_cwd)
             .arg("clone")
             .arg("--filter=blob:none")
             .arg("--no-checkout")
@@ -82,7 +93,7 @@ pub(super) fn clone_git_source(
     )?;
     ensure_git_success(&output, "git clone marketplace source")?;
 
-    let mut sparse_checkout = git_command();
+    let mut sparse_checkout = git_command(&neutral_cwd);
     sparse_checkout
         .arg("-C")
         .arg(&git_destination)
@@ -97,7 +108,7 @@ pub(super) fn clone_git_source(
     ensure_git_success(&output, "git sparse-checkout marketplace source")?;
 
     let output = run_git_command_with_timeout(
-        git_command()
+        git_command(&neutral_cwd)
             .arg("-C")
             .arg(&git_destination)
             .arg("checkout")
@@ -106,12 +117,16 @@ pub(super) fn clone_git_source(
         timeout,
     )?;
     ensure_git_success(&output, "git checkout marketplace ref")?;
-    git_worktree_revision(&git_destination, timeout)
+    git_worktree_revision(&git_destination, timeout, &neutral_cwd)
 }
 
-fn git_worktree_revision(destination: &Path, timeout: Duration) -> Result<String, String> {
+fn git_worktree_revision(
+    destination: &Path,
+    timeout: Duration,
+    neutral_cwd: &NeutralGitCwd,
+) -> Result<String, String> {
     let output = run_git_command_with_timeout(
-        git_command()
+        git_command(neutral_cwd)
             .arg("-C")
             .arg(destination)
             .arg("rev-parse")
@@ -133,11 +148,12 @@ fn is_full_git_sha(value: &str) -> bool {
     value.len() == 40 && value.chars().all(|ch| ch.is_ascii_hexdigit())
 }
 
-fn git_command() -> Command {
+fn git_command(neutral_cwd: &NeutralGitCwd) -> Command {
     let mut command = Command::new("git");
     command
         .env("GIT_OPTIONAL_LOCKS", "0")
         .env("GIT_TERMINAL_PROMPT", "0");
+    neutral_cwd.configure(&mut command);
     command
 }
 
@@ -226,6 +242,7 @@ mod tests {
     use super::git_command;
     use super::is_full_git_sha;
     use super::strip_windows_verbatim_path_prefix;
+    use crate::git_transport::NeutralGitCwd;
     use pretty_assertions::assert_eq;
     use std::ffi::OsStr;
 
@@ -238,7 +255,8 @@ mod tests {
 
     #[test]
     fn git_command_uses_path_lookup_with_stable_noninteractive_env() {
-        let command = git_command();
+        let neutral_cwd = NeutralGitCwd::new().expect("create neutral Git working directory");
+        let command = git_command(&neutral_cwd);
 
         assert_eq!(command.get_program(), OsStr::new("git"));
         assert_eq!(

--- a/codex-rs/core-plugins/src/startup_sync.rs
+++ b/codex-rs/core-plugins/src/startup_sync.rs
@@ -583,7 +583,7 @@ fn git_ls_remote_head_sha(git_binary: &str) -> Result<String, String> {
         .arg("ls-remote")
         .arg("https://github.com/openai/plugins.git")
         .arg("HEAD");
-    neutral_cwd.configure(&mut command);
+    neutral_cwd.configure_transport_command(&mut command);
     let output = run_git_command_with_timeout(
         &mut command,
         "git ls-remote curated plugins repo",

--- a/codex-rs/core-plugins/src/startup_sync.rs
+++ b/codex-rs/core-plugins/src/startup_sync.rs
@@ -1,3 +1,4 @@
+use crate::git_transport::NeutralGitCwd;
 use std::fs::File;
 use std::path::Path;
 use std::path::PathBuf;
@@ -595,11 +596,14 @@ fn read_local_git_or_sha_file(
 }
 
 fn git_ls_remote_head_sha(git_binary: &str) -> Result<String, String> {
+    let neutral_cwd = NeutralGitCwd::new()
+        .map_err(|err| format!("failed to create neutral Git working directory: {err}"))?;
     let mut command = git_command(git_binary);
     command
         .arg("ls-remote")
         .arg("https://github.com/openai/plugins.git")
         .arg("HEAD");
+    neutral_cwd.configure(&mut command);
     let output = run_git_command_with_timeout(
         &mut command,
         "git ls-remote curated plugins repo",

--- a/codex-rs/core-plugins/src/startup_sync.rs
+++ b/codex-rs/core-plugins/src/startup_sync.rs
@@ -1,4 +1,5 @@
 use crate::git_transport::NeutralGitCwd;
+use crate::git_transport::sanitize_repository_environment;
 use std::fs::File;
 use std::path::Path;
 use std::path::PathBuf;
@@ -35,27 +36,6 @@ const CURATED_PLUGINS_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 const CURATED_PLUGINS_BACKUP_ARCHIVE_TIMEOUT: Duration = Duration::from_secs(30);
 // Keep this comfortably above a normal sync attempt so we do not race another Codex process.
 const CURATED_PLUGINS_STALE_TEMP_DIR_MAX_AGE: Duration = Duration::from_secs(10 * 60);
-// These variables can redirect Git away from the repository selected by `-C`,
-// or inject command-scoped configuration into the sync commands.
-const REPOSITORY_LOCAL_GIT_ENVIRONMENT_VARIABLES: &[&str] = &[
-    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-    "GIT_CEILING_DIRECTORIES",
-    "GIT_COMMON_DIR",
-    "GIT_CONFIG",
-    "GIT_CONFIG_COUNT",
-    "GIT_CONFIG_PARAMETERS",
-    "GIT_DIR",
-    "GIT_DISCOVERY_ACROSS_FILESYSTEM",
-    "GIT_GRAFT_FILE",
-    "GIT_IMPLICIT_WORK_TREE",
-    "GIT_INDEX_FILE",
-    "GIT_NAMESPACE",
-    "GIT_OBJECT_DIRECTORY",
-    "GIT_PREFIX",
-    "GIT_REPLACE_REF_BASE",
-    "GIT_SHALLOW_FILE",
-    "GIT_WORK_TREE",
-];
 
 #[derive(Debug, Deserialize)]
 struct GitHubRepositorySummary {
@@ -654,9 +634,7 @@ fn git_head_sha(repo_path: &Path, git_binary: &str) -> Result<String, String> {
 fn git_command(git_binary: &str) -> Command {
     let mut command = Command::new(git_binary);
     command.env("GIT_OPTIONAL_LOCKS", "0");
-    for name in REPOSITORY_LOCAL_GIT_ENVIRONMENT_VARIABLES {
-        command.env_remove(name);
-    }
+    sanitize_repository_environment(&mut command);
     command
 }
 

--- a/codex-rs/core-plugins/src/startup_sync_tests.rs
+++ b/codex-rs/core-plugins/src/startup_sync_tests.rs
@@ -20,15 +20,21 @@ const TEST_CURATED_PLUGIN_SHA: &str = "0123456789abcdef0123456789abcdef01234567"
 #[test]
 fn git_command_sanitizes_ambient_repository_environment() {
     let command = git_command("git");
-
-    for name in REPOSITORY_LOCAL_GIT_ENVIRONMENT_VARIABLES {
+    for name in [
+        "GIT_COMMON_DIR",
+        "GIT_CONFIG_COUNT",
+        "GIT_CONFIG_PARAMETERS",
+        "GIT_DIR",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_WORK_TREE",
+    ] {
         assert_eq!(
             command
                 .get_envs()
                 .find(|(key, _)| *key == OsStr::new(name))
                 .map(|(_, value)| value),
             Some(None),
-            "{name} should be removed from startup sync Git commands"
+            "{name} should be removed from startup-sync Git commands"
         );
     }
 }


### PR DESCRIPTION
## Why

Marketplace operations intentionally clone and fetch repositories. If those commands start inside an untrusted workspace, Git can inherit that workspace's URL rewrites, SSH commands, credential helpers, or custom protocols.

Changing the working directory is not enough because environment variables and command-level configuration can select a repository without using the current directory.

## What

Start marketplace and curated startup-sync Git operations inside an owned temporary directory that is not a Git repository. Set a Git discovery boundary there and remove inherited settings that could select another repository, worktree, object store, index, or command-level configuration.

## How

Keep trusted user and system configuration, including normal SSH and credential integration. After cloning, run follow-up commands inside the new repository so legitimate destination-specific configuration continues to work.

## Testing

- 11 transport-policy tests passed.
- 4 marketplace and startup-sync caller tests passed.
- All 320 `codex-core-plugins` tests passed.

Functional tests cover hostile parent repositories, URL rewrites, `ext` helpers, inherited selectors, cleanup failures, and trusted global authentication behavior. Formatting and fix checks passed.

31/31 non-Codeownerous CI checks are green at `5e88962589`, including native Windows.

Related: [PSEC-4398](https://linear.app/openai/issue/PSEC-4398)
