### PR TITLE
Synchronize realtime notification test requests

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/realtime_conversation.rs
+++ b/codex-rs/app-server/tests/suite/v2/realtime_conversation.rs
@@ -538,6 +538,7 @@ async fn realtime_conversation_streams_v2_notifications() -> Result<()> {
             "session": { "id": "sess_backend", "instructions": "backend prompt" }
         })],
         vec![],
+        vec![],
         vec![
             json!({
                 "type": "response.output_audio.delta",
@@ -590,7 +591,6 @@ async fn realtime_conversation_streams_v2_notifications() -> Result<()> {
                 "message": "upstream boom"
             }),
         ],
-        vec![],
     ]])
     .await;
 


### PR DESCRIPTION
## What

Deliver the scripted realtime notification batch after the assistant text append request instead of after the preceding developer text append request.

## Why

The batch ends with an upstream error that closes the realtime conversation. When it is emitted after the developer append, it races the subsequent assistant append: the app-server RPC can acknowledge the append before its downstream WebSocket send completes, and the test intermittently observes three requests instead of four.

Making the fake server wait for the assistant append before emitting the terminal batch establishes the ordering the test asserts without sleeps or production-code changes.

## Validation

- `git diff --check`
- CI (the failure is timing-dependent and most reproducible in the Windows Bazel shard)