### PR TITLE
Document raw response item compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,7 @@ Codex maintains a context (history of messages) that is sent to the model in inf
 Search for breaking changes in external integration surfaces:
 
 - app-server APIs
+- raw response item events (`rawResponseItem/*`), even while experimental
 - CLI parameters
 - configuration loading
 - resuming sessions from existing rollouts


### PR DESCRIPTION
Adds a short AGENTS.md note asking reviewers to treat raw response item events as compatibility-sensitive, even while they are experimental.

This keeps future app-server changes from accidentally breaking Codex Cloud consumers of raw response item events.