### PR TITLE
[codex] Skip curated repo sync for remote plugins

### DIFF
--- a/codex-rs/core-plugins/src/manager.rs
+++ b/codex-rs/core-plugins/src/manager.rs
@@ -1764,7 +1764,11 @@ impl PluginsManager {
         on_effective_plugins_changed: Option<Arc<dyn Fn() + Send + Sync + 'static>>,
     ) {
         if config.plugins_enabled {
-            self.start_curated_repo_sync();
+            let use_remote_global_catalog =
+                config.remote_plugin_enabled && auth_manager.current_auth_uses_codex_backend();
+            if !use_remote_global_catalog {
+                self.start_curated_repo_sync();
+            }
             let should_spawn_marketplace_auto_upgrade = {
                 let mut state = match self.configured_marketplace_upgrade_state.write() {
                     Ok(state) => state,


### PR DESCRIPTION
## Summary

- skip the legacy `openai-curated` startup repository sync when remote plugins are enabled and the current auth uses the Codex backend
- keep the curated sync for API-key, Bedrock, and unauthenticated sessions that fall back to the local marketplace
- preserve configured marketplace upgrades and all remote plugin startup warmups

## Why

The remote catalog owns plugin discovery and materialization only when it is usable for the current auth mode. Starting the legacy curated repository sync in that case performs an unnecessary Git/HTTP/archive download and cache refresh. API-key and Bedrock sessions still require the local curated marketplace, so they must continue syncing it.

## User impact

Codex startup no longer downloads or refreshes the local `openai-curated` snapshot when the remote catalog is active. Behavior is unchanged for auth modes that use the local curated marketplace.

## Validation

- `just fmt`
- `git diff --check`

Rust tests were not run per the repository's local verification policy for this narrow conditional change.