### PR TITLE
Scope token-budget accounting to body-after-prefix window

### DIFF
--- a/codex-rs/core/src/session/context_window.rs
+++ b/codex-rs/core/src/session/context_window.rs
@@ -1,0 +1,95 @@
+use super::session::Session;
+use super::turn_context::TurnContext;
+use codex_protocol::config_types::AutoCompactTokenLimitScope;
+
+#[derive(Debug)]
+pub(crate) struct ContextWindowTokenStatus {
+    // Full active context usage, independent of the configured auto-compact scope.
+    pub(crate) active_context_tokens: i64,
+    // Usage counted against `model_auto_compact_token_limit` for the current scope.
+    pub(crate) auto_compact_scope_tokens: i64,
+    pub(crate) auto_compact_scope_limit: i64,
+    pub(crate) full_context_window_limit: Option<i64>,
+    pub(crate) auto_compact_window_prefill_tokens: Option<i64>,
+    pub(crate) full_context_window_limit_reached: bool,
+    pub(crate) token_limit_reached: bool,
+    pub(crate) context_remaining_tokens: Option<i64>,
+}
+
+impl ContextWindowTokenStatus {
+    pub(crate) fn tokens_until_compaction(&self) -> i64 {
+        let full_context_remaining = self.full_context_window_limit.map_or(i64::MAX, |limit| {
+            limit.saturating_sub(self.active_context_tokens)
+        });
+        self.auto_compact_scope_limit
+            .saturating_sub(self.auto_compact_scope_tokens)
+            .min(full_context_remaining)
+            .max(0)
+    }
+}
+
+impl Session {
+    pub(crate) async fn context_window_token_status(
+        &self,
+        turn_context: &TurnContext,
+    ) -> ContextWindowTokenStatus {
+        let active_context_tokens = self.get_total_token_usage().await;
+        let mut auto_compact_window_prefill_tokens = None;
+        let mut has_context_remaining_limit = false;
+        let (auto_compact_scope_tokens, auto_compact_scope_limit, full_context_window_limit) =
+            match turn_context.config.model_auto_compact_token_limit_scope {
+                AutoCompactTokenLimitScope::Total => (
+                    active_context_tokens,
+                    turn_context
+                        .model_info
+                        .auto_compact_token_limit()
+                        .unwrap_or(i64::MAX),
+                    None,
+                ),
+                AutoCompactTokenLimitScope::BodyAfterPrefix => {
+                    let window = self.auto_compact_window_snapshot().await;
+                    auto_compact_window_prefill_tokens = window.prefill_input_tokens;
+                    let baseline = window.prefill_input_tokens.unwrap_or(active_context_tokens);
+                    let scope_limit = turn_context
+                        .config
+                        .model_auto_compact_token_limit
+                        .or_else(|| turn_context.model_info.auto_compact_token_limit());
+                    let full_context_window_limit = turn_context.model_context_window();
+                    has_context_remaining_limit =
+                        scope_limit.is_some() || full_context_window_limit.is_some();
+                    (
+                        active_context_tokens.saturating_sub(baseline),
+                        scope_limit.unwrap_or(i64::MAX),
+                        full_context_window_limit,
+                    )
+                }
+            };
+        let full_context_window_limit_reached =
+            full_context_window_limit.is_some_and(|full_context_window_limit| {
+                active_context_tokens >= full_context_window_limit
+            });
+        let token_limit_reached = auto_compact_scope_tokens >= auto_compact_scope_limit
+            || full_context_window_limit_reached;
+        let mut status = ContextWindowTokenStatus {
+            active_context_tokens,
+            auto_compact_scope_tokens,
+            auto_compact_scope_limit,
+            full_context_window_limit,
+            auto_compact_window_prefill_tokens,
+            full_context_window_limit_reached,
+            token_limit_reached,
+            context_remaining_tokens: None,
+        };
+        status.context_remaining_tokens =
+            match turn_context.config.model_auto_compact_token_limit_scope {
+                AutoCompactTokenLimitScope::Total => turn_context
+                    .model_context_window()
+                    .map(|limit| limit.saturating_sub(active_context_tokens).max(0)),
+                AutoCompactTokenLimitScope::BodyAfterPrefix if has_context_remaining_limit => {
+                    Some(status.tokens_until_compaction())
+                }
+                AutoCompactTokenLimitScope::BodyAfterPrefix => None,
+            };
+        status
+    }
+}

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -209,6 +209,7 @@ use codex_protocol::error::Result as CodexResult;
 use codex_protocol::exec_output::StreamOutput;
 
 mod config_lock;
