### PR TITLE
[codex] trace pre-sampling skill and persistence latency

### DIFF
--- a/codex-rs/core-skills/src/injection.rs
+++ b/codex-rs/core-skills/src/injection.rs
@@ -55,6 +55,11 @@ impl InjectedHostSkillPrompts {
     }
 }
 
+#[tracing::instrument(
+    level = "trace",
+    skip_all,
+    fields(mentioned_skill_count = mentioned_skills.len())
+)]
 pub async fn build_skill_injections(
     mentioned_skills: &[SkillMetadata],
     loaded_skills: Option<&SkillLoadOutcome>,

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -1199,6 +1199,11 @@ impl Session {
     }
 
     // Merges connector IDs into the session-level explicit connector selection.
+    #[tracing::instrument(
+        level = "trace",
+        skip_all,
+        fields(connector_count = connector_ids.len())
+    )]
     pub(crate) async fn merge_connector_selection(
         &self,
         connector_ids: HashSet<String>,
@@ -1390,6 +1395,7 @@ impl Session {
         state.previous_turn_settings()
     }
 
+    #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) async fn set_previous_turn_settings(
         &self,
         previous_turn_settings: Option<PreviousTurnSettings>,
@@ -2667,6 +2673,7 @@ impl Session {
         ))
     }
 
+    #[tracing::instrument(level = "trace", skip_all, fields(item_count = items.len()))]
     pub(crate) async fn record_conversation_items(
         &self,
         turn_context: &TurnContext,
@@ -2850,6 +2857,7 @@ impl Session {
         self.set_multi_agent_version_if_unset(selected)
     }
 
+    #[tracing::instrument(level = "trace", skip_all, fields(item_count = items.len()))]
     async fn send_raw_response_items(&self, turn_context: &TurnContext, items: &[ResponseItem]) {
         for item in items {
             self.send_event(
@@ -3121,6 +3129,7 @@ impl Session {
         items
     }
 
+    #[tracing::instrument(level = "trace", skip_all, fields(item_count = items.len()))]
     pub(crate) async fn persist_rollout_items(&self, items: &[RolloutItem]) {
         if let Some(live_thread) = self.live_thread()
             && let Err(e) = live_thread.append_items(items).await

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -624,6 +624,11 @@ async fn build_skills_and_plugins(
     Some((injection_items, explicitly_enabled_connectors))
 }
 
+#[tracing::instrument(
+    level = "trace",
+    skip_all,
+    fields(user_input_count = user_input.len())
+)]
 async fn build_extension_turn_input_items(
     sess: &Arc<Session>,
     turn_context: &TurnContext,
@@ -679,6 +684,11 @@ async fn build_extension_turn_input_items(
     Some(items)
 }
 
+#[tracing::instrument(
+    level = "trace",
+    skip_all,
+    fields(input_count = input.len())
+)]
 async fn track_turn_resolved_config_analytics(
     sess: &Session,
     turn_context: &TurnContext,

--- a/codex-rs/ext/skills/src/extension.rs
+++ b/codex-rs/ext/skills/src/extension.rs
@@ -287,6 +287,7 @@ where
 }
 
 impl<C> SkillsExtension<C> {
+    #[tracing::instrument(level = "trace", skip_all)]
     async fn list_skills(
         &self,
         mut query: SkillListQuery,
@@ -311,6 +312,7 @@ impl<C> SkillsExtension<C> {
         catalog
     }
 
+    #[tracing::instrument(level = "trace", skip_all, fields(skill = %entry.name))]
     async fn read_main_prompt(
         &self,
         entry: &SkillCatalogEntry,

--- a/codex-rs/ext/skills/src/render.rs
+++ b/codex-rs/ext/skills/src/render.rs
@@ -10,6 +10,11 @@ const MAX_MAIN_PROMPT_BYTES: usize = 8_000;
 pub(crate) const MAX_SKILL_NAME_BYTES: usize = 256;
 pub(crate) const MAX_SKILL_PATH_BYTES: usize = 1_024;
 
+#[tracing::instrument(
+    level = "trace",
+    skip_all,
+    fields(catalog_entry_count = catalog.entries.len())
+)]
 pub(crate) fn available_skills_fragment(
     catalog: &SkillCatalog,
 ) -> Option<AvailableSkillsInstructions> {

--- a/codex-rs/ext/skills/src/selection.rs
+++ b/codex-rs/ext/skills/src/selection.rs
@@ -10,6 +10,14 @@ use crate::catalog::SkillPackageId;
 
 const SKILL_PATH_PREFIX: &str = "skill://";
 
+#[tracing::instrument(
+    level = "trace",
+    skip_all,
+    fields(
+        input_count = inputs.len(),
+        catalog_entry_count = catalog.entries.len()
+    )
+)]
 pub(crate) fn collect_explicit_skill_mentions(
     inputs: &[UserInput],
     catalog: &SkillCatalog,

--- a/codex-rs/thread-store/src/live_thread.rs
+++ b/codex-rs/thread-store/src/live_thread.rs
@@ -133,6 +133,11 @@ impl LiveThread {
         })
     }
 
+    #[tracing::instrument(
+        level = "trace",
+        skip_all,
+        fields(item_count = items.len())
+    )]
     pub async fn append_items(&self, items: &[RolloutItem]) -> ThreadStoreResult<()> {
         let canonical_items = persisted_rollout_items(items);
         if items.is_empty() {

--- a/codex-rs/thread-store/src/local/live_writer.rs
+++ b/codex-rs/thread-store/src/local/live_writer.rs
@@ -74,6 +74,11 @@ pub(super) async fn resume_thread(
     store.insert_live_recorder(params.thread_id, recorder).await
 }
 
+#[tracing::instrument(
+    level = "trace",
+    skip_all,
+    fields(item_count = params.items.len())
+)]
 pub(super) async fn append_items(
     store: &LocalThreadStore,
     params: AppendThreadItemsParams,


### PR DESCRIPTION
## Summary

- Add trace spans around skill listing, selection, catalog rendering, and prompt loading.
- Trace extension and legacy skill injection along with connector/session bookkeeping.
- Trace conversation recording through rollout persistence, thread-store append, and local writer flush.
- Record bounded item, input, connector, catalog, and skill counts on the relevant spans.

## Why

`run_turn` traces had a substantial pre-sampling attribution gap after skill/plugin preparation and before `run_sampling_request`. Skill context recording and the synchronous rollout flush were covered only by the outer turn span, making it impossible to distinguish skill work, event emission, and persistence latency.

This change uses function-level `#[tracing::instrument]` attributes only and does not change runtime behavior.

## Validation

- `just test -p codex-core-skills -p codex-skills-extension -p codex-thread-store` — 196 passed.
- `just test -p codex-core suite::skills::user_turn_includes_skill_instructions` — passed.
- Broader affected-crate run compiled all four crates and ran 2,948 tests: 2,920 passed; 28 unrelated sandbox/timing-sensitive integration tests failed, including Seatbelt permission errors and websocket/mock timeouts.
- Rust formatting completed and `git diff --check` passed. The aggregate formatter also attempted unavailable `uv`/`dotslash` formatters and could not rewrite the parent `justfile` under the workspace sandbox.