### PR TITLE
[codex] Make thread store turn filter optional

### DIFF
--- a/codex-rs/thread-store/src/in_memory.rs
+++ b/codex-rs/thread-store/src/in_memory.rs
@@ -79,7 +79,7 @@ mod tests {
         let items_err = store
             .list_items(ListItemsParams {
                 thread_id,
-                turn_id: "turn_1".to_string(),
+                turn_id: None,
                 include_archived: true,
                 cursor: None,
                 page_size: 10,

--- a/codex-rs/thread-store/src/store.rs
+++ b/codex-rs/thread-store/src/store.rs
@@ -102,7 +102,7 @@ pub trait ThreadStore: Any + Send + Sync {
         })
     }
 
-    /// Lists persisted items within a stored turn.
+    /// Lists persisted items within a stored thread, optionally filtered to a turn.
     fn list_items(&self, _params: ListItemsParams) -> ThreadStoreFuture<'_, ItemPage> {
         Box::pin(async {
             Err(ThreadStoreError::Unsupported {

--- a/codex-rs/thread-store/src/types.rs
+++ b/codex-rs/thread-store/src/types.rs
@@ -332,13 +332,13 @@ pub struct TurnPage {
     pub backwards_cursor: Option<String>,
 }
 
-/// Parameters for listing persisted items within a single turn.
+/// Parameters for listing persisted items within a thread.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ListItemsParams {
     /// Thread id to read.
     pub thread_id: ThreadId,
-    /// Turn id to hydrate.
-    pub turn_id: String,
+    /// Optional turn id to filter by. When omitted, returns items across the thread.
+    pub turn_id: Option<String>,
     /// Whether archived threads are eligible.
     pub include_archived: bool,
     /// Opaque cursor returned by a previous list call.
@@ -359,7 +359,7 @@ pub struct StoredThreadItem {
     pub materialized_thread_item_json: Vec<u8>,
 }
 
-/// A page of persisted items within a turn.
+/// A page of persisted items within a thread, optionally filtered to a turn.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ItemPage {
     /// Items returned for this page.


### PR DESCRIPTION
Make `ListItemsParams::turn_id` optional so callers can list persisted items across an entire thread or narrow the result to one turn. This aligns the thread-store API and documentation with thread-wide item listing while preserving the optional turn-filter behavior for implementations.