### PR TITLE
fix(config): address permission profile review follow-ups

### DIFF
--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -4108,7 +4108,7 @@ impl Config {
     }
 
     /// Returns whether effective requirements allow selecting a concrete profile.
-    pub fn permission_profile_allowed(
+    pub fn is_permission_profile_allowed(
         &self,
         profile_id: &str,
         permission_profile: &PermissionProfile,

--- a/codex-rs/tui/src/chatwidget/permissions_menu.rs
+++ b/codex-rs/tui/src/chatwidget/permissions_menu.rs
@@ -1,4 +1,5 @@
 use super::*;
+use codex_protocol::models::BUILT_IN_PERMISSION_PROFILE_DANGER_FULL_ACCESS;
 
 impl ChatWidget {
     pub(super) fn open_permission_profiles_popup(&mut self) {
@@ -48,7 +49,7 @@ impl ChatWidget {
         }
         items.push(self.builtin_permission_mode_selection_item(
             full_access,
-            ":danger-full-access",
+            BUILT_IN_PERMISSION_PROFILE_DANGER_FULL_ACCESS,
             full_access.description.to_string(),
             AskForApproval::from(full_access.approval),
             ApprovalsReviewer::User,
@@ -146,7 +147,7 @@ impl ChatWidget {
                 .or_else(|| {
                     (!self
                         .config
-                        .permission_profile_allowed(id, &preset.permission_profile))
+                        .is_permission_profile_allowed(id, &preset.permission_profile))
                     .then(|| "Disabled by requirements.".to_string())
                 }),
             ..Default::default()

--- a/codex-rs/tui/src/chatwidget/tests/permissions.rs
+++ b/codex-rs/tui/src/chatwidget/tests/permissions.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::legacy_core::config::PermissionProfileCatalogEntry;
 use codex_protocol::models::ActivePermissionProfile;
+use codex_protocol::models::BUILT_IN_PERMISSION_PROFILE_DANGER_FULL_ACCESS;
 use codex_protocol::models::ManagedFileSystemPermissions;
 use codex_protocol::permissions::FileSystemAccessMode;
 use codex_protocol::permissions::FileSystemPath;
@@ -283,7 +284,7 @@ async fn profile_permissions_full_access_opens_confirmation() {
                 display_label,
             }),
         } if preset.id == "full-access"
-            && profile_id == ":danger-full-access"
+            && profile_id == BUILT_IN_PERMISSION_PROFILE_DANGER_FULL_ACCESS
             && display_label == "Full Access"
     ));
 }


### PR DESCRIPTION
## Summary

- rename `Config::permission_profile_allowed` to `is_permission_profile_allowed`
- use `BUILT_IN_PERMISSION_PROFILE_DANGER_FULL_ACCESS` in the TUI and its assertion
- follow up on the late review comments from #26678

The previous `:danger-no-sandbox` value was an invalid built-in profile ID. #26678 corrected it to `:danger-full-access`; this PR centralizes the value to prevent future drift.

## Testing

- Not run per request; `cargo fmt` only