+pub(crate) mod context_window;
 mod handlers;
 mod inject;
 mod input_queue;

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -294,8 +294,9 @@ pub(crate) async fn run_turn(
                 let (has_pending_input, token_status, estimated_token_count) = async {
                     let has_pending_input =
                         sess.input_queue.has_pending_input(&sess.active_turn).await;
-                    let token_status =
-                        auto_compact_token_status(sess.as_ref(), turn_context.as_ref()).await;
+                    let token_status = sess
+                        .context_window_token_status(turn_context.as_ref())
+                        .await;
                     let estimated_token_count =
                         sess.get_estimated_token_count(turn_context.as_ref()).await;
                     (has_pending_input, token_status, estimated_token_count)
@@ -322,17 +323,7 @@ pub(crate) async fn run_turn(
                     "post sampling token usage"
                 );
 
-                let tokens_after_sampling = token_status.active_context_tokens;
-                let full_context_remaining = token_status
-                    .full_context_window_limit
-                    .map_or(i64::MAX, |limit| {
-                        limit.saturating_sub(tokens_after_sampling)
-                    });
-                let tokens_until_compaction = token_status
-                    .auto_compact_scope_limit
-                    .saturating_sub(token_status.auto_compact_scope_tokens)
-                    .min(full_context_remaining)
-                    .max(0);
+                let tokens_until_compaction = token_status.tokens_until_compaction();
                 super::token_budget::maybe_record(
                     sess.as_ref(),
                     turn_context.as_ref(),
@@ -802,68 +793,6 @@ async fn track_turn_resolved_config_analytics(
         });
 }
 
-#[derive(Debug)]
-struct AutoCompactTokenStatus {
-    // Full active context usage, independent of the configured auto-compact scope.
-    active_context_tokens: i64,
-    // Usage counted against `model_auto_compact_token_limit` for the current scope.
-    auto_compact_scope_tokens: i64,
-    auto_compact_scope_limit: i64,
-    full_context_window_limit: Option<i64>,
-    auto_compact_window_prefill_tokens: Option<i64>,
-    full_context_window_limit_reached: bool,
-    token_limit_reached: bool,
-}
-
-async fn auto_compact_token_status(
-    sess: &Session,
-    turn_context: &TurnContext,
-) -> AutoCompactTokenStatus {
-    let active_context_tokens = sess.get_total_token_usage().await;
-    let mut auto_compact_window_prefill_tokens = None;
-    let (auto_compact_scope_tokens, auto_compact_scope_limit, full_context_window_limit) =
-        match turn_context.config.model_auto_compact_token_limit_scope {
-            AutoCompactTokenLimitScope::Total => (
-                active_context_tokens,
-                turn_context
-                    .model_info
-                    .auto_compact_token_limit()
-                    .unwrap_or(i64::MAX),
-                None,
-            ),
-            AutoCompactTokenLimitScope::BodyAfterPrefix => {
-                let window = sess.auto_compact_window_snapshot().await;
-                auto_compact_window_prefill_tokens = window.prefill_input_tokens;
-                let baseline = window.prefill_input_tokens.unwrap_or(active_context_tokens);
-                (
-                    active_context_tokens.saturating_sub(baseline),
-                    turn_context
-                        .config
-                        .model_auto_compact_token_limit
-                        .or_else(|| turn_context.model_info.auto_compact_token_limit())
-                        .unwrap_or(i64::MAX),
-                    turn_context.model_context_window(),
-                )
-            }
-        };
-    let full_context_window_limit_reached =
-        full_context_window_limit.is_some_and(|full_context_window_limit| {
-            active_context_tokens >= full_context_window_limit
-        });
-    let token_limit_reached =
-        auto_compact_scope_tokens >= auto_compact_scope_limit || full_context_window_limit_reached;
-
-    AutoCompactTokenStatus {
-        active_context_tokens,
-        auto_compact_scope_tokens,
-        auto_compact_scope_limit,
-        full_context_window_limit,
-        auto_compact_window_prefill_tokens,
-        full_context_window_limit_reached,
-        token_limit_reached,
-    }
-}
-
 #[instrument(level = "trace", skip_all)]
 async fn run_pre_sampling_compact(
     sess: &Arc<Session>,
@@ -879,7 +808,9 @@ async fn run_pre_sampling_compact(
     }
 
     maybe_run_previous_model_inline_compact(sess, turn_context, client_session).await?;
-    let token_status = auto_compact_token_status(sess.as_ref(), turn_context.as_ref()).await;
+    let token_status = sess
+        .context_window_token_status(turn_context.as_ref())
+        .await;
     // Compact if the configured auto-compaction budget or usable context window is exhausted.
     if token_status.token_limit_reached {
         run_auto_compact(

--- a/codex-rs/core/src/tools/handlers/get_context_remaining.rs
+++ b/codex-rs/core/src/tools/handlers/get_context_remaining.rs
@@ -75,19 +75,14 @@ impl ToolExecutor<ToolInvocation> for GetContextRemainingHandler {
                 ));
             }
 
-            let Some(model_context_window) = invocation.turn.model_context_window() else {
-                return Ok(boxed_tool_output(GetContextRemainingOutput::new(
-                    /*tokens_left*/ None,
-                )));
-            };
-            let active_context_tokens = invocation.session.get_total_token_usage().await.max(0);
-            let tokens_left = model_context_window
-                .saturating_sub(active_context_tokens)
-                .max(0);
+            let token_status = invocation
+                .session
+                .context_window_token_status(invocation.turn.as_ref())
+                .await;
 
-            Ok(boxed_tool_output(GetContextRemainingOutput::new(Some(
-                tokens_left,
-            ))))
+            Ok(boxed_tool_output(GetContextRemainingOutput::new(
+                token_status.context_remaining_tokens,
+            )))
         })
     }
 }

