### PR TITLE
[exec-server] Test prepared upload transport recovery

### DIFF
--- a/codex-rs/exec-server/src/server/file_transfer_handler_tests.rs
+++ b/codex-rs/exec-server/src/server/file_transfer_handler_tests.rs
@@ -248,6 +248,57 @@ async fn cancel_after_remote_receives_body_reports_unknown_completion() {
 }
 
 #[tokio::test]
+async fn concurrent_starts_cannot_exceed_the_active_upload_quota() {
+    let server = MockServer::start().await;
+    Mock::given(method("PUT"))
+        .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(2)))
+        .mount(&server)
+        .await;
+    let source_dir = tempfile::tempdir().expect("source tempdir");
+    let source = source_dir.path().join("report.txt");
+    tokio::fs::write(&source, b"bytes")
+        .await
+        .expect("write source");
+    let handler = test_handler();
+    let first = handler
+        .prepare_upload(prepare_params(&source, /*max_bytes*/ 1024))
+        .await
+        .expect("prepare first upload");
+    let second = handler
+        .prepare_upload(prepare_params(&source, /*max_bytes*/ 1024))
+        .await
+        .expect("prepare second upload");
+    let third = handler
+        .prepare_upload(prepare_params(&source, /*max_bytes*/ 1024))
+        .await
+        .expect("prepare third upload");
+
+    let (first, second, third) = tokio::join!(
+        handler.start_upload(FileTransferStartUploadParams {
+            transfer_id: first.transfer_id,
+            descriptor: upload_descriptor(format!("{}/first", server.uri())),
+        }),
+        handler.start_upload(FileTransferStartUploadParams {
+            transfer_id: second.transfer_id,
+            descriptor: upload_descriptor(format!("{}/second", server.uri())),
+        }),
+        handler.start_upload(FileTransferStartUploadParams {
+            transfer_id: third.transfer_id,
+            descriptor: upload_descriptor(format!("{}/third", server.uri())),
+        }),
+    );
+    let results = [first, second, third];
+    assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 2);
+    let error = results
+        .iter()
+        .find_map(|result| result.as_ref().err())
+        .expect("one concurrent start should be rejected");
+    assert_eq!(error.code, -32600);
+    assert_eq!(error.message, "active file upload quota exceeded");
+    handler.shutdown().await;
+}
+
+#[tokio::test]
 async fn prepared_snapshot_expires_without_a_follow_up_rpc() {
     let source_dir = tempfile::tempdir().expect("source tempdir");
     let source = source_dir.path().join("report.txt");

--- a/codex-rs/exec-server/tests/file_transfer.rs
+++ b/codex-rs/exec-server/tests/file_transfer.rs
@@ -1,0 +1,212 @@
+#![cfg(unix)]
+
+mod common;
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use codex_exec_server::Environment;
+use codex_exec_server::ExecServerError;
+use codex_exec_server::FileSystemSandboxContext;
+use codex_exec_server::FileTransferDigestAlgorithm;
+use codex_exec_server::FileTransferOperationState;
+use codex_exec_server::FileTransferPrepareUploadParams;
+use codex_exec_server::FileTransferStartUploadParams;
+use codex_exec_server::FileTransferUploadDescriptor;
+use codex_exec_server::MAX_PREPARED_FILE_UPLOAD_BYTES;
+use codex_exec_server::PREPARED_FILE_UPLOAD_PROTOCOL_VERSION;
+use codex_protocol::models::PermissionProfile;
+use codex_utils_path_uri::PathUri;
+use common::exec_server::exec_server;
+use common::exec_server::exec_server_with_env;
+use pretty_assertions::assert_eq;
+use sha2::Digest;
+use sha2::Sha256;
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+use tokio::time::timeout;
+use wiremock::Mock;
+use wiremock::MockServer;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::body_bytes;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
+
+const FILE_TRANSFER_ENABLED_ENV_VAR: &str = "CODEX_EXEC_SERVER_PREPARED_FILE_UPLOAD_ENABLED";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_environment_prepares_and_cancels_upload_without_returning_bytes()
+-> anyhow::Result<()> {
+    let source_dir = tempfile::tempdir()?;
+    let source = source_dir.path().join("report.txt");
+    let source_bytes = b"executor-owned bytes";
+    tokio::fs::write(&source, source_bytes).await?;
+
+    let mut server = exec_server_with_env([(FILE_TRANSFER_ENABLED_ENV_VAR, "1")]).await?;
+    let environment = Environment::create_for_tests(Some(server.websocket_url().to_string()))?;
+    let capability = environment
+        .info()
+        .await?
+        .capabilities
+        .prepared_file_upload
+        .expect("development-enabled executor should advertise upload support");
+    assert_eq!(
+        capability.protocol_version,
+        PREPARED_FILE_UPLOAD_PROTOCOL_VERSION
+    );
+    assert_eq!(capability.max_upload_bytes, MAX_PREPARED_FILE_UPLOAD_BYTES);
+    assert!(capability.supports_status_reconciliation);
+
+    let prepared = environment
+        .file_transfer_prepare_upload(FileTransferPrepareUploadParams {
+            path: PathUri::from_path(&source)?,
+            sandbox: full_access_context(),
+            max_bytes: 1024,
+        })
+        .await?;
+    assert_eq!(prepared.name, "report.txt");
+    assert_eq!(prepared.size, source_bytes.len() as u64);
+    assert_eq!(
+        prepared.digest.algorithm,
+        FileTransferDigestAlgorithm::Sha256
+    );
+    assert_eq!(
+        prepared.digest.value,
+        URL_SAFE_NO_PAD.encode(Sha256::digest(source_bytes))
+    );
+
+    let status = environment
+        .file_transfer_status(prepared.transfer_id.clone())
+        .await?;
+    assert_eq!(status.state, FileTransferOperationState::Prepared);
+    let canceled = environment
+        .file_transfer_cancel(prepared.transfer_id.clone())
+        .await?;
+    assert_eq!(canceled.state, FileTransferOperationState::Canceled);
+    assert_eq!(
+        environment
+            .file_transfer_status(prepared.transfer_id)
+            .await?
+            .state,
+        FileTransferOperationState::Canceled
+    );
+
+    server.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn executor_hides_and_rejects_file_transfer_by_default() -> anyhow::Result<()> {
+    let source_dir = tempfile::tempdir()?;
+    let source = source_dir.path().join("report.txt");
+    tokio::fs::write(&source, b"must not be read").await?;
+    let mut server = exec_server().await?;
+    let environment = Environment::create_for_tests(Some(server.websocket_url().to_string()))?;
+    assert!(
+        environment
+            .info()
+            .await?
+            .capabilities
+            .prepared_file_upload
+            .is_none()
+    );
+    let error = environment
+        .file_transfer_prepare_upload(FileTransferPrepareUploadParams {
+            path: PathUri::from_path(&source)?,
+            sandbox: full_access_context(),
+            max_bytes: 1024,
+        })
+        .await
+        .expect_err("default-disabled executor must reject prepare");
+    assert!(matches!(
+        error,
+        ExecServerError::Server {
+            code: -32600,
+            ref message,
+        } if message == "prepared file upload is disabled on this executor"
+    ));
+
+    server.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn remote_environment_file_transfer_resumes_then_uploads_executor_owned_bytes()
+-> anyhow::Result<()> {
+    let destination = MockServer::start().await;
+    Mock::given(method("PUT"))
+        .and(path("/upload"))
+        .and(body_bytes(b"bytes across reconnect".as_slice()))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&destination)
+        .await;
+    let source_dir = tempfile::tempdir()?;
+    let source = source_dir.path().join("report.txt");
+    tokio::fs::write(&source, b"bytes across reconnect").await?;
+    let mut server = exec_server_with_env([(FILE_TRANSFER_ENABLED_ENV_VAR, "1")]).await?;
+    let mut proxy = server.disconnectable_websocket_proxy().await?;
+    let environment = Environment::create_for_tests(Some(proxy.websocket_url().to_string()))?;
+    let prepared = environment
+        .file_transfer_prepare_upload(FileTransferPrepareUploadParams {
+            path: PathUri::from_path(&source)?,
+            sandbox: full_access_context(),
+            max_bytes: 1024,
+        })
+        .await?;
+
+    proxy.pause_and_disconnect().await?;
+    let environment_for_status = environment.clone();
+    let transfer_id_for_status = prepared.transfer_id.clone();
+    let mut pending_status = tokio::spawn(async move {
+        environment_for_status
+            .file_transfer_status(transfer_id_for_status)
+            .await
+    });
+    assert!(
+        timeout(Duration::from_millis(200), &mut pending_status)
+            .await
+            .is_err(),
+        "status should wait while the executor session is recovering"
+    );
+    proxy.resume()?;
+    let recovered = timeout(Duration::from_secs(5), pending_status).await???;
+    assert_eq!(recovered.state, FileTransferOperationState::Prepared);
+
+    let started = environment
+        .file_transfer_start_upload(FileTransferStartUploadParams {
+            transfer_id: prepared.transfer_id,
+            descriptor: FileTransferUploadDescriptor::HttpsPut {
+                url: format!("{}/upload", destination.uri()),
+                headers: Vec::new(),
+                expires_at_unix_seconds: unix_seconds(SystemTime::now() + Duration::from_secs(60)),
+            },
+        })
+        .await?;
+    let terminal = timeout(Duration::from_secs(5), async {
+        loop {
+            let status = environment
+                .file_transfer_status(started.transfer_id.clone())
+                .await?;
+            if status.state != FileTransferOperationState::Uploading {
+                return Ok::<_, ExecServerError>(status);
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await??;
+    assert_eq!(terminal.state, FileTransferOperationState::Succeeded);
+
+    server.shutdown().await?;
+    Ok(())
+}
+
+fn full_access_context() -> FileSystemSandboxContext {
+    FileSystemSandboxContext::from_permission_profile(PermissionProfile::Disabled)
+}
+
+fn unix_seconds(time: SystemTime) -> i64 {
+    time.duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or(0)
+}


### PR DESCRIPTION
## Context

This is PR 5 of the five-PR prerequisite stack for [CCA-50](https://linear.app/openai/issue/CCA-50/support-environment-scoped-mcp-file-transfer-in-cca) and the [CCA file-transfer RFC](https://app.notion.com/p/3878e50b62b0817c9abfc359cf1d5979). It is stacked on #29445.

The implementation in the preceding PRs keeps prepared bytes inside the selected executor and streams them directly to a protected destination. This final layer adds black-box evidence across the public environment client and spawned exec-server transport.

## What changed

- Verify the capability is absent and prepare is rejected by default.
- Verify development-enabled prepare/status/cancel returns metadata but never file bytes.
- Disconnect the client after prepare, resume the same logical session, and reconcile status.
- Perform a real executor-side PUT to a local test server and verify the exact prepared body arrives once.
- Verify three concurrent starts admit exactly two and reject the third at the active-upload quota.

The complete stack remains release-hard-disabled and has no Codex Core or production CCA consumer. The dependent CCA PR pins this stack, rejects `features.mcp_file_transfer=true` fail-closed, and exercises the same RPCs through real rendezvous + Noise.

## Test plan

- `just test -p codex-exec-server --test file_transfer` (3 passed)
- `just test -p codex-exec-server file_transfer` (10 passed, including the concurrent quota test)
- Full cumulative package suite: 288 passed, 2 skipped.

Independent architecture, security, and Rust/conventions reviewers explicitly approved the complete stack with no remaining P0/P1/P2 findings.
