### PR TITLE
[codex] Avoid skill filesystem scans on cache hits

### DIFF
--- a/codex-rs/core-plugins/src/manager_tests.rs
+++ b/codex-rs/core-plugins/src/manager_tests.rs
@@ -2078,7 +2078,11 @@ async fn skills_service_reuses_skills_parsed_during_plugin_load() {
     .with_plugin_skill_snapshots(plugin_skill_snapshots);
     let skills_service = SkillsService::new(codex_home_abs, /*bundled_skills_enabled*/ false);
     let cached = skills_service
-        .snapshot_for_config(&skills_input, /*fs*/ None)
+        .snapshot_for_config(
+            &skills_input,
+            /*fs*/ None,
+            /*refresh_filesystem*/ false,
+        )
         .await;
 
     assert_eq!(

--- a/codex-rs/core-skills/src/service.rs
+++ b/codex-rs/core-skills/src/service.rs
@@ -1,9 +1,13 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::sync::Arc;
 use std::sync::RwLock;
 
+use codex_app_server_protocol::ConfigLayerSource;
 use codex_config::ConfigLayerStack;
+use codex_config::ConfigLayerStackOrdering;
 use codex_exec_server::ExecutorFileSystem;
 use codex_protocol::protocol::Product;
 use codex_protocol::protocol::SkillScope;
@@ -128,13 +132,16 @@ impl SkillsService {
         input: &SkillsLoadInput,
         fs: Option<Arc<dyn ExecutorFileSystem>>,
     ) -> HostSkillsSnapshot {
-        let roots = self.skill_roots_for_config(input, fs).await;
-        let skill_config_rules = skill_config_rules_from_stack(&input.config_layer_stack);
-        let cache_key = config_skills_cache_key(&roots, &skill_config_rules);
+        let extra_roots = self.extra_roots();
+        let cache_key = config_skills_cache_key(input, &extra_roots, fs.as_ref());
         if let Some(snapshot) = self.cached_snapshot_for_config(&cache_key) {
             return snapshot;
         }
 
+        let roots = self
+            .skill_roots_for_config_with_extra_roots(input, fs, extra_roots)
+            .await;
+        let skill_config_rules = skill_config_rules_from_stack(&input.config_layer_stack);
         let snapshot = HostSkillsSnapshot::new(Arc::new(
             self.build_skill_outcome(input, roots, &skill_config_rules)
                 .await,
@@ -152,12 +159,22 @@ impl SkillsService {
         input: &SkillsLoadInput,
         fs: Option<Arc<dyn ExecutorFileSystem>>,
     ) -> Vec<SkillRoot> {
+        self.skill_roots_for_config_with_extra_roots(input, fs, self.extra_roots())
+            .await
+    }
+
+    async fn skill_roots_for_config_with_extra_roots(
+        &self,
+        input: &SkillsLoadInput,
+        fs: Option<Arc<dyn ExecutorFileSystem>>,
+        extra_roots: Vec<AbsolutePathBuf>,
+    ) -> Vec<SkillRoot> {
         let mut roots = skill_roots(
             fs,
             &input.config_layer_stack,
             &input.cwd,
             input.effective_skill_roots.clone(),
-            self.extra_roots(),
+            extra_roots,
         )
         .await;
         if !input.bundled_skills_enabled {
@@ -268,10 +285,42 @@ impl SkillsService {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+/// Skill-relevant inputs that can be compared before root discovery touches the filesystem.
+#[derive(Clone, PartialEq, Eq, Hash)]
 struct ConfigSkillsCacheKey {
-    roots: Vec<(AbsolutePathBuf, u8, Option<String>, Option<String>)>,
-    skill_config_rules: SkillConfigRules,
+    cwd: AbsolutePathBuf,
+    config_layers: Vec<ConfigLayerSkillsCacheKey>,
+    effective_skill_roots: Vec<PluginSkillRoot>,
+    bundled_skills_enabled: bool,
+    extra_roots: Vec<AbsolutePathBuf>,
+    file_system: Option<ExecutorFileSystemCacheKey>,
+}
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct ConfigLayerSkillsCacheKey {
+    source: std::mem::Discriminant<ConfigLayerSource>,
+    config_folder: Option<AbsolutePathBuf>,
+    disabled: bool,
+    skills_config: Option<String>,
+    project_root_markers: Option<String>,
+}
+
+// Snapshots retain filesystem-bound skill paths, so cache entries must distinguish instances.
+#[derive(Clone)]
+struct ExecutorFileSystemCacheKey(Arc<dyn ExecutorFileSystem>);
+
+impl PartialEq for ExecutorFileSystemCacheKey {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Eq for ExecutorFileSystemCacheKey {}
+
+impl Hash for ExecutorFileSystemCacheKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::ptr::hash(Arc::as_ptr(&self.0), state);
+    }
 }
 
 pub fn bundled_skills_enabled_from_stack(
@@ -297,28 +346,55 @@ pub fn bundled_skills_enabled_from_stack(
 }
 
 fn config_skills_cache_key(
-    roots: &[SkillRoot],
-    skill_config_rules: &SkillConfigRules,
+    input: &SkillsLoadInput,
+    extra_roots: &[AbsolutePathBuf],
+    fs: Option<&Arc<dyn ExecutorFileSystem>>,
 ) -> ConfigSkillsCacheKey {
     ConfigSkillsCacheKey {
-        roots: roots
-            .iter()
-            .map(|root| {
-                let scope_rank = match root.scope {
-                    SkillScope::Repo => 0,
-                    SkillScope::User => 1,
-                    SkillScope::System => 2,
-                    SkillScope::Admin => 3,
+        cwd: input.cwd.clone(),
+        config_layers: input
+            .config_layer_stack
+            .get_layers(
+                ConfigLayerStackOrdering::LowestPrecedenceFirst,
+                /*include_disabled*/ true,
+            )
+            .into_iter()
+            .filter_map(|layer| {
+                let config_folder = layer.config_folder();
+                let skills_config = if matches!(
+                    layer.name,
+                    ConfigLayerSource::User { .. } | ConfigLayerSource::SessionFlags
+                ) {
+                    layer.config.get("skills").map(ToString::to_string)
+                } else {
+                    None
                 };
-                (
-                    root.path.clone(),
-                    scope_rank,
-                    root.plugin_id.clone(),
-                    root.plugin_namespace.clone(),
-                )
+                let project_root_markers = if !layer.is_disabled()
+                    && !matches!(layer.name, ConfigLayerSource::Project { .. })
+                {
+                    layer
+                        .config
+                        .get("project_root_markers")
+                        .map(ToString::to_string)
+                } else {
+                    None
+                };
+                (config_folder.is_some()
+                    || skills_config.is_some()
+                    || project_root_markers.is_some())
+                .then(|| ConfigLayerSkillsCacheKey {
+                    source: std::mem::discriminant(&layer.name),
+                    config_folder,
+                    disabled: layer.is_disabled(),
+                    skills_config,
+                    project_root_markers,
+                })
             })
             .collect(),
-        skill_config_rules: skill_config_rules.clone(),
+        effective_skill_roots: input.effective_skill_roots.clone(),
+        bundled_skills_enabled: input.bundled_skills_enabled,
+        extra_roots: extra_roots.to_vec(),
+        file_system: fs.cloned().map(ExecutorFileSystemCacheKey),
     }
 }
 

--- a/codex-rs/core-skills/src/service.rs
+++ b/codex-rs/core-skills/src/service.rs
@@ -120,46 +120,24 @@ impl SkillsService {
     ///
     /// This path uses a cache keyed by the effective skill-relevant config state rather than just
     /// cwd so role-local and session-local skill overrides cannot bleed across sessions that happen
-    /// to share a directory.
-    pub async fn snapshot_for_config(
-        &self,
-        input: &SkillsLoadInput,
-        fs: Option<Arc<dyn ExecutorFileSystem>>,
-    ) -> HostSkillsSnapshot {
-        self.snapshot_for_config_with_lookup(input, fs, ConfigSnapshotLookup::ReuseCached)
-            .await
-    }
-
-    /// Revalidates filesystem-derived roots and skill configuration rules before returning the
-    /// cached snapshot. If they are unchanged, the existing snapshot is reused without rescanning
-    /// skill contents.
-    pub async fn refresh_snapshot_for_config(
-        &self,
-        input: &SkillsLoadInput,
-        fs: Option<Arc<dyn ExecutorFileSystem>>,
-    ) -> HostSkillsSnapshot {
-        self.snapshot_for_config_with_lookup(input, fs, ConfigSnapshotLookup::RefreshFilesystem)
-            .await
-    }
-
+    /// to share a directory. When `refresh_filesystem` is true, filesystem-derived roots and skill
+    /// configuration rules are revalidated before reusing the cached snapshot.
     #[instrument(
         name = "skills_for_config",
         level = "info",
         skip_all,
         fields(otel.name = "skills_for_config")
     )]
-    async fn snapshot_for_config_with_lookup(
+    pub async fn snapshot_for_config(
         &self,
         input: &SkillsLoadInput,
         fs: Option<Arc<dyn ExecutorFileSystem>>,
-        lookup: ConfigSnapshotLookup,
+        refresh_filesystem: bool,
     ) -> HostSkillsSnapshot {
         let extra_roots = self.extra_roots();
         let cache_key = config_skills_cache_key(input, &extra_roots, fs.as_ref());
         let cached = self.cached_snapshot_for_config(&cache_key);
-        if lookup == ConfigSnapshotLookup::ReuseCached
-            && let Some(cached) = &cached
-        {
+        if !refresh_filesystem && let Some(cached) = &cached {
             return cached.snapshot.clone();
         }
 
@@ -321,12 +299,6 @@ impl SkillsService {
             Err(err) => err.into_inner().clone(),
         }
     }
-}
-
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum ConfigSnapshotLookup {
-    ReuseCached,
-    RefreshFilesystem,
 }
 
 #[derive(Clone)]

--- a/codex-rs/core-skills/src/service.rs
+++ b/codex-rs/core-skills/src/service.rs
@@ -74,7 +74,7 @@ pub struct SkillsService {
     restriction_product: Option<Product>,
     extra_roots: RwLock<Vec<AbsolutePathBuf>>,
     cache_by_cwd: RwLock<HashMap<AbsolutePathBuf, HostSkillsSnapshot>>,
-    cache_by_config: RwLock<HashMap<ConfigSkillsCacheKey, HostSkillsSnapshot>>,
+    cache_by_config: RwLock<HashMap<ConfigSkillsCacheKey, CachedConfigSkillsSnapshot>>,
 }
 
 impl SkillsService {
@@ -121,27 +121,59 @@ impl SkillsService {
     /// This path uses a cache keyed by the effective skill-relevant config state rather than just
     /// cwd so role-local and session-local skill overrides cannot bleed across sessions that happen
     /// to share a directory.
+    pub async fn snapshot_for_config(
+        &self,
+        input: &SkillsLoadInput,
+        fs: Option<Arc<dyn ExecutorFileSystem>>,
+    ) -> HostSkillsSnapshot {
+        self.snapshot_for_config_with_lookup(input, fs, ConfigSnapshotLookup::ReuseCached)
+            .await
+    }
+
+    /// Revalidates filesystem-derived roots and skill configuration rules before returning the
+    /// cached snapshot. If they are unchanged, the existing snapshot is reused without rescanning
+    /// skill contents.
+    pub async fn refresh_snapshot_for_config(
+        &self,
+        input: &SkillsLoadInput,
+        fs: Option<Arc<dyn ExecutorFileSystem>>,
+    ) -> HostSkillsSnapshot {
+        self.snapshot_for_config_with_lookup(input, fs, ConfigSnapshotLookup::RefreshFilesystem)
+            .await
+    }
+
     #[instrument(
         name = "skills_for_config",
         level = "info",
         skip_all,
         fields(otel.name = "skills_for_config")
     )]
-    pub async fn snapshot_for_config(
+    async fn snapshot_for_config_with_lookup(
         &self,
         input: &SkillsLoadInput,
         fs: Option<Arc<dyn ExecutorFileSystem>>,
+        lookup: ConfigSnapshotLookup,
     ) -> HostSkillsSnapshot {
         let extra_roots = self.extra_roots();
         let cache_key = config_skills_cache_key(input, &extra_roots, fs.as_ref());
-        if let Some(snapshot) = self.cached_snapshot_for_config(&cache_key) {
-            return snapshot;
+        let cached = self.cached_snapshot_for_config(&cache_key);
+        if lookup == ConfigSnapshotLookup::ReuseCached
+            && let Some(cached) = &cached
+        {
+            return cached.snapshot.clone();
         }
 
         let roots = self
             .skill_roots_for_config_with_extra_roots(input, fs, extra_roots)
             .await;
         let skill_config_rules = skill_config_rules_from_stack(&input.config_layer_stack);
+        let fingerprint = config_skills_filesystem_fingerprint(&roots, &skill_config_rules);
+        if let Some(cached) = cached
+            && cached.fingerprint == fingerprint
+        {
+            return cached.snapshot;
+        }
+
         let snapshot = HostSkillsSnapshot::new(Arc::new(
             self.build_skill_outcome(input, roots, &skill_config_rules)
                 .await,
@@ -150,7 +182,13 @@ impl SkillsService {
             .cache_by_config
             .write()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        cache.insert(cache_key, snapshot.clone());
+        cache.insert(
+            cache_key,
+            CachedConfigSkillsSnapshot {
+                fingerprint,
+                snapshot: snapshot.clone(),
+            },
+        );
         snapshot
     }
 
@@ -270,7 +308,7 @@ impl SkillsService {
     fn cached_snapshot_for_config(
         &self,
         cache_key: &ConfigSkillsCacheKey,
-    ) -> Option<HostSkillsSnapshot> {
+    ) -> Option<CachedConfigSkillsSnapshot> {
         match self.cache_by_config.read() {
             Ok(cache) => cache.get(cache_key).cloned(),
             Err(err) => err.into_inner().get(cache_key).cloned(),
@@ -283,6 +321,18 @@ impl SkillsService {
             Err(err) => err.into_inner().clone(),
         }
     }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ConfigSnapshotLookup {
+    ReuseCached,
+    RefreshFilesystem,
+}
+
+#[derive(Clone)]
+struct CachedConfigSkillsSnapshot {
+    fingerprint: ConfigSkillsFilesystemFingerprint,
+    snapshot: HostSkillsSnapshot,
 }
 
 /// Skill-relevant inputs that can be compared before root discovery touches the filesystem.
@@ -303,6 +353,12 @@ struct ConfigLayerSkillsCacheKey {
     disabled: bool,
     skills_config: Option<String>,
     project_root_markers: Option<String>,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct ConfigSkillsFilesystemFingerprint {
+    roots: Vec<(AbsolutePathBuf, u8, Option<String>, Option<String>)>,
+    skill_config_rules: SkillConfigRules,
 }
 
 // Snapshots retain filesystem-bound skill paths, so cache entries must distinguish instances.
@@ -395,6 +451,32 @@ fn config_skills_cache_key(
         bundled_skills_enabled: input.bundled_skills_enabled,
         extra_roots: extra_roots.to_vec(),
         file_system: fs.cloned().map(ExecutorFileSystemCacheKey),
+    }
+}
+
+fn config_skills_filesystem_fingerprint(
+    roots: &[SkillRoot],
+    skill_config_rules: &SkillConfigRules,
+) -> ConfigSkillsFilesystemFingerprint {
+    ConfigSkillsFilesystemFingerprint {
+        roots: roots
+            .iter()
+            .map(|root| {
+                let scope_rank = match root.scope {
+                    SkillScope::Repo => 0,
+                    SkillScope::User => 1,
+                    SkillScope::System => 2,
+                    SkillScope::Admin => 3,
+                };
+                (
+                    root.path.clone(),
+                    scope_rank,
+                    root.plugin_id.clone(),
+                    root.plugin_namespace.clone(),
+                )
+            })
+            .collect(),
+        skill_config_rules: skill_config_rules.clone(),
     }
 }
 

--- a/codex-rs/core-skills/src/service_tests.rs
+++ b/codex-rs/core-skills/src/service_tests.rs
@@ -320,7 +320,11 @@ async fn skills_for_config_with_stack(
         bundled_skills_enabled_from_stack(config_layer_stack),
     );
     skills_service
-        .snapshot_for_config(&skills_input, Some(Arc::clone(&LOCAL_FS)))
+        .snapshot_for_config(
+            &skills_input,
+            Some(Arc::clone(&LOCAL_FS)),
+            /*refresh_filesystem*/ false,
+        )
         .await
         .outcome()
         .clone()
@@ -393,7 +397,11 @@ async fn skills_for_config_cache_hit_avoids_environment_filesystem_operations() 
     let file_system: Arc<dyn ExecutorFileSystem> = counting_file_system.clone();
 
     skills_service
-        .snapshot_for_config(&skills_input, Some(Arc::clone(&file_system)))
+        .snapshot_for_config(
+            &skills_input,
+            Some(Arc::clone(&file_system)),
+            /*refresh_filesystem*/ false,
+        )
         .await;
     let operations_after_cache_miss = counting_file_system.operation_count();
     let content_scans_after_cache_miss = counting_file_system.content_scan_operation_count();
@@ -401,7 +409,11 @@ async fn skills_for_config_cache_hit_avoids_environment_filesystem_operations() 
     assert!(content_scans_after_cache_miss > 0);
 
     skills_service
-        .snapshot_for_config(&skills_input, Some(Arc::clone(&file_system)))
+        .snapshot_for_config(
+            &skills_input,
+            Some(Arc::clone(&file_system)),
+            /*refresh_filesystem*/ false,
+        )
         .await;
     assert_eq!(
         counting_file_system.operation_count(),
@@ -413,7 +425,11 @@ async fn skills_for_config_cache_hit_avoids_environment_filesystem_operations() 
     );
 
     skills_service
-        .refresh_snapshot_for_config(&skills_input, Some(Arc::clone(&file_system)))
+        .snapshot_for_config(
+            &skills_input,
+            Some(Arc::clone(&file_system)),
+            /*refresh_filesystem*/ true,
+        )
         .await;
     let operations_after_refresh = counting_file_system.operation_count();
     assert!(operations_after_refresh > operations_after_cache_miss);
@@ -432,6 +448,7 @@ async fn skills_for_config_cache_hit_avoids_environment_filesystem_operations() 
         .snapshot_for_config(
             &unrelated_session_flag_input,
             Some(Arc::clone(&file_system)),
+            /*refresh_filesystem*/ false,
         )
         .await;
     assert_eq!(
@@ -441,14 +458,18 @@ async fn skills_for_config_cache_hit_avoids_environment_filesystem_operations() 
 
     skills_service.clear_cache();
     skills_service
-        .snapshot_for_config(&skills_input, Some(file_system))
+        .snapshot_for_config(
+            &skills_input,
+            Some(file_system),
+            /*refresh_filesystem*/ false,
+        )
         .await;
     assert!(counting_file_system.operation_count() > operations_after_refresh);
     assert!(counting_file_system.content_scan_operation_count() > content_scans_after_cache_miss);
 }
 
 #[tokio::test]
-async fn refresh_snapshot_for_config_discovers_new_repo_skill_root() {
+async fn snapshot_for_config_refresh_discovers_new_repo_skill_root() {
     let codex_home = tempfile::tempdir().expect("tempdir");
     let cwd = tempfile::tempdir().expect("tempdir");
     fs::create_dir(cwd.path().join(".git")).expect("create project marker");
@@ -465,7 +486,11 @@ async fn refresh_snapshot_for_config_discovers_new_repo_skill_root() {
     );
 
     let initial_snapshot = skills_service
-        .snapshot_for_config(&skills_input, Some(Arc::clone(&LOCAL_FS)))
+        .snapshot_for_config(
+            &skills_input,
+            Some(Arc::clone(&LOCAL_FS)),
+            /*refresh_filesystem*/ false,
+        )
         .await;
     assert!(
         initial_snapshot
@@ -483,7 +508,11 @@ async fn refresh_snapshot_for_config_discovers_new_repo_skill_root() {
     );
 
     let cached_snapshot = skills_service
-        .snapshot_for_config(&skills_input, Some(Arc::clone(&LOCAL_FS)))
+        .snapshot_for_config(
+            &skills_input,
+            Some(Arc::clone(&LOCAL_FS)),
+            /*refresh_filesystem*/ false,
+        )
         .await;
     assert!(
         cached_snapshot
@@ -494,7 +523,11 @@ async fn refresh_snapshot_for_config_discovers_new_repo_skill_root() {
     );
 
     let refreshed_snapshot = skills_service
-        .refresh_snapshot_for_config(&skills_input, Some(Arc::clone(&LOCAL_FS)))
+        .snapshot_for_config(
+            &skills_input,
+            Some(Arc::clone(&LOCAL_FS)),
+            /*refresh_filesystem*/ true,
+        )
         .await;
     assert!(
         refreshed_snapshot

--- a/codex-rs/core-skills/src/service_tests.rs
+++ b/codex-rs/core-skills/src/service_tests.rs
@@ -7,10 +7,20 @@ use codex_config::CONFIG_TOML_FILE;
 use codex_config::ConfigLayerEntry;
 use codex_config::ConfigLayerStack;
 use codex_config::ConfigRequirementsToml;
+use codex_exec_server::CopyOptions;
+use codex_exec_server::CreateDirectoryOptions;
+use codex_exec_server::ExecutorFileSystem;
+use codex_exec_server::ExecutorFileSystemFuture;
+use codex_exec_server::FileMetadata;
+use codex_exec_server::FileSystemReadStream;
+use codex_exec_server::FileSystemSandboxContext;
 use codex_exec_server::LOCAL_FS;
+use codex_exec_server::ReadDirectoryEntry;
+use codex_exec_server::RemoveOptions;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_absolute_path::test_support::PathBufExt;
 use codex_utils_absolute_path::test_support::PathExt;
+use codex_utils_path_uri::PathUri;
 use codex_utils_plugins::PluginSkillRoot;
 use pretty_assertions::assert_eq;
 use std::collections::HashSet;
@@ -18,7 +28,120 @@ use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use tempfile::TempDir;
+
+struct CountingFileSystem {
+    delegate: Arc<dyn ExecutorFileSystem>,
+    operation_count: AtomicUsize,
+}
+
+impl CountingFileSystem {
+    fn new(delegate: Arc<dyn ExecutorFileSystem>) -> Self {
+        Self {
+            delegate,
+            operation_count: AtomicUsize::new(0),
+        }
+    }
+
+    fn operation_count(&self) -> usize {
+        self.operation_count.load(Ordering::Relaxed)
+    }
+
+    fn record_operation(&self) {
+        self.operation_count.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+impl ExecutorFileSystem for CountingFileSystem {
+    fn canonicalize<'a>(
+        &'a self,
+        path: &'a PathUri,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, PathUri> {
+        self.record_operation();
+        self.delegate.canonicalize(path, sandbox)
+    }
+
+    fn read_file<'a>(
+        &'a self,
+        path: &'a PathUri,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, Vec<u8>> {
+        self.record_operation();
+        self.delegate.read_file(path, sandbox)
+    }
+
+    fn read_file_stream<'a>(
+        &'a self,
+        path: &'a PathUri,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, FileSystemReadStream> {
+        self.record_operation();
+        self.delegate.read_file_stream(path, sandbox)
+    }
+
+    fn write_file<'a>(
+        &'a self,
+        path: &'a PathUri,
+        contents: Vec<u8>,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, ()> {
+        self.record_operation();
+        self.delegate.write_file(path, contents, sandbox)
+    }
+
+    fn create_directory<'a>(
+        &'a self,
+        path: &'a PathUri,
+        options: CreateDirectoryOptions,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, ()> {
+        self.record_operation();
+        self.delegate.create_directory(path, options, sandbox)
+    }
+
+    fn get_metadata<'a>(
+        &'a self,
+        path: &'a PathUri,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, FileMetadata> {
+        self.record_operation();
+        self.delegate.get_metadata(path, sandbox)
+    }
+
+    fn read_directory<'a>(
+        &'a self,
+        path: &'a PathUri,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, Vec<ReadDirectoryEntry>> {
+        self.record_operation();
+        self.delegate.read_directory(path, sandbox)
+    }
+
+    fn remove<'a>(
+        &'a self,
+        path: &'a PathUri,
+        options: RemoveOptions,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, ()> {
+        self.record_operation();
+        self.delegate.remove(path, options, sandbox)
+    }
+
+    fn copy<'a>(
+        &'a self,
+        source_path: &'a PathUri,
+        destination_path: &'a PathUri,
+        options: CopyOptions,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, ()> {
+        self.record_operation();
+        self.delegate
+            .copy(source_path, destination_path, options, sandbox)
+    }
+}
 
 fn write_user_skill(codex_home: &TempDir, dir: &str, name: &str, description: &str) {
     let skill_dir = codex_home.path().join("skills").join(dir);
@@ -226,6 +349,62 @@ async fn skills_for_config_reuses_cache_for_same_effective_config() {
         skills_for_config_with_stack(&skills_service, &cwd, &config_layer_stack, &[]).await;
     assert_eq!(outcome2.errors, outcome1.errors);
     assert_eq!(outcome2.skills, outcome1.skills);
+}
+
+#[tokio::test]
+async fn skills_for_config_cache_hit_avoids_environment_filesystem_operations() {
+    let codex_home = tempfile::tempdir().expect("tempdir");
+    let cwd = tempfile::tempdir().expect("tempdir");
+    let config_layer_stack = config_stack(&codex_home, "");
+    let skills_service = SkillsService::new(
+        codex_home.path().abs(),
+        /*bundled_skills_enabled*/ true,
+    );
+    let skills_input = SkillsLoadInput::new(
+        cwd.path().abs(),
+        Vec::new(),
+        config_layer_stack,
+        /*bundled_skills_enabled*/ true,
+    );
+    let counting_file_system = Arc::new(CountingFileSystem::new(Arc::clone(&LOCAL_FS)));
+    let file_system: Arc<dyn ExecutorFileSystem> = counting_file_system.clone();
+
+    skills_service
+        .snapshot_for_config(&skills_input, Some(Arc::clone(&file_system)))
+        .await;
+    let operations_after_cache_miss = counting_file_system.operation_count();
+    assert!(operations_after_cache_miss > 0);
+
+    skills_service
+        .snapshot_for_config(&skills_input, Some(Arc::clone(&file_system)))
+        .await;
+    assert_eq!(
+        counting_file_system.operation_count(),
+        operations_after_cache_miss
+    );
+
+    let unrelated_session_flag_input = SkillsLoadInput::new(
+        cwd.path().abs(),
+        Vec::new(),
+        config_stack_with_session_flags(&codex_home, "", "model = 'gpt-5'"),
+        /*bundled_skills_enabled*/ true,
+    );
+    skills_service
+        .snapshot_for_config(
+            &unrelated_session_flag_input,
+            Some(Arc::clone(&file_system)),
+        )
+        .await;
+    assert_eq!(
+        counting_file_system.operation_count(),
+        operations_after_cache_miss
+    );
+
+    skills_service.clear_cache();
+    skills_service
+        .snapshot_for_config(&skills_input, Some(file_system))
+        .await;
+    assert!(counting_file_system.operation_count() > operations_after_cache_miss);
 }
 
 #[tokio::test]

--- a/codex-rs/core-skills/src/service_tests.rs
+++ b/codex-rs/core-skills/src/service_tests.rs
@@ -35,6 +35,7 @@ use tempfile::TempDir;
 struct CountingFileSystem {
     delegate: Arc<dyn ExecutorFileSystem>,
     operation_count: AtomicUsize,
+    content_scan_operation_count: AtomicUsize,
 }
 
 impl CountingFileSystem {
@@ -42,6 +43,7 @@ impl CountingFileSystem {
         Self {
             delegate,
             operation_count: AtomicUsize::new(0),
+            content_scan_operation_count: AtomicUsize::new(0),
         }
     }
 
@@ -51,6 +53,15 @@ impl CountingFileSystem {
 
     fn record_operation(&self) {
         self.operation_count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn content_scan_operation_count(&self) -> usize {
+        self.content_scan_operation_count.load(Ordering::Relaxed)
+    }
+
+    fn record_content_scan_operation(&self) {
+        self.content_scan_operation_count
+            .fetch_add(1, Ordering::Relaxed);
     }
 }
 
@@ -70,6 +81,7 @@ impl ExecutorFileSystem for CountingFileSystem {
         sandbox: Option<&'a FileSystemSandboxContext>,
     ) -> ExecutorFileSystemFuture<'a, Vec<u8>> {
         self.record_operation();
+        self.record_content_scan_operation();
         self.delegate.read_file(path, sandbox)
     }
 
@@ -79,6 +91,7 @@ impl ExecutorFileSystem for CountingFileSystem {
         sandbox: Option<&'a FileSystemSandboxContext>,
     ) -> ExecutorFileSystemFuture<'a, FileSystemReadStream> {
         self.record_operation();
+        self.record_content_scan_operation();
         self.delegate.read_file_stream(path, sandbox)
     }
 
@@ -117,6 +130,7 @@ impl ExecutorFileSystem for CountingFileSystem {
         sandbox: Option<&'a FileSystemSandboxContext>,
     ) -> ExecutorFileSystemFuture<'a, Vec<ReadDirectoryEntry>> {
         self.record_operation();
+        self.record_content_scan_operation();
         self.delegate.read_directory(path, sandbox)
     }
 
@@ -145,6 +159,13 @@ impl ExecutorFileSystem for CountingFileSystem {
 
 fn write_user_skill(codex_home: &TempDir, dir: &str, name: &str, description: &str) {
     let skill_dir = codex_home.path().join("skills").join(dir);
+    fs::create_dir_all(&skill_dir).unwrap();
+    let content = format!("---\nname: {name}\ndescription: {description}\n---\n\n# Body\n");
+    fs::write(skill_dir.join("SKILL.md"), content).unwrap();
+}
+
+fn write_repo_skill(cwd: &TempDir, dir: &str, name: &str, description: &str) {
+    let skill_dir = cwd.path().join(".agents/skills").join(dir);
     fs::create_dir_all(&skill_dir).unwrap();
     let content = format!("---\nname: {name}\ndescription: {description}\n---\n\n# Body\n");
     fs::write(skill_dir.join("SKILL.md"), content).unwrap();
@@ -355,6 +376,8 @@ async fn skills_for_config_reuses_cache_for_same_effective_config() {
 async fn skills_for_config_cache_hit_avoids_environment_filesystem_operations() {
     let codex_home = tempfile::tempdir().expect("tempdir");
     let cwd = tempfile::tempdir().expect("tempdir");
+    fs::create_dir(cwd.path().join(".git")).expect("create project marker");
+    write_repo_skill(&cwd, "repo-skill", "repo-skill", "from repo");
     let config_layer_stack = config_stack(&codex_home, "");
     let skills_service = SkillsService::new(
         codex_home.path().abs(),
@@ -373,7 +396,9 @@ async fn skills_for_config_cache_hit_avoids_environment_filesystem_operations() 
         .snapshot_for_config(&skills_input, Some(Arc::clone(&file_system)))
         .await;
     let operations_after_cache_miss = counting_file_system.operation_count();
+    let content_scans_after_cache_miss = counting_file_system.content_scan_operation_count();
     assert!(operations_after_cache_miss > 0);
+    assert!(content_scans_after_cache_miss > 0);
 
     skills_service
         .snapshot_for_config(&skills_input, Some(Arc::clone(&file_system)))
@@ -381,6 +406,20 @@ async fn skills_for_config_cache_hit_avoids_environment_filesystem_operations() 
     assert_eq!(
         counting_file_system.operation_count(),
         operations_after_cache_miss
+    );
+    assert_eq!(
+        counting_file_system.content_scan_operation_count(),
+        content_scans_after_cache_miss
+    );
+
+    skills_service
+        .refresh_snapshot_for_config(&skills_input, Some(Arc::clone(&file_system)))
+        .await;
+    let operations_after_refresh = counting_file_system.operation_count();
+    assert!(operations_after_refresh > operations_after_cache_miss);
+    assert_eq!(
+        counting_file_system.content_scan_operation_count(),
+        content_scans_after_cache_miss
     );
 
     let unrelated_session_flag_input = SkillsLoadInput::new(
@@ -397,14 +436,73 @@ async fn skills_for_config_cache_hit_avoids_environment_filesystem_operations() 
         .await;
     assert_eq!(
         counting_file_system.operation_count(),
-        operations_after_cache_miss
+        operations_after_refresh
     );
 
     skills_service.clear_cache();
     skills_service
         .snapshot_for_config(&skills_input, Some(file_system))
         .await;
-    assert!(counting_file_system.operation_count() > operations_after_cache_miss);
+    assert!(counting_file_system.operation_count() > operations_after_refresh);
+    assert!(counting_file_system.content_scan_operation_count() > content_scans_after_cache_miss);
+}
+
+#[tokio::test]
+async fn refresh_snapshot_for_config_discovers_new_repo_skill_root() {
+    let codex_home = tempfile::tempdir().expect("tempdir");
+    let cwd = tempfile::tempdir().expect("tempdir");
+    fs::create_dir(cwd.path().join(".git")).expect("create project marker");
+    let config_layer_stack = config_stack(&codex_home, "");
+    let skills_service = SkillsService::new(
+        codex_home.path().abs(),
+        /*bundled_skills_enabled*/ true,
+    );
+    let skills_input = SkillsLoadInput::new(
+        cwd.path().abs(),
+        Vec::new(),
+        config_layer_stack,
+        /*bundled_skills_enabled*/ true,
+    );
+
+    let initial_snapshot = skills_service
+        .snapshot_for_config(&skills_input, Some(Arc::clone(&LOCAL_FS)))
+        .await;
+    assert!(
+        initial_snapshot
+            .outcome()
+            .skills
+            .iter()
+            .all(|skill| skill.name != "late-repo-skill")
+    );
+
+    write_repo_skill(
+        &cwd,
+        "late-repo-skill",
+        "late-repo-skill",
+        "created after the snapshot",
+    );
+
+    let cached_snapshot = skills_service
+        .snapshot_for_config(&skills_input, Some(Arc::clone(&LOCAL_FS)))
+        .await;
+    assert!(
+        cached_snapshot
+            .outcome()
+            .skills
+            .iter()
+            .all(|skill| skill.name != "late-repo-skill")
+    );
+
+    let refreshed_snapshot = skills_service
+        .refresh_snapshot_for_config(&skills_input, Some(Arc::clone(&LOCAL_FS)))
+        .await;
+    assert!(
+        refreshed_snapshot
+            .outcome()
+            .skills
+            .iter()
+            .any(|skill| skill.name == "late-repo-skill")
+    );
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/agent/role_tests.rs
+++ b/codex-rs/core/src/agent/role_tests.rs
@@ -428,6 +428,7 @@ enabled = false
         .snapshot_for_config(
             &skills_input,
             Some(Arc::clone(&codex_exec_server::LOCAL_FS)),
+            /*refresh_filesystem*/ false,
         )
         .await;
     let outcome = snapshot.outcome();

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -449,7 +449,7 @@ async fn warm_plugins_and_skills_for_session_init(
     let skills_input = skills_load_input_from_config(config.as_ref(), effective_skill_roots)
         .with_plugin_skill_snapshots(plugin_skill_snapshots);
     skills_service
-        .snapshot_for_config(&skills_input, fs)
+        .refresh_snapshot_for_config(&skills_input, fs)
         .await
         .outcome()
         .errors

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -449,7 +449,7 @@ async fn warm_plugins_and_skills_for_session_init(
     let skills_input = skills_load_input_from_config(config.as_ref(), effective_skill_roots)
         .with_plugin_skill_snapshots(plugin_skill_snapshots);
     skills_service
-        .refresh_snapshot_for_config(&skills_input, fs)
+        .snapshot_for_config(&skills_input, fs, /*refresh_filesystem*/ true)
         .await
         .outcome()
         .errors

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -5113,7 +5113,11 @@ pub(crate) async fn make_session_and_context() -> (Session, TurnContext) {
     let skill_fs = environment.get_filesystem();
     let skills_snapshot = services
         .skills_service
-        .snapshot_for_config(&skills_input, Some(Arc::clone(&skill_fs)))
+        .snapshot_for_config(
+            &skills_input,
+            Some(Arc::clone(&skill_fs)),
+            /*refresh_filesystem*/ false,
+        )
         .await;
     let turn_context = Session::make_turn_context(
         thread_id,
@@ -7168,7 +7172,11 @@ where
     let skill_fs = environment.get_filesystem();
     let skills_snapshot = services
         .skills_service
-        .snapshot_for_config(&skills_input, Some(Arc::clone(&skill_fs)))
+        .snapshot_for_config(
+            &skills_input,
+            Some(Arc::clone(&skill_fs)),
+            /*refresh_filesystem*/ false,
+        )
         .await;
     let turn_context = Arc::new(Session::make_turn_context(
         thread_id,

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -740,7 +740,7 @@ impl Session {
         let skills_snapshot = self
             .services
             .skills_service
-            .snapshot_for_config(&skills_input, fs)
+            .snapshot_for_config(&skills_input, fs, /*refresh_filesystem*/ false)
             .await;
         let mut turn_context: TurnContext = Self::make_turn_context(
             self.thread_id(),


### PR DESCRIPTION
## Why

Every turn resolves a skills snapshot before model work starts. Previously, `snapshot_for_config()` discovered skill roots before checking the process-wide cache. Even when the snapshot was already cached, the turn still walked cwd ancestors for project markers and checked candidate `.agents/skills` directories. Those metadata operations can noticeably delay turn startup on slow or remote filesystems.

Returning from the cache before root discovery removes that per-turn I/O, but it also means filesystem-derived roots need an explicit refresh boundary. Otherwise, a repo `.agents/skills` root created after the first lookup could remain invisible for the lifetime of the process.

## What changed

The config-aware cache now uses a skill-relevant, in-memory request key, so normal turn lookups can return a cached snapshot without touching the environment filesystem. Cache entries also retain a fingerprint of the resolved roots and skill configuration rules.

Conversation initialization explicitly refreshes that fingerprint. If the roots and rules are unchanged, it reuses the complete snapshot without rescanning skill contents. If they changed, it rebuilds the snapshot. This makes a newly created repo `.agents/skills` root visible by the next conversation while keeping the per-turn path free of filesystem work.

Plugin skill snapshot ownership, watcher behavior, and existing explicit cache invalidation remain unchanged. Changes inside an already discovered root continue to use those existing invalidation paths.

## Testing

- `just test -p codex-core-skills` (108 passed)
- Added regression coverage showing that cache hits perform no environment filesystem operations, an unchanged conversation-start refresh avoids rescanning skill contents, and a newly created repo `.agents/skills` root is discovered by refresh.
