### PR TITLE
[codex] stylistic changes

### DIFF
--- a/codex-rs/core/src/compact_remote_v2.rs
+++ b/codex-rs/core/src/compact_remote_v2.rs
@@ -165,18 +165,18 @@ async fn run_remote_compact_task_inner(
     attempt
         .track(sess.as_ref(), status, codex_error, analytics_details)
         .await;
-    if matches!(&result, Err(CodexErr::TurnAborted)) {
-        return result;
+    match result {
+        Ok(()) => Ok(()),
+        Err(err @ CodexErr::TurnAborted) => Err(err),
+        Err(err) => {
+            sess.track_turn_codex_error(turn_context, &err);
+            let event = EventMsg::Error(
+                err.to_error_event(Some("Error running remote compact task".to_string())),
+            );
+            sess.send_event(turn_context, event).await;
+            Err(err)
+        }
     }
-    if let Err(err) = result {
-        sess.track_turn_codex_error(turn_context, &err);
-        let event = EventMsg::Error(
-            err.to_error_event(Some("Error running remote compact task".to_string())),
-        );
-        sess.send_event(turn_context, event).await;
-        return Err(err);
-    }
-    Ok(())
 }
 
 async fn run_remote_compact_task_inner_impl(

--- a/codex-rs/core/tests/suite/rollout_budget.rs
+++ b/codex-rs/core/tests/suite/rollout_budget.rs
@@ -282,15 +282,8 @@ async fn compaction_budget_exhaustion_aborts_without_error_or_retry(remote_v2: b
         ])
     };
     let responses = mount_sse_sequence(&server, vec![compact_response]).await;
-    let mut model_provider = built_in_model_providers(/*openai_base_url*/ None)["openai"].clone();
-    model_provider.base_url = Some(format!("{}/v1", server.uri()));
-    model_provider.supports_websockets = false;
-    if !remote_v2 {
-        model_provider.name = "OpenAI-compatible test provider".to_string();
-    }
     let test = test_codex()
         .with_config(move |config| {
-            config.model_provider = model_provider;
             config.rollout_budget = Some(RolloutBudgetConfig {
                 limit_tokens: 10,
                 reminder_interval_tokens: 5,
@@ -301,6 +294,8 @@ async fn compaction_budget_exhaustion_aborts_without_error_or_retry(remote_v2: b
                     .features
                     .enable(Feature::RemoteCompactionV2)
                     .expect("test config should allow remote compaction v2");
+            } else {
+                config.model_provider.name = "OpenAI-compatible test provider".to_string();
             }
         })
         .build(&server)


### PR DESCRIPTION
## Summary

- express remote compaction result handling as an exhaustive match
- preserve the special `TurnAborted` path without emitting a generic compaction error
- rely on the standard `test_codex` provider setup in the compaction budget test

Follow-up to review feedback on #28707.

## Testing

- `just test -p codex-core compaction_budget_exhaustion_aborts_without_error_or_retry`
- `just fmt`