### PR TITLE
[codex] force reauth on workspace-restricted ChatGPT 401

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -3256,6 +3256,7 @@ dependencies = [
  "codex-terminal-detection",
  "codex-utils-template",
  "core_test_support",
+ "hmac 0.12.1",
  "jsonwebtoken",
  "keyring",
  "once_cell",

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -2053,7 +2053,7 @@ async fn handle_unauthorized(
     provider: &SharedModelProvider,
 ) -> Result<UnauthorizedRecoveryExecution> {
     let debug = extract_response_debug_context(&transport);
-    if is_chatgpt_ip_workspace_restricted_unauthorized(&transport)
+    if is_chatgpt_ip_workspace_restricted_unauthorized(&transport, &debug)
         && let Some(recovery) = auth_recovery
         && recovery.current_auth_uses_codex_backend()
     {
@@ -2210,12 +2210,18 @@ async fn handle_unauthorized(
     Err(provider.map_api_error(ApiError::Transport(transport)))
 }
 
-fn is_chatgpt_ip_workspace_restricted_unauthorized(transport: &TransportError) -> bool {
+fn is_chatgpt_ip_workspace_restricted_unauthorized(
+    transport: &TransportError,
+    debug: &codex_response_debug_context::ResponseDebugContext,
+) -> bool {
     let TransportError::Http { status, body, .. } = transport else {
         return false;
     };
     if *status != StatusCode::UNAUTHORIZED {
         return false;
+    }
+    if debug.auth_error_code.as_deref() == Some(CHATGPT_IP_WORKSPACE_RESTRICTED_ERROR_CODE) {
+        return true;
     }
     body.as_deref()
         .is_some_and(|body| body_has_error_code(body, CHATGPT_IP_WORKSPACE_RESTRICTED_ERROR_CODE))

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -2008,7 +2008,7 @@ where
                                     .await
                                 } else {
                                     None
-                            };
+                                };
                             forced_logout_error.unwrap_or_else(|| {
                                 provider.map_api_error(ApiError::Transport(transport))
                             })

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -275,6 +275,7 @@ struct LastResponse {
 #[derive(Debug, Default)]
 struct WebsocketSession {
     connection: Option<ApiWebSocketConnection>,
+    connection_auth: Option<CodexAuth>,
     last_request: Option<ResponsesApiRequest>,
     last_response_rx: Option<oneshot::Receiver<LastResponse>>,
     last_response_from_untraced_warmup: bool,
@@ -1039,6 +1040,7 @@ impl ModelClientSession {
 
     fn reset_websocket_session(&mut self) {
         self.websocket_session.connection = None;
+        self.websocket_session.connection_auth = None;
         self.websocket_session.last_request = None;
         self.websocket_session.last_response_rx = None;
         self.websocket_session.last_response_from_untraced_warmup = false;
@@ -1191,6 +1193,7 @@ impl ModelClientSession {
             client_setup.api_auth.as_ref(),
             PendingUnauthorizedRetry::default(),
         );
+        let connection_auth = client_setup.auth.clone();
         let connection = self
             .client
             .connect_websocket(
@@ -1203,6 +1206,7 @@ impl ModelClientSession {
             )
             .await?;
         self.websocket_session.connection = Some(connection);
+        self.websocket_session.connection_auth = connection_auth;
         self.websocket_session
             .set_connection_reused(/*connection_reused*/ false);
         Ok(())
@@ -1228,6 +1232,7 @@ impl ModelClientSession {
             session_telemetry,
             api_provider,
             api_auth,
+            auth,
             responses_metadata,
             auth_context,
             request_route_telemetry,
@@ -1241,6 +1246,7 @@ impl ModelClientSession {
             self.websocket_session.last_request = None;
             self.websocket_session.last_response_rx = None;
             self.websocket_session.last_response_from_untraced_warmup = false;
+            self.websocket_session.connection_auth = None;
             let new_conn = match self
                 .client
                 .connect_websocket(
@@ -1262,6 +1268,7 @@ impl ModelClientSession {
                 }
             };
             self.websocket_session.connection = Some(new_conn);
+            self.websocket_session.connection_auth = auth;
             self.websocket_session
                 .set_connection_reused(/*connection_reused*/ false);
         } else {
@@ -1376,6 +1383,10 @@ impl ModelClientSession {
                         request_session_telemetry,
                         inference_trace_attempt,
                         Arc::clone(&self.client.state.provider),
+                        Some(StreamAuthRecovery {
+                            auth_recovery,
+                            rejected_auth: client_setup.auth,
+                        }),
                     );
                     return Ok(stream);
                 }
@@ -1395,6 +1406,7 @@ impl ModelClientSession {
                             &mut auth_recovery,
                             session_telemetry,
                             &self.client.state.provider,
+                            client_setup.auth.as_ref(),
                         )
                         .await?,
                     );
@@ -1493,6 +1505,7 @@ impl ModelClientSession {
                     session_telemetry,
                     api_provider: client_setup.api_provider,
                     api_auth: client_setup.api_auth,
+                    auth: client_setup.auth.clone(),
                     responses_metadata,
                     auth_context: request_auth_context,
                     request_route_telemetry: RequestRouteTelemetry::for_endpoint(
@@ -1516,6 +1529,7 @@ impl ModelClientSession {
                             &mut auth_recovery,
                             session_telemetry,
                             &self.client.state.provider,
+                            client_setup.auth.as_ref(),
                         )
                         .await?,
                     );
@@ -1572,11 +1586,20 @@ impl ModelClientSession {
                     );
                     err
                 })?;
+            let rejected_auth = self
+                .websocket_session
+                .connection_auth
+                .clone()
+                .or_else(|| client_setup.auth.clone());
             let (stream, last_request_rx) = map_response_stream(
                 stream_result,
                 request_session_telemetry,
                 inference_trace_attempt,
                 Arc::clone(&self.client.state.provider),
+                Some(StreamAuthRecovery {
+                    auth_recovery,
+                    rejected_auth,
+                }),
             );
             self.websocket_session.last_response_rx = Some(last_request_rx);
             return Ok(WebsocketStreamOutcome::Stream(stream));
@@ -1810,6 +1833,7 @@ fn map_response_stream(
     session_telemetry: SessionTelemetry,
     inference_trace_attempt: InferenceTraceAttempt,
     provider: SharedModelProvider,
+    stream_auth_recovery: Option<StreamAuthRecovery>,
 ) -> (ResponseStream, oneshot::Receiver<LastResponse>) {
     let codex_api::ResponseStream {
         rx_event,
@@ -1825,6 +1849,7 @@ fn map_response_stream(
         session_telemetry,
         inference_trace_attempt,
         provider,
+        stream_auth_recovery,
     )
 }
 
@@ -1834,6 +1859,7 @@ fn map_response_events<S>(
     session_telemetry: SessionTelemetry,
     inference_trace_attempt: InferenceTraceAttempt,
     provider: SharedModelProvider,
+    mut stream_auth_recovery: Option<StreamAuthRecovery>,
 ) -> (ResponseStream, oneshot::Receiver<LastResponse>)
 where
     S: futures::Stream<Item = std::result::Result<ResponseEvent, ApiError>>
@@ -1944,7 +1970,28 @@ where
                     if let Some(upstream_request_id) = upstream_request_id {
                         feedback_tags!(last_model_request_id = upstream_request_id);
                     }
-                    let mapped = provider.map_api_error(err);
+                    let mapped = match err {
+                        ApiError::Transport(transport @ TransportError::Http { status, .. })
+                            if status == StatusCode::UNAUTHORIZED =>
+                        {
+                            let forced_logout_error =
+                                if let Some(stream_auth_recovery) = stream_auth_recovery.as_mut() {
+                                    force_logout_if_workspace_restricted_unauthorized(
+                                        &transport,
+                                        &mut stream_auth_recovery.auth_recovery,
+                                        &session_telemetry,
+                                        stream_auth_recovery.rejected_auth.as_ref(),
+                                    )
+                                    .await
+                                } else {
+                                    None
+                            };
+                            forced_logout_error.unwrap_or_else(|| {
+                                provider.map_api_error(ApiError::Transport(transport))
+                            })
+                        }
+                        err => provider.map_api_error(err),
+                    };
                     inference_trace_attempt.record_failed(
                         &mapped,
                         upstream_request_id,
@@ -2041,9 +2088,78 @@ struct WebsocketConnectParams<'a> {
     session_telemetry: &'a SessionTelemetry,
     api_provider: codex_api::Provider,
     api_auth: SharedAuthProvider,
+    auth: Option<CodexAuth>,
     responses_metadata: &'a CodexResponsesMetadata,
     auth_context: AuthRequestTelemetryContext,
     request_route_telemetry: RequestRouteTelemetry,
+}
+
+struct StreamAuthRecovery {
+    auth_recovery: Option<UnauthorizedRecovery>,
+    rejected_auth: Option<CodexAuth>,
+}
+
+async fn force_logout_if_workspace_restricted_unauthorized(
+    transport: &TransportError,
+    auth_recovery: &mut Option<UnauthorizedRecovery>,
+    session_telemetry: &SessionTelemetry,
+    rejected_auth: Option<&CodexAuth>,
+) -> Option<CodexErr> {
+    let debug = extract_response_debug_context(transport);
+    if !is_chatgpt_ip_workspace_restricted_unauthorized(transport, &debug) {
+        return None;
+    }
+    let Some(recovery) = auth_recovery else {
+        return None;
+    };
+    if !recovery.current_auth_uses_codex_backend() {
+        return None;
+    }
+
+    let mode = recovery.mode_name();
+    let phase = recovery.step_name();
+    let auth_error_code = Some(
+        debug
+            .auth_error_code
+            .as_deref()
+            .unwrap_or(CHATGPT_IP_WORKSPACE_RESTRICTED_ERROR_CODE),
+    );
+    let auth_state_changed = match recovery
+        .force_logout_due_to_server_auth_rejection(rejected_auth)
+        .await
+    {
+        Ok(changed) => Some(changed),
+        Err(err) => {
+            warn!("failed to clear auth after server auth rejection: {err}");
+            None
+        }
+    };
+    session_telemetry.record_auth_recovery(
+        mode,
+        phase,
+        "forced_logout",
+        debug.request_id.as_deref(),
+        debug.cf_ray.as_deref(),
+        debug.auth_error.as_deref(),
+        auth_error_code,
+        Some(CHATGPT_IP_WORKSPACE_RESTRICTED_ERROR_CODE),
+        auth_state_changed,
+    );
+    emit_feedback_auth_recovery_tags(
+        mode,
+        phase,
+        "forced_logout",
+        debug.request_id.as_deref(),
+        debug.cf_ray.as_deref(),
+        debug.auth_error.as_deref(),
+        auth_error_code,
+    );
+    Some(CodexErr::RefreshTokenFailed(
+        codex_protocol::auth::RefreshTokenFailedError::new(
+            codex_protocol::auth::RefreshTokenFailedReason::Other,
+            CHATGPT_IP_WORKSPACE_RESTRICTED_MESSAGE,
+        ),
+    ))
 }
 
 async fn handle_unauthorized(
@@ -2051,55 +2167,20 @@ async fn handle_unauthorized(
     auth_recovery: &mut Option<UnauthorizedRecovery>,
     session_telemetry: &SessionTelemetry,
     provider: &SharedModelProvider,
+    rejected_auth: Option<&CodexAuth>,
 ) -> Result<UnauthorizedRecoveryExecution> {
-    let debug = extract_response_debug_context(&transport);
-    if is_chatgpt_ip_workspace_restricted_unauthorized(&transport, &debug)
-        && let Some(recovery) = auth_recovery
-        && recovery.current_auth_uses_codex_backend()
+    if let Some(err) = force_logout_if_workspace_restricted_unauthorized(
+        &transport,
+        auth_recovery,
+        session_telemetry,
+        rejected_auth,
+    )
+    .await
     {
-        let mode = recovery.mode_name();
-        let phase = recovery.step_name();
-        let auth_error_code = Some(
-            debug
-                .auth_error_code
-                .as_deref()
-                .unwrap_or(CHATGPT_IP_WORKSPACE_RESTRICTED_ERROR_CODE),
-        );
-        let auth_state_changed = match recovery.force_logout_due_to_server_auth_rejection().await {
-            Ok(changed) => Some(changed),
-            Err(err) => {
-                warn!("failed to clear auth after server auth rejection: {err}");
-                None
-            }
-        };
-        session_telemetry.record_auth_recovery(
-            mode,
-            phase,
-            "forced_logout",
-            debug.request_id.as_deref(),
-            debug.cf_ray.as_deref(),
-            debug.auth_error.as_deref(),
-            auth_error_code,
-            Some(CHATGPT_IP_WORKSPACE_RESTRICTED_ERROR_CODE),
-            auth_state_changed,
-        );
-        emit_feedback_auth_recovery_tags(
-            mode,
-            phase,
-            "forced_logout",
-            debug.request_id.as_deref(),
-            debug.cf_ray.as_deref(),
-            debug.auth_error.as_deref(),
-            auth_error_code,
-        );
-        return Err(CodexErr::RefreshTokenFailed(
-            codex_protocol::auth::RefreshTokenFailedError::new(
-                codex_protocol::auth::RefreshTokenFailedReason::Other,
-                CHATGPT_IP_WORKSPACE_RESTRICTED_MESSAGE,
-            ),
-        ));
+        return Err(err);
     }
 
+    let debug = extract_response_debug_context(&transport);
     if let Some(recovery) = auth_recovery
         && recovery.has_next()
     {

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -276,7 +276,7 @@ struct LastResponse {
 #[derive(Debug, Default)]
 struct WebsocketSession {
     connection: Option<ApiWebSocketConnection>,
-    connection_auth: Option<AuthFingerprint>,
+    connection_auth_fingerprint: Option<AuthFingerprint>,
     last_request: Option<ResponsesApiRequest>,
     last_response_rx: Option<oneshot::Receiver<LastResponse>>,
     last_response_from_untraced_warmup: bool,
@@ -1041,7 +1041,7 @@ impl ModelClientSession {
 
     fn reset_websocket_session(&mut self) {
         self.websocket_session.connection = None;
-        self.websocket_session.connection_auth = None;
+        self.websocket_session.connection_auth_fingerprint = None;
         self.websocket_session.last_request = None;
         self.websocket_session.last_response_rx = None;
         self.websocket_session.last_response_from_untraced_warmup = false;
@@ -1194,7 +1194,7 @@ impl ModelClientSession {
             client_setup.api_auth.as_ref(),
             PendingUnauthorizedRetry::default(),
         );
-        let connection_auth = client_setup
+        let connection_auth_fingerprint = client_setup
             .auth
             .as_ref()
             .and_then(AuthFingerprint::from_auth);
@@ -1210,7 +1210,7 @@ impl ModelClientSession {
             )
             .await?;
         self.websocket_session.connection = Some(connection);
-        self.websocket_session.connection_auth = connection_auth;
+        self.websocket_session.connection_auth_fingerprint = connection_auth_fingerprint;
         self.websocket_session
             .set_connection_reused(/*connection_reused*/ false);
         Ok(())
@@ -1250,7 +1250,7 @@ impl ModelClientSession {
             self.websocket_session.last_request = None;
             self.websocket_session.last_response_rx = None;
             self.websocket_session.last_response_from_untraced_warmup = false;
-            self.websocket_session.connection_auth = None;
+            self.websocket_session.connection_auth_fingerprint = None;
             let new_conn = match self
                 .client
                 .connect_websocket(
@@ -1272,7 +1272,7 @@ impl ModelClientSession {
                 }
             };
             self.websocket_session.connection = Some(new_conn);
-            self.websocket_session.connection_auth = auth;
+            self.websocket_session.connection_auth_fingerprint = auth;
             self.websocket_session
                 .set_connection_reused(/*connection_reused*/ false);
         } else {
@@ -1389,7 +1389,7 @@ impl ModelClientSession {
                         Arc::clone(&self.client.state.provider),
                         Some(StreamAuthRecovery {
                             auth_recovery,
-                            rejected_auth: client_setup
+                            rejected_auth_fingerprint: client_setup
                                 .auth
                                 .as_ref()
                                 .and_then(AuthFingerprint::from_auth),
@@ -1407,7 +1407,7 @@ impl ModelClientSession {
                         response_debug_context.request_id.as_deref(),
                         /*output_items*/ &[],
                     );
-                    let rejected_auth = client_setup
+                    let rejected_auth_fingerprint = client_setup
                         .auth
                         .as_ref()
                         .and_then(AuthFingerprint::from_auth);
@@ -1417,7 +1417,7 @@ impl ModelClientSession {
                             &mut auth_recovery,
                             session_telemetry,
                             &self.client.state.provider,
-                            rejected_auth.as_ref(),
+                            rejected_auth_fingerprint.as_ref(),
                         )
                         .await?,
                     );
@@ -1537,7 +1537,7 @@ impl ModelClientSession {
                 Err(ApiError::Transport(
                     unauthorized_transport @ TransportError::Http { status, .. },
                 )) if status == StatusCode::UNAUTHORIZED => {
-                    let rejected_auth = client_setup
+                    let rejected_auth_fingerprint = client_setup
                         .auth
                         .as_ref()
                         .and_then(AuthFingerprint::from_auth);
@@ -1547,7 +1547,7 @@ impl ModelClientSession {
                             &mut auth_recovery,
                             session_telemetry,
                             &self.client.state.provider,
-                            rejected_auth.as_ref(),
+                            rejected_auth_fingerprint.as_ref(),
                         )
                         .await?,
                     );
@@ -1604,12 +1604,16 @@ impl ModelClientSession {
                     );
                     err
                 })?;
-            let rejected_auth = self.websocket_session.connection_auth.clone().or_else(|| {
-                client_setup
-                    .auth
-                    .as_ref()
-                    .and_then(AuthFingerprint::from_auth)
-            });
+            let rejected_auth_fingerprint = self
+                .websocket_session
+                .connection_auth_fingerprint
+                .clone()
+                .or_else(|| {
+                    client_setup
+                        .auth
+                        .as_ref()
+                        .and_then(AuthFingerprint::from_auth)
+                });
             let (stream, last_request_rx) = map_response_stream(
                 stream_result,
                 request_session_telemetry,
@@ -1617,7 +1621,7 @@ impl ModelClientSession {
                 Arc::clone(&self.client.state.provider),
                 Some(StreamAuthRecovery {
                     auth_recovery,
-                    rejected_auth,
+                    rejected_auth_fingerprint,
                 }),
             );
             self.websocket_session.last_response_rx = Some(last_request_rx);
@@ -1999,7 +2003,7 @@ where
                                         &transport,
                                         &mut stream_auth_recovery.auth_recovery,
                                         &session_telemetry,
-                                        stream_auth_recovery.rejected_auth.as_ref(),
+                                        stream_auth_recovery.rejected_auth_fingerprint.as_ref(),
                                     )
                                     .await
                                 } else {
@@ -2115,14 +2119,14 @@ struct WebsocketConnectParams<'a> {
 
 struct StreamAuthRecovery {
     auth_recovery: Option<UnauthorizedRecovery>,
-    rejected_auth: Option<AuthFingerprint>,
+    rejected_auth_fingerprint: Option<AuthFingerprint>,
 }
 
 async fn force_logout_if_workspace_restricted_unauthorized(
     transport: &TransportError,
     auth_recovery: &mut Option<UnauthorizedRecovery>,
     session_telemetry: &SessionTelemetry,
-    rejected_auth: Option<&AuthFingerprint>,
+    rejected_auth_fingerprint: Option<&AuthFingerprint>,
 ) -> Option<CodexErr> {
     let debug = extract_response_debug_context(transport);
     if !is_chatgpt_ip_workspace_restricted_unauthorized(transport, &debug) {
@@ -2144,7 +2148,7 @@ async fn force_logout_if_workspace_restricted_unauthorized(
             .unwrap_or(CHATGPT_IP_WORKSPACE_RESTRICTED_ERROR_CODE),
     );
     let auth_state_changed = match recovery
-        .force_logout_due_to_server_auth_rejection(rejected_auth)
+        .force_logout_due_to_server_auth_rejection(rejected_auth_fingerprint)
         .await
     {
         Ok(changed) => Some(changed),
@@ -2186,13 +2190,13 @@ async fn handle_unauthorized(
     auth_recovery: &mut Option<UnauthorizedRecovery>,
     session_telemetry: &SessionTelemetry,
     provider: &SharedModelProvider,
-    rejected_auth: Option<&AuthFingerprint>,
+    rejected_auth_fingerprint: Option<&AuthFingerprint>,
 ) -> Result<UnauthorizedRecoveryExecution> {
     if let Some(err) = force_logout_if_workspace_restricted_unauthorized(
         &transport,
         auth_recovery,
         session_telemetry,
-        rejected_auth,
+        rejected_auth_fingerprint,
     )
     .await
     {

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -140,6 +140,8 @@ pub const X_OPENAI_MEMGEN_REQUEST_HEADER: &str = "x-openai-memgen-request";
 pub const X_OPENAI_SUBAGENT_HEADER: &str = "x-openai-subagent";
 pub const X_RESPONSESAPI_INCLUDE_TIMING_METRICS_HEADER: &str =
     "x-responsesapi-include-timing-metrics";
+pub const CHATGPT_IP_WORKSPACE_RESTRICTED_ERROR_CODE: &str = "chatgpt_ip_workspace_restricted";
+const CHATGPT_IP_WORKSPACE_RESTRICTED_MESSAGE: &str = "Your ChatGPT session is no longer authorized for this network or workspace. Please sign in again and choose an allowed workspace.";
 const X_CODEX_WS_STREAM_REQUEST_START_MS_CLIENT_METADATA_KEY: &str =
     "x-codex-ws-stream-request-start-ms";
 const WS_REQUEST_HEADER_RESPONSES_LITE_CLIENT_METADATA_KEY: &str =
@@ -2051,6 +2053,53 @@ async fn handle_unauthorized(
     provider: &SharedModelProvider,
 ) -> Result<UnauthorizedRecoveryExecution> {
     let debug = extract_response_debug_context(&transport);
+    if is_chatgpt_ip_workspace_restricted_unauthorized(&transport)
+        && let Some(recovery) = auth_recovery
+        && recovery.current_auth_uses_codex_backend()
+    {
+        let mode = recovery.mode_name();
+        let phase = recovery.step_name();
+        let auth_error_code = Some(
+            debug
+                .auth_error_code
+                .as_deref()
+                .unwrap_or(CHATGPT_IP_WORKSPACE_RESTRICTED_ERROR_CODE),
+        );
+        let auth_state_changed = match recovery.force_logout_due_to_server_auth_rejection().await {
+            Ok(changed) => Some(changed),
+            Err(err) => {
+                warn!("failed to clear auth after server auth rejection: {err}");
+                None
+            }
+        };
+        session_telemetry.record_auth_recovery(
+            mode,
+            phase,
+            "forced_logout",
+            debug.request_id.as_deref(),
+            debug.cf_ray.as_deref(),
+            debug.auth_error.as_deref(),
+            auth_error_code,
+            Some(CHATGPT_IP_WORKSPACE_RESTRICTED_ERROR_CODE),
+            auth_state_changed,
+        );
+        emit_feedback_auth_recovery_tags(
+            mode,
+            phase,
+            "forced_logout",
+            debug.request_id.as_deref(),
+            debug.cf_ray.as_deref(),
+            debug.auth_error.as_deref(),
+            auth_error_code,
+        );
+        return Err(CodexErr::RefreshTokenFailed(
+            codex_protocol::auth::RefreshTokenFailedError::new(
+                codex_protocol::auth::RefreshTokenFailedReason::Other,
+                CHATGPT_IP_WORKSPACE_RESTRICTED_MESSAGE,
+            ),
+        ));
+    }
+
     if let Some(recovery) = auth_recovery
         && recovery.has_next()
     {
@@ -2159,6 +2208,29 @@ async fn handle_unauthorized(
     );
 
     Err(provider.map_api_error(ApiError::Transport(transport)))
+}
+
+fn is_chatgpt_ip_workspace_restricted_unauthorized(transport: &TransportError) -> bool {
+    let TransportError::Http { status, body, .. } = transport else {
+        return false;
+    };
+    if *status != StatusCode::UNAUTHORIZED {
+        return false;
+    }
+    body.as_deref()
+        .is_some_and(|body| body_has_error_code(body, CHATGPT_IP_WORKSPACE_RESTRICTED_ERROR_CODE))
+}
+
+fn body_has_error_code(body: &str, expected_code: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(body) else {
+        return false;
+    };
+    value
+        .get("error")
+        .and_then(|error| error.get("code"))
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| value.get("code").and_then(serde_json::Value::as_str))
+        == Some(expected_code)
 }
 
 fn api_error_http_status(error: &ApiError) -> Option<u16> {

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -62,6 +62,7 @@ use codex_api::build_session_headers;
 use codex_api::create_text_param_for_request;
 use codex_api::response_create_client_metadata;
 use codex_app_server_protocol::AuthMode;
+use codex_login::AuthFingerprint;
 use codex_login::AuthManager;
 use codex_login::CodexAuth;
 use codex_login::RefreshTokenError;
@@ -275,7 +276,7 @@ struct LastResponse {
 #[derive(Debug, Default)]
 struct WebsocketSession {
     connection: Option<ApiWebSocketConnection>,
-    connection_auth: Option<CodexAuth>,
+    connection_auth: Option<AuthFingerprint>,
     last_request: Option<ResponsesApiRequest>,
     last_response_rx: Option<oneshot::Receiver<LastResponse>>,
     last_response_from_untraced_warmup: bool,
@@ -1193,7 +1194,10 @@ impl ModelClientSession {
             client_setup.api_auth.as_ref(),
             PendingUnauthorizedRetry::default(),
         );
-        let connection_auth = client_setup.auth.clone();
+        let connection_auth = client_setup
+            .auth
+            .as_ref()
+            .and_then(AuthFingerprint::from_auth);
         let connection = self
             .client
             .connect_websocket(
@@ -1385,7 +1389,10 @@ impl ModelClientSession {
                         Arc::clone(&self.client.state.provider),
                         Some(StreamAuthRecovery {
                             auth_recovery,
-                            rejected_auth: client_setup.auth,
+                            rejected_auth: client_setup
+                                .auth
+                                .as_ref()
+                                .and_then(AuthFingerprint::from_auth),
                         }),
                     );
                     return Ok(stream);
@@ -1400,13 +1407,17 @@ impl ModelClientSession {
                         response_debug_context.request_id.as_deref(),
                         /*output_items*/ &[],
                     );
+                    let rejected_auth = client_setup
+                        .auth
+                        .as_ref()
+                        .and_then(AuthFingerprint::from_auth);
                     pending_retry = PendingUnauthorizedRetry::from_recovery(
                         handle_unauthorized(
                             unauthorized_transport,
                             &mut auth_recovery,
                             session_telemetry,
                             &self.client.state.provider,
-                            client_setup.auth.as_ref(),
+                            rejected_auth.as_ref(),
                         )
                         .await?,
                     );
@@ -1505,7 +1516,10 @@ impl ModelClientSession {
                     session_telemetry,
                     api_provider: client_setup.api_provider,
                     api_auth: client_setup.api_auth,
-                    auth: client_setup.auth.clone(),
+                    auth: client_setup
+                        .auth
+                        .as_ref()
+                        .and_then(AuthFingerprint::from_auth),
                     responses_metadata,
                     auth_context: request_auth_context,
                     request_route_telemetry: RequestRouteTelemetry::for_endpoint(
@@ -1523,13 +1537,17 @@ impl ModelClientSession {
                 Err(ApiError::Transport(
                     unauthorized_transport @ TransportError::Http { status, .. },
                 )) if status == StatusCode::UNAUTHORIZED => {
+                    let rejected_auth = client_setup
+                        .auth
+                        .as_ref()
+                        .and_then(AuthFingerprint::from_auth);
                     pending_retry = PendingUnauthorizedRetry::from_recovery(
                         handle_unauthorized(
                             unauthorized_transport,
                             &mut auth_recovery,
                             session_telemetry,
                             &self.client.state.provider,
-                            client_setup.auth.as_ref(),
+                            rejected_auth.as_ref(),
                         )
                         .await?,
                     );
@@ -1586,11 +1604,12 @@ impl ModelClientSession {
                     );
                     err
                 })?;
-            let rejected_auth = self
-                .websocket_session
-                .connection_auth
-                .clone()
-                .or_else(|| client_setup.auth.clone());
+            let rejected_auth = self.websocket_session.connection_auth.clone().or_else(|| {
+                client_setup
+                    .auth
+                    .as_ref()
+                    .and_then(AuthFingerprint::from_auth)
+            });
             let (stream, last_request_rx) = map_response_stream(
                 stream_result,
                 request_session_telemetry,
@@ -2088,7 +2107,7 @@ struct WebsocketConnectParams<'a> {
     session_telemetry: &'a SessionTelemetry,
     api_provider: codex_api::Provider,
     api_auth: SharedAuthProvider,
-    auth: Option<CodexAuth>,
+    auth: Option<AuthFingerprint>,
     responses_metadata: &'a CodexResponsesMetadata,
     auth_context: AuthRequestTelemetryContext,
     request_route_telemetry: RequestRouteTelemetry,
@@ -2096,14 +2115,14 @@ struct WebsocketConnectParams<'a> {
 
 struct StreamAuthRecovery {
     auth_recovery: Option<UnauthorizedRecovery>,
-    rejected_auth: Option<CodexAuth>,
+    rejected_auth: Option<AuthFingerprint>,
 }
 
 async fn force_logout_if_workspace_restricted_unauthorized(
     transport: &TransportError,
     auth_recovery: &mut Option<UnauthorizedRecovery>,
     session_telemetry: &SessionTelemetry,
-    rejected_auth: Option<&CodexAuth>,
+    rejected_auth: Option<&AuthFingerprint>,
 ) -> Option<CodexErr> {
     let debug = extract_response_debug_context(transport);
     if !is_chatgpt_ip_workspace_restricted_unauthorized(transport, &debug) {
@@ -2167,7 +2186,7 @@ async fn handle_unauthorized(
     auth_recovery: &mut Option<UnauthorizedRecovery>,
     session_telemetry: &SessionTelemetry,
     provider: &SharedModelProvider,
-    rejected_auth: Option<&CodexAuth>,
+    rejected_auth: Option<&AuthFingerprint>,
 ) -> Result<UnauthorizedRecoveryExecution> {
     if let Some(err) = force_logout_if_workspace_restricted_unauthorized(
         &transport,

--- a/codex-rs/core/src/client_tests.rs
+++ b/codex-rs/core/src/client_tests.rs
@@ -20,6 +20,7 @@ use codex_api::TransportError;
 use codex_app_server_protocol::AuthMode;
 use codex_config::types::AuthCredentialsStoreMode;
 use codex_login::AuthDotJson;
+use codex_login::AuthFingerprint;
 use codex_login::AuthKeyringBackendKind;
 use codex_login::AuthManager;
 use codex_login::CodexAuth;
@@ -768,6 +769,8 @@ async fn workspace_restricted_401_uses_request_auth_for_forced_logout() -> anyho
     let request_auth = request_auth_manager
         .auth_cached()
         .expect("request auth should load");
+    let request_auth_fingerprint =
+        AuthFingerprint::from_auth(&request_auth).expect("request auth can be fingerprinted");
     let auth_manager = AuthManager::from_auth_for_testing_with_home(
         CodexAuth::create_dummy_chatgpt_auth_for_testing(),
         codex_home.path().to_path_buf(),
@@ -779,7 +782,7 @@ async fn workspace_restricted_401_uses_request_auth_for_forced_logout() -> anyho
         &mut recovery,
         &test_session_telemetry(),
         &test_model_provider(),
-        Some(&request_auth),
+        Some(&request_auth_fingerprint),
     )
     .await
     .expect_err("matching 401 should force reauth without retry");
@@ -892,7 +895,9 @@ async fn workspace_restricted_stream_401_forces_chatgpt_logout() -> anyhow::Resu
         test_model_provider(),
         Some(super::StreamAuthRecovery {
             auth_recovery: Some(auth_manager.unauthorized_recovery()),
-            rejected_auth: Some(CodexAuth::create_dummy_chatgpt_auth_for_testing()),
+            rejected_auth: AuthFingerprint::from_auth(
+                &CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+            ),
         }),
     );
 

--- a/codex-rs/core/src/client_tests.rs
+++ b/codex-rs/core/src/client_tests.rs
@@ -200,7 +200,7 @@ fn test_auth_dot_json_with_account_and_tokens(
 }
 
 fn unauthorized_transport(body: &str) -> TransportError {
-    unauthorized_transport_with_headers(body, None)
+    unauthorized_transport_with_headers(body, /*headers*/ None)
 }
 
 fn unauthorized_transport_with_headers(
@@ -250,7 +250,7 @@ impl ExternalAuth for TestExternalAuth {
             Ok(ExternalAuthTokens::chatgpt(
                 "access-token",
                 "account_id",
-                None,
+                /*chatgpt_plan_type*/ None,
             ))
         })
     }

--- a/codex-rs/core/src/client_tests.rs
+++ b/codex-rs/core/src/client_tests.rs
@@ -199,6 +199,12 @@ fn test_auth_dot_json_with_account_and_tokens(
     }
 }
 
+fn test_chatgpt_auth_tokens_dot_json(account_id: &str, access_token: &str) -> AuthDotJson {
+    let mut auth = test_auth_dot_json_with_account_and_tokens(account_id, access_token, "");
+    auth.auth_mode = Some(AuthMode::ChatgptAuthTokens);
+    auth
+}
+
 fn unauthorized_transport(body: &str) -> TransportError {
     unauthorized_transport_with_headers(body, /*headers*/ None)
 }
@@ -502,6 +508,7 @@ async fn dropped_response_stream_traces_cancelled_partial_output() -> anyhow::Re
         test_session_telemetry(),
         attempt,
         test_model_provider(),
+        /*stream_auth_recovery*/ None,
     );
 
     let observed = stream
@@ -552,6 +559,7 @@ async fn response_stream_records_last_model_feedback_ids() {
         test_session_telemetry(),
         InferenceTraceAttempt::disabled(),
         test_model_provider(),
+        /*stream_auth_recovery*/ None,
     );
 
     while stream.next().await.is_some() {}
@@ -588,6 +596,7 @@ async fn bedrock_unauthorized_error_uses_provider_mapping() {
         &mut auth_recovery,
         &test_session_telemetry(),
         &provider,
+        /*rejected_auth*/ None,
     )
     .await
     .expect_err("expired Bedrock signature should fail");
@@ -627,6 +636,7 @@ async fn dropped_backpressured_response_stream_traces_cancelled_partial_output()
         test_session_telemetry(),
         attempt,
         test_model_provider(),
+        /*stream_auth_recovery*/ None,
     );
 
     // Fill the mapper channel with non-terminal events, then yield one output
@@ -670,74 +680,6 @@ fn auth_request_telemetry_context_tracks_attached_auth_and_retry_phase() {
 }
 
 #[tokio::test]
-async fn workspace_restricted_401_forces_chatgpt_logout() -> anyhow::Result<()> {
-    let codex_home = TempDir::new()?;
-    save_auth(
-        codex_home.path(),
-        &test_auth_dot_json(),
-        AuthCredentialsStoreMode::File,
-        AuthKeyringBackendKind::default(),
-    )?;
-    let auth_manager = AuthManager::from_auth_for_testing_with_home(
-        CodexAuth::create_dummy_chatgpt_auth_for_testing(),
-        codex_home.path().to_path_buf(),
-    );
-    assert!(auth_manager.auth_cached().is_some());
-
-    let mut recovery = Some(auth_manager.unauthorized_recovery());
-    let err = super::handle_unauthorized(
-        unauthorized_transport(r#"{"error":{"code":"chatgpt_ip_workspace_restricted"}}"#),
-        &mut recovery,
-        &test_session_telemetry(),
-    )
-    .await
-    .expect_err("matching 401 should force reauth without retry");
-
-    match err {
-        CodexErr::RefreshTokenFailed(failed) => {
-            assert_eq!(
-                failed.message,
-                "Your ChatGPT session is no longer authorized for this network or workspace. Please sign in again and choose an allowed workspace."
-            );
-        }
-        other => panic!("expected RefreshTokenFailed, got {other:?}"),
-    }
-    assert!(auth_manager.auth_cached().is_none());
-    assert!(
-        load_auth_dot_json(
-            codex_home.path(),
-            AuthCredentialsStoreMode::File,
-            AuthKeyringBackendKind::default(),
-        )?
-        .is_none()
-    );
-    assert!(!recovery.as_ref().expect("recovery").has_next());
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn workspace_restricted_401_does_not_clear_api_key_auth() {
-    let auth_manager = AuthManager::from_auth_for_testing(CodexAuth::from_api_key("sk-test"));
-    let mut recovery = Some(auth_manager.unauthorized_recovery());
-
-    let err = super::handle_unauthorized(
-        unauthorized_transport(r#"{"error":{"code":"chatgpt_ip_workspace_restricted"}}"#),
-        &mut recovery,
-        &test_session_telemetry(),
-    )
-    .await
-    .expect_err("api key auth should not use ChatGPT forced logout");
-
-    assert!(matches!(err, CodexErr::UnexpectedStatus(_)));
-    assert!(
-        auth_manager
-            .auth_cached()
-            .is_some_and(|auth| auth.is_api_key_auth())
-    );
-}
-
-#[tokio::test]
 async fn workspace_restricted_401_preserves_external_auth_bridge() {
     let auth_manager =
         AuthManager::from_auth_for_testing(CodexAuth::create_dummy_chatgpt_auth_for_testing());
@@ -748,6 +690,8 @@ async fn workspace_restricted_401_preserves_external_auth_bridge() {
         unauthorized_transport(r#"{"error":{"code":"chatgpt_ip_workspace_restricted"}}"#),
         &mut recovery,
         &test_session_telemetry(),
+        &test_model_provider(),
+        /*rejected_auth*/ None,
     )
     .await
     .expect_err("matching 401 should force reauth without retry");
@@ -755,47 +699,6 @@ async fn workspace_restricted_401_preserves_external_auth_bridge() {
     assert!(matches!(err, CodexErr::RefreshTokenFailed(_)));
     assert!(auth_manager.auth_cached().is_none());
     assert!(auth_manager.has_external_auth());
-}
-
-#[tokio::test]
-async fn workspace_restricted_401_preserves_replacement_auth() -> anyhow::Result<()> {
-    let codex_home = TempDir::new()?;
-    save_auth(
-        codex_home.path(),
-        &test_auth_dot_json_with_account("replacement_account"),
-        AuthCredentialsStoreMode::File,
-        AuthKeyringBackendKind::default(),
-    )?;
-    let auth_manager = AuthManager::from_auth_for_testing_with_home(
-        CodexAuth::create_dummy_chatgpt_auth_for_testing(),
-        codex_home.path().to_path_buf(),
-    );
-    let mut recovery = Some(auth_manager.unauthorized_recovery());
-
-    let err = super::handle_unauthorized(
-        unauthorized_transport(r#"{"error":{"code":"chatgpt_ip_workspace_restricted"}}"#),
-        &mut recovery,
-        &test_session_telemetry(),
-    )
-    .await
-    .expect_err("matching 401 should force reauth without retry");
-
-    assert!(matches!(err, CodexErr::RefreshTokenFailed(_)));
-    let persisted_auth = load_auth_dot_json(
-        codex_home.path(),
-        AuthCredentialsStoreMode::File,
-        AuthKeyringBackendKind::default(),
-    )?
-    .expect("replacement auth should not be removed");
-    assert_eq!(
-        persisted_auth
-            .tokens
-            .and_then(|tokens| tokens.account_id)
-            .as_deref(),
-        Some("replacement_account")
-    );
-
-    Ok(())
 }
 
 #[tokio::test]
@@ -817,6 +720,8 @@ async fn workspace_restricted_401_preserves_newer_same_account_auth() -> anyhow:
         unauthorized_transport(r#"{"error":{"code":"chatgpt_ip_workspace_restricted"}}"#),
         &mut recovery,
         &test_session_telemetry(),
+        &test_model_provider(),
+        /*rejected_auth*/ None,
     )
     .await
     .expect_err("matching 401 should force reauth without retry");
@@ -840,7 +745,179 @@ async fn workspace_restricted_401_preserves_newer_same_account_auth() -> anyhow:
 }
 
 #[tokio::test]
-async fn generic_or_malformed_401_uses_existing_recovery_path() {
+async fn workspace_restricted_401_uses_request_auth_for_forced_logout() -> anyhow::Result<()> {
+    let codex_home = TempDir::new()?;
+    save_auth(
+        codex_home.path(),
+        &test_auth_dot_json_with_account_and_tokens(
+            "account_id",
+            "request-access-token",
+            "request-refresh-token",
+        ),
+        AuthCredentialsStoreMode::File,
+        AuthKeyringBackendKind::default(),
+    )?;
+    let request_auth_manager = AuthManager::shared(
+        codex_home.path().to_path_buf(),
+        /*enable_codex_api_key_env*/ false,
+        AuthCredentialsStoreMode::File,
+        /*chatgpt_base_url*/ None,
+        AuthKeyringBackendKind::default(),
+    )
+    .await;
+    let request_auth = request_auth_manager
+        .auth_cached()
+        .expect("request auth should load");
+    let auth_manager = AuthManager::from_auth_for_testing_with_home(
+        CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+        codex_home.path().to_path_buf(),
+    );
+    let mut recovery = Some(auth_manager.unauthorized_recovery());
+
+    let err = super::handle_unauthorized(
+        unauthorized_transport(r#"{"error":{"code":"chatgpt_ip_workspace_restricted"}}"#),
+        &mut recovery,
+        &test_session_telemetry(),
+        &test_model_provider(),
+        Some(&request_auth),
+    )
+    .await
+    .expect_err("matching 401 should force reauth without retry");
+
+    match err {
+        CodexErr::RefreshTokenFailed(failed) => {
+            assert_eq!(
+                failed.message,
+                "Your ChatGPT session is no longer authorized for this network or workspace. Please sign in again and choose an allowed workspace."
+            );
+        }
+        other => panic!("expected RefreshTokenFailed, got {other:?}"),
+    }
+    assert!(
+        load_auth_dot_json(
+            codex_home.path(),
+            AuthCredentialsStoreMode::File,
+            AuthKeyringBackendKind::default(),
+        )?
+        .is_none()
+    );
+    assert!(!recovery.as_ref().expect("recovery").has_next());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn workspace_restricted_401_clears_stale_persistent_external_auth() -> anyhow::Result<()> {
+    let codex_home = TempDir::new()?;
+    save_auth(
+        codex_home.path(),
+        &test_auth_dot_json_with_account("old_persistent_account"),
+        AuthCredentialsStoreMode::File,
+        AuthKeyringBackendKind::default(),
+    )?;
+    save_auth(
+        codex_home.path(),
+        &test_chatgpt_auth_tokens_dot_json("account_id", "external-access-token"),
+        AuthCredentialsStoreMode::Ephemeral,
+        AuthKeyringBackendKind::default(),
+    )?;
+    let auth_manager = AuthManager::shared(
+        codex_home.path().to_path_buf(),
+        /*enable_codex_api_key_env*/ false,
+        AuthCredentialsStoreMode::File,
+        /*chatgpt_base_url*/ None,
+        AuthKeyringBackendKind::default(),
+    )
+    .await;
+    assert!(
+        auth_manager
+            .auth_cached()
+            .is_some_and(|auth| { matches!(auth.api_auth_mode(), AuthMode::ChatgptAuthTokens) })
+    );
+    let mut recovery = Some(auth_manager.unauthorized_recovery());
+
+    let err = super::handle_unauthorized(
+        unauthorized_transport(r#"{"error":{"code":"chatgpt_ip_workspace_restricted"}}"#),
+        &mut recovery,
+        &test_session_telemetry(),
+        &test_model_provider(),
+        /*rejected_auth*/ None,
+    )
+    .await
+    .expect_err("matching 401 should force reauth without retry");
+
+    assert!(matches!(err, CodexErr::RefreshTokenFailed(_)));
+    assert!(auth_manager.auth_cached().is_none());
+    assert!(
+        load_auth_dot_json(
+            codex_home.path(),
+            AuthCredentialsStoreMode::Ephemeral,
+            AuthKeyringBackendKind::default(),
+        )?
+        .is_none()
+    );
+    assert!(
+        load_auth_dot_json(
+            codex_home.path(),
+            AuthCredentialsStoreMode::File,
+            AuthKeyringBackendKind::default(),
+        )?
+        .is_none()
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn workspace_restricted_stream_401_forces_chatgpt_logout() -> anyhow::Result<()> {
+    let codex_home = TempDir::new()?;
+    save_auth(
+        codex_home.path(),
+        &test_auth_dot_json(),
+        AuthCredentialsStoreMode::File,
+        AuthKeyringBackendKind::default(),
+    )?;
+    let auth_manager = AuthManager::from_auth_for_testing_with_home(
+        CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+        codex_home.path().to_path_buf(),
+    );
+    let api_stream = futures::stream::iter([Err(ApiError::Transport(unauthorized_transport(
+        r#"{"type":"error","status":401,"error":{"code":"chatgpt_ip_workspace_restricted"}}"#,
+    )))]);
+    let (mut stream, _) = super::map_response_events(
+        /*upstream_request_id*/ None,
+        api_stream,
+        test_session_telemetry(),
+        InferenceTraceAttempt::disabled(),
+        test_model_provider(),
+        Some(super::StreamAuthRecovery {
+            auth_recovery: Some(auth_manager.unauthorized_recovery()),
+            rejected_auth: Some(CodexAuth::create_dummy_chatgpt_auth_for_testing()),
+        }),
+    );
+
+    let err = stream
+        .next()
+        .await
+        .expect("stream should yield forced logout error")
+        .expect_err("workspace-restricted stream 401 should force logout");
+
+    assert!(matches!(err, CodexErr::RefreshTokenFailed(_)));
+    assert!(auth_manager.auth_cached().is_none());
+    assert!(
+        load_auth_dot_json(
+            codex_home.path(),
+            AuthCredentialsStoreMode::File,
+            AuthKeyringBackendKind::default(),
+        )?
+        .is_none()
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn workspace_restricted_401_ignores_non_matching_cases() {
     for body in [
         r#"{"error":{"code":"token_expired"}}"#,
         "not json",
@@ -854,6 +931,8 @@ async fn generic_or_malformed_401_uses_existing_recovery_path() {
             unauthorized_transport(body),
             &mut recovery,
             &test_session_telemetry(),
+            &test_model_provider(),
+            /*rejected_auth*/ None,
         )
         .await
         .expect_err("non-matching 401 should fall back to normal recovery");
@@ -861,10 +940,29 @@ async fn generic_or_malformed_401_uses_existing_recovery_path() {
         assert!(matches!(err, CodexErr::RefreshTokenFailed(_)));
         assert!(auth_manager.auth_cached().is_some());
     }
+
+    let auth_manager = AuthManager::from_auth_for_testing(CodexAuth::from_api_key("sk-test"));
+    let mut recovery = Some(auth_manager.unauthorized_recovery());
+    let err = super::handle_unauthorized(
+        unauthorized_transport(r#"{"error":{"code":"chatgpt_ip_workspace_restricted"}}"#),
+        &mut recovery,
+        &test_session_telemetry(),
+        &test_model_provider(),
+        /*rejected_auth*/ None,
+    )
+    .await
+    .expect_err("api key auth should not use ChatGPT forced logout");
+
+    assert!(matches!(err, CodexErr::UnexpectedStatus(_)));
+    assert!(
+        auth_manager
+            .auth_cached()
+            .is_some_and(|auth| auth.is_api_key_auth())
+    );
 }
 
 #[test]
-fn workspace_restricted_error_code_parser_accepts_supported_shapes() {
+fn workspace_restricted_error_code_parser_accepts_body_and_header_shapes() {
     for body in [
         r#"{"error":{"code":"chatgpt_ip_workspace_restricted"}}"#,
         r#"{"code":"chatgpt_ip_workspace_restricted"}"#,
@@ -874,10 +972,7 @@ fn workspace_restricted_error_code_parser_accepts_supported_shapes() {
             &Default::default()
         ));
     }
-}
 
-#[test]
-fn workspace_restricted_error_code_parser_accepts_x_error_json_header() {
     let mut headers = http::HeaderMap::new();
     headers.insert(
         "x-error-json",

--- a/codex-rs/core/src/client_tests.rs
+++ b/codex-rs/core/src/client_tests.rs
@@ -13,25 +13,13 @@ use crate::GenerateAttestationFuture;
 use crate::responses_metadata::CodexResponsesMetadata;
 use crate::test_support::TestCodexResponsesRequestKind;
 use crate::test_support::responses_metadata as test_responses_metadata;
-use base64::Engine;
 use codex_api::ApiError;
 use codex_api::ResponseEvent;
 use codex_api::TransportError;
 use codex_app_server_protocol::AuthMode;
-use codex_config::types::AuthCredentialsStoreMode;
-use codex_login::AuthDotJson;
 use codex_login::AuthFingerprint;
-use codex_login::AuthKeyringBackendKind;
 use codex_login::AuthManager;
 use codex_login::CodexAuth;
-use codex_login::ExternalAuth;
-use codex_login::ExternalAuthFuture;
-use codex_login::ExternalAuthRefreshContext;
-use codex_login::ExternalAuthTokens;
-use codex_login::TokenData;
-use codex_login::load_auth_dot_json;
-use codex_login::save_auth;
-use codex_login::token_data::IdTokenInfo;
 use codex_model_provider::BearerAuthProvider;
 use codex_model_provider::SharedModelProvider;
 use codex_model_provider::create_model_provider;
@@ -167,45 +155,6 @@ fn test_session_telemetry() -> SessionTelemetry {
     )
 }
 
-fn test_auth_dot_json() -> AuthDotJson {
-    test_auth_dot_json_with_account("account_id")
-}
-
-fn test_auth_dot_json_with_account(account_id: &str) -> AuthDotJson {
-    test_auth_dot_json_with_account_and_tokens(account_id, "Access Token", "test")
-}
-
-fn test_auth_dot_json_with_account_and_tokens(
-    account_id: &str,
-    access_token: &str,
-    refresh_token: &str,
-) -> AuthDotJson {
-    AuthDotJson {
-        auth_mode: Some(AuthMode::Chatgpt),
-        openai_api_key: None,
-        tokens: Some(TokenData {
-            id_token: IdTokenInfo {
-                chatgpt_account_id: Some(account_id.to_string()),
-                raw_jwt: fake_jwt_with_account(account_id),
-                ..Default::default()
-            },
-            access_token: access_token.to_string(),
-            refresh_token: refresh_token.to_string(),
-            account_id: Some(account_id.to_string()),
-        }),
-        last_refresh: Some(chrono::Utc::now()),
-        agent_identity: None,
-        personal_access_token: None,
-        bedrock_api_key: None,
-    }
-}
-
-fn test_chatgpt_auth_tokens_dot_json(account_id: &str, access_token: &str) -> AuthDotJson {
-    let mut auth = test_auth_dot_json_with_account_and_tokens(account_id, access_token, "");
-    auth.auth_mode = Some(AuthMode::ChatgptAuthTokens);
-    auth
-}
-
 fn unauthorized_transport(body: &str) -> TransportError {
     unauthorized_transport_with_headers(body, /*headers*/ None)
 }
@@ -219,47 +168,6 @@ fn unauthorized_transport_with_headers(
         url: Some("https://chatgpt.com/backend-api/codex/responses".to_string()),
         headers,
         body: Some(body.to_string()),
-    }
-}
-
-fn fake_jwt_with_account(account_id: &str) -> String {
-    let header = json!({
-        "alg": "none",
-        "typ": "JWT",
-    });
-    let payload = json!({
-        "email": "user@example.com",
-        "https://api.openai.com/auth": {
-            "chatgpt_user_id": "user-12345",
-            "user_id": "user-12345",
-            "chatgpt_account_id": account_id,
-        },
-    });
-    let b64 = |value: serde_json::Value| {
-        base64::engine::general_purpose::URL_SAFE_NO_PAD
-            .encode(serde_json::to_vec(&value).expect("serialize jwt segment"))
-    };
-    format!("{}.{}.{}", b64(header), b64(payload), b64(json!("sig")))
-}
-
-struct TestExternalAuth;
-
-impl ExternalAuth for TestExternalAuth {
-    fn auth_mode(&self) -> AuthMode {
-        AuthMode::ChatgptAuthTokens
-    }
-
-    fn refresh(
-        &self,
-        _context: ExternalAuthRefreshContext,
-    ) -> ExternalAuthFuture<'_, ExternalAuthTokens> {
-        Box::pin(async {
-            Ok(ExternalAuthTokens::chatgpt(
-                "access-token",
-                "account_id",
-                /*chatgpt_plan_type*/ None,
-            ))
-        })
     }
 }
 
@@ -681,10 +589,11 @@ fn auth_request_telemetry_context_tracks_attached_auth_and_retry_phase() {
 }
 
 #[tokio::test]
-async fn workspace_restricted_401_preserves_external_auth_bridge() {
-    let auth_manager =
-        AuthManager::from_auth_for_testing(CodexAuth::create_dummy_chatgpt_auth_for_testing());
-    auth_manager.set_external_auth(Arc::new(TestExternalAuth));
+async fn workspace_restricted_401_forces_chatgpt_logout_without_retry() {
+    let rejected_auth_snapshot = CodexAuth::create_dummy_chatgpt_auth_for_testing();
+    let rejected_auth_fingerprint = AuthFingerprint::from_auth(&rejected_auth_snapshot)
+        .expect("ChatGPT auth can be fingerprinted");
+    let auth_manager = AuthManager::from_auth_for_testing(rejected_auth_snapshot);
     let mut recovery = Some(auth_manager.unauthorized_recovery());
 
     let err = super::handle_unauthorized(
@@ -692,97 +601,7 @@ async fn workspace_restricted_401_preserves_external_auth_bridge() {
         &mut recovery,
         &test_session_telemetry(),
         &test_model_provider(),
-        /*rejected_auth*/ None,
-    )
-    .await
-    .expect_err("matching 401 should force reauth without retry");
-
-    assert!(matches!(err, CodexErr::RefreshTokenFailed(_)));
-    assert!(auth_manager.auth_cached().is_none());
-    assert!(auth_manager.has_external_auth());
-}
-
-#[tokio::test]
-async fn workspace_restricted_401_preserves_newer_same_account_auth() -> anyhow::Result<()> {
-    let codex_home = TempDir::new()?;
-    save_auth(
-        codex_home.path(),
-        &test_auth_dot_json_with_account_and_tokens("account_id", "new-access-token", "new-test"),
-        AuthCredentialsStoreMode::File,
-        AuthKeyringBackendKind::default(),
-    )?;
-    let auth_manager = AuthManager::from_auth_for_testing_with_home(
-        CodexAuth::create_dummy_chatgpt_auth_for_testing(),
-        codex_home.path().to_path_buf(),
-    );
-    let mut recovery = Some(auth_manager.unauthorized_recovery());
-
-    let err = super::handle_unauthorized(
-        unauthorized_transport(r#"{"error":{"code":"chatgpt_ip_workspace_restricted"}}"#),
-        &mut recovery,
-        &test_session_telemetry(),
-        &test_model_provider(),
-        /*rejected_auth*/ None,
-    )
-    .await
-    .expect_err("matching 401 should force reauth without retry");
-
-    assert!(matches!(err, CodexErr::RefreshTokenFailed(_)));
-    let persisted_auth = load_auth_dot_json(
-        codex_home.path(),
-        AuthCredentialsStoreMode::File,
-        AuthKeyringBackendKind::default(),
-    )?
-    .expect("newer auth should not be removed");
-    assert_eq!(
-        persisted_auth
-            .tokens
-            .map(|tokens| tokens.access_token)
-            .as_deref(),
-        Some("new-access-token")
-    );
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn workspace_restricted_401_uses_request_auth_for_forced_logout() -> anyhow::Result<()> {
-    let codex_home = TempDir::new()?;
-    save_auth(
-        codex_home.path(),
-        &test_auth_dot_json_with_account_and_tokens(
-            "account_id",
-            "request-access-token",
-            "request-refresh-token",
-        ),
-        AuthCredentialsStoreMode::File,
-        AuthKeyringBackendKind::default(),
-    )?;
-    let request_auth_manager = AuthManager::shared(
-        codex_home.path().to_path_buf(),
-        /*enable_codex_api_key_env*/ false,
-        AuthCredentialsStoreMode::File,
-        /*chatgpt_base_url*/ None,
-        AuthKeyringBackendKind::default(),
-    )
-    .await;
-    let request_auth = request_auth_manager
-        .auth_cached()
-        .expect("request auth should load");
-    let request_auth_fingerprint =
-        AuthFingerprint::from_auth(&request_auth).expect("request auth can be fingerprinted");
-    let auth_manager = AuthManager::from_auth_for_testing_with_home(
-        CodexAuth::create_dummy_chatgpt_auth_for_testing(),
-        codex_home.path().to_path_buf(),
-    );
-    let mut recovery = Some(auth_manager.unauthorized_recovery());
-
-    let err = super::handle_unauthorized(
-        unauthorized_transport(r#"{"error":{"code":"chatgpt_ip_workspace_restricted"}}"#),
-        &mut recovery,
-        &test_session_telemetry(),
-        &test_model_provider(),
-        Some(&request_auth_fingerprint),
+        Some(&rejected_auth_fingerprint),
     )
     .await
     .expect_err("matching 401 should force reauth without retry");
@@ -796,94 +615,16 @@ async fn workspace_restricted_401_uses_request_auth_for_forced_logout() -> anyho
         }
         other => panic!("expected RefreshTokenFailed, got {other:?}"),
     }
-    assert!(
-        load_auth_dot_json(
-            codex_home.path(),
-            AuthCredentialsStoreMode::File,
-            AuthKeyringBackendKind::default(),
-        )?
-        .is_none()
-    );
-    assert!(!recovery.as_ref().expect("recovery").has_next());
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn workspace_restricted_401_clears_stale_persistent_external_auth() -> anyhow::Result<()> {
-    let codex_home = TempDir::new()?;
-    save_auth(
-        codex_home.path(),
-        &test_auth_dot_json_with_account("old_persistent_account"),
-        AuthCredentialsStoreMode::File,
-        AuthKeyringBackendKind::default(),
-    )?;
-    save_auth(
-        codex_home.path(),
-        &test_chatgpt_auth_tokens_dot_json("account_id", "external-access-token"),
-        AuthCredentialsStoreMode::Ephemeral,
-        AuthKeyringBackendKind::default(),
-    )?;
-    let auth_manager = AuthManager::shared(
-        codex_home.path().to_path_buf(),
-        /*enable_codex_api_key_env*/ false,
-        AuthCredentialsStoreMode::File,
-        /*chatgpt_base_url*/ None,
-        AuthKeyringBackendKind::default(),
-    )
-    .await;
-    assert!(
-        auth_manager
-            .auth_cached()
-            .is_some_and(|auth| { matches!(auth.api_auth_mode(), AuthMode::ChatgptAuthTokens) })
-    );
-    let mut recovery = Some(auth_manager.unauthorized_recovery());
-
-    let err = super::handle_unauthorized(
-        unauthorized_transport(r#"{"error":{"code":"chatgpt_ip_workspace_restricted"}}"#),
-        &mut recovery,
-        &test_session_telemetry(),
-        &test_model_provider(),
-        /*rejected_auth*/ None,
-    )
-    .await
-    .expect_err("matching 401 should force reauth without retry");
-
-    assert!(matches!(err, CodexErr::RefreshTokenFailed(_)));
     assert!(auth_manager.auth_cached().is_none());
-    assert!(
-        load_auth_dot_json(
-            codex_home.path(),
-            AuthCredentialsStoreMode::Ephemeral,
-            AuthKeyringBackendKind::default(),
-        )?
-        .is_none()
-    );
-    assert!(
-        load_auth_dot_json(
-            codex_home.path(),
-            AuthCredentialsStoreMode::File,
-            AuthKeyringBackendKind::default(),
-        )?
-        .is_none()
-    );
-
-    Ok(())
+    assert!(!recovery.as_ref().expect("recovery").has_next());
 }
 
 #[tokio::test]
-async fn workspace_restricted_stream_401_forces_chatgpt_logout() -> anyhow::Result<()> {
-    let codex_home = TempDir::new()?;
-    save_auth(
-        codex_home.path(),
-        &test_auth_dot_json(),
-        AuthCredentialsStoreMode::File,
-        AuthKeyringBackendKind::default(),
-    )?;
-    let auth_manager = AuthManager::from_auth_for_testing_with_home(
-        CodexAuth::create_dummy_chatgpt_auth_for_testing(),
-        codex_home.path().to_path_buf(),
-    );
+async fn workspace_restricted_stream_401_forces_chatgpt_logout() {
+    let rejected_auth_snapshot = CodexAuth::create_dummy_chatgpt_auth_for_testing();
+    let rejected_auth_fingerprint = AuthFingerprint::from_auth(&rejected_auth_snapshot)
+        .expect("ChatGPT auth can be fingerprinted");
+    let auth_manager = AuthManager::from_auth_for_testing(rejected_auth_snapshot);
     let api_stream = futures::stream::iter([Err(ApiError::Transport(unauthorized_transport(
         r#"{"type":"error","status":401,"error":{"code":"chatgpt_ip_workspace_restricted"}}"#,
     )))]);
@@ -895,9 +636,7 @@ async fn workspace_restricted_stream_401_forces_chatgpt_logout() -> anyhow::Resu
         test_model_provider(),
         Some(super::StreamAuthRecovery {
             auth_recovery: Some(auth_manager.unauthorized_recovery()),
-            rejected_auth: AuthFingerprint::from_auth(
-                &CodexAuth::create_dummy_chatgpt_auth_for_testing(),
-            ),
+            rejected_auth_fingerprint: Some(rejected_auth_fingerprint),
         }),
     );
 
@@ -909,42 +648,26 @@ async fn workspace_restricted_stream_401_forces_chatgpt_logout() -> anyhow::Resu
 
     assert!(matches!(err, CodexErr::RefreshTokenFailed(_)));
     assert!(auth_manager.auth_cached().is_none());
-    assert!(
-        load_auth_dot_json(
-            codex_home.path(),
-            AuthCredentialsStoreMode::File,
-            AuthKeyringBackendKind::default(),
-        )?
-        .is_none()
-    );
-
-    Ok(())
 }
 
 #[tokio::test]
 async fn workspace_restricted_401_ignores_non_matching_cases() {
-    for body in [
-        r#"{"error":{"code":"token_expired"}}"#,
-        "not json",
-        r#"{"error":{"message":"missing code"}}"#,
-    ] {
-        let auth_manager =
-            AuthManager::from_auth_for_testing(CodexAuth::create_dummy_chatgpt_auth_for_testing());
-        let mut recovery = Some(auth_manager.unauthorized_recovery());
+    let auth_manager =
+        AuthManager::from_auth_for_testing(CodexAuth::create_dummy_chatgpt_auth_for_testing());
+    let mut recovery = Some(auth_manager.unauthorized_recovery());
 
-        let err = super::handle_unauthorized(
-            unauthorized_transport(body),
-            &mut recovery,
-            &test_session_telemetry(),
-            &test_model_provider(),
-            /*rejected_auth*/ None,
-        )
-        .await
-        .expect_err("non-matching 401 should fall back to normal recovery");
+    let err = super::handle_unauthorized(
+        unauthorized_transport(r#"{"error":{"code":"token_expired"}}"#),
+        &mut recovery,
+        &test_session_telemetry(),
+        &test_model_provider(),
+        /*rejected_auth_fingerprint*/ None,
+    )
+    .await
+    .expect_err("generic 401 should fall back to normal recovery");
 
-        assert!(matches!(err, CodexErr::RefreshTokenFailed(_)));
-        assert!(auth_manager.auth_cached().is_some());
-    }
+    assert!(matches!(err, CodexErr::RefreshTokenFailed(_)));
+    assert!(auth_manager.auth_cached().is_some());
 
     let auth_manager = AuthManager::from_auth_for_testing(CodexAuth::from_api_key("sk-test"));
     let mut recovery = Some(auth_manager.unauthorized_recovery());
@@ -953,7 +676,7 @@ async fn workspace_restricted_401_ignores_non_matching_cases() {
         &mut recovery,
         &test_session_telemetry(),
         &test_model_provider(),
-        /*rejected_auth*/ None,
+        /*rejected_auth_fingerprint*/ None,
     )
     .await
     .expect_err("api key auth should not use ChatGPT forced logout");
@@ -968,14 +691,23 @@ async fn workspace_restricted_401_ignores_non_matching_cases() {
 
 #[test]
 fn workspace_restricted_error_code_parser_accepts_body_and_header_shapes() {
-    for body in [
-        r#"{"error":{"code":"chatgpt_ip_workspace_restricted"}}"#,
-        r#"{"code":"chatgpt_ip_workspace_restricted"}"#,
+    for (body, expected) in [
+        (
+            r#"{"error":{"code":"chatgpt_ip_workspace_restricted"}}"#,
+            true,
+        ),
+        (r#"{"code":"chatgpt_ip_workspace_restricted"}"#, true),
+        (r#"{"error":{"code":"token_expired"}}"#, false),
+        ("not json", false),
+        (r#"{"error":{"message":"missing code"}}"#, false),
     ] {
-        assert!(super::is_chatgpt_ip_workspace_restricted_unauthorized(
-            &unauthorized_transport(body),
-            &Default::default()
-        ));
+        assert_eq!(
+            super::is_chatgpt_ip_workspace_restricted_unauthorized(
+                &unauthorized_transport(body),
+                &Default::default()
+            ),
+            expected
+        );
     }
 
     let mut headers = http::HeaderMap::new();

--- a/codex-rs/core/src/client_tests.rs
+++ b/codex-rs/core/src/client_tests.rs
@@ -505,7 +505,7 @@ async fn bedrock_unauthorized_error_uses_provider_mapping() {
         &mut auth_recovery,
         &test_session_telemetry(),
         &provider,
-        /*rejected_auth*/ None,
+        /*rejected_auth_fingerprint*/ None,
     )
     .await
     .expect_err("expired Bedrock signature should fail");

--- a/codex-rs/core/src/client_tests.rs
+++ b/codex-rs/core/src/client_tests.rs
@@ -13,6 +13,7 @@ use crate::GenerateAttestationFuture;
 use crate::responses_metadata::CodexResponsesMetadata;
 use crate::test_support::TestCodexResponsesRequestKind;
 use crate::test_support::responses_metadata as test_responses_metadata;
+use base64::Engine;
 use codex_api::ApiError;
 use codex_api::ResponseEvent;
 use codex_api::TransportError;
@@ -22,9 +23,14 @@ use codex_login::AuthDotJson;
 use codex_login::AuthKeyringBackendKind;
 use codex_login::AuthManager;
 use codex_login::CodexAuth;
+use codex_login::ExternalAuth;
+use codex_login::ExternalAuthFuture;
+use codex_login::ExternalAuthRefreshContext;
+use codex_login::ExternalAuthTokens;
 use codex_login::TokenData;
 use codex_login::load_auth_dot_json;
 use codex_login::save_auth;
+use codex_login::token_data::IdTokenInfo;
 use codex_model_provider::BearerAuthProvider;
 use codex_model_provider::SharedModelProvider;
 use codex_model_provider::create_model_provider;
@@ -161,14 +167,30 @@ fn test_session_telemetry() -> SessionTelemetry {
 }
 
 fn test_auth_dot_json() -> AuthDotJson {
+    test_auth_dot_json_with_account("account_id")
+}
+
+fn test_auth_dot_json_with_account(account_id: &str) -> AuthDotJson {
+    test_auth_dot_json_with_account_and_tokens(account_id, "Access Token", "test")
+}
+
+fn test_auth_dot_json_with_account_and_tokens(
+    account_id: &str,
+    access_token: &str,
+    refresh_token: &str,
+) -> AuthDotJson {
     AuthDotJson {
         auth_mode: Some(AuthMode::Chatgpt),
         openai_api_key: None,
         tokens: Some(TokenData {
-            id_token: Default::default(),
-            access_token: "access-token".to_string(),
-            refresh_token: "refresh-token".to_string(),
-            account_id: Some("account_id".to_string()),
+            id_token: IdTokenInfo {
+                chatgpt_account_id: Some(account_id.to_string()),
+                raw_jwt: fake_jwt_with_account(account_id),
+                ..Default::default()
+            },
+            access_token: access_token.to_string(),
+            refresh_token: refresh_token.to_string(),
+            account_id: Some(account_id.to_string()),
         }),
         last_refresh: Some(chrono::Utc::now()),
         agent_identity: None,
@@ -178,11 +200,59 @@ fn test_auth_dot_json() -> AuthDotJson {
 }
 
 fn unauthorized_transport(body: &str) -> TransportError {
+    unauthorized_transport_with_headers(body, None)
+}
+
+fn unauthorized_transport_with_headers(
+    body: &str,
+    headers: Option<http::HeaderMap>,
+) -> TransportError {
     TransportError::Http {
         status: http::StatusCode::UNAUTHORIZED,
         url: Some("https://chatgpt.com/backend-api/codex/responses".to_string()),
-        headers: None,
+        headers,
         body: Some(body.to_string()),
+    }
+}
+
+fn fake_jwt_with_account(account_id: &str) -> String {
+    let header = json!({
+        "alg": "none",
+        "typ": "JWT",
+    });
+    let payload = json!({
+        "email": "user@example.com",
+        "https://api.openai.com/auth": {
+            "chatgpt_user_id": "user-12345",
+            "user_id": "user-12345",
+            "chatgpt_account_id": account_id,
+        },
+    });
+    let b64 = |value: serde_json::Value| {
+        base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(serde_json::to_vec(&value).expect("serialize jwt segment"))
+    };
+    format!("{}.{}.{}", b64(header), b64(payload), b64(json!("sig")))
+}
+
+struct TestExternalAuth;
+
+impl ExternalAuth for TestExternalAuth {
+    fn auth_mode(&self) -> AuthMode {
+        AuthMode::ChatgptAuthTokens
+    }
+
+    fn refresh(
+        &self,
+        _context: ExternalAuthRefreshContext,
+    ) -> ExternalAuthFuture<'_, ExternalAuthTokens> {
+        Box::pin(async {
+            Ok(ExternalAuthTokens::chatgpt(
+                "access-token",
+                "account_id",
+                None,
+            ))
+        })
     }
 }
 
@@ -668,6 +738,108 @@ async fn workspace_restricted_401_does_not_clear_api_key_auth() {
 }
 
 #[tokio::test]
+async fn workspace_restricted_401_preserves_external_auth_bridge() {
+    let auth_manager =
+        AuthManager::from_auth_for_testing(CodexAuth::create_dummy_chatgpt_auth_for_testing());
+    auth_manager.set_external_auth(Arc::new(TestExternalAuth));
+    let mut recovery = Some(auth_manager.unauthorized_recovery());
+
+    let err = super::handle_unauthorized(
+        unauthorized_transport(r#"{"error":{"code":"chatgpt_ip_workspace_restricted"}}"#),
+        &mut recovery,
+        &test_session_telemetry(),
+    )
+    .await
+    .expect_err("matching 401 should force reauth without retry");
+
+    assert!(matches!(err, CodexErr::RefreshTokenFailed(_)));
+    assert!(auth_manager.auth_cached().is_none());
+    assert!(auth_manager.has_external_auth());
+}
+
+#[tokio::test]
+async fn workspace_restricted_401_preserves_replacement_auth() -> anyhow::Result<()> {
+    let codex_home = TempDir::new()?;
+    save_auth(
+        codex_home.path(),
+        &test_auth_dot_json_with_account("replacement_account"),
+        AuthCredentialsStoreMode::File,
+        AuthKeyringBackendKind::default(),
+    )?;
+    let auth_manager = AuthManager::from_auth_for_testing_with_home(
+        CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+        codex_home.path().to_path_buf(),
+    );
+    let mut recovery = Some(auth_manager.unauthorized_recovery());
+
+    let err = super::handle_unauthorized(
+        unauthorized_transport(r#"{"error":{"code":"chatgpt_ip_workspace_restricted"}}"#),
+        &mut recovery,
+        &test_session_telemetry(),
+    )
+    .await
+    .expect_err("matching 401 should force reauth without retry");
+
+    assert!(matches!(err, CodexErr::RefreshTokenFailed(_)));
+    let persisted_auth = load_auth_dot_json(
+        codex_home.path(),
+        AuthCredentialsStoreMode::File,
+        AuthKeyringBackendKind::default(),
+    )?
+    .expect("replacement auth should not be removed");
+    assert_eq!(
+        persisted_auth
+            .tokens
+            .and_then(|tokens| tokens.account_id)
+            .as_deref(),
+        Some("replacement_account")
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn workspace_restricted_401_preserves_newer_same_account_auth() -> anyhow::Result<()> {
+    let codex_home = TempDir::new()?;
+    save_auth(
+        codex_home.path(),
+        &test_auth_dot_json_with_account_and_tokens("account_id", "new-access-token", "new-test"),
+        AuthCredentialsStoreMode::File,
+        AuthKeyringBackendKind::default(),
+    )?;
+    let auth_manager = AuthManager::from_auth_for_testing_with_home(
+        CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+        codex_home.path().to_path_buf(),
+    );
+    let mut recovery = Some(auth_manager.unauthorized_recovery());
+
+    let err = super::handle_unauthorized(
+        unauthorized_transport(r#"{"error":{"code":"chatgpt_ip_workspace_restricted"}}"#),
+        &mut recovery,
+        &test_session_telemetry(),
+    )
+    .await
+    .expect_err("matching 401 should force reauth without retry");
+
+    assert!(matches!(err, CodexErr::RefreshTokenFailed(_)));
+    let persisted_auth = load_auth_dot_json(
+        codex_home.path(),
+        AuthCredentialsStoreMode::File,
+        AuthKeyringBackendKind::default(),
+    )?
+    .expect("newer auth should not be removed");
+    assert_eq!(
+        persisted_auth
+            .tokens
+            .map(|tokens| tokens.access_token)
+            .as_deref(),
+        Some("new-access-token")
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn generic_or_malformed_401_uses_existing_recovery_path() {
     for body in [
         r#"{"error":{"code":"token_expired"}}"#,
@@ -698,9 +870,30 @@ fn workspace_restricted_error_code_parser_accepts_supported_shapes() {
         r#"{"code":"chatgpt_ip_workspace_restricted"}"#,
     ] {
         assert!(super::is_chatgpt_ip_workspace_restricted_unauthorized(
-            &unauthorized_transport(body)
+            &unauthorized_transport(body),
+            &Default::default()
         ));
     }
+}
+
+#[test]
+fn workspace_restricted_error_code_parser_accepts_x_error_json_header() {
+    let mut headers = http::HeaderMap::new();
+    headers.insert(
+        "x-error-json",
+        http::HeaderValue::from_static(
+            "eyJlcnJvciI6eyJjb2RlIjoiY2hhdGdwdF9pcF93b3Jrc3BhY2VfcmVzdHJpY3RlZCJ9fQ==",
+        ),
+    );
+    let transport = unauthorized_transport_with_headers(
+        r#"{"error":{"code":"different_error_code"}}"#,
+        Some(headers),
+    );
+    let debug = codex_response_debug_context::extract_response_debug_context(&transport);
+
+    assert!(super::is_chatgpt_ip_workspace_restricted_unauthorized(
+        &transport, &debug
+    ));
 }
 
 fn model_client_with_counting_attestation(

--- a/codex-rs/core/src/client_tests.rs
+++ b/codex-rs/core/src/client_tests.rs
@@ -17,8 +17,14 @@ use codex_api::ApiError;
 use codex_api::ResponseEvent;
 use codex_api::TransportError;
 use codex_app_server_protocol::AuthMode;
+use codex_config::types::AuthCredentialsStoreMode;
+use codex_login::AuthDotJson;
+use codex_login::AuthKeyringBackendKind;
 use codex_login::AuthManager;
 use codex_login::CodexAuth;
+use codex_login::TokenData;
+use codex_login::load_auth_dot_json;
+use codex_login::save_auth;
 use codex_model_provider::BearerAuthProvider;
 use codex_model_provider::SharedModelProvider;
 use codex_model_provider::create_model_provider;
@@ -28,6 +34,7 @@ use codex_model_provider_info::WireApi;
 use codex_model_provider_info::create_oss_provider_with_base_url;
 use codex_otel::SessionTelemetry;
 use codex_protocol::ThreadId;
+use codex_protocol::error::CodexErr;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::openai_models::ModelInfo;
@@ -151,6 +158,32 @@ fn test_session_telemetry() -> SessionTelemetry {
         "test-terminal".to_string(),
         SessionSource::Cli,
     )
+}
+
+fn test_auth_dot_json() -> AuthDotJson {
+    AuthDotJson {
+        auth_mode: Some(AuthMode::Chatgpt),
+        openai_api_key: None,
+        tokens: Some(TokenData {
+            id_token: Default::default(),
+            access_token: "access-token".to_string(),
+            refresh_token: "refresh-token".to_string(),
+            account_id: Some("account_id".to_string()),
+        }),
+        last_refresh: Some(chrono::Utc::now()),
+        agent_identity: None,
+        personal_access_token: None,
+        bedrock_api_key: None,
+    }
+}
+
+fn unauthorized_transport(body: &str) -> TransportError {
+    TransportError::Http {
+        status: http::StatusCode::UNAUTHORIZED,
+        url: Some("https://chatgpt.com/backend-api/codex/responses".to_string()),
+        headers: None,
+        body: Some(body.to_string()),
+    }
 }
 
 #[derive(Default)]
@@ -564,6 +597,110 @@ fn auth_request_telemetry_context_tracks_attached_auth_and_retry_phase() {
     assert!(auth_context.retry_after_unauthorized);
     assert_eq!(auth_context.recovery_mode, Some("managed"));
     assert_eq!(auth_context.recovery_phase, Some("refresh_token"));
+}
+
+#[tokio::test]
+async fn workspace_restricted_401_forces_chatgpt_logout() -> anyhow::Result<()> {
+    let codex_home = TempDir::new()?;
+    save_auth(
+        codex_home.path(),
+        &test_auth_dot_json(),
+        AuthCredentialsStoreMode::File,
+        AuthKeyringBackendKind::default(),
+    )?;
+    let auth_manager = AuthManager::from_auth_for_testing_with_home(
+        CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+        codex_home.path().to_path_buf(),
+    );
+    assert!(auth_manager.auth_cached().is_some());
+
+    let mut recovery = Some(auth_manager.unauthorized_recovery());
+    let err = super::handle_unauthorized(
+        unauthorized_transport(r#"{"error":{"code":"chatgpt_ip_workspace_restricted"}}"#),
+        &mut recovery,
+        &test_session_telemetry(),
+    )
+    .await
+    .expect_err("matching 401 should force reauth without retry");
+
+    match err {
+        CodexErr::RefreshTokenFailed(failed) => {
+            assert_eq!(
+                failed.message,
+                "Your ChatGPT session is no longer authorized for this network or workspace. Please sign in again and choose an allowed workspace."
+            );
+        }
+        other => panic!("expected RefreshTokenFailed, got {other:?}"),
+    }
+    assert!(auth_manager.auth_cached().is_none());
+    assert!(
+        load_auth_dot_json(
+            codex_home.path(),
+            AuthCredentialsStoreMode::File,
+            AuthKeyringBackendKind::default(),
+        )?
+        .is_none()
+    );
+    assert!(!recovery.as_ref().expect("recovery").has_next());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn workspace_restricted_401_does_not_clear_api_key_auth() {
+    let auth_manager = AuthManager::from_auth_for_testing(CodexAuth::from_api_key("sk-test"));
+    let mut recovery = Some(auth_manager.unauthorized_recovery());
+
+    let err = super::handle_unauthorized(
+        unauthorized_transport(r#"{"error":{"code":"chatgpt_ip_workspace_restricted"}}"#),
+        &mut recovery,
+        &test_session_telemetry(),
+    )
+    .await
+    .expect_err("api key auth should not use ChatGPT forced logout");
+
+    assert!(matches!(err, CodexErr::UnexpectedStatus(_)));
+    assert!(
+        auth_manager
+            .auth_cached()
+            .is_some_and(|auth| auth.is_api_key_auth())
+    );
+}
+
+#[tokio::test]
+async fn generic_or_malformed_401_uses_existing_recovery_path() {
+    for body in [
+        r#"{"error":{"code":"token_expired"}}"#,
+        "not json",
+        r#"{"error":{"message":"missing code"}}"#,
+    ] {
+        let auth_manager =
+            AuthManager::from_auth_for_testing(CodexAuth::create_dummy_chatgpt_auth_for_testing());
+        let mut recovery = Some(auth_manager.unauthorized_recovery());
+
+        let err = super::handle_unauthorized(
+            unauthorized_transport(body),
+            &mut recovery,
+            &test_session_telemetry(),
+        )
+        .await
+        .expect_err("non-matching 401 should fall back to normal recovery");
+
+        assert!(matches!(err, CodexErr::RefreshTokenFailed(_)));
+        assert!(auth_manager.auth_cached().is_some());
+    }
+}
+
+#[test]
+fn workspace_restricted_error_code_parser_accepts_supported_shapes() {
+    for body in [
+        r#"{"error":{"code":"chatgpt_ip_workspace_restricted"}}"#,
+        r#"{"code":"chatgpt_ip_workspace_restricted"}"#,
+    ] {
+        assert!(super::is_chatgpt_ip_workspace_restricted_unauthorized(
+            &unauthorized_transport(body)
+        ));
+    }
 }
 
 fn model_client_with_counting_attestation(

--- a/codex-rs/login/Cargo.toml
+++ b/codex-rs/login/Cargo.toml
@@ -21,6 +21,7 @@ codex-protocol = { workspace = true }
 codex-secrets = { workspace = true }
 codex-terminal-detection = { workspace = true }
 codex-utils-template = { workspace = true }
+hmac = { workspace = true }
 once_cell = { workspace = true }
 os_info = { workspace = true }
 rand = { workspace = true }

--- a/codex-rs/login/src/auth/auth_tests.rs
+++ b/codex-rs/login/src/auth/auth_tests.rs
@@ -940,7 +940,7 @@ async fn unauthorized_recovery_reports_mode_and_step_names() {
         manager: Arc::clone(&manager),
         step: UnauthorizedRecoveryStep::Reload,
         expected_account_id: None,
-        rejected_auth: None,
+        rejected_auth_snapshot: None,
         mode: UnauthorizedRecoveryMode::Managed,
     };
     assert_eq!(managed.mode_name(), "managed");
@@ -950,7 +950,7 @@ async fn unauthorized_recovery_reports_mode_and_step_names() {
         manager,
         step: UnauthorizedRecoveryStep::ExternalRefresh,
         expected_account_id: None,
-        rejected_auth: None,
+        rejected_auth_snapshot: None,
         mode: UnauthorizedRecoveryMode::External,
     };
     assert_eq!(external.mode_name(), "external");
@@ -1608,6 +1608,60 @@ fn auth_fingerprint_debug_redacts_auth_material() {
     assert!(!debug.contains("account_id"));
 }
 
+fn test_auth_dot_json_with_mode_and_tokens(
+    auth_mode: AuthMode,
+    account_id: &str,
+    access_token: &str,
+    refresh_token: &str,
+) -> AuthDotJson {
+    let id_token = fake_jwt_for_auth_file_params(&AuthFileParams {
+        openai_api_key: None,
+        chatgpt_plan_type: None,
+        chatgpt_account_id: Some(account_id.to_string()),
+    })
+    .expect("fake jwt should serialize");
+    AuthDotJson {
+        auth_mode: Some(auth_mode),
+        openai_api_key: None,
+        tokens: Some(TokenData {
+            id_token: IdTokenInfo {
+                chatgpt_account_id: Some(account_id.to_string()),
+                raw_jwt: id_token,
+                ..Default::default()
+            },
+            access_token: access_token.to_string(),
+            refresh_token: refresh_token.to_string(),
+            account_id: Some(account_id.to_string()),
+        }),
+        last_refresh: Some(Utc::now()),
+        agent_identity: None,
+        personal_access_token: None,
+        bedrock_api_key: None,
+    }
+}
+
+fn test_chatgpt_auth_dot_json(
+    account_id: &str,
+    access_token: &str,
+    refresh_token: &str,
+) -> AuthDotJson {
+    test_auth_dot_json_with_mode_and_tokens(
+        AuthMode::Chatgpt,
+        account_id,
+        access_token,
+        refresh_token,
+    )
+}
+
+fn test_chatgpt_auth_tokens_dot_json(account_id: &str, access_token: &str) -> AuthDotJson {
+    test_auth_dot_json_with_mode_and_tokens(
+        AuthMode::ChatgptAuthTokens,
+        account_id,
+        access_token,
+        "",
+    )
+}
+
 #[tokio::test]
 #[serial(codex_auth_env)]
 async fn forced_server_auth_rejection_does_not_reload_access_token_env() {
@@ -1625,11 +1679,11 @@ async fn forced_server_auth_rejection_does_not_reload_access_token_env() {
         .await;
     let _authapi_guard = EnvVarGuard::set("CODEX_AUTHAPI_BASE_URL", &server.uri());
     let _access_token_guard = EnvVarGuard::set(CODEX_ACCESS_TOKEN_ENV_VAR, "at-env-test");
-    let rejected_auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
-    let rejected_auth_fingerprint =
-        AuthFingerprint::from_auth(&rejected_auth).expect("ChatGPT auth can be fingerprinted");
+    let rejected_auth_snapshot = CodexAuth::create_dummy_chatgpt_auth_for_testing();
+    let rejected_auth_fingerprint = AuthFingerprint::from_auth(&rejected_auth_snapshot)
+        .expect("ChatGPT auth can be fingerprinted");
     let manager = AuthManager::from_auth_for_testing_with_home(
-        rejected_auth.clone(),
+        rejected_auth_snapshot.clone(),
         codex_home.path().to_path_buf(),
     );
 
@@ -1641,6 +1695,101 @@ async fn forced_server_auth_rejection_does_not_reload_access_token_env() {
     assert!(changed);
     assert!(manager.auth_cached().is_none());
     server.verify().await;
+}
+
+#[tokio::test]
+async fn forced_server_auth_rejection_preserves_newer_same_account_auth() {
+    let codex_home = tempdir().unwrap();
+    save_auth(
+        codex_home.path(),
+        &test_chatgpt_auth_dot_json("account_id", "new-access-token", "new-refresh-token"),
+        AuthCredentialsStoreMode::File,
+        AuthKeyringBackendKind::default(),
+    )
+    .expect("seed newer auth");
+    let rejected_auth_snapshot = CodexAuth::create_dummy_chatgpt_auth_for_testing();
+    let rejected_auth_fingerprint = AuthFingerprint::from_auth(&rejected_auth_snapshot)
+        .expect("ChatGPT auth can be fingerprinted");
+    let manager = AuthManager::from_auth_for_testing_with_home(
+        rejected_auth_snapshot,
+        codex_home.path().to_path_buf(),
+    );
+
+    manager
+        .force_logout_due_to_server_auth_rejection(Some(&rejected_auth_fingerprint))
+        .await
+        .expect("forced logout should succeed");
+
+    let persisted_auth = load_auth_dot_json(
+        codex_home.path(),
+        AuthCredentialsStoreMode::File,
+        AuthKeyringBackendKind::default(),
+    )
+    .expect("load auth")
+    .expect("newer auth should not be removed");
+    assert_eq!(
+        persisted_auth
+            .tokens
+            .map(|tokens| tokens.access_token)
+            .as_deref(),
+        Some("new-access-token")
+    );
+}
+
+#[tokio::test]
+async fn forced_server_auth_rejection_clears_stale_persistent_external_auth() {
+    let codex_home = tempdir().unwrap();
+    save_auth(
+        codex_home.path(),
+        &test_chatgpt_auth_dot_json("old_persistent_account", "old-access-token", "old-refresh"),
+        AuthCredentialsStoreMode::File,
+        AuthKeyringBackendKind::default(),
+    )
+    .expect("seed stale persistent auth");
+    save_auth(
+        codex_home.path(),
+        &test_chatgpt_auth_tokens_dot_json("account_id", "external-access-token"),
+        AuthCredentialsStoreMode::Ephemeral,
+        AuthKeyringBackendKind::default(),
+    )
+    .expect("seed ephemeral external auth");
+    let manager = AuthManager::shared(
+        codex_home.path().to_path_buf(),
+        /*enable_codex_api_key_env*/ false,
+        AuthCredentialsStoreMode::File,
+        /*chatgpt_base_url*/ None,
+        AuthKeyringBackendKind::default(),
+    )
+    .await;
+    let rejected_auth_fingerprint =
+        AuthFingerprint::from_auth(&manager.auth_cached().expect("external auth should load"))
+            .expect("ChatGPT auth can be fingerprinted");
+
+    let changed = manager
+        .force_logout_due_to_server_auth_rejection(Some(&rejected_auth_fingerprint))
+        .await
+        .expect("forced logout should succeed");
+
+    assert!(changed);
+    assert!(manager.auth_cached().is_none());
+    assert!(
+        load_auth_dot_json(
+            codex_home.path(),
+            AuthCredentialsStoreMode::Ephemeral,
+            AuthKeyringBackendKind::default(),
+        )
+        .expect("load ephemeral auth")
+        .is_none()
+    );
+    assert!(
+        load_auth_dot_json(
+            codex_home.path(),
+            AuthCredentialsStoreMode::File,
+            AuthKeyringBackendKind::default(),
+        )
+        .expect("load file auth")
+        .is_none()
+    );
 }
 
 #[tokio::test]

--- a/codex-rs/login/src/auth/auth_tests.rs
+++ b/codex-rs/login/src/auth/auth_tests.rs
@@ -1757,8 +1757,10 @@ async fn forced_server_auth_rejection_clears_stale_persistent_external_auth() {
         codex_home.path().to_path_buf(),
         /*enable_codex_api_key_env*/ false,
         AuthCredentialsStoreMode::File,
+        /*forced_chatgpt_workspace_id*/ None,
         /*chatgpt_base_url*/ None,
         AuthKeyringBackendKind::default(),
+        /*auth_route_config*/ None,
     )
     .await;
     let rejected_auth_fingerprint =

--- a/codex-rs/login/src/auth/auth_tests.rs
+++ b/codex-rs/login/src/auth/auth_tests.rs
@@ -940,6 +940,7 @@ async fn unauthorized_recovery_reports_mode_and_step_names() {
         manager: Arc::clone(&manager),
         step: UnauthorizedRecoveryStep::Reload,
         expected_account_id: None,
+        rejected_auth: None,
         mode: UnauthorizedRecoveryMode::Managed,
     };
     assert_eq!(managed.mode_name(), "managed");
@@ -949,6 +950,7 @@ async fn unauthorized_recovery_reports_mode_and_step_names() {
         manager,
         step: UnauthorizedRecoveryStep::ExternalRefresh,
         expected_account_id: None,
+        rejected_auth: None,
         mode: UnauthorizedRecoveryMode::External,
     };
     assert_eq!(external.mode_name(), "external");

--- a/codex-rs/login/src/auth/auth_tests.rs
+++ b/codex-rs/login/src/auth/auth_tests.rs
@@ -1594,6 +1594,55 @@ async fn personal_access_token_does_not_offer_unauthorized_recovery() {
     server.verify().await;
 }
 
+#[test]
+fn auth_fingerprint_debug_redacts_auth_material() {
+    let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
+    let fingerprint = AuthFingerprint::from_auth(&auth).expect("ChatGPT auth can be fingerprinted");
+
+    let debug = format!("{fingerprint:?}");
+
+    assert!(debug.contains("AuthFingerprint"));
+    assert!(debug.contains("fingerprint_prefix"));
+    assert!(!debug.contains("Access Token"));
+    assert!(!debug.contains("test"));
+    assert!(!debug.contains("account_id"));
+}
+
+#[tokio::test]
+#[serial(codex_auth_env)]
+async fn forced_server_auth_rejection_does_not_reload_access_token_env() {
+    let codex_home = tempdir().unwrap();
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/user-auth-credential/whoami"))
+        .and(header("authorization", "Bearer at-env-test"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(personal_access_token_whoami(WORKSPACE_ID_ALLOWED)),
+        )
+        .expect(0)
+        .mount(&server)
+        .await;
+    let _authapi_guard = EnvVarGuard::set("CODEX_AUTHAPI_BASE_URL", &server.uri());
+    let _access_token_guard = EnvVarGuard::set(CODEX_ACCESS_TOKEN_ENV_VAR, "at-env-test");
+    let rejected_auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
+    let rejected_auth_fingerprint =
+        AuthFingerprint::from_auth(&rejected_auth).expect("ChatGPT auth can be fingerprinted");
+    let manager = AuthManager::from_auth_for_testing_with_home(
+        rejected_auth.clone(),
+        codex_home.path().to_path_buf(),
+    );
+
+    let changed = manager
+        .force_logout_due_to_server_auth_rejection(Some(&rejected_auth_fingerprint))
+        .await
+        .expect("forced logout should succeed");
+
+    assert!(changed);
+    assert!(manager.auth_cached().is_none());
+    server.verify().await;
+}
+
 #[tokio::test]
 #[serial(codex_auth_env)]
 async fn load_auth_keeps_codex_api_key_env_precedence() {

--- a/codex-rs/login/src/auth/manager.rs
+++ b/codex-rs/login/src/auth/manager.rs
@@ -1324,17 +1324,17 @@ fn logout_all_stores(
     Ok(removed_ephemeral || removed_managed)
 }
 
-fn logout_store_matching_rejected_auth(
+fn logout_store_matching_rejected_auth_fingerprint(
     codex_home: &Path,
     auth_credentials_store_mode: AuthCredentialsStoreMode,
     keyring_backend_kind: AuthKeyringBackendKind,
-    rejected_auth: &AuthFingerprint,
+    rejected_auth_fingerprint: &AuthFingerprint,
 ) -> std::io::Result<bool> {
     logout_store_if(
         codex_home,
         auth_credentials_store_mode,
         keyring_backend_kind,
-        |auth_dot_json| rejected_auth.matches_auth_dot_json(auth_dot_json),
+        |auth_dot_json| rejected_auth_fingerprint.matches_auth_dot_json(auth_dot_json),
     )
 }
 
@@ -1848,7 +1848,7 @@ pub struct UnauthorizedRecovery {
     manager: Arc<AuthManager>,
     step: UnauthorizedRecoveryStep,
     expected_account_id: Option<String>,
-    rejected_auth: Option<CodexAuth>,
+    rejected_auth_snapshot: Option<CodexAuth>,
     mode: UnauthorizedRecoveryMode,
 }
 
@@ -1884,7 +1884,7 @@ impl UnauthorizedRecovery {
             manager,
             step,
             expected_account_id,
-            rejected_auth: cached_auth,
+            rejected_auth_snapshot: cached_auth,
             mode,
         }
     }
@@ -1970,16 +1970,17 @@ impl UnauthorizedRecovery {
 
     pub async fn force_logout_due_to_server_auth_rejection(
         &mut self,
-        rejected_auth: Option<&AuthFingerprint>,
+        rejected_auth_fingerprint: Option<&AuthFingerprint>,
     ) -> std::io::Result<bool> {
         self.step = UnauthorizedRecoveryStep::Done;
-        let fallback_rejected_auth = self
-            .rejected_auth
+        let fallback_rejected_auth_fingerprint = self
+            .rejected_auth_snapshot
             .as_ref()
             .and_then(AuthFingerprint::from_auth);
-        let rejected_auth = rejected_auth.or(fallback_rejected_auth.as_ref());
+        let rejected_auth_fingerprint =
+            rejected_auth_fingerprint.or(fallback_rejected_auth_fingerprint.as_ref());
         self.manager
-            .force_logout_due_to_server_auth_rejection(rejected_auth)
+            .force_logout_due_to_server_auth_rejection(rejected_auth_fingerprint)
             .await
     }
 
@@ -2742,13 +2743,14 @@ impl AuthManager {
 
     pub async fn force_logout_due_to_server_auth_rejection(
         &self,
-        rejected_auth: Option<&AuthFingerprint>,
+        rejected_auth_fingerprint: Option<&AuthFingerprint>,
     ) -> std::io::Result<bool> {
         if !self.current_auth_uses_codex_backend() {
             return Ok(false);
         }
 
-        let removal_result = self.logout_stores_matching_rejected_auth(rejected_auth);
+        let removal_result =
+            self.logout_stores_matching_rejected_auth_fingerprint(rejected_auth_fingerprint);
         let cache_changed = self.set_cached_auth(
             self.load_auth_from_storage_without_codex_access_token_env()
                 .await,
@@ -2757,11 +2759,11 @@ impl AuthManager {
         Ok(removed || cache_changed)
     }
 
-    fn logout_stores_matching_rejected_auth(
+    fn logout_stores_matching_rejected_auth_fingerprint(
         &self,
-        rejected_auth: Option<&AuthFingerprint>,
+        rejected_auth_fingerprint: Option<&AuthFingerprint>,
     ) -> std::io::Result<bool> {
-        let Some(rejected_auth) = rejected_auth else {
+        let Some(rejected_auth_fingerprint) = rejected_auth_fingerprint else {
             return logout_all_stores(
                 &self.codex_home,
                 self.auth_credentials_store_mode,
@@ -2769,12 +2771,12 @@ impl AuthManager {
             );
         };
 
-        if rejected_auth.is_external_chatgpt_tokens() {
-            let removed_ephemeral = logout_store_matching_rejected_auth(
+        if rejected_auth_fingerprint.is_external_chatgpt_tokens() {
+            let removed_ephemeral = logout_store_matching_rejected_auth_fingerprint(
                 &self.codex_home,
                 AuthCredentialsStoreMode::Ephemeral,
                 AuthKeyringBackendKind::default(),
-                rejected_auth,
+                rejected_auth_fingerprint,
             )?;
             if self.auth_credentials_store_mode == AuthCredentialsStoreMode::Ephemeral {
                 return Ok(removed_ephemeral);
@@ -2800,35 +2802,35 @@ impl AuthManager {
         }
 
         if self.auth_credentials_store_mode == AuthCredentialsStoreMode::Ephemeral {
-            return logout_store_matching_rejected_auth(
+            return logout_store_matching_rejected_auth_fingerprint(
                 &self.codex_home,
                 AuthCredentialsStoreMode::Ephemeral,
                 AuthKeyringBackendKind::default(),
-                rejected_auth,
+                rejected_auth_fingerprint,
             );
         }
 
-        let removed_ephemeral = logout_store_matching_rejected_auth(
+        let removed_ephemeral = logout_store_matching_rejected_auth_fingerprint(
             &self.codex_home,
             AuthCredentialsStoreMode::Ephemeral,
             AuthKeyringBackendKind::default(),
-            rejected_auth,
+            rejected_auth_fingerprint,
         )?;
         let removed_file = if self.auth_credentials_store_mode == AuthCredentialsStoreMode::File {
             false
         } else {
-            logout_store_matching_rejected_auth(
+            logout_store_matching_rejected_auth_fingerprint(
                 &self.codex_home,
                 AuthCredentialsStoreMode::File,
                 AuthKeyringBackendKind::default(),
-                rejected_auth,
+                rejected_auth_fingerprint,
             )?
         };
-        let removed_managed = logout_store_matching_rejected_auth(
+        let removed_managed = logout_store_matching_rejected_auth_fingerprint(
             &self.codex_home,
             self.auth_credentials_store_mode,
             self.keyring_backend_kind,
-            rejected_auth,
+            rejected_auth_fingerprint,
         )?;
         Ok(removed_ephemeral || removed_file || removed_managed)
     }

--- a/codex-rs/login/src/auth/manager.rs
+++ b/codex-rs/login/src/auth/manager.rs
@@ -1,4 +1,7 @@
 use chrono::Utc;
+use hmac::Hmac;
+use hmac::Mac;
+use rand::RngCore;
 use reqwest::StatusCode;
 use serde::Deserialize;
 use serde::Serialize;
@@ -6,6 +9,7 @@ use serde::Serialize;
 use serial_test::serial;
 use std::env;
 use std::fmt::Debug;
+use std::fmt::Formatter;
 use std::future::Future;
 use std::path::Path;
 use std::path::PathBuf;
@@ -62,7 +66,10 @@ use codex_protocol::auth::RefreshTokenFailedError;
 use codex_protocol::auth::RefreshTokenFailedReason;
 use codex_protocol::protocol::SessionSource;
 use serde_json::Value;
+use sha2::Sha256;
 use thiserror::Error;
+
+type HmacSha256 = Hmac<Sha256>;
 
 /// Authentication mechanism used by the current user.
 #[derive(Debug, Clone)]
@@ -82,6 +89,174 @@ pub enum AgentIdentityAuthPolicy {
     JwtOnly,
     /// Allow managed ChatGPT auth to register or reuse Agent Identity auth.
     ChatGptAuth,
+}
+
+/// A more secure way to match auth credentials without storing or printing raw key material.
+///
+/// The fingerprint is keyed with random in-memory material. Debug output can safely include the
+/// auth kind and a short fingerprint prefix, while matching can still recompute the keyed
+/// fingerprint for candidate stored auth records.
+#[derive(Clone)]
+pub struct AuthFingerprint {
+    kind: ApiAuthMode,
+    fingerprint: [u8; 32],
+    key: [u8; 32],
+}
+
+impl AuthFingerprint {
+    pub fn from_auth(auth: &CodexAuth) -> Option<Self> {
+        let kind = auth.api_auth_mode();
+        let mut key = [0_u8; 32];
+        rand::rng().fill_bytes(&mut key);
+        let fingerprint = match auth {
+            CodexAuth::Chatgpt(_) | CodexAuth::ChatgptAuthTokens(_) => {
+                let auth_dot_json = auth.get_current_auth_json()?;
+                fingerprint_chatgpt_auth_dot_json(kind, &auth_dot_json, &key)?
+            }
+            CodexAuth::AgentIdentity(auth) => fingerprint_agent_identity_record(
+                kind,
+                serde_json::to_vec(auth.record()).ok()?.as_slice(),
+                &key,
+            ),
+            CodexAuth::PersonalAccessToken(auth) => {
+                fingerprint_single_secret(kind, auth.access_token(), &key)
+            }
+            CodexAuth::ApiKey(_) | CodexAuth::BedrockApiKey(_) => return None,
+        };
+
+        Some(Self {
+            kind,
+            fingerprint,
+            key,
+        })
+    }
+
+    fn matches_auth_dot_json(&self, auth_dot_json: &AuthDotJson) -> bool {
+        if auth_dot_json.resolved_mode() != self.kind {
+            return false;
+        }
+
+        let Some(candidate) = fingerprint_auth_dot_json(self.kind, auth_dot_json, &self.key) else {
+            return false;
+        };
+        candidate == self.fingerprint
+    }
+
+    fn is_external_chatgpt_tokens(&self) -> bool {
+        self.kind == ApiAuthMode::ChatgptAuthTokens
+    }
+}
+
+impl Debug for AuthFingerprint {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthFingerprint")
+            .field("kind", &self.kind)
+            .field("fingerprint_prefix", &FingerprintPrefix(&self.fingerprint))
+            .finish()
+    }
+}
+
+struct FingerprintPrefix<'a>(&'a [u8; 32]);
+
+impl Debug for FingerprintPrefix<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        for byte in self.0.iter().take(4) {
+            write!(f, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+fn fingerprint_auth_dot_json(
+    kind: ApiAuthMode,
+    auth_dot_json: &AuthDotJson,
+    key: &[u8; 32],
+) -> Option<[u8; 32]> {
+    match kind {
+        ApiAuthMode::Chatgpt | ApiAuthMode::ChatgptAuthTokens => {
+            fingerprint_chatgpt_auth_dot_json(kind, auth_dot_json, key)
+        }
+        ApiAuthMode::AgentIdentity => {
+            let record = auth_dot_json
+                .agent_identity
+                .as_deref()
+                .and_then(|jwt| AgentIdentityAuthRecord::from_agent_identity_jwt(jwt).ok())?;
+            Some(fingerprint_agent_identity_record(
+                kind,
+                serde_json::to_vec(&record).ok()?.as_slice(),
+                key,
+            ))
+        }
+        ApiAuthMode::PersonalAccessToken => auth_dot_json
+            .personal_access_token
+            .as_deref()
+            .map(|access_token| fingerprint_single_secret(kind, access_token, key)),
+        ApiAuthMode::ApiKey | ApiAuthMode::BedrockApiKey => None,
+    }
+}
+
+fn fingerprint_chatgpt_auth_dot_json(
+    kind: ApiAuthMode,
+    auth_dot_json: &AuthDotJson,
+    key: &[u8; 32],
+) -> Option<[u8; 32]> {
+    let tokens = auth_dot_json.tokens.as_ref()?;
+    let mut mac = auth_fingerprint_mac(kind, key);
+    update_mac_field(&mut mac, tokens.access_token.as_bytes());
+    update_mac_field(&mut mac, tokens.refresh_token.as_bytes());
+    update_mac_optional_field(
+        &mut mac,
+        auth_dot_json_chatgpt_account_id(auth_dot_json).map(str::as_bytes),
+    );
+    Some(mac.finalize().into_bytes().into())
+}
+
+fn fingerprint_agent_identity_record(
+    kind: ApiAuthMode,
+    serialized_record: &[u8],
+    key: &[u8; 32],
+) -> [u8; 32] {
+    let mut mac = auth_fingerprint_mac(kind, key);
+    update_mac_field(&mut mac, serialized_record);
+    mac.finalize().into_bytes().into()
+}
+
+fn fingerprint_single_secret(kind: ApiAuthMode, secret: &str, key: &[u8; 32]) -> [u8; 32] {
+    let mut mac = auth_fingerprint_mac(kind, key);
+    update_mac_field(&mut mac, secret.as_bytes());
+    mac.finalize().into_bytes().into()
+}
+
+fn auth_fingerprint_mac(kind: ApiAuthMode, key: &[u8; 32]) -> HmacSha256 {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts keys of any size");
+    update_mac_field(&mut mac, auth_kind_label(kind));
+    mac
+}
+
+fn auth_kind_label(kind: ApiAuthMode) -> &'static [u8] {
+    match kind {
+        ApiAuthMode::ApiKey => b"ApiKey",
+        ApiAuthMode::Chatgpt => b"Chatgpt",
+        ApiAuthMode::ChatgptAuthTokens => b"ChatgptAuthTokens",
+        ApiAuthMode::AgentIdentity => b"AgentIdentity",
+        ApiAuthMode::PersonalAccessToken => b"PersonalAccessToken",
+        ApiAuthMode::BedrockApiKey => b"BedrockApiKey",
+    }
+}
+
+fn update_mac_optional_field(mac: &mut HmacSha256, value: Option<&[u8]>) {
+    match value {
+        Some(value) => {
+            mac.update(&[1]);
+            update_mac_field(mac, value);
+        }
+        None => mac.update(&[0]),
+    }
+}
+
+fn update_mac_field(mac: &mut HmacSha256, value: &[u8]) {
+    mac.update(&(value.len() as u64).to_be_bytes());
+    mac.update(value);
 }
 
 impl PartialEq for CodexAuth {
@@ -1153,13 +1328,13 @@ fn logout_store_matching_rejected_auth(
     codex_home: &Path,
     auth_credentials_store_mode: AuthCredentialsStoreMode,
     keyring_backend_kind: AuthKeyringBackendKind,
-    rejected_auth: &CodexAuth,
+    rejected_auth: &AuthFingerprint,
 ) -> std::io::Result<bool> {
     logout_store_if(
         codex_home,
         auth_credentials_store_mode,
         keyring_backend_kind,
-        |auth_dot_json| auth_dot_json_matches_rejected_auth(auth_dot_json, rejected_auth),
+        |auth_dot_json| rejected_auth.matches_auth_dot_json(auth_dot_json),
     )
 }
 
@@ -1212,49 +1387,6 @@ fn logout_store_if(
     Ok(removed)
 }
 
-fn auth_dot_json_matches_rejected_auth(
-    auth_dot_json: &AuthDotJson,
-    rejected_auth: &CodexAuth,
-) -> bool {
-    if auth_dot_json.resolved_mode() != rejected_auth.api_auth_mode() {
-        return false;
-    }
-
-    match rejected_auth {
-        CodexAuth::Chatgpt(_) | CodexAuth::ChatgptAuthTokens(_) => {
-            auth_dot_json_matches_rejected_chatgpt_auth(auth_dot_json, rejected_auth)
-        }
-        CodexAuth::AgentIdentity(rejected) => auth_dot_json
-            .agent_identity
-            .as_deref()
-            .and_then(|jwt| AgentIdentityAuthRecord::from_agent_identity_jwt(jwt).ok())
-            .is_some_and(|record| &record == rejected.record()),
-        CodexAuth::PersonalAccessToken(rejected) => {
-            auth_dot_json.personal_access_token.as_deref() == Some(rejected.access_token())
-        }
-        CodexAuth::ApiKey(_) | CodexAuth::BedrockApiKey(_) => false,
-    }
-}
-
-fn auth_dot_json_matches_rejected_chatgpt_auth(
-    auth_dot_json: &AuthDotJson,
-    rejected_auth: &CodexAuth,
-) -> bool {
-    let Some(rejected_auth_dot_json) = rejected_auth.get_current_auth_json() else {
-        return false;
-    };
-    let (Some(tokens), Some(rejected_tokens)) =
-        (&auth_dot_json.tokens, &rejected_auth_dot_json.tokens)
-    else {
-        return false;
-    };
-
-    tokens.access_token == rejected_tokens.access_token
-        && tokens.refresh_token == rejected_tokens.refresh_token
-        && auth_dot_json_chatgpt_account_id(auth_dot_json)
-            == auth_dot_json_chatgpt_account_id(&rejected_auth_dot_json)
-}
-
 fn auth_dot_json_chatgpt_account_id(auth_dot_json: &AuthDotJson) -> Option<&str> {
     auth_dot_json.tokens.as_ref().and_then(|tokens| {
         tokens
@@ -1272,6 +1404,55 @@ fn auth_dot_json_uses_codex_backend(auth_dot_json: &AuthDotJson) -> bool {
 async fn load_auth(
     codex_home: &Path,
     enable_codex_api_key_env: bool,
+    auth_credentials_store_mode: AuthCredentialsStoreMode,
+    forced_chatgpt_workspace_id: Option<&[String]>,
+    chatgpt_base_url: Option<&str>,
+    keyring_backend_kind: AuthKeyringBackendKind,
+    agent_identity_authapi_base_url: Option<&str>,
+    auth_route_config: Option<&AuthRouteConfig>,
+) -> std::io::Result<Option<CodexAuth>> {
+    load_auth_impl(
+        codex_home,
+        enable_codex_api_key_env,
+        /*enable_codex_access_token_env*/ true,
+        auth_credentials_store_mode,
+        forced_chatgpt_workspace_id,
+        chatgpt_base_url,
+        keyring_backend_kind,
+        agent_identity_authapi_base_url,
+        auth_route_config,
+    )
+    .await
+}
+
+async fn load_auth_without_codex_access_token_env(
+    codex_home: &Path,
+    enable_codex_api_key_env: bool,
+    auth_credentials_store_mode: AuthCredentialsStoreMode,
+    forced_chatgpt_workspace_id: Option<&[String]>,
+    chatgpt_base_url: Option<&str>,
+    keyring_backend_kind: AuthKeyringBackendKind,
+    agent_identity_authapi_base_url: Option<&str>,
+    auth_route_config: Option<&AuthRouteConfig>,
+) -> std::io::Result<Option<CodexAuth>> {
+    load_auth_impl(
+        codex_home,
+        enable_codex_api_key_env,
+        /*enable_codex_access_token_env*/ false,
+        auth_credentials_store_mode,
+        forced_chatgpt_workspace_id,
+        chatgpt_base_url,
+        keyring_backend_kind,
+        agent_identity_authapi_base_url,
+        auth_route_config,
+    )
+    .await
+}
+
+async fn load_auth_impl(
+    codex_home: &Path,
+    enable_codex_api_key_env: bool,
+    enable_codex_access_token_env: bool,
     auth_credentials_store_mode: AuthCredentialsStoreMode,
     forced_chatgpt_workspace_id: Option<&[String]>,
     chatgpt_base_url: Option<&str>,
@@ -1308,7 +1489,8 @@ async fn load_auth(
         return Ok(Some(auth));
     }
 
-    if let Some(access_token) = read_codex_access_token_from_env() {
+    if enable_codex_access_token_env && let Some(access_token) = read_codex_access_token_from_env()
+    {
         return match classify_codex_access_token(&access_token) {
             CodexAccessToken::PersonalAccessToken(access_token) => {
                 let auth = PersonalAccessTokenAuth::load(access_token, auth_route_config).await?;
@@ -1788,10 +1970,14 @@ impl UnauthorizedRecovery {
 
     pub async fn force_logout_due_to_server_auth_rejection(
         &mut self,
-        rejected_auth: Option<&CodexAuth>,
+        rejected_auth: Option<&AuthFingerprint>,
     ) -> std::io::Result<bool> {
         self.step = UnauthorizedRecoveryStep::Done;
-        let rejected_auth = rejected_auth.or(self.rejected_auth.as_ref());
+        let fallback_rejected_auth = self
+            .rejected_auth
+            .as_ref()
+            .and_then(AuthFingerprint::from_auth);
+        let rejected_auth = rejected_auth.or(fallback_rejected_auth.as_ref());
         self.manager
             .force_logout_due_to_server_auth_rejection(rejected_auth)
             .await
@@ -2271,6 +2457,23 @@ impl AuthManager {
         .flatten()
     }
 
+    async fn load_auth_from_storage_without_codex_access_token_env(&self) -> Option<CodexAuth> {
+        let forced_chatgpt_workspace_id = self.forced_chatgpt_workspace_id();
+        load_auth_without_codex_access_token_env(
+            &self.codex_home,
+            self.enable_codex_api_key_env,
+            self.auth_credentials_store_mode,
+            forced_chatgpt_workspace_id.as_deref(),
+            self.chatgpt_base_url.as_deref(),
+            self.keyring_backend_kind,
+            /*agent_identity_authapi_base_url*/ None,
+            self.auth_route_config.as_ref(),
+        )
+        .await
+        .ok()
+        .flatten()
+    }
+
     fn set_cached_auth(&self, new_auth: Option<CodexAuth>) -> bool {
         if let Ok(mut guard) = self.inner.write() {
             let previous = guard.auth.as_ref();
@@ -2539,21 +2742,24 @@ impl AuthManager {
 
     pub async fn force_logout_due_to_server_auth_rejection(
         &self,
-        rejected_auth: Option<&CodexAuth>,
+        rejected_auth: Option<&AuthFingerprint>,
     ) -> std::io::Result<bool> {
         if !self.current_auth_uses_codex_backend() {
             return Ok(false);
         }
 
         let removal_result = self.logout_stores_matching_rejected_auth(rejected_auth);
-        let cache_changed = self.set_cached_auth(self.load_auth_from_storage().await);
+        let cache_changed = self.set_cached_auth(
+            self.load_auth_from_storage_without_codex_access_token_env()
+                .await,
+        );
         let removed = removal_result?;
         Ok(removed || cache_changed)
     }
 
     fn logout_stores_matching_rejected_auth(
         &self,
-        rejected_auth: Option<&CodexAuth>,
+        rejected_auth: Option<&AuthFingerprint>,
     ) -> std::io::Result<bool> {
         let Some(rejected_auth) = rejected_auth else {
             return logout_all_stores(

--- a/codex-rs/login/src/auth/manager.rs
+++ b/codex-rs/login/src/auth/manager.rs
@@ -1149,6 +1149,84 @@ fn logout_all_stores(
     Ok(removed_ephemeral || removed_managed)
 }
 
+fn logout_store_matching_rejected_auth(
+    codex_home: &Path,
+    auth_credentials_store_mode: AuthCredentialsStoreMode,
+    keyring_backend_kind: AuthKeyringBackendKind,
+    rejected_auth: &CodexAuth,
+) -> std::io::Result<bool> {
+    let Some(auth_dot_json) = load_auth_dot_json(
+        codex_home,
+        auth_credentials_store_mode,
+        keyring_backend_kind,
+    )?
+    else {
+        return Ok(false);
+    };
+
+    if auth_dot_json_matches_rejected_auth(&auth_dot_json, rejected_auth) {
+        logout(
+            codex_home,
+            auth_credentials_store_mode,
+            keyring_backend_kind,
+        )
+    } else {
+        Ok(false)
+    }
+}
+
+fn auth_dot_json_matches_rejected_auth(
+    auth_dot_json: &AuthDotJson,
+    rejected_auth: &CodexAuth,
+) -> bool {
+    if auth_dot_json.resolved_mode() != rejected_auth.api_auth_mode() {
+        return false;
+    }
+
+    match rejected_auth {
+        CodexAuth::Chatgpt(_) | CodexAuth::ChatgptAuthTokens(_) => {
+            auth_dot_json_matches_rejected_chatgpt_auth(auth_dot_json, rejected_auth)
+        }
+        CodexAuth::AgentIdentity(rejected) => auth_dot_json
+            .agent_identity
+            .as_deref()
+            .and_then(|jwt| AgentIdentityAuthRecord::from_agent_identity_jwt(jwt).ok())
+            .is_some_and(|record| record.account_id == rejected.account_id()),
+        CodexAuth::PersonalAccessToken(rejected) => {
+            auth_dot_json.personal_access_token.as_deref() == Some(rejected.access_token())
+        }
+        CodexAuth::ApiKey(_) | CodexAuth::BedrockApiKey(_) => false,
+    }
+}
+
+fn auth_dot_json_matches_rejected_chatgpt_auth(
+    auth_dot_json: &AuthDotJson,
+    rejected_auth: &CodexAuth,
+) -> bool {
+    let Some(rejected_auth_dot_json) = rejected_auth.get_current_auth_json() else {
+        return false;
+    };
+    let (Some(tokens), Some(rejected_tokens)) =
+        (&auth_dot_json.tokens, &rejected_auth_dot_json.tokens)
+    else {
+        return false;
+    };
+
+    tokens.access_token == rejected_tokens.access_token
+        && tokens.refresh_token == rejected_tokens.refresh_token
+        && auth_dot_json_chatgpt_account_id(auth_dot_json)
+            == auth_dot_json_chatgpt_account_id(&rejected_auth_dot_json)
+}
+
+fn auth_dot_json_chatgpt_account_id(auth_dot_json: &AuthDotJson) -> Option<&str> {
+    auth_dot_json.tokens.as_ref().and_then(|tokens| {
+        tokens
+            .account_id
+            .as_deref()
+            .or(tokens.id_token.chatgpt_account_id.as_deref())
+    })
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn load_auth(
     codex_home: &Path,
@@ -1547,6 +1625,7 @@ pub struct UnauthorizedRecovery {
     manager: Arc<AuthManager>,
     step: UnauthorizedRecoveryStep,
     expected_account_id: Option<String>,
+    rejected_auth: Option<CodexAuth>,
     mode: UnauthorizedRecoveryMode,
 }
 
@@ -1582,6 +1661,7 @@ impl UnauthorizedRecovery {
             manager,
             step,
             expected_account_id,
+            rejected_auth: cached_auth,
             mode,
         }
     }
@@ -1668,7 +1748,7 @@ impl UnauthorizedRecovery {
     pub async fn force_logout_due_to_server_auth_rejection(&mut self) -> std::io::Result<bool> {
         self.step = UnauthorizedRecoveryStep::Done;
         self.manager
-            .force_logout_due_to_server_auth_rejection()
+            .force_logout_due_to_server_auth_rejection(self.rejected_auth.as_ref())
             .await
     }
 
@@ -2412,21 +2492,54 @@ impl AuthManager {
         Ok(result)
     }
 
-    pub async fn force_logout_due_to_server_auth_rejection(&self) -> std::io::Result<bool> {
+    pub async fn force_logout_due_to_server_auth_rejection(
+        &self,
+        rejected_auth: Option<&CodexAuth>,
+    ) -> std::io::Result<bool> {
         if !self.current_auth_uses_codex_backend() {
             return Ok(false);
         }
 
-        let removal_result = logout_all_stores(
+        let removal_result = self.logout_stores_matching_rejected_auth(rejected_auth);
+        let cache_changed = self.set_cached_auth(self.load_auth_from_storage().await);
+        let removed = removal_result?;
+        Ok(removed || cache_changed)
+    }
+
+    fn logout_stores_matching_rejected_auth(
+        &self,
+        rejected_auth: Option<&CodexAuth>,
+    ) -> std::io::Result<bool> {
+        let Some(rejected_auth) = rejected_auth else {
+            return logout_all_stores(
+                &self.codex_home,
+                self.auth_credentials_store_mode,
+                self.keyring_backend_kind,
+            );
+        };
+
+        if self.auth_credentials_store_mode == AuthCredentialsStoreMode::Ephemeral {
+            return logout_store_matching_rejected_auth(
+                &self.codex_home,
+                AuthCredentialsStoreMode::Ephemeral,
+                AuthKeyringBackendKind::default(),
+                rejected_auth,
+            );
+        }
+
+        let removed_ephemeral = logout_store_matching_rejected_auth(
+            &self.codex_home,
+            AuthCredentialsStoreMode::Ephemeral,
+            AuthKeyringBackendKind::default(),
+            rejected_auth,
+        )?;
+        let removed_managed = logout_store_matching_rejected_auth(
             &self.codex_home,
             self.auth_credentials_store_mode,
             self.keyring_backend_kind,
-        );
-        let had_external_auth = self.has_external_auth();
-        self.clear_external_auth();
-        let cache_changed = self.set_cached_auth(None);
-        let removed = removal_result?;
-        Ok(removed || had_external_auth || cache_changed)
+            rejected_auth,
+        )?;
+        Ok(removed_ephemeral || removed_managed)
     }
 
     pub fn get_api_auth_mode(&self) -> Option<ApiAuthMode> {

--- a/codex-rs/login/src/auth/manager.rs
+++ b/codex-rs/login/src/auth/manager.rs
@@ -179,8 +179,13 @@ fn fingerprint_auth_dot_json(
         ApiAuthMode::AgentIdentity => {
             let record = auth_dot_json
                 .agent_identity
-                .as_deref()
-                .and_then(|jwt| AgentIdentityAuthRecord::from_agent_identity_jwt(jwt).ok())?;
+                .as_ref()
+                .and_then(|agent_identity| match agent_identity {
+                    AgentIdentityStorage::Jwt(jwt) => {
+                        AgentIdentityAuthRecord::from_agent_identity_jwt(jwt).ok()
+                    }
+                    AgentIdentityStorage::Record(record) => Some(record.clone()),
+                })?;
             Some(fingerprint_agent_identity_record(
                 kind,
                 serde_json::to_vec(&record).ok()?.as_slice(),

--- a/codex-rs/login/src/auth/manager.rs
+++ b/codex-rs/login/src/auth/manager.rs
@@ -1155,6 +1155,20 @@ fn logout_store_matching_rejected_auth(
     keyring_backend_kind: AuthKeyringBackendKind,
     rejected_auth: &CodexAuth,
 ) -> std::io::Result<bool> {
+    logout_store_if(
+        codex_home,
+        auth_credentials_store_mode,
+        keyring_backend_kind,
+        |auth_dot_json| auth_dot_json_matches_rejected_auth(auth_dot_json, rejected_auth),
+    )
+}
+
+fn logout_store_if(
+    codex_home: &Path,
+    auth_credentials_store_mode: AuthCredentialsStoreMode,
+    keyring_backend_kind: AuthKeyringBackendKind,
+    should_logout: impl Fn(&AuthDotJson) -> bool,
+) -> std::io::Result<bool> {
     let Some(auth_dot_json) = load_auth_dot_json(
         codex_home,
         auth_credentials_store_mode,
@@ -1164,15 +1178,38 @@ fn logout_store_matching_rejected_auth(
         return Ok(false);
     };
 
-    if auth_dot_json_matches_rejected_auth(&auth_dot_json, rejected_auth) {
-        logout(
-            codex_home,
-            auth_credentials_store_mode,
-            keyring_backend_kind,
-        )
-    } else {
-        Ok(false)
+    if !should_logout(&auth_dot_json) {
+        return Ok(false);
     }
+
+    let fallback_file_auth = if matches!(
+        auth_credentials_store_mode,
+        AuthCredentialsStoreMode::Auto | AuthCredentialsStoreMode::Keyring
+    ) {
+        load_auth_dot_json(
+            codex_home,
+            AuthCredentialsStoreMode::File,
+            AuthKeyringBackendKind::default(),
+        )?
+        .filter(|auth_dot_json| !should_logout(auth_dot_json))
+    } else {
+        None
+    };
+
+    let removed = logout(
+        codex_home,
+        auth_credentials_store_mode,
+        keyring_backend_kind,
+    )?;
+    if let Some(auth_dot_json) = fallback_file_auth.as_ref() {
+        save_auth(
+            codex_home,
+            auth_dot_json,
+            AuthCredentialsStoreMode::File,
+            AuthKeyringBackendKind::default(),
+        )?;
+    }
+    Ok(removed)
 }
 
 fn auth_dot_json_matches_rejected_auth(
@@ -1191,7 +1228,7 @@ fn auth_dot_json_matches_rejected_auth(
             .agent_identity
             .as_deref()
             .and_then(|jwt| AgentIdentityAuthRecord::from_agent_identity_jwt(jwt).ok())
-            .is_some_and(|record| record.account_id == rejected.account_id()),
+            .is_some_and(|record| &record == rejected.record()),
         CodexAuth::PersonalAccessToken(rejected) => {
             auth_dot_json.personal_access_token.as_deref() == Some(rejected.access_token())
         }
@@ -1225,6 +1262,10 @@ fn auth_dot_json_chatgpt_account_id(auth_dot_json: &AuthDotJson) -> Option<&str>
             .as_deref()
             .or(tokens.id_token.chatgpt_account_id.as_deref())
     })
+}
+
+fn auth_dot_json_uses_codex_backend(auth_dot_json: &AuthDotJson) -> bool {
+    auth_dot_json.resolved_mode().uses_codex_backend()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1745,10 +1786,14 @@ impl UnauthorizedRecovery {
         self.manager.current_auth_uses_codex_backend()
     }
 
-    pub async fn force_logout_due_to_server_auth_rejection(&mut self) -> std::io::Result<bool> {
+    pub async fn force_logout_due_to_server_auth_rejection(
+        &mut self,
+        rejected_auth: Option<&CodexAuth>,
+    ) -> std::io::Result<bool> {
         self.step = UnauthorizedRecoveryStep::Done;
+        let rejected_auth = rejected_auth.or(self.rejected_auth.as_ref());
         self.manager
-            .force_logout_due_to_server_auth_rejection(self.rejected_auth.as_ref())
+            .force_logout_due_to_server_auth_rejection(rejected_auth)
             .await
     }
 
@@ -2518,6 +2563,36 @@ impl AuthManager {
             );
         };
 
+        if rejected_auth.is_external_chatgpt_tokens() {
+            let removed_ephemeral = logout_store_matching_rejected_auth(
+                &self.codex_home,
+                AuthCredentialsStoreMode::Ephemeral,
+                AuthKeyringBackendKind::default(),
+                rejected_auth,
+            )?;
+            if self.auth_credentials_store_mode == AuthCredentialsStoreMode::Ephemeral {
+                return Ok(removed_ephemeral);
+            }
+            let removed_file = logout_store_if(
+                &self.codex_home,
+                AuthCredentialsStoreMode::File,
+                AuthKeyringBackendKind::default(),
+                auth_dot_json_uses_codex_backend,
+            )?;
+            let removed_managed =
+                if self.auth_credentials_store_mode == AuthCredentialsStoreMode::File {
+                    false
+                } else {
+                    logout_store_if(
+                        &self.codex_home,
+                        self.auth_credentials_store_mode,
+                        self.keyring_backend_kind,
+                        auth_dot_json_uses_codex_backend,
+                    )?
+                };
+            return Ok(removed_ephemeral || removed_file || removed_managed);
+        }
+
         if self.auth_credentials_store_mode == AuthCredentialsStoreMode::Ephemeral {
             return logout_store_matching_rejected_auth(
                 &self.codex_home,
@@ -2533,13 +2608,23 @@ impl AuthManager {
             AuthKeyringBackendKind::default(),
             rejected_auth,
         )?;
+        let removed_file = if self.auth_credentials_store_mode == AuthCredentialsStoreMode::File {
+            false
+        } else {
+            logout_store_matching_rejected_auth(
+                &self.codex_home,
+                AuthCredentialsStoreMode::File,
+                AuthKeyringBackendKind::default(),
+                rejected_auth,
+            )?
+        };
         let removed_managed = logout_store_matching_rejected_auth(
             &self.codex_home,
             self.auth_credentials_store_mode,
             self.keyring_backend_kind,
             rejected_auth,
         )?;
-        Ok(removed_ephemeral || removed_managed)
+        Ok(removed_ephemeral || removed_file || removed_managed)
     }
 
     pub fn get_api_auth_mode(&self) -> Option<ApiAuthMode> {

--- a/codex-rs/login/src/auth/manager.rs
+++ b/codex-rs/login/src/auth/manager.rs
@@ -233,7 +233,9 @@ fn fingerprint_single_secret(kind: ApiAuthMode, secret: &str, key: &[u8; 32]) ->
 }
 
 fn auth_fingerprint_mac(kind: ApiAuthMode, key: &[u8; 32]) -> HmacSha256 {
-    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts keys of any size");
+    let Ok(mut mac) = HmacSha256::new_from_slice(key) else {
+        unreachable!("HMAC accepts keys of any size");
+    };
     update_mac_field(&mut mac, auth_kind_label(kind));
     mac
 }
@@ -1430,6 +1432,7 @@ async fn load_auth(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn load_auth_without_codex_access_token_env(
     codex_home: &Path,
     enable_codex_api_key_env: bool,
@@ -1454,6 +1457,7 @@ async fn load_auth_without_codex_access_token_env(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn load_auth_impl(
     codex_home: &Path,
     enable_codex_api_key_env: bool,

--- a/codex-rs/login/src/auth/manager.rs
+++ b/codex-rs/login/src/auth/manager.rs
@@ -1661,6 +1661,17 @@ impl UnauthorizedRecovery {
         }
     }
 
+    pub fn current_auth_uses_codex_backend(&self) -> bool {
+        self.manager.current_auth_uses_codex_backend()
+    }
+
+    pub async fn force_logout_due_to_server_auth_rejection(&mut self) -> std::io::Result<bool> {
+        self.step = UnauthorizedRecoveryStep::Done;
+        self.manager
+            .force_logout_due_to_server_auth_rejection()
+            .await
+    }
+
     pub async fn next(&mut self) -> Result<UnauthorizedRecoveryStepResult, RefreshTokenError> {
         if !self.has_next() {
             return Err(RefreshTokenError::Permanent(RefreshTokenFailedError::new(
@@ -2399,6 +2410,23 @@ impl AuthManager {
         // Always reload to clear any cached auth (even if file absent).
         self.reload().await;
         Ok(result)
+    }
+
+    pub async fn force_logout_due_to_server_auth_rejection(&self) -> std::io::Result<bool> {
+        if !self.current_auth_uses_codex_backend() {
+            return Ok(false);
+        }
+
+        let removal_result = logout_all_stores(
+            &self.codex_home,
+            self.auth_credentials_store_mode,
+            self.keyring_backend_kind,
+        );
+        let had_external_auth = self.has_external_auth();
+        self.clear_external_auth();
+        let cache_changed = self.set_cached_auth(None);
+        let removed = removal_result?;
+        Ok(removed || had_external_auth || cache_changed)
     }
 
     pub fn get_api_auth_mode(&self) -> Option<ApiAuthMode> {

--- a/codex-rs/login/src/lib.rs
+++ b/codex-rs/login/src/lib.rs
@@ -21,6 +21,7 @@ pub use server::run_login_server;
 pub use auth::AgentIdentityAuthPolicy;
 pub use auth::AuthConfig;
 pub use auth::AuthDotJson;
+pub use auth::AuthFingerprint;
 pub use auth::AuthKeyringBackendKind;
 pub use auth::AuthManager;
 pub use auth::AuthManagerConfig;


### PR DESCRIPTION
## Summary

- detect workspace-restricted ChatGPT 401 responses before normal auth recovery
- clear active Codex-backend auth state and return an Unauthorized reauth error
- leave generic 401s, malformed bodies, and API-key auth on existing paths

## Testing

- `cargo test -p codex-core workspace_restricted --lib`
- `cargo test -p codex-core generic_or_malformed_401_uses_existing_recovery_path --lib`
- `cargo fmt`
- `git diff --check`

# External (non-OpenAI) Pull Request Requirements

External code contributions are by invitation only. Please read the dedicated "Contributing" markdown file for details:
https://github.com/openai/codex/blob/main/docs/contributing.md

If your PR conforms to our contribution guidelines, replace this text with a detailed and high quality description of your changes.

Include a link to a bug report or enhancement request.
