### PR TITLE
fix: world state response item test

### DIFF
--- a/codex-rs/core/src/context/world_state/environment_tests.rs
+++ b/codex-rs/core/src/context/world_state/environment_tests.rs
@@ -251,6 +251,6 @@ fn user_message(text: &str) -> ResponseItem {
             text: text.to_string(),
         }],
         phase: None,
-        metadata: None,
+        internal_chat_message_metadata_passthrough: None,
     }
 }


### PR DESCRIPTION
seems to be a merge conflict on main:

> pakrym-oai introduced the stale initializer in commit 3b32d861c5, PR #29249.
> Context: Owen Lin renamed metadata to internal_chat_message_metadata_passthrough in PR #28968. PR #29249 then landed afterward with the old field name, causing the compile/Clippy failure.