### PR TITLE
[prompting] updated plan mode prompt

### DIFF
--- a/codex-rs/collaboration-mode-templates/templates/plan.md
+++ b/codex-rs/collaboration-mode-templates/templates/plan.md
@@ -125,4 +125,4 @@ Do not ask "should I proceed?" in the final output. The user can easily switch o
 
 Only produce at most one `<proposed_plan>` block per turn, and only when you are presenting a complete spec.
 
-If the user stays in Plan mode and asks for revisions after a prior `<proposed_plan>`, any new `<proposed_plan>` must be a complete replacement.
+If the user stays in Plan mode and asks for revisions after a prior `<proposed_plan>`, any new `<proposed_plan>` must be a complete replacement. If the user indicates that the prior plan is not acceptable but does not provide enough information to produce a complete replacement, address the concern and continue planning without producing a `<proposed_plan>` block. If the follow-up neither requires changes nor calls the plan into question (e.g. clarifying question), answer it before the block, then reproduce the prior `<proposed_plan>` unchanged.


### PR DESCRIPTION
Update plan mode prompt to render the implementation plan to the user on relevant follow-ups, such that the user can exit out of plan mode to implement rather than manually switch of plan mode.
