### PR TITLE
feat(app-server): expose filesystem metadata size

### DIFF
--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -9888,6 +9888,12 @@
             "description": "File modification time in Unix milliseconds when available, otherwise `0`.",
             "format": "int64",
             "type": "integer"
+          },
+          "sizeBytes": {
+            "description": "File size in bytes.",
+            "format": "uint64",
+            "minimum": 0.0,
+            "type": "integer"
           }
         },
         "required": [
@@ -9895,7 +9901,8 @@
           "isDirectory",
           "isFile",
           "isSymlink",
-          "modifiedAtMs"
+          "modifiedAtMs",
+          "sizeBytes"
         ],
         "title": "FsGetMetadataResponse",
         "type": "object"

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
@@ -6173,6 +6173,12 @@
           "description": "File modification time in Unix milliseconds when available, otherwise `0`.",
           "format": "int64",
           "type": "integer"
+        },
+        "sizeBytes": {
+          "description": "File size in bytes.",
+          "format": "uint64",
+          "minimum": 0.0,
+          "type": "integer"
         }
       },
       "required": [
@@ -6180,7 +6186,8 @@
         "isDirectory",
         "isFile",
         "isSymlink",
-        "modifiedAtMs"
+        "modifiedAtMs",
+        "sizeBytes"
       ],
       "title": "FsGetMetadataResponse",
       "type": "object"

--- a/codex-rs/app-server-protocol/schema/json/v2/FsGetMetadataResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/FsGetMetadataResponse.json
@@ -23,6 +23,12 @@
       "description": "File modification time in Unix milliseconds when available, otherwise `0`.",
       "format": "int64",
       "type": "integer"
+    },
+    "sizeBytes": {
+      "description": "File size in bytes.",
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": "integer"
     }
   },
   "required": [
@@ -30,7 +36,8 @@
     "isDirectory",
     "isFile",
     "isSymlink",
-    "modifiedAtMs"
+    "modifiedAtMs",
+    "sizeBytes"
   ],
   "title": "FsGetMetadataResponse",
   "type": "object"

--- a/codex-rs/app-server-protocol/schema/typescript/v2/FsGetMetadataResponse.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/FsGetMetadataResponse.ts
@@ -19,6 +19,10 @@ isFile: boolean,
  */
 isSymlink: boolean,
 /**
+ * File size in bytes.
+ */
+sizeBytes: number,
+/**
  * File creation time in Unix milliseconds when available, otherwise `0`.
  */
 createdAtMs: number,

--- a/codex-rs/app-server-protocol/src/protocol/v2/fs.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2/fs.rs
@@ -77,6 +77,9 @@ pub struct FsGetMetadataResponse {
     pub is_file: bool,
     /// Whether the path itself is a symbolic link.
     pub is_symlink: bool,
+    /// File size in bytes.
+    #[ts(type = "number")]
+    pub size_bytes: u64,
     /// File creation time in Unix milliseconds when available, otherwise `0`.
     #[ts(type = "number")]
     pub created_at_ms: i64,

--- a/codex-rs/app-server-protocol/src/protocol/v2/tests.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2/tests.rs
@@ -813,6 +813,7 @@ fn fs_get_metadata_response_round_trips_minimal_fields() {
         is_directory: false,
         is_file: true,
         is_symlink: false,
+        size_bytes: 5,
         created_at_ms: 123,
         modified_at_ms: 456,
     };
@@ -824,6 +825,7 @@ fn fs_get_metadata_response_round_trips_minimal_fields() {
             "isDirectory": false,
             "isFile": true,
             "isSymlink": false,
+            "sizeBytes": 5,
             "createdAtMs": 123,
             "modifiedAtMs": 456,
         })

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -185,7 +185,7 @@ Example with notification opt-out:
 - `fs/readFile` — read an absolute file path and return `{ dataBase64 }`.
 - `fs/writeFile` — write an absolute file path from base64-encoded `{ dataBase64 }`; returns `{}`.
 - `fs/createDirectory` — create an absolute directory path; `recursive` defaults to `true`.
