### PR TITLE
Prevent duplicate same-name plugin installations

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2780,6 +2780,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
@@ -2789,6 +2790,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-test",
  "url",
+ "walkdir",
  "wiremock",
  "zip 2.4.2",
 ]

--- a/codex-rs/app-server/src/request_processors/plugins.rs
+++ b/codex-rs/app-server/src/request_processors/plugins.rs
@@ -1632,6 +1632,7 @@ impl PluginRequestProcessor {
             .reconcile_remote_plugin_install(&config.plugins_config_input(), &result.plugin_id)
             .await
             .map_err(Self::plugin_install_error)?;
+        self.clear_plugin_related_caches();
         plugins_manager.maybe_start_remote_installed_plugins_cache_refresh_after_mutation(
             &config.plugins_config_input(),
             auth.clone(),

--- a/codex-rs/app-server/src/request_processors/plugins.rs
+++ b/codex-rs/app-server/src/request_processors/plugins.rs
@@ -1627,13 +1627,16 @@ impl PluginRequestProcessor {
             remote_plugin_catalog_error_to_jsonrpc(err, "install remote plugin")
         })?;
 
-        self.thread_manager
-            .plugins_manager()
-            .maybe_start_remote_installed_plugins_cache_refresh_after_mutation(
-                &config.plugins_config_input(),
-                auth.clone(),
-                Some(self.effective_plugins_changed_callback()),
-            );
+        let plugins_manager = self.thread_manager.plugins_manager();
+        plugins_manager
+            .reconcile_remote_plugin_install(&config.plugins_config_input(), &result.plugin_id)
+            .await
+            .map_err(Self::plugin_install_error)?;
+        plugins_manager.maybe_start_remote_installed_plugins_cache_refresh_after_mutation(
+            &config.plugins_config_input(),
+            auth.clone(),
+            Some(self.effective_plugins_changed_callback()),
+        );
 
         let plugin_metadata = self
             .thread_manager

--- a/codex-rs/app-server/tests/suite/v2/plugin_install.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_install.rs
@@ -30,6 +30,8 @@ use codex_app_server_protocol::PluginAuthPolicy;
 use codex_app_server_protocol::PluginAvailability;
 use codex_app_server_protocol::PluginInstallParams;
 use codex_app_server_protocol::PluginInstallResponse;
+use codex_app_server_protocol::PluginReadParams;
+use codex_app_server_protocol::PluginReadResponse;
 use codex_app_server_protocol::RequestId;
 use codex_config::types::AuthCredentialsStoreMode;
 use codex_utils_absolute_path::AbsolutePathBuf;
@@ -215,6 +217,16 @@ async fn plugin_install_writes_remote_plugin_to_cloud_and_cache() -> Result<()> 
     )
     .await;
     configure_remote_plugin_test(codex_home.path(), &server)?;
