### PR TITLE
extension-api: expose thread manager to contributors

### DIFF
--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -111,6 +111,7 @@ pub use codex_prompts as review_prompts;
 mod thread_manager;
 pub(crate) mod web_search;
 pub(crate) mod windows_sandbox_read_grants;
+pub use thread_manager::ExtensionThreadManager;
 pub use thread_manager::ForkSnapshot;
 pub use thread_manager::NewThread;
 pub use thread_manager::StartThreadOptions;

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -73,6 +73,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::Weak;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -188,6 +189,34 @@ pub struct StartThreadOptions {
     pub environments: Vec<TurnEnvironmentSelection>,
     pub thread_extension_init: ExtensionDataInit,
     pub supports_openai_form_elicitation: bool,
+}
+
+/// Weak access to the host thread manager attached to thread-scoped extension data.
+#[derive(Clone)]
+pub struct ExtensionThreadManager {
+    threads: Weak<RwLock<HashMap<ThreadId, Arc<CodexThread>>>>,
+}
+
+impl ExtensionThreadManager {
+    fn new(threads: Weak<RwLock<HashMap<ThreadId, Arc<CodexThread>>>>) -> Self {
+        Self { threads }
+    }
+
+    /// Fetches a loaded, non-internal thread by ID.
+    pub async fn get_thread(&self, thread_id: ThreadId) -> CodexResult<Arc<CodexThread>> {
+        let Some(threads) = self.threads.upgrade() else {
+            return Err(CodexErr::ThreadNotFound(thread_id));
+        };
+        get_thread(&threads, thread_id).await
+    }
+}
+
+impl std::fmt::Debug for ExtensionThreadManager {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ExtensionThreadManager")
+            .finish_non_exhaustive()
+    }
 }
 
 pub(crate) struct ResumeThreadWithHistoryOptions {
@@ -1059,11 +1088,7 @@ impl ThreadManagerState {
 
     /// Fetch a thread by ID or return ThreadNotFound.
     pub(crate) async fn get_thread(&self, thread_id: ThreadId) -> CodexResult<Arc<CodexThread>> {
-        let threads = self.threads.read().await;
-        match threads.get(&thread_id) {
-            Some(thread) if !thread.session_source.is_internal() => Ok(thread.clone()),
-            Some(_) | None => Err(CodexErr::ThreadNotFound(thread_id)),
-        }
+        get_thread(&self.threads, thread_id).await
     }
 
     pub(crate) async fn read_stored_thread(
@@ -1398,7 +1423,7 @@ impl ThreadManagerState {
         inherited_exec_policy: Option<Arc<crate::exec_policy::ExecPolicyManager>>,
         parent_trace: Option<W3cTraceContext>,
         environments: Vec<TurnEnvironmentSelection>,
-        thread_extension_init: ExtensionDataInit,
+        mut thread_extension_init: ExtensionDataInit,
         supports_openai_form_elicitation: bool,
         user_shell_override: Option<crate::shell::Shell>,
     ) -> CodexResult<NewThread> {
@@ -1439,6 +1464,7 @@ impl ThreadManagerState {
                 forked_from_thread_id,
             )
             .await;
+        thread_extension_init.insert(ExtensionThreadManager::new(Arc::downgrade(&self.threads)));
         let CodexSpawnOk {
             codex, thread_id, ..
         } = Box::pin(Codex::spawn(CodexSpawnArgs {
@@ -1559,6 +1585,17 @@ impl ThreadManagerState {
             .ok()
             .map(|thread| thread.codex.session.services.rollout_thread_trace.clone())
             .unwrap_or_else(codex_rollout_trace::ThreadTraceContext::disabled)
+    }
+}
+
+async fn get_thread(
+    threads: &RwLock<HashMap<ThreadId, Arc<CodexThread>>>,
+    thread_id: ThreadId,
+) -> CodexResult<Arc<CodexThread>> {
+    let threads = threads.read().await;
+    match threads.get(&thread_id) {
+        Some(thread) if !thread.session_source.is_internal() => Ok(thread.clone()),
+        Some(_) | None => Err(CodexErr::ThreadNotFound(thread_id)),
     }
 }
 

--- a/codex-rs/core/src/thread_manager_tests.rs
+++ b/codex-rs/core/src/thread_manager_tests.rs
@@ -299,6 +299,47 @@ async fn shutdown_all_threads_bounded_submits_shutdown_to_every_thread() {
 }
 
 #[tokio::test]
+async fn start_thread_exposes_thread_manager_to_extensions() {
+    let temp_dir = tempdir().expect("tempdir");
+    let mut config = test_config().await;
+    config.codex_home = temp_dir.path().join("codex-home").abs();
+    config.cwd = config.codex_home.abs();
+    std::fs::create_dir_all(&config.codex_home).expect("create codex home");
+
+    let manager = ThreadManager::with_models_provider_and_home_for_tests(
+        CodexAuth::from_api_key("dummy"),
+        config.model_provider.clone(),
+        config.codex_home.to_path_buf(),
+        Arc::new(codex_exec_server::EnvironmentManager::default_for_tests()),
+    );
+    let started = manager
+        .start_thread(config)
+        .await
+        .expect("thread should start");
+
+    let extension_manager = started
+        .thread
+        .codex
+        .session
+        .services
+        .thread_extension_data
+        .get::<crate::ExtensionThreadManager>()
+        .expect("extension thread manager should be attached");
+    let extension_thread = extension_manager
+        .get_thread(started.thread_id)
+        .await
+        .expect("extension thread manager should find the thread");
+
+    assert!(Arc::ptr_eq(&extension_thread, &started.thread));
+
+    started
+        .thread
+        .shutdown_and_wait()
+        .await
+        .expect("thread should shut down");
+}
+
+#[tokio::test]
 async fn start_thread_keeps_internal_threads_hidden_from_normal_lookups() {
     let temp_dir = tempdir().expect("tempdir");
     let mut config = test_config().await;


### PR DESCRIPTION
## Summary

- attach a weak host thread-manager capability to thread-scoped extension data after thread construction
- let extension contributors resolve loaded threads through the existing lookup semantics without extending manager lifetime
- cover manager availability and thread identity with a thread-manager test

## Validation

- just fmt
- just fix -p codex-core
- focused extension thread-manager test passes
- full codex-core suite: 2,683 passed; remaining failures are pre-existing environment-dependent cases involving unavailable test binaries, local configuration, and sandbox process timeouts