### PR TITLE
Superseded: plugin install stack cleanup

### DIFF
--- a/codex-rs/core/src/tools/request_plugin_installs_tests.rs
+++ b/codex-rs/core/src/tools/request_plugin_installs_tests.rs
@@ -12,16 +12,8 @@ use codex_config::types::ToolSuggestDiscoverableType;
 use codex_core_plugins::PluginInstallRequest;
 use codex_core_plugins::PluginsManager;
 use codex_core_plugins::startup_sync::curated_plugins_repo_path;
-use codex_plugin_installs_extension::MAX_REQUEST_PLUGIN_INSTALLS_ENTRIES;
-use codex_plugin_installs_extension::RequestPluginInstallPickerCategory;
-use codex_plugin_installs_extension::RequestPluginInstallPickerEntry;
-use codex_plugin_installs_extension::RequestPluginInstallsArgs;
-use codex_plugin_installs_extension::ToolSuggestPresentation;
-use codex_plugin_installs_extension::request_plugin_install_picker_completed;
-use codex_plugin_installs_extension::validate_request_plugin_install_picker_args;
 use codex_rmcp_client::ElicitationResponse;
 use codex_tools::DiscoverablePluginInfo;
-use codex_tools::DiscoverableToolAction;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use core_test_support::PathExt;
 use pretty_assertions::assert_eq;
@@ -113,182 +105,6 @@ fn request_plugin_install_response_persists_only_decline_always_mode() {
 }
 
 #[test]