+    let config_path = codex_home.path().join("config.toml");
+    std::fs::write(
+        &config_path,
+        format!(
+            "{}\n[plugins.\"linear@debug\"]\nenabled = true\n",
+            std::fs::read_to_string(&config_path)?
+        ),
+    )?;
+    let stale_root = codex_home.path().join("plugins/cache/debug/linear");
+    std::fs::create_dir_all(stale_root.join("local"))?;
     mount_remote_plugin_detail_with_app_manifest(
         &server,
         REMOTE_PLUGIN_ID,
@@ -277,6 +289,8 @@ async fn plugin_install_writes_remote_plugin_to_cloud_and_cache() -> Result<()> 
         serde_json::from_str(&std::fs::read_to_string(installed_path.join(".app.json"))?)?;
     assert_eq!(installed_app_manifest, remote_app_manifest);
     assert!(installed_path.join("skills/plan-work/SKILL.md").is_file());
+    assert!(!stale_root.exists());
+    assert!(!std::fs::read_to_string(config_path)?.contains("linear@debug"));
     assert!(
         !codex_home
             .path()
@@ -1680,31 +1694,35 @@ async fn plugin_install_includes_formerly_disallowed_apps_needing_auth() -> Resu
 }
 
 #[tokio::test]
-async fn plugin_install_makes_bundled_mcp_servers_available_to_followup_requests() -> Result<()> {
+async fn plugin_install_reconciles_config_and_exposes_one_server_and_skill() -> Result<()> {
     let codex_home = TempDir::new()?;
     std::fs::write(
         codex_home.path().join("config.toml"),
-        "[features]\nplugins = true\n",
+        "[features]\nplugins = true\n[plugins.\"structure-viewer@openai-internal-testing\"]\nenabled = true\n",
     )?;
+    let stale_root = codex_home
+        .path()
+        .join("plugins/cache/openai-internal-testing/structure-viewer");
+    std::fs::create_dir_all(stale_root.join("local"))?;
     let repo_root = TempDir::new()?;
     write_plugin_marketplace(
         repo_root.path(),
-        "debug",
-        "sample-plugin",
-        "./sample-plugin",
+        "openai-monorepo",
+        "structure-viewer",
+        "./structure-viewer",
         /*install_policy*/ None,
         /*auth_policy*/ None,
     )?;
-    write_plugin_source(repo_root.path(), "sample-plugin", &[])?;
+    write_plugin_source(repo_root.path(), "structure-viewer", &[])?;
+    let plugin_root = repo_root.path().join("structure-viewer");
+    std::fs::create_dir_all(plugin_root.join("skills/structure-viewer"))?;
     std::fs::write(
-        repo_root.path().join("sample-plugin/.mcp.json"),
-        r#"{
-  "mcpServers": {
-    "sample-mcp": {
-      "command": "echo"
-    }
-  }
-}"#,
+        plugin_root.join("skills/structure-viewer/SKILL.md"),
+        "---\nname: structure-viewer\ndescription: View structures\n---\n",
+    )?;
+    std::fs::write(
+        plugin_root.join(".mcp.json"),
+        r#"{"mcpServers":{"structure":{"command":"echo"}}}"#,
     )?;
     let marketplace_path =
         AbsolutePathBuf::try_from(repo_root.path().join(".agents/plugins/marketplace.json"))?;
@@ -1714,9 +1732,9 @@ async fn plugin_install_makes_bundled_mcp_servers_available_to_followup_requests
 
     let request_id = mcp
         .send_plugin_install_request(PluginInstallParams {
-            marketplace_path: Some(marketplace_path),
+            marketplace_path: Some(marketplace_path.clone()),
             remote_marketplace_name: None,
-            plugin_name: "sample-plugin".to_string(),
+            plugin_name: "structure-viewer".to_string(),
         })
         .await?;
     let response: JSONRPCResponse = timeout(
@@ -1727,14 +1745,22 @@ async fn plugin_install_makes_bundled_mcp_servers_available_to_followup_requests
     let response: PluginInstallResponse = to_response(response)?;
     assert_eq!(response.apps_needing_auth, Vec::<AppSummary>::new());
     let config = std::fs::read_to_string(codex_home.path().join("config.toml"))?;
-    assert!(!config.contains("[mcp_servers.sample-mcp]"));
+    assert!(!config.contains("[mcp_servers.structure]"));
     assert!(!config.contains("command = \"echo\""));
+    let config: toml::Value = toml::from_str(&config)?;
+    let plugins = config["plugins"].as_table().expect("plugins table");
+    assert_eq!(plugins.len(), 1);
+    assert_eq!(
+        plugins.keys().next().map(String::as_str),
+        Some("structure-viewer@openai-monorepo")
+    );
+    assert!(!stale_root.exists());
 
     let request_id = mcp
         .send_raw_request(
             "mcpServer/oauth/login",
             Some(json!({
-                "name": "sample-mcp",
+                "name": "structure",
             })),
         )
         .await?;
@@ -1749,6 +1775,25 @@ async fn plugin_install_makes_bundled_mcp_servers_available_to_followup_requests
         err.error.message,
         "OAuth login is only supported for streamable HTTP servers."
     );
+    let request_id = mcp
+        .send_plugin_read_request(PluginReadParams {
+            marketplace_path: Some(marketplace_path),
+            remote_marketplace_name: None,
+            plugin_name: "structure-viewer".to_string(),
+        })
+        .await?;
+    let response: JSONRPCResponse = timeout(
+        DEFAULT_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    let response: PluginReadResponse = to_response(response)?;
+    assert_eq!(response.plugin.skills.len(), 1);
+    assert_eq!(
+        response.plugin.skills[0].name,
+        "structure-viewer:structure-viewer"
+    );
+    assert_eq!(response.plugin.mcp_servers, vec!["structure"]);
     Ok(())
 }
 

--- a/codex-rs/config/src/lib.rs
+++ b/codex-rs/config/src/lib.rs
@@ -127,6 +127,7 @@ pub use overrides::build_cli_overrides_layer;
 pub use plugin_edit::PluginConfigEdit;
 pub use plugin_edit::apply_user_plugin_config_edits;
 pub use plugin_edit::clear_user_plugin;
+pub use plugin_edit::reconcile_user_plugin_registrations;
 pub use plugin_edit::set_user_plugin_enabled;
 pub use project_root_markers::default_project_root_markers;
 pub use project_root_markers::project_root_markers_from_config;

--- a/codex-rs/config/src/plugin_edit.rs
+++ b/codex-rs/config/src/plugin_edit.rs
@@ -47,7 +47,7 @@ pub async fn reconcile_user_plugin_registrations(
     plugin_key: String,
     plugin_name: String,
     enable_canonical: bool,
-) -> std::io::Result<()> {
+) -> std::io::Result<Vec<String>> {
     let target_path = codex_home.join(CONFIG_TOML_FILE);
     let mut paths = BTreeSet::new();
     if let Some(config_layer_stack) = config_layer_stack {
@@ -62,10 +62,24 @@ pub async fn reconcile_user_plugin_registrations(
     }
     paths.remove(&target_path);
     task::spawn_blocking(move || {
+        let mut removed_plugin_keys = BTreeSet::new();
         for path in paths {
-            reconcile_plugin_config_path(&path, &plugin_key, &plugin_name, /*enable*/ false)?;
+            removed_plugin_keys.extend(reconcile_plugin_config_path(
+                &path,
+                &plugin_key,
+                &plugin_name,
+                enable_canonical,
+                /*is_target*/ false,
+            )?);
         }
-        reconcile_plugin_config_path(&target_path, &plugin_key, &plugin_name, enable_canonical)
+        removed_plugin_keys.extend(reconcile_plugin_config_path(
+            &target_path,
+            &plugin_key,
+            &plugin_name,
+            enable_canonical,
+            /*is_target*/ true,
+        )?);
+        Ok(removed_plugin_keys.into_iter().collect())
     })
     .await
     .map_err(|err| std::io::Error::other(format!("config persistence task panicked: {err}")))?
@@ -112,19 +126,24 @@ fn reconcile_plugin_config_path(
     config_path: &Path,
     plugin_key: &str,
     plugin_name: &str,
-    enable: bool,
-) -> std::io::Result<()> {
+    enable_canonical: bool,
+    is_target: bool,
+) -> std::io::Result<Vec<String>> {
     let write_paths = resolve_symlink_write_paths(config_path)?;
     let mut doc = read_or_create_document(write_paths.read_path.as_deref())?;
-    let mutated = if enable {
-        set_plugin_enabled_exclusively(&mut doc, plugin_key, plugin_name)
+    let removed_plugin_keys = remove_other_plugin_registrations(&mut doc, plugin_key, plugin_name);
+    let canonical_mutated = if enable_canonical && is_target {
+        set_plugin_enabled(&mut doc, plugin_key, /*enabled*/ true)
+    } else if enable_canonical {
+        clear_plugin_enabled(&mut doc, plugin_key)
     } else {
-        remove_other_plugin_registrations(&mut doc, plugin_key, plugin_name)
+        false
     };
+    let mutated = canonical_mutated || !removed_plugin_keys.is_empty();
     if mutated {
         write_atomically(&write_paths.write_path, &doc.to_string())?;
     }
-    Ok(())
+    Ok(removed_plugin_keys)
 }
 
 fn read_or_create_document(config_path: Option<&Path>) -> std::io::Result<DocumentMut> {
@@ -155,26 +174,17 @@ fn set_plugin_enabled(doc: &mut DocumentMut, plugin_key: &str, enabled: bool) ->
     true
 }
 
-fn set_plugin_enabled_exclusively(
-    doc: &mut DocumentMut,
-    plugin_key: &str,
-    plugin_name: &str,
-) -> bool {
-    let removed_duplicate = remove_other_plugin_registrations(doc, plugin_key, plugin_name);
-    set_plugin_enabled(doc, plugin_key, /*enabled*/ true) || removed_duplicate
-}
-
 fn remove_other_plugin_registrations(
     doc: &mut DocumentMut,
     plugin_key: &str,
     plugin_name: &str,
-) -> bool {
+) -> Vec<String> {
     let Some(plugins) = doc
         .as_table_mut()
         .get_mut("plugins")
         .and_then(ensure_table_for_read)
     else {
-        return false;
+        return Vec::new();
     };
     let duplicate_keys = plugins
         .iter()
@@ -187,9 +197,26 @@ fn remove_other_plugin_registrations(
         })
         .map(str::to_string)
         .collect::<Vec<_>>();
-    let mut removed = false;
-    for key in duplicate_keys {
-        removed |= plugins.remove(&key).is_some();
+    duplicate_keys
+        .into_iter()
+        .filter(|key| plugins.remove(key).is_some())
+        .collect()
+}
+
+fn clear_plugin_enabled(doc: &mut DocumentMut, plugin_key: &str) -> bool {
+    let Some(plugins) = doc
+        .as_table_mut()
+        .get_mut("plugins")
+        .and_then(ensure_table_for_read)
+    else {
+        return false;
+    };
+    let Some(plugin) = plugins.get_mut(plugin_key).and_then(ensure_table_for_read) else {
+        return false;
+    };
+    let removed = plugin.remove("enabled").is_some();
+    if removed && plugin.is_empty() {
+        plugins.remove(plugin_key);
     }
     removed
 }
@@ -341,7 +368,13 @@ source = "/tmp/plugin"
         let base_path = codex_home.path().join(CONFIG_TOML_FILE);
         let profile_path = codex_home.path().join("work.config.toml");
         let base_config = "[plugins.\"structure-viewer@openai-internal-testing\"]\nenabled = true\n[plugins.\"sequence-viewer@openai-internal-testing\"]\nenabled = true\n";
-        let profile_config = "[plugins.\"structure-viewer@debug\"]\nenabled = true\n";
+        let profile_config = r#"[plugins."structure-viewer@debug"]
+enabled = true
+[plugins."structure-viewer@openai-monorepo"]
+enabled = false
+[plugins."structure-viewer@openai-monorepo".mcp_servers.structure]
+enabled = false
+"#;
         fs::write(&base_path, base_config).unwrap();
         fs::write(&profile_path, profile_config).unwrap();
         let layer = |file: &Path, profile: Option<&str>, config: &str| {
@@ -362,7 +395,7 @@ source = "/tmp/plugin"
             ConfigRequirementsToml::default(),
         )
         .unwrap();
-        reconcile_user_plugin_registrations(
+        let removed_plugin_keys = reconcile_user_plugin_registrations(
             codex_home.path(),
             Some(&stack),
             "structure-viewer@openai-monorepo".to_string(),
@@ -371,6 +404,13 @@ source = "/tmp/plugin"
         )
         .await
         .unwrap();
+        assert_eq!(
+            removed_plugin_keys,
+            vec![
+                "structure-viewer@debug".to_string(),
+                "structure-viewer@openai-internal-testing".to_string(),
+            ]
+        );
         let parse = |path: &Path| {
             toml::from_str::<toml::Value>(&fs::read_to_string(path).unwrap()).unwrap()
         };
@@ -383,7 +423,10 @@ source = "/tmp/plugin"
         );
         assert_eq!(
             parse(&profile_path),
-            toml::from_str::<toml::Value>("").unwrap(),
+            toml::from_str::<toml::Value>(
+                "[plugins.\"structure-viewer@openai-monorepo\".mcp_servers.structure]\nenabled = false\n"
+            )
+            .unwrap(),
         );
     }
 

--- a/codex-rs/config/src/plugin_edit.rs
+++ b/codex-rs/config/src/plugin_edit.rs
@@ -1,7 +1,9 @@
+use std::collections::BTreeSet;
 use std::fs;
 use std::io::ErrorKind;
 use std::path::Path;
 
+use codex_app_server_protocol::ConfigLayerSource;
 use codex_utils_path::resolve_symlink_write_paths;
 use codex_utils_path::write_atomically;
 use tokio::task;
@@ -11,6 +13,8 @@ use toml_edit::Table as TomlTable;
 use toml_edit::value;
 
 use crate::CONFIG_TOML_FILE;
+use crate::ConfigLayerStack;
+use crate::ConfigLayerStackOrdering;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PluginConfigEdit {
@@ -35,6 +39,36 @@ pub async fn set_user_plugin_enabled(
 
 pub async fn clear_user_plugin(codex_home: &Path, plugin_key: String) -> std::io::Result<()> {
     apply_user_plugin_config_edits(codex_home, vec![PluginConfigEdit::Clear { plugin_key }]).await
+}
+
+pub async fn reconcile_user_plugin_registrations(
+    codex_home: &Path,
+    config_layer_stack: Option<&ConfigLayerStack>,
+    plugin_key: String,
+    plugin_name: String,
+    enable_canonical: bool,
+) -> std::io::Result<()> {
+    let target_path = codex_home.join(CONFIG_TOML_FILE);
+    let mut paths = BTreeSet::new();
+    if let Some(config_layer_stack) = config_layer_stack {
+        for layer in config_layer_stack.get_user_layers(
+            ConfigLayerStackOrdering::LowestPrecedenceFirst,
+            /*include_disabled*/ false,
+        ) {
+            if let ConfigLayerSource::User { file, .. } = &layer.name {
+                paths.insert(file.as_path().to_path_buf());
+            }
+        }
+    }
+    paths.remove(&target_path);
+    task::spawn_blocking(move || {
+        for path in paths {
+            reconcile_plugin_config_path(&path, &plugin_key, &plugin_name, /*enable*/ false)?;
+        }
+        reconcile_plugin_config_path(&target_path, &plugin_key, &plugin_name, enable_canonical)
+    })
+    .await
+    .map_err(|err| std::io::Error::other(format!("config persistence task panicked: {err}")))?
 }
 
 pub async fn apply_user_plugin_config_edits(
@@ -74,6 +108,25 @@ fn apply_user_plugin_config_edits_blocking(
     write_atomically(&write_paths.write_path, &doc.to_string())
 }
 
+fn reconcile_plugin_config_path(
+    config_path: &Path,
+    plugin_key: &str,
+    plugin_name: &str,
+    enable: bool,
+) -> std::io::Result<()> {
+    let write_paths = resolve_symlink_write_paths(config_path)?;
+    let mut doc = read_or_create_document(write_paths.read_path.as_deref())?;
+    let mutated = if enable {
+        set_plugin_enabled_exclusively(&mut doc, plugin_key, plugin_name)
+    } else {
+        remove_other_plugin_registrations(&mut doc, plugin_key, plugin_name)
+    };
+    if mutated {
+        write_atomically(&write_paths.write_path, &doc.to_string())?;
+    }
+    Ok(())
+}
+
 fn read_or_create_document(config_path: Option<&Path>) -> std::io::Result<DocumentMut> {
     let Some(config_path) = config_path else {
         return Ok(DocumentMut::new());
@@ -100,6 +153,45 @@ fn set_plugin_enabled(doc: &mut DocumentMut, plugin_key: &str, enabled: bool) ->
     }
     plugin["enabled"] = replacement;
     true
+}
+
+fn set_plugin_enabled_exclusively(
+    doc: &mut DocumentMut,
+    plugin_key: &str,
+    plugin_name: &str,
+) -> bool {
+    let removed_duplicate = remove_other_plugin_registrations(doc, plugin_key, plugin_name);
+    set_plugin_enabled(doc, plugin_key, /*enabled*/ true) || removed_duplicate
+}
+
+fn remove_other_plugin_registrations(
+    doc: &mut DocumentMut,
+    plugin_key: &str,
+    plugin_name: &str,
+) -> bool {
+    let Some(plugins) = doc
+        .as_table_mut()
+        .get_mut("plugins")
+        .and_then(ensure_table_for_read)
+    else {
+        return false;
+    };
+    let duplicate_keys = plugins
+        .iter()
+        .map(|(key, _)| key)
+        .filter(|key| {
+            *key != plugin_key
+                && key.rsplit_once('@').is_some_and(|(name, marketplace)| {
+                    name == plugin_name && !marketplace.is_empty()
+                })
+        })
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let mut removed = false;
+    for key in duplicate_keys {
+        removed |= plugins.remove(&key).is_some();
+    }
+    removed
 }
 
 fn clear_plugin(doc: &mut DocumentMut, plugin_key: &str) -> bool {
@@ -180,6 +272,10 @@ fn preserve_decor(existing: &TomlItem, replacement: &mut TomlItem) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ConfigLayerEntry;
+    use crate::config_requirements::ConfigRequirements;
+    use crate::config_requirements::ConfigRequirementsToml;
+    use codex_utils_absolute_path::AbsolutePathBuf;
     use pretty_assertions::assert_eq;
     use tempfile::TempDir;
 
@@ -237,6 +333,58 @@ source = "/tmp/plugin"
         )
         .unwrap();
         assert_eq!(config, expected);
+    }
+
+    #[tokio::test]
+    async fn exclusive_registration_reconciles_active_profile_layers() {
+        let codex_home = TempDir::new().unwrap();
+        let base_path = codex_home.path().join(CONFIG_TOML_FILE);
+        let profile_path = codex_home.path().join("work.config.toml");
+        let base_config = "[plugins.\"structure-viewer@openai-internal-testing\"]\nenabled = true\n[plugins.\"sequence-viewer@openai-internal-testing\"]\nenabled = true\n";
+        let profile_config = "[plugins.\"structure-viewer@debug\"]\nenabled = true\n";
+        fs::write(&base_path, base_config).unwrap();
+        fs::write(&profile_path, profile_config).unwrap();
+        let layer = |file: &Path, profile: Option<&str>, config: &str| {
+            ConfigLayerEntry::new(
+                ConfigLayerSource::User {
+                    file: AbsolutePathBuf::try_from(file.to_path_buf()).unwrap(),
+                    profile: profile.map(str::to_string),
+                },
+                toml::from_str(config).unwrap(),
+            )
+        };
+        let stack = ConfigLayerStack::new(
+            vec![
+                layer(&base_path, None, base_config),
+                layer(&profile_path, Some("work"), profile_config),
+            ],
+            ConfigRequirements::default(),
+            ConfigRequirementsToml::default(),
+        )
+        .unwrap();
+        reconcile_user_plugin_registrations(
+            codex_home.path(),
+            Some(&stack),
+            "structure-viewer@openai-monorepo".to_string(),
+            "structure-viewer".to_string(),
+            /*enable_canonical*/ true,
+        )
+        .await
+        .unwrap();
+        let parse = |path: &Path| {
+            toml::from_str::<toml::Value>(&fs::read_to_string(path).unwrap()).unwrap()
+        };
+        assert_eq!(
+            parse(&base_path),
+            toml::from_str::<toml::Value>(
+                "[plugins.\"sequence-viewer@openai-internal-testing\"]\nenabled = true\n[plugins.\"structure-viewer@openai-monorepo\"]\nenabled = true\n"
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            parse(&profile_path),
+            toml::from_str::<toml::Value>("").unwrap(),
+        );
     }
 
     #[tokio::test]

--- a/codex-rs/config/src/plugin_edit.rs
+++ b/codex-rs/config/src/plugin_edit.rs
@@ -3,7 +3,6 @@ use std::fs;
 use std::io::ErrorKind;
 use std::path::Path;
 
-use codex_app_server_protocol::ConfigLayerSource;
 use codex_utils_path::resolve_symlink_write_paths;
 use codex_utils_path::write_atomically;
 use tokio::task;
@@ -13,6 +12,7 @@ use toml_edit::Table as TomlTable;
 use toml_edit::value;
 
 use crate::CONFIG_TOML_FILE;
+use crate::ConfigLayerSource;
 use crate::ConfigLayerStack;
 use crate::ConfigLayerStackOrdering;
 

--- a/codex-rs/core-plugins/Cargo.toml
+++ b/codex-rs/core-plugins/Cargo.toml
@@ -41,6 +41,7 @@ regex = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 tar = { workspace = true }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
@@ -48,6 +49,7 @@ tokio = { workspace = true, features = ["fs", "macros", "rt", "time"] }
 toml = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
+walkdir = { workspace = true }
 zip = { workspace = true }
 
 [dev-dependencies]

--- a/codex-rs/core-plugins/src/install_provenance.rs
+++ b/codex-rs/core-plugins/src/install_provenance.rs
@@ -25,8 +25,10 @@ pub(crate) fn fingerprint_plugin_tree(
     root: &Path,
     manifest_override: Option<&str>,
 ) -> Result<String, PluginStoreError> {
+    let traversal_root = fs::canonicalize(root)
+        .map_err(|error| PluginStoreError::io("failed to resolve plugin source", error))?;
     let mut entries = BTreeMap::new();
-    for entry in WalkDir::new(root)
+    for entry in WalkDir::new(&traversal_root)
         .sort_by_file_name()
         .into_iter()
         .filter_entry(|entry| entry.depth() != 1 || entry.file_name() != ".git")
@@ -38,9 +40,12 @@ pub(crate) fn fingerprint_plugin_tree(
                 std::io::Error::other(error),
             )
         })?;
-        let relative = entry.path().strip_prefix(root).map_err(|error| {
-            PluginStoreError::Invalid(format!("failed to fingerprint plugin path: {error}"))
-        })?;
+        let relative = entry
+            .path()
+            .strip_prefix(&traversal_root)
+            .map_err(|error| {
+                PluginStoreError::Invalid(format!("failed to fingerprint plugin path: {error}"))
+            })?;
         let tree_entry = if entry.file_type().is_dir() {
             TreeEntry::Directory
         } else if entry.file_type().is_file() {
@@ -69,7 +74,7 @@ pub(crate) fn fingerprint_plugin_tree(
         hash_contents(&mut hasher, path.as_os_str().as_encoded_bytes());
         match entry {
             TreeEntry::Directory => {}
-            TreeEntry::File => hash_file(&mut hasher, &root.join(path))?,
+            TreeEntry::File => hash_file(&mut hasher, &traversal_root.join(path))?,
             TreeEntry::VirtualFile(contents) => hash_contents(&mut hasher, &contents),
         }
     }

--- a/codex-rs/core-plugins/src/install_provenance.rs
+++ b/codex-rs/core-plugins/src/install_provenance.rs
@@ -1,0 +1,148 @@
+use crate::store::PluginStoreError;
+use serde::Deserialize;
+use serde::Serialize;
+use sha2::Digest;
+use sha2::Sha256;
+use std::collections::BTreeMap;
+use std::fs;
+use std::io;
+use std::path::Path;
+use std::path::PathBuf;
+use walkdir::WalkDir;
+pub(crate) const INSTALL_PROVENANCE_FILE: &str = ".codex-plugin-install.json";
+const INSTALL_PROVENANCE_SCHEMA_VERSION: u8 = 1;
+#[derive(Debug, Deserialize, Serialize)]
+struct PluginInstallProvenance {
+    schema_version: u8,
+    content_sha256: String,
+}
+enum TreeEntry {
+    Directory,
+    File,
+    VirtualFile(Vec<u8>),
+}
+pub(crate) fn fingerprint_plugin_tree(
+    root: &Path,
+    manifest_override: Option<&str>,
+) -> Result<String, PluginStoreError> {
+    let mut entries = BTreeMap::new();
+    for entry in WalkDir::new(root)
+        .sort_by_file_name()
+        .into_iter()
+        .filter_entry(|entry| entry.depth() != 1 || entry.file_name() != ".git")
+        .skip(1)
+    {
+        let entry = entry.map_err(|error| {
+            PluginStoreError::io(
+                "failed to enumerate plugin source",
+                std::io::Error::other(error),
+            )
+        })?;
+        let relative = entry.path().strip_prefix(root).map_err(|error| {
+            PluginStoreError::Invalid(format!("failed to fingerprint plugin path: {error}"))
+        })?;
+        let tree_entry = if entry.file_type().is_dir() {
+            TreeEntry::Directory
+        } else if entry.file_type().is_file() {
+            TreeEntry::File
+        } else {
+            continue;
+        };
+        entries.insert(relative.to_path_buf(), tree_entry);
+    }
+    if let Some(manifest) = manifest_override {
+        entries
+            .entry(PathBuf::from(".codex-plugin"))
+            .or_insert(TreeEntry::Directory);
+        entries.insert(
+            PathBuf::from(".codex-plugin").join("plugin.json"),
+            TreeEntry::VirtualFile(manifest.as_bytes().to_vec()),
+        );
+    }
+    let mut hasher = Sha256::new();
+    for (path, entry) in entries {
+        hasher.update([if matches!(entry, TreeEntry::Directory) {
+            b'd'
+        } else {
+            b'f'
+        }]);
+        hash_contents(&mut hasher, path.as_os_str().as_encoded_bytes());
+        match entry {
+            TreeEntry::Directory => {}
+            TreeEntry::File => hash_file(&mut hasher, &root.join(path))?,
+            TreeEntry::VirtualFile(contents) => hash_contents(&mut hasher, &contents),
+        }
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+pub(crate) fn read_install_fingerprint(
+    plugin_base_root: &Path,
+) -> Result<Option<String>, PluginStoreError> {
+    let path = plugin_base_root.join(INSTALL_PROVENANCE_FILE);
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(PluginStoreError::io(
+                "failed to read plugin install provenance",
+                error,
+            ));
+        }
+    };
+    let Ok(provenance) = serde_json::from_str::<PluginInstallProvenance>(&contents) else {
+        return Ok(None);
+    };
+    let fingerprint = provenance.content_sha256;
+    Ok(
+        (provenance.schema_version == INSTALL_PROVENANCE_SCHEMA_VERSION
+            && fingerprint.len() == 64
+            && fingerprint
+                .chars()
+                .all(|character| character.is_ascii_hexdigit()))
+        .then(|| fingerprint.to_ascii_lowercase()),
+    )
+}
+pub(crate) fn write_install_fingerprint(
+    plugin_base_root: &Path,
+    content_sha256: &str,
+) -> Result<(), PluginStoreError> {
+    let provenance = PluginInstallProvenance {
+        schema_version: INSTALL_PROVENANCE_SCHEMA_VERSION,
+        content_sha256: content_sha256.to_string(),
+    };
+    let mut temporary = tempfile::NamedTempFile::new_in(plugin_base_root).map_err(|error| {
+        PluginStoreError::io(
+            "failed to create temporary plugin install provenance",
+            error,
+        )
+    })?;
+    serde_json::to_writer_pretty(&mut temporary, &provenance).map_err(|error| {
+        PluginStoreError::Invalid(format!("failed to serialize plugin provenance: {error}"))
+    })?;
+    io::Write::write_all(&mut temporary, b"\n")
+        .map_err(|error| PluginStoreError::io("failed to write plugin provenance", error))?;
+    io::Write::flush(temporary.as_file_mut())
+        .map_err(|error| PluginStoreError::io("failed to flush plugin provenance", error))?;
+    temporary
+        .persist(plugin_base_root.join(INSTALL_PROVENANCE_FILE))
+        .map_err(|error| {
+            PluginStoreError::io("failed to persist plugin install provenance", error.error)
+        })?;
+    Ok(())
+}
+fn hash_file(hasher: &mut Sha256, path: &Path) -> Result<(), PluginStoreError> {
+    let mut file = fs::File::open(path)
+        .map_err(|error| PluginStoreError::io("failed to open plugin file", error))?;
+    let length = file
+        .metadata()
+        .map_err(|error| PluginStoreError::io("failed to inspect plugin file", error))?
+        .len();
+    hasher.update(length.to_le_bytes());
+    io::copy(&mut file, hasher)
+        .map_err(|error| PluginStoreError::io("failed to read plugin file", error))?;
+    Ok(())
+}
+fn hash_contents(hasher: &mut Sha256, contents: &[u8]) {
+    hasher.update((contents.len() as u64).to_le_bytes());
+    hasher.update(contents);
+}

--- a/codex-rs/core-plugins/src/lib.rs
+++ b/codex-rs/core-plugins/src/lib.rs
@@ -1,5 +1,6 @@
 mod app_mcp_routing;
 mod discoverable;
+mod install_provenance;
 pub mod installed_marketplaces;
 pub mod loader;
 mod manager;

--- a/codex-rs/core-plugins/src/loader.rs
+++ b/codex-rs/core-plugins/src/loader.rs
@@ -151,18 +151,27 @@ async fn load_plugins_from_layer_stack_with_scope(
     configured_plugins.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
 
     let mut plugins = Vec::with_capacity(configured_plugins.len());
-    let mut seen_mcp_server_names = HashMap::<String, String>::new();
+    let mut seen_mcp_server_names = HashMap::<String, (String, AbsolutePathBuf)>::new();
     for (configured_name, plugin) in configured_plugins {
         let loaded_plugin = load_plugin(configured_name.clone(), &plugin, store, &scope).await;
         for name in loaded_plugin.mcp_servers.keys() {
-            if let Some(previous_plugin) =
-                seen_mcp_server_names.insert(name.clone(), configured_name.clone())
-            {
+            if let Some((winner_plugin, winner_path)) = seen_mcp_server_names.get(name) {
+                let remediation = format!(
+                    "remove `{configured_name}` or set [plugins.\"{configured_name}\"].enabled = false"
+                );
                 warn!(
-                    plugin = configured_name,
-                    previous_plugin,
                     server = name,
-                    "skipping duplicate plugin MCP server name"
+                    winner_plugin = %winner_plugin,
+                    winner_path = %winner_path.display(),
+                    duplicate_plugin = %configured_name,
+                    duplicate_path = %loaded_plugin.root.display(),
+                    remediation = %remediation,
+                    "duplicate plugin MCP server ownership for `{name}`: `{winner_plugin}` wins over `{configured_name}`; {remediation}"
+                );
+            } else {
+                seen_mcp_server_names.insert(
+                    name.clone(),
+                    (configured_name.clone(), loaded_plugin.root.clone()),
                 );
             }
         }
@@ -374,7 +383,21 @@ pub fn refresh_curated_plugin_cache(
 
         if store.active_plugin_version(plugin_id).as_deref() == Some(cache_plugin_version.as_str())
         {
-            continue;
+            let source_matches = store
+                .active_plugin_matches_source(plugin_id, source_path.as_path())
+                .map_err(|err| {
+                    format!(
+                        "failed to verify curated plugin cache for {}: {err}",
+                        plugin_id.as_key()
+                    )
+                })?;
+            if source_matches {
+                continue;
+            }
+            warn!(
+                plugin = %plugin_id.as_key(),
+                "curated plugin cache bytes differ from the intended source; reinstalling"
+            );
         }
 
         store
@@ -545,7 +568,28 @@ fn refresh_non_curated_plugin_cache_with_mode(
         if mode == NonCuratedCacheRefreshMode::IfVersionChanged
             && store.active_plugin_version(&plugin_id).as_deref() == Some(plugin_version.as_str())
         {
-            continue;
+            let source_matches = match manifest_fallback_contents.as_deref() {
+                Some(manifest_contents) => store
+                    .active_plugin_matches_source_with_fallback_manifest(
+                        &plugin_id,
+                        source_path.as_path(),
+                        manifest_contents,
+                    ),
+                None => store.active_plugin_matches_source(&plugin_id, source_path.as_path()),
+            }
+            .map_err(|err| {
+                format!(
+                    "failed to verify plugin cache for {}: {err}",
+                    plugin_id.as_key()
+                )
+            })?;
+            if source_matches {
+                continue;
+            }
+            warn!(
+                plugin = %plugin_id.as_key(),
+                "plugin cache bytes differ from the intended source; reinstalling"
+            );
         }
 
         match manifest_fallback_contents.as_deref() {

--- a/codex-rs/core-plugins/src/loader_tests.rs
+++ b/codex-rs/core-plugins/src/loader_tests.rs
@@ -227,6 +227,52 @@ fn curated_plugin_cache_version_preserves_non_git_sha_versions() {
     assert_eq!(curated_plugin_cache_version("0123456"), "0123456");
 }
 
+#[tokio::test]
+#[tracing_test::traced_test]
+async fn duplicate_mcp_diagnostic_names_the_stable_winner_and_remediation() {
+    let codex_home = tempfile::tempdir().expect("codex home");
+    for marketplace in ["a", "b", "c"] {
+        let plugin_root = codex_home.path().join(format!(
+            "plugins/cache/{marketplace}/structure-viewer/local"
+        ));
+        write_file(
+            &plugin_root.join(".codex-plugin/plugin.json"),
+            r#"{"name":"structure-viewer"}"#,
+        );
+        write_file(
+            &plugin_root.join(".mcp.json"),
+            r#"{"mcpServers":{"structure":{"command":"echo"}}}"#,
+        );
+    }
+    let stack = ConfigLayerStack::new(
+        vec![user_layer(
+            user_config_path(&codex_home, "config.toml"),
+            "[plugins.\"structure-viewer@c\"]\nenabled = true\n[plugins.\"structure-viewer@a\"]\nenabled = true\n[plugins.\"structure-viewer@b\"]\nenabled = true\n",
+        )],
+        ConfigRequirements::default(),
+        ConfigRequirementsToml::default(),
+    )
+    .expect("valid config stack");
+    let store = PluginStore::new(codex_home.path().to_path_buf());
+    let plugins = load_plugins_from_layer_stack(
+        &stack,
+        HashMap::new(),
+        &store,
+        /*plugin_skill_snapshots*/ None,
+        Some(Product::Codex),
+        /*prefer_remote_curated_conflicts*/ false,
+    )
+    .await;
+    assert_eq!(plugins.len(), 3);
+    for expected in [
+        "`structure-viewer@a` wins over `structure-viewer@b`",
+        "`structure-viewer@a` wins over `structure-viewer@c`",
+        "[plugins.\"structure-viewer@b\"].enabled = false",
+    ] {
+        assert!(logs_contain(expected));
+    }
+}
+
 fn plugin_id() -> PluginId {
     PluginId::parse("demo-plugin@test-marketplace").expect("plugin id")
 }

--- a/codex-rs/core-plugins/src/loader_tests.rs
+++ b/codex-rs/core-plugins/src/loader_tests.rs
@@ -260,7 +260,7 @@ async fn duplicate_mcp_diagnostic_names_the_stable_winner_and_remediation() {
         &store,
         /*plugin_skill_snapshots*/ None,
         Some(Product::Codex),
-        /*prefer_remote_curated_conflicts*/ false,
+        /*remote_global_catalog_active*/ false,
     )
     .await;
     assert_eq!(plugins.len(), 3);

--- a/codex-rs/core-plugins/src/manager.rs
+++ b/codex-rs/core-plugins/src/manager.rs
@@ -56,7 +56,7 @@ use crate::tool_suggest_metadata::ToolSuggestMetadataCache;
 use codex_analytics::AnalyticsEventsClient;
 use codex_config::ConfigLayerStack;
 use codex_config::clear_user_plugin;
-use codex_config::set_user_plugin_enabled;
+use codex_config::reconcile_user_plugin_registrations;
 use codex_config::types::PluginConfig;
 use codex_config::types::ToolSuggestDisabledTool;
 use codex_config::types::ToolSuggestDiscoverableType;
@@ -365,6 +365,7 @@ pub struct PluginsManager {
     restriction_product: Option<Product>,
     auth_mode: RwLock<Option<AuthMode>>,
     analytics_events_client: RwLock<Option<AnalyticsEventsClient>>,
+    plugin_mutation_lock: Semaphore,
 }
 
 #[derive(Clone)]
@@ -437,6 +438,7 @@ impl PluginsManager {
             restriction_product,
             auth_mode: RwLock::new(auth_mode),
             analytics_events_client: RwLock::new(None),
+            plugin_mutation_lock: Semaphore::new(/*permits*/ 1),
         }
     }
 
@@ -1258,7 +1260,10 @@ impl PluginsManager {
     ) -> Result<PluginInstallOutcome, PluginInstallError> {
         let resolved = self.resolve_installable_plugin(config_layer_stack, &request)?;
         let plugin_id = resolved.plugin_id.clone();
-        match self.install_resolved_plugin(resolved).await {
+        match self
+            .install_resolved_plugin(resolved, Some(config_layer_stack))
+            .await
+        {
             Ok(outcome) => Ok(outcome),
             Err(err) => {
                 self.track_plugin_install_failed(
@@ -1331,7 +1336,10 @@ impl PluginsManager {
             return Err(err);
         }
         let plugin_id = resolved.plugin_id.clone();
-        match self.install_resolved_plugin(resolved).await {
+        match self
+            .install_resolved_plugin(resolved, Some(&config.config_layer_stack))
+            .await
+        {
             Ok(outcome) => Ok(outcome),
             Err(err) => {
                 self.track_plugin_install_failed(
@@ -1402,7 +1410,13 @@ impl PluginsManager {
     async fn install_resolved_plugin(
         &self,
         resolved: ResolvedMarketplacePlugin,
+        config_layer_stack: Option<&ConfigLayerStack>,
     ) -> Result<PluginInstallOutcome, PluginInstallError> {
+        let _mutation_guard = self
+            .plugin_mutation_lock
+            .acquire()
+            .await
+            .unwrap_or_else(|_| unreachable!("plugin mutation lock should stay open"));
         let auth_policy = resolved.policy.authentication;
         let plugin_version =
             if is_openai_curated_marketplace_name(&resolved.plugin_id.marketplace_name) {
@@ -1449,13 +1463,12 @@ impl PluginsManager {
         .await
         .map_err(PluginInstallError::join)??;
 
-        set_user_plugin_enabled(
-            &self.codex_home,
-            result.plugin_id.as_key(),
-            /*enabled*/ true,
+        self.reconcile_plugin_install_locked(
+            &result.plugin_id,
+            config_layer_stack,
+            /*enable_canonical*/ true,
         )
-        .await
-        .map_err(anyhow::Error::from)?;
+        .await?;
 
         let analytics_events_client = match self.analytics_events_client.read() {
             Ok(client) => client.clone(),
@@ -1474,6 +1487,60 @@ impl PluginsManager {
             installed_path: result.installed_path,
             auth_policy,
         })
+    }
+
+    pub async fn reconcile_remote_plugin_install(
+        &self,
+        config: &PluginsConfigInput,
+        plugin_id: &PluginId,
+    ) -> Result<(), PluginInstallError> {
+        let _mutation_guard = self
+            .plugin_mutation_lock
+            .acquire()
+            .await
+            .unwrap_or_else(|_| unreachable!("plugin mutation lock should stay open"));
+        self.reconcile_plugin_install_locked(
+            plugin_id,
+            Some(&config.config_layer_stack),
+            /*enable_canonical*/ false,
+        )
+        .await
+    }
+
+    async fn reconcile_plugin_install_locked(
+        &self,
+        plugin_id: &PluginId,
+        config_layer_stack: Option<&ConfigLayerStack>,
+        enable_canonical: bool,
+    ) -> Result<(), PluginInstallError> {
+        reconcile_user_plugin_registrations(
+            &self.codex_home,
+            config_layer_stack,
+            plugin_id.as_key(),
+            plugin_id.plugin_name.clone(),
+            enable_canonical,
+        )
+        .await
+        .map_err(anyhow::Error::from)?;
+        let store = self.store.clone();
+        let canonical_plugin_id = plugin_id.clone();
+        let removed_plugin_ids = tokio::task::spawn_blocking(move || {
+            let removed = store.other_sources(&canonical_plugin_id, /*active_only*/ false)?;
+            removed
+                .iter()
+                .try_for_each(|plugin_id| store.uninstall(plugin_id))?;
+            Ok::<_, PluginStoreError>(removed)
+        })
+        .await
+        .map_err(PluginInstallError::join)??;
+        for removed_plugin_id in removed_plugin_ids {
+            tracing::info!(
+                canonical_plugin = %plugin_id.as_key(),
+                removed_plugin = %removed_plugin_id.as_key(),
+                "removed stale duplicate plugin installation"
+            );
+        }
+        Ok(())
     }
 
     pub async fn uninstall_plugin(&self, plugin_id: String) -> Result<(), PluginUninstallError> {
@@ -1503,6 +1570,11 @@ impl PluginsManager {
     }
 
     async fn uninstall_plugin_id(&self, plugin_id: PluginId) -> Result<(), PluginUninstallError> {
+        let _mutation_guard = self
+            .plugin_mutation_lock
+            .acquire()
+            .await
+            .unwrap_or_else(|_| unreachable!("plugin mutation lock should stay open"));
         let plugin_telemetry = if self.store.active_plugin_root(&plugin_id).is_some() {
             Some(
                 self.telemetry_metadata_for_installed_plugin(&plugin_id)

--- a/codex-rs/core-plugins/src/manager.rs
+++ b/codex-rs/core-plugins/src/manager.rs
@@ -42,6 +42,7 @@ use crate::remote::REMOTE_GLOBAL_MARKETPLACE_NAME;
 use crate::remote::RecommendedPluginsMode;
 use crate::remote::RemoteInstalledPlugin;
 use crate::remote::RemotePluginCatalogError;
+use crate::remote::RemotePluginScope;
 use crate::remote::RemotePluginServiceConfig;
 use crate::remote_legacy::RemotePluginFetchError;
 use crate::remote_legacy::RemotePluginMutationError;
@@ -982,6 +983,7 @@ impl PluginsManager {
             self.codex_home.clone(),
             remote_plugin_service_config(config),
             auth,
+            enabled_local_plugin_names(&config.config_layer_stack),
             Some(on_local_cache_changed),
         );
     }
@@ -1515,7 +1517,7 @@ impl PluginsManager {
         config_layer_stack: Option<&ConfigLayerStack>,
         enable_canonical: bool,
     ) -> Result<(), PluginInstallError> {
-        reconcile_user_plugin_registrations(
+        let removed_plugin_keys = reconcile_user_plugin_registrations(
             &self.codex_home,
             config_layer_stack,
             plugin_id.as_key(),
@@ -1527,10 +1529,26 @@ impl PluginsManager {
         let store = self.store.clone();
         let canonical_plugin_id = plugin_id.clone();
         let removed_plugin_ids = tokio::task::spawn_blocking(move || {
-            let removed = store.other_sources(&canonical_plugin_id, /*active_only*/ false)?;
-            removed
-                .iter()
-                .try_for_each(|plugin_id| store.uninstall(plugin_id))?;
+            let mut removed = Vec::new();
+            for plugin_key in removed_plugin_keys {
+                let Ok(removed_plugin_id) = PluginId::parse(&plugin_key) else {
+                    tracing::warn!(
+                        plugin = %plugin_key,
+                        "skipping cache cleanup for invalid reconciled plugin key"
+                    );
+                    continue;
+                };
+                if removed_plugin_id == canonical_plugin_id
+                    || !store
+                        .plugin_base_root(&removed_plugin_id)
+                        .as_path()
+                        .is_dir()
+                {
+                    continue;
+                }
+                store.uninstall(&removed_plugin_id)?;
+                removed.push(removed_plugin_id);
+            }
             Ok::<_, PluginStoreError>(removed)
         })
         .await
@@ -2676,6 +2694,18 @@ pub(crate) fn configured_plugins_from_stack(
         return HashMap::new();
     };
     configured_plugins_from_user_config_value(&user_config)
+}
+
+fn enabled_local_plugin_names(config_layer_stack: &ConfigLayerStack) -> HashSet<String> {
+    configured_plugins_from_stack(config_layer_stack)
+        .into_iter()
+        .filter_map(|(plugin_key, config)| config.enabled.then_some(plugin_key))
+        .filter_map(|plugin_key| PluginId::parse(&plugin_key).ok())
+        .filter(|plugin_id| {
+            RemotePluginScope::from_marketplace_name(&plugin_id.marketplace_name).is_none()
+        })
+        .map(|plugin_id| plugin_id.plugin_name)
+        .collect()
 }
 
 fn configured_plugins_from_user_config_value(

--- a/codex-rs/core-plugins/src/manager.rs
+++ b/codex-rs/core-plugins/src/manager.rs
@@ -1504,7 +1504,9 @@ impl PluginsManager {
             Some(&config.config_layer_stack),
             /*enable_canonical*/ false,
         )
-        .await
+        .await?;
+        self.clear_cache();
+        Ok(())
     }
 
     async fn reconcile_plugin_install_locked(

--- a/codex-rs/core-plugins/src/manager_tests.rs
+++ b/codex-rs/core-plugins/src/manager_tests.rs
@@ -2413,6 +2413,65 @@ enabled = true
 }
 
 #[tokio::test]
+async fn reconcile_plugin_install_preserves_inactive_profile_cache() {
+    let codex_home = TempDir::new().unwrap();
+    let base_path = codex_home.path().join(CONFIG_TOML_FILE);
+    let inactive_profile_path = codex_home.path().join("inactive.config.toml");
+    let base_config = "[plugins.\"linear@active\"]\nenabled = true\n";
+    let inactive_profile_config = "[plugins.\"linear@inactive\"]\nenabled = true\n";
+    write_file(&base_path, base_config);
+    write_file(&inactive_profile_path, inactive_profile_config);
+    write_cached_plugin(codex_home.path(), "active", "linear");
+    write_cached_plugin(codex_home.path(), "inactive", "linear");
+    let stack = ConfigLayerStack::new(
+        vec![ConfigLayerEntry::new(
+            ConfigLayerSource::User {
+                file: AbsolutePathBuf::try_from(base_path.clone()).unwrap(),
+                profile: None,
+            },
+            toml::from_str(base_config).unwrap(),
+        )],
+        ConfigRequirements::default(),
+        ConfigRequirementsToml::default(),
+    )
+    .unwrap();
+    let manager = PluginsManager::new(codex_home.path().to_path_buf());
+    let canonical = PluginId::new("linear".to_string(), "canonical".to_string()).unwrap();
+
+    manager
+        .reconcile_plugin_install_locked(&canonical, Some(&stack), /*enable_canonical*/ true)
+        .await
+        .unwrap();
+
+    assert!(
+        !codex_home
+            .path()
+            .join("plugins/cache/active/linear")
+            .exists()
+    );
+    assert!(
+        codex_home
+            .path()
+            .join("plugins/cache/inactive/linear/local")
+            .is_dir()
+    );
+    assert_eq!(
+        fs::read_to_string(&inactive_profile_path).unwrap(),
+        inactive_profile_config
+    );
+    let base: toml::Value = toml::from_str(&fs::read_to_string(base_path).unwrap()).unwrap();
+    assert_eq!(
+        base["plugins"]
+            .as_table()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+        vec!["linear@canonical"]
+    );
+}
+
+#[tokio::test]
 async fn load_plugins_rejects_invalid_plugin_keys() {
     let codex_home = TempDir::new().unwrap();
     let plugin_root = codex_home
@@ -5214,6 +5273,15 @@ fn refresh_curated_plugin_cache_reinstalls_unverified_current_version() {
     assert!(
         refresh_curated_plugin_cache(tmp.path(), TEST_CURATED_PLUGIN_SHA, &[plugin_id])
             .expect("cache refresh should reinstall current but unverified plugin bytes")
+    );
+    let plugin_id = PluginId::new(
+        "slack".to_string(),
+        OPENAI_CURATED_MARKETPLACE_NAME.to_string(),
+    )
+    .unwrap();
+    assert!(
+        !refresh_curated_plugin_cache(tmp.path(), TEST_CURATED_PLUGIN_SHA, &[plugin_id])
+            .expect("verified current plugin bytes should be a no-op")
     );
 }
 

--- a/codex-rs/core-plugins/src/manager_tests.rs
+++ b/codex-rs/core-plugins/src/manager_tests.rs
@@ -5153,7 +5153,7 @@ plugins = true
 }
 
 #[test]
-fn refresh_curated_plugin_cache_returns_false_when_configured_plugins_are_current() {
+fn refresh_curated_plugin_cache_reinstalls_unverified_current_version() {
     let tmp = tempfile::tempdir().unwrap();
     let curated_root = curated_plugins_repo_path(tmp.path());
     write_openai_curated_marketplace(&curated_root, &["slack"]);
@@ -5169,8 +5169,8 @@ fn refresh_curated_plugin_cache_returns_false_when_configured_plugins_are_curren
     );
 
     assert!(
-        !refresh_curated_plugin_cache(tmp.path(), TEST_CURATED_PLUGIN_SHA, &[plugin_id])
-            .expect("cache refresh should be a no-op when configured plugins are current")
+        refresh_curated_plugin_cache(tmp.path(), TEST_CURATED_PLUGIN_SHA, &[plugin_id])
+            .expect("cache refresh should reinstall current but unverified plugin bytes")
     );
 }
 
@@ -5374,7 +5374,7 @@ enabled = true
 }
 
 #[test]
-fn refresh_non_curated_plugin_cache_returns_false_when_configured_plugins_are_current() {
+fn refresh_non_curated_plugin_cache_reinstalls_changed_current_version() {
     let tmp = tempfile::tempdir().unwrap();
     let repo_root = tmp.path().join("repo");
     fs::create_dir_all(repo_root.join(".git")).unwrap();
@@ -5395,12 +5395,6 @@ fn refresh_non_curated_plugin_cache_returns_false_when_configured_plugins_are_cu
   ]
 }"#,
     );
-    write_plugin_with_version(
-        &tmp.path().join("plugins/cache/debug"),
-        "sample-plugin/1.2.3",
-        "sample-plugin",
-        Some("1.2.3"),
-    );
     write_file(
         &tmp.path().join(CONFIG_TOML_FILE),
         r#"[features]
@@ -5411,13 +5405,11 @@ enabled = true
 "#,
     );
 
-    assert!(
-        !refresh_non_curated_plugin_cache(
-            tmp.path(),
-            &[AbsolutePathBuf::try_from(repo_root).unwrap()],
-        )
-        .expect("cache refresh should be a no-op when configured plugins are current")
-    );
+    let roots = [AbsolutePathBuf::try_from(repo_root.clone()).unwrap()];
+    assert!(refresh_non_curated_plugin_cache(tmp.path(), &roots).unwrap());
+    fs::write(repo_root.join("sample-plugin/skills/SKILL.md"), "updated").unwrap();
+    assert!(refresh_non_curated_plugin_cache(tmp.path(), &roots).unwrap());
+    assert!(!refresh_non_curated_plugin_cache(tmp.path(), &roots).unwrap());
 }
 
 #[test]

--- a/codex-rs/core-plugins/src/manager_tests.rs
+++ b/codex-rs/core-plugins/src/manager_tests.rs
@@ -2370,6 +2370,49 @@ fn loaded_plugins_cache_invalidation_rejects_stale_load_completion() {
 }
 
 #[tokio::test]
+async fn reconcile_remote_plugin_install_invalidates_loaded_plugin_cache() {
+    let codex_home = TempDir::new().unwrap();
+    write_cached_plugin(codex_home.path(), "debug", "linear");
+    write_file(
+        &codex_home.path().join(CONFIG_TOML_FILE),
+        r#"[features]
+plugins = true
+remote_plugin = true
+
+[plugins."linear@debug"]
+enabled = true
+"#,
+    );
+    let config = load_config(codex_home.path(), codex_home.path()).await;
+    let manager = PluginsManager::new(codex_home.path().to_path_buf());
+
+    let before = manager.plugins_for_config(&config).await;
+    assert_eq!(before.plugins().len(), 1);
+    assert!(before.plugins()[0].is_active());
+
+    manager
+        .reconcile_remote_plugin_install(
+            &config,
+            &PluginId::new(
+                "linear".to_string(),
+                REMOTE_GLOBAL_MARKETPLACE_NAME.to_string(),
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        !codex_home
+            .path()
+            .join("plugins/cache/debug/linear")
+            .exists()
+    );
+    let after = manager.plugins_for_config(&config).await;
+    assert!(after.plugins().iter().all(|plugin| !plugin.is_active()));
+}
+
+#[tokio::test]
 async fn load_plugins_rejects_invalid_plugin_keys() {
     let codex_home = TempDir::new().unwrap();
     let plugin_root = codex_home

--- a/codex-rs/core-plugins/src/remote.rs
+++ b/codex-rs/core-plugins/src/remote.rs
@@ -414,7 +414,7 @@ impl RemotePluginScope {
         }
     }
 
-    fn from_marketplace_name(name: &str) -> Option<Self> {
+    pub(crate) fn from_marketplace_name(name: &str) -> Option<Self> {
         match name {
             REMOTE_GLOBAL_MARKETPLACE_NAME => Some(Self::Global),
             REMOTE_CREATED_BY_ME_MARKETPLACE_NAME => Some(Self::User),

--- a/codex-rs/core-plugins/src/remote/remote_installed_plugin_sync.rs
+++ b/codex-rs/core-plugins/src/remote/remote_installed_plugin_sync.rs
@@ -83,6 +83,7 @@ pub(crate) fn maybe_start_remote_installed_plugin_bundle_sync(
     codex_home: PathBuf,
     config: RemotePluginServiceConfig,
     auth: Option<CodexAuth>,
+    local_competitor_plugin_names: HashSet<String>,
     on_local_cache_changed: Option<Arc<dyn Fn() + Send + Sync + 'static>>,
 ) {
     let Some(auth) = auth else {
@@ -96,8 +97,13 @@ pub(crate) fn maybe_start_remote_installed_plugin_bundle_sync(
     }
 
     tokio::spawn(async move {
-        let result =
-            sync_remote_installed_plugin_bundles_once(codex_home, &config, Some(&auth)).await;
+        let result = sync_remote_installed_plugin_bundles_once(
+            codex_home,
+            &config,
+            Some(&auth),
+            &local_competitor_plugin_names,
+        )
+        .await;
         match result {
             Ok(outcome) => {
                 if outcome.changed_local_cache()
@@ -127,6 +133,7 @@ pub async fn sync_remote_installed_plugin_bundles_once(
     codex_home: PathBuf,
     config: &RemotePluginServiceConfig,
     auth: Option<&CodexAuth>,
+    local_competitor_plugin_names: &HashSet<String>,
 ) -> Result<RemoteInstalledPluginBundleSyncOutcome, RemoteInstalledPluginBundleSyncError> {
     let auth = ensure_chatgpt_auth(auth)?;
     let global = async {
@@ -201,7 +208,7 @@ pub async fn sync_remote_installed_plugin_bundles_once(
                     continue;
                 }
             };
-            if has_active_local_competitor(&store, &plugin_id)? {
+            if local_competitor_plugin_names.contains(&plugin.name) {
                 continue;
             }
             installed_plugin_names_by_marketplace
@@ -257,11 +264,7 @@ pub async fn sync_remote_installed_plugin_bundles_once(
             .await
             {
                 Ok(result) => {
-                    if !has_active_local_competitor(&store, &result.plugin_id)? {
-                        installed_plugin_ids.insert(result.plugin_id.as_key());
-                    } else {
-                        store.uninstall(&result.plugin_id)?;
-                    }
+                    installed_plugin_ids.insert(result.plugin_id.as_key());
                 }
                 Err(err) => {
                     warn!(
@@ -293,15 +296,6 @@ pub async fn sync_remote_installed_plugin_bundles_once(
     })
 }
 
-fn has_active_local_competitor(
-    store: &PluginStore,
-    plugin_id: &PluginId,
-) -> Result<bool, PluginStoreError> {
-    Ok(store
-        .other_sources(plugin_id, /*active_only*/ true)?
-        .iter()
-        .any(|other| RemotePluginScope::from_marketplace_name(&other.marketplace_name).is_none()))
-}
 pub fn mark_remote_plugin_cache_mutation_in_flight(
     codex_home: &Path,
     marketplace_name: &str,
@@ -495,7 +489,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sync_backfills_metadata_and_keeps_local_same_name_install_canonical() {
+    async fn sync_uses_configured_local_competitors_not_stale_local_caches() {
         let server = MockServer::start().await;
         let codex_home = tempfile::tempdir().expect("create codex home");
         let cached_manifest = codex_home
@@ -510,7 +504,13 @@ mod tests {
             .expect("create cached plugin manifest parent");
         std::fs::write(&cached_manifest, r#"{"name":"linear","version":"1.2.3"}"#)
             .expect("write cached plugin manifest");
-        assert!(fs::create_dir_all(codex_home.path().join("plugins/cache/debug/linear")).is_ok());
+        let local_manifest = codex_home
+            .path()
+            .join("plugins/cache/debug/linear/local/.codex-plugin/plugin.json");
+        std::fs::create_dir_all(local_manifest.parent().expect("manifest parent"))
+            .expect("create local plugin manifest parent");
+        std::fs::write(&local_manifest, r#"{"name":"linear"}"#)
+            .expect("write stale local plugin manifest");
         let stale_remote = codex_home
             .path()
             .join("plugins/cache/workspace-shared-with-me-private/linear/local");
@@ -572,6 +572,7 @@ mod tests {
             codex_home.path().to_path_buf(),
             &config,
             Some(&auth),
+            &HashSet::new(),
         )
         .await
         .expect("sync current remote plugin bundle");
@@ -601,18 +602,12 @@ mod tests {
                 "remote_plugin_id": remote_plugin_id,
             })
         );
-        let local_manifest = codex_home
-            .path()
-            .join("plugins/cache/debug/linear/local/.codex-plugin/plugin.json");
-        std::fs::create_dir_all(local_manifest.parent().expect("manifest parent"))
-            .expect("create local plugin manifest parent");
-        std::fs::write(&local_manifest, r#"{"name":"linear"}"#)
-            .expect("write local plugin manifest");
         store.uninstall(&plugin_id).expect("remove remote cache");
         let outcome = sync_remote_installed_plugin_bundles_once(
             codex_home.path().to_path_buf(),
             &config,
             Some(&auth),
+            &HashSet::from(["linear".to_string()]),
         )
         .await
         .expect("sync after local plugin becomes canonical");

--- a/codex-rs/core-plugins/src/remote/remote_installed_plugin_sync.rs
+++ b/codex-rs/core-plugins/src/remote/remote_installed_plugin_sync.rs
@@ -187,10 +187,6 @@ pub async fn sync_remote_installed_plugin_bundles_once(
         for installed_plugin in installed_plugins {
             let plugin = installed_plugin.plugin;
             let marketplace_name = remote_plugin_canonical_marketplace_name(&plugin)?.to_string();
-            installed_plugin_names_by_marketplace
-                .entry(marketplace_name.clone())
-                .or_default()
-                .insert(plugin.name.clone());
             let plugin_id = match PluginId::new(plugin.name.clone(), marketplace_name.clone()) {
                 Ok(plugin_id) => plugin_id,
                 Err(err) => {
@@ -205,6 +201,13 @@ pub async fn sync_remote_installed_plugin_bundles_once(
                     continue;
                 }
             };
+            if has_active_local_competitor(&store, &plugin_id)? {
+                continue;
+            }
+            installed_plugin_names_by_marketplace
+                .entry(marketplace_name.clone())
+                .or_default()
+                .insert(plugin.name.clone());
             let release_version = plugin
                 .release
                 .version
@@ -254,7 +257,11 @@ pub async fn sync_remote_installed_plugin_bundles_once(
             .await
             {
                 Ok(result) => {
-                    installed_plugin_ids.insert(result.plugin_id.as_key());
+                    if !has_active_local_competitor(&store, &result.plugin_id)? {
+                        installed_plugin_ids.insert(result.plugin_id.as_key());
+                    } else {
+                        store.uninstall(&result.plugin_id)?;
+                    }
                 }
                 Err(err) => {
                     warn!(
@@ -286,6 +293,15 @@ pub async fn sync_remote_installed_plugin_bundles_once(
     })
 }
 
+fn has_active_local_competitor(
+    store: &PluginStore,
+    plugin_id: &PluginId,
+) -> Result<bool, PluginStoreError> {
+    Ok(store
+        .other_sources(plugin_id, /*active_only*/ true)?
+        .iter()
+        .any(|other| RemotePluginScope::from_marketplace_name(&other.marketplace_name).is_none()))
+}
 pub fn mark_remote_plugin_cache_mutation_in_flight(
     codex_home: &Path,
     marketplace_name: &str,
@@ -479,7 +495,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn sync_backfills_remote_plugin_install_metadata_for_current_bundle() {
+    async fn sync_backfills_metadata_and_keeps_local_same_name_install_canonical() {
         let server = MockServer::start().await;
         let codex_home = tempfile::tempdir().expect("create codex home");
         let cached_manifest = codex_home
@@ -494,6 +510,11 @@ mod tests {
             .expect("create cached plugin manifest parent");
         std::fs::write(&cached_manifest, r#"{"name":"linear","version":"1.2.3"}"#)
             .expect("write cached plugin manifest");
+        assert!(fs::create_dir_all(codex_home.path().join("plugins/cache/debug/linear")).is_ok());
+        let stale_remote = codex_home
+            .path()
+            .join("plugins/cache/workspace-shared-with-me-private/linear/local");
+        assert!(fs::create_dir_all(&stale_remote).is_ok());
         let remote_plugin_id = "plugins~Plugin_linear";
         Mock::given(method("GET"))
             .and(path("/backend-api/ps/plugins/installed"))
@@ -517,7 +538,7 @@ mod tests {
                 }],
                 "pagination": {"next_page_token": null},
             })))
-            .expect(1)
+            .expect(2)
             .mount(&server)
             .await;
         Mock::given(method("GET"))
@@ -528,7 +549,7 @@ mod tests {
                 "plugins": [],
                 "pagination": {"next_page_token": null},
             })))
-            .expect(1)
+            .expect(2)
             .mount(&server)
             .await;
         Mock::given(method("GET"))
@@ -539,7 +560,7 @@ mod tests {
                 "plugins": [],
                 "pagination": {"next_page_token": null},
             })))
-            .expect(1)
+            .expect(2)
             .mount(&server)
             .await;
         let config = RemotePluginServiceConfig {
@@ -555,18 +576,23 @@ mod tests {
         .await
         .expect("sync current remote plugin bundle");
 
-        assert_eq!(outcome, RemoteInstalledPluginBundleSyncOutcome::default());
+        assert_eq!(
+            outcome.removed_cache_plugin_ids,
+            vec!["linear@workspace-shared-with-me-private".to_string()]
+        );
+        assert!(!stale_remote.exists());
         let plugin_id = PluginId::new(
             "linear".to_string(),
             REMOTE_GLOBAL_MARKETPLACE_NAME.to_string(),
         )
         .expect("valid plugin id");
-        let metadata_path = PluginStore::new(codex_home.path().to_path_buf())
+        let store = PluginStore::new(codex_home.path().to_path_buf());
+        let metadata = store
             .plugin_base_root(&plugin_id)
             .join(".codex-remote-plugin-install.json");
         assert_eq!(
             serde_json::from_str::<serde_json::Value>(
-                &std::fs::read_to_string(metadata_path.as_path())
+                &std::fs::read_to_string(metadata.as_path())
                     .expect("read remote plugin install metadata")
             )
             .expect("parse remote plugin install metadata"),
@@ -575,6 +601,23 @@ mod tests {
                 "remote_plugin_id": remote_plugin_id,
             })
         );
+        let local_manifest = codex_home
+            .path()
+            .join("plugins/cache/debug/linear/local/.codex-plugin/plugin.json");
+        std::fs::create_dir_all(local_manifest.parent().expect("manifest parent"))
+            .expect("create local plugin manifest parent");
+        std::fs::write(&local_manifest, r#"{"name":"linear"}"#)
+            .expect("write local plugin manifest");
+        store.uninstall(&plugin_id).expect("remove remote cache");
+        let outcome = sync_remote_installed_plugin_bundles_once(
+            codex_home.path().to_path_buf(),
+            &config,
+            Some(&auth),
+        )
+        .await
+        .expect("sync after local plugin becomes canonical");
+        assert_eq!(outcome, RemoteInstalledPluginBundleSyncOutcome::default());
+        assert!(local_manifest.is_file() && !cached_manifest.exists());
     }
 
     #[test]

--- a/codex-rs/core-plugins/src/store.rs
+++ b/codex-rs/core-plugins/src/store.rs
@@ -386,49 +386,6 @@ impl PluginStore {
         remove_existing_target(self.plugin_base_root(plugin_id).as_path())
     }
 
-    pub(crate) fn other_sources(
-        &self,
-        canonical_plugin_id: &PluginId,
-        active_only: bool,
-    ) -> Result<Vec<PluginId>, PluginStoreError> {
-        let mut installed = Vec::new();
-        let marketplaces = match fs::read_dir(self.root.as_path()) {
-            Ok(entries) => entries,
-            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(installed),
-            Err(err) => {
-                return Err(PluginStoreError::io(
-                    "failed to enumerate plugin cache marketplaces",
-                    err,
-                ));
-            }
-        };
-        for marketplace in marketplaces.filter_map(Result::ok) {
-            let Ok(file_type) = marketplace.file_type() else {
-                continue;
-            };
-            if !file_type.is_dir() {
-                continue;
-            }
-            let Ok(marketplace_name) = marketplace.file_name().into_string() else {
-                continue;
-            };
-            let Ok(plugin_id) =
-                PluginId::new(canonical_plugin_id.plugin_name.clone(), marketplace_name)
-            else {
-                continue;
-            };
-            if &plugin_id == canonical_plugin_id
-                || (active_only && !self.is_installed(&plugin_id))
-                || (!active_only && !self.plugin_base_root(&plugin_id).as_path().is_dir())
-            {
-                continue;
-            }
-            installed.push(plugin_id);
-        }
-        installed.sort_unstable_by_key(PluginId::as_key);
-        Ok(installed)
-    }
-
     fn remote_plugin_install_metadata_path(&self, plugin_id: &PluginId) -> AbsolutePathBuf {
         self.plugin_base_root(plugin_id)
             .join(REMOTE_PLUGIN_INSTALL_METADATA_FILE)

--- a/codex-rs/core-plugins/src/store.rs
+++ b/codex-rs/core-plugins/src/store.rs
@@ -1,3 +1,6 @@
+use crate::install_provenance::fingerprint_plugin_tree;
+use crate::install_provenance::read_install_fingerprint;
+use crate::install_provenance::write_install_fingerprint;
 use crate::manifest::PluginManifest;
 use crate::manifest::load_plugin_manifest;
 use crate::manifest::parse_plugin_manifest;
@@ -19,6 +22,7 @@ use std::path::PathBuf;
 pub const DEFAULT_PLUGIN_VERSION: &str = "local";
 pub const PLUGINS_CACHE_DIR: &str = "plugins/cache";
 pub const PLUGINS_DATA_DIR: &str = "plugins/data";
+const NO_MANIFEST_OVERRIDE: Option<&str> = None;
 const REMOTE_PLUGIN_INSTALL_METADATA_FILE: &str = ".codex-remote-plugin-install.json";
 const REMOTE_PLUGIN_INSTALL_METADATA_SCHEMA_VERSION: u8 = 1;
 
@@ -45,6 +49,15 @@ pub struct PluginStore {
 enum InstallManifest<'a> {
     OnDisk,
     Fallback(&'a str),
+}
+
+impl<'a> InstallManifest<'a> {
+    fn contents_override(self) -> Option<&'a str> {
+        match self {
+            Self::OnDisk => None,
+            Self::Fallback(contents) => Some(contents),
+        }
+    }
 }
 
 impl PluginStore {
@@ -114,6 +127,48 @@ impl PluginStore {
 
     pub fn is_installed(&self, plugin_id: &PluginId) -> bool {
         self.active_plugin_version(plugin_id).is_some()
+    }
+
+    pub fn active_plugin_matches_source(
+        &self,
+        plugin_id: &PluginId,
+        source_path: &Path,
+    ) -> Result<bool, PluginStoreError> {
+        self.active_plugin_matches_install_manifest(plugin_id, source_path, InstallManifest::OnDisk)
+    }
+
+    pub(crate) fn active_plugin_matches_source_with_fallback_manifest(
+        &self,
+        plugin_id: &PluginId,
+        source_path: &Path,
+        manifest_contents: &str,
+    ) -> Result<bool, PluginStoreError> {
+        self.active_plugin_matches_install_manifest(
+            plugin_id,
+            source_path,
+            InstallManifest::Fallback(manifest_contents),
+        )
+    }
+
+    fn active_plugin_matches_install_manifest(
+        &self,
+        plugin_id: &PluginId,
+        source_path: &Path,
+        manifest: InstallManifest<'_>,
+    ) -> Result<bool, PluginStoreError> {
+        let Some(installed_root) = self.active_plugin_root(plugin_id) else {
+            return Ok(false);
+        };
+        let manifest = resolve_install_manifest(source_path, manifest);
+        let expected = fingerprint_plugin_tree(source_path, manifest.contents_override())?;
+        let Some(recorded) = read_install_fingerprint(self.plugin_base_root(plugin_id).as_path())?
+        else {
+            return Ok(false);
+        };
+        if recorded != expected {
+            return Ok(false);
+        }
+        Ok(fingerprint_plugin_tree(installed_root.as_path(), NO_MANIFEST_OVERRIDE)? == expected)
     }
 
     pub fn remote_plugin_id(
@@ -297,11 +352,26 @@ impl PluginStore {
         }
         validate_plugin_version_segment(&plugin_version).map_err(PluginStoreError::Invalid)?;
         let installed_path = self.plugin_root(&plugin_id, &plugin_version);
+        let source_fingerprint =
+            fingerprint_plugin_tree(source_path.as_path(), manifest.contents_override())?;
         replace_plugin_root_atomically(
             source_path.as_path(),
             self.plugin_base_root(&plugin_id).as_path(),
             &plugin_version,
             manifest,
+            &source_fingerprint,
+        )?;
+        let installed_fingerprint =
+            fingerprint_plugin_tree(installed_path.as_path(), NO_MANIFEST_OVERRIDE)?;
+        if installed_fingerprint != source_fingerprint {
+            return Err(PluginStoreError::Invalid(format!(
+                "installed plugin bytes do not match source for `{}`",
+                plugin_id.as_key()
+            )));
+        }
+        write_install_fingerprint(
+            self.plugin_base_root(&plugin_id).as_path(),
+            &source_fingerprint,
         )?;
         self.remove_remote_plugin_install_metadata(&plugin_id)?;
 
@@ -314,6 +384,49 @@ impl PluginStore {
 
     pub fn uninstall(&self, plugin_id: &PluginId) -> Result<(), PluginStoreError> {
         remove_existing_target(self.plugin_base_root(plugin_id).as_path())
+    }
+
+    pub(crate) fn other_sources(
+        &self,
+        canonical_plugin_id: &PluginId,
+        active_only: bool,
+    ) -> Result<Vec<PluginId>, PluginStoreError> {
+        let mut installed = Vec::new();
+        let marketplaces = match fs::read_dir(self.root.as_path()) {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(installed),
+            Err(err) => {
+                return Err(PluginStoreError::io(
+                    "failed to enumerate plugin cache marketplaces",
+                    err,
+                ));
+            }
+        };
+        for marketplace in marketplaces.filter_map(Result::ok) {
+            let Ok(file_type) = marketplace.file_type() else {
+                continue;
+            };
+            if !file_type.is_dir() {
+                continue;
+            }
+            let Ok(marketplace_name) = marketplace.file_name().into_string() else {
+                continue;
+            };
+            let Ok(plugin_id) =
+                PluginId::new(canonical_plugin_id.plugin_name.clone(), marketplace_name)
+            else {
+                continue;
+            };
+            if &plugin_id == canonical_plugin_id
+                || (active_only && !self.is_installed(&plugin_id))
+                || (!active_only && !self.plugin_base_root(&plugin_id).as_path().is_dir())
+            {
+                continue;
+            }
+            installed.push(plugin_id);
+        }
+        installed.sort_unstable_by_key(PluginId::as_key);
+        Ok(installed)
     }
 
     fn remote_plugin_install_metadata_path(&self, plugin_id: &PluginId) -> AbsolutePathBuf {
@@ -351,7 +464,7 @@ pub enum PluginStoreError {
 }
 
 impl PluginStoreError {
-    fn io(context: &'static str, source: io::Error) -> Self {
+    pub(crate) fn io(context: &'static str, source: io::Error) -> Self {
         Self::Io { context, source }
     }
 }
@@ -500,6 +613,7 @@ fn replace_plugin_root_atomically(
     target_root: &Path,
     plugin_version: &str,
     manifest: InstallManifest<'_>,
+    source_fingerprint: &str,
 ) -> Result<(), PluginStoreError> {
     let Some(parent) = target_root.parent() else {
         return Err(PluginStoreError::Invalid(format!(
@@ -540,6 +654,12 @@ fn replace_plugin_root_atomically(
         })?;
         fs::write(&manifest_path, contents)
             .map_err(|err| PluginStoreError::io("failed to write fallback plugin manifest", err))?;
+    }
+    let staged_fingerprint = fingerprint_plugin_tree(&staged_version_root, NO_MANIFEST_OVERRIDE)?;
+    if staged_fingerprint != source_fingerprint {
+        return Err(PluginStoreError::Invalid(
+            "staged plugin bytes do not match source".to_string(),
+        ));
     }
 
     let target_version_root = target_root.join(plugin_version);

--- a/codex-rs/core-plugins/src/store_tests.rs
+++ b/codex-rs/core-plugins/src/store_tests.rs
@@ -222,6 +222,32 @@ fn install_records_and_verifies_exact_source_bytes() {
     fs::write(source.join("skills/SKILL.md"), "updated source").expect("update source file");
     assert!(!matches_source());
 }
+
+#[test]
+#[cfg(unix)]
+fn install_accepts_symlinked_plugin_source_root() {
+    use std::os::unix::fs::symlink;
+
+    let tmp = tempdir().unwrap();
+    write_plugin(tmp.path(), "real-plugin", "sample-plugin");
+    let linked_source = tmp.path().join("linked-plugin");
+    symlink(tmp.path().join("real-plugin"), &linked_source).unwrap();
+    let plugin_id = PluginId::new("sample-plugin".to_string(), "debug".to_string()).unwrap();
+    let store = PluginStore::new(tmp.path().to_path_buf());
+    let source = AbsolutePathBuf::try_from(linked_source).unwrap();
+
+    let result = store
+        .install(source.clone(), plugin_id.clone())
+        .expect("install plugin through symlinked source root");
+
+    assert!(result.installed_path.join("skills/SKILL.md").is_file());
+    assert!(
+        store
+            .active_plugin_matches_source(&plugin_id, source.as_path())
+            .expect("verify symlinked source bytes")
+    );
+}
+
 #[test]
 fn remote_plugin_install_metadata_follows_installed_cache_lifecycle() {
     let tmp = tempdir().unwrap();

--- a/codex-rs/core-plugins/src/store_tests.rs
+++ b/codex-rs/core-plugins/src/store_tests.rs
@@ -193,6 +193,36 @@ fn install_with_version_uses_requested_cache_version() {
 }
 
 #[test]
+fn install_records_and_verifies_exact_source_bytes() {
+    let tmp = tempdir().unwrap();
+    write_plugin_with_version(tmp.path(), "sample-plugin", "sample-plugin", Some("1.2.3"));
+    let plugin_id = PluginId::new("sample-plugin".to_string(), "debug".to_string()).unwrap();
+    let store = PluginStore::new(tmp.path().to_path_buf());
+    let source = AbsolutePathBuf::try_from(tmp.path().join("sample-plugin")).unwrap();
+    let result = store
+        .install(source.clone(), plugin_id.clone())
+        .expect("install plugin");
+    let matches_source = || {
+        store
+            .active_plugin_matches_source(&plugin_id, source.as_path())
+            .expect("verify installed bytes")
+    };
+    assert!(matches_source());
+    let provenance_path = store
+        .plugin_base_root(&plugin_id)
+        .join(crate::install_provenance::INSTALL_PROVENANCE_FILE);
+    assert!(provenance_path.is_file());
+    fs::write(result.installed_path.join("skills/SKILL.md"), "tampered")
+        .expect("tamper installed file");
+    assert!(!matches_source());
+    store.install(source.clone(), plugin_id.clone()).unwrap();
+    fs::write(&provenance_path, "corrupt").expect("corrupt install provenance");
+    assert!(!matches_source());
+    store.install(source.clone(), plugin_id.clone()).unwrap();
+    fs::write(source.join("skills/SKILL.md"), "updated source").expect("update source file");
+    assert!(!matches_source());
+}
+#[test]
 fn remote_plugin_install_metadata_follows_installed_cache_lifecycle() {
     let tmp = tempdir().unwrap();
     write_plugin(tmp.path(), "sample-plugin", "sample-plugin");

--- a/codex-rs/core/tests/suite/plugins.rs
+++ b/codex-rs/core/tests/suite/plugins.rs
@@ -346,7 +346,8 @@ async fn agent_context_uses_only_configured_same_name_plugin_install() -> Result
     )?;
     let mut builder = test_codex()
         .with_home(codex_home)
-        .with_auth(CodexAuth::from_api_key("Test API Key"));
+        .with_auth(CodexAuth::from_api_key("Test API Key"))
+        .with_model_info_override("gpt-5.4", |model| model.supports_search_tool = false);
     let codex = builder.build(&server).await?.codex;
     wait_for_mcp_server(&codex, "canonical").await?;
 

--- a/codex-rs/core/tests/suite/plugins.rs
+++ b/codex-rs/core/tests/suite/plugins.rs
@@ -95,6 +95,41 @@ fn write_plugin_mcp_plugin(home: &TempDir, command: &str) {
     .expect("write plugin mcp config");
 }
 
+fn write_installed_structure_plugin(
+    home: &TempDir,
+    marketplace: &str,
+    skill_name: &str,
+    server_name: &str,
+    command: &str,
+) {
+    let plugin_root = home
+        .path()
+        .join("plugins/cache")
+        .join(marketplace)
+        .join("structure-viewer/local");
+    std::fs::create_dir_all(plugin_root.join(".codex-plugin"))
+        .expect("create installed plugin manifest dir");
+    std::fs::write(
+        plugin_root.join(".codex-plugin/plugin.json"),
+        r#"{"name":"structure-viewer","description":"View structures"}"#,
+    )
+    .expect("write installed plugin manifest");
+    let skill_root = plugin_root.join("skills").join(skill_name);
+    std::fs::create_dir_all(&skill_root).expect("create installed plugin skill dir");
+    std::fs::write(
+        skill_root.join("SKILL.md"),
+        format!("---\nname: {skill_name}\ndescription: {skill_name} structure skill\n---\n"),
+    )
+    .expect("write installed plugin skill");
+    std::fs::write(
+        plugin_root.join(".mcp.json"),
+        format!(
+            r#"{{"mcpServers":{{"{server_name}":{{"command":"{command}","cwd":".","startup_timeout_sec":60.0}}}}}}"#
+        ),
+    )
+    .expect("write installed plugin MCP config");
+}
+
 fn write_plugin_app_plugin(home: &TempDir) {
     write_plugin_app_plugin_with_name(home, "sample");
 }
@@ -271,6 +306,70 @@ async fn capability_sections_render_in_developer_message_in_order() -> Result<()
         "expected namespaced plugin skill summary in developer message: {developer_messages:?}"
     );
 
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn agent_context_uses_only_configured_same_name_plugin_install() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+    let server = start_mock_server().await;
+    let response_mock = mount_sse_once(
+        &server,
+        sse(vec![ev_response_created("resp1"), ev_completed("resp1")]),
+    )
+    .await;
+    let rmcp_test_server_bin = match stdio_server_bin() {
+        Ok(bin) => bin,
+        Err(err) => {
+            eprintln!("test_stdio_server binary not available, skipping test: {err}");
+            return Ok(());
+        }
+    };
+    let codex_home = Arc::new(TempDir::new()?);
+    write_installed_structure_plugin(
+        codex_home.as_ref(),
+        "openai-monorepo",
+        "canonical",
+        "canonical",
+        &rmcp_test_server_bin,
+    );
+    write_installed_structure_plugin(
+        codex_home.as_ref(),
+        "openai-internal-testing",
+        "stale",
+        "stale",
+        &rmcp_test_server_bin,
+    );
+    std::fs::write(
+        codex_home.path().join("config.toml"),
+        "[features]\nplugins = true\n[plugins.\"structure-viewer@openai-monorepo\"]\nenabled = true\n",
+    )?;
+    let mut builder = test_codex()
+        .with_home(codex_home)
+        .with_auth(CodexAuth::from_api_key("Test API Key"));
+    let codex = builder.build(&server).await?.codex;
+    wait_for_mcp_server(&codex, "canonical").await?;
+
+    codex
+        .submit(Op::UserInput {
+            items: vec![codex_protocol::user_input::UserInput::Text {
+                text: "inspect the structure".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: Default::default(),
+        })
+        .await?;
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    let request = response_mock.single_request();
+    let developer_text = request.message_input_texts("developer").join("\n");
+    assert!(developer_text.contains("structure-viewer:canonical: canonical structure skill"));
+    assert!(!developer_text.contains("stale structure skill"));
+    assert!(request.tool_by_name("mcp__canonical", "echo").is_some());
+    assert!(request.tool_by_name("mcp__stale", "echo").is_none());
     Ok(())
 }
 


### PR DESCRIPTION
## What

- Make explicit local and remote plugin install/update select one canonical marketplace registration, remove stale same-name caches, and reconcile active user/profile config layers.
- Record a deterministic SHA-256 provenance fingerprint and verify staged plus installed plugin bytes against the intended source, including fallback manifests.
- Refresh same-version plugins when the source, installed bytes, or provenance has drifted.
- Emit deterministic duplicate MCP ownership diagnostics with the winning plugin, both paths, and an actionable config remediation.

## Why

Multiple enabled Structure Viewer installations can claim the same MCP server and skill. A version label alone cannot distinguish different local builds, so stale debug installs can survive updates and make plugin ownership ambiguous.

## How

- Serialize local install/uninstall mutations with a one-permit semaphore.
- Reconcile same-name registrations across active base/profile user layers, write the canonical local registration to the active user layer, and remove other marketplace installations after successful local or remote install.
- Fingerprint sorted plugin tree entries and persist install provenance atomically.
- Add config, store, refresh, diagnostic regression, and app-server JSON-RPC end-to-end coverage.

## Tests

- codex-config + codex-core-plugins suite: 455 passed
- codex-cli suite: 290 passed
- focused production app-server local canonical install/read and remote-marketplace cleanup end-to-end tests: 2 passed
- unrestricted codex-app-server suite: 912 passed, 1 skipped; 2 existing zsh-fork handshake tests passed on retry
- `just fix -p codex-config -p codex-core-plugins -p codex-app-server -p codex-cli`
- Rustfmt check, Buildifier formatting, `git diff --check`, and `bazel mod deps --lockfile_mode=error`

Fixes [LSC-38](https://linear.app/openai/issue/LSC-38/operational-detect-and-prevent-duplicate-enabled-structure-viewer)