### PR TITLE
[codex] Route image generation writes through ExecutorFileSystem

### DIFF
--- a/codex-rs/core/src/stream_events_utils.rs
+++ b/codex-rs/core/src/stream_events_utils.rs
@@ -3,6 +3,9 @@ use std::sync::Arc;
 
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use codex_exec_server::CreateDirectoryOptions;
+use codex_exec_server::ExecutorFileSystem;
+use codex_exec_server::LOCAL_FS;
 use codex_extension_api::ExtensionData;
 use codex_protocol::config_types::ModeKind;
 use codex_protocol::items::ImageGenerationItem;
@@ -30,6 +33,7 @@ use codex_protocol::models::ResponseInputItem;
 use codex_protocol::models::ResponseItem;
 use codex_rollout::state_db;
 use codex_utils_absolute_path::AbsolutePathBuf;
+use codex_utils_path_uri::PathUri;
 use codex_utils_stream_parser::strip_proposed_plan_blocks;
 use futures::Future;
 use tracing::debug;
@@ -109,6 +113,7 @@ pub(crate) fn raw_assistant_output_text_from_item(item: &ResponseItem) -> Option
 }
 
 async fn save_image_generation_result(
+    fs: &dyn ExecutorFileSystem,
     codex_home: &AbsolutePathBuf,
     session_id: &str,
     call_id: &str,
@@ -121,9 +126,15 @@ async fn save_image_generation_result(
         })?;
     let path = image_generation_artifact_path(codex_home, session_id, call_id);
     if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent).await?;
+        fs.create_directory(
+            &PathUri::from_abs_path(&parent),
+            CreateDirectoryOptions { recursive: true },
+            /*sandbox*/ None,
+        )
+        .await?;
     }
-    tokio::fs::write(&path, bytes).await?;
+    fs.write_file(&PathUri::from_abs_path(&path), bytes, /*sandbox*/ None)
+        .await?;
     Ok(path)
 }
 
