### PR TITLE
[connectors] Fix stale codex_apps MCP auth

### DIFF
--- a/codex-rs/codex-mcp/src/connection_manager.rs
+++ b/codex-rs/codex-mcp/src/connection_manager.rs
@@ -40,11 +40,11 @@ use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
 use async_channel::Sender;
+use codex_api::SharedAuthProvider;
 use codex_config::Constrained;
 use codex_config::McpServerTransportConfig;
 use codex_config::types::AuthKeyringBackendKind;
 use codex_config::types::OAuthCredentialsStoreMode;
-use codex_login::CodexAuth;
 use codex_protocol::mcp::CallToolResult;
 use codex_protocol::mcp::McpServerInfo;
 use codex_protocol::models::PermissionProfile;
@@ -135,7 +135,7 @@ impl McpConnectionManager {
         client_elicitation_capability: ElicitationCapability,
         supports_openai_form_elicitation: bool,
         tool_plugin_provenance: ToolPluginProvenance,
-        auth: Option<&CodexAuth>,
+        codex_apps_auth_provider: Option<SharedAuthProvider>,
         elicitation_reviewer: Option<ElicitationReviewerHandle>,
     ) -> Self {
         let mut required_servers = mcp_servers
@@ -154,9 +154,6 @@ impl McpConnectionManager {
         );
         let tool_plugin_provenance = Arc::new(tool_plugin_provenance);
         let startup_submit_id = submit_id.clone();
-        let codex_apps_auth_provider = auth
-            .filter(|auth| auth.uses_codex_backend())
-            .map(codex_model_provider::auth_provider_from_auth);
         let mcp_servers = mcp_servers.clone();
         for (server_name, server) in mcp_servers
             .into_iter()

--- a/codex-rs/codex-mcp/src/connection_manager_tests.rs
+++ b/codex-rs/codex-mcp/src/connection_manager_tests.rs
@@ -1281,7 +1281,7 @@ async fn no_local_runtime_fails_local_stdio_but_keeps_local_http_server() {
         ElicitationCapability::default(),
         /*supports_openai_form_elicitation*/ false,
         ToolPluginProvenance::default(),
-        /*auth*/ None,
+        /*codex_apps_auth_provider*/ None,
         /*elicitation_reviewer*/ None,
     )
     .await;

--- a/codex-rs/codex-mcp/src/mcp/mod.rs
+++ b/codex-rs/codex-mcp/src/mcp/mod.rs
@@ -307,7 +307,8 @@ pub async fn read_mcp_resource(
         config.client_elicitation_capability.clone(),
         /*supports_openai_form_elicitation*/ false,
         tool_plugin_provenance(config),
-        auth,
+        auth.filter(|auth| auth.uses_codex_backend())
+            .map(codex_model_provider::auth_provider_from_auth),
         /*elicitation_reviewer*/ None,
     )
     .await;
@@ -382,7 +383,8 @@ pub async fn collect_mcp_server_status_snapshot_with_detail(
         config.client_elicitation_capability.clone(),
         /*supports_openai_form_elicitation*/ false,
         tool_plugin_provenance,
-        auth,
+        auth.filter(|auth| auth.uses_codex_backend())
+            .map(codex_model_provider::auth_provider_from_auth),
         /*elicitation_reviewer*/ None,
     )
     .await;

--- a/codex-rs/core/src/connectors.rs
+++ b/codex-rs/core/src/connectors.rs
@@ -280,7 +280,9 @@ pub async fn list_accessible_connectors_from_mcp_tools_with_mcp_manager(
         mcp_config.client_elicitation_capability,
         /*supports_openai_form_elicitation*/ false,
         ToolPluginProvenance::default(),
-        auth.as_ref(),
+        host_owned_codex_apps_enabled.then(|| {
+            codex_model_provider::auth_provider_from_auth_manager(Arc::clone(&auth_manager))
+        }),
         /*elicitation_reviewer*/ None,
     )
     .await;

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -1359,7 +1359,7 @@ async fn install_host_owned_codex_apps_manager(session: &Session, turn_context: 
         rmcp::model::ElicitationCapability::default(),
         /*supports_openai_form_elicitation*/ false,
         codex_mcp::ToolPluginProvenance::default(),
-        auth.as_ref(),
+        /*codex_apps_auth_provider*/ None,
         /*elicitation_reviewer*/ None,
     )
     .await;

--- a/codex-rs/core/src/session/mcp.rs
+++ b/codex-rs/core/src/session/mcp.rs
@@ -366,7 +366,11 @@ impl Session {
                 .supports_openai_form_elicitation
                 .load(std::sync::atomic::Ordering::Relaxed),
             tool_plugin_provenance,
-            auth.as_ref(),
+            host_owned_codex_apps_enabled.then(|| {
+                codex_model_provider::auth_provider_from_auth_manager(Arc::clone(
+                    &self.services.auth_manager,
+                ))
+            }),
             elicitation_reviewer,
         )
         .await;

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -1190,7 +1190,11 @@ impl Session {
                     .supports_openai_form_elicitation
                     .load(std::sync::atomic::Ordering::Relaxed),
                 tool_plugin_provenance,
-                auth,
+                host_owned_codex_apps_enabled.then(|| {
+                    codex_model_provider::auth_provider_from_auth_manager(Arc::clone(
+                        &sess.services.auth_manager,
+                    ))
+                }),
                 Some(sess.mcp_elicitation_reviewer()),
             )
             .instrument(info_span!(

--- a/codex-rs/model-provider/src/auth.rs
+++ b/codex-rs/model-provider/src/auth.rs
@@ -49,6 +49,23 @@ impl AuthProvider for AgentIdentityAuthProvider {
     }
 }
 
+struct AuthManagerAuthProvider {
+    auth_manager: Arc<AuthManager>,
+}
+
+impl AuthProvider for AuthManagerAuthProvider {
+    fn add_auth_headers(&self, headers: &mut HeaderMap) {
+        let Some(auth) = self
+            .auth_manager
+            .auth_cached()
+            .filter(CodexAuth::uses_codex_backend)
+        else {
+            return;
+        };
+        auth_provider_from_auth(&auth).add_auth_headers(headers);
+    }
+}
+
 // Some providers are meant to send no auth headers. Examples include local OSS
 // providers and custom test providers with `requires_openai_auth = false`.
 #[derive(Clone, Debug)]
@@ -127,11 +144,22 @@ pub fn auth_provider_from_auth(auth: &CodexAuth) -> SharedAuthProvider {
     }
 }
 
+/// Builds request-header auth that reads the current managed auth snapshot on every request.
+pub fn auth_provider_from_auth_manager(auth_manager: Arc<AuthManager>) -> SharedAuthProvider {
+    Arc::new(AuthManagerAuthProvider { auth_manager })
+}
+
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
+    use codex_login::AuthCredentialsStoreMode;
+    use codex_login::AuthKeyringBackendKind;
     use codex_login::auth::BedrockApiKeyAuth;
+    use codex_login::auth::login_with_chatgpt_auth_tokens;
     use codex_model_provider_info::WireApi;
     use codex_model_provider_info::create_oss_provider_with_base_url;
+    use http::header::AUTHORIZATION;
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -160,5 +188,51 @@ mod tests {
             Err(err) => panic!("unexpected auth error: {err:?}"),
             Ok(_) => panic!("Bedrock API key auth should be rejected"),
         }
+    }
+
+    #[tokio::test]
+    async fn auth_manager_provider_uses_reloaded_token() {
+        let codex_home =
+            PathBuf::from(format!("auth-manager-provider-test-{}", std::process::id()));
+        let store_mode = AuthCredentialsStoreMode::Ephemeral;
+        let keyring_backend_kind = AuthKeyringBackendKind::default();
+        login_with_chatgpt_auth_tokens(
+            &codex_home,
+            "header.e30.first",
+            "test-account",
+            /*chatgpt_plan_type*/ None,
+        )
+        .expect("save initial auth");
+        let auth_manager = Arc::new(
+            AuthManager::new(
+                codex_home.clone(),
+                /*enable_codex_api_key_env*/ false,
+                store_mode,
+                /*forced_chatgpt_workspace_id*/ None,
+                /*chatgpt_base_url*/ None,
+                keyring_backend_kind,
+            )
+            .await,
+        );
+        let provider = auth_provider_from_auth_manager(Arc::clone(&auth_manager));
+
+        assert_eq!(
+            provider.to_auth_headers().get(AUTHORIZATION),
+            Some(&HeaderValue::from_static("Bearer header.e30.first"))
+        );
+
+        login_with_chatgpt_auth_tokens(
+            &codex_home,
+            "header.e30.reloaded",
+            "test-account",
+            /*chatgpt_plan_type*/ None,
+        )
+        .expect("save reloaded auth");
+        auth_manager.reload().await;
+
+        assert_eq!(
+            provider.to_auth_headers().get(AUTHORIZATION),
+            Some(&HeaderValue::from_static("Bearer header.e30.reloaded"))
+        );
     }
 }