-- `fs/getMetadata` — return metadata for an absolute path: `isDirectory`, `isFile`, `isSymlink`, `createdAtMs`, and `modifiedAtMs`.
+- `fs/getMetadata` — return metadata for an absolute path: `isDirectory`, `isFile`, `isSymlink`, `sizeBytes`, `createdAtMs`, and `modifiedAtMs`.
 - `fs/readDirectory` — list direct child entries for an absolute directory path; each entry contains `fileName`, `isDirectory`, and `isFile`, and `fileName` is just the child name, not a path.
 - `fs/remove` — remove an absolute file or directory tree; `recursive` and `force` default to `true`.
 - `fs/copy` — copy between absolute paths; directory copies require `recursive: true`.
@@ -1242,6 +1242,7 @@ All filesystem paths in this section must be absolute.
     "isDirectory": false,
     "isFile": true,
     "isSymlink": false,
+    "sizeBytes": 5,
     "createdAtMs": 1730910000000,
     "modifiedAtMs": 1730910000000
 } }
@@ -1253,7 +1254,7 @@ All filesystem paths in this section must be absolute.
 } }
 ```
 
-- `fs/getMetadata` returns whether the path resolves to a directory or regular file, whether the path itself is a symlink, plus `createdAtMs` and `modifiedAtMs` in Unix milliseconds. If a timestamp is unavailable on the current platform, that field is `0`.
+- `fs/getMetadata` returns whether the path resolves to a directory or regular file, whether the path itself is a symlink, its byte size, plus `createdAtMs` and `modifiedAtMs` in Unix milliseconds. If a timestamp is unavailable on the current platform, that field is `0`.
 - `fs/createDirectory` defaults `recursive` to `true` when omitted.
 - `fs/remove` defaults both `recursive` and `force` to `true` when omitted.
 - `fs/readFile` always returns base64 bytes via `dataBase64`, and `fs/writeFile` always expects base64 bytes in `dataBase64`.

--- a/codex-rs/app-server/src/request_processors/fs_processor.rs
+++ b/codex-rs/app-server/src/request_processors/fs_processor.rs
@@ -125,6 +125,7 @@ impl FsRequestProcessor {
             is_directory: metadata.is_directory,
             is_file: metadata.is_file,
             is_symlink: metadata.is_symlink,
+            size_bytes: metadata.size,
             created_at_ms: metadata.created_at_ms,
             modified_at_ms: metadata.modified_at_ms,
         })

--- a/codex-rs/app-server/tests/suite/v2/fs.rs
+++ b/codex-rs/app-server/tests/suite/v2/fs.rs
@@ -97,6 +97,7 @@ async fn fs_get_metadata_returns_only_used_fields() -> Result<()> {
             "isFile".to_string(),
             "isSymlink".to_string(),
             "modifiedAtMs".to_string(),
+            "sizeBytes".to_string(),
         ]
     );
 
@@ -107,6 +108,7 @@ async fn fs_get_metadata_returns_only_used_fields() -> Result<()> {
             is_directory: false,
             is_file: true,
             is_symlink: false,
+            size_bytes: 5,
             created_at_ms: stat.created_at_ms,
             modified_at_ms: stat.modified_at_ms,
         }


### PR DESCRIPTION
## Why

Codex Apps adapts app-server filesystem responses to its execution-host interface, which needs file sizes from metadata queries.

## What

Add `sizeBytes` to the `fs/getMetadata` response and map the existing filesystem metadata size through app-server. Update the protocol fixtures, API documentation, and metadata behavior coverage.

This PR is intentionally limited to file size metadata. Symlink semantics and exclusive copies are split into independent changes.

## Validation

- `just write-app-server-schema`
- `just test -p codex-app-server-protocol`
- `just test -p codex-app-server fs_get_metadata`
- `just fmt`