@@ -135,6 +146,7 @@ pub(crate) async fn persist_image_generation_item(
     image_item.saved_path = None;
     let session_id = sess.thread_id.to_string();
     match save_image_generation_result(
+        LOCAL_FS.as_ref(),
         &turn_context.config.codex_home,
         &session_id,
         &image_item.id,

--- a/codex-rs/core/src/stream_events_utils_tests.rs
+++ b/codex-rs/core/src/stream_events_utils_tests.rs
@@ -12,6 +12,7 @@ use crate::session::tests::make_session_and_context;
 use crate::tools::ToolRouter;
 use crate::tools::parallel::ToolCallRuntime;
 use crate::turn_diff_tracker::TurnDiffTracker;
+use codex_exec_server::LOCAL_FS;
 use codex_extension_api::ExtensionData;
 use codex_extension_api::TurnItemContributor;
 use codex_protocol::error::CodexErr;
@@ -440,10 +441,15 @@ async fn save_image_generation_result_saves_base64_to_png_in_codex_home() {
     let expected_path = image_generation_artifact_path(&codex_home, "session-1", "ig_save_base64");
     let _ = std::fs::remove_file(&expected_path);
 
-    let saved_path =
-        save_image_generation_result(&codex_home, "session-1", "ig_save_base64", "Zm9v")
-            .await
-            .expect("image should be saved");
+    let saved_path = save_image_generation_result(
+        LOCAL_FS.as_ref(),
+        &codex_home,
+        "session-1",
+        "ig_save_base64",
+        "Zm9v",
+    )
+    .await
+    .expect("image should be saved");
 
     assert_eq!(saved_path, expected_path);
     assert_eq!(std::fs::read(&saved_path).expect("saved file"), b"foo");
@@ -456,9 +462,15 @@ async fn save_image_generation_result_rejects_data_url_payload() {
     let codex_home = tempfile::tempdir().expect("create codex home");
     let codex_home = codex_home.path().abs();
 
-    let err = save_image_generation_result(&codex_home, "session-1", "ig_456", result)
-        .await
-        .expect_err("data url payload should error");
+    let err = save_image_generation_result(
+        LOCAL_FS.as_ref(),
+        &codex_home,
+        "session-1",
+        "ig_456",
+        result,
+    )
+    .await
+    .expect_err("data url payload should error");
     assert!(matches!(err, CodexErr::InvalidRequest(_)));
 }
 
@@ -475,9 +487,15 @@ async fn save_image_generation_result_overwrites_existing_file() {
     .expect("create image output dir");
     std::fs::write(&existing_path, b"existing").expect("seed existing image");
 
-    let saved_path = save_image_generation_result(&codex_home, "session-1", "ig_overwrite", "Zm9v")
-        .await
-        .expect("image should be saved");
+    let saved_path = save_image_generation_result(
+        LOCAL_FS.as_ref(),
+        &codex_home,
+        "session-1",
+        "ig_overwrite",
+        "Zm9v",
+    )
+    .await
+    .expect("image should be saved");
 
     assert_eq!(saved_path, existing_path);
     assert_eq!(std::fs::read(&saved_path).expect("saved file"), b"foo");
@@ -491,9 +509,15 @@ async fn save_image_generation_result_sanitizes_call_id_for_codex_home_output_pa
     let expected_path = image_generation_artifact_path(&codex_home, "session-1", "../ig/..");
     let _ = std::fs::remove_file(&expected_path);
 
-    let saved_path = save_image_generation_result(&codex_home, "session-1", "../ig/..", "Zm9v")
-        .await
-        .expect("image should be saved");
+    let saved_path = save_image_generation_result(
+        LOCAL_FS.as_ref(),
+        &codex_home,
+        "session-1",
+        "../ig/..",
+        "Zm9v",
+    )
+    .await
+    .expect("image should be saved");
 
     assert_eq!(saved_path, expected_path);
     assert_eq!(std::fs::read(&saved_path).expect("saved file"), b"foo");
@@ -504,9 +528,15 @@ async fn save_image_generation_result_sanitizes_call_id_for_codex_home_output_pa
 async fn save_image_generation_result_rejects_non_standard_base64() {
     let codex_home = tempfile::tempdir().expect("create codex home");
     let codex_home = codex_home.path().abs();
-    let err = save_image_generation_result(&codex_home, "session-1", "ig_urlsafe", "_-8")
-        .await
-        .expect_err("non-standard base64 should error");
+    let err = save_image_generation_result(
+        LOCAL_FS.as_ref(),
+        &codex_home,
+        "session-1",
+        "ig_urlsafe",
+        "_-8",
+    )
+    .await
+    .expect_err("non-standard base64 should error");
     assert!(matches!(err, CodexErr::InvalidRequest(_)));
 }
 
@@ -515,6 +545,7 @@ async fn save_image_generation_result_rejects_non_base64_data_urls() {
     let codex_home = tempfile::tempdir().expect("create codex home");
     let codex_home = codex_home.path().abs();
     let err = save_image_generation_result(
+        LOCAL_FS.as_ref(),
         &codex_home,
         "session-1",
         "ig_svg",


### PR DESCRIPTION
## Summary

- route generated-image directory creation and file writes through `ExecutorFileSystem`
- preserve the existing host-owned `CODEX_HOME/generated_images` destination via `LOCAL_FS`
- keep save outcomes, output hints, and environment selection unchanged for a follow-up

## Why

Image generation still called `tokio::fs` directly when persisting generated images. This is the mechanical first step toward the executor/environment split while preserving current behavior.

## Impact

No user-visible behavior change is intended. Generated images continue to be written under host `CODEX_HOME` without the turn sandbox, matching the previous direct filesystem calls.

## Test plan

- `just test -p codex-core save_image_generation_result` (6 passed)

A broader local `codex-core` run was attempted but remained red on unrelated integration-harness failures, including unavailable `codex` and `test_stdio_server` helper binaries.
