### PR TITLE
Record more path migration guidance for codex.

### DIFF
--- a/.codex/skills/path-types/SKILL.md
+++ b/.codex/skills/path-types/SKILL.md
@@ -31,7 +31,9 @@ Keep these requirements in mind while migrating code to conform with the above g
 * path reasoning must work before the related environment has come online
 * URIs cannot explicitly encode the executor’s path convention or operating system
 * users must not configure the environment’s OS/path convention explicitly
-* URIs should not yet be stored in rollouts
+* URIs should not yet be stored in rollouts, databases, or other persistent storage
+* path conversion errors: fail-closed for security-relevant paths, fail-open for UI/diagnostics
+* prefer small focused methods on `PathUri` or `LegacyAppPathString` over local helpers
 
 It is OK if the conversion between paths and URIs is somewhat lossy as long as it will do the right
 thing for real users.


### PR DESCRIPTION
Some common themes pulled out of both human and automated reviews from the last couple of days' migrations to `PathUri` and `LegacyAppPathString`.