### PR TITLE
[codex] Prewarm Guardian after permission switches

### DIFF
--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -715,7 +715,10 @@ async fn maybe_auto_review_mcp_request_user_input(
     .await;
     let approvals_reviewer =
         mcp_approvals_reviewer(parent_ctx, &invocation.server, metadata.as_ref());
-    if !routes_approval_to_guardian_with_reviewer(parent_ctx, approvals_reviewer) {
+    if !routes_approval_to_guardian_with_reviewer(
+        parent_ctx.approval_policy.value(),
+        approvals_reviewer,
+    ) {
         return None;
     }
     let review_cancel = cancel_token.child_token();

--- a/codex-rs/core/src/guardian/review.rs
+++ b/codex-rs/core/src/guardian/review.rs
@@ -166,16 +166,19 @@ fn guardian_risk_level_str(level: GuardianRiskLevel) -> &'static str {
 /// reviewer instead of surfacing them to the user. ARC may still block actions
 /// earlier in the flow.
 pub(crate) fn routes_approval_to_guardian(turn: &TurnContext) -> bool {
-    routes_approval_to_guardian_with_reviewer(turn, turn.config.approvals_reviewer)
+    routes_approval_to_guardian_with_reviewer(
+        turn.approval_policy.value(),
+        turn.config.approvals_reviewer,
+    )
 }
 
 /// Whether an approval with its own reviewer selection should be routed through guardian.
 pub(crate) fn routes_approval_to_guardian_with_reviewer(
-    turn: &TurnContext,
+    approval_policy: AskForApproval,
     approvals_reviewer: ApprovalsReviewer,
 ) -> bool {
     matches!(
-        turn.approval_policy.value(),
+        approval_policy,
         AskForApproval::OnRequest | AskForApproval::Granular(_)
     ) && approvals_reviewer == ApprovalsReviewer::AutoReview
 }

--- a/codex-rs/core/src/guardian/tests.rs
+++ b/codex-rs/core/src/guardian/tests.rs
@@ -1215,11 +1215,11 @@ async fn routes_approval_to_guardian_can_use_app_reviewer_override() {
     let (_session, turn) = crate::session::tests::make_session_and_context().await;
 
     assert!(!routes_approval_to_guardian_with_reviewer(
-        &turn,
+        turn.approval_policy.value(),
         ApprovalsReviewer::User
     ));
     assert!(routes_approval_to_guardian_with_reviewer(
-        &turn,
+        turn.approval_policy.value(),
         ApprovalsReviewer::AutoReview
     ));
 }

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -1274,7 +1274,10 @@ async fn maybe_request_mcp_tool_approval(
         .features
         .enabled(Feature::ToolCallMcpElicitation);
 
-    if routes_approval_to_guardian_with_reviewer(turn_context, approvals_reviewer) {
+    if routes_approval_to_guardian_with_reviewer(
+        turn_context.approval_policy.value(),
+        approvals_reviewer,
+    ) {
         let review_id = new_guardian_review_id();
         let decision = review_approval_request(
             sess,

--- a/codex-rs/core/src/session/mcp.rs
+++ b/codex-rs/core/src/session/mcp.rs
@@ -511,7 +511,7 @@ async fn review_guardian_mcp_elicitation(
         elicitation_connector_id(&request.elicitation),
     );
     if !crate::guardian::routes_approval_to_guardian_with_reviewer(
-        turn_context.as_ref(),
+        turn_context.approval_policy.value(),
         approvals_reviewer,
     ) {
         return Ok(None);

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -37,6 +37,7 @@ use crate::current_time::TimeProvider;
 use crate::default_skill_metadata_budget;
 use crate::environment_selection::TurnEnvironmentSnapshot;
 use crate::exec_policy::ExecPolicyManager;
+use crate::guardian::routes_approval_to_guardian_with_reviewer;
 use crate::image_preparation::prepare_response_items;
 use crate::parse_turn_item;
 use crate::realtime_conversation::RealtimeConversationManager;
@@ -1458,11 +1459,16 @@ impl Session {
     }
 
     pub(crate) async fn update_settings(
-        &self,
+        self: &Arc<Self>,
         updates: SessionSettingsUpdate,
     ) -> ConstraintResult<()> {
         let notify_config_contributors = !self.services.extensions.config_contributors().is_empty();
-        let (previous_config, new_config, permission_profile_changed) = {
+        let (
+            previous_config,
+            new_config,
+            permission_profile_changed,
+            guardian_routing_became_enabled,
+        ) = {
             let mut state = self.state.lock().await;
             let updated = match state.session_configuration.apply(&updates) {
                 Ok(updated) => updated,
@@ -1480,18 +1486,39 @@ impl Session {
             let updated_permission_profile = updated.permission_profile();
             let permission_profile_changed =
                 previous_permission_profile != updated_permission_profile;
+            let guardian_routing_was_enabled = routes_approval_to_guardian_with_reviewer(
+                state.session_configuration.approval_policy.value(),
+                state.session_configuration.approvals_reviewer,
+            );
+            let guardian_routing_is_enabled = routes_approval_to_guardian_with_reviewer(
+                updated.approval_policy.value(),
+                updated.approvals_reviewer,
+            );
+            let guardian_routing_became_enabled =
+                !guardian_routing_was_enabled && guardian_routing_is_enabled;
             if updates.environments.is_some() {
                 self.services
                     .turn_environments
                     .update_selections(updated.environment_selections());
             }
             state.session_configuration = updated;
-            (previous_config, new_config, permission_profile_changed)
+            (
+                previous_config,
+                new_config,
+                permission_profile_changed,
+                guardian_routing_became_enabled,
+            )
         };
         self.emit_config_changed_contributors(previous_config.as_ref(), new_config.as_ref());
         if permission_profile_changed {
             self.refresh_managed_network_proxy_for_current_permission_profile()
                 .await;
+        }
+        if guardian_routing_became_enabled {
+            let parent_turn = self
+                .new_startup_prewarm_turn_with_sub_id(INITIAL_SUBMIT_ID.to_owned())
+                .await;
+            self.schedule_guardian_review_session_prewarm(parent_turn);
         }
 
         Ok(())

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -876,6 +876,7 @@ async fn managed_network_proxy_decider_survives_full_access_start() -> anyhow::R
 #[tokio::test]
 async fn new_turn_refreshes_managed_network_proxy_for_sandbox_change() -> anyhow::Result<()> {
     let (session, _turn_context) = make_session_and_context().await;
+    let session = Arc::new(session);
     let initial_permission_profile = PermissionProfile::workspace_write();
 
     let mut network_config = NetworkProxyConfig::default();
@@ -2502,6 +2503,7 @@ async fn config_change_contributor_observes_effective_config_changes() {
         records: Arc::clone(&records),
     }));
     session.services.extensions = Arc::new(builder.build());
+    let session = Arc::new(session);
     session
         .services
         .session_extension_data
@@ -4766,6 +4768,7 @@ async fn session_configuration_apply_preserves_absolute_cwd_write_root_on_cwd_up
 #[tokio::test]
 async fn session_update_settings_does_not_rewrite_sticky_environment_cwds() {
     let (session, turn_context) = make_session_and_context().await;
+    let session = Arc::new(session);
     #[allow(deprecated)]
     let updated_cwd = turn_context.cwd.join("project");
     let current_environments = {
@@ -4816,6 +4819,7 @@ async fn session_update_settings_does_not_rewrite_sticky_environment_cwds() {
 #[tokio::test]
 async fn relative_cwd_update_without_environments_resolves_under_session_cwd() {
     let (session, _turn_context) = make_session_and_context().await;
+    let session = Arc::new(session);
     let original_cwd = {
         let mut state = session.state.lock().await;
         state.session_configuration.environments.environments = Vec::new();
@@ -4848,6 +4852,7 @@ async fn relative_cwd_update_without_environments_resolves_under_session_cwd() {
 #[tokio::test]
 async fn environment_settings_preserve_explicit_primary_cwd() {
     let (session, _turn_context) = make_session_and_context().await;
+    let session = Arc::new(session);
     let (original_cwd, environment_cwd, environments) = {
         let mut state = session.state.lock().await;
         let original_cwd = state.session_configuration.cwd().clone();

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -593,7 +593,7 @@ impl Session {
     }
 
     pub(crate) async fn new_turn_with_sub_id(
-        &self,
+        self: &Arc<Self>,
         sub_id: String,
         updates: SessionSettingsUpdate,
     ) -> CodexResult<Arc<TurnContext>> {
@@ -607,6 +607,16 @@ impl Session {
                     let next_permission_profile = next.permission_profile();
                     let permission_profile_changed =
                         previous_permission_profile != next_permission_profile;
+                    let guardian_routing_was_enabled = routes_approval_to_guardian_with_reviewer(
+                        state.session_configuration.approval_policy.value(),
+                        state.session_configuration.approvals_reviewer,
+                    );
+                    let guardian_routing_is_enabled = routes_approval_to_guardian_with_reviewer(
+                        next.approval_policy.value(),
+                        next.approvals_reviewer,
+                    );
+                    let guardian_routing_became_enabled =
+                        !guardian_routing_was_enabled && guardian_routing_is_enabled;
                     let previous_config = notify_config_contributors.then(|| {
                         Self::build_effective_session_config(&state.session_configuration)
                     });
@@ -621,6 +631,7 @@ impl Session {
                     Ok((
                         next,
                         permission_profile_changed,
+                        guardian_routing_became_enabled,
                         previous_config,
                         new_config,
                     ))
@@ -629,22 +640,27 @@ impl Session {
             }
         };
 
-        let (session_configuration, permission_profile_changed, previous_config, new_config) =
-            match update_result {
-                Ok(update) => update,
-                Err(err) => {
-                    let message = err.to_string();
-                    self.send_event_raw(Event {
-                        id: sub_id.clone(),
-                        msg: EventMsg::Error(ErrorEvent {
-                            message: message.clone(),
-                            codex_error_info: Some(CodexErrorInfo::BadRequest),
-                        }),
-                    })
-                    .await;
-                    return Err(CodexErr::InvalidRequest(message));
-                }
-            };
+        let (
+            session_configuration,
+            permission_profile_changed,
+            guardian_routing_became_enabled,
+            previous_config,
+            new_config,
+        ) = match update_result {
+            Ok(update) => update,
+            Err(err) => {
+                let message = err.to_string();
+                self.send_event_raw(Event {
+                    id: sub_id.clone(),
+                    msg: EventMsg::Error(ErrorEvent {
+                        message: message.clone(),
+                        codex_error_info: Some(CodexErrorInfo::BadRequest),
+                    }),
+                })
+                .await;
+                return Err(CodexErr::InvalidRequest(message));
+            }
+        };
         self.emit_config_changed_contributors(previous_config.as_ref(), new_config.as_ref());
 
         if permission_profile_changed {
@@ -652,13 +668,17 @@ impl Session {
                 .await;
         }
 
-        Ok(self
+        let turn_context = self
             .new_turn_from_configuration(
                 sub_id,
                 session_configuration,
                 updates.final_output_json_schema,
             )
-            .await)
+            .await;
+        if guardian_routing_became_enabled {
+            self.schedule_guardian_review_session_prewarm(Arc::clone(&turn_context));
+        }
+        Ok(turn_context)
     }
 
     async fn new_turn_from_configuration(

--- a/codex-rs/core/src/session_startup_prewarm.rs
+++ b/codex-rs/core/src/session_startup_prewarm.rs
@@ -16,6 +16,7 @@ use crate::session::INITIAL_SUBMIT_ID;
 use crate::session::session::Session;
 use crate::session::turn::build_prompt;
 use crate::session::turn::built_tools;
+use crate::session::turn_context::TurnContext;
 use codex_otel::STARTUP_PREWARM_AGE_AT_FIRST_TURN_METRIC;
 use codex_otel::STARTUP_PREWARM_DURATION_METRIC;
 use codex_otel::SessionTelemetry;
@@ -181,6 +182,28 @@ impl SessionStartupPrewarmHandle {
 }
 
 impl Session {
+    pub(crate) fn schedule_guardian_review_session_prewarm(
+        self: &Arc<Self>,
+        parent_turn: Arc<TurnContext>,
+    ) {
+        if !self.services.model_client.responses_websocket_enabled()
+            || !routes_approval_to_guardian(&parent_turn)
+        {
+            return;
+        }
+
+        let parent_session = Arc::clone(self);
+        drop(tokio::spawn(async move {
+            if let Err(err) = parent_session
+                .guardian_review_session
+                .initialize(Arc::clone(&parent_session), parent_turn)
+                .await
+            {
+                warn!("failed to initialize guardian review session: {err:#}");
+            }
+        }));
+    }
+
     pub(crate) async fn schedule_startup_prewarm(self: &Arc<Self>, base_instructions: String) {
         if !self.services.model_client.responses_websocket_enabled() {
             return;
@@ -243,19 +266,7 @@ async fn schedule_startup_prewarm_inner(
         prewarm_started_at.elapsed(),
         /*status*/ None,
     );
-    if routes_approval_to_guardian(&startup_turn_context) {
-        let guardian_session = Arc::clone(&session);
-        let guardian_parent_turn = Arc::clone(&startup_turn_context);
-        drop(tokio::spawn(async move {
-            if let Err(err) = guardian_session
-                .guardian_review_session
-                .initialize(Arc::clone(&guardian_session), guardian_parent_turn)
-                .await
-            {
-                warn!("failed to initialize guardian review session: {err:#}");
-            }
-        }));
-    }
+    session.schedule_guardian_review_session_prewarm(Arc::clone(&startup_turn_context));
     let startup_cancellation_token = CancellationToken::new();
     let built_tools_started_at = Instant::now();
     let startup_router = built_tools(

--- a/codex-rs/core/tests/suite/guardian_review.rs
+++ b/codex-rs/core/tests/suite/guardian_review.rs
@@ -20,6 +20,7 @@ use core_test_support::responses::start_mock_server;
 use core_test_support::responses::start_websocket_server;
 use core_test_support::skip_if_no_network;
 use core_test_support::skip_if_sandbox;
+use core_test_support::submit_thread_settings;
 use core_test_support::test_codex::local_selections;
 use core_test_support::test_codex::test_codex;
 use core_test_support::wait_for_event;
@@ -104,6 +105,58 @@ async fn guardian_session_prewarms_and_is_reused_for_first_review() -> Result<()
         Some(guardian_thread_id)
     );
     assert_eq!(guardian_review.get("generate"), None);
+
+    test.codex.shutdown_and_wait().await?;
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn guardian_session_prewarms_when_enabled_mid_thread() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_websocket_server(vec![
+        vec![vec![ev_response_created("warm-1"), ev_completed("warm-1")]],
+        vec![vec![ev_response_created("warm-2"), ev_completed("warm-2")]],
+    ])
+    .await;
+    let mut builder = test_codex().with_config(|config| {
+        config.permissions.approval_policy = Constrained::allow_any(AskForApproval::Never);
+        config.approvals_reviewer = ApprovalsReviewer::User;
+    });
+    let test = builder.build_with_websocket_server(&server).await?;
+    let initial_prewarm = tokio::time::timeout(
+        Duration::from_secs(5),
+        server.wait_for_request(/*connection_index*/ 0, /*request_index*/ 0),
+    )
+    .await?
+    .body_json();
+    assert_eq!(
+        initial_prewarm["client_metadata"]["x-openai-subagent"].as_str(),
+        None
+    );
+
+    submit_thread_settings(
+        &test.codex,
+        codex_protocol::protocol::ThreadSettingsOverrides {
+            approval_policy: Some(AskForApproval::OnRequest),
+            approvals_reviewer: Some(ApprovalsReviewer::AutoReview),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let guardian_prewarm = tokio::time::timeout(
+        Duration::from_secs(5),
+        server.wait_for_request(/*connection_index*/ 1, /*request_index*/ 0),
+    )
+    .await?
+    .body_json();
+    assert_eq!(
+        guardian_prewarm["client_metadata"]["x-openai-subagent"].as_str(),
+        Some("guardian")
+    );
+    assert_eq!(guardian_prewarm["generate"].as_bool(), Some(false));
 
     test.codex.shutdown_and_wait().await?;
     server.shutdown().await;


### PR DESCRIPTION
## Summary

- prewarm the Guardian review session when a settings update starts routing approvals to Guardian
- cover both standalone thread settings updates and settings supplied with a new turn
- reuse the existing startup prewarm path and keep the routing decision in Guardian's existing policy predicate

## Why

Follow-up to #27982. Guardian was prewarmed when a session started with automatic review enabled, but not when a user enabled it by switching permissions or reviewer settings mid-thread. That left the first subsequent approval paying Guardian session startup latency.

## User impact

When Guardian routing transitions from disabled to enabled during an existing thread, its review session is prepared eagerly. Settings changes that do not make that transition are unaffected.

## Validation

- `just fmt`
- `just test -p codex-core --test all guardian_session_prewarms_when_enabled_mid_thread`
- `just test -p codex-core` reaches compilation but is blocked by an unchanged `origin/main` unit-test fixture in `context/world_state/environment_tests.rs` that still initializes the removed `ResponseItem::Message::metadata` field.
