### PR TITLE
Superseded: plugin install extension executor

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -3606,6 +3606,7 @@ name = "codex-plugin-installs-extension"
 version = "0.0.0"
 dependencies = [
  "codex-app-server-protocol",
+ "codex-extension-api",
  "codex-tools",
  "pretty_assertions",
  "serde",

--- a/codex-rs/ext/plugin-installs/Cargo.toml
+++ b/codex-rs/ext/plugin-installs/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 codex-app-server-protocol = { workspace = true }
+codex-extension-api = { workspace = true }
 codex-tools = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/codex-rs/ext/plugin-installs/src/lib.rs
+++ b/codex-rs/ext/plugin-installs/src/lib.rs
@@ -1,8 +1,15 @@
 mod domain;
 mod spec;
+mod tool;
+mod validation;
 
 pub const REQUEST_PLUGIN_INSTALLS_TOOL_NAME: &str = "request_plugin_installs";
 pub(crate) const MAX_REQUEST_PLUGIN_INSTALLS_ENTRIES: usize = 16;
+
+use std::future::Future;
+use std::pin::Pin;
+
+use codex_extension_api::FunctionCallError;
 pub use domain::REQUEST_PLUGIN_INSTALL_PERSIST_ALWAYS_VALUE;
 pub use domain::REQUEST_PLUGIN_INSTALL_PERSIST_KEY;
 pub use domain::RequestPluginInstallEntryResult;
@@ -18,3 +25,25 @@ pub use domain::verified_connector_install_completed;
 pub use spec::ToolSuggestPresentation;
 pub use spec::create_request_plugin_installs_tool;
 pub use spec::create_request_plugin_installs_tool_for_tui;
+pub use tool::RequestPluginInstallsMode;
+pub use tool::request_plugin_installs_tool;
+pub use validation::request_plugin_install_picker_completed;
+
+pub type RequestPluginInstallsBackendFuture<'a> = Pin<
+    Box<dyn Future<Output = Result<RequestPluginInstallsResult, FunctionCallError>> + Send + 'a>,
+>;
+
+pub struct RequestPluginInstallsRequest {
+    pub call_id: String,
+    pub turn_id: String,
+    pub args: RequestPluginInstallsArgs,
+    pub resolved_entries: Vec<RequestPluginInstallResolvedPickerEntry>,
+}
+
+/// Host operations needed to complete a plugin install suggestion.
+pub trait RequestPluginInstallsBackend: Send + Sync {
+    fn execute(
+        &self,
+        request: RequestPluginInstallsRequest,
+    ) -> RequestPluginInstallsBackendFuture<'_>;
+}

--- a/codex-rs/ext/plugin-installs/src/tool.rs
+++ b/codex-rs/ext/plugin-installs/src/tool.rs
@@ -1,0 +1,108 @@
+use std::sync::Arc;
+
+use codex_extension_api::FunctionCallError;
+use codex_extension_api::JsonToolOutput;
+use codex_extension_api::ToolCall;
+use codex_extension_api::ToolExecutor;
+use codex_extension_api::ToolName;
+use codex_extension_api::ToolOutput;
+use codex_extension_api::ToolSpec;
+use codex_tools::DiscoverableTool;
+use codex_tools::DiscoverableToolAction;
+
+use crate::REQUEST_PLUGIN_INSTALLS_TOOL_NAME;
+use crate::RequestPluginInstallsArgs;
+use crate::RequestPluginInstallsBackend;
+use crate::RequestPluginInstallsRequest;
+use crate::ToolSuggestPresentation;
+use crate::spec::create_request_plugin_installs_tool;
+use crate::spec::create_request_plugin_installs_tool_for_tui;
+use crate::validation::validate_request_plugin_install_picker_args;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RequestPluginInstallsMode {
+    SingleEntry,
+    MultipleEntries,
+}
+
+struct RequestPluginInstallsTool {
+    backend: Arc<dyn RequestPluginInstallsBackend>,
+    discoverable_tools: Vec<DiscoverableTool>,
+    presentation: ToolSuggestPresentation,
+    mode: RequestPluginInstallsMode,
+}
+
+pub fn request_plugin_installs_tool(
+    backend: Arc<dyn RequestPluginInstallsBackend>,
+    discoverable_tools: Vec<DiscoverableTool>,
+    presentation: ToolSuggestPresentation,
+    mode: RequestPluginInstallsMode,
+) -> Arc<dyn ToolExecutor<ToolCall>> {
+    Arc::new(RequestPluginInstallsTool {
+        backend,
+        discoverable_tools,
+        presentation,
+        mode,
+    })
+}
+
+impl ToolExecutor<ToolCall> for RequestPluginInstallsTool {
+    fn tool_name(&self) -> ToolName {
+        ToolName::plain(REQUEST_PLUGIN_INSTALLS_TOOL_NAME)
+    }
+
+    fn spec(&self) -> ToolSpec {
+        match self.mode {
+            RequestPluginInstallsMode::SingleEntry => {
+                create_request_plugin_installs_tool_for_tui(self.presentation)
+            }
+            RequestPluginInstallsMode::MultipleEntries => {
+                create_request_plugin_installs_tool(self.presentation)
+            }
+        }
+    }
+
+    fn handle(&self, call: ToolCall) -> codex_extension_api::ToolExecutorFuture<'_> {
+        Box::pin(self.handle_call(call))
+    }
+}
+
+impl RequestPluginInstallsTool {
+    async fn handle_call(&self, call: ToolCall) -> Result<Box<dyn ToolOutput>, FunctionCallError> {
+        let arguments = call.function_arguments()?;
+        let args: RequestPluginInstallsArgs = serde_json::from_str(arguments).map_err(|err| {
+            FunctionCallError::RespondToModel(format!("failed to parse function arguments: {err}"))
+        })?;
+        if args.action_type != DiscoverableToolAction::Install {
+            return Err(FunctionCallError::RespondToModel(
+                "plugin install requests currently support only action_type=\"install\""
+                    .to_string(),
+            ));
+        }
+        let client_name = match self.mode {
+            RequestPluginInstallsMode::SingleEntry => Some("codex-tui"),
+            RequestPluginInstallsMode::MultipleEntries => None,
+        };
+        let resolved_entries = validate_request_plugin_install_picker_args(
+            &args,
+            &self.discoverable_tools,
+            client_name,
+            self.presentation,
+        )?;
+        let result = self
+            .backend
+            .execute(RequestPluginInstallsRequest {
+                call_id: call.call_id,
+                turn_id: call.turn_id,
+                args,
+                resolved_entries,
+            })
+            .await?;
+        let value = serde_json::to_value(result).map_err(|err| {
+            FunctionCallError::Fatal(format!(
+                "failed to serialize {REQUEST_PLUGIN_INSTALLS_TOOL_NAME} response: {err}"
+            ))
+        })?;
+        Ok(Box::new(JsonToolOutput::with_success(value, Some(true))))
+    }
+}

