### PR TITLE
Revert "Scope MCP sandbox metadata to server environment (#28914)"

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -3290,7 +3290,6 @@ dependencies = [
  "codex-plugin",
  "codex-protocol",
  "codex-rmcp-client",
- "codex-utils-path-uri",
  "codex-utils-plugins",
  "futures",
  "pretty_assertions",

--- a/codex-rs/codex-mcp/Cargo.toml
+++ b/codex-rs/codex-mcp/Cargo.toml
@@ -26,7 +26,6 @@ codex-otel = { workspace = true }
 codex-plugin = { workspace = true }
 codex-protocol = { workspace = true }
 codex-rmcp-client = { workspace = true }
-codex-utils-path-uri = { workspace = true }
 codex-utils-plugins = { workspace = true }
 futures = { workspace = true }
 regex-lite = { workspace = true }

--- a/codex-rs/codex-mcp/src/connection_manager.rs
+++ b/codex-rs/codex-mcp/src/connection_manager.rs
@@ -372,12 +372,6 @@ impl McpConnectionManager {
             .map(super::server::McpServerOrigin::as_str)
     }
 
-    pub fn server_environment_id(&self, server_name: &str) -> Option<&str> {
-        self.server_metadata
-            .get(server_name)
-            .map(|metadata| metadata.environment_id.as_str())
-    }
-
     pub fn server_pollutes_memory(&self, server_name: &str) -> bool {
         self.server_metadata
             .get(server_name)

--- a/codex-rs/codex-mcp/src/connection_manager_tests.rs
+++ b/codex-rs/codex-mcp/src/connection_manager_tests.rs
@@ -1141,7 +1141,6 @@ async fn list_all_tools_adds_server_metadata_to_cached_tools() {
     manager.server_metadata.insert(
         server_name.to_string(),
         McpServerMetadata {
-            environment_id: codex_config::DEFAULT_MCP_SERVER_ENVIRONMENT_ID.to_string(),
             pollutes_memory: true,
             origin: Some(McpServerOrigin::StreamableHttp(
                 "https://docs.example".to_string(),
@@ -1177,7 +1176,6 @@ fn server_metadata_preserves_tool_approval_policy() {
         "https://docs.example",
         /*apps_mcp_product_sku*/ None,
     );
-    config.environment_id = "remote".to_string();
     config.default_tools_approval_mode = Some(AppToolApproval::Prompt);
     config.tools.insert(
         "search".to_string(),
@@ -1187,7 +1185,6 @@ fn server_metadata_preserves_tool_approval_policy() {
     );
     let metadata = McpServerMetadata::from(&EffectiveMcpServer::configured(config));
 
-    assert_eq!(metadata.environment_id, "remote");
     assert_eq!(metadata.tool_approval_mode("read"), AppToolApproval::Prompt);
     assert_eq!(
         metadata.tool_approval_mode("search"),

--- a/codex-rs/codex-mcp/src/runtime.rs
+++ b/codex-rs/codex-mcp/src/runtime.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use codex_exec_server::Environment;
 use codex_exec_server::EnvironmentManager;
 use codex_protocol::models::PermissionProfile;
-use codex_utils_path_uri::PathUri;
+use codex_protocol::protocol::SandboxPolicy;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -22,8 +22,9 @@ use serde::Serialize;
 pub struct SandboxState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub permission_profile: Option<PermissionProfile>,
+    pub sandbox_policy: SandboxPolicy,
     pub codex_linux_sandbox_exe: Option<PathBuf>,
-    pub sandbox_cwd: PathUri,
+    pub sandbox_cwd: PathBuf,
     #[serde(default)]
     pub use_legacy_landlock: bool,
 }

--- a/codex-rs/codex-mcp/src/server.rs
+++ b/codex-rs/codex-mcp/src/server.rs
@@ -75,7 +75,6 @@ impl McpServerOrigin {
 /// Semantic metadata that must survive after the server is launched.
 #[derive(Debug, Clone)]
 pub(crate) struct McpServerMetadata {
-    pub environment_id: String,
     pub pollutes_memory: bool,
     pub origin: Option<McpServerOrigin>,
     pub supports_parallel_tool_calls: bool,
@@ -97,7 +96,6 @@ impl From<&EffectiveMcpServer> for McpServerMetadata {
     fn from(server: &EffectiveMcpServer) -> Self {
         match server.launch() {
             McpServerLaunch::Configured(config) => Self {
-                environment_id: config.environment_id.clone(),
                 pollutes_memory: true,
                 origin: McpServerOrigin::from_transport(&config.transport),
                 supports_parallel_tool_calls: config.supports_parallel_tool_calls,

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -81,7 +81,6 @@ use codex_rollout::state_db;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_output_truncation::TruncationPolicy;
 use codex_utils_output_truncation::truncate_text;
-use codex_utils_path_uri::PathUri;
 use codex_utils_pty::DEFAULT_OUTPUT_BYTES_CAP;
 use rmcp::model::ToolAnnotations;
 use serde::Deserialize;
@@ -727,8 +726,10 @@ async fn augment_mcp_tool_request_meta_with_sandbox_state(
     server: &str,
     mut meta: Option<serde_json::Value>,
 ) -> anyhow::Result<Option<serde_json::Value>> {
-    let mcp_connection_manager = sess.services.mcp_connection_manager.load_full();
-    let supports_sandbox_state_meta = mcp_connection_manager
+    let supports_sandbox_state_meta = sess
+        .services
+        .mcp_connection_manager
+        .load_full()
         .server_supports_sandbox_state_meta_capability(server)
         .await
         .unwrap_or(false);
@@ -736,17 +737,12 @@ async fn augment_mcp_tool_request_meta_with_sandbox_state(
         return Ok(meta);
     }
 
-    let server_environment_id = mcp_connection_manager
-        .server_environment_id(server)
-        .unwrap_or(codex_config::DEFAULT_MCP_SERVER_ENVIRONMENT_ID);
-    let Some(sandbox_cwd) = sandbox_cwd_for_mcp_server(turn_context, server_environment_id) else {
-        return Ok(meta);
-    };
-    let permission_profile = turn_context.permission_profile();
     let sandbox_state = serde_json::to_value(SandboxState {
-        permission_profile: Some(permission_profile),
+        permission_profile: Some(turn_context.permission_profile()),
+        sandbox_policy: turn_context.sandbox_policy(),
         codex_linux_sandbox_exe: turn_context.config.codex_linux_sandbox_exe.clone(),
-        sandbox_cwd,
+        #[allow(deprecated)]
+        sandbox_cwd: turn_context.cwd.to_path_buf(),
         use_legacy_landlock: turn_context.config.features.use_legacy_landlock(),
     })?;
 
@@ -769,24 +765,6 @@ async fn augment_mcp_tool_request_meta_with_sandbox_state(
     }
 
     Ok(meta)
-}
-
-fn sandbox_cwd_for_mcp_server(turn_context: &TurnContext, environment_id: &str) -> Option<PathUri> {
-    if let Some(environment) = turn_context
-        .environments
-        .turn_environments
-        .iter()
-        .find(|environment| environment.environment_id == environment_id)
-    {
-        return Some(environment.cwd().clone());
-    }
-
-    if environment_id == codex_config::DEFAULT_MCP_SERVER_ENVIRONMENT_ID {
-        #[allow(deprecated)]
-        return Some(PathUri::from_abs_path(&turn_context.cwd));
-    }
-
-    None
 }
 
 async fn maybe_mark_thread_memory_mode_polluted(

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -3,7 +3,6 @@ use crate::config::ConfigBuilder;
 use crate::config::ManagedFeatures;
 use crate::session::tests::make_session_and_context;
 use crate::session::tests::make_session_and_context_with_rx;
-use crate::session::turn_context::TurnEnvironment;
 use crate::state::ActiveTurn;
 use crate::test_support::models_manager_with_provider;
 use crate::tools::hook_names::HookToolName;
@@ -32,7 +31,6 @@ use codex_rollout_trace::ToolDispatchInvocation;
 use codex_rollout_trace::ToolDispatchPayload;
 use codex_rollout_trace::ToolDispatchRequester;
 use codex_rollout_trace::replay_bundle;
-use codex_utils_path_uri::PathUri;
 use core_test_support::hooks::trusted_config_layer_stack;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
@@ -1092,39 +1090,6 @@ async fn mcp_tool_call_request_meta_includes_turn_started_at_unix_ms() {
             .and_then(serde_json::Value::as_i64),
         Some(1_700_000_000_123)
     );
-}
-
-#[tokio::test]
-async fn mcp_sandbox_cwd_uses_matching_server_environment_uri() -> anyhow::Result<()> {
-    let (_, mut turn_context) = make_session_and_context().await;
-    let secondary_cwd = PathUri::parse("file:///C:/remote/project")?;
-    let environment = turn_context.environments.turn_environments[0]
-        .environment
-        .clone();
-    turn_context
-        .environments
-        .turn_environments
-        .push(TurnEnvironment::new(
-            "remote".to_string(),
-            environment,
-            secondary_cwd.clone(),
-            /*shell*/ None,
-        ));
-
-    let sandbox_cwd = sandbox_cwd_for_mcp_server(&turn_context, "remote");
-
-    assert_eq!(sandbox_cwd, Some(secondary_cwd));
-    Ok(())
-}
-
-#[tokio::test]
-async fn mcp_sandbox_cwd_is_none_for_unselected_server_environment() -> anyhow::Result<()> {
-    let (_, turn_context) = make_session_and_context().await;
-
-    let sandbox_cwd = sandbox_cwd_for_mcp_server(&turn_context, "remote");
-
-    assert_eq!(sandbox_cwd, None);
-    Ok(())
 }
 
 #[tokio::test]

--- a/codex-rs/core/tests/suite/rmcp_client.rs
+++ b/codex-rs/core/tests/suite/rmcp_client.rs
@@ -926,11 +926,16 @@ async fn stdio_mcp_tool_call_includes_sandbox_state_meta() -> anyhow::Result<()>
     let sandbox_meta = meta
         .get(MCP_SANDBOX_STATE_META_CAPABILITY)
         .expect("sandbox state metadata should be present");
-    assert_eq!(sandbox_meta.get("sandboxPolicy"), None);
-    let expected_sandbox_cwd = PathUri::from_abs_path(&fixture.config.cwd).to_string();
+    let (sandbox_policy, _) =
+        turn_permission_fields(PermissionProfile::read_only(), fixture.config.cwd.as_path());
+    let expected_sandbox_policy = serde_json::to_value(&sandbox_policy)?;
+    assert_eq!(
+        sandbox_meta.get("sandboxPolicy"),
+        Some(&expected_sandbox_policy)
+    );
     assert_eq!(
         sandbox_meta.get("sandboxCwd").and_then(Value::as_str),
-        Some(expected_sandbox_cwd.as_str())
+        fixture.config.cwd.as_path().to_str()
     );
     assert_eq!(sandbox_meta.get("useLegacyLandlock"), Some(&json!(false)));
 


### PR DESCRIPTION
This reverts commit 790213ded0588d824e99f830f41f04f3d98196df.