--- a/codex-rs/core/tests/suite/token_budget.rs
+++ b/codex-rs/core/tests/suite/token_budget.rs
@@ -4,6 +4,7 @@ use codex_config::types::McpServerTransportConfig;
 use codex_core::config::TokenBudgetConfig;
 use codex_features::Feature;
 use codex_model_provider_info::built_in_model_providers;
+use codex_protocol::config_types::AutoCompactTokenLimitScope;
 use codex_protocol::protocol::CONTEXT_WINDOW_CLOSE_TAG;
 use codex_protocol::protocol::CONTEXT_WINDOW_OPEN_TAG;
 use codex_protocol::protocol::EventMsg;
@@ -77,6 +78,22 @@ fn tool_names(request: &ResponsesRequest) -> Vec<String> {
         .flatten()
         .filter_map(|tool| tool.get("name").and_then(Value::as_str).map(str::to_string))
         .collect()
+}
+
+fn ev_completed_with_usage(id: &str, input_tokens: i64, output_tokens: i64) -> Value {
+    json!({
+        "type": "response.completed",
+        "response": {
+            "id": id,
+            "usage": {
+                "input_tokens": input_tokens,
+                "input_tokens_details": null,
+                "output_tokens": output_tokens,
+                "output_tokens_details": null,
+                "total_tokens": input_tokens + output_tokens
+            }
+        }
+    })
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -265,6 +282,70 @@ async fn token_budget_reminder_emits_after_crossing_compaction_threshold() -> Re
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn token_budget_reminder_uses_body_after_prefix_window() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let responses = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                ev_completed_with_tokens("resp-1", /*total_tokens*/ 8_000),
+            ]),
+            sse(vec![
+                ev_response_created("resp-2"),
+                ev_completed_with_tokens("resp-2", /*total_tokens*/ 8_600),
+            ]),
+            sse(vec![ev_response_created("resp-3"), ev_completed("resp-3")]),
+        ],
+    )
+    .await;
+    let test = test_codex()
+        .with_config(|config| {
+            config.model_context_window = Some(10_000);
+            config.model_auto_compact_token_limit = Some(1_000);
+            config.model_auto_compact_token_limit_scope =
+                AutoCompactTokenLimitScope::BodyAfterPrefix;
+            config.token_budget = Some(TokenBudgetConfig {
+                reminder_threshold_tokens: Some(600),
+                ..TokenBudgetConfig::default()
+            });
+            config
+                .features
+                .enable(Feature::TokenBudget)
+                .expect("test config should allow token budget");
+        })
+        .build(&server)
+        .await?;
+
+    test.submit_turn("establish prefix").await?;
+    test.submit_turn("grow body").await?;
+    test.submit_turn("observe reminder").await?;
+
+    let requests = responses.requests();
+    assert_eq!(requests.len(), 3);
+    let reminder = "Your context window is nearly exhausted (only 400 tokens remaining) and will be automatically reset for you soon. Once reset, message items in current context window will be cleared in the new window, but notes and history items will be persistent across windows.";
+    assert!(
+        requests[1]
+            .message_input_texts("developer")
+            .into_iter()
+            .all(|text| text != reminder),
+        "first-window prefix should not count against the body-after-prefix reminder threshold"
+    );
+    assert_eq!(
+        requests[2]
+            .message_input_texts("developer")
+            .into_iter()
+            .filter(|text| text == reminder)
+            .count(),
+        1
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_context_remaining_returns_token_budget_remaining_fragment() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
@@ -319,6 +400,70 @@ async fn get_context_remaining_returns_token_budget_remaining_fragment() -> Resu
     let token_budgets = token_budget_contexts(&requests[1]);
     assert_eq!(token_budgets.len(), 1);
     token_budget_window_ids(&token_budgets[0], thread_id);
+    assert_eq!(
+        requests[2].function_call_output_content_and_success(call_id),
+        Some((Some(remaining_context), None))
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_context_remaining_uses_body_after_prefix_window() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let call_id = "remaining-call";
+    let responses = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                ev_assistant_message("msg-1", "noted"),
+                ev_completed_with_usage(
+                    "resp-1", /*input_tokens*/ 2_000, /*output_tokens*/ 500,
+                ),
+            ]),
+            sse(vec![
+                ev_response_created("resp-2"),
+                ev_function_call(call_id, "get_context_remaining", "{}"),
+                ev_completed_with_tokens("resp-2", /*total_tokens*/ 2_500),
+            ]),
+            sse(vec![
+                ev_response_created("resp-3"),
+                ev_assistant_message("msg-3", "done"),
+                ev_completed("resp-3"),
+            ]),
+        ],
+    )
+    .await;
+    let test = test_codex()
+        .with_config(|config| {
+            config.model_context_window = Some(10_000);
+            config.model_auto_compact_token_limit = Some(7_000);
+            config.model_auto_compact_token_limit_scope =
+                AutoCompactTokenLimitScope::BodyAfterPrefix;
+            config
+                .features
+                .enable(Feature::TokenBudget)
+                .expect("test config should allow token budget");
+        })
+        .build(&server)
+        .await?;
+
+    test.submit_turn("spend some tokens").await?;
+    test.submit_turn("check remaining context").await?;
+
+    let requests = responses.requests();
+    assert_eq!(requests.len(), 3);
+    assert!(
+        tool_names(&requests[1])
+            .iter()
+            .any(|name| name == "get_context_remaining"),
+        "get_context_remaining should be exposed when token budget is enabled"
+    );
+
+    let remaining_context = "You have 6500 tokens left in this context window.".to_string();
     assert_eq!(
         requests[2].function_call_output_content_and_success(call_id),
         Some((Some(remaining_context), None))


### PR DESCRIPTION
## Why

`BodyAfterPrefix` is meant to charge the configured body budget against growth after the carried harness prefix, while still respecting the full model context window as a safety cap. `get_context_remaining` and the token-budget reminder were still deriving remaining tokens from total active context, so large fixed prefixes could make the model see little or no remaining budget even when the body window was mostly unused.

## What Changed

- Added shared session context-window accounting that computes total active tokens, scoped body-after-prefix tokens, the configured scoped limit, and the full-context cap in one place.
- Reused that accounting for pre-turn and post-sampling auto-compaction checks.
- Updated `get_context_remaining` to report remaining tokens for the same scoped window used by auto-compaction and reminders.
- Added token-budget regression coverage for body-after-prefix reminder behavior and `get_context_remaining` output.

## Testing

- `just test -p codex-core body_after_prefix_window`
- `just test -p codex-core auto_compact_body_after_prefix`
- `just test -p codex-core token_budget` reports 13/14 passing; the remaining local failure is unrelated because this sandbox cannot locate `target/debug/test_stdio_server` for `token_budget_context_injects_plain_thread_hint_text`.
- `just fix -p codex-core`
