### PR TITLE
Pin Windows argument lint to Windows 2022

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -173,11 +173,8 @@ jobs:
             runner: macos-15-xlarge
             timeout_minutes: 30
           - name: Windows
-            runner: windows-x64
+            runner: windows-2022
             timeout_minutes: 30
-            runs_on:
-              group: ${{ github.event.repository.name }}-runners
-              labels: ${{ github.event.repository.name }}-windows-x64
     steps:
       - name: Check whether argument comment lint should run
         id: argument_comment_lint_gate


### PR DESCRIPTION
## What

Run the Windows argument-comment-lint job on the `windows-2022` hosted runner instead of the custom Windows runner pool.

## Why

The custom pool recently moved from the Visual Studio 2022 Windows image to `windows-2025-vs2026`. Since that migration, the job fails while Bazel materializes LLVM external repository sources, before the argument lint itself runs. The same failure appears across unrelated PRs.

This narrow change tests GitHub’s recommended mitigation for workloads that still require the Visual Studio 2022 image: https://github.com/actions/runner-images/issues/14017

## How

Use the standard `windows-2022` runner for only the Windows argument-comment-lint matrix entry. No product code or lint behavior changes.