### PR TITLE
[codex] skip initial rollout budget prefill

### DIFF
--- a/codex-rs/core/src/rollout_budget.rs
+++ b/codex-rs/core/src/rollout_budget.rs
@@ -49,13 +49,13 @@ impl RolloutBudget {
         let Some(mut state) = self.lock() else {
             return false;
         };
-        let charge_prefill = state.threads_with_usage.insert(thread_id);
+        let skip_prefill = state.threads_with_usage.insert(thread_id);
         state.weighted_tokens_used += usage.output_tokens.max(0) as f64
             * state.config.sampling_token_weight
-            + if charge_prefill {
-                usage.non_cached_input() as f64 * state.config.prefill_token_weight
-            } else {
+            + if skip_prefill {
                 0.0
+            } else {
+                usage.non_cached_input() as f64 * state.config.prefill_token_weight
             };
         state.weighted_tokens_used >= state.config.limit_tokens as f64
     }

--- a/codex-rs/core/src/rollout_budget.rs
+++ b/codex-rs/core/src/rollout_budget.rs
@@ -2,6 +2,7 @@ use crate::config::RolloutBudgetConfig;
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::TokenUsage;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Mutex;
 use std::sync::MutexGuard;
 use std::sync::OnceLock;
@@ -20,6 +21,8 @@ pub(crate) struct RolloutBudget {
 struct RolloutBudgetState {
     config: RolloutBudgetConfig,
     weighted_tokens_used: f64,
+    /// Threads whose initial prompt prefill has already been skipped.
+    threads_with_usage: HashSet<ThreadId>,
     /// Last reminder delivered to each thread, so every thread observes crossed thresholds.
     deliveries: HashMap<ThreadId, ThreadBudgetDelivery>,
 }
@@ -35,19 +38,25 @@ impl RolloutBudget {
             Mutex::new(RolloutBudgetState {
                 config,
                 weighted_tokens_used: 0.0,
+                threads_with_usage: HashSet::new(),
                 deliveries: HashMap::new(),
             })
         });
     }
 
     /// Returns true once the configured budget is exhausted, including on later calls.
-    pub(crate) fn record_usage(&self, usage: &TokenUsage) -> bool {
+    pub(crate) fn record_usage(&self, thread_id: ThreadId, usage: &TokenUsage) -> bool {
         let Some(mut state) = self.lock() else {
             return false;
         };
+        let charge_prefill = state.threads_with_usage.insert(thread_id);
         state.weighted_tokens_used += usage.output_tokens.max(0) as f64
             * state.config.sampling_token_weight
-            + usage.non_cached_input() as f64 * state.config.prefill_token_weight;
+            + if charge_prefill {
+                usage.non_cached_input() as f64 * state.config.prefill_token_weight
+            } else {
+                0.0
+            };
         state.weighted_tokens_used >= state.config.limit_tokens as f64
     }
 

--- a/codex-rs/core/src/session/rollout_budget.rs
+++ b/codex-rs/core/src/session/rollout_budget.rs
@@ -28,7 +28,7 @@ impl Session {
             .services
             .agent_control
             .rollout_budget()
-            .record_usage(usage)
+            .record_usage(self.thread_id(), usage)
         {
             return Err(CodexErr::TurnAborted);
         }

--- a/codex-rs/core/tests/suite/rollout_budget.rs
+++ b/codex-rs/core/tests/suite/rollout_budget.rs
@@ -53,7 +53,7 @@ fn wire_request_contains(request: &wiremock::Request, text: &str) -> bool {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn adds_weighted_initial_and_threshold_reminders() -> Result<()> {
+async fn skips_initial_prefill_then_adds_weighted_threshold_reminders() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
@@ -76,7 +76,23 @@ async fn adds_weighted_initial_and_threshold_reminders() -> Result<()> {
                     }
                 }),
             ]),
-            sse(vec![ev_response_created("resp-2"), ev_completed("resp-2")]),
+            sse(vec![
+                ev_response_created("resp-2"),
+                json!({
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp-2",
+                        "usage": {
+                            "input_tokens": 20,
+                            "input_tokens_details": { "cached_tokens": 0 },
+                            "output_tokens": 5,
+                            "output_tokens_details": null,
+                            "total_tokens": 25
+                        }
+                    }
+                }),
+            ]),
+            sse(vec![ev_response_created("resp-3"), ev_completed("resp-3")]),
         ],
     )
     .await;