-fn validate_request_plugin_install_picker_args_supports_categories() {
-    let args = RequestPluginInstallsArgs {
-        action_type: DiscoverableToolAction::Install,
-        entries: None,
-        categories: Some(vec![RequestPluginInstallPickerCategory {
-            title: "Calendar".to_string(),
-            entries: vec![RequestPluginInstallPickerEntry {
-                tool_id: "connector_calendar".to_string(),
-                tool_type: DiscoverableToolType::Connector,
-            }],
-        }]),
-    };
-    let discoverable_tools = vec![connector_tool("connector_calendar", "Google Calendar")];
-
-    let resolved_entries = validate_request_plugin_install_picker_args(
-        &args,
-        &discoverable_tools,
-        /*app_server_client_name*/ None,
-        ToolSuggestPresentation::ListTool,
-    )
-    .expect("categorized picker args");
-
-    assert_eq!(resolved_entries.len(), 1);
-    assert_eq!(resolved_entries[0].category_index, Some(0));
-    assert_eq!(resolved_entries[0].tool.id(), "connector_calendar");
-}
-
-#[test]
-fn validate_request_plugin_install_picker_args_rejects_mixed_sources() {
-    let entry = RequestPluginInstallPickerEntry {
-        tool_id: "connector_calendar".to_string(),
-        tool_type: DiscoverableToolType::Connector,
-    };
-    let args = RequestPluginInstallsArgs {
-        action_type: DiscoverableToolAction::Install,
-        entries: Some(vec![entry]),
-        categories: Some(vec![RequestPluginInstallPickerCategory {
-            title: "Calendar".to_string(),
-            entries: vec![RequestPluginInstallPickerEntry {
-                tool_id: "connector_calendar".to_string(),
-                tool_type: DiscoverableToolType::Connector,
-            }],
-        }]),
-    };
-    let discoverable_tools = vec![connector_tool("connector_calendar", "Google Calendar")];
-
-    assert_eq!(
-        validate_request_plugin_install_picker_args(
-            &args,
-            &discoverable_tools,
-            /*app_server_client_name*/ None,
-            ToolSuggestPresentation::ListTool,
-        )
-        .expect_err("mixed picker args"),
-        FunctionCallError::RespondToModel(
-            "picker install requests must include exactly one of entries or categories".to_string(),
-        ),
-    );
-}
-
-#[test]
-fn validate_request_plugin_install_picker_args_rejects_duplicate_tools() {
-    let entry = RequestPluginInstallPickerEntry {
-        tool_id: "connector_calendar".to_string(),
-        tool_type: DiscoverableToolType::Connector,
-    };
-    let args = RequestPluginInstallsArgs {
-        action_type: DiscoverableToolAction::Install,
-        entries: None,
-        categories: Some(vec![
-            RequestPluginInstallPickerCategory {
-                title: "Calendar".to_string(),
-                entries: vec![entry],
-            },
-            RequestPluginInstallPickerCategory {
-                title: "Meetings".to_string(),
-                entries: vec![RequestPluginInstallPickerEntry {
-                    tool_id: "connector_calendar".to_string(),
-                    tool_type: DiscoverableToolType::Connector,
-                }],
-            },
-        ]),
-    };
-    let discoverable_tools = vec![connector_tool("connector_calendar", "Google Calendar")];
-
-    assert_eq!(
-        validate_request_plugin_install_picker_args(
-            &args,
-            &discoverable_tools,
-            /*app_server_client_name*/ None,
-            ToolSuggestPresentation::ListTool,
-        )
-        .expect_err("duplicate picker tool"),
-        FunctionCallError::RespondToModel(
-            "picker install requests must not repeat a tool_type/tool_id pair".to_string(),
-        ),
-    );
-}
-
-#[test]
-fn validate_request_plugin_install_picker_args_rejects_multi_tool_tui_requests() {
-    let args = RequestPluginInstallsArgs {
-        action_type: DiscoverableToolAction::Install,
-        entries: Some(vec![
-            RequestPluginInstallPickerEntry {
-                tool_id: "connector_calendar".to_string(),
-                tool_type: DiscoverableToolType::Connector,
-            },
-            RequestPluginInstallPickerEntry {
-                tool_id: "connector_gmail".to_string(),
-                tool_type: DiscoverableToolType::Connector,
-            },
-        ]),
-        categories: None,
-    };
-    let discoverable_tools = vec![
-        connector_tool("connector_calendar", "Google Calendar"),
-        connector_tool("connector_gmail", "Gmail"),
-    ];
-
-    assert_eq!(
-        validate_request_plugin_install_picker_args(
-            &args,
-            &discoverable_tools,
-            Some("codex-tui"),
-            ToolSuggestPresentation::ListTool,
-        )
-        .expect_err("multi-tool TUI request"),
-        FunctionCallError::RespondToModel(
-            "multi-tool install requests are not available in codex-tui yet".to_string(),
-        ),
-    );
-}
-
-#[test]
-fn validate_request_plugin_install_picker_args_caps_entries() {
-    let entries = || {
-        (0..=MAX_REQUEST_PLUGIN_INSTALLS_ENTRIES)
-            .map(|index| RequestPluginInstallPickerEntry {
-                tool_id: format!("connector_{index}"),
-                tool_type: DiscoverableToolType::Connector,
-            })
-            .collect()
-    };
-
-    for args in [
-        RequestPluginInstallsArgs {
-            action_type: DiscoverableToolAction::Install,
-            entries: Some(entries()),
-            categories: None,
-        },
-        RequestPluginInstallsArgs {
-            action_type: DiscoverableToolAction::Install,
-            entries: None,
-            categories: Some(vec![RequestPluginInstallPickerCategory {
-                title: "Connectors".to_string(),
-                entries: entries(),
-            }]),
-        },
-    ] {
-        assert_eq!(
-            validate_request_plugin_install_picker_args(
-                &args,
-                &[],
-                /*app_server_client_name*/ None,
-                ToolSuggestPresentation::ListTool,
-            )
-            .expect_err("oversized picker args"),
-            FunctionCallError::RespondToModel(format!(
-                "picker install requests support at most {MAX_REQUEST_PLUGIN_INSTALLS_ENTRIES} entries"
-            )),
-        );
-    }
-}
-
-#[test]
 fn picker_response_acknowledgements_apply_only_to_plugins() {
     let connector = RequestedPickerInstallEntry {
         tool: connector_tool("connector_calendar", "Google Calendar"),
@@ -322,26 +138,6 @@ fn picker_response_acknowledgements_apply_only_to_plugins() {
         ),
         (false, true),
     );
-}
-
-#[test]
-fn picker_completion_only_requires_one_completed_entry() {
-    let entries = vec![
-        RequestPluginInstallEntryResult {
-            tool_type: DiscoverableToolType::Connector,
-            tool_id: "connector_salesforce".to_string(),
-            tool_name: "Salesforce".to_string(),
-            completed: true,
-        },
-        RequestPluginInstallEntryResult {
-            tool_type: DiscoverableToolType::Connector,
-            tool_id: "connector_hubspot".to_string(),
-            tool_name: "HubSpot".to_string(),
-            completed: false,
-        },
-    ];
-
-    assert!(request_plugin_install_picker_completed(&entries));
 }
 
 #[tokio::test]

