### PR TITLE
core: remove unused permissions cwd plumbing

### DIFF
--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -3207,7 +3207,6 @@ impl Config {
                     effective_permission_selection.profiles.as_ref(),
                     default_permissions,
                     builtin_workspace_write_settings,
-                    resolved_cwd.as_path(),
                     &mut startup_warnings,
                 )?;
             let mut configured_workspace_roots = compile_permission_profile_workspace_roots(

--- a/codex-rs/core/src/config/permissions.rs
+++ b/codex-rs/core/src/config/permissions.rs
@@ -346,7 +346,6 @@ pub(crate) fn network_proxy_config_for_profile_selection(
 pub(crate) fn compile_permission_profile(
     permissions: &PermissionsToml,
     profile_name: &str,
-    policy_cwd: &Path,
     startup_warnings: &mut Vec<String>,
 ) -> io::Result<(FileSystemSandboxPolicy, NetworkSandboxPolicy)> {
     let profile = resolve_permission_profile(permissions, profile_name)?;
@@ -383,7 +382,6 @@ pub(crate) fn compile_permission_profile(
                     .extend(compile_filesystem_permission(
                         path,
                         permission,
-                        policy_cwd,
                         startup_warnings,
                     )?);
             }
@@ -412,7 +410,6 @@ pub(crate) fn compile_permission_profile_selection(
     permissions: Option<&PermissionsToml>,
     profile_name: &str,
     workspace_write: Option<&SandboxWorkspaceWrite>,
-    policy_cwd: &Path,
     startup_warnings: &mut Vec<String>,
 ) -> io::Result<(FileSystemSandboxPolicy, NetworkSandboxPolicy)> {
     if let Some(permission_profile) = builtin_permission_profile(profile_name, workspace_write) {
@@ -426,7 +423,7 @@ pub(crate) fn compile_permission_profile_selection(
             "default_permissions requires a `[permissions]` table",
         )
     })?;
-    compile_permission_profile(permissions, profile_name, policy_cwd, startup_warnings)
+    compile_permission_profile(permissions, profile_name, startup_warnings)
 }
 
 pub(crate) fn compile_permission_profile_workspace_roots(
@@ -524,7 +521,6 @@ fn compile_network_sandbox_policy(
 fn compile_filesystem_permission(
     path: &str,
     permission: &FilesystemPermissionToml,
-    policy_cwd: &Path,
     startup_warnings: &mut Vec<String>,
 ) -> io::Result<Vec<FileSystemSandboxEntry>> {
     let mut entries = Vec::new();
@@ -548,9 +544,7 @@ fn compile_filesystem_permission(
                     // exact-path parser so existing path semantics stay intact.
                     let entry = FileSystemSandboxEntry {
                         path: FileSystemPath::GlobPattern {
-                            pattern: compile_scoped_filesystem_pattern(
-                                path, subpath, *access, policy_cwd,
-                            )?,
+                            pattern: compile_scoped_filesystem_pattern(path, subpath, *access)?,
                         },
                         access: *access,
                     };
@@ -643,7 +637,6 @@ fn compile_scoped_filesystem_pattern(
     path: &str,
     subpath: &str,
     access: FileSystemAccessMode,
-    _policy_cwd: &Path,
 ) -> io::Result<String> {
     // Pattern entries currently mean deny-read only. Supporting broader access
     // modes here would imply glob-based read/write allow semantics that the

--- a/codex-rs/core/src/config/permissions_tests.rs
+++ b/codex-rs/core/src/config/permissions_tests.rs
@@ -543,7 +543,6 @@ fn glob_scan_max_depth_must_be_positive() {
 
 #[test]
 fn read_write_trailing_glob_suffix_compiles_as_subpath() -> std::io::Result<()> {
-    let cwd = TempDir::new()?;
     let mut startup_warnings = Vec::new();
     let (file_system_policy, _) = compile_permission_profile(
         &PermissionsToml {
@@ -568,7 +567,6 @@ fn read_write_trailing_glob_suffix_compiles_as_subpath() -> std::io::Result<()> 
             )]),
         },
         "workspace",
-        cwd.path(),
         &mut startup_warnings,
     )?;
 


### PR DESCRIPTION
## Why

`compile_scoped_filesystem_pattern()` accepted a `_policy_cwd` parameter even though scoped glob compilation no longer uses the policy working directory. Keeping that unused argument forced the surrounding permissions compilation path to keep forwarding `policy_cwd` through call sites that did not need it, making the API look more dependent on cwd resolution than it is.

## What changed

Removed the unused cwd parameter from `compile_scoped_filesystem_pattern()` and the callers that only forwarded it: `compile_filesystem_permission()`, `compile_permission_profile()`, and `compile_permission_profile_selection()`. Workspace root resolution still keeps `policy_cwd`, because that path still resolves relative roots against the active policy cwd.

Relevant code: [`codex-rs/core/src/config/permissions.rs`](https://github.com/openai/codex/blob/b8b9816102e064dae4488ec130cf560f63c1ab78/codex-rs/core/src/config/permissions.rs#L346).

## Verification

- `just test -p codex-core config::permissions`
- `just test -p codex-core` was also run after building `test_stdio_server`; it passed the touched permissions coverage but still reported unrelated existing failures in `cli_stream` and shell snapshot tests.
