### PR TITLE
feat(app-server): add exclusive filesystem copies

### DIFF
--- a/codex-rs/app-server-protocol/schema/json/ClientRequest.json
+++ b/codex-rs/app-server-protocol/schema/json/ClientRequest.json
@@ -929,6 +929,10 @@
           ],
           "description": "Absolute destination path."
         },
+        "exclusive": {
+          "description": "Fail if the destination already exists.",
+          "type": "boolean"
+        },
         "recursive": {
           "description": "Required for directory copies; ignored for file copies.",
           "type": "boolean"

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -9786,6 +9786,10 @@
             ],
             "description": "Absolute destination path."
           },
+          "exclusive": {
+            "description": "Fail if the destination already exists.",
+            "type": "boolean"
+          },
           "recursive": {
             "description": "Required for directory copies; ignored for file copies.",
             "type": "boolean"

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
@@ -6071,6 +6071,10 @@
           ],
           "description": "Absolute destination path."
         },
+        "exclusive": {
+          "description": "Fail if the destination already exists.",
+          "type": "boolean"
+        },
         "recursive": {
           "description": "Required for directory copies; ignored for file copies.",
           "type": "boolean"

--- a/codex-rs/app-server-protocol/schema/json/v2/FsCopyParams.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/FsCopyParams.json
@@ -16,6 +16,10 @@
       ],
       "description": "Absolute destination path."
     },
+    "exclusive": {
+      "description": "Fail if the destination already exists.",
+      "type": "boolean"
+    },
     "recursive": {
       "description": "Required for directory copies; ignored for file copies.",
       "type": "boolean"

--- a/codex-rs/app-server-protocol/schema/typescript/v2/FsCopyParams.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/FsCopyParams.ts
@@ -18,4 +18,8 @@ destinationPath: AbsolutePathBuf,
 /**
  * Required for directory copies; ignored for file copies.
  */
-recursive?: boolean, };
+recursive?: boolean,
+/**
+ * Fail if the destination already exists.
+ */
+exclusive?: boolean, };

--- a/codex-rs/app-server-protocol/src/protocol/v2/fs.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2/fs.rs
@@ -149,6 +149,9 @@ pub struct FsCopyParams {
     /// Required for directory copies; ignored for file copies.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub recursive: bool,
+    /// Fail if the destination already exists.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub exclusive: bool,
 }
 
 /// Successful response for `fs/copy`.

--- a/codex-rs/app-server-protocol/src/protocol/v2/tests.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2/tests.rs
@@ -920,6 +920,7 @@ fn fs_copy_params_round_trip_with_recursive_directory_copy() {
         source_path: absolute_path("tmp/source"),
         destination_path: absolute_path("tmp/destination"),
         recursive: true,
+        exclusive: true,
     };
 
     let value = serde_json::to_value(&params).expect("serialize fs/copy params");
@@ -928,6 +929,7 @@ fn fs_copy_params_round_trip_with_recursive_directory_copy() {
         json!({
             "sourcePath": absolute_path_string("tmp/source"),
             "destinationPath": absolute_path_string("tmp/destination"),
+            "exclusive": true,
             "recursive": true,
         })
     );

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -188,7 +188,7 @@ Example with notification opt-out:
 - `fs/getMetadata` — return metadata for an absolute path: `isDirectory`, `isFile`, `isSymlink`, `createdAtMs`, and `modifiedAtMs`.
 - `fs/readDirectory` — list direct child entries for an absolute directory path; each entry contains `fileName`, `isDirectory`, and `isFile`, and `fileName` is just the child name, not a path.
 - `fs/remove` — remove an absolute file or directory tree; `recursive` and `force` default to `true`.
