### PR TITLE
[codex] make image artifact directory configurable

### DIFF
--- a/codex-rs/config/src/config_toml.rs
+++ b/codex-rs/config/src/config_toml.rs
@@ -330,6 +330,10 @@ pub struct ConfigToml {
     /// Defaults to `$CODEX_HOME/log`.
     pub log_dir: Option<AbsolutePathBuf>,
 
+    /// Directory where Codex writes generated image artifacts.
+    /// Defaults to `$CODEX_HOME/generated_images`.
+    pub image_generation_artifacts_dir: Option<AbsolutePathBuf>,
+
     /// Debugging and reproducibility settings.
     pub debug: Option<DebugToml>,
 

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -5056,6 +5056,14 @@
       ],
       "description": "Lifecycle hooks configured inline in TOML plus user-level overrides."
     },
+    "image_generation_artifacts_dir": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/AbsolutePathBuf"
+        }
+      ],
+      "description": "Directory where Codex writes generated image artifacts. Defaults to `$CODEX_HOME/generated_images`."
+    },
     "include_apps_instructions": {
       "description": "Whether to inject the `<apps_instructions>` developer block.",
       "type": "boolean"

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -4899,6 +4899,43 @@ async fn sqlite_home_defaults_to_codex_home_for_workspace_write() -> std::io::Re
 }
 
 #[tokio::test]
