### PR TITLE
[rmcp-client] Serialize MCP OAuth login and logout

### DIFF
--- a/codex-rs/cli/src/mcp_cmd.rs
+++ b/codex-rs/cli/src/mcp_cmd.rs
@@ -29,7 +29,7 @@ use codex_mcp::oauth_login_support;
 use codex_mcp::resolve_oauth_scopes;
 use codex_mcp::should_retry_without_scopes;
 use codex_protocol::protocol::McpAuthStatus;
-use codex_rmcp_client::delete_oauth_tokens;
+use codex_rmcp_client::delete_oauth_tokens_locked;
 use codex_rmcp_client::perform_oauth_login;
 use codex_utils_cli::CliConfigOverrides;
 use codex_utils_cli::format_env_display;
@@ -523,12 +523,14 @@ async fn run_logout(config_overrides: &CliConfigOverrides, logout_args: LogoutAr
         _ => bail!("OAuth logout is only supported for streamable_http transports."),
     };
 
-    match delete_oauth_tokens(
+    match delete_oauth_tokens_locked(
         &name,
         &url,
         config.mcp_oauth_credentials_store_mode,
         config.auth_keyring_backend_kind(),
-    ) {
+    )
+    .await
+    {
         Ok(true) => println!("Removed OAuth credentials for '{name}'."),
         Ok(false) => println!("No OAuth credentials stored for '{name}'."),
         Err(err) => return Err(anyhow!("failed to delete OAuth credentials: {err}")),

--- a/codex-rs/rmcp-client/src/lib.rs
+++ b/codex-rs/rmcp-client/src/lib.rs
@@ -23,6 +23,7 @@ pub use in_process_transport::InProcessTransportFactory;
 pub use oauth::StoredOAuthTokens;
 pub use oauth::WrappedOAuthTokenResponse;
 pub use oauth::delete_oauth_tokens;
+pub use oauth::delete_oauth_tokens_locked;
 pub use oauth::save_oauth_tokens;
 pub use perform_oauth_login::OAuthProviderError;
 pub use perform_oauth_login::OauthLoginHandle;

--- a/codex-rs/rmcp-client/src/oauth.rs
+++ b/codex-rs/rmcp-client/src/oauth.rs
@@ -58,6 +58,7 @@ use codex_keyring_store::KeyringStore;
 use codex_utils_home_dir::find_codex_home;
 
 pub(crate) use self::persistor::OAuthPersistor;
+use self::refresh_lock::RefreshCredentialLock;
 pub(crate) use self::resolved_store::ResolvedOAuthCredentialStore;
 pub(crate) use self::resolved_store::ResolvedOAuthTokens;
 pub(crate) use self::resolved_store::load_oauth_tokens_from_store;
@@ -231,6 +232,43 @@ pub fn save_oauth_tokens(
     )
 }
 
+pub(crate) async fn save_oauth_tokens_locked(
+    server_name: &str,
+    tokens: &StoredOAuthTokens,
+    store_mode: OAuthCredentialsStoreMode,
+    keyring_backend_kind: AuthKeyringBackendKind,
+) -> Result<()> {
+    let keyring_store = DefaultKeyringStore;
+    save_oauth_tokens_locked_with_keyring_store(
+        &keyring_store,
+        server_name,
+        tokens,
+        store_mode,
+        keyring_backend_kind,
+    )
+    .await
+}
+
+async fn save_oauth_tokens_locked_with_keyring_store<K: KeyringStore + Clone + 'static>(
+    keyring_store: &K,
+    server_name: &str,
+    tokens: &StoredOAuthTokens,
+    store_mode: OAuthCredentialsStoreMode,
+    keyring_backend_kind: AuthKeyringBackendKind,
+) -> Result<()> {
+    // Login persistence shares the refresh transaction lock so a completed login always becomes
+    // authoritative: it either lands before refresh's reread or waits and overwrites the refresh
+    // result afterward.
+    let _lock = RefreshCredentialLock::acquire_for_server(server_name, &tokens.url).await?;
+    save_oauth_tokens_with_keyring_store(
+        keyring_store,
+        server_name,
+        tokens,
+        store_mode,
+        keyring_backend_kind,
+    )
+}
+
 fn save_oauth_tokens_with_keyring_store<K: KeyringStore + Clone + 'static>(
     keyring_store: &K,
     server_name: &str,