-- `fs/copy` — copy between absolute paths; directory copies require `recursive: true`.
+- `fs/copy` — copy between absolute paths; directory copies require `recursive: true`, and file copies can set `exclusive: true` to reject an existing destination.
 - `fs/watch` — subscribe this connection to filesystem change notifications for an absolute file or directory path and caller-provided `watchId`; returns the canonicalized `path`.
 - `fs/unwatch` — stop sending notifications for a prior `fs/watch`; returns `{}`.
 - `fs/changed` — notification emitted when watched paths change, including the `watchId` and `changedPaths`.
@@ -1257,7 +1257,7 @@ All filesystem paths in this section must be absolute.
 - `fs/createDirectory` defaults `recursive` to `true` when omitted.
 - `fs/remove` defaults both `recursive` and `force` to `true` when omitted.
 - `fs/readFile` always returns base64 bytes via `dataBase64`, and `fs/writeFile` always expects base64 bytes in `dataBase64`.
-- `fs/copy` handles both file copies and directory-tree copies; it requires `recursive: true` when `sourcePath` is a directory. Recursive copies traverse regular files, directories, and symlinks; other entry types are skipped.
+- `fs/copy` handles both file copies and directory-tree copies; it requires `recursive: true` when `sourcePath` is a directory. `exclusive: true` atomically rejects an existing destination for file copies. Recursive copies traverse regular files, directories, and symlinks; other entry types are skipped.
 
 ### Example: Filesystem watch
 

--- a/codex-rs/app-server/src/request_processors/fs_processor.rs
+++ b/codex-rs/app-server/src/request_processors/fs_processor.rs
@@ -183,6 +183,7 @@ impl FsRequestProcessor {
                 &destination_path,
                 CopyOptions {
                     recursive: params.recursive,
+                    exclusive: params.exclusive,
                 },
                 /*sandbox*/ None,
             )
