### PR TITLE
core: fix world state response item metadata

### DIFF
--- a/codex-rs/core/src/context/world_state/environment_tests.rs
+++ b/codex-rs/core/src/context/world_state/environment_tests.rs
@@ -251,6 +251,6 @@ fn user_message(text: &str) -> ResponseItem {
             text: text.to_string(),
         }],
         phase: None,
-        metadata: None,
+        internal_chat_message_metadata_passthrough: None,
     }
 }


### PR DESCRIPTION
This fixes the CI compile break caused by the interaction between #28968 renaming `ResponseItem.metadata` and #29249 adding a new world-state test helper that still used the old field name. The fix updates that single stale initializer to the renamed passthrough metadata field.

- References #28968
- References #29249
- Keeps the change scoped to the failing test helper