--- a/codex-rs/model-provider/src/lib.rs
+++ b/codex-rs/model-provider/src/lib.rs
@@ -5,6 +5,7 @@ mod models_endpoint;
 mod provider;
 
 pub use auth::auth_provider_from_auth;
+pub use auth::auth_provider_from_auth_manager;
 pub use auth::unauthenticated_auth_provider;
 pub use bearer_auth_provider::BearerAuthProvider;
 pub use bearer_auth_provider::BearerAuthProvider as CoreAuthProvider;


### PR DESCRIPTION
Summary
- Read hosted `codex_apps` MCP auth from the shared `AuthManager` on each request instead of snapshotting the bearer token when the manager starts.
- Preserve environment bearer-token precedence and static auth for short-lived generic MCP helpers.
- Prevent a normal Codex token refresh from leaving later `/ps/mcp` calls on an expired token and surfacing a false auth elicitation.

Root Cause
The Responses path refreshes the shared `AuthManager`, but the long-lived MCP request provider retained the original bearer token for the rest of the session.

Context: [Slack thread](https://openai.slack.com/archives/C0APBC6JH1U/p1782058723250869?thread_ts=1781907273.276659&cid=C0APBC6JH1U)

Validation
- `just test -p codex-model-provider` (40 passed)
- `just test -p codex-mcp` (88 passed)
- `just test -p codex-core codex_apps_auth_elicitation` (5 passed)
- `just fix -p codex-model-provider`
- `just fix -p codex-mcp`
- `just fix -p codex-core`
- `just fmt`
- `git diff --check`