@@ -93,6 +109,7 @@ async fn adds_weighted_initial_and_threshold_reminders() -> Result<()> {
 
     test.submit_turn("first turn").await?;
     test.submit_turn("second turn").await?;
+    test.submit_turn("third turn").await?;
 
     let requests = responses.requests();
     assert_eq!(
@@ -103,7 +120,15 @@ async fn adds_weighted_initial_and_threshold_reminders() -> Result<()> {
         rollout_budget_texts(&requests[1]),
         vec![
             rollout_budget_message(/*remaining_tokens*/ 100),
-            rollout_budget_message(/*remaining_tokens*/ 60),
+            rollout_budget_message(/*remaining_tokens*/ 70),
+        ]
+    );
+    assert_eq!(
+        rollout_budget_texts(&requests[2]),
+        vec![
+            rollout_budget_message(/*remaining_tokens*/ 100),
+            rollout_budget_message(/*remaining_tokens*/ 70),
+            rollout_budget_message(/*remaining_tokens*/ 50),
         ]
     );
 

--- a/codex-rs/core/tests/suite/rollout_budget.rs
+++ b/codex-rs/core/tests/suite/rollout_budget.rs
@@ -9,7 +9,6 @@ use codex_protocol::user_input::UserInput;
 use core_test_support::responses::ResponsesRequest;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
-use core_test_support::responses::ev_completed_with_tokens;
 use core_test_support::responses::ev_function_call;
 use core_test_support::responses::ev_response_created;
 use core_test_support::responses::mount_sse_once_match;
@@ -46,6 +45,22 @@ fn rollout_budget_message(remaining_tokens: i64) -> String {
     format!(
         "<rollout_budget>\nYou have {remaining_tokens} weighted tokens left in the shared session token budget.\n</rollout_budget>"
     )
+}
+
+fn ev_completed_with_output_tokens(id: &str, output_tokens: i64) -> serde_json::Value {
+    json!({
+        "type": "response.completed",
+        "response": {
+            "id": id,
+            "usage": {
+                "input_tokens": 0,
+                "input_tokens_details": null,
+                "output_tokens": output_tokens,
+                "output_tokens_details": null,
+                "total_tokens": output_tokens
+            }
+        }
+    })
 }
 
 fn wire_request_contains(request: &wiremock::Request, text: &str) -> bool {
@@ -156,7 +171,7 @@ async fn subagent_usage_draws_from_the_shared_budget() -> Result<()> {
         sse(vec![
             ev_response_created("root-1"),
             ev_function_call(SPAWN_CALL_ID, "spawn_agent", &spawn_args),
-            ev_completed_with_tokens("root-1", /*total_tokens*/ 10),
+            ev_completed_with_output_tokens("root-1", /*output_tokens*/ 10),
         ]),
     )
     .await;
@@ -165,7 +180,7 @@ async fn subagent_usage_draws_from_the_shared_budget() -> Result<()> {
         |request: &wiremock::Request| wire_request_contains(request, "\"type\":\"agent_message\""),
         sse(vec![
             ev_response_created("child-1"),
-            ev_completed_with_tokens("child-1", /*total_tokens*/ 30),
+            ev_completed_with_output_tokens("child-1", /*output_tokens*/ 30),
         ]),
     )
     .await;
@@ -177,7 +192,7 @@ async fn subagent_usage_draws_from_the_shared_budget() -> Result<()> {
         },
         sse(vec![
             ev_response_created("root-2"),
-            ev_completed_with_tokens("root-2", /*total_tokens*/ 10),
+            ev_completed_with_output_tokens("root-2", /*output_tokens*/ 10),
         ]),
     )
     .await;
@@ -232,11 +247,11 @@ async fn exhausted_budget_aborts_current_and_later_turns() -> Result<()> {
         vec![
             sse(vec![
                 ev_response_created("exhaust-budget"),
-                ev_completed_with_tokens("exhaust-budget", /*total_tokens*/ 30),
+                ev_completed_with_output_tokens("exhaust-budget", /*output_tokens*/ 30),
             ]),
             sse(vec![
                 ev_response_created("already-exhausted"),
-                ev_completed_with_tokens("already-exhausted", /*total_tokens*/ 1),
+                ev_completed_with_output_tokens("already-exhausted", /*output_tokens*/ 1),
             ]),
         ],
     )
@@ -299,13 +314,13 @@ async fn compaction_budget_exhaustion_aborts_without_error_or_retry(remote_v2: b
                     "encrypted_content": "encrypted-summary",
                 }
             }),
-            ev_completed_with_tokens("compact", /*total_tokens*/ 10),
+            ev_completed_with_output_tokens("compact", /*output_tokens*/ 10),
         ])
     } else {
         sse(vec![
             ev_response_created("compact"),
             ev_assistant_message("compact-summary", "compact summary"),
-            ev_completed_with_tokens("compact", /*total_tokens*/ 10),
+            ev_completed_with_output_tokens("compact", /*output_tokens*/ 10),
         ])
     };
     let responses = mount_sse_sequence(&server, vec![compact_response]).await;
@@ -362,12 +377,12 @@ async fn restates_the_current_remainder_after_compaction() -> Result<()> {
         vec![
             sse(vec![
                 ev_response_created("resp-1"),
-                ev_completed_with_tokens("resp-1", /*total_tokens*/ 20),
+                ev_completed_with_output_tokens("resp-1", /*output_tokens*/ 20),
             ]),
             sse(vec![
                 ev_response_created("resp-compact"),
                 ev_assistant_message("msg-compact", "compact summary"),
-                ev_completed_with_tokens("resp-compact", /*total_tokens*/ 10),
+                ev_completed_with_output_tokens("resp-compact", /*output_tokens*/ 10),
             ]),
             sse(vec![ev_response_created("resp-2"), ev_completed("resp-2")]),
         ],
@@ -427,7 +442,7 @@ async fn restates_the_current_remainder_after_rollback() -> Result<()> {
         vec![
             sse(vec![
                 ev_response_created("resp-1"),
-                ev_completed_with_tokens("resp-1", /*total_tokens*/ 30),
+                ev_completed_with_output_tokens("resp-1", /*output_tokens*/ 30),
             ]),
             sse(vec![ev_response_created("resp-2"), ev_completed("resp-2")]),
         ],


### PR DESCRIPTION
## Summary
- do not charge the initial prompt prefill for each rollout-budget thread
- continue charging sampled output on the first response and prefill on later responses
- cover the initial-vs-later prefill behavior in the existing rollout-budget integration test

## Why
The first Responses API usage carrier includes the initial system/developer/user prompt. Rollout budgets should measure work performed during the rollout, so charging that initial prefill can consume most of the budget before the model has done meaningful work.

## Testing
- `cargo fmt --manifest-path codex-rs/Cargo.toml -p codex-core`
- attempted `cargo test --manifest-path codex-rs/Cargo.toml -p codex-core --test all rollout_budget::skips_initial_prefill_then_adds_weighted_threshold_reminders` (blocked before compilation: local rustc 1.90.0, current dependencies require rustc 1.91-1.94)