@@ -360,6 +398,42 @@ pub fn delete_oauth_tokens(
     let keyring_store = DefaultKeyringStore;
     delete_oauth_tokens_from_keyring_and_file(
         &keyring_store,
+        store_mode,
+        keyring_backend_kind,
+        server_name,
+        url,
+    )
+}
+
+pub async fn delete_oauth_tokens_locked(
+    server_name: &str,
+    url: &str,
+    store_mode: OAuthCredentialsStoreMode,
+    keyring_backend_kind: AuthKeyringBackendKind,
+) -> Result<bool> {
+    let keyring_store = DefaultKeyringStore;
+    delete_oauth_tokens_locked_with_keyring_store(
+        &keyring_store,
+        store_mode,
+        keyring_backend_kind,
+        server_name,
+        url,
+    )
+    .await
+}
+
+async fn delete_oauth_tokens_locked_with_keyring_store<K: KeyringStore + Clone + 'static>(
+    keyring_store: &K,
+    store_mode: OAuthCredentialsStoreMode,
+    keyring_backend_kind: AuthKeyringBackendKind,
+    server_name: &str,
+    url: &str,
+) -> Result<bool> {
+    // Logout shares the refresh transaction lock so refresh cannot resurrect credentials after a
+    // completed delete: it either observes the deletion or finishes before logout removes it.
+    let _lock = RefreshCredentialLock::acquire_for_server(server_name, url).await?;
+    delete_oauth_tokens_from_keyring_and_file(
+        keyring_store,
         store_mode,
         keyring_backend_kind,
         server_name,

--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs
@@ -28,8 +28,8 @@ use urlencoding::decode;
 use crate::StoredOAuthTokens;
 use crate::WrappedOAuthTokenResponse;
 use crate::oauth::compute_expires_at_millis;
+use crate::oauth::save_oauth_tokens_locked;
 use crate::oauth_http_client::OAuthHttpClientAdapter;
-use crate::save_oauth_tokens;
 use crate::utils::build_default_headers;
 use codex_config::types::AuthKeyringBackendKind;
 use codex_config::types::OAuthCredentialsStoreMode;
@@ -623,12 +623,13 @@ impl OauthLoginFlow {
                 token_response: WrappedOAuthTokenResponse(credentials),
                 expires_at,
             };
-            save_oauth_tokens(
+            save_oauth_tokens_locked(
                 &self.server_name,
                 &stored,
                 self.store_mode,
                 self.keyring_backend_kind,
-            )?;
+            )
+            .await?;
 
             Ok(())
         }


### PR DESCRIPTION
[Codex Thread 019edd6d-6f14-74e2-853c-345d1803d4a6](https://codex-thread-link.openai.chatgpt-team.site/thread/019edd6d-6f14-74e2-853c-345d1803d4a6)

<!-- superseded-by-mcp-oauth-stack-30292 -->
> [!IMPORTANT]
> **This PR belongs to the superseded MCP OAuth stack.** Please review and merge the replacement stack beginning with [openai/codex#30292](https://github.com/openai/codex/pull/30292). This PR remains available only as historical/reference context.
>
> Replacement review order:
> 1. [openai/codex#30292](https://github.com/openai/codex/pull/30292) — shared File/Secrets store locking
> 2. [openai/codex#30293](https://github.com/openai/codex/pull/30293) — authoritative serialized refresh
> 3. [openai/codex#30294](https://github.com/openai/codex/pull/30294) — Codex-owned transport refresh and one-shot 401 recovery
> 4. [openai/codex#30295](https://github.com/openai/codex/pull/30295) — login/logout transaction serialization
> 5. [openai/codex#30296](https://github.com/openai/codex/pull/30296) — diagnostic-only Auto store drift reporting


This is part 2 of a five-PR stack that prevents concurrent MCP OAuth refreshes from replaying a rotating refresh token or overwriting newer credentials.

> **Review and merge as one stack.** The five PRs are an atomic merge unit split only for reviewability. Each tip compiles and is testable, but implementation and regression tests are intentionally not duplicated across intermediate layers.

## Review order

1. [openai/codex#29017](https://github.com/openai/codex/pull/29017) — refresh ownership, authoritative reread, and lifecycle-local store pinning
2. **[openai/codex#29019](https://github.com/openai/codex/pull/29019) — serialize login and logout with refresh (this PR)**
3. [openai/codex#29021](https://github.com/openai/codex/pull/29021) — lock aggregate stores and observe `Auto` resolution drift
4. [openai/codex#29018](https://github.com/openai/codex/pull/29018) — route all OAuth recovery through Codex
5. [openai/codex#30089](https://github.com/openai/codex/pull/30089) — consolidated concurrency and transport regression tests

## Why

Login, logout, and refresh all mutate the same credential identity. If login or logout bypasses the refresh transaction lock, an older in-flight refresh can overwrite a completed login or recreate credentials after logout.

## What changes

- Make OAuth callback persistence acquire the same per-credential transaction lock as refresh.
- Make CLI logout acquire that lock before deleting credentials.
- Preserve the lock order: per-credential transaction lock before any aggregate store lock.

## Decisions encoded by this stack

- Login, logout, and refresh serialize on the same `compute_store_key(server_name, url)` identity.
- A completed login or logout is authoritative over stale in-memory refresh state.
- Lock acquisition remains bounded.
- `Auto` remains lifecycle-local; part 3 records only non-authoritative diagnostic history and does not add selector metadata or migration.
- [openai/codex#28647](https://github.com/openai/codex/pull/28647) and its branch remain untouched.

## Review focus

Review credential identity consistency and lock ordering across callback persistence, refresh, and CLI logout. Part 3 separately protects aggregate File/Secrets maps after a transaction reaches a store.

## Non-goals

- Changing the OAuth callback or CLI contract.
- Deleting residue from the non-selected `Auto` store.

## Validation

- `just test -p codex-rmcp-client`: 90 passed, 2 skipped.
- `just test -p codex-cli`: 292 passed.
- The refresh-vs-login and refresh-vs-logout race cases are consolidated in part 5.