--- a/codex-rs/core/templates/search_tool/request_plugin_install_description.md
+++ b/codex-rs/core/templates/search_tool/request_plugin_install_description.md
@@ -1,13 +1,13 @@
 # Request plugin/connector install
 
-Use this tool only to ask the user to install one or more known plugins/connectors from the list below. The list contains known candidates that are not currently installed.
+Use this tool only to ask the user to install one known plugin or connector from the list below. The list contains known candidates that are not currently installed.
 
 Use this ONLY when all of the following are true:
 - The user explicitly asks to use a specific plugin or connector that is not already available in the current context or active `tools` list.
 - `tool_search` is not available, or it has already been called and did not find or make the requested tool callable.
-- Every requested plugin or connector is one of the known installable plugins or connectors listed below. Only ask to install plugins or connectors from this list.
+- The plugin or connector is one of the known installable plugins or connectors listed below. Only ask to install plugins or connectors from this list.
 
-Do not use this tool for adjacent capabilities, broad recommendations, or tools that merely seem useful. Only use when the user explicitly asks to use exact listed plugins or connectors.
+Do not use this tool for adjacent capabilities, broad recommendations, or tools that merely seem useful. Only use when the user explicitly asks to use that exact listed plugin or connector.
 
 Known plugins/connectors available to install:
 {{discoverable_tools}}
@@ -15,19 +15,14 @@ Known plugins/connectors available to install:
 Workflow:
 
 1. Check the current context and active `tools` list first. If current active tools aren't relevant and `tool_search` is available, only call this tool after `tool_search` has already been tried and found no relevant tool.
-2. Match the user's explicit request against the known plugin/connector list above. Only proceed for exact listed plugins/connectors.
+2. Match the user's explicit request against the known plugin/connector list above. Only proceed when one listed plugin or connector exactly fits.
 3. If we found both connectors and plugins to install, use plugins first, only use connectors if the corresponding plugin is installed but the connector is not.
-4. Do not invent ids or copy display metadata into this tool call. Every flat or categorized entry must contain only the exact `tool_type` and `tool_id` from the known plugin/connector list above; Codex resolves picker labels and metadata from that known list.
-   - Include at most 16 entries total across the request.
-5. If one or more plugins or connectors clearly fit, call `request_plugin_installs` once with:
+4. If one plugin or connector clearly fits, call `request_plugin_install` with:
+   - `tool_type`: `connector` or `plugin`
    - `action_type`: `install`
-   - `entries`: a flat list of candidates, each with `tool_type` and `tool_id`
-   - use a one-item `entries` list when one plugin or connector clearly fits
-6. If multiple exact install candidates are alternatives within named categories, call `request_plugin_installs` once with:
-   - `action_type`: `install`
-   - `categories`: a list of categories, each with `title` and `entries`
-   - each categorized entry must include only `tool_type` and `tool_id`
-7. After the request flow completes:
+   - `tool_id`: exact id from the known plugin/connector list above
+   - `suggest_reason`: concise one-line user-facing reason this plugin or connector can help with the current request
+5. After the request flow completes:
    - if the user finished the install flow, continue by searching again or using the newly available plugin or connector
    - if the user did not finish, continue without that plugin or connector, and don't request it again unless the user explicitly asks for it.
 

--- a/codex-rs/ext/plugin-installs/src/lib.rs
+++ b/codex-rs/ext/plugin-installs/src/lib.rs
@@ -7,18 +7,14 @@ use std::future::Future;
 use std::pin::Pin;
 
 use codex_extension_api::FunctionCallError;
-pub use domain::REQUEST_PLUGIN_INSTALL_APPROVAL_KIND_VALUE;
 pub use domain::REQUEST_PLUGIN_INSTALL_PERSIST_ALWAYS_VALUE;
 pub use domain::REQUEST_PLUGIN_INSTALL_PERSIST_KEY;
-pub use domain::RequestPluginInstallCategoryMeta;
-pub use domain::RequestPluginInstallEntryMeta;
 pub use domain::RequestPluginInstallEntryResult;
 pub use domain::RequestPluginInstallInstalledEntry;
 pub use domain::RequestPluginInstallPickerCategory;
 pub use domain::RequestPluginInstallPickerEntry;
 pub use domain::RequestPluginInstallResolvedPickerEntry;
 pub use domain::RequestPluginInstallsArgs;
