### PR TITLE
core: log AGENTS.md paths as URIs

### DIFF
--- a/.codex/skills/path-types/SKILL.md
+++ b/.codex/skills/path-types/SKILL.md
@@ -34,6 +34,7 @@ Keep these requirements in mind while migrating code to conform with the above g
 * URIs should not yet be stored in rollouts, databases, or other persistent storage
 * path conversion errors: fail-closed for security-relevant paths, fail-open for UI/diagnostics
 * prefer small focused methods on `PathUri` or `LegacyAppPathString` over local helpers
+* represent `PathUri` values as URIs in diagnostics
 
 It is OK if the conversion between paths and URIs is somewhat lossy as long as it will do the right
 thing for real users.

--- a/codex-rs/core/src/agents_md.rs
+++ b/codex-rs/core/src/agents_md.rs
@@ -132,9 +132,9 @@ async fn read_agents_md(
 
         if size > remaining {
             tracing::warn!(
-                "Project doc `{}` exceeds remaining budget ({} bytes) - truncating.",
-                p.inferred_native_path_string(),
-                remaining,
+                path = %p,
+                remaining_bytes = remaining,
+                "project doc exceeds remaining budget; truncating"
             );
         }
 


### PR DESCRIPTION
## Why

No need to do path contortions when it's for our own logs.

## What

Follow up on a previous PR's nit and update the path-types skill for future reference.
