### PR TITLE
Use plugin manifest name during install

### DIFF
--- a/codex-rs/app-server/src/request_processors/plugins.rs
+++ b/codex-rs/app-server/src/request_processors/plugins.rs
@@ -1552,6 +1552,14 @@ impl PluginRequestProcessor {
         )
         .await
         .map_err(remote_plugin_bundle_install_error_to_jsonrpc)?;
+        let _manifest_plugin_cache_mutation =
+            (result.plugin_id.plugin_name != remote_detail.summary.name).then(|| {
+                codex_core_plugins::remote::mark_remote_plugin_cache_mutation_in_flight(
+                    config.codex_home.as_path(),
+                    &actual_remote_marketplace_name,
+                    &result.plugin_id.plugin_name,
+                )
+            });
 
         // Cache first so a backend install cannot succeed when local materialization fails.
         // If this backend call fails, the cache entry is harmless because remote installed state

--- a/codex-rs/app-server/tests/suite/v2/plugin_install.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_install.rs
@@ -289,6 +289,71 @@ async fn plugin_install_writes_remote_plugin_to_cloud_and_cache() -> Result<()> 
 }
 
 #[tokio::test]
+async fn plugin_install_uses_plugin_json_name_when_remote_detail_name_differs() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    let server = MockServer::start().await;
+    let installed_path = codex_home
+        .path()
+        .join("plugins/cache/openai-curated-remote/manifest-linear/1.2.3");
+    let bundle_url = mount_remote_plugin_bundle(
+        &server,
+        /*status_code*/ 200,
+        remote_plugin_bundle_tar_gz_bytes_with_contents(
+            r#"{"name":"manifest-linear","version":"0.0.1"}"#,
+            /*app_manifest*/ None,
+        )?,
+    )
+    .await;
+    configure_remote_plugin_test(codex_home.path(), &server)?;
+    mount_remote_plugin_detail(&server, REMOTE_PLUGIN_ID, "1.2.3", Some(&bundle_url)).await;
+    mount_empty_remote_installed_plugins(&server).await;
+    mount_remote_plugin_install_after_cache_write(
+        &server,
+        REMOTE_PLUGIN_ID,
+        installed_path.join(".codex-plugin/plugin.json"),
+    )
+    .await;
+
+    let mut mcp = TestAppServer::new_with_env(
+        codex_home.path(),
+        &[(TEST_ALLOW_HTTP_REMOTE_PLUGIN_BUNDLE_DOWNLOADS, Some("1"))],
+    )
+    .await?;
+    timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;
+
+    let request_id = send_remote_plugin_install_request(&mut mcp, REMOTE_PLUGIN_ID).await?;
+    let response: JSONRPCResponse = timeout(
+        DEFAULT_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    let response: PluginInstallResponse = to_response(response)?;
+
+    assert_eq!(
+        response,
+        PluginInstallResponse {
+            auth_policy: PluginAuthPolicy::OnUse,
+            apps_needing_auth: Vec::new(),
+        }
+    );
+    wait_for_remote_plugin_request_count(
+        &server,
+        "POST",
+        &format!("/ps/plugins/{REMOTE_PLUGIN_ID}/install"),
+        /*expected_count*/ 1,
+    )
+    .await?;
+    assert!(installed_path.join(".codex-plugin/plugin.json").is_file());
+    assert!(
+        !codex_home
+            .path()
+            .join("plugins/cache/openai-curated-remote/linear/1.2.3")
+            .exists()
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn plugin_install_uses_remote_apps_needing_auth_response() -> Result<()> {
     let codex_home = TempDir::new()?;
     let server = MockServer::start().await;

--- a/codex-rs/core-plugins/src/marketplace.rs
+++ b/codex-rs/core-plugins/src/marketplace.rs
@@ -177,14 +177,27 @@ pub fn find_marketplace_plugin(
     let marketplace_name = marketplace.name;
     let marketplace_name_for_not_found = marketplace_name.clone();
     for plugin in marketplace.plugins {
-        if plugin.name != plugin_name {
-            continue;
-        }
-
-        if let Some(plugin) =
-            resolve_marketplace_plugin_entry(marketplace_path, &marketplace_name, plugin)?
-        {
-            return Ok(plugin);
+        let marketplace_plugin_name = plugin.name.clone();
+        match resolve_marketplace_plugin_entry(marketplace_path, &marketplace_name, plugin) {
+            Ok(Some(plugin))
+                if plugin.plugin_id.plugin_name == plugin_name
+                    || marketplace_plugin_name == plugin_name =>
+            {
+                return Ok(plugin);
+            }
+            Ok(Some(_)) | Ok(None) => {}
+            Err(MarketplaceError::InvalidPlugin(message))
+                if marketplace_plugin_name != plugin_name =>
+            {
+                warn!(
+                    path = %marketplace_path.display(),
+                    marketplace = %marketplace_name,
+                    plugin = %marketplace_plugin_name,
+                    error = %message,
+                    "skipping invalid marketplace plugin"
+                );
+            }
+            Err(err) => return Err(err),
         }
     }
 
@@ -443,6 +456,10 @@ fn resolve_marketplace_plugin_entry(
         MarketplacePluginSource::Local { path } => load_plugin_manifest(path.as_path()),
         MarketplacePluginSource::Git { .. } => None,
     };
+    let plugin_name = manifest
+        .as_ref()
+        .map(|manifest| manifest.name.clone())
+        .unwrap_or(name);
     let interface = plugin_interface_with_marketplace_category(
         manifest
             .as_ref()
@@ -451,9 +468,11 @@ fn resolve_marketplace_plugin_entry(
     );
 
     Ok(Some(ResolvedMarketplacePlugin {
-        plugin_id: PluginId::new(name, marketplace_name.to_string()).map_err(|err| match err {
-            PluginIdError::Invalid(message) => MarketplaceError::InvalidPlugin(message),
-        })?,
+        plugin_id: PluginId::new(plugin_name, marketplace_name.to_string()).map_err(
+            |err| match err {
+                PluginIdError::Invalid(message) => MarketplaceError::InvalidPlugin(message),
+            },
+        )?,
         source,
         policy: MarketplacePluginPolicy {
             installation: policy.installation,

--- a/codex-rs/core-plugins/src/marketplace_tests.rs
+++ b/codex-rs/core-plugins/src/marketplace_tests.rs
@@ -345,6 +345,60 @@ fn find_marketplace_plugin_reports_missing_plugin() {
 }
 
 #[test]
+fn find_marketplace_plugin_skips_invalid_unmatched_manifest_names() {
+    let tmp = tempdir().unwrap();
+    let repo_root = tmp.path().join("repo");
+    fs::create_dir_all(repo_root.join(".git")).unwrap();
+    fs::create_dir_all(repo_root.join(".agents/plugins")).unwrap();
+    fs::create_dir_all(repo_root.join("invalid-plugin/.codex-plugin")).unwrap();
+    fs::write(
+        repo_root.join("invalid-plugin/.codex-plugin/plugin.json"),
+        r#"{"name":"invalid.plugin"}"#,
+    )
+    .unwrap();
+    fs::create_dir_all(repo_root.join("valid-plugin/.codex-plugin")).unwrap();
+    fs::write(
+        repo_root.join("valid-plugin/.codex-plugin/plugin.json"),
+        r#"{"name":"valid-plugin"}"#,
+    )
+    .unwrap();
+    fs::write(
+        repo_root.join(".agents/plugins/marketplace.json"),
+        r#"{
+  "name": "codex-curated",
+  "plugins": [
+    {
+      "name": "invalid-entry",
+      "source": {
+        "source": "local",
+        "path": "./invalid-plugin"
+      }
+    },
+    {
+      "name": "valid-entry",
+      "source": {
+        "source": "local",
+        "path": "./valid-plugin"
+      }
+    }
+  ]
+}"#,
+    )
+    .unwrap();
+
+    let resolved = find_marketplace_plugin(
+        &AbsolutePathBuf::try_from(repo_root.join(".agents/plugins/marketplace.json")).unwrap(),
+        "valid-plugin",
+    )
+    .unwrap();
+
+    assert_eq!(
+        resolved.plugin_id,
+        PluginId::new("valid-plugin".to_string(), "codex-curated".to_string()).unwrap()
+    );
+}
+
+#[test]
 fn list_marketplaces_supports_alternate_manifest_layout() {
     let tmp = tempdir().unwrap();
     let repo_root = tmp.path().join("repo");
@@ -400,6 +454,95 @@ fn list_marketplaces_supports_alternate_manifest_layout() {
                 },
                 interface: Some(PluginManifestInterface {
                     display_name: Some("String Source Plugin".to_string()),
+                    short_description: None,
+                    long_description: None,
+                    developer_name: None,
+                    category: None,
+                    capabilities: Vec::new(),
+                    website_url: None,
+                    privacy_policy_url: None,
+                    terms_of_service_url: None,
+                    default_prompt: None,
+                    brand_color: None,
+                    composer_icon: None,
+                    logo: None,
+                    screenshots: Vec::new(),
+                }),
+                keywords: Vec::new(),
+            }],
+        }]
+    );
+}
+
+#[test]
+fn list_marketplaces_uses_local_plugin_manifest_name_when_marketplace_entry_differs() {
+    let tmp = tempdir().unwrap();
+    let repo_root = tmp.path().join("repo");
+    let plugin_root = repo_root.join("plugins/source-dir");
+
+    fs::create_dir_all(repo_root.join(".git")).unwrap();
+    write_alternate_plugin_manifest(
+        &plugin_root,
+        r#"{
+  "name":"manifest-name",
+  "interface": {
+    "displayName": "Manifest Name"
+  }
+}"#,
+    );
+    let marketplace_path = write_alternate_marketplace(
+        &repo_root,
+        r#"{
+  "name": "alternate-marketplace",
+  "plugins": [
+    {
+      "name": "marketplace-entry-name",
+      "source": "./plugins/source-dir"
+    }
+  ]
+}"#,
+    );
+
+    let resolved_by_manifest_name =
+        find_marketplace_plugin(&marketplace_path, "manifest-name").unwrap();
+    let resolved_by_entry_name =
+        find_marketplace_plugin(&marketplace_path, "marketplace-entry-name").unwrap();
+    assert_eq!(resolved_by_manifest_name, resolved_by_entry_name);
+    assert_eq!(
+        resolved_by_manifest_name.plugin_id,
+        PluginId::new(
+            "manifest-name".to_string(),
+            "alternate-marketplace".to_string()
+        )
+        .unwrap()
+    );
+
+    let marketplaces = list_marketplaces_with_home(
+        &[AbsolutePathBuf::try_from(repo_root.clone()).unwrap()],
+        /*home_dir*/ None,
+    )
+    .unwrap()
+    .marketplaces;
+
+    assert_eq!(
+        marketplaces,
+        vec![Marketplace {
+            name: "alternate-marketplace".to_string(),
+            path: marketplace_path,
+            interface: None,
+            plugins: vec![MarketplacePlugin {
+                name: "manifest-name".to_string(),
+                local_version: None,
+                source: MarketplacePluginSource::Local {
+                    path: AbsolutePathBuf::try_from(repo_root.join("plugins/source-dir")).unwrap(),
+                },
+                policy: MarketplacePluginPolicy {
+                    installation: MarketplacePluginInstallPolicy::Available,
+                    authentication: MarketplacePluginAuthPolicy::OnInstall,
+                    products: None,
+                },
+                interface: Some(PluginManifestInterface {
+                    display_name: Some("Manifest Name".to_string()),
                     short_description: None,
                     long_description: None,
                     developer_name: None,

--- a/codex-rs/core-plugins/src/remote/remote_installed_plugin_sync.rs
+++ b/codex-rs/core-plugins/src/remote/remote_installed_plugin_sync.rs
@@ -244,6 +244,10 @@ pub async fn sync_remote_installed_plugin_bundles_once(
             .await
             {
                 Ok(result) => {
+                    installed_plugin_names_by_marketplace
+                        .entry(result.plugin_id.marketplace_name.clone())
+                        .or_default()
+                        .insert(result.plugin_id.plugin_name.clone());
                     installed_plugin_ids.insert(result.plugin_id.as_key());
                 }
                 Err(err) => {

--- a/codex-rs/core-plugins/src/remote_bundle.rs
+++ b/codex-rs/core-plugins/src/remote_bundle.rs
@@ -385,7 +385,7 @@ fn install_remote_plugin_bundle(
 }
 
 fn extract_remote_plugin_bundle_to_path(
-    bundle: ValidatedRemotePluginBundle,
+    _bundle: ValidatedRemotePluginBundle,
     bundle_bytes: Vec<u8>,
     destination: AbsolutePathBuf,
 ) -> Result<AbsolutePathBuf, RemotePluginBundleInstallError> {
@@ -418,17 +418,11 @@ fn extract_remote_plugin_bundle_to_path(
 
     extract_plugin_bundle_tar_gz(&bundle_bytes, extract_dir.path())?;
     let plugin_root = find_extracted_plugin_root(extract_dir.path())?;
-    let manifest = crate::manifest::load_plugin_manifest(&plugin_root).ok_or_else(|| {
+    crate::manifest::load_plugin_manifest(&plugin_root).ok_or_else(|| {
         RemotePluginBundleInstallError::InvalidBundle(
             "remote plugin bundle did not contain a valid plugin.json".to_string(),
         )
     })?;
-    if manifest.name != bundle.plugin_id.plugin_name {
-        return Err(RemotePluginBundleInstallError::InvalidBundle(format!(
-            "plugin.json name `{}` does not match remote plugin name `{}`",
-            manifest.name, bundle.plugin_id.plugin_name
-        )));
-    }
 
     let staged_path = extract_dir.keep();
     fs::rename(&staged_path, destination.as_path()).map_err(|source| {
@@ -790,6 +784,52 @@ mod tests {
                     },
                 },
             })
+        );
+    }
+
+    #[test]
+    fn install_uses_plugin_json_name_when_remote_detail_name_differs() {
+        let codex_home = tempdir().expect("tempdir");
+        let bundle = validate_remote_plugin_bundle(
+            REMOTE_PLUGIN_ID,
+            "openai-curated-remote",
+            "marketplace-name",
+            Some("1.2.3"),
+            Some("https://example.com/linear.tar.gz"),
+            /*app_manifest*/ None,
+        )
+        .expect("valid install plan");
+
+        let result = install_remote_plugin_bundle(
+            codex_home.path().to_path_buf(),
+            bundle,
+            tar_gz_bytes(&[(
+                ".codex-plugin/plugin.json",
+                br#"{"name":"manifest-name"}"#,
+                /*mode*/ 0o644,
+            )]),
+        )
+        .expect("install bundle");
+
+        assert_eq!(
+            result.plugin_id,
+            PluginId::new(
+                "manifest-name".to_string(),
+                "openai-curated-remote".to_string()
+            )
+            .unwrap()
+        );
+        assert_eq!(
+            result.installed_path.as_path(),
+            codex_home
+                .path()
+                .join("plugins/cache/openai-curated-remote/manifest-name/1.2.3")
+        );
+        assert!(
+            !codex_home
+                .path()
+                .join("plugins/cache/openai-curated-remote/marketplace-name/1.2.3")
+                .exists()
         );
     }
 

--- a/codex-rs/core-plugins/src/store.rs
+++ b/codex-rs/core-plugins/src/store.rs
@@ -122,12 +122,9 @@ impl PluginStore {
         }
 
         let plugin_name = plugin_name_for_source(source_path.as_path())?;
-        if plugin_name != plugin_id.plugin_name {
-            return Err(PluginStoreError::Invalid(format!(
-                "plugin.json name `{plugin_name}` does not match marketplace plugin name `{}`",
-                plugin_id.plugin_name
-            )));
-        }
+        let plugin_id = PluginId::new(plugin_name, plugin_id.marketplace_name).map_err(|err| {
+            PluginStoreError::Invalid(format!("invalid plugin id from plugin.json: {err}"))
+        })?;
         validate_plugin_version_segment(&plugin_version).map_err(PluginStoreError::Invalid)?;
         let installed_path = self.plugin_root(&plugin_id, &plugin_version);
         replace_plugin_root_atomically(

--- a/codex-rs/core-plugins/src/store_tests.rs
+++ b/codex-rs/core-plugins/src/store_tests.rs
@@ -422,19 +422,28 @@ fn install_rejects_marketplace_names_with_path_separators() {
 }
 
 #[test]
-fn install_rejects_manifest_names_that_do_not_match_marketplace_plugin_name() {
+fn install_uses_manifest_name_when_marketplace_plugin_name_differs() {
     let tmp = tempdir().unwrap();
     write_plugin(tmp.path(), "source-dir", "manifest-name");
+    let marketplace_plugin_id =
+        PluginId::new("different-name".to_string(), "debug".to_string()).unwrap();
 
-    let err = PluginStore::new(tmp.path().to_path_buf())
+    let result = PluginStore::new(tmp.path().to_path_buf())
         .install(
             AbsolutePathBuf::try_from(tmp.path().join("source-dir")).unwrap(),
-            PluginId::new("different-name".to_string(), "debug".to_string()).unwrap(),
+            marketplace_plugin_id,
         )
-        .unwrap_err();
+        .unwrap();
 
     assert_eq!(
-        err.to_string(),
-        "plugin.json name `manifest-name` does not match marketplace plugin name `different-name`"
+        result,
+        PluginInstallResult {
+            plugin_id: PluginId::new("manifest-name".to_string(), "debug".to_string()).unwrap(),
+            plugin_version: "local".to_string(),
+            installed_path: AbsolutePathBuf::try_from(
+                tmp.path().join("plugins/cache/debug/manifest-name/local"),
+            )
+            .unwrap(),
+        }
     );
 }


### PR DESCRIPTION
## Summary
- tolerate marketplace/plugin.json name mismatches during plugin installation and use the plugin.json name as the installed plugin id
- resolve local marketplace entries with the plugin manifest name when available, while still allowing lookup by the marketplace entry name
- keep remote installed plugin sync/cache cleanup aware of manifest-name installs and add coverage across core plugin, marketplace, remote bundle, and app-server install flows

## Testing
- `just fmt`
- `just test -p codex-core-plugins`
- `just test -p codex-app-server plugin_install`
- `git diff --check`