+async fn image_generation_artifacts_dir_defaults_to_codex_home() -> std::io::Result<()> {
+    let codex_home = TempDir::new()?;
+    let config = Config::load_from_base_config_with_overrides(
+        ConfigToml::default(),
+        ConfigOverrides::default(),
+        codex_home.abs(),
+    )
+    .await?;
+
+    assert_eq!(
+        config.image_generation_artifacts_dir,
+        codex_home.path().join("generated_images").abs()
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn image_generation_artifacts_dir_uses_configured_path() -> std::io::Result<()> {
+    let codex_home = TempDir::new()?;
+    let artifacts_dir = codex_home.path().join("team-images").abs();
+    let config = Config::load_from_base_config_with_overrides(
+        ConfigToml {
+            image_generation_artifacts_dir: Some(artifacts_dir.clone()),
+            ..Default::default()
+        },
+        ConfigOverrides::default(),
+        codex_home.abs(),
+    )
+    .await?;
+
+    assert_eq!(config.image_generation_artifacts_dir, artifacts_dir);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn workspace_write_includes_configured_writable_root_once_without_memories_root()
 -> std::io::Result<()> {
     let codex_home = TempDir::new()?;

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -873,6 +873,9 @@ pub struct Config {
     /// Directory where Codex writes log files (defaults to `$CODEX_HOME/log`).
     pub log_dir: PathBuf,
 
+    /// Directory where Codex writes generated image artifacts.
+    pub image_generation_artifacts_dir: AbsolutePathBuf,
+
     /// Directory where Codex writes effective session config lock files.
     pub config_lock_export_dir: Option<AbsolutePathBuf>,
 
@@ -3545,6 +3548,10 @@ impl Config {
             .map(AbsolutePathBuf::to_path_buf)
             .or_else(|| resolve_sqlite_home_env(&resolved_cwd))
             .unwrap_or_else(|| codex_home.to_path_buf());
+        let image_generation_artifacts_dir = cfg
+            .image_generation_artifacts_dir
+            .clone()
+            .unwrap_or_else(|| codex_home.join("generated_images"));
         let original_permission_profile = permission_profile.clone();
         apply_requirement_constrained_value(
             "approval_policy",
@@ -3748,6 +3755,7 @@ impl Config {
             codex_home,
             sqlite_home,
             log_dir,
+            image_generation_artifacts_dir,
             config_lock_export_dir: cfg
                 .debug
                 .as_ref()

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -8143,7 +8143,7 @@ async fn handle_output_item_done_records_image_save_history_message() {
     let turn_context = Arc::new(turn_context);
     let call_id = "ig_history_records_message";
     let expected_saved_path = crate::stream_events_utils::image_generation_artifact_path(
-        &turn_context.config.codex_home,
+        &turn_context.config.image_generation_artifacts_dir,
         &session.thread_id.to_string(),
         call_id,
     );
@@ -8171,7 +8171,7 @@ async fn handle_output_item_done_records_image_save_history_message() {
 
     let history = session.clone_history().await;
     let image_output_path = crate::stream_events_utils::image_generation_artifact_path(
-        &turn_context.config.codex_home,
+        &turn_context.config.image_generation_artifacts_dir,
         &session.thread_id.to_string(),
         "<image_id>",
     );
@@ -8200,7 +8200,7 @@ async fn handle_output_item_done_skips_image_save_message_when_save_fails() {
     let turn_context = Arc::new(turn_context);
     let call_id = "ig_history_no_message";
     let expected_saved_path = crate::stream_events_utils::image_generation_artifact_path(
-        &turn_context.config.codex_home,
+        &turn_context.config.image_generation_artifacts_dir,
         &session.thread_id.to_string(),
         call_id,
     );

--- a/codex-rs/core/src/stream_events_utils.rs
+++ b/codex-rs/core/src/stream_events_utils.rs
@@ -36,11 +36,9 @@ use tracing::debug;
 use tracing::instrument;
 use tracing::warn;
 
-const GENERATED_IMAGE_ARTIFACTS_DIR: &str = "generated_images";
-
-/// Returns the host-owned default artifact path for a generated image.
+/// Returns the path for a generated image within the configured artifact directory.
 pub fn image_generation_artifact_path(
-    codex_home: &AbsolutePathBuf,
+    artifacts_dir: &AbsolutePathBuf,
     session_id: &str,
     call_id: &str,
 ) -> AbsolutePathBuf {
@@ -61,8 +59,7 @@ pub fn image_generation_artifact_path(
         sanitized
     };
 
-    codex_home
-        .join(GENERATED_IMAGE_ARTIFACTS_DIR)
+    artifacts_dir
         .join(sanitize(session_id))
         .join(format!("{}.png", sanitize(call_id)))
 }
@@ -109,7 +106,7 @@ pub(crate) fn raw_assistant_output_text_from_item(item: &ResponseItem) -> Option
 }
 
 async fn save_image_generation_result(
-    codex_home: &AbsolutePathBuf,
+    artifacts_dir: &AbsolutePathBuf,
     session_id: &str,
     call_id: &str,
     result: &str,
@@ -119,7 +116,7 @@ async fn save_image_generation_result(
         .map_err(|err| {
             CodexErr::InvalidRequest(format!("invalid image generation payload: {err}"))
         })?;
-    let path = image_generation_artifact_path(codex_home, session_id, call_id);
+    let path = image_generation_artifact_path(artifacts_dir, session_id, call_id);
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent).await?;
     }
@@ -135,7 +132,7 @@ pub(crate) async fn persist_image_generation_item(
     image_item.saved_path = None;
     let session_id = sess.thread_id.to_string();
     match save_image_generation_result(
-        &turn_context.config.codex_home,
+        &turn_context.config.image_generation_artifacts_dir,
         &session_id,
         &image_item.id,
         &image_item.result,
@@ -148,13 +145,13 @@ pub(crate) async fn persist_image_generation_item(
         }
         Err(err) => {
             let output_path = image_generation_artifact_path(
-                &turn_context.config.codex_home,
+                &turn_context.config.image_generation_artifacts_dir,
                 &session_id,
                 &image_item.id,
             );
             let output_dir = output_path
                 .parent()
-                .unwrap_or_else(|| turn_context.config.codex_home.clone());
+                .unwrap_or_else(|| turn_context.config.image_generation_artifacts_dir.clone());
             tracing::warn!(
                 call_id = %image_item.id,
                 output_dir = %output_dir.display(),
@@ -174,11 +171,14 @@ async fn record_image_generation_instructions(
         return;
     }
     let session_id = sess.thread_id.to_string();
-    let image_output_path =
-        image_generation_artifact_path(&turn_context.config.codex_home, &session_id, "<image_id>");
+    let image_output_path = image_generation_artifact_path(
+        &turn_context.config.image_generation_artifacts_dir,
+        &session_id,
+        "<image_id>",
+    );
     let image_output_dir = image_output_path
         .parent()
-        .unwrap_or_else(|| turn_context.config.codex_home.clone());
+        .unwrap_or_else(|| turn_context.config.image_generation_artifacts_dir.clone());
     let message: ResponseItem = ContextualUserFragment::into(ImageGenerationInstructions::new(
         image_output_dir.display(),
         image_output_path.display(),

--- a/codex-rs/core/src/stream_events_utils_tests.rs
+++ b/codex-rs/core/src/stream_events_utils_tests.rs
@@ -434,14 +434,15 @@ fn completed_item_defers_mailbox_delivery_for_image_generation_calls() {
 }
 
 #[tokio::test]
-async fn save_image_generation_result_saves_base64_to_png_in_codex_home() {
-    let codex_home = tempfile::tempdir().expect("create codex home");
-    let codex_home = codex_home.path().abs();
-    let expected_path = image_generation_artifact_path(&codex_home, "session-1", "ig_save_base64");
+async fn save_image_generation_result_saves_base64_to_png_in_artifacts_dir() {
+    let artifacts_dir = tempfile::tempdir().expect("create artifacts dir");
+    let artifacts_dir = artifacts_dir.path().abs();
+    let expected_path =
+        image_generation_artifact_path(&artifacts_dir, "session-1", "ig_save_base64");
     let _ = std::fs::remove_file(&expected_path);
 
     let saved_path =
-        save_image_generation_result(&codex_home, "session-1", "ig_save_base64", "Zm9v")
+        save_image_generation_result(&artifacts_dir, "session-1", "ig_save_base64", "Zm9v")
             .await
             .expect("image should be saved");
 
@@ -453,10 +454,10 @@ async fn save_image_generation_result_saves_base64_to_png_in_codex_home() {
 #[tokio::test]
 async fn save_image_generation_result_rejects_data_url_payload() {
     let result = "data:image/jpeg;base64,Zm9v";
-    let codex_home = tempfile::tempdir().expect("create codex home");
-    let codex_home = codex_home.path().abs();
+    let artifacts_dir = tempfile::tempdir().expect("create artifacts dir");
+    let artifacts_dir = artifacts_dir.path().abs();
 
-    let err = save_image_generation_result(&codex_home, "session-1", "ig_456", result)
+    let err = save_image_generation_result(&artifacts_dir, "session-1", "ig_456", result)
         .await
         .expect_err("data url payload should error");
     assert!(matches!(err, CodexErr::InvalidRequest(_)));
@@ -464,9 +465,9 @@ async fn save_image_generation_result_rejects_data_url_payload() {
 
 #[tokio::test]
 async fn save_image_generation_result_overwrites_existing_file() {
-    let codex_home = tempfile::tempdir().expect("create codex home");
-    let codex_home = codex_home.path().abs();
-    let existing_path = image_generation_artifact_path(&codex_home, "session-1", "ig_overwrite");
+    let artifacts_dir = tempfile::tempdir().expect("create artifacts dir");
+    let artifacts_dir = artifacts_dir.path().abs();
+    let existing_path = image_generation_artifact_path(&artifacts_dir, "session-1", "ig_overwrite");
     std::fs::create_dir_all(
         existing_path
             .parent()
@@ -475,9 +476,10 @@ async fn save_image_generation_result_overwrites_existing_file() {
     .expect("create image output dir");
     std::fs::write(&existing_path, b"existing").expect("seed existing image");
 
-    let saved_path = save_image_generation_result(&codex_home, "session-1", "ig_overwrite", "Zm9v")
-        .await
-        .expect("image should be saved");
+    let saved_path =
+        save_image_generation_result(&artifacts_dir, "session-1", "ig_overwrite", "Zm9v")
+            .await
+            .expect("image should be saved");
 
     assert_eq!(saved_path, existing_path);
     assert_eq!(std::fs::read(&saved_path).expect("saved file"), b"foo");
@@ -485,13 +487,13 @@ async fn save_image_generation_result_overwrites_existing_file() {
 }
 
 #[tokio::test]
-async fn save_image_generation_result_sanitizes_call_id_for_codex_home_output_path() {
-    let codex_home = tempfile::tempdir().expect("create codex home");
-    let codex_home = codex_home.path().abs();
-    let expected_path = image_generation_artifact_path(&codex_home, "session-1", "../ig/..");
+async fn save_image_generation_result_sanitizes_call_id_for_artifact_path() {
+    let artifacts_dir = tempfile::tempdir().expect("create artifacts dir");
+    let artifacts_dir = artifacts_dir.path().abs();
+    let expected_path = image_generation_artifact_path(&artifacts_dir, "session-1", "../ig/..");
     let _ = std::fs::remove_file(&expected_path);
 
-    let saved_path = save_image_generation_result(&codex_home, "session-1", "../ig/..", "Zm9v")
+    let saved_path = save_image_generation_result(&artifacts_dir, "session-1", "../ig/..", "Zm9v")
         .await
         .expect("image should be saved");
 
@@ -502,9 +504,9 @@ async fn save_image_generation_result_sanitizes_call_id_for_codex_home_output_pa
 
 #[tokio::test]
 async fn save_image_generation_result_rejects_non_standard_base64() {
-    let codex_home = tempfile::tempdir().expect("create codex home");
-    let codex_home = codex_home.path().abs();
-    let err = save_image_generation_result(&codex_home, "session-1", "ig_urlsafe", "_-8")
+    let artifacts_dir = tempfile::tempdir().expect("create artifacts dir");
+    let artifacts_dir = artifacts_dir.path().abs();
+    let err = save_image_generation_result(&artifacts_dir, "session-1", "ig_urlsafe", "_-8")
         .await
         .expect_err("non-standard base64 should error");
     assert!(matches!(err, CodexErr::InvalidRequest(_)));
@@ -512,10 +514,10 @@ async fn save_image_generation_result_rejects_non_standard_base64() {
 
 #[tokio::test]
 async fn save_image_generation_result_rejects_non_base64_data_urls() {
-    let codex_home = tempfile::tempdir().expect("create codex home");
-    let codex_home = codex_home.path().abs();
+    let artifacts_dir = tempfile::tempdir().expect("create artifacts dir");
+    let artifacts_dir = artifacts_dir.path().abs();
     let err = save_image_generation_result(
-        &codex_home,
+        &artifacts_dir,
         "session-1",
         "ig_svg",
         "data:image/svg+xml,<svg/>",

--- a/codex-rs/core/src/tools/handlers/extension_tools.rs
+++ b/codex-rs/core/src/tools/handlers/extension_tools.rs
@@ -536,7 +536,7 @@ mod tests {
         let handler = ExtensionToolAdapter::new(Arc::new(ImageGenerationExtensionExecutor));
         let (session, turn, rx) = crate::session::tests::make_session_and_context_with_rx().await;
         let expected_path = crate::stream_events_utils::image_generation_artifact_path(
-            &turn.config.codex_home,
+            &turn.config.image_generation_artifacts_dir,
             &session.thread_id.to_string(),
             "call-image",
         );

--- a/codex-rs/core/tests/suite/items.rs
+++ b/codex-rs/core/tests/suite/items.rs
@@ -71,7 +71,11 @@ fn disabled_plan_turn(
     })
 }
 
-fn image_generation_artifact_path(codex_home: &Path, session_id: &str, call_id: &str) -> PathBuf {
+fn image_generation_artifact_path(
+    artifacts_dir: &Path,
+    session_id: &str,
+    call_id: &str,
+) -> PathBuf {
     fn sanitize(value: &str) -> String {
         let mut sanitized: String = value
             .chars()
@@ -89,8 +93,7 @@ fn image_generation_artifact_path(codex_home: &Path, session_id: &str, call_id: 
         sanitized
     }
 
-    codex_home
-        .join("generated_images")
+    artifacts_dir
         .join(sanitize(session_id))
         .join(format!("{}.png", sanitize(call_id)))
 }
@@ -348,20 +351,28 @@ async fn web_search_item_is_emitted() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn builtin_image_generation_call_persisted() -> anyhow::Result<()> {
+async fn builtin_image_generation_call_persisted_to_configured_directory() -> anyhow::Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
+    let artifacts_parent = tempfile::tempdir()?;
+    let artifacts_dir = artifacts_parent.path().join("team-images").abs();
 
     let TestCodex {
         codex,
         config,
         session_configured,
         ..
-    } = test_codex().build(&server).await?;
-    let call_id = "ig_image_saved_to_temp_dir_default";
+    } = test_codex()
+        .with_config({
+            let artifacts_dir = artifacts_dir.clone();
+            move |config| config.image_generation_artifacts_dir = artifacts_dir
+        })
+        .build(&server)
+        .await?;
+    let call_id = "ig_image_saved_to_configured_dir";
     let expected_saved_path = image_generation_artifact_path(
-        config.codex_home.as_path(),
+        config.image_generation_artifacts_dir.as_path(),
         &session_configured.thread_id.to_string(),
         call_id,
     );
@@ -448,7 +459,7 @@ async fn image_generation_call_event_is_emitted_when_image_save_fails() -> anyho
         ..
     } = test_codex().build(&server).await?;
     let expected_saved_path = image_generation_artifact_path(
-        config.codex_home.as_path(),
+        config.image_generation_artifacts_dir.as_path(),
         &session_configured.thread_id.to_string(),
         "ig_invalid",
     );

--- a/codex-rs/core/tests/suite/model_switching.rs
+++ b/codex-rs/core/tests/suite/model_switching.rs
@@ -67,7 +67,11 @@ fn read_only_user_turn(test: &TestCodex, items: Vec<UserInput>, model: String) -
     }
 }
 
-fn image_generation_artifact_path(codex_home: &Path, session_id: &str, call_id: &str) -> PathBuf {
+fn image_generation_artifact_path(
+    artifacts_dir: &Path,
+    session_id: &str,
+    call_id: &str,
+) -> PathBuf {
     fn sanitize(value: &str) -> String {
         let mut sanitized: String = value
             .chars()
@@ -85,8 +89,7 @@ fn image_generation_artifact_path(codex_home: &Path, session_id: &str, call_id: 
         sanitized
     }
 
-    codex_home
-        .join("generated_images")
+    artifacts_dir
         .join(sanitize(session_id))
         .join(format!("{}.png", sanitize(call_id)))
 }
@@ -603,7 +606,7 @@ async fn generated_image_is_replayed_for_image_capable_models() -> Result<()> {
         });
     let test = builder.build(&server).await?;
     let saved_path = image_generation_artifact_path(
-        test.codex_home_path(),
+        test.config.image_generation_artifacts_dir.as_path(),
         &test.session_configured.thread_id.to_string(),
         "ig_123",
     );
@@ -717,7 +720,7 @@ async fn model_change_from_generated_image_to_text_preserves_prior_generated_ima
         });
     let test = builder.build(&server).await?;
     let saved_path = image_generation_artifact_path(
-        test.codex_home_path(),
+        test.config.image_generation_artifacts_dir.as_path(),
         &test.session_configured.thread_id.to_string(),
         "ig_123",
     );
@@ -833,7 +836,7 @@ async fn thread_rollback_after_generated_image_drops_entire_image_turn_history()
         });
     let test = builder.build(&server).await?;
     let saved_path = image_generation_artifact_path(
-        test.codex_home_path(),
+        test.config.image_generation_artifacts_dir.as_path(),
         &test.session_configured.thread_id.to_string(),
         "ig_rollback",
     );

--- a/codex-rs/ext/image-generation/src/extension.rs
+++ b/codex-rs/ext/image-generation/src/extension.rs
@@ -27,7 +27,7 @@ struct ImageGenerationExtension {
 struct ImageGenerationExtensionConfig {
     available: bool,
     provider: ModelProviderInfo,
-    codex_home: AbsolutePathBuf,
+    artifacts_dir: AbsolutePathBuf,
 }
 
 impl From<&Config> for ImageGenerationExtensionConfig {
@@ -37,7 +37,7 @@ impl From<&Config> for ImageGenerationExtensionConfig {
             // Core selects this executor per turn using the feature flag or model metadata.
             available: config.model_provider.is_openai(),
             provider: config.model_provider.clone(),
-            codex_home: config.codex_home.clone(),
+            artifacts_dir: config.image_generation_artifacts_dir.clone(),
         }
     }
 }
@@ -88,7 +88,7 @@ impl ToolContributor for ImageGenerationExtension {
                 config.provider.clone(),
                 Some(self.auth_manager.clone()),
             )),
-            config.codex_home.clone(),
+            config.artifacts_dir.clone(),
             thread_store.level_id().to_string(),
         ))]
     }

--- a/codex-rs/ext/image-generation/src/tool.rs
+++ b/codex-rs/ext/image-generation/src/tool.rs
@@ -51,7 +51,7 @@ const IMAGEGEN_DESCRIPTION: &str = include_str!("../imagegen_description.md");
 #[derive(Clone)]
 pub(crate) struct ImageGenerationTool {
     backend: CodexImagesBackend,
-    codex_home: AbsolutePathBuf,
+    artifacts_dir: AbsolutePathBuf,
     thread_id: String,
 }
 
@@ -59,12 +59,12 @@ impl ImageGenerationTool {
     /// Creates an image-generation tool backed by an image API executor.
     pub(crate) fn new(
         backend: CodexImagesBackend,
-        codex_home: AbsolutePathBuf,
+        artifacts_dir: AbsolutePathBuf,
         thread_id: String,
     ) -> Self {
         Self {
             backend,
-            codex_home,
+            artifacts_dir,
             thread_id,
         }
     }
@@ -155,10 +155,10 @@ impl ImageGenerationTool {
             }))
             .await;
         let output_path =
-            image_generation_artifact_path(&self.codex_home, &self.thread_id, &call.call_id);
+            image_generation_artifact_path(&self.artifacts_dir, &self.thread_id, &call.call_id);
         let output_dir = output_path
             .parent()
-            .unwrap_or_else(|| self.codex_home.clone());
+            .unwrap_or_else(|| self.artifacts_dir.clone());
         let output_hint =
             extension_image_generation_output_hint(output_dir.display(), output_path.display());
         Ok(Box::new(GeneratedImageOutput {


### PR DESCRIPTION
## Summary

- add an optional `image_generation_artifacts_dir` setting to `config.toml`
- preserve the existing `$CODEX_HOME/generated_images` default
- use the configured directory for hosted image saves and standalone image-generation output hints
- regenerate the config schema

## Why

Hosted deployments may need generated image artifacts written to a deployment-specific location instead of the default Codex home directory. This adds that option without changing existing behavior when the setting is omitted.

## Testing

- `just test -p codex-config`
- `just test -p codex-image-generation-extension`
- `just test -p codex-core image_generation_artifacts_dir`
- `just test -p codex-core builtin_image_generation_call_persisted_to_configured_directory`
- `just test -p codex-core image_generation`
- `just fix -p codex-config`
- `just fix -p codex-image-generation-extension`
- `just fix -p codex-core`