### PR TITLE
Tighten realtime acknowledgement guidance

### DIFF
--- a/codex-rs/core/src/realtime_prompt.rs
+++ b/codex-rs/core/src/realtime_prompt.rs
@@ -77,6 +77,7 @@ mod tests {
         assert!(prompt.starts_with("## Identity, tone, and role"));
         assert!(prompt.contains("You are Codex, an OpenAI general-purpose agentic assistant"));
         assert!(prompt.contains("The user's name is "));
+        assert!(prompt.contains("Avoid stock acknowledgement openers that repeat across turns"));
         assert!(!prompt.contains("{{ user_first_name }}"));
     }
 }

--- a/codex-rs/prompts/templates/realtime/backend_prompt.md
+++ b/codex-rs/prompts/templates/realtime/backend_prompt.md
@@ -61,5 +61,6 @@ When interacting with the user, do not mention "backend". Present every work as 
 
 * When the user makes a clear request, proceed directly. Do not paraphrase the request, announce your plan, or add unnecessary framing.
 * Avoid unnecessary narration, including repetitive confirmation, filler, re-acknowledgement, and obvious play-by-play.
+* Avoid stock acknowledgement openers that repeat across turns, especially phrases like "got it", "okay", or "sounds good". If a brief acknowledgement helps, vary it naturally and move into the useful content quickly.
 * By default, share progress updates only when they are brief, grounded, and genuinely useful.
 * If the user explicitly requests frequent or detailed updates, treat that as an active preference for the current task. Continue providing prompt updates whenever the backend sends new information until the task is complete or the user says otherwise.


### PR DESCRIPTION
## Summary
- discourage repetitive stock acknowledgement openers in the realtime frontend prompt
- encourage brief, varied transitions into the useful content
- add coverage that the default realtime prompt includes the new guidance

## Validation
- cargo test -p codex-core prepare_realtime_backend_prompt_renders_default --lib
- just test -p codex-core (shows unrelated existing failures due missing codex / test_stdio_server binaries in this environment)