-pub use domain::RequestPluginInstallsMeta;
 pub use domain::RequestPluginInstallsResult;
 pub use domain::all_requested_connectors_picked_up;
 pub use domain::build_request_plugin_installs_elicitation_request;
@@ -29,9 +25,7 @@ pub use spec::create_request_plugin_installs_tool_for_tui;
 pub use tool::REQUEST_PLUGIN_INSTALLS_TOOL_NAME;
 pub use tool::RequestPluginInstallsMode;
 pub use tool::request_plugin_installs_tool;
-pub use validation::MAX_REQUEST_PLUGIN_INSTALLS_ENTRIES;
 pub use validation::request_plugin_install_picker_completed;
-pub use validation::validate_request_plugin_install_picker_args;
 
 pub type RequestPluginInstallsBackendFuture<'a> = Pin<
     Box<dyn Future<Output = Result<RequestPluginInstallsResult, FunctionCallError>> + Send + 'a>,

--- a/codex-rs/ext/plugin-installs/src/spec.rs
+++ b/codex-rs/ext/plugin-installs/src/spec.rs
@@ -5,8 +5,8 @@ use codex_tools::ToolSpec;
 use serde_json::json;
 use std::collections::BTreeMap;
 
-use crate::MAX_REQUEST_PLUGIN_INSTALLS_ENTRIES;
 use crate::tool::REQUEST_PLUGIN_INSTALLS_TOOL_NAME;