@@ -211,9 +212,13 @@ impl FsRequestProcessor {
 }
 
 fn map_fs_error(err: io::Error) -> JSONRPCErrorError {
-    if err.kind() == io::ErrorKind::InvalidInput {
-        invalid_request(err.to_string())
-    } else {
-        internal_error(err.to_string())
+    match err.kind() {
+        io::ErrorKind::InvalidInput => invalid_request(err.to_string()),
+        io::ErrorKind::AlreadyExists => JSONRPCErrorError {
+            code: -32603,
+            message: err.to_string(),
+            data: Some(serde_json::json!({ "code": "EEXIST" })),
+        },
+        _ => internal_error(err.to_string()),
     }
 }

--- a/codex-rs/app-server/tests/suite/v2/fs.rs
+++ b/codex-rs/app-server/tests/suite/v2/fs.rs
@@ -171,6 +171,35 @@ async fn fs_get_metadata_reports_symlink() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fs_copy_exclusive_preserves_existing_destination() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    let source_path = codex_home.path().join("source.txt");
+    let destination_path = codex_home.path().join("destination.txt");
+    std::fs::write(&source_path, "source")?;
+    std::fs::write(&destination_path, "destination")?;
+
+    let mut mcp = initialized_mcp(&codex_home).await?;
+    let request_id = mcp
+        .send_fs_copy_request(FsCopyParams {
+            source_path: absolute_path(source_path),
+            destination_path: absolute_path(destination_path.clone()),
+            recursive: false,
+            exclusive: true,
+        })
+        .await?;
+    let error = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+
+    assert_eq!(error.error.data, Some(json!({ "code": "EEXIST" })));
+    assert_eq!(std::fs::read_to_string(destination_path)?, "destination");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn fs_methods_cover_current_fs_utils_surface() -> Result<()> {
     let codex_home = TempDir::new()?;
     let source_dir = codex_home.path().join("source");
@@ -242,6 +271,7 @@ async fn fs_methods_cover_current_fs_utils_surface() -> Result<()> {
             source_path: absolute_path(nested_file.clone()),
             destination_path: absolute_path(copy_file_path.clone()),
             recursive: false,
+            exclusive: false,
         })
         .await?;
     timeout(
@@ -259,6 +289,7 @@ async fn fs_methods_cover_current_fs_utils_surface() -> Result<()> {
             source_path: absolute_path(source_dir.clone()),
             destination_path: absolute_path(copied_dir.clone()),
             recursive: true,
+            exclusive: false,
         })
         .await?;
     timeout(
@@ -528,6 +559,7 @@ async fn fs_copy_rejects_directory_without_recursive() -> Result<()> {
             source_path: absolute_path(source_dir),
             destination_path: absolute_path(codex_home.path().join("dest")),
             recursive: false,
+            exclusive: false,
         })
         .await?;
     let error = timeout(
@@ -555,6 +587,7 @@ async fn fs_copy_rejects_copying_directory_into_descendant() -> Result<()> {
             source_path: absolute_path(source_dir.clone()),
             destination_path: absolute_path(source_dir.join("nested").join("copy")),
             recursive: true,
+            exclusive: false,
         })
         .await?;
     let error = timeout(
@@ -586,6 +619,7 @@ async fn fs_copy_preserves_symlinks_in_recursive_copy() -> Result<()> {
             source_path: absolute_path(source_dir),
             destination_path: absolute_path(copied_dir.clone()),
             recursive: true,
+            exclusive: false,
         })
         .await?;
     timeout(
@@ -626,6 +660,7 @@ async fn fs_copy_ignores_unknown_special_files_in_recursive_copy() -> Result<()>
             source_path: absolute_path(source_dir),
             destination_path: absolute_path(copied_dir.clone()),
             recursive: true,
+            exclusive: false,
         })
         .await?;
     timeout(
@@ -663,6 +698,7 @@ async fn fs_copy_rejects_standalone_fifo_source() -> Result<()> {
             source_path: absolute_path(fifo_path),
             destination_path: absolute_path(codex_home.path().join("copied")),
             recursive: false,
+            exclusive: false,
         })
         .await?;
     expect_error_message(

--- a/codex-rs/core/tests/suite/remote_env.rs
+++ b/codex-rs/core/tests/suite/remote_env.rs
@@ -1173,7 +1173,10 @@ async fn remote_test_env_copy_preserves_symlink_source() -> Result<()> {
         .copy(
             &PathUri::from_path(&source_symlink)?,
             &PathUri::from_path(&copied_symlink)?,
-            CopyOptions { recursive: false },
+            CopyOptions {
+                recursive: false,
+                exclusive: false,
+            },
             Some(&sandbox),
         )
         .await?;

--- a/codex-rs/exec-server/src/fs_helper.rs
+++ b/codex-rs/exec-server/src/fs_helper.rs
@@ -284,6 +284,7 @@ pub(crate) async fn run_direct_request(
                     &params.destination_path,
                     CopyOptions {
                         recursive: params.recursive,
+                        exclusive: params.exclusive,
                     },
                     /*sandbox*/ None,
                 )

--- a/codex-rs/exec-server/src/local_file_system.rs
+++ b/codex-rs/exec-server/src/local_file_system.rs
@@ -676,7 +676,17 @@ impl DirectFileSystem {
             }
 
             if file_type.is_file() {
-                std::fs::copy(source_path.as_path(), destination_path.as_path())?;
+                if options.exclusive {
+                    let mut source = std::fs::File::open(source_path.as_path())?;
+                    let mut destination = std::fs::OpenOptions::new()
+                        .write(true)
+                        .create_new(true)
+                        .open(destination_path.as_path())?;
+                    std::io::copy(&mut source, &mut destination)?;
+                    std::fs::set_permissions(destination_path.as_path(), metadata.permissions())?;
+                } else {
+                    std::fs::copy(source_path.as_path(), destination_path.as_path())?;
+                }
                 return Ok(());
             }
 

--- a/codex-rs/exec-server/src/protocol.rs
+++ b/codex-rs/exec-server/src/protocol.rs
@@ -347,6 +347,7 @@ pub struct FsCopyParams {
     pub source_path: PathUri,
     pub destination_path: PathUri,
     pub recursive: bool,
+    pub exclusive: bool,
     pub sandbox: Option<FileSystemSandboxContext>,
 }
 

--- a/codex-rs/exec-server/src/remote_file_system.rs
+++ b/codex-rs/exec-server/src/remote_file_system.rs
@@ -27,6 +27,7 @@ use crate::protocol::FsWriteFileParams;
 
 const INVALID_REQUEST_ERROR_CODE: i64 = -32600;
 const NOT_FOUND_ERROR_CODE: i64 = -32004;
+const ALREADY_EXISTS_ERROR_CODE: i64 = -32005;
 
 #[path = "remote_file_stream.rs"]
 mod file_stream;
@@ -217,6 +218,7 @@ impl RemoteFileSystem {
                 source_path: source_path.clone(),
                 destination_path: destination_path.clone(),
                 recursive: options.recursive,
+                exclusive: options.exclusive,
                 sandbox: remote_sandbox_context(sandbox),
             })
             .await
@@ -324,6 +326,9 @@ fn map_remote_error(error: ExecServerError) -> io::Error {
     match error {
         ExecServerError::Server { code, message } if code == NOT_FOUND_ERROR_CODE => {
             io::Error::new(io::ErrorKind::NotFound, message)
+        }
+        ExecServerError::Server { code, message } if code == ALREADY_EXISTS_ERROR_CODE => {
+            io::Error::new(io::ErrorKind::AlreadyExists, message)
         }
         ExecServerError::Server { code, message } if code == INVALID_REQUEST_ERROR_CODE => {
             io::Error::new(io::ErrorKind::InvalidInput, message)

--- a/codex-rs/exec-server/src/rpc.rs
+++ b/codex-rs/exec-server/src/rpc.rs
@@ -27,6 +27,7 @@ use crate::connection::JsonRpcConnectionEvent;
 use crate::connection::JsonRpcTransport;
 
 pub(crate) const SESSION_ALREADY_ATTACHED_ERROR_CODE: i64 = -32010;
+pub(crate) const ALREADY_EXISTS_ERROR_CODE: i64 = -32005;
 
 #[derive(Debug)]
 pub(crate) enum RpcCallError {
@@ -459,6 +460,14 @@ pub(crate) fn invalid_params(message: String) -> JSONRPCErrorError {
 pub(crate) fn not_found(message: String) -> JSONRPCErrorError {
     JSONRPCErrorError {
         code: -32004,
+        data: None,
+        message,
+    }
+}
+
+pub(crate) fn already_exists(message: String) -> JSONRPCErrorError {
+    JSONRPCErrorError {
+        code: ALREADY_EXISTS_ERROR_CODE,
         data: None,
         message,
     }

--- a/codex-rs/exec-server/src/sandboxed_file_system.rs
+++ b/codex-rs/exec-server/src/sandboxed_file_system.rs
@@ -239,6 +239,7 @@ impl SandboxedFileSystem {
                 source_path: source_path.clone(),
                 destination_path: destination_path.clone(),
                 recursive: options.recursive,
+                exclusive: options.exclusive,
                 sandbox: None,
             }),
         )

--- a/codex-rs/exec-server/src/server/file_system_handler.rs
+++ b/codex-rs/exec-server/src/server/file_system_handler.rs
@@ -35,6 +35,7 @@ use crate::protocol::FsRemoveParams;
 use crate::protocol::FsRemoveResponse;
 use crate::protocol::FsWriteFileParams;
 use crate::protocol::FsWriteFileResponse;
+use crate::rpc::already_exists;
 use crate::rpc::internal_error;
 use crate::rpc::invalid_request;
 use crate::rpc::not_found;
@@ -225,6 +226,7 @@ impl FileSystemHandler {
                 &params.destination_path,
                 CopyOptions {
                     recursive: params.recursive,
+                    exclusive: params.exclusive,
                 },
                 params.sandbox.as_ref(),
             )
@@ -246,6 +248,7 @@ fn validate_file_read_handle_id(handle_id: &str) -> Result<(), JSONRPCErrorError
 fn map_fs_error(err: io::Error) -> JSONRPCErrorError {
     match err.kind() {
         io::ErrorKind::NotFound => not_found(err.to_string()),
+        io::ErrorKind::AlreadyExists => already_exists(err.to_string()),
         io::ErrorKind::InvalidInput | io::ErrorKind::PermissionDenied => {
             invalid_request(err.to_string())
         }

--- a/codex-rs/exec-server/tests/file_system/shared.rs
+++ b/codex-rs/exec-server/tests/file_system/shared.rs
@@ -273,12 +273,47 @@ async fn file_system_copy_copies_file(implementation: FileSystemImplementation) 
         .copy(
             &PathUri::from_path(&source_file)?,
             &PathUri::from_path(&copied_file)?,
-            CopyOptions { recursive: false },
+            CopyOptions {
+                recursive: false,
+                exclusive: false,
+            },
             /*sandbox*/ None,
         )
         .await
         .with_context(|| format!("mode={implementation}"))?;
     assert_eq!(std::fs::read_to_string(copied_file)?, "hello from trait");
+
+    Ok(())
+}
+
+#[test_case(FileSystemImplementation::Local ; "local")]
+#[test_case(FileSystemImplementation::Remote ; "remote")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn file_system_copy_exclusive_preserves_existing_destination(
+    implementation: FileSystemImplementation,
+) -> Result<()> {
+    let context = create_file_system_context(implementation).await?;
+    let file_system = context.file_system;
+    let tmp = TempDir::new()?;
+    let source_file = tmp.path().join("source.txt");
+    let destination_file = tmp.path().join("destination.txt");
+    std::fs::write(&source_file, "source")?;
+    std::fs::write(&destination_file, "destination")?;
+
+    let error = file_system
+        .copy(
+            &PathUri::from_path(&source_file)?,
+            &PathUri::from_path(&destination_file)?,
+            CopyOptions {
+                recursive: false,
+                exclusive: true,
+            },
+            /*sandbox*/ None,
+        )
+        .await
+        .expect_err("exclusive copy should reject an existing destination");
+    assert_eq!(error.kind(), std::io::ErrorKind::AlreadyExists);
+    assert_eq!(std::fs::read_to_string(destination_file)?, "destination");
 
     Ok(())
 }
@@ -304,7 +339,10 @@ async fn file_system_copy_copies_directory_recursively(
         .copy(
             &PathUri::from_path(&source_dir)?,
             &PathUri::from_path(&copied_dir)?,
-            CopyOptions { recursive: true },
+            CopyOptions {
+                recursive: true,
+                exclusive: false,
+            },
             /*sandbox*/ None,
         )
         .await
@@ -434,7 +472,10 @@ async fn file_system_copy_rejects_directory_without_recursive(
         .copy(
             &PathUri::from_path(&source_dir)?,
             &PathUri::from_path(tmp.path().join("dest"))?,
-            CopyOptions { recursive: false },
+            CopyOptions {
+                recursive: false,
+                exclusive: false,
+            },
             /*sandbox*/ None,
         )
         .await;
@@ -619,7 +660,10 @@ async fn file_system_copy_rejects_copying_directory_into_descendant(
         .copy(
             &PathUri::from_path(&source_dir)?,
             &PathUri::from_path(source_dir.join("nested").join("copy"))?,
-            CopyOptions { recursive: true },
+            CopyOptions {
+                recursive: true,
+                exclusive: false,
+            },
             /*sandbox*/ None,
         )
         .await;

--- a/codex-rs/exec-server/tests/file_system_unix.rs
+++ b/codex-rs/exec-server/tests/file_system_unix.rs
@@ -564,7 +564,10 @@ async fn file_system_copy_rejects_symlink_escape_destination(
         .copy(
             &PathUri::from_path(allowed_dir.join("source.txt"))?,
             &PathUri::from_path(&requested_destination)?,
-            CopyOptions { recursive: false },
+            CopyOptions {
+                recursive: false,
+                exclusive: false,
+            },
             Some(&sandbox),
         )
         .await
@@ -642,7 +645,10 @@ async fn file_system_copy_preserves_symlink_source(
         .copy(
             &PathUri::from_path(&source_symlink)?,
             &PathUri::from_path(&copied_symlink)?,
-            CopyOptions { recursive: false },
+            CopyOptions {
+                recursive: false,
+                exclusive: false,
+            },
             Some(&sandbox),
         )
         .await
@@ -720,7 +726,10 @@ async fn file_system_copy_rejects_symlink_escape_source(
         .copy(
             &PathUri::from_path(&requested_source)?,
             &PathUri::from_path(&requested_destination)?,
-            CopyOptions { recursive: false },
+            CopyOptions {
+                recursive: false,
+                exclusive: false,
+            },
             Some(&sandbox),
         )
         .await
@@ -754,7 +763,10 @@ async fn file_system_copy_preserves_symlinks_in_recursive_copy(
         .copy(
             &PathUri::from_path(&source_dir)?,
             &PathUri::from_path(&copied_dir)?,
-            CopyOptions { recursive: true },
+            CopyOptions {
+                recursive: true,
+                exclusive: false,
+            },
             /*sandbox*/ None,
         )
         .await
@@ -800,7 +812,10 @@ async fn file_system_copy_ignores_unknown_special_files_in_recursive_copy(
         .copy(
             &PathUri::from_path(&source_dir)?,
             &PathUri::from_path(&copied_dir)?,
-            CopyOptions { recursive: true },
+            CopyOptions {
+                recursive: true,
+                exclusive: false,
+            },
             /*sandbox*/ None,
         )
         .await
@@ -839,7 +854,10 @@ async fn file_system_copy_rejects_standalone_fifo_source(
         .copy(
             &PathUri::from_path(&fifo_path)?,
             &PathUri::from_path(tmp.path().join("copied"))?,
-            CopyOptions { recursive: false },
+            CopyOptions {
+                recursive: false,
+                exclusive: false,
+            },
             /*sandbox*/ None,
         )
         .await;

--- a/codex-rs/file-system/src/lib.rs
+++ b/codex-rs/file-system/src/lib.rs
@@ -36,6 +36,7 @@ pub struct RemoveOptions {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CopyOptions {
     pub recursive: bool,
+    pub exclusive: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Why

Codex Apps adapts app-server filesystem operations to its execution-host interface. Callers need an atomic copy mode that refuses to replace an existing destination and reports that condition consistently across local and remote hosts.

## What

- Add `exclusive` to `fs/copy`, defaulting to `false`.
- Implement exclusive regular-file copies with create-new destination semantics so an existing file is never overwritten.
- Preserve `AlreadyExists` across exec-server RPC and expose structured app-server error data as `{ "code": "EEXIST" }`.
- Cover local, remote, sandbox transport, and app-server destination-preservation behavior.
- Update generated protocol schemas and API documentation.

This PR is intentionally limited to exclusive file copies. File-size metadata and symlink semantics are independent changes.

## Validation

- `just write-app-server-schema`
- `just test -p codex-app-server-protocol`
- `just test -p codex-exec-server file_system_copy_exclusive_preserves_existing_destination`
- `just test -p codex-app-server fs_copy_exclusive_preserves_existing_destination`
- `just fix -p codex-file-system -p codex-exec-server -p codex-app-server-protocol -p codex-app-server`
- `just fmt`
