### PR TITLE
code-mode: release acknowledged terminal observations

### DIFF
--- a/codex-rs/code-mode-protocol/src/lib.rs
+++ b/codex-rs/code-mode-protocol/src/lib.rs
@@ -28,6 +28,7 @@ pub use runtime::DEFAULT_WAIT_YIELD_TIME_MS;
 pub use runtime::ObservationGeneration;
 pub use runtime::ObserveOutcome;
 pub use runtime::ObserveRequest;
+pub use runtime::ReleaseObservationRequest;
 pub use runtime::RuntimeResponse;
 pub use runtime::TerminateOutcome;
 pub use session::CellId;

--- a/codex-rs/code-mode-protocol/src/runtime.rs
+++ b/codex-rs/code-mode-protocol/src/runtime.rs
@@ -27,6 +27,12 @@ pub struct ObserveRequest {
     pub yield_time_ms: u64,
 }
 
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ReleaseObservationRequest {
+    pub cell_id: CellId,
+    pub generation: ObservationGeneration,
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(transparent)]
 pub struct ObservationGeneration(u64);

--- a/codex-rs/code-mode-protocol/src/runtime_tests.rs
+++ b/codex-rs/code-mode-protocol/src/runtime_tests.rs
@@ -101,6 +101,16 @@ fn requests_round_trip_with_exact_tool_and_namespace_fields() {
             "yield_time_ms": 250,
         }),
     );
+    assert_json_round_trip(
+        &ReleaseObservationRequest {
+            cell_id: CellId::new("cell-a7".to_string()),
+            generation: ObservationGeneration::new(/*value*/ 3),
+        },
+        json!({
+            "cell_id": "cell-a7",
+            "generation": 3,
+        }),
+    );
 }
 
 #[test]

--- a/codex-rs/code-mode-protocol/src/session.rs
+++ b/codex-rs/code-mode-protocol/src/session.rs
@@ -12,6 +12,7 @@ use crate::CodeModeNestedToolCall;
 use crate::CreateCellRequest;
 use crate::ObserveOutcome;
 use crate::ObserveRequest;
+use crate::ReleaseObservationRequest;
 use crate::TerminateOutcome;
 
 pub type CodeModeSessionResultFuture<'a, T> =
@@ -94,6 +95,11 @@ pub trait CodeModeSession: Send + Sync {
         &'a self,
         request: ObserveRequest,
     ) -> CodeModeSessionResultFuture<'a, ObserveOutcome>;
+
+    fn release_observation<'a>(
+        &'a self,
+        request: ReleaseObservationRequest,
+    ) -> CodeModeSessionResultFuture<'a, ()>;
 
     fn terminate<'a>(
         &'a self,

--- a/codex-rs/code-mode/src/service.rs
+++ b/codex-rs/code-mode/src/service.rs
@@ -17,6 +17,7 @@ use codex_code_mode_protocol::NotificationFuture;
 use codex_code_mode_protocol::ObservationGeneration;
 use codex_code_mode_protocol::ObserveOutcome;
 use codex_code_mode_protocol::ObserveRequest;
+use codex_code_mode_protocol::ReleaseObservationRequest;
 #[cfg(test)]
 use codex_code_mode_protocol::RuntimeResponse;
 use codex_code_mode_protocol::TerminateOutcome;
@@ -102,9 +103,14 @@ pub struct CodeModeService {
     pending_generations: Mutex<HashMap<runtime::CellId, runtime::PendingGeneration>>,
 }
 