--- a/codex-rs/ext/plugin-installs/src/validation.rs
+++ b/codex-rs/ext/plugin-installs/src/validation.rs
@@ -1,0 +1,191 @@
+use std::collections::HashSet;
+
+use crate::MAX_REQUEST_PLUGIN_INSTALLS_ENTRIES;
+use crate::RequestPluginInstallEntryResult;
+use crate::RequestPluginInstallPickerCategory;
+use crate::RequestPluginInstallPickerEntry;
+use crate::RequestPluginInstallResolvedPickerEntry;
+use crate::RequestPluginInstallsArgs;
+use crate::ToolSuggestPresentation;
+use codex_tools::DiscoverableTool;
+use codex_tools::DiscoverableToolType;
+use codex_tools::FunctionCallError;
+use codex_tools::LIST_AVAILABLE_PLUGINS_TO_INSTALL_TOOL_NAME;
+
+pub fn validate_request_plugin_install_picker_args(
+    args: &RequestPluginInstallsArgs,
+    discoverable_tools: &[DiscoverableTool],
+    app_server_client_name: Option<&str>,
+    presentation: ToolSuggestPresentation,
+) -> Result<Vec<RequestPluginInstallResolvedPickerEntry>, FunctionCallError> {
+    if app_server_client_name == Some("codex-tui")
+        && (args.categories.is_some()
+            || args
+                .entries
+                .as_ref()
+                .is_some_and(|entries| entries.len() != 1))
+    {
+        return Err(FunctionCallError::RespondToModel(
+            "multi-tool install requests are not available in codex-tui yet".to_string(),
+        ));
+    }
+
+    let mut resolved_entries = Vec::new();
+    let mut seen_tools = HashSet::new();
+
+    match (&args.entries, &args.categories) {
+        (Some(entries), None) => {
+            if entries.len() > MAX_REQUEST_PLUGIN_INSTALLS_ENTRIES {
+                return Err(too_many_request_plugin_installs_entries_error());
+            }
+            for entry in entries {
+                resolved_entries.push(validate_request_plugin_install_picker_entry(
+                    /*category_index*/ None,
+                    entry,
+                    discoverable_tools,
+                    app_server_client_name,
+                    presentation,
+                    &mut seen_tools,
+                )?);
+            }
+            if resolved_entries.is_empty() {
+                return Err(FunctionCallError::RespondToModel(
+                    "picker install requests must include at least one entry".to_string(),
+                ));
+            }
+        }
+        (None, Some(categories)) => {
+            if categories
+                .iter()
+                .try_fold(0usize, |count, category| {
+                    count.checked_add(category.entries.len())
+                })
+                .is_none_or(|count| count > MAX_REQUEST_PLUGIN_INSTALLS_ENTRIES)
+            {
+                return Err(too_many_request_plugin_installs_entries_error());
+            }
+            validate_request_plugin_install_picker_categories(
+                categories,
+                discoverable_tools,
+                app_server_client_name,
+                presentation,
+                &mut seen_tools,
+                &mut resolved_entries,
+            )?;
+        }
+        _ => {
+            return Err(FunctionCallError::RespondToModel(
+                "picker install requests must include exactly one of entries or categories"
+                    .to_string(),
+            ));
+        }
+    }
+
+    Ok(resolved_entries)
+}
+
+fn too_many_request_plugin_installs_entries_error() -> FunctionCallError {
+    FunctionCallError::RespondToModel(format!(
+        "picker install requests support at most {MAX_REQUEST_PLUGIN_INSTALLS_ENTRIES} entries"
+    ))
+}
+
+fn validate_request_plugin_install_picker_categories(
+    categories: &[RequestPluginInstallPickerCategory],
+    discoverable_tools: &[DiscoverableTool],
+    app_server_client_name: Option<&str>,
+    presentation: ToolSuggestPresentation,
+    seen_tools: &mut HashSet<(DiscoverableToolType, String)>,
+    resolved_entries: &mut Vec<RequestPluginInstallResolvedPickerEntry>,
+) -> Result<(), FunctionCallError> {
+    if categories.is_empty() {
+        return Err(FunctionCallError::RespondToModel(
+            "picker install requests must include at least one category".to_string(),
+        ));
+    }
+
+    for (category_index, category) in categories.iter().enumerate() {
+        if category.title.trim().is_empty() {
+            return Err(FunctionCallError::RespondToModel(
+                "categories[].title must not be empty".to_string(),
+            ));
+        }
+        if category.entries.is_empty() {
+            return Err(FunctionCallError::RespondToModel(
+                "categories[].entries must include at least one install candidate".to_string(),
+            ));
+        }
+        for entry in &category.entries {
+            resolved_entries.push(validate_request_plugin_install_picker_entry(
+                Some(category_index),
+                entry,
+                discoverable_tools,
+                app_server_client_name,
+                presentation,
+                seen_tools,
+            )?);
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_request_plugin_install_picker_entry(
+    category_index: Option<usize>,
+    entry: &RequestPluginInstallPickerEntry,
+    discoverable_tools: &[DiscoverableTool],
+    app_server_client_name: Option<&str>,
+    presentation: ToolSuggestPresentation,
+    seen_tools: &mut HashSet<(DiscoverableToolType, String)>,
+) -> Result<RequestPluginInstallResolvedPickerEntry, FunctionCallError> {
+    if entry.tool_id.trim().is_empty() {
+        return Err(FunctionCallError::RespondToModel(
+            "entries[].tool_id must not be empty".to_string(),
+        ));
+    }
+    if entry.tool_type == DiscoverableToolType::Plugin
+        && app_server_client_name == Some("codex-tui")
+    {
+        return Err(FunctionCallError::RespondToModel(
+            "plugin install requests are not available in codex-tui yet".to_string(),
+        ));
+    }
+
+    if !seen_tools.insert((entry.tool_type, entry.tool_id.clone())) {
+        return Err(FunctionCallError::RespondToModel(
+            "picker install requests must not repeat a tool_type/tool_id pair".to_string(),
+        ));
+    }
+
+    let tool = discoverable_tools
+        .iter()
+        .find(|tool| tool.tool_type() == entry.tool_type && tool.id() == entry.tool_id)
+        .ok_or_else(|| {
+            let source = match presentation {
+                ToolSuggestPresentation::ListTool => format!(
+                    "the discoverable tools returned by {LIST_AVAILABLE_PLUGINS_TO_INSTALL_TOOL_NAME}"
+                ),
+                ToolSuggestPresentation::RecommendationContext => {
+                    "the <recommended_plugins> list".to_string()
+                }
+            };
+            FunctionCallError::RespondToModel(format!(
+                "entries[].tool_id must match one of {source}"
+            ))
+        })?;
+
+    Ok(RequestPluginInstallResolvedPickerEntry {
+        category_index,
+        tool: tool.clone(),
+    })
+}
+
+pub fn request_plugin_install_picker_completed(
+    entries: &[RequestPluginInstallEntryResult],
+) -> bool {
+    entries.iter().any(|entry| entry.completed)
+}
+
+#[cfg(test)]
+#[path = "validation_tests.rs"]
+mod tests;

--- a/codex-rs/ext/plugin-installs/src/validation_tests.rs
+++ b/codex-rs/ext/plugin-installs/src/validation_tests.rs
@@ -1,0 +1,223 @@
+use super::*;
+
+use codex_app_server_protocol::AppInfo;
+use codex_tools::DiscoverableToolAction;
+use pretty_assertions::assert_eq;
+
+use crate::RequestPluginInstallPickerCategory;
+use crate::RequestPluginInstallPickerEntry;
+use crate::RequestPluginInstallsArgs;
+
+#[test]
+fn validate_request_plugin_install_picker_args_supports_categories() {
+    let args = RequestPluginInstallsArgs {
+        action_type: DiscoverableToolAction::Install,
+        entries: None,
+        categories: Some(vec![RequestPluginInstallPickerCategory {
+            title: "Calendar".to_string(),
+            entries: vec![RequestPluginInstallPickerEntry {
+                tool_id: "connector_calendar".to_string(),
+                tool_type: DiscoverableToolType::Connector,
+            }],
+        }]),
+    };
+    let discoverable_tools = vec![connector_tool("connector_calendar", "Google Calendar")];
+
+    let resolved_entries = validate_request_plugin_install_picker_args(
+        &args,
+        &discoverable_tools,
+        /*app_server_client_name*/ None,
+        ToolSuggestPresentation::ListTool,
+    )
+    .expect("categorized picker args");
+
+    assert_eq!(resolved_entries.len(), 1);
+    assert_eq!(resolved_entries[0].category_index, Some(0));
+    assert_eq!(resolved_entries[0].tool.id(), "connector_calendar");
+}
+
+#[test]
+fn validate_request_plugin_install_picker_args_rejects_mixed_sources() {
+    let entry = RequestPluginInstallPickerEntry {
+        tool_id: "connector_calendar".to_string(),
+        tool_type: DiscoverableToolType::Connector,
+    };
+    let args = RequestPluginInstallsArgs {
+        action_type: DiscoverableToolAction::Install,
+        entries: Some(vec![entry]),
+        categories: Some(vec![RequestPluginInstallPickerCategory {
+            title: "Calendar".to_string(),
+            entries: vec![RequestPluginInstallPickerEntry {
+                tool_id: "connector_calendar".to_string(),
+                tool_type: DiscoverableToolType::Connector,
+            }],
+        }]),
+    };
+    let discoverable_tools = vec![connector_tool("connector_calendar", "Google Calendar")];
+
+    assert_eq!(
+        validate_request_plugin_install_picker_args(
+            &args,
+            &discoverable_tools,
+            /*app_server_client_name*/ None,
+            ToolSuggestPresentation::ListTool,
+        )
+        .expect_err("mixed picker args"),
+        FunctionCallError::RespondToModel(
+            "picker install requests must include exactly one of entries or categories".to_string(),
+        ),
+    );
+}
+
+#[test]
+fn validate_request_plugin_install_picker_args_rejects_duplicate_tools() {
+    let entry = RequestPluginInstallPickerEntry {
+        tool_id: "connector_calendar".to_string(),
+        tool_type: DiscoverableToolType::Connector,
+    };
+    let args = RequestPluginInstallsArgs {
+        action_type: DiscoverableToolAction::Install,
+        entries: None,
+        categories: Some(vec![
+            RequestPluginInstallPickerCategory {
+                title: "Calendar".to_string(),
+                entries: vec![entry],
+            },
+            RequestPluginInstallPickerCategory {
+                title: "Meetings".to_string(),
+                entries: vec![RequestPluginInstallPickerEntry {
+                    tool_id: "connector_calendar".to_string(),
+                    tool_type: DiscoverableToolType::Connector,
+                }],
+            },
+        ]),
+    };
+    let discoverable_tools = vec![connector_tool("connector_calendar", "Google Calendar")];
+
+    assert_eq!(
+        validate_request_plugin_install_picker_args(
+            &args,
+            &discoverable_tools,
+            /*app_server_client_name*/ None,
+            ToolSuggestPresentation::ListTool,
+        )
+        .expect_err("duplicate picker tool"),
+        FunctionCallError::RespondToModel(
+            "picker install requests must not repeat a tool_type/tool_id pair".to_string(),
+        ),
+    );
+}
+
+#[test]
+fn validate_request_plugin_install_picker_args_rejects_multi_tool_tui_requests() {
+    let args = RequestPluginInstallsArgs {
+        action_type: DiscoverableToolAction::Install,
+        entries: Some(vec![
+            RequestPluginInstallPickerEntry {
+                tool_id: "connector_calendar".to_string(),
+                tool_type: DiscoverableToolType::Connector,
+            },
+            RequestPluginInstallPickerEntry {
+                tool_id: "connector_gmail".to_string(),
+                tool_type: DiscoverableToolType::Connector,
+            },
+        ]),
+        categories: None,
+    };
+    let discoverable_tools = vec![
+        connector_tool("connector_calendar", "Google Calendar"),
+        connector_tool("connector_gmail", "Gmail"),
+    ];
+
+    assert_eq!(
+        validate_request_plugin_install_picker_args(
+            &args,
+            &discoverable_tools,
+            Some("codex-tui"),
+            ToolSuggestPresentation::ListTool,
+        )
+        .expect_err("multi-tool TUI request"),
+        FunctionCallError::RespondToModel(
+            "multi-tool install requests are not available in codex-tui yet".to_string(),
+        ),
+    );
+}
+
+#[test]
+fn validate_request_plugin_install_picker_args_caps_entries() {
+    let entries = || {
+        (0..=MAX_REQUEST_PLUGIN_INSTALLS_ENTRIES)
+            .map(|index| RequestPluginInstallPickerEntry {
+                tool_id: format!("connector_{index}"),
+                tool_type: DiscoverableToolType::Connector,
+            })
+            .collect()
+    };
+
+    for args in [
+        RequestPluginInstallsArgs {
+            action_type: DiscoverableToolAction::Install,
+            entries: Some(entries()),
+            categories: None,
+        },
+        RequestPluginInstallsArgs {
+            action_type: DiscoverableToolAction::Install,
+            entries: None,
+            categories: Some(vec![RequestPluginInstallPickerCategory {
+                title: "Connectors".to_string(),
+                entries: entries(),
+            }]),
+        },
+    ] {
+        assert_eq!(
+            validate_request_plugin_install_picker_args(
+                &args,
+                &[],
+                /*app_server_client_name*/ None,
+                ToolSuggestPresentation::ListTool,
+            )
+            .expect_err("oversized picker args"),
+            FunctionCallError::RespondToModel(format!(
+                "picker install requests support at most {MAX_REQUEST_PLUGIN_INSTALLS_ENTRIES} entries"
+            )),
+        );
+    }
+}
+
+#[test]
+fn picker_completion_only_requires_one_completed_entry() {
+    let entries = vec![
+        RequestPluginInstallEntryResult {
+            tool_type: DiscoverableToolType::Connector,
+            tool_id: "connector_salesforce".to_string(),
+            tool_name: "Salesforce".to_string(),
+            completed: true,
+        },
+        RequestPluginInstallEntryResult {
+            tool_type: DiscoverableToolType::Connector,
+            tool_id: "connector_hubspot".to_string(),
+            tool_name: "HubSpot".to_string(),
+            completed: false,
+        },
+    ];
+
+    assert!(request_plugin_install_picker_completed(&entries));
+}
+
+fn connector_tool(id: &str, name: &str) -> DiscoverableTool {
+    DiscoverableTool::Connector(Box::new(AppInfo {
+        id: id.to_string(),
+        name: name.to_string(),
+        description: None,
+        logo_url: None,
+        logo_url_dark: None,
+        distribution_channel: None,
+        branding: None,
+        app_metadata: None,
+        labels: None,
+        install_url: None,
+        is_accessible: false,
+        is_enabled: true,
+        plugin_display_names: Vec::new(),
+    }))
+}

--- a/codex-rs/tools/src/tool_discovery.rs
+++ b/codex-rs/tools/src/tool_discovery.rs
@@ -14,7 +14,7 @@ pub struct ToolSearchSourceInfo {
     pub description: Option<String>,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Deserialize, Hash, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum DiscoverableToolType {
     Connector,


### PR DESCRIPTION
Superseded by the behavior-preserving three-PR stack: #28798 contains the complete runtime implementation with Noah's original picker contract, followed by test-only PRs #28796 and #28802.