### PR TITLE
[privacy-export] Propose CLI command schema for Codex local export

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -53,6 +53,9 @@ mod exec_server_telemetry;
 mod marketplace_cmd;
 mod mcp_cmd;
 mod plugin_cmd;
+// Keep the proposed privacy CLI schema out of production builds until it is approved.
+#[cfg(test)]
+mod privacy_cmd;
 mod remote_control_cmd;
 #[cfg(target_os = "windows")]
 mod sandbox_setup;
@@ -2822,6 +2825,16 @@ mod tests {
             command
                 .get_subcommands()
                 .all(|subcommand| subcommand.get_name() != "responses")
+        );
+    }
+
+    #[test]
+    fn privacy_subcommand_is_not_registered() {
+        let command = MultitoolCli::command();
+        assert!(
+            command
+                .get_subcommands()
+                .all(|subcommand| subcommand.get_name() != "privacy")
         );
     }
 

--- a/codex-rs/cli/src/privacy_cmd.rs
+++ b/codex-rs/cli/src/privacy_cmd.rs
@@ -1,0 +1,28 @@
+use std::path::PathBuf;
+
+use clap::Args;
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+#[command(bin_name = "codex privacy")]
+pub(crate) struct PrivacyCommand {
+    #[command(subcommand)]
+    subcommand: PrivacySubcommand,
+}
+
+#[derive(Debug, clap::Subcommand)]
+enum PrivacySubcommand {
+    /// Export your local Codex data.
+    Export(PrivacyExportCommand),
+}
+
+#[derive(Debug, Args)]
+struct PrivacyExportCommand {
+    /// Directory to copy the export into.
+    #[arg(value_name = "PATH")]
+    output: PathBuf,
+}
+
+#[cfg(test)]
+#[path = "privacy_cmd_tests.rs"]
+mod tests;

--- a/codex-rs/cli/src/privacy_cmd_tests.rs
+++ b/codex-rs/cli/src/privacy_cmd_tests.rs
@@ -1,0 +1,35 @@
+use std::path::PathBuf;
+
+use clap::CommandFactory;
+use clap::Parser;
+use pretty_assertions::assert_eq;
+
+use super::PrivacyCommand;
+use super::PrivacyExportCommand;
+use super::PrivacySubcommand;
+
+#[test]
+fn parses_export_output() {
+    let PrivacyCommand {
+        subcommand: PrivacySubcommand::Export(PrivacyExportCommand { output }),
+    } = PrivacyCommand::try_parse_from(["codex privacy", "export", "out"]).expect("parse");
+
+    assert_eq!(output, PathBuf::from("out"));
+}
+
+#[test]
+fn privacy_help() {
+    let mut command = PrivacyCommand::command();
+
+    insta::assert_snapshot!(command.render_long_help().to_string());
+}
+
+#[test]
+fn export_help() {
+    let mut command = PrivacyCommand::command();
+    let export = command
+        .find_subcommand_mut("export")
+        .expect("export subcommand");
+
+    insta::assert_snapshot!(export.render_long_help().to_string());
+}

--- a/codex-rs/cli/src/snapshots/codex__privacy_cmd__tests__export_help.snap
+++ b/codex-rs/cli/src/snapshots/codex__privacy_cmd__tests__export_help.snap
@@ -1,0 +1,15 @@
+---
+source: cli/src/privacy_cmd_tests.rs
+expression: export.render_long_help().to_string()
+---
+Export your local Codex data
+
+Usage: export <PATH>
+
+Arguments:
+  <PATH>
+          Directory to copy the export into
+
+Options:
+  -h, --help
+          Print help

--- a/codex-rs/cli/src/snapshots/codex__privacy_cmd__tests__privacy_help.snap
+++ b/codex-rs/cli/src/snapshots/codex__privacy_cmd__tests__privacy_help.snap
@@ -1,0 +1,13 @@
+---
+source: cli/src/privacy_cmd_tests.rs
+expression: command.render_long_help().to_string()
+---
+Usage: codex privacy <COMMAND>
+
+Commands:
+  export  Export your local Codex data
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help
+          Print help


### PR DESCRIPTION
## Why

This PR proposes the CLI contract before exposing or implementing it. The planned local export should stay close to the existing Codex DSR shape: task identity/title/archive state plus ordered user and assistant turns, rather than becoming a general backup of `~/.codex`.

The implementation should remain deliberately small: copy files that already match the task/turn intent, modify only included files with a concrete credential-leak risk, and leave everything else out - the files are already available to the user, this is a simpler and safer alternative for them to access their local Codex files.

**This PR still adds no production command, dispatch, or export behavior.**

## Proposed CLI

```text
codex privacy export <PATH>
```

The command schema is test-only. Snapshots make the proposed command name, subcommand, positional argument, and help text reviewable without releasing them.

## Proposed file scope

### 1. Ready as-is

- `sessions/**/*.jsonl`: active task conversations, including user and assistant turns and their associated tool activity.
- `archived_sessions/**/*.jsonl`: archived task conversations. The directory location preserves archived state.
- `session_index.jsonl`: task/session ID, thread title, and update time.
- `history.jsonl`: user-entered text keyed by session ID and timestamp.
- `AGENTS.md`: global user-authored instructions, analogous to custom instructions in user turns. Include only when the file exists.

These files are copied without record-level transformation. User-provided content is the subject of the export, so this phase does not attempt heuristic redaction of prompts, responses, or tool output.

### 2. Needs modification before inclusion

- `config.toml` requires transformation before export. Remove literal values from MCP env and `http_headers`, and model-provider `experimental_bearer_token` and `http_headers`. Preserve environment-variable references.

### 3. Not included

- Credentials and secrets: `auth.json`, `.credentials.json`, `app-server-signing-secret`, `secrets/**`, `.sandbox-secrets/**`, and similar files if present.
- Databases and mixed app state that would require snapshotting or field-level extraction: `state_5.sqlite*`, `.codex-global-state.json`, `.codex-global-state.json.bak`, `memories_1.sqlite*`, `goals_1.sqlite*`, `logs_2.sqlite*`, `codex-dev.db`, and SQLite WAL/SHM files.
- Separate feature state outside the `codex.json` task/turn intent: `memories/**`, `agents/**`, `automations/**`, `rules/**`, `computer-use/**`, and `ambient-suggestions/**`.
- Installation/update/UI metadata that does not add task or turn content: `installation_id`, `version.json`, `models_cache.json`, cloud cache files, native-host config, and migration markers.
- Runtime and diagnostics: `log/**`, `shell_snapshots/**`, `node_repl/**`, `process_manager/**`, `host-cache/**`, and `visualizations/**`.
- Rebuildable or unrelated content: `cache/**`, `plugins/**`, `skills/**`, `vendor_imports/**`, `worktrees/**`, `avatars/**`, `pets/**`, `.tmp/**`, `tmp/**`, Git metadata, and symlinks.

## User impact

None. `privacy` is explicitly absent from the production command tree.

## Validation

- focused parser and non-registration tests: `just test -p codex-cli privacy`
- help snapshots for `codex privacy` and `codex privacy export <PATH>`
- no pending snapshots