-struct ObservationRecord {
-    request: ObserveRequest,
-    result_rx: watch::Receiver<Option<Result<ObserveOutcome, String>>>,
+enum ObservationRecord {
+    Retained {
+        request: ObserveRequest,
+        result_rx: watch::Receiver<Option<Result<ObserveOutcome, String>>>,
+    },
+    Released {
+        generation: ObservationGeneration,
+    },
 }
 
 impl CodeModeService {
@@ -150,17 +156,24 @@ impl CodeModeService {
         let cell_id = request.cell_id.clone();
         let mut result_rx = {
             let mut observations = self.observations.lock().await;
-            if let Some(existing) = observations.get(&cell_id) {
-                if existing.request.generation == request.generation {
-                    if existing.request != request {
+            let replay = match observations.get(&cell_id) {
+                Some(ObservationRecord::Retained {
+                    request: existing_request,
+                    result_rx,
+                }) if existing_request.generation == request.generation => {
+                    if *existing_request != request {
                         return Err(format!(
                             "observation generation {} for cell {cell_id} was reused for a different request",
                             request.generation.get()
                         ));
                     }
-                    existing.result_rx.clone()
-                } else {
-                    let Some(next_generation) = existing.request.generation.next() else {
+                    Some(result_rx.clone())
+                }
+                Some(ObservationRecord::Retained {
+                    request: existing_request,
+                    result_rx,
+                }) => {
+                    let Some(next_generation) = existing_request.generation.next() else {
                         return Err(format!(
                             "observation generation exhausted for cell {cell_id}"
                         ));
@@ -172,37 +185,43 @@ impl CodeModeService {
                             request.generation.get()
                         ));
                     }
-                    if existing.result_rx.borrow().is_none() {
+                    if result_rx.borrow().is_none() {
                         return Err(format!(
                             "observation generation {} for cell {cell_id} is still pending",
-                            existing.request.generation.get()
+                            existing_request.generation.get()
                         ));
                     }
-                    let (result_tx, result_rx) = watch::channel(None);
-                    observations.insert(
-                        cell_id,
-                        ObservationRecord {
-                            request: request.clone(),
-                            result_rx: result_rx.clone(),
-                        },
-                    );
-                    let runtime = Arc::clone(&self.runtime);
-                    tokio::spawn(async move {
-                        let result = begin_observe_runtime(runtime, request).await.await;
-                        result_tx.send_replace(Some(result));
-                    });
-                    result_rx
+                    None
                 }
-            } else {
-                if request.generation != ObservationGeneration::INITIAL {
+                Some(ObservationRecord::Released { generation }) => {
+                    let Some(next_generation) = generation.next() else {
+                        return Err(format!(
+                            "observation generation exhausted for cell {cell_id}"
+                        ));
+                    };
+                    if request.generation != next_generation {
+                        return Err(format!(
+                            "expected observation generation {} for cell {cell_id}, got {}",
+                            next_generation.get(),
+                            request.generation.get()
+                        ));
+                    }
+                    None
+                }
+                None if request.generation != ObservationGeneration::INITIAL => {
                     return Err(format!(
                         "first observation for cell {cell_id} must use generation 0"
                     ));
                 }
+                None => None,
+            };
+            if let Some(result_rx) = replay {
+                result_rx
+            } else {
                 let (result_tx, result_rx) = watch::channel(None);
                 observations.insert(
                     cell_id,
-                    ObservationRecord {
+                    ObservationRecord::Retained {
                         request: request.clone(),
                         result_rx: result_rx.clone(),
                     },
@@ -225,6 +244,76 @@ impl CodeModeService {
             .borrow()
             .clone()
             .ok_or_else(|| "observation ended before producing a result".to_string())?
+    }
+
+    pub async fn release_observation(
+        &self,
+        request: ReleaseObservationRequest,
+    ) -> Result<(), String> {
+        let mut observations = self.observations.lock().await;
+        let Some(record) = observations.get(&request.cell_id) else {
+            return Ok(());
+        };
+        match record {
+            ObservationRecord::Released { generation } => {
+                if request.generation <= *generation {
+                    return Ok(());
+                }
+                return Err(format!(
+                    "cannot release future observation generation {} for cell {}",
+                    request.generation.get(),
+                    request.cell_id
+                ));
+            }
+            ObservationRecord::Retained {
+                request: retained_request,
+                result_rx,
+            } => {
+                if request.generation < retained_request.generation {
+                    return Ok(());
+                }
+                if request.generation > retained_request.generation {
+                    return Err(format!(
+                        "cannot release future observation generation {} for cell {}; latest generation is {}",
+                        request.generation.get(),
+                        request.cell_id,
+                        retained_request.generation.get()
+                    ));
+                }
+                let result = result_rx.borrow();
+                let result = result.as_ref().ok_or_else(|| {
+                    format!(
+                        "observation generation {} for cell {} is still pending",
+                        request.generation.get(),
+                        request.cell_id
+                    )
+                })?;
+                let outcome = result.as_ref().map_err(|error| {
+                    format!(
+                        "observation generation {} for cell {} failed and cannot be released: {error}",
+                        request.generation.get(),
+                        request.cell_id
+                    )
+                })?;
+                if !matches!(
+                    outcome,
+                    ObserveOutcome::Completed { .. } | ObserveOutcome::Terminated { .. }
+                ) {
+                    return Err(format!(
+                        "observation generation {} for cell {} is not terminal",
+                        request.generation.get(),
+                        request.cell_id
+                    ));
+                }
+            }
+        }
+        observations.insert(
+            request.cell_id,
+            ObservationRecord::Released {
+                generation: request.generation,
+            },
+        );
+        Ok(())
     }
 
     #[cfg(test)]
@@ -386,6 +475,13 @@ impl CodeModeSession for CodeModeService {
         request: ObserveRequest,
     ) -> CodeModeSessionResultFuture<'a, ObserveOutcome> {
         Box::pin(CodeModeService::observe(self, request))
+    }
+
+    fn release_observation<'a>(
+        &'a self,
+        request: ReleaseObservationRequest,
+    ) -> CodeModeSessionResultFuture<'a, ()> {
+        Box::pin(CodeModeService::release_observation(self, request))
     }
 
     fn terminate<'a>(

--- a/codex-rs/code-mode/src/service_contract_tests.rs
+++ b/codex-rs/code-mode/src/service_contract_tests.rs
@@ -367,6 +367,16 @@ async fn next_observation_generation_evicts_the_previous_result() {
             }],
         }
     );
+    assert_eq!(
+        service
+            .release_observation(ReleaseObservationRequest {
+                cell_id: cell_id("1"),
+                generation: ObservationGeneration::INITIAL,
+            })
+            .await
+            .unwrap_err(),
+        "observation generation 0 for cell 1 is not terminal"
+    );
 
     assert_eq!(
         service
@@ -392,7 +402,10 @@ async fn next_observation_generation_evicts_the_previous_result() {
         assert_eq!(
             observations
                 .get(&cell_id("1"))
-                .map(|record| record.request.generation),
+                .and_then(|record| match record {
+                    ObservationRecord::Retained { request, .. } => Some(request.generation),
+                    ObservationRecord::Released { .. } => None,
+                }),
             Some(ObservationGeneration::new(/*value*/ 1))
         );
     }
@@ -407,6 +420,18 @@ async fn next_observation_generation_evicts_the_previous_result() {
             .unwrap_err(),
         "expected observation generation 2 for cell 1, got 0"
     );
+
+    let release = ReleaseObservationRequest {
+        cell_id: cell_id("1"),
+        generation: ObservationGeneration::new(/*value*/ 1),
+    };
+    assert_eq!(service.release_observation(release.clone()).await, Ok(()));
+    assert_eq!(service.release_observation(release).await, Ok(()));
+    assert!(matches!(
+        service.observations.lock().await.get(&cell_id("1")),
+        Some(ObservationRecord::Released { generation })
+            if *generation == ObservationGeneration::new(/*value*/ 1)
+    ));
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/tools/code_mode/mod.rs
+++ b/codex-rs/core/src/tools/code_mode/mod.rs
@@ -175,6 +175,25 @@ impl CodeModeService {
                 yield_time_ms,
             })
             .await?;
+        let is_terminal = matches!(
+            &outcome,
+            codex_code_mode::ObserveOutcome::Completed { .. }
+                | codex_code_mode::ObserveOutcome::Terminated { .. }
+        );
+        if is_terminal
+            && let Err(error) = self
+                .session()?
+                .release_observation(codex_code_mode::ReleaseObservationRequest {
+                    cell_id: cell_id.clone(),
+                    generation,
+                })
+                .await
+        {
+            tracing::warn!(
+                "failed to release terminal observation generation {} for code-mode cell {cell_id}: {error}",
+                generation.get()
+            );
+        }
         let next_generation = generation.next().ok_or_else(|| {
             format!("observation generation exhausted for code-mode cell {cell_id}")
         })?;
@@ -450,6 +469,7 @@ fn build_freeform_tool_payload(
 #[cfg(test)]
 mod tests {
     use super::CodeModeDispatchBroker;
+    use super::CodeModeService;
     use super::InitialObservationGuard;
     use super::build_nested_tool_payload;
     use super::cell_id_for_tool_call;
@@ -460,17 +480,20 @@ mod tests {
     use codex_code_mode::CodeModeSessionResultFuture;
     use codex_code_mode::CodeModeToolKind;
     use codex_code_mode::CreateCellRequest;
+    use codex_code_mode::ObservationGeneration;
     use codex_code_mode::ObserveOutcome;
     use codex_code_mode::ObserveRequest;
     use codex_code_mode::TerminateOutcome;
     use codex_protocol::models::FunctionCallOutputContentItem;
     use codex_tools::ToolName;
     use serde_json::json;
+    use std::collections::HashMap;
     use std::sync::Arc;
     use std::sync::Mutex;
 
     struct RecordingCodeModeSession {
         terminated_cells: Mutex<Vec<CellId>>,
+        released_observations: Mutex<Vec<codex_code_mode::ReleaseObservationRequest>>,
         termination: tokio::sync::Notify,
     }
 
@@ -488,9 +511,28 @@ mod tests {
 
         fn observe<'a>(
             &'a self,
-            _request: ObserveRequest,
+            request: ObserveRequest,
         ) -> CodeModeSessionResultFuture<'a, ObserveOutcome> {
-            Box::pin(async { panic!("unexpected cell observation") })
+            Box::pin(async move {
+                Ok(ObserveOutcome::Completed {
+                    cell_id: request.cell_id,
+                    content_items: Vec::new(),
+                    error_text: None,
+                })
+            })
+        }
+
+        fn release_observation<'a>(
+            &'a self,
+            request: codex_code_mode::ReleaseObservationRequest,
+        ) -> CodeModeSessionResultFuture<'a, ()> {
+            Box::pin(async move {
+                self.released_observations
+                    .lock()
+                    .expect("released-observation lock should not be poisoned")
+                    .push(request);
+                Ok(())
+            })
         }
 
         fn terminate<'a>(
@@ -590,6 +632,7 @@ mod tests {
     async fn dropping_initial_observation_guard_terminates_the_cell() {
         let session = Arc::new(RecordingCodeModeSession {
             terminated_cells: Mutex::new(Vec::new()),
+            released_observations: Mutex::new(Vec::new()),
             termination: tokio::sync::Notify::new(),
         });
         let session_trait: Arc<dyn CodeModeSession> = session.clone();
@@ -618,6 +661,40 @@ mod tests {
                 .lock()
                 .expect("terminated-cell lock should not be poisoned"),
             vec![cell_id]
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_observation_is_released_after_core_reads_it() {
+        let session = Arc::new(RecordingCodeModeSession {
+            terminated_cells: Mutex::new(Vec::new()),
+            released_observations: Mutex::new(Vec::new()),
+            termination: tokio::sync::Notify::new(),
+        });
+        let cell_id = CellId::new("cell-1".to_string());
+        let service = CodeModeService {
+            session: Some(session.clone()),
+            dispatch_broker: Arc::new(CodeModeDispatchBroker::new()),
+            observation_generations: Mutex::new(HashMap::new()),
+        };
+
+        assert_eq!(
+            service.observe(cell_id.clone(), /*yield_time_ms*/ 10).await,
+            Ok(ObserveOutcome::Completed {
+                cell_id: cell_id.clone(),
+                content_items: Vec::new(),
+                error_text: None,
+            })
+        );
+        assert_eq!(
+            *session
+                .released_observations
+                .lock()
+                .expect("released-observation lock should not be poisoned"),
+            vec![codex_code_mode::ReleaseObservationRequest {
+                cell_id,
+                generation: ObservationGeneration::INITIAL,
+            }]
         );
     }
 }


### PR DESCRIPTION
## Why

An `ObserveOutcome::Yielded` value is implicitly acknowledged by the next generation. `ObserveOutcome::Completed` and `ObserveOutcome::Terminated` have no successor, so their replay payload otherwise remains retained until the session ends.

## What

- Add `ReleaseObservationRequest { cell_id, generation }` and `release_observation(ReleaseObservationRequest) -> Result<(), String>` to the wire/session contract.
- Allow release only when the retained `ObserveOutcome` is `Completed` or `Terminated`.
- Do not release `Yielded` or `Missing` outcomes; reject them as non-terminal.
- Reject pending, failed, or future generations.
- Make repeated or older releases idempotent.
- Replace released terminal output with a lightweight generation tombstone.
- Have Core send the acknowledgement only after reading a terminal `ObserveOutcome`.
- Preserve the result and log a warning if release fails.

## Host/Core wire sequence

```mermaid
sequenceDiagram
    participant Core
    participant Host
    Core->>Host: ObserveRequest { cell_id, generation, ... }
    Host-->>Core: ObserveOutcome::Completed or ::Terminated
    Core->>Core: consume terminal outcome
    Core->>Host: ReleaseObservationRequest { cell_id, generation }
    Host->>Host: replace payload with generation tombstone
    Host-->>Core: Result<(), String>
    opt release returns Err(String)
        Core->>Core: warn; consumed outcome remains valid
    end
```

## Stack boundary

`release_observation(ReleaseObservationRequest)` acknowledges transport delivery of terminal output. It is separate from `resume(PendingGeneration)`, which advances a pausable runtime frontier.

## Validation

- `just test -p codex-code-mode`
- `just test -p codex-code-mode-protocol`
- Focused Core regression verifies release after terminal result consumption.

Stack parent: #29398.
