### PR TITLE
Use cached and live web access terminology

### DIFF
--- a/codex-rs/codex-api/src/search.rs
+++ b/codex-rs/codex-api/src/search.rs
@@ -214,9 +214,9 @@ pub enum SearchResponseLength {
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExternalWebAccessMode {
-    Offline,
+    Cached,
     Indexed,
-    Online,
+    Live,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]


### PR DESCRIPTION
## Summary

- Rename the string-valued external web access enum variants from `Offline` / `Online` to `Cached` / `Live`.
- Align the transport names with the existing `web_search = "cached"` / `"live"` configuration vocabulary.

Existing behavior is unchanged: `WebSearchMode::Cached` and `WebSearchMode::Live` continue to send the backward-compatible boolean values `false` and `true`; `Indexed` remains the only mode currently sent as a string.

## Validation

- `just fmt`
- `just test -p codex-api` (127 passed)