+use crate::validation::MAX_REQUEST_PLUGIN_INSTALLS_ENTRIES;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ToolSuggestPresentation {
@@ -195,69 +195,5 @@ fn install_action_schema() -> JsonSchema {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use pretty_assertions::assert_eq;
-
-    #[test]
-    fn create_request_plugin_installs_tool_uses_expected_wire_shape() {
-        let expected_description = concat!(
-            "# Request plugin/connector install\n\n",
-            "Use this tool only after `list_available_plugins_to_install` returns one or more plugins or connectors that exactly match the user's explicit request.\n\n",
-            "Do not use it for adjacent capabilities, broad recommendations, or tools that merely seem useful. Make one call with `entries` for a flat list or `categories` when alternatives are organized by category; use one flat `entries` item for a single target, with at most 16 entries total. Pass only exact `tool_type` and `tool_id` values returned by `list_available_plugins_to_install`; Codex resolves picker labels and metadata from that known tool list.\n\n",
-            "When this tool returns, the user-visible install picker has resolved and is no longer visible.\n\n",
-            "IMPORTANT: DO NOT call this tool in parallel with other tools.",
-        );
-
-        assert_eq!(
-            create_request_plugin_installs_tool(ToolSuggestPresentation::ListTool),
-            ToolSpec::Function(ResponsesApiTool {
-                name: "request_plugin_installs".to_string(),
-                description: expected_description.to_string(),
-                strict: false,
-                defer_loading: None,
-                parameters: picker_schema(),
-                output_schema: None,
-            })
-        );
-    }
-
-    #[test]
-    fn create_request_plugin_installs_tool_for_tui_uses_single_entry_shape() {
-        let expected_description = concat!(
-            "# Request plugin/connector install\n\n",
-            "Use this tool only after `list_available_plugins_to_install` returns a connector that exactly matches the user's explicit request.\n\n",
-            "Do not use it for adjacent capabilities, broad recommendations, or tools that merely seem useful. Make one call with exactly one `entries` item. Pass only exact `tool_type` and `tool_id` values returned by `list_available_plugins_to_install`; Codex resolves picker labels and metadata from that known tool list.\n\n",
-            "When this tool returns, the user-visible install picker has resolved and is no longer visible.\n\n",
-            "IMPORTANT: DO NOT call this tool in parallel with other tools.",
-        );
-
-        assert_eq!(
-            create_request_plugin_installs_tool_for_tui(ToolSuggestPresentation::ListTool),
-            ToolSpec::Function(ResponsesApiTool {
-                name: "request_plugin_installs".to_string(),
-                description: expected_description.to_string(),
-                strict: false,
-                defer_loading: None,
-                parameters: single_entry_picker_schema(),
-                output_schema: None,
-            })
-        );
-    }
-
-    #[test]
-    fn plural_developer_recommendations_change_only_the_description() {
-        let mut expected = create_request_plugin_installs_tool(ToolSuggestPresentation::ListTool);
-        let recommendations =
-            create_request_plugin_installs_tool(ToolSuggestPresentation::RecommendationContext);
-
-        let ToolSpec::Function(expected_function) = &mut expected else {
-            panic!("expected function tool specs");
-        };
-        expected_function.description = format!(
-            "# Suggest recommended plugin installations\n\nSuggest installing one or more plugins from the `<recommended_plugins>` list when they would help with the user's current request. Make one call with `entries` for a flat list or `categories` when alternatives are organized by category; use one flat `entries` item for a single target, with at most {MAX_REQUEST_PLUGIN_INSTALLS_ENTRIES} entries total.\n\nWhen this tool returns, the user-visible install picker has resolved and is no longer visible.\n\nIMPORTANT: DO NOT call this tool in parallel with other tools."
-        );
-
-        assert_eq!(recommendations, expected);
-    }
-}
+#[path = "spec_tests.rs"]
+mod tests;

--- a/codex-rs/ext/plugin-installs/src/spec_tests.rs
+++ b/codex-rs/ext/plugin-installs/src/spec_tests.rs
@@ -1,0 +1,64 @@
+use super::*;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn create_request_plugin_installs_tool_uses_expected_wire_shape() {
+    let expected_description = concat!(
+        "# Request plugin/connector install\n\n",
+        "Use this tool only after `list_available_plugins_to_install` returns one or more plugins or connectors that exactly match the user's explicit request.\n\n",
+        "Do not use it for adjacent capabilities, broad recommendations, or tools that merely seem useful. Make one call with `entries` for a flat list or `categories` when alternatives are organized by category; use one flat `entries` item for a single target, with at most 16 entries total. Pass only exact `tool_type` and `tool_id` values returned by `list_available_plugins_to_install`; Codex resolves picker labels and metadata from that known tool list.\n\n",
+        "When this tool returns, the user-visible install picker has resolved and is no longer visible.\n\n",
+        "IMPORTANT: DO NOT call this tool in parallel with other tools.",
+    );
+
+    assert_eq!(
+        create_request_plugin_installs_tool(ToolSuggestPresentation::ListTool),
+        ToolSpec::Function(ResponsesApiTool {
+            name: "request_plugin_installs".to_string(),
+            description: expected_description.to_string(),
+            strict: false,
+            defer_loading: None,
+            parameters: picker_schema(),
+            output_schema: None,
+        })
+    );
+}
+
+#[test]
+fn create_request_plugin_installs_tool_for_tui_uses_single_entry_shape() {
+    let expected_description = concat!(
+        "# Request plugin/connector install\n\n",
+        "Use this tool only after `list_available_plugins_to_install` returns a connector that exactly matches the user's explicit request.\n\n",
+        "Do not use it for adjacent capabilities, broad recommendations, or tools that merely seem useful. Make one call with exactly one `entries` item. Pass only exact `tool_type` and `tool_id` values returned by `list_available_plugins_to_install`; Codex resolves picker labels and metadata from that known tool list.\n\n",
+        "When this tool returns, the user-visible install picker has resolved and is no longer visible.\n\n",
+        "IMPORTANT: DO NOT call this tool in parallel with other tools.",
+    );
+
+    assert_eq!(
+        create_request_plugin_installs_tool_for_tui(ToolSuggestPresentation::ListTool),
+        ToolSpec::Function(ResponsesApiTool {
+            name: "request_plugin_installs".to_string(),
+            description: expected_description.to_string(),
+            strict: false,
+            defer_loading: None,
+            parameters: single_entry_picker_schema(),
+            output_schema: None,
+        })
+    );
+}
+
+#[test]
+fn plural_developer_recommendations_change_only_the_description() {
+    let mut expected = create_request_plugin_installs_tool(ToolSuggestPresentation::ListTool);
+    let recommendations =
+        create_request_plugin_installs_tool(ToolSuggestPresentation::RecommendationContext);
+
+    let ToolSpec::Function(expected_function) = &mut expected else {
+        panic!("expected function tool specs");
+    };
+    expected_function.description = format!(
+        "# Suggest recommended plugin installations\n\nSuggest installing one or more plugins from the `<recommended_plugins>` list when they would help with the user's current request. Make one call with `entries` for a flat list or `categories` when alternatives are organized by category; use one flat `entries` item for a single target, with at most {MAX_REQUEST_PLUGIN_INSTALLS_ENTRIES} entries total.\n\nWhen this tool returns, the user-visible install picker has resolved and is no longer visible.\n\nIMPORTANT: DO NOT call this tool in parallel with other tools."
+    );
+
+    assert_eq!(recommendations, expected);
+}

--- a/codex-rs/ext/plugin-installs/src/validation.rs
+++ b/codex-rs/ext/plugin-installs/src/validation.rs
@@ -186,3 +186,7 @@ pub fn request_plugin_install_picker_completed(
 ) -> bool {
     entries.iter().any(|entry| entry.completed)
 }
+
+#[cfg(test)]
+#[path = "validation_tests.rs"]
+mod tests;

--- a/codex-rs/ext/plugin-installs/src/validation_tests.rs
+++ b/codex-rs/ext/plugin-installs/src/validation_tests.rs
@@ -1,0 +1,223 @@
+use super::*;
+
+use codex_app_server_protocol::AppInfo;
+use codex_tools::DiscoverableToolAction;
+use pretty_assertions::assert_eq;
+
+use crate::RequestPluginInstallPickerCategory;
+use crate::RequestPluginInstallPickerEntry;
+use crate::RequestPluginInstallsArgs;
+
+#[test]
+fn validate_request_plugin_install_picker_args_supports_categories() {
+    let args = RequestPluginInstallsArgs {
+        action_type: DiscoverableToolAction::Install,
+        entries: None,
+        categories: Some(vec![RequestPluginInstallPickerCategory {
+            title: "Calendar".to_string(),
+            entries: vec![RequestPluginInstallPickerEntry {
+                tool_id: "connector_calendar".to_string(),
+                tool_type: DiscoverableToolType::Connector,
+            }],
+        }]),
+    };
+    let discoverable_tools = vec![connector_tool("connector_calendar", "Google Calendar")];
+
+    let resolved_entries = validate_request_plugin_install_picker_args(
+        &args,
+        &discoverable_tools,
+        /*app_server_client_name*/ None,
+        ToolSuggestPresentation::ListTool,
+    )
+    .expect("categorized picker args");
+
+    assert_eq!(resolved_entries.len(), 1);
+    assert_eq!(resolved_entries[0].category_index, Some(0));
+    assert_eq!(resolved_entries[0].tool.id(), "connector_calendar");
+}
+
+#[test]
+fn validate_request_plugin_install_picker_args_rejects_mixed_sources() {
+    let entry = RequestPluginInstallPickerEntry {
+        tool_id: "connector_calendar".to_string(),
+        tool_type: DiscoverableToolType::Connector,
+    };
+    let args = RequestPluginInstallsArgs {
+        action_type: DiscoverableToolAction::Install,
+        entries: Some(vec![entry]),
+        categories: Some(vec![RequestPluginInstallPickerCategory {
+            title: "Calendar".to_string(),
+            entries: vec![RequestPluginInstallPickerEntry {
+                tool_id: "connector_calendar".to_string(),
+                tool_type: DiscoverableToolType::Connector,
+            }],
+        }]),
+    };
+    let discoverable_tools = vec![connector_tool("connector_calendar", "Google Calendar")];
+
+    assert_eq!(
+        validate_request_plugin_install_picker_args(
+            &args,
+            &discoverable_tools,
+            /*app_server_client_name*/ None,
+            ToolSuggestPresentation::ListTool,
+        )
+        .expect_err("mixed picker args"),
+        FunctionCallError::RespondToModel(
+            "picker install requests must include exactly one of entries or categories".to_string(),
+        ),
+    );
+}
+
+#[test]
+fn validate_request_plugin_install_picker_args_rejects_duplicate_tools() {
+    let entry = RequestPluginInstallPickerEntry {
+        tool_id: "connector_calendar".to_string(),
+        tool_type: DiscoverableToolType::Connector,
+    };
+    let args = RequestPluginInstallsArgs {
+        action_type: DiscoverableToolAction::Install,
+        entries: None,
+        categories: Some(vec![
+            RequestPluginInstallPickerCategory {
+                title: "Calendar".to_string(),
+                entries: vec![entry],
+            },
+            RequestPluginInstallPickerCategory {
+                title: "Meetings".to_string(),
+                entries: vec![RequestPluginInstallPickerEntry {
+                    tool_id: "connector_calendar".to_string(),
+                    tool_type: DiscoverableToolType::Connector,
+                }],
+            },
+        ]),
+    };
+    let discoverable_tools = vec![connector_tool("connector_calendar", "Google Calendar")];
+
+    assert_eq!(
+        validate_request_plugin_install_picker_args(
+            &args,
+            &discoverable_tools,
+            /*app_server_client_name*/ None,
+            ToolSuggestPresentation::ListTool,
+        )
+        .expect_err("duplicate picker tool"),
+        FunctionCallError::RespondToModel(
+            "picker install requests must not repeat a tool_type/tool_id pair".to_string(),
+        ),
+    );
+}
+
+#[test]
+fn validate_request_plugin_install_picker_args_rejects_multi_tool_tui_requests() {
+    let args = RequestPluginInstallsArgs {
+        action_type: DiscoverableToolAction::Install,
+        entries: Some(vec![
+            RequestPluginInstallPickerEntry {
+                tool_id: "connector_calendar".to_string(),
+                tool_type: DiscoverableToolType::Connector,
+            },
+            RequestPluginInstallPickerEntry {
+                tool_id: "connector_gmail".to_string(),
+                tool_type: DiscoverableToolType::Connector,
+            },
+        ]),
+        categories: None,
+    };
+    let discoverable_tools = vec![
+        connector_tool("connector_calendar", "Google Calendar"),
+        connector_tool("connector_gmail", "Gmail"),
+    ];
+
+    assert_eq!(
+        validate_request_plugin_install_picker_args(
+            &args,
+            &discoverable_tools,
+            Some("codex-tui"),
+            ToolSuggestPresentation::ListTool,
+        )
+        .expect_err("multi-tool TUI request"),
+        FunctionCallError::RespondToModel(
+            "multi-tool install requests are not available in codex-tui yet".to_string(),
+        ),
+    );
+}
+
+#[test]
+fn validate_request_plugin_install_picker_args_caps_entries() {
+    let entries = || {
+        (0..=MAX_REQUEST_PLUGIN_INSTALLS_ENTRIES)
+            .map(|index| RequestPluginInstallPickerEntry {
+                tool_id: format!("connector_{index}"),
+                tool_type: DiscoverableToolType::Connector,
+            })
+            .collect()
+    };
+
+    for args in [
+        RequestPluginInstallsArgs {
+            action_type: DiscoverableToolAction::Install,
+            entries: Some(entries()),
+            categories: None,
+        },
+        RequestPluginInstallsArgs {
+            action_type: DiscoverableToolAction::Install,
+            entries: None,
+            categories: Some(vec![RequestPluginInstallPickerCategory {
+                title: "Connectors".to_string(),
+                entries: entries(),
+            }]),
+        },
+    ] {
+        assert_eq!(
+            validate_request_plugin_install_picker_args(
+                &args,
+                &[],
+                /*app_server_client_name*/ None,
+                ToolSuggestPresentation::ListTool,
+            )
+            .expect_err("oversized picker args"),
+            FunctionCallError::RespondToModel(format!(
+                "picker install requests support at most {MAX_REQUEST_PLUGIN_INSTALLS_ENTRIES} entries"
+            )),
+        );
+    }
+}
+
+#[test]
+fn picker_completion_only_requires_one_completed_entry() {
+    let entries = vec![
+        RequestPluginInstallEntryResult {
+            tool_type: DiscoverableToolType::Connector,
+            tool_id: "connector_salesforce".to_string(),
+            tool_name: "Salesforce".to_string(),
+            completed: true,
+        },
+        RequestPluginInstallEntryResult {
+            tool_type: DiscoverableToolType::Connector,
+            tool_id: "connector_hubspot".to_string(),
+            tool_name: "HubSpot".to_string(),
+            completed: false,
+        },
+    ];
+
+    assert!(request_plugin_install_picker_completed(&entries));
+}
+
+fn connector_tool(id: &str, name: &str) -> DiscoverableTool {
+    DiscoverableTool::Connector(Box::new(AppInfo {
+        id: id.to_string(),
+        name: name.to_string(),
+        description: None,
+        logo_url: None,
+        logo_url_dark: None,
+        distribution_channel: None,
+        branding: None,
+        app_metadata: None,
+        labels: None,
+        install_url: None,
+        is_accessible: false,
+        is_enabled: true,
+        plugin_display_names: Vec::new(),
+    }))
+}


### PR DESCRIPTION
Superseded by the monotonic five-PR stack in #28798, #28796, #28802, #28799, and #28803. The replacement stack introduces each piece once and removes the earlier move/revert cleanup churn.