### PR TITLE
Add Config for Time Reminders (1/n)

### DIFF
--- a/codex-rs/config/src/schema.rs
+++ b/codex-rs/config/src/schema.rs
@@ -49,6 +49,11 @@ pub fn features_schema(schema_gen: &mut SchemaGenerator) -> Schema {
                 feature.key.to_string(),
                 schema_gen.subschema_for::<codex_features::FeatureToml<
                     codex_features::RolloutBudgetConfigToml,
+        if feature.id == codex_features::Feature::Varlatency {
+            validation.properties.insert(
+                feature.key.to_string(),
+                schema_gen.subschema_for::<codex_features::FeatureToml<
+                    codex_features::VarlatencyConfigToml,
                 >>(),
             );
             continue;

--- a/codex-rs/config/src/schema.rs
+++ b/codex-rs/config/src/schema.rs
@@ -49,11 +49,15 @@ pub fn features_schema(schema_gen: &mut SchemaGenerator) -> Schema {
                 feature.key.to_string(),
                 schema_gen.subschema_for::<codex_features::FeatureToml<
                     codex_features::RolloutBudgetConfigToml,
-        if feature.id == codex_features::Feature::Varlatency {
+                >>(),
+            );
+            continue;
+        }
+        if feature.id == codex_features::Feature::CurrentTimeReminder {
             validation.properties.insert(
                 feature.key.to_string(),
                 schema_gen.subschema_for::<codex_features::FeatureToml<
-                    codex_features::VarlatencyConfigToml,
+                    codex_features::CurrentTimeReminderConfigToml,
                 >>(),
             );
             continue;

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -822,7 +822,7 @@
     "CurrentTimeSource": {
       "enum": [
         "system",
-        "app_server_client"
+        "external"
       ],
       "type": "string"
     },

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -695,8 +695,8 @@
             "use_linux_sandbox_bwrap": {
               "type": "boolean"
             },
-            "varlatency": {
-              "$ref": "#/definitions/FeatureToml_for_VarlatencyConfigToml"
+            "current_time_reminder": {
+              "$ref": "#/definitions/FeatureToml_for_CurrentTimeReminderConfigToml"
             },
             "web_search": {
               "type": "boolean"
@@ -915,14 +915,14 @@
       ]
     },
     "FeatureToml_for_RolloutBudgetConfigToml": {
-    "FeatureToml_for_VarlatencyConfigToml": {
+    "FeatureToml_for_CurrentTimeReminderConfigToml": {
       "anyOf": [
         {
           "type": "boolean"
         },
         {
           "$ref": "#/definitions/RolloutBudgetConfigToml"
-          "$ref": "#/definitions/VarlatencyConfigToml"
+          "$ref": "#/definitions/CurrentTimeReminderConfigToml"
         }
       ]
     },
@@ -4349,18 +4349,18 @@
         }
       ]
     },
-    "VarlatencyClockSource": {
+    "CurrentTimeSource": {
       "enum": [
         "system",
         "app_server_client"
       ],
       "type": "string"
     },
-    "VarlatencyConfigToml": {
+    "CurrentTimeReminderConfigToml": {
       "additionalProperties": false,
       "properties": {
         "clock_source": {
-          "$ref": "#/definitions/VarlatencyClockSource"
+          "$ref": "#/definitions/CurrentTimeSource"
         },
         "enabled": {
           "type": "boolean"
@@ -4927,8 +4927,8 @@
         "use_linux_sandbox_bwrap": {
           "type": "boolean"
         },
-        "varlatency": {
-          "$ref": "#/definitions/FeatureToml_for_VarlatencyConfigToml"
+        "current_time_reminder": {
+          "$ref": "#/definitions/FeatureToml_for_CurrentTimeReminderConfigToml"
         },
         "web_search": {
           "type": "boolean"

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -476,6 +476,9 @@
             "connectors": {
               "type": "boolean"
             },
+            "current_time_reminder": {
+              "$ref": "#/definitions/FeatureToml_for_CurrentTimeReminderConfigToml"
+            },
             "default_mode_request_user_input": {
               "type": "boolean"
             },
@@ -695,9 +698,6 @@
             "use_linux_sandbox_bwrap": {
               "type": "boolean"
             },
-            "current_time_reminder": {
-              "$ref": "#/definitions/FeatureToml_for_CurrentTimeReminderConfigToml"
-            },
             "web_search": {
               "type": "boolean"
             },
@@ -802,6 +802,30 @@
       },
       "type": "object"
     },
+    "CurrentTimeReminderConfigToml": {
+      "additionalProperties": false,
+      "properties": {
+        "clock_source": {
+          "$ref": "#/definitions/CurrentTimeSource"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "reminder_interval_model_requests": {
+          "format": "uint64",
+          "minimum": 1.0,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "CurrentTimeSource": {
+      "enum": [
+        "system",
+        "app_server_client"
+      ],
+      "type": "string"
+    },
     "DebugConfigLockToml": {
       "additionalProperties": false,
       "properties": {
@@ -894,6 +918,16 @@
         }
       ]
     },
+    "FeatureToml_for_CurrentTimeReminderConfigToml": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/CurrentTimeReminderConfigToml"
+        }
+      ]
+    },
     "FeatureToml_for_MultiAgentV2ConfigToml": {
       "anyOf": [
         {
@@ -915,14 +949,12 @@
       ]
     },
     "FeatureToml_for_RolloutBudgetConfigToml": {
-    "FeatureToml_for_CurrentTimeReminderConfigToml": {
       "anyOf": [
         {
           "type": "boolean"
         },
         {
           "$ref": "#/definitions/RolloutBudgetConfigToml"
-          "$ref": "#/definitions/CurrentTimeReminderConfigToml"
         }
       ]
     },
@@ -4349,30 +4381,6 @@
         }
       ]
     },
-    "CurrentTimeSource": {
-      "enum": [
-        "system",
-        "app_server_client"
-      ],
-      "type": "string"
-    },
-    "CurrentTimeReminderConfigToml": {
-      "additionalProperties": false,
-      "properties": {
-        "clock_source": {
-          "$ref": "#/definitions/CurrentTimeSource"
-        },
-        "enabled": {
-          "type": "boolean"
-        },
-        "reminder_interval_model_requests": {
-          "format": "uint64",
-          "minimum": 1.0,
-          "type": "integer"
-        }
-      },
-      "type": "object"
-    },
     "Verbosity": {
       "description": "Controls output length/detail on GPT-5 models via the Responses API. Serialized with lowercase values to match the OpenAI API.",
       "enum": [
@@ -4708,6 +4716,9 @@
         "connectors": {
           "type": "boolean"
         },
+        "current_time_reminder": {
+          "$ref": "#/definitions/FeatureToml_for_CurrentTimeReminderConfigToml"
+        },
         "default_mode_request_user_input": {
           "type": "boolean"
         },
@@ -4926,9 +4937,6 @@
         },
         "use_linux_sandbox_bwrap": {
           "type": "boolean"
-        },
-        "current_time_reminder": {
-          "$ref": "#/definitions/FeatureToml_for_CurrentTimeReminderConfigToml"
         },
         "web_search": {
           "type": "boolean"

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -695,6 +695,9 @@
             "use_linux_sandbox_bwrap": {
               "type": "boolean"
             },
+            "varlatency": {
+              "$ref": "#/definitions/FeatureToml_for_VarlatencyConfigToml"
+            },
             "web_search": {
               "type": "boolean"
             },
@@ -912,12 +915,14 @@
       ]
     },
     "FeatureToml_for_RolloutBudgetConfigToml": {
+    "FeatureToml_for_VarlatencyConfigToml": {
       "anyOf": [
         {
           "type": "boolean"
         },
         {
           "$ref": "#/definitions/RolloutBudgetConfigToml"
+          "$ref": "#/definitions/VarlatencyConfigToml"
         }
       ]
     },
@@ -4344,6 +4349,30 @@
         }
       ]
     },
+    "VarlatencyClockSource": {
+      "enum": [
+        "system",
+        "app_server_client"
+      ],
+      "type": "string"
+    },
+    "VarlatencyConfigToml": {
+      "additionalProperties": false,
+      "properties": {
+        "clock_source": {
+          "$ref": "#/definitions/VarlatencyClockSource"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "reminder_interval_model_requests": {
+          "format": "uint64",
+          "minimum": 1.0,
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
     "Verbosity": {
       "description": "Controls output length/detail on GPT-5 models via the Responses API. Serialized with lowercase values to match the OpenAI API.",
       "enum": [
@@ -4897,6 +4926,9 @@
         },
         "use_linux_sandbox_bwrap": {
           "type": "boolean"
+        },
+        "varlatency": {
+          "$ref": "#/definitions/FeatureToml_for_VarlatencyConfigToml"
         },
         "web_search": {
           "type": "boolean"

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -66,6 +66,7 @@ use codex_core_plugins::PluginsManager;
 use codex_exec_server::LOCAL_FS;
 use codex_features::Feature;
 use codex_features::FeaturesToml;
+use codex_features::VarlatencyClockSource;
 use codex_model_provider_info::LMSTUDIO_OSS_PROVIDER_ID;
 use codex_model_provider_info::OLLAMA_OSS_PROVIDER_ID;
 use codex_model_provider_info::WireApi;
@@ -472,6 +473,12 @@ limit_tokens = 100000
 reminder_interval_tokens = 10000
 sampling_token_weight = 1.0
 prefill_token_weight = 0.1
+async fn load_config_resolves_varlatency_defaults() -> std::io::Result<()> {
+    let codex_home = tempdir()?;
+    let config_toml: ConfigToml = toml::from_str(
+        r#"
+[features]
+varlatency = true
 "#,
     )
     .expect("TOML deserialization should succeed");
@@ -491,6 +498,36 @@ prefill_token_weight = 0.1
             reminder_interval_tokens: 10_000,
             sampling_token_weight: 1.0,
             prefill_token_weight: 0.1,
+    assert!(config.features.enabled(Feature::Varlatency));
+    assert_eq!(config.varlatency, Some(VarlatencyConfig::default()));
+    Ok(())
+}
+
+#[tokio::test]
+async fn load_config_resolves_varlatency_overrides() -> std::io::Result<()> {
+    let codex_home = tempdir()?;
+    let config_toml: ConfigToml = toml::from_str(
+        r#"
+[features.varlatency]
+enabled = true
+reminder_interval_model_requests = 4
+clock_source = "app_server_client"
+"#,
+    )
+    .expect("TOML deserialization should succeed");
+    let config = Config::load_from_base_config_with_overrides(
+        config_toml,
+        ConfigOverrides::default(),
+        codex_home.abs(),
+    )
+    .await?;
+
+    assert!(config.features.enabled(Feature::Varlatency));
+    assert_eq!(
+        config.varlatency,
+        Some(VarlatencyConfig {
+            reminder_interval_model_requests: 4,
+            clock_source: VarlatencyClockSource::AppServerClient,
         })
     );
     Ok(())
@@ -519,6 +556,29 @@ async fn load_config_rejects_enabled_rollout_budget_without_limit() -> std::io::
             "features.rollout_budget.limit_tokens is required when rollout_budget is enabled"
         );
     }
+async fn load_config_rejects_zero_varlatency_interval() -> std::io::Result<()> {
+    let codex_home = tempdir()?;
+    let config_toml: ConfigToml = toml::from_str(
+        r#"
+[features.varlatency]
+enabled = true
+reminder_interval_model_requests = 0
+"#,
+    )
+    .expect("TOML deserialization should succeed");
+    let error = Config::load_from_base_config_with_overrides(
+        config_toml,
+        ConfigOverrides::default(),
+        codex_home.abs(),
+    )
+    .await
+    .expect_err("zero reminder interval should be rejected");
+
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    assert_eq!(
+        error.to_string(),
+        "features.varlatency.reminder_interval_model_requests must be positive"
+    );
     Ok(())
 }
 

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -523,40 +523,40 @@ async fn load_config_rejects_enabled_rollout_budget_without_limit() -> std::io::
 }
 
 #[tokio::test]
-async fn load_config_resolves_varlatency() -> std::io::Result<()> {
+async fn load_config_resolves_current_time_reminder() -> std::io::Result<()> {
     for (config_toml, expected) in [
         (
             r#"
 [features]
-varlatency = true
+current_time_reminder = true
 "#,
-            VarlatencyConfig::default(),
+            CurrentTimeReminderConfig::default(),
         ),
         (
             r#"
-[features.varlatency]
+[features.current_time_reminder]
 enabled = true
 reminder_interval_model_requests = 4
 clock_source = "app_server_client"
 "#,
-            VarlatencyConfig {
+            CurrentTimeReminderConfig {
                 reminder_interval_model_requests: 4,
-                clock_source: VarlatencyClockSource::AppServerClient,
+                clock_source: CurrentTimeSource::AppServerClient,
             },
         ),
     ] {
-        let config = load_varlatency_config(config_toml).await?;
-        assert!(config.features.enabled(Feature::Varlatency));
-        assert_eq!(config.varlatency, Some(expected));
+        let config = load_current_time_reminder_config(config_toml).await?;
+        assert!(config.features.enabled(Feature::CurrentTimeReminder));
+        assert_eq!(config.current_time_reminder, Some(expected));
     }
     Ok(())
 }
 
 #[tokio::test]
-async fn load_config_rejects_zero_varlatency_interval() -> std::io::Result<()> {
-    let error = load_varlatency_config(
+async fn load_config_rejects_zero_current_time_reminder_interval() -> std::io::Result<()> {
+    let error = load_current_time_reminder_config(
         r#"
-[features.varlatency]
+[features.current_time_reminder]
 enabled = true
 reminder_interval_model_requests = 0
 "#,
@@ -567,12 +567,12 @@ reminder_interval_model_requests = 0
     assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
     assert_eq!(
         error.to_string(),
-        "features.varlatency.reminder_interval_model_requests must be positive"
+        "features.current_time_reminder.reminder_interval_model_requests must be positive"
     );
     Ok(())
 }
 
-async fn load_varlatency_config(config_toml: &str) -> std::io::Result<Config> {
+async fn load_current_time_reminder_config(config_toml: &str) -> std::io::Result<Config> {
     let codex_home = tempdir()?;
     let config_toml = toml::from_str(config_toml).expect("TOML should deserialize");
     Config::load_from_base_config_with_overrides(

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -537,11 +537,11 @@ current_time_reminder = true
 [features.current_time_reminder]
 enabled = true
 reminder_interval_model_requests = 4
-clock_source = "app_server_client"
+clock_source = "external"
 "#,
             CurrentTimeReminderConfig {
                 reminder_interval_model_requests: 4,
-                clock_source: CurrentTimeSource::AppServerClient,
+                clock_source: CurrentTimeSource::External,
             },
         ),
     ] {

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -66,7 +66,6 @@ use codex_core_plugins::PluginsManager;
 use codex_exec_server::LOCAL_FS;
 use codex_features::Feature;
 use codex_features::FeaturesToml;
-use codex_features::VarlatencyClockSource;
 use codex_model_provider_info::LMSTUDIO_OSS_PROVIDER_ID;
 use codex_model_provider_info::OLLAMA_OSS_PROVIDER_ID;
 use codex_model_provider_info::WireApi;
@@ -473,12 +472,6 @@ limit_tokens = 100000
 reminder_interval_tokens = 10000
 sampling_token_weight = 1.0
 prefill_token_weight = 0.1
-async fn load_config_resolves_varlatency_defaults() -> std::io::Result<()> {
-    let codex_home = tempdir()?;
-    let config_toml: ConfigToml = toml::from_str(
-        r#"
-[features]
-varlatency = true
 "#,
     )
     .expect("TOML deserialization should succeed");
@@ -498,36 +491,6 @@ varlatency = true
             reminder_interval_tokens: 10_000,
             sampling_token_weight: 1.0,
             prefill_token_weight: 0.1,
-    assert!(config.features.enabled(Feature::Varlatency));
-    assert_eq!(config.varlatency, Some(VarlatencyConfig::default()));
-    Ok(())
-}
-
-#[tokio::test]
-async fn load_config_resolves_varlatency_overrides() -> std::io::Result<()> {
-    let codex_home = tempdir()?;
-    let config_toml: ConfigToml = toml::from_str(
-        r#"
-[features.varlatency]
-enabled = true
-reminder_interval_model_requests = 4
-clock_source = "app_server_client"
-"#,
-    )
-    .expect("TOML deserialization should succeed");
-    let config = Config::load_from_base_config_with_overrides(
-        config_toml,
-        ConfigOverrides::default(),
-        codex_home.abs(),
-    )
-    .await?;
-
-    assert!(config.features.enabled(Feature::Varlatency));
-    assert_eq!(
-        config.varlatency,
-        Some(VarlatencyConfig {
-            reminder_interval_model_requests: 4,
-            clock_source: VarlatencyClockSource::AppServerClient,
         })
     );
     Ok(())
@@ -556,20 +519,47 @@ async fn load_config_rejects_enabled_rollout_budget_without_limit() -> std::io::
             "features.rollout_budget.limit_tokens is required when rollout_budget is enabled"
         );
     }
+    Ok(())
+}
+
+#[tokio::test]
+async fn load_config_resolves_varlatency() -> std::io::Result<()> {
+    for (config_toml, expected) in [
+        (
+            r#"
+[features]
+varlatency = true
+"#,
+            VarlatencyConfig::default(),
+        ),
+        (
+            r#"
+[features.varlatency]
+enabled = true
+reminder_interval_model_requests = 4
+clock_source = "app_server_client"
+"#,
+            VarlatencyConfig {
+                reminder_interval_model_requests: 4,
+                clock_source: VarlatencyClockSource::AppServerClient,
+            },
+        ),
+    ] {
+        let config = load_varlatency_config(config_toml).await?;
+        assert!(config.features.enabled(Feature::Varlatency));
+        assert_eq!(config.varlatency, Some(expected));
+    }
+    Ok(())
+}
+
+#[tokio::test]
 async fn load_config_rejects_zero_varlatency_interval() -> std::io::Result<()> {
-    let codex_home = tempdir()?;
-    let config_toml: ConfigToml = toml::from_str(
+    let error = load_varlatency_config(
         r#"
 [features.varlatency]
 enabled = true
 reminder_interval_model_requests = 0
 "#,
-    )
-    .expect("TOML deserialization should succeed");
-    let error = Config::load_from_base_config_with_overrides(
-        config_toml,
-        ConfigOverrides::default(),
-        codex_home.abs(),
     )
     .await
     .expect_err("zero reminder interval should be rejected");
@@ -580,6 +570,17 @@ reminder_interval_model_requests = 0
         "features.varlatency.reminder_interval_model_requests must be positive"
     );
     Ok(())
+}
+
+async fn load_varlatency_config(config_toml: &str) -> std::io::Result<Config> {
+    let codex_home = tempdir()?;
+    let config_toml = toml::from_str(config_toml).expect("TOML should deserialize");
+    Config::load_from_base_config_with_overrides(
+        config_toml,
+        ConfigOverrides::default(),
+        codex_home.abs(),
+    )
+    .await
 }
 
 #[test]

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -58,6 +58,8 @@ use codex_core_plugins::PluginsConfigInput;
 use codex_exec_server::ExecutorFileSystem;
 use codex_exec_server::LOCAL_FS;
 use codex_features::CodeModeConfigToml;
+use codex_features::CurrentTimeReminderConfigToml;
+use codex_features::CurrentTimeSource;
 use codex_features::Feature;
 use codex_features::FeatureConfigSource;
 use codex_features::FeatureOverrides;
@@ -66,8 +68,6 @@ use codex_features::Features;
 use codex_features::FeaturesToml;
 use codex_features::MultiAgentV2ConfigToml;
 use codex_features::NetworkProxyConfigToml;
-use codex_features::VarlatencyClockSource;
-use codex_features::VarlatencyConfigToml;
 use codex_git_utils::resolve_root_git_project_for_trust;
 use codex_install_context::InstallContext;
 use codex_login::AuthManagerConfig;
@@ -1025,7 +1025,7 @@ pub struct Config {
     /// Shared token budget for the root thread and its sub-agents.
     pub rollout_budget: Option<RolloutBudgetConfig>,
     /// Current-time reminder configuration, when enabled.
-    pub varlatency: Option<VarlatencyConfig>,
+    pub current_time_reminder: Option<CurrentTimeReminderConfig>,
 
     /// Centralized feature flags; source of truth for feature gating.
     pub features: ManagedFeatures,
@@ -1080,16 +1080,16 @@ pub struct RolloutBudgetConfig {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
-pub struct VarlatencyConfig {
+pub struct CurrentTimeReminderConfig {
     pub reminder_interval_model_requests: u64,
-    pub clock_source: VarlatencyClockSource,
+    pub clock_source: CurrentTimeSource,
 }
 
-impl Default for VarlatencyConfig {
+impl Default for CurrentTimeReminderConfig {
     fn default() -> Self {
         Self {
             reminder_interval_model_requests: 1,
-            clock_source: VarlatencyClockSource::System,
+            clock_source: CurrentTimeSource::System,
         }
     }
 }
@@ -2555,27 +2555,30 @@ fn resolve_rollout_budget_config(
         reminder_interval_tokens,
         sampling_token_weight,
         prefill_token_weight,
-fn resolve_varlatency_config(
+    }))
+}
+
+fn resolve_current_time_reminder_config(
     config_toml: &ConfigToml,
     features: &ManagedFeatures,
-) -> std::io::Result<Option<VarlatencyConfig>> {
-    if !features.enabled(Feature::Varlatency) {
+) -> std::io::Result<Option<CurrentTimeReminderConfig>> {
+    if !features.enabled(Feature::CurrentTimeReminder) {
         return Ok(None);
     }
 
-    let base = varlatency_toml_config(config_toml.features.as_ref());
-    let default = VarlatencyConfig::default();
+    let base = current_time_reminder_toml_config(config_toml.features.as_ref());
+    let default = CurrentTimeReminderConfig::default();
     let reminder_interval_model_requests = base
         .and_then(|config| config.reminder_interval_model_requests)
         .unwrap_or(default.reminder_interval_model_requests);
     if reminder_interval_model_requests == 0 {
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
-            "features.varlatency.reminder_interval_model_requests must be positive",
+            "features.current_time_reminder.reminder_interval_model_requests must be positive",
         ));
     }
 
-    Ok(Some(VarlatencyConfig {
+    Ok(Some(CurrentTimeReminderConfig {
         reminder_interval_model_requests,
         clock_source: base
             .and_then(|config| config.clock_source)
@@ -2622,8 +2625,10 @@ fn multi_agent_v2_toml_config(features: Option<&FeaturesToml>) -> Option<&MultiA
     }
 }
 
-fn varlatency_toml_config(features: Option<&FeaturesToml>) -> Option<&VarlatencyConfigToml> {
-    match features?.varlatency.as_ref()? {
+fn current_time_reminder_toml_config(
+    features: Option<&FeaturesToml>,
+) -> Option<&CurrentTimeReminderConfigToml> {
+    match features?.current_time_reminder.as_ref()? {
         FeatureToml::Enabled(_) => None,
         FeatureToml::Config(config) => Some(config),
     }
@@ -3268,7 +3273,7 @@ impl Config {
         let code_mode = resolve_code_mode_config(&cfg);
         let multi_agent_v2 = resolve_multi_agent_v2_config(&cfg);
         let rollout_budget = resolve_rollout_budget_config(&cfg, &features)?;
-        let varlatency = resolve_varlatency_config(&cfg, &features)?;
+        let current_time_reminder = resolve_current_time_reminder_config(&cfg, &features)?;
         let terminal_resize_reflow = resolve_terminal_resize_reflow_config(&cfg);
 
         let agent_roles =
@@ -3810,7 +3815,7 @@ impl Config {
             ghost_snapshot,
             multi_agent_v2,
             rollout_budget,
-            varlatency,
+            current_time_reminder,
             features,
             suppress_unstable_features_warning: cfg
                 .suppress_unstable_features_warning

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -66,6 +66,8 @@ use codex_features::Features;
 use codex_features::FeaturesToml;
 use codex_features::MultiAgentV2ConfigToml;
 use codex_features::NetworkProxyConfigToml;
+use codex_features::VarlatencyClockSource;
+use codex_features::VarlatencyConfigToml;
 use codex_git_utils::resolve_root_git_project_for_trust;
 use codex_install_context::InstallContext;
 use codex_login::AuthManagerConfig;
@@ -1022,6 +1024,8 @@ pub struct Config {
 
     /// Shared token budget for the root thread and its sub-agents.
     pub rollout_budget: Option<RolloutBudgetConfig>,
+    /// Current-time reminder configuration, when enabled.
+    pub varlatency: Option<VarlatencyConfig>,
 
     /// Centralized feature flags; source of truth for feature gating.
     pub features: ManagedFeatures,
@@ -1073,6 +1077,21 @@ pub struct RolloutBudgetConfig {
     pub reminder_interval_tokens: i64,
     pub sampling_token_weight: f64,
     pub prefill_token_weight: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct VarlatencyConfig {
+    pub reminder_interval_model_requests: u64,
+    pub clock_source: VarlatencyClockSource,
+}
+
+impl Default for VarlatencyConfig {
+    fn default() -> Self {
+        Self {
+            reminder_interval_model_requests: 1,
+            clock_source: VarlatencyClockSource::System,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -2536,6 +2555,31 @@ fn resolve_rollout_budget_config(
         reminder_interval_tokens,
         sampling_token_weight,
         prefill_token_weight,
+fn resolve_varlatency_config(
+    config_toml: &ConfigToml,
+    features: &ManagedFeatures,
+) -> std::io::Result<Option<VarlatencyConfig>> {
+    if !features.enabled(Feature::Varlatency) {
+        return Ok(None);
+    }
+
+    let base = varlatency_toml_config(config_toml.features.as_ref());
+    let default = VarlatencyConfig::default();
+    let reminder_interval_model_requests = base
+        .and_then(|config| config.reminder_interval_model_requests)
+        .unwrap_or(default.reminder_interval_model_requests);
+    if reminder_interval_model_requests == 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "features.varlatency.reminder_interval_model_requests must be positive",
+        ));
+    }
+
+    Ok(Some(VarlatencyConfig {
+        reminder_interval_model_requests,
+        clock_source: base
+            .and_then(|config| config.clock_source)
+            .unwrap_or(default.clock_source),
     }))
 }
 
@@ -2573,6 +2617,13 @@ fn code_mode_toml_config(features: Option<&FeaturesToml>) -> Option<&CodeModeCon
 
 fn multi_agent_v2_toml_config(features: Option<&FeaturesToml>) -> Option<&MultiAgentV2ConfigToml> {
     match features?.multi_agent_v2.as_ref()? {
+        FeatureToml::Enabled(_) => None,
+        FeatureToml::Config(config) => Some(config),
+    }
+}
+
+fn varlatency_toml_config(features: Option<&FeaturesToml>) -> Option<&VarlatencyConfigToml> {
+    match features?.varlatency.as_ref()? {
         FeatureToml::Enabled(_) => None,
         FeatureToml::Config(config) => Some(config),
     }
@@ -3217,6 +3268,7 @@ impl Config {
         let code_mode = resolve_code_mode_config(&cfg);
         let multi_agent_v2 = resolve_multi_agent_v2_config(&cfg);
         let rollout_budget = resolve_rollout_budget_config(&cfg, &features)?;
+        let varlatency = resolve_varlatency_config(&cfg, &features)?;
         let terminal_resize_reflow = resolve_terminal_resize_reflow_config(&cfg);
 
         let agent_roles =
@@ -3758,6 +3810,7 @@ impl Config {
             ghost_snapshot,
             multi_agent_v2,
             rollout_budget,
+            varlatency,
             features,
             suppress_unstable_features_warning: cfg
                 .suppress_unstable_features_warning

--- a/codex-rs/core/src/session/config_lock.rs
+++ b/codex-rs/core/src/session/config_lock.rs
@@ -7,6 +7,7 @@ use codex_features::FeatureToml;
 use codex_features::FeaturesToml;
 use codex_features::MultiAgentV2ConfigToml;
 use codex_features::RolloutBudgetConfigToml;
+use codex_features::VarlatencyConfigToml;
 use codex_protocol::ThreadId;
 
 use crate::config::Config;
@@ -154,6 +155,11 @@ fn save_config_resolved_fields(
             resolved_config_to_toml(rollout_budget, "features.rollout_budget")?;
         rollout_budget.enabled = Some(config.features.enabled(Feature::RolloutBudget));
         features.rollout_budget = Some(FeatureToml::Config(rollout_budget));
+    if let Some(varlatency) = config.varlatency.as_ref() {
+        let mut varlatency: VarlatencyConfigToml =
+            resolved_config_to_toml(varlatency, "features.varlatency")?;
+        varlatency.enabled = Some(config.features.enabled(Feature::Varlatency));
+        features.varlatency = Some(FeatureToml::Config(varlatency));
     }
     lock_config.memories = Some(resolved_config_to_toml::<MemoriesToml>(
         &config.memories,
@@ -227,6 +233,11 @@ mod tests {
             .features
             .enable(Feature::RolloutBudget)
             .expect("rollout_budget should be enableable in tests");
+        config.varlatency = Some(crate::config::VarlatencyConfig::default());
+        config
+            .features
+            .enable(Feature::Varlatency)
+            .expect("varlatency should be enableable in tests");
         sc.original_config_do_not_use = Arc::new(config);
         sc.base_instructions = "resolved instructions".to_string();
         sc.developer_instructions = Some("resolved developer instructions".to_string());
@@ -300,6 +311,11 @@ mod tests {
                 reminder_interval_tokens: Some(10_000),
                 sampling_token_weight: Some(1.0),
                 prefill_token_weight: Some(0.25),
+            features.varlatency,
+            Some(FeatureToml::Config(VarlatencyConfigToml {
+                enabled: Some(true),
+                reminder_interval_model_requests: Some(1),
+                clock_source: Some(codex_features::VarlatencyClockSource::System),
             }))
         );
 

--- a/codex-rs/core/src/session/config_lock.rs
+++ b/codex-rs/core/src/session/config_lock.rs
@@ -2,12 +2,12 @@ use anyhow::Context;
 use codex_config::config_toml::ConfigLockfileToml;
 use codex_config::config_toml::ConfigToml;
 use codex_config::types::MemoriesToml;
+use codex_features::CurrentTimeReminderConfigToml;
 use codex_features::Feature;
 use codex_features::FeatureToml;
 use codex_features::FeaturesToml;
 use codex_features::MultiAgentV2ConfigToml;
 use codex_features::RolloutBudgetConfigToml;
-use codex_features::VarlatencyConfigToml;
 use codex_protocol::ThreadId;
 
 use crate::config::Config;
@@ -155,11 +155,12 @@ fn save_config_resolved_fields(
             resolved_config_to_toml(rollout_budget, "features.rollout_budget")?;
         rollout_budget.enabled = Some(config.features.enabled(Feature::RolloutBudget));
         features.rollout_budget = Some(FeatureToml::Config(rollout_budget));
-    if let Some(varlatency) = config.varlatency.as_ref() {
-        let mut varlatency: VarlatencyConfigToml =
-            resolved_config_to_toml(varlatency, "features.varlatency")?;
-        varlatency.enabled = Some(config.features.enabled(Feature::Varlatency));
-        features.varlatency = Some(FeatureToml::Config(varlatency));
+    }
+    if let Some(current_time_reminder) = config.current_time_reminder.as_ref() {
+        let mut current_time_reminder: CurrentTimeReminderConfigToml =
+            resolved_config_to_toml(current_time_reminder, "features.current_time_reminder")?;
+        current_time_reminder.enabled = Some(config.features.enabled(Feature::CurrentTimeReminder));
+        features.current_time_reminder = Some(FeatureToml::Config(current_time_reminder));
     }
     lock_config.memories = Some(resolved_config_to_toml::<MemoriesToml>(
         &config.memories,
@@ -233,11 +234,11 @@ mod tests {
             .features
             .enable(Feature::RolloutBudget)
             .expect("rollout_budget should be enableable in tests");
-        config.varlatency = Some(crate::config::VarlatencyConfig::default());
+        config.current_time_reminder = Some(crate::config::CurrentTimeReminderConfig::default());
         config
             .features
-            .enable(Feature::Varlatency)
-            .expect("varlatency should be enableable in tests");
+            .enable(Feature::CurrentTimeReminder)
+            .expect("current_time_reminder should be enableable in tests");
         sc.original_config_do_not_use = Arc::new(config);
         sc.base_instructions = "resolved instructions".to_string();
         sc.developer_instructions = Some("resolved developer instructions".to_string());
@@ -311,11 +312,14 @@ mod tests {
                 reminder_interval_tokens: Some(10_000),
                 sampling_token_weight: Some(1.0),
                 prefill_token_weight: Some(0.25),
-            features.varlatency,
-            Some(FeatureToml::Config(VarlatencyConfigToml {
+            }))
+        );
+        assert_eq!(
+            features.current_time_reminder,
+            Some(FeatureToml::Config(CurrentTimeReminderConfigToml {
                 enabled: Some(true),
                 reminder_interval_model_requests: Some(1),
-                clock_source: Some(codex_features::VarlatencyClockSource::System),
+                clock_source: Some(codex_features::CurrentTimeSource::System),
             }))
         );
 

--- a/codex-rs/features/src/feature_configs.rs
+++ b/codex-rs/features/src/feature_configs.rs
@@ -76,17 +76,6 @@ impl FeatureConfig for MultiAgentV2ConfigToml {
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RolloutBudgetConfigToml {
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum VarlatencyClockSource {
-    #[default]
-    System,
-    AppServerClient,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, JsonSchema)]
-#[serde(deny_unknown_fields)]
-pub struct VarlatencyConfigToml {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -104,12 +93,32 @@ pub struct VarlatencyConfigToml {
 }
 
 impl FeatureConfig for RolloutBudgetConfigToml {
-    pub reminder_interval_model_requests: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub clock_source: Option<VarlatencyClockSource>,
+    fn enabled(&self) -> Option<bool> {
+        self.enabled
+    }
 }
 
-impl FeatureConfig for VarlatencyConfigToml {
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CurrentTimeSource {
+    #[default]
+    System,
+    AppServerClient,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct CurrentTimeReminderConfigToml {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 1))]
+    pub reminder_interval_model_requests: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub clock_source: Option<CurrentTimeSource>,
+}
+
+impl FeatureConfig for CurrentTimeReminderConfigToml {
     fn enabled(&self) -> Option<bool> {
         self.enabled
     }

--- a/codex-rs/features/src/feature_configs.rs
+++ b/codex-rs/features/src/feature_configs.rs
@@ -107,7 +107,7 @@ impl FeatureConfig for RolloutBudgetConfigToml {
 pub enum CurrentTimeSource {
     #[default]
     System,
-    AppServerClient,
+    External,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, JsonSchema)]

--- a/codex-rs/features/src/feature_configs.rs
+++ b/codex-rs/features/src/feature_configs.rs
@@ -76,6 +76,17 @@ impl FeatureConfig for MultiAgentV2ConfigToml {
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RolloutBudgetConfigToml {
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum VarlatencyClockSource {
+    #[default]
+    System,
+    AppServerClient,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct VarlatencyConfigToml {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -93,6 +104,12 @@ pub struct RolloutBudgetConfigToml {
 }
 
 impl FeatureConfig for RolloutBudgetConfigToml {
+    pub reminder_interval_model_requests: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub clock_source: Option<VarlatencyClockSource>,
+}
+
+impl FeatureConfig for VarlatencyConfigToml {
     fn enabled(&self) -> Option<bool> {
         self.enabled
     }

--- a/codex-rs/features/src/feature_configs.rs
+++ b/codex-rs/features/src/feature_configs.rs
@@ -96,6 +96,10 @@ impl FeatureConfig for RolloutBudgetConfigToml {
     fn enabled(&self) -> Option<bool> {
         self.enabled
     }
+
+    fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = Some(enabled);
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Default, PartialEq, Eq, JsonSchema)]

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -24,6 +24,8 @@ pub use feature_configs::NetworkProxyModeToml;
 pub use feature_configs::NetworkProxyUnixSocketPermissionToml;
 use feature_configs::RemovedAppsMcpPathOverrideConfigToml;
 pub use feature_configs::RolloutBudgetConfigToml;
+pub use feature_configs::VarlatencyClockSource;
+pub use feature_configs::VarlatencyConfigToml;
 use legacy::LegacyFeatureToggles;
 pub use legacy::legacy_feature_keys;
 
@@ -206,6 +208,8 @@ pub enum Feature {
     TokenBudget,
     /// Track and report a shared token budget across a session's agent threads.
     RolloutBudget,
+    /// Add current-time reminders to model-visible context.
+    Varlatency,
     /// Expose an input-interruptible sleep tool.
     SleepTool,
     /// Route MCP tool approval prompts through the MCP elicitation request path.
@@ -623,6 +627,7 @@ pub struct FeaturesToml {
     pub multi_agent_v2: Option<FeatureToml<MultiAgentV2ConfigToml>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rollout_budget: Option<FeatureToml<RolloutBudgetConfigToml>>,
+    pub varlatency: Option<FeatureToml<VarlatencyConfigToml>>,
     #[serde(default, rename = "apps_mcp_path_override", skip_serializing)]
     #[schemars(skip)]
     removed_apps_mcp_path_override: Option<FeatureToml<RemovedAppsMcpPathOverrideConfigToml>>,
@@ -657,6 +662,8 @@ impl FeaturesToml {
         }
         if let Some(enabled) = self.rollout_budget.as_ref().and_then(FeatureToml::enabled) {
             entries.insert(Feature::RolloutBudget.key().to_string(), enabled);
+        if let Some(enabled) = self.varlatency.as_ref().and_then(FeatureToml::enabled) {
+            entries.insert(Feature::Varlatency.key().to_string(), enabled);
         }
         if let Some(enabled) = self.network_proxy.as_ref().and_then(FeatureToml::enabled) {
             entries.insert(Feature::NetworkProxy.key().to_string(), enabled);
@@ -670,6 +677,7 @@ impl FeaturesToml {
             code_mode,
             multi_agent_v2,
             rollout_budget,
+            varlatency,
             removed_apps_mcp_path_override: _,
             network_proxy,
             entries,
@@ -685,6 +693,8 @@ impl FeaturesToml {
                 materialize_resolved_feature_enabled(multi_agent_v2, enabled);
             } else if spec.id == Feature::RolloutBudget {
                 materialize_resolved_feature_enabled(rollout_budget, enabled);
+            } else if spec.id == Feature::Varlatency {
+                materialize_resolved_feature_enabled(varlatency, enabled);
             } else if spec.id == Feature::NetworkProxy {
                 materialize_resolved_feature_enabled(network_proxy, enabled);
             } else {
@@ -1181,6 +1191,8 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::RolloutBudget,
         key: "rollout_budget",
+        id: Feature::Varlatency,
+        key: "varlatency",
         stage: Stage::UnderDevelopment,
         default_enabled: false,
     },

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -17,6 +17,8 @@ use toml::Table;
 mod feature_configs;
 mod legacy;
 pub use feature_configs::CodeModeConfigToml;
+pub use feature_configs::CurrentTimeReminderConfigToml;
+pub use feature_configs::CurrentTimeSource;
 pub use feature_configs::MultiAgentV2ConfigToml;
 pub use feature_configs::NetworkProxyConfigToml;
 pub use feature_configs::NetworkProxyDomainPermissionToml;
@@ -24,8 +26,6 @@ pub use feature_configs::NetworkProxyModeToml;
 pub use feature_configs::NetworkProxyUnixSocketPermissionToml;
 use feature_configs::RemovedAppsMcpPathOverrideConfigToml;
 pub use feature_configs::RolloutBudgetConfigToml;
-pub use feature_configs::VarlatencyClockSource;
-pub use feature_configs::VarlatencyConfigToml;
 use legacy::LegacyFeatureToggles;
 pub use legacy::legacy_feature_keys;
 
@@ -209,7 +209,7 @@ pub enum Feature {
     /// Track and report a shared token budget across a session's agent threads.
     RolloutBudget,
     /// Add current-time reminders to model-visible context.
-    Varlatency,
+    CurrentTimeReminder,
     /// Expose an input-interruptible sleep tool.
     SleepTool,
     /// Route MCP tool approval prompts through the MCP elicitation request path.
@@ -627,7 +627,8 @@ pub struct FeaturesToml {
     pub multi_agent_v2: Option<FeatureToml<MultiAgentV2ConfigToml>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rollout_budget: Option<FeatureToml<RolloutBudgetConfigToml>>,
-    pub varlatency: Option<FeatureToml<VarlatencyConfigToml>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_time_reminder: Option<FeatureToml<CurrentTimeReminderConfigToml>>,
     #[serde(default, rename = "apps_mcp_path_override", skip_serializing)]
     #[schemars(skip)]
     removed_apps_mcp_path_override: Option<FeatureToml<RemovedAppsMcpPathOverrideConfigToml>>,
@@ -662,8 +663,13 @@ impl FeaturesToml {
         }
         if let Some(enabled) = self.rollout_budget.as_ref().and_then(FeatureToml::enabled) {
             entries.insert(Feature::RolloutBudget.key().to_string(), enabled);
-        if let Some(enabled) = self.varlatency.as_ref().and_then(FeatureToml::enabled) {
-            entries.insert(Feature::Varlatency.key().to_string(), enabled);
+        }
+        if let Some(enabled) = self
+            .current_time_reminder
+            .as_ref()
+            .and_then(FeatureToml::enabled)
+        {
+            entries.insert(Feature::CurrentTimeReminder.key().to_string(), enabled);
         }
         if let Some(enabled) = self.network_proxy.as_ref().and_then(FeatureToml::enabled) {
             entries.insert(Feature::NetworkProxy.key().to_string(), enabled);
@@ -677,7 +683,7 @@ impl FeaturesToml {
             code_mode,
             multi_agent_v2,
             rollout_budget,
-            varlatency,
+            current_time_reminder,
             removed_apps_mcp_path_override: _,
             network_proxy,
             entries,
@@ -693,8 +699,8 @@ impl FeaturesToml {
                 materialize_resolved_feature_enabled(multi_agent_v2, enabled);
             } else if spec.id == Feature::RolloutBudget {
                 materialize_resolved_feature_enabled(rollout_budget, enabled);
-            } else if spec.id == Feature::Varlatency {
-                materialize_resolved_feature_enabled(varlatency, enabled);
+            } else if spec.id == Feature::CurrentTimeReminder {
+                materialize_resolved_feature_enabled(current_time_reminder, enabled);
             } else if spec.id == Feature::NetworkProxy {
                 materialize_resolved_feature_enabled(network_proxy, enabled);
             } else {
@@ -1191,8 +1197,12 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::RolloutBudget,
         key: "rollout_budget",
-        id: Feature::Varlatency,
-        key: "varlatency",
+        stage: Stage::UnderDevelopment,
+        default_enabled: false,
+    },
+    FeatureSpec {
+        id: Feature::CurrentTimeReminder,
+        key: "current_time_reminder",
         stage: Stage::UnderDevelopment,
         default_enabled: false,
     },

--- a/codex-rs/thread-manager-sample/src/main.rs
+++ b/codex-rs/thread-manager-sample/src/main.rs
@@ -278,7 +278,7 @@ fn new_config(model: Option<String>, arg0_paths: Arg0DispatchPaths) -> anyhow::R
         ghost_snapshot: GhostSnapshotConfig::default(),
         multi_agent_v2: MultiAgentV2Config::default(),
         rollout_budget: None,
-        varlatency: None,
+        current_time_reminder: None,
         features: Default::default(),
         suppress_unstable_features_warning: false,
         active_project: ProjectConfig { trust_level: None },

--- a/codex-rs/thread-manager-sample/src/main.rs
+++ b/codex-rs/thread-manager-sample/src/main.rs
@@ -278,6 +278,7 @@ fn new_config(model: Option<String>, arg0_paths: Arg0DispatchPaths) -> anyhow::R
         ghost_snapshot: GhostSnapshotConfig::default(),
         multi_agent_v2: MultiAgentV2Config::default(),
         rollout_budget: None,
+        varlatency: None,
         features: Default::default(),
         suppress_unstable_features_warning: false,
         active_project: ProjectConfig { trust_level: None },


### PR DESCRIPTION
## Summary

Example:

> [features.current_time_reminder]
enabled = true
reminder_interval_model_requests = 1
clock_source = "system"

## Testing

- `just test -p codex-core varlatency`
- `just test -p codex-core lock_contains_prompts_and_materializes_features`
- `just fix -p codex-core -p codex-config -p codex-features`
