### PR TITLE
[codex] Propagate dynamic tool failures in code mode

### DIFF
--- a/codex-rs/core/src/tools/handlers/dynamic.rs
+++ b/codex-rs/core/src/tools/handlers/dynamic.rs
@@ -2,6 +2,7 @@ use crate::function_tool::FunctionCallError;
 use crate::session::session::Session;
 use crate::session::turn_context::TurnContext;
 use crate::tools::context::FunctionToolOutput;
+use crate::tools::context::ToolCallSource;
 use crate::tools::context::ToolInvocation;
 use crate::tools::context::ToolPayload;
 use crate::tools::context::boxed_tool_output;
@@ -121,6 +122,7 @@ impl DynamicToolHandler {
             turn,
             call_id,
             payload,
+            source,
             ..
         } = invocation;
 
@@ -156,10 +158,19 @@ impl DynamicToolHandler {
             .into_iter()
             .map(FunctionCallOutputContentItem::from)
             .collect::<Vec<_>>();
-        Ok(boxed_tool_output(FunctionToolOutput::from_content(
-            body,
-            Some(success),
-        )))
+        let output = FunctionToolOutput::from_content(body, Some(success));
+        if !success && matches!(source, ToolCallSource::CodeMode { .. }) {
+            let message = output.into_text();
+            return Err(FunctionCallError::RespondToModel(
+                if message.trim().is_empty() {
+                    "dynamic tool call failed".to_string()
+                } else {
+                    message
+                },
+            ));
+        }
+
+        Ok(boxed_tool_output(output))
     }
 }
 

--- a/codex-rs/core/tests/suite/code_mode.rs
+++ b/codex-rs/core/tests/suite/code_mode.rs
@@ -3423,7 +3423,7 @@ text(JSON.stringify(tool));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn code_mode_can_call_hidden_dynamic_tools() -> Result<()> {
+async fn code_mode_can_call_hidden_dynamic_tools_and_catch_failures() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = responses::start_mock_server().await;
@@ -3463,11 +3463,18 @@ async fn code_mode_can_call_hidden_dynamic_tools() -> Result<()> {
     let code = r#"
 const tool = ALL_TOOLS.find(({ name }) => name === "codex_app__hidden_dynamic_tool");
 const out = await tools.codex_app__hidden_dynamic_tool({ city: "Paris" });
+let error = null;
+try {
+  await tools.codex_app__hidden_dynamic_tool({ city: "London" });
+} catch (caught) {
+  error = caught?.message ?? String(caught);
+}
 text(
   JSON.stringify({
     name: tool?.name ?? null,
     description: tool?.description ?? null,
     out,
+    error,
   })
 );
 "#;
@@ -3549,6 +3556,25 @@ text(
             },
         })
         .await?;
+    let request = wait_for_event_match(&test.codex, |event| match event {
+        EventMsg::DynamicToolCallRequest(request) => Some(request.clone()),
+        _ => None,
+    })
+    .await;
+    assert_eq!(request.namespace.as_deref(), Some("codex_app"));
+    assert_eq!(request.tool, "hidden_dynamic_tool");
+    assert_eq!(request.arguments, serde_json::json!({ "city": "London" }));
+    test.codex
+        .submit(Op::DynamicToolResponse {
+            id: request.call_id,
+            response: DynamicToolResponse {
+                content_items: vec![DynamicToolCallOutputContentItem::InputText {
+                    text: "automation_update received invalid arguments.".to_string(),
+                }],
+                success: false,
+            },
+        })
+        .await?;
     wait_for_event(&test.codex, |event| match event {
         EventMsg::TurnComplete(event) => event.turn_id == turn_id,
         _ => false,
@@ -3574,6 +3600,12 @@ text(
     assert_eq!(
         parsed.get("out"),
         Some(&Value::String("hidden-ok".to_string()))
+    );
+    assert_eq!(
+        parsed.get("error"),
+        Some(&Value::String(
+            "automation_update received invalid arguments.".to_string()
+        ))
     );
     assert!(
         parsed


### PR DESCRIPTION
## Summary

- reject failed app dynamic-tool responses as JavaScript exceptions when they are invoked through code mode
- preserve existing successful code-mode return values and direct dynamic-tool response behavior
- extend the dynamic-tool code-mode integration test to cover a successful call followed by a catchable failure

## What happened

App dynamic tools already return a structured response with `contentItems` and a `success` bit. The Codex dynamic-tool handler preserved both when it built a `FunctionToolOutput`, so direct model tool calls could distinguish success from failure.

Code mode then adapted that `FunctionToolOutput` into the value returned from `await tools.<name>(...)`. The generic conversion returned only the output body—usually a string—and dropped the `success` bit. A dynamic tool response such as:

```json
{
  "contentItems": [
    {
      "type": "inputText",
      "text": "automation_update received invalid arguments."
    }
  ],
  "success": false
}
```

therefore became a successfully resolved JavaScript string instead of a rejected promise.

This surfaced while creating an automation. `automation_update` rejected a cron request whose runtime-required `model` field was omitted, but code mode resolved the failure text as an ordinary string. The calling JavaScript expected a structured content object and rendered nothing from the string, making the failed call look silent. Because no exception interrupted the flow, the caller incorrectly reported that the automation had been created; checking the automation store showed that nothing had been persisted.

There is a separate follow-up in the app dynamic tool: the advertised `automation_update` schema currently presents `model` as optional while its runtime validator requires it for cron create/update calls, and the validation response does not identify the missing field. That mismatch made the original invalid call easier to produce, but it is not the reason code mode lost the failure state. This PR fixes the generic Codex-side propagation issue.

## Behavior

Before this change:

```js
const result = await tools.codex_app__automation_update(invalidArgs);
// result === "automation_update received invalid arguments."
// No exception was raised.
```

After this change:

```js
try {
  await tools.codex_app__automation_update(invalidArgs);
} catch (error) {
  // error.message === "automation_update received invalid arguments."
}
```

The conversion is limited to failed dynamic tools invoked from code mode. Direct dynamic-tool calls keep their existing `success: false` response, successful nested calls keep their current return values, and MCP tools retain their established `isError` result-object semantics.

## Validation

- `just fmt`
- `just test -p codex-core code_mode_can_call_hidden_dynamic_tools_and_catch_failures`
- `just fix -p codex-core`

The focused integration test drives the full path: code mode invokes a namespaced dynamic tool, the app response succeeds once, a second app response returns `success: false`, and the JavaScript caller catches the returned failure text as an exception.
