### PR TITLE
feat(app-server): add filesystem symlink semantics

### DIFF
--- a/codex-rs/app-server-protocol/schema/json/ClientRequest.json
+++ b/codex-rs/app-server-protocol/schema/json/ClientRequest.json
@@ -975,6 +975,13 @@
     "FsGetMetadataParams": {
       "description": "Request metadata for an absolute path.",
       "properties": {
+        "followSymlinks": {
+          "description": "Whether metadata should describe the symlink target. Defaults to `true`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "path": {
           "allOf": [
             {

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -9848,6 +9848,13 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "description": "Request metadata for an absolute path.",
         "properties": {
+          "followSymlinks": {
+            "description": "Whether metadata should describe the symlink target. Defaults to `true`.",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "path": {
             "allOf": [
               {
@@ -9914,12 +9921,17 @@
           "isFile": {
             "description": "Whether this entry resolves to a regular file.",
             "type": "boolean"
+          },
+          "isSymlink": {
+            "description": "Whether this entry itself is a symbolic link.",
+            "type": "boolean"
           }
         },
         "required": [
           "fileName",
           "isDirectory",
-          "isFile"
+          "isFile",
+          "isSymlink"
         ],
         "type": "object"
       },

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
@@ -6133,6 +6133,13 @@
       "$schema": "http://json-schema.org/draft-07/schema#",
       "description": "Request metadata for an absolute path.",
       "properties": {
+        "followSymlinks": {
+          "description": "Whether metadata should describe the symlink target. Defaults to `true`.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "path": {
           "allOf": [
             {
@@ -6199,12 +6206,17 @@
         "isFile": {
           "description": "Whether this entry resolves to a regular file.",
           "type": "boolean"
+        },
+        "isSymlink": {
+          "description": "Whether this entry itself is a symbolic link.",
+          "type": "boolean"
         }
       },
       "required": [
         "fileName",
         "isDirectory",
-        "isFile"
+        "isFile",
+        "isSymlink"
       ],
       "type": "object"
     },

--- a/codex-rs/app-server-protocol/schema/json/v2/FsGetMetadataParams.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/FsGetMetadataParams.json
@@ -8,6 +8,13 @@
   },
   "description": "Request metadata for an absolute path.",
   "properties": {
+    "followSymlinks": {
+      "description": "Whether metadata should describe the symlink target. Defaults to `true`.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "path": {
       "allOf": [
         {

--- a/codex-rs/app-server-protocol/schema/json/v2/FsReadDirectoryResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/FsReadDirectoryResponse.json
@@ -15,12 +15,17 @@
         "isFile": {
           "description": "Whether this entry resolves to a regular file.",
           "type": "boolean"
+        },
+        "isSymlink": {
+          "description": "Whether this entry itself is a symbolic link.",
+          "type": "boolean"
         }
       },
       "required": [
         "fileName",
         "isDirectory",
-        "isFile"
+        "isFile",
+        "isSymlink"
       ],
       "type": "object"
     }

--- a/codex-rs/app-server-protocol/schema/typescript/v2/FsGetMetadataParams.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/FsGetMetadataParams.ts
@@ -10,4 +10,8 @@ export type FsGetMetadataParams = {
 /**
  * Absolute path to inspect.
  */
-path: AbsolutePathBuf, };
+path: AbsolutePathBuf,
+/**
+ * Whether metadata should describe the symlink target. Defaults to `true`.
+ */
+followSymlinks?: boolean | null, };

--- a/codex-rs/app-server-protocol/schema/typescript/v2/FsReadDirectoryEntry.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/FsReadDirectoryEntry.ts
@@ -17,4 +17,8 @@ isDirectory: boolean,
 /**
  * Whether this entry resolves to a regular file.
  */
-isFile: boolean, };
+isFile: boolean,
+/**
+ * Whether this entry itself is a symbolic link.
+ */
+isSymlink: boolean, };

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -2923,6 +2923,7 @@ mod tests {
             request_id: RequestId::Integer(10),
             params: v2::FsGetMetadataParams {
                 path: absolute_path("tmp/example"),
+                follow_symlinks: None,
             },
         };
         assert_eq!(
@@ -2930,6 +2931,7 @@ mod tests {
                 "method": "fs/getMetadata",
                 "id": 10,
                 "params": {
+                    "followSymlinks": null,
                     "path": absolute_path_string("tmp/example")
                 }
             }),

--- a/codex-rs/app-server-protocol/src/protocol/v2/fs.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2/fs.rs
@@ -64,6 +64,9 @@ pub struct FsCreateDirectoryResponse {}
 pub struct FsGetMetadataParams {
     /// Absolute path to inspect.
     pub path: AbsolutePathBuf,
+    /// Whether metadata should describe the symlink target. Defaults to `true`.
+    #[ts(optional = nullable)]
+    pub follow_symlinks: Option<bool>,
 }
 
 /// Metadata returned by `fs/getMetadata`.
@@ -105,6 +108,8 @@ pub struct FsReadDirectoryEntry {
     pub is_directory: bool,
     /// Whether this entry resolves to a regular file.
     pub is_file: bool,
+    /// Whether this entry itself is a symbolic link.
+    pub is_symlink: bool,
 }
 
 /// Directory entries returned by `fs/readDirectory`.

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -185,8 +185,8 @@ Example with notification opt-out:
 - `fs/readFile` — read an absolute file path and return `{ dataBase64 }`.
 - `fs/writeFile` — write an absolute file path from base64-encoded `{ dataBase64 }`; returns `{}`.
 - `fs/createDirectory` — create an absolute directory path; `recursive` defaults to `true`.
-- `fs/getMetadata` — return metadata for an absolute path: `isDirectory`, `isFile`, `isSymlink`, `createdAtMs`, and `modifiedAtMs`.
-- `fs/readDirectory` — list direct child entries for an absolute directory path; each entry contains `fileName`, `isDirectory`, and `isFile`, and `fileName` is just the child name, not a path.
+- `fs/getMetadata` — return metadata for an absolute path: `isDirectory`, `isFile`, `isSymlink`, `createdAtMs`, and `modifiedAtMs`; set `followSymlinks: false` to inspect a link instead of its target.
+- `fs/readDirectory` — list direct child entries for an absolute directory path; each entry contains `fileName`, `isDirectory`, `isFile`, and `isSymlink`, and `fileName` is just the child name, not a path.
 - `fs/remove` — remove an absolute file or directory tree; `recursive` and `force` default to `true`.
 - `fs/copy` — copy between absolute paths; directory copies require `recursive: true`.
 - `fs/watch` — subscribe this connection to filesystem change notifications for an absolute file or directory path and caller-provided `watchId`; returns the canonicalized `path`.
@@ -1253,7 +1253,7 @@ All filesystem paths in this section must be absolute.
 } }
 ```
 
-- `fs/getMetadata` returns whether the path resolves to a directory or regular file, whether the path itself is a symlink, plus `createdAtMs` and `modifiedAtMs` in Unix milliseconds. If a timestamp is unavailable on the current platform, that field is `0`.
+- `fs/getMetadata` returns whether the path resolves to a directory or regular file, whether the path itself is a symlink, plus `createdAtMs` and `modifiedAtMs` in Unix milliseconds. `followSymlinks` defaults to `true`; set it to `false` for lstat-style metadata. If a timestamp is unavailable on the current platform, that field is `0`.
 - `fs/createDirectory` defaults `recursive` to `true` when omitted.
 - `fs/remove` defaults both `recursive` and `force` to `true` when omitted.
 - `fs/readFile` always returns base64 bytes via `dataBase64`, and `fs/writeFile` always expects base64 bytes in `dataBase64`.

--- a/codex-rs/app-server/src/request_processors/fs_processor.rs
+++ b/codex-rs/app-server/src/request_processors/fs_processor.rs
@@ -116,11 +116,15 @@ impl FsRequestProcessor {
         params: FsGetMetadataParams,
     ) -> Result<FsGetMetadataResponse, JSONRPCErrorError> {
         let path = PathUri::from_abs_path(&params.path);
-        let metadata = self
-            .file_system()?
-            .get_metadata(&path, /*sandbox*/ None)
-            .await
-            .map_err(map_fs_error)?;
+        let file_system = self.file_system()?;
+        let metadata = if params.follow_symlinks.unwrap_or(true) {
+            file_system.get_metadata(&path, /*sandbox*/ None).await
+        } else {
+            file_system
+                .get_symlink_metadata(&path, /*sandbox*/ None)
+                .await
+        }
+        .map_err(map_fs_error)?;
         Ok(FsGetMetadataResponse {
             is_directory: metadata.is_directory,
             is_file: metadata.is_file,
@@ -147,6 +151,7 @@ impl FsRequestProcessor {
                     file_name: entry.file_name,
                     is_directory: entry.is_directory,
                     is_file: entry.is_file,
+                    is_symlink: entry.is_symlink,
                 })
                 .collect(),
         })

--- a/codex-rs/app-server/tests/suite/v2/fs.rs
+++ b/codex-rs/app-server/tests/suite/v2/fs.rs
@@ -75,6 +75,7 @@ async fn fs_get_metadata_returns_only_used_fields() -> Result<()> {
     let request_id = mcp
         .send_fs_get_metadata_request(codex_app_server_protocol::FsGetMetadataParams {
             path: absolute_path(file_path.clone()),
+            follow_symlinks: None,
         })
         .await?;
     let response = timeout(
@@ -154,6 +155,7 @@ async fn fs_get_metadata_reports_symlink() -> Result<()> {
     let request_id = mcp
         .send_fs_get_metadata_request(codex_app_server_protocol::FsGetMetadataParams {
             path: absolute_path(symlink_path),
+            follow_symlinks: Some(false),
         })
         .await?;
     let response = timeout(
@@ -164,8 +166,45 @@ async fn fs_get_metadata_reports_symlink() -> Result<()> {
 
     let stat: FsGetMetadataResponse = to_response(response)?;
     assert_eq!(stat.is_directory, false);
-    assert_eq!(stat.is_file, true);
+    assert_eq!(stat.is_file, false);
     assert_eq!(stat.is_symlink, true);
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fs_read_directory_reports_symlink_entries() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    let target_path = codex_home.path().join("target");
+    std::fs::create_dir(&target_path)?;
+    symlink(&target_path, codex_home.path().join("target-link"))?;
+
+    let mut mcp = initialized_mcp(&codex_home).await?;
+    let request_id = mcp
+        .send_fs_read_directory_request(codex_app_server_protocol::FsReadDirectoryParams {
+            path: absolute_path(codex_home.path().to_path_buf()),
+        })
+        .await?;
+    let response = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    let entries =
+        to_response::<codex_app_server_protocol::FsReadDirectoryResponse>(response)?.entries;
+
+    assert_eq!(
+        entries
+            .into_iter()
+            .find(|entry| entry.file_name == "target-link"),
+        Some(FsReadDirectoryEntry {
+            file_name: "target-link".to_string(),
+            is_directory: true,
+            is_file: false,
+            is_symlink: true,
+        })
+    );
 
     Ok(())
 }
@@ -292,11 +331,13 @@ async fn fs_methods_cover_current_fs_utils_surface() -> Result<()> {
                 file_name: "nested".to_string(),
                 is_directory: true,
                 is_file: false,
+                is_symlink: false,
             },
             FsReadDirectoryEntry {
                 file_name: "root.txt".to_string(),
                 is_directory: false,
                 is_file: true,
+                is_symlink: false,
             },
         ]
     );

--- a/codex-rs/exec-server/src/fs_helper.rs
+++ b/codex-rs/exec-server/src/fs_helper.rs
@@ -225,10 +225,16 @@ pub(crate) async fn run_direct_request(
             ))
         }
         FsHelperRequest::GetMetadata(params) => {
-            let metadata = file_system
-                .get_metadata(&params.path, /*sandbox*/ None)
-                .await
-                .map_err(map_fs_error)?;
+            let metadata = if params.follow_symlinks {
+                file_system
+                    .get_metadata(&params.path, /*sandbox*/ None)
+                    .await
+            } else {
+                file_system
+                    .get_symlink_metadata(&params.path, /*sandbox*/ None)
+                    .await
+            }
+            .map_err(map_fs_error)?;
             Ok(FsHelperPayload::GetMetadata(FsGetMetadataResponse {
                 is_directory: metadata.is_directory,
                 is_file: metadata.is_file,
@@ -257,6 +263,7 @@ pub(crate) async fn run_direct_request(
                     file_name: entry.file_name,
                     is_directory: entry.is_directory,
                     is_file: entry.is_file,
+                    is_symlink: entry.is_symlink,
                 })
                 .collect();
             Ok(FsHelperPayload::ReadDirectory(FsReadDirectoryResponse {

--- a/codex-rs/exec-server/src/local_file_system.rs
+++ b/codex-rs/exec-server/src/local_file_system.rs
@@ -611,7 +611,8 @@ impl DirectFileSystem {
         path: &PathUri,
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<FileMetadata> {
-        self.get_metadata_impl(path, sandbox, true).await
+        self.get_metadata_impl(path, sandbox, /*follow_symlinks*/ true)
+            .await
     }
 
     async fn get_symlink_metadata(
@@ -619,7 +620,8 @@ impl DirectFileSystem {
         path: &PathUri,
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<FileMetadata> {
-        self.get_metadata_impl(path, sandbox, false).await
+        self.get_metadata_impl(path, sandbox, /*follow_symlinks*/ false)
+            .await
     }
 
     async fn get_metadata_impl(

--- a/codex-rs/exec-server/src/local_file_system.rs
+++ b/codex-rs/exec-server/src/local_file_system.rs
@@ -161,6 +161,15 @@ impl LocalFileSystem {
         file_system.get_metadata(path, sandbox).await
     }
 
+    async fn get_symlink_metadata(
+        &self,
+        path: &PathUri,
+        sandbox: Option<&FileSystemSandboxContext>,
+    ) -> FileSystemResult<FileMetadata> {
+        let (file_system, sandbox) = self.file_system_for(sandbox)?;
+        file_system.get_symlink_metadata(path, sandbox).await
+    }
+
     async fn read_directory(
         &self,
         path: &PathUri,
@@ -245,6 +254,14 @@ impl ExecutorFileSystem for LocalFileSystem {
         sandbox: Option<&'a FileSystemSandboxContext>,
     ) -> ExecutorFileSystemFuture<'a, FileMetadata> {
         Box::pin(LocalFileSystem::get_metadata(self, path, sandbox))
+    }
+
+    fn get_symlink_metadata<'a>(
+        &'a self,
+        path: &'a PathUri,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, FileMetadata> {
+        Box::pin(LocalFileSystem::get_symlink_metadata(self, path, sandbox))
     }
 
     fn read_directory<'a>(
@@ -355,6 +372,17 @@ impl UnsandboxedFileSystem {
         self.file_system.get_metadata(path, /*sandbox*/ None).await
     }
 
+    async fn get_symlink_metadata(
+        &self,
+        path: &PathUri,
+        sandbox: Option<&FileSystemSandboxContext>,
+    ) -> FileSystemResult<FileMetadata> {
+        reject_platform_sandbox_context(sandbox)?;
+        self.file_system
+            .get_symlink_metadata(path, /*sandbox*/ None)
+            .await
+    }
+
     async fn read_directory(
         &self,
         path: &PathUri,
@@ -450,6 +478,16 @@ impl ExecutorFileSystem for UnsandboxedFileSystem {
         sandbox: Option<&'a FileSystemSandboxContext>,
     ) -> ExecutorFileSystemFuture<'a, FileMetadata> {
         Box::pin(UnsandboxedFileSystem::get_metadata(self, path, sandbox))
+    }
+
+    fn get_symlink_metadata<'a>(
+        &'a self,
+        path: &'a PathUri,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, FileMetadata> {
+        Box::pin(UnsandboxedFileSystem::get_symlink_metadata(
+            self, path, sandbox,
+        ))
     }
 
     fn read_directory<'a>(
@@ -573,10 +611,31 @@ impl DirectFileSystem {
         path: &PathUri,
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<FileMetadata> {
+        self.get_metadata_impl(path, sandbox, true).await
+    }
+
+    async fn get_symlink_metadata(
+        &self,
+        path: &PathUri,
+        sandbox: Option<&FileSystemSandboxContext>,
+    ) -> FileSystemResult<FileMetadata> {
+        self.get_metadata_impl(path, sandbox, false).await
+    }
+
+    async fn get_metadata_impl(
+        &self,
+        path: &PathUri,
+        sandbox: Option<&FileSystemSandboxContext>,
+        follow_symlinks: bool,
+    ) -> FileSystemResult<FileMetadata> {
         reject_sandbox_context(sandbox)?;
         let path = path.to_abs_path()?;
-        let metadata = tokio::fs::metadata(path.as_path()).await?;
         let symlink_metadata = tokio::fs::symlink_metadata(path.as_path()).await?;
+        let metadata = if follow_symlinks {
+            tokio::fs::metadata(path.as_path()).await?
+        } else {
+            symlink_metadata.clone()
+        };
         Ok(FileMetadata {
             is_directory: metadata.is_dir(),
             is_file: metadata.is_file(),
@@ -597,13 +656,20 @@ impl DirectFileSystem {
         let mut entries = Vec::new();
         let mut read_dir = tokio::fs::read_dir(path.as_path()).await?;
         while let Some(entry) = read_dir.next_entry().await? {
-            let Ok(metadata) = tokio::fs::metadata(entry.path()).await else {
-                continue;
+            let symlink_metadata = entry.metadata().await?;
+            let is_symlink = symlink_metadata.file_type().is_symlink();
+            let metadata = if is_symlink {
+                tokio::fs::metadata(entry.path())
+                    .await
+                    .unwrap_or_else(|_| symlink_metadata.clone())
+            } else {
+                symlink_metadata
             };
             entries.push(ReadDirectoryEntry {
                 file_name: entry.file_name().to_string_lossy().into_owned(),
                 is_directory: metadata.is_dir(),
                 is_file: metadata.is_file(),
+                is_symlink,
             });
         }
         Ok(entries)
@@ -741,6 +807,14 @@ impl ExecutorFileSystem for DirectFileSystem {
         sandbox: Option<&'a FileSystemSandboxContext>,
     ) -> ExecutorFileSystemFuture<'a, FileMetadata> {
         Box::pin(DirectFileSystem::get_metadata(self, path, sandbox))
+    }
+
+    fn get_symlink_metadata<'a>(
+        &'a self,
+        path: &'a PathUri,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, FileMetadata> {
+        Box::pin(DirectFileSystem::get_symlink_metadata(self, path, sandbox))
     }
 
     fn read_directory<'a>(

--- a/codex-rs/exec-server/src/protocol.rs
+++ b/codex-rs/exec-server/src/protocol.rs
@@ -280,6 +280,7 @@ pub struct FsCreateDirectoryResponse {}
 #[serde(rename_all = "camelCase")]
 pub struct FsGetMetadataParams {
     pub path: PathUri,
+    pub follow_symlinks: bool,
     pub sandbox: Option<FileSystemSandboxContext>,
 }
 
@@ -320,6 +321,7 @@ pub struct FsReadDirectoryEntry {
     pub file_name: String,
     pub is_directory: bool,
     pub is_file: bool,
+    pub is_symlink: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/codex-rs/exec-server/src/remote_file_system.rs
+++ b/codex-rs/exec-server/src/remote_file_system.rs
@@ -139,7 +139,7 @@ impl RemoteFileSystem {
         path: &PathUri,
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<FileMetadata> {
-        self.get_metadata_with_follow_symlinks(path, sandbox, true)
+        self.get_metadata_with_follow_symlinks(path, sandbox, /*follow_symlinks*/ true)
             .await
     }
 
@@ -148,7 +148,7 @@ impl RemoteFileSystem {
         path: &PathUri,
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<FileMetadata> {
-        self.get_metadata_with_follow_symlinks(path, sandbox, false)
+        self.get_metadata_with_follow_symlinks(path, sandbox, /*follow_symlinks*/ false)
             .await
     }
 

--- a/codex-rs/exec-server/src/remote_file_system.rs
+++ b/codex-rs/exec-server/src/remote_file_system.rs
@@ -139,11 +139,31 @@ impl RemoteFileSystem {
         path: &PathUri,
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<FileMetadata> {
+        self.get_metadata_with_follow_symlinks(path, sandbox, true)
+            .await
+    }
+
+    async fn get_symlink_metadata(
+        &self,
+        path: &PathUri,
+        sandbox: Option<&FileSystemSandboxContext>,
+    ) -> FileSystemResult<FileMetadata> {
+        self.get_metadata_with_follow_symlinks(path, sandbox, false)
+            .await
+    }
+
+    async fn get_metadata_with_follow_symlinks(
+        &self,
+        path: &PathUri,
+        sandbox: Option<&FileSystemSandboxContext>,
+        follow_symlinks: bool,
+    ) -> FileSystemResult<FileMetadata> {
         trace!("remote fs get_metadata");
         let client = self.client.get().await.map_err(map_remote_error)?;
         let response = client
             .fs_get_metadata(FsGetMetadataParams {
                 path: path.clone(),
+                follow_symlinks,
                 sandbox: remote_sandbox_context(sandbox),
             })
             .await
@@ -179,6 +199,7 @@ impl RemoteFileSystem {
                 file_name: entry.file_name,
                 is_directory: entry.is_directory,
                 is_file: entry.is_file,
+                is_symlink: entry.is_symlink,
             })
             .collect())
     }
@@ -276,6 +297,14 @@ impl ExecutorFileSystem for RemoteFileSystem {
         sandbox: Option<&'a FileSystemSandboxContext>,
     ) -> ExecutorFileSystemFuture<'a, FileMetadata> {
         Box::pin(RemoteFileSystem::get_metadata(self, path, sandbox))
+    }
+
+    fn get_symlink_metadata<'a>(
+        &'a self,
+        path: &'a PathUri,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, FileMetadata> {
+        Box::pin(RemoteFileSystem::get_symlink_metadata(self, path, sandbox))
     }
 
     fn read_directory<'a>(

--- a/codex-rs/exec-server/src/sandboxed_file_system.rs
+++ b/codex-rs/exec-server/src/sandboxed_file_system.rs
@@ -148,6 +148,25 @@ impl SandboxedFileSystem {
         path: &PathUri,
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<FileMetadata> {
+        self.get_metadata_with_follow_symlinks(path, sandbox, true)
+            .await
+    }
+
+    async fn get_symlink_metadata(
+        &self,
+        path: &PathUri,
+        sandbox: Option<&FileSystemSandboxContext>,
+    ) -> FileSystemResult<FileMetadata> {
+        self.get_metadata_with_follow_symlinks(path, sandbox, false)
+            .await
+    }
+
+    async fn get_metadata_with_follow_symlinks(
+        &self,
+        path: &PathUri,
+        sandbox: Option<&FileSystemSandboxContext>,
+        follow_symlinks: bool,
+    ) -> FileSystemResult<FileMetadata> {
         let sandbox = require_platform_sandbox(sandbox)?;
         validate_native_path(path)?;
         let response = self
@@ -155,6 +174,7 @@ impl SandboxedFileSystem {
                 sandbox,
                 FsHelperRequest::GetMetadata(FsGetMetadataParams {
                     path: path.clone(),
+                    follow_symlinks,
                     sandbox: None,
                 }),
             )
@@ -196,6 +216,7 @@ impl SandboxedFileSystem {
                 file_name: entry.file_name,
                 is_directory: entry.is_directory,
                 is_file: entry.is_file,
+                is_symlink: entry.is_symlink,
             })
             .collect())
     }
@@ -307,6 +328,16 @@ impl ExecutorFileSystem for SandboxedFileSystem {
         sandbox: Option<&'a FileSystemSandboxContext>,
     ) -> ExecutorFileSystemFuture<'a, FileMetadata> {
         Box::pin(SandboxedFileSystem::get_metadata(self, path, sandbox))
+    }
+
+    fn get_symlink_metadata<'a>(
+        &'a self,
+        path: &'a PathUri,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, FileMetadata> {
+        Box::pin(SandboxedFileSystem::get_symlink_metadata(
+            self, path, sandbox,
+        ))
     }
 
     fn read_directory<'a>(

--- a/codex-rs/exec-server/src/sandboxed_file_system.rs
+++ b/codex-rs/exec-server/src/sandboxed_file_system.rs
@@ -148,7 +148,7 @@ impl SandboxedFileSystem {
         path: &PathUri,
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<FileMetadata> {
-        self.get_metadata_with_follow_symlinks(path, sandbox, true)
+        self.get_metadata_with_follow_symlinks(path, sandbox, /*follow_symlinks*/ true)
             .await
     }
 
@@ -157,7 +157,7 @@ impl SandboxedFileSystem {
         path: &PathUri,
         sandbox: Option<&FileSystemSandboxContext>,
     ) -> FileSystemResult<FileMetadata> {
-        self.get_metadata_with_follow_symlinks(path, sandbox, false)
+        self.get_metadata_with_follow_symlinks(path, sandbox, /*follow_symlinks*/ false)
             .await
     }
 

--- a/codex-rs/exec-server/src/server/file_system_handler.rs
+++ b/codex-rs/exec-server/src/server/file_system_handler.rs
@@ -152,11 +152,16 @@ impl FileSystemHandler {
         &self,
         params: FsGetMetadataParams,
     ) -> Result<FsGetMetadataResponse, JSONRPCErrorError> {
-        let metadata = self
-            .file_system
-            .get_metadata(&params.path, params.sandbox.as_ref())
-            .await
-            .map_err(map_fs_error)?;
+        let metadata = if params.follow_symlinks {
+            self.file_system
+                .get_metadata(&params.path, params.sandbox.as_ref())
+                .await
+        } else {
+            self.file_system
+                .get_symlink_metadata(&params.path, params.sandbox.as_ref())
+                .await
+        }
+        .map_err(map_fs_error)?;
         Ok(FsGetMetadataResponse {
             is_directory: metadata.is_directory,
             is_file: metadata.is_file,
@@ -193,6 +198,7 @@ impl FileSystemHandler {
                 file_name: entry.file_name,
                 is_directory: entry.is_directory,
                 is_file: entry.is_file,
+                is_symlink: entry.is_symlink,
             })
             .collect();
         Ok(FsReadDirectoryResponse { entries })

--- a/codex-rs/exec-server/tests/file_system/shared.rs
+++ b/codex-rs/exec-server/tests/file_system/shared.rs
@@ -343,11 +343,13 @@ async fn file_system_read_directory_lists_entries(
                 file_name: "nested".to_string(),
                 is_directory: true,
                 is_file: false,
+                is_symlink: false,
             },
             ReadDirectoryEntry {
                 file_name: "root.txt".to_string(),
                 is_directory: false,
                 is_file: true,
+                is_symlink: false,
             },
         ]
     );

--- a/codex-rs/exec-server/tests/file_system_unix.rs
+++ b/codex-rs/exec-server/tests/file_system_unix.rs
@@ -237,6 +237,22 @@ async fn file_system_get_metadata_reports_symlink_targets(
     );
     assert!(symlink_metadata.modified_at_ms > 0);
 
+    let link_metadata = file_system
+        .get_symlink_metadata(&PathUri::from_path(&symlink_path)?, /*sandbox*/ None)
+        .await
+        .with_context(|| format!("mode={implementation}"))?;
+    assert_eq!(
+        link_metadata,
+        FileMetadata {
+            is_directory: false,
+            is_file: false,
+            is_symlink: true,
+            size: std::fs::symlink_metadata(&symlink_path)?.len(),
+            created_at_ms: link_metadata.created_at_ms,
+            modified_at_ms: link_metadata.modified_at_ms,
+        }
+    );
+
     let dir_path = tmp.path().join("notes");
     std::fs::create_dir(&dir_path)?;
     let dir_symlink_path = tmp.path().join("notes-link");
@@ -259,6 +275,34 @@ async fn file_system_get_metadata_reports_symlink_targets(
             modified_at_ms: dir_symlink_metadata.modified_at_ms,
         }
     );
+
+    Ok(())
+}
+
+#[test_case(FileSystemImplementation::Local ; "local")]
+#[test_case(FileSystemImplementation::Remote ; "remote")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn file_system_read_directory_reports_symlinks(
+    implementation: FileSystemImplementation,
+) -> Result<()> {
+    let context = create_file_system_context(implementation).await?;
+    let file_system = context.file_system;
+    let tmp = TempDir::new()?;
+    let target_path = tmp.path().join("target");
+    std::fs::create_dir(&target_path)?;
+    symlink(&target_path, tmp.path().join("target-link"))?;
+
+    let entries = file_system
+        .read_directory(&PathUri::from_path(tmp.path())?, /*sandbox*/ None)
+        .await
+        .with_context(|| format!("mode={implementation}"))?;
+    let entry = entries
+        .into_iter()
+        .find(|entry| entry.file_name == "target-link")
+        .context("missing symlink entry")?;
+    assert_eq!(entry.is_directory, true);
+    assert_eq!(entry.is_file, false);
+    assert_eq!(entry.is_symlink, true);
 
     Ok(())
 }

--- a/codex-rs/ext/skills/tests/executor_file_system_authority.rs
+++ b/codex-rs/ext/skills/tests/executor_file_system_authority.rs
@@ -60,12 +60,14 @@ impl SyntheticFileSystem {
                 file_name: "skill".to_string(),
                 is_directory: true,
                 is_file: false,
+                is_symlink: false,
             }])
         } else if path == self.canonical_root.join("skill") {
             Ok(vec![ReadDirectoryEntry {
                 file_name: "SKILL.md".to_string(),
                 is_directory: false,
                 is_file: true,
+                is_symlink: false,
             }])
         } else {
             Err(io::Error::new(io::ErrorKind::NotFound, "not found"))

--- a/codex-rs/file-system/src/lib.rs
+++ b/codex-rs/file-system/src/lib.rs
@@ -54,6 +54,7 @@ pub struct ReadDirectoryEntry {
     pub file_name: String,
     pub is_directory: bool,
     pub is_file: bool,
+    pub is_symlink: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -242,6 +243,14 @@ pub trait ExecutorFileSystem: Send + Sync {
         path: &'a PathUri,
         sandbox: Option<&'a FileSystemSandboxContext>,
     ) -> ExecutorFileSystemFuture<'a, FileMetadata>;
+
+    fn get_symlink_metadata<'a>(
+        &'a self,
+        path: &'a PathUri,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, FileMetadata> {
+        self.get_metadata(path, sandbox)
+    }
 
     fn read_directory<'a>(
         &'a self,


### PR DESCRIPTION
## Why

Codex Apps adapts app-server filesystem operations to its execution-host interface. Callers need to distinguish a symlink from its target both for explicit metadata queries and directory listings.

## What

- Add nullable `followSymlinks` to `fs/getMetadata`, defaulting to target-following behavior.
- Add lstat-style metadata support across direct, sandboxed, and remote exec-server transports.
- Add `isSymlink` to `fs/readDirectory` entries while preserving target-derived `isDirectory` and `isFile` values.
- Update generated protocol schemas, API documentation, and local/remote behavior coverage.

This PR is intentionally limited to symlink semantics. File-size metadata and exclusive copies are independent changes.

## Validation

- `just write-app-server-schema`
- `just test -p codex-app-server-protocol`
- `just test -p codex-exec-server -E 'test(file_system_get_metadata_reports_symlink_targets) | test(file_system_read_directory_reports_symlinks)'`
- `just test -p codex-app-server -E 'test(fs_get_metadata_reports_symlink) | test(fs_read_directory_reports_symlink_entries)'`
- `just fix -p codex-file-system -p codex-exec-server -p codex-app-server-protocol -p codex-app-server`
- `just fmt`
