### PR TITLE
[codex] add continuing code-mode cell actor

### DIFF
--- a/codex-rs/code-mode-protocol/src/host/error.rs
+++ b/codex-rs/code-mode-protocol/src/host/error.rs
@@ -1,0 +1,19 @@
+use serde::Deserialize;
+use serde::Serialize;
+
+use super::Capability;
+use super::SupportedProtocolVersions;
+
+/// Explains why connection negotiation was rejected before any session opened.
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, tag = "type", rename_all_fields = "camelCase")]
+pub enum HandshakeRejectReason {
+    #[serde(rename = "noCompatibleVersion")]
+    NoCompatibleVersion {
+        supported_versions: SupportedProtocolVersions,
+    },
+    #[serde(rename = "missingRequiredCapability")]
+    MissingRequiredCapability { capability: Capability },
+    #[serde(rename = "invalidHello")]
+    InvalidHello { message: String },
+}

--- a/codex-rs/code-mode-protocol/src/host/host_tests.rs
+++ b/codex-rs/code-mode-protocol/src/host/host_tests.rs
@@ -141,14 +141,14 @@ fn session_lifecycle_wire_contract_is_explicit_and_round_trips() {
 fn invalid_protocol_states_cannot_be_constructed_or_decoded() {
     assert!(SessionId::new("").is_err());
     assert!(Capability::new("   ").is_err());
-    assert!(ProtocolVersion::new(0).is_none());
+    assert!(ProtocolVersion::new(/*value*/ 0).is_none());
     assert!(SupportedProtocolVersions::try_new([]).is_err());
     assert!(
         SupportedProtocolVersions::try_new([ProtocolVersion::V1, ProtocolVersion::V1]).is_err()
     );
     assert!(CapabilitySet::try_new([capability("same"), capability("same")]).is_err());
 
-    let version_two = ProtocolVersion::new(2).expect("valid protocol version");
+    let version_two = ProtocolVersion::new(/*value*/ 2).expect("valid protocol version");
     let versions = SupportedProtocolVersions::try_new([ProtocolVersion::V1, version_two])
         .expect("valid versions");
     assert!(versions.contains(ProtocolVersion::V1));

--- a/codex-rs/code-mode-protocol/src/host/host_tests.rs
+++ b/codex-rs/code-mode-protocol/src/host/host_tests.rs
@@ -1,0 +1,207 @@
+use pretty_assertions::assert_eq;
+use serde_json::json;
+
+use super::Capability;
+use super::CapabilitySet;
+use super::ClientHello;
+use super::ClientToHost;
+use super::HandshakeRejectReason;
+use super::HostHello;
+use super::HostToClient;
+use super::ProtocolVersion;
+use super::SessionId;
+use super::SupportedProtocolVersions;
+
+fn session_id() -> SessionId {
+    SessionId::new("session-1").expect("valid session ID")
+}
+
+fn capability(value: &str) -> Capability {
+    Capability::new(value).expect("valid capability")
+}
+
+fn supported_versions() -> SupportedProtocolVersions {
+    SupportedProtocolVersions::try_new([ProtocolVersion::V1])
+        .expect("nonempty unique protocol versions")
+}
+
+#[test]
+fn handshake_wire_contract_is_explicit_and_round_trips() {
+    let client_hello = ClientToHost::ClientHello(
+        ClientHello::new(
+            supported_versions(),
+            CapabilitySet::try_new([capability("required")]).expect("valid required set"),
+            CapabilitySet::try_new([capability("optional")]).expect("valid optional set"),
+        )
+        .expect("disjoint capabilities"),
+    );
+    let client_hello_json = json!({
+        "type": "connection/hello",
+        "supportedVersions": [1],
+        "requiredCapabilities": ["required"],
+        "optionalCapabilities": ["optional"],
+    });
+    assert_eq!(
+        serde_json::to_value(&client_hello).expect("serialize"),
+        client_hello_json
+    );
+    assert_eq!(
+        serde_json::from_value::<ClientToHost>(client_hello_json).expect("deserialize"),
+        client_hello
+    );
+
+    let host_hello = HostToClient::HostHello(HostHello::new(
+        ProtocolVersion::V1,
+        CapabilitySet::try_new([capability("required")]).expect("valid capabilities"),
+    ));
+    let host_hello_json = json!({
+        "type": "connection/ready",
+        "selectedVersion": 1,
+        "capabilities": ["required"],
+    });
+    assert_eq!(
+        serde_json::to_value(&host_hello).expect("serialize"),
+        host_hello_json
+    );
+    assert_eq!(
+        serde_json::from_value::<HostToClient>(host_hello_json).expect("deserialize"),
+        host_hello
+    );
+
+    let rejected = HostToClient::HandshakeRejected {
+        reason: HandshakeRejectReason::NoCompatibleVersion {
+            supported_versions: supported_versions(),
+        },
+    };
+    let rejected_json = json!({
+        "type": "connection/rejected",
+        "reason": {
+            "type": "noCompatibleVersion",
+            "supportedVersions": [1],
+        },
+    });
+    assert_eq!(
+        serde_json::to_value(&rejected).expect("serialize"),
+        rejected_json
+    );
+    assert_eq!(
+        serde_json::from_value::<HostToClient>(rejected_json).expect("deserialize"),
+        rejected
+    );
+}
+
+#[test]
+fn session_lifecycle_wire_contract_is_explicit_and_round_trips() {
+    let client_messages = [
+        (
+            ClientToHost::OpenSession {
+                session_id: session_id(),
+            },
+            json!({ "type": "session/open", "sessionId": "session-1" }),
+        ),
+        (
+            ClientToHost::CloseSession {
+                session_id: session_id(),
+            },
+            json!({ "type": "session/close", "sessionId": "session-1" }),
+        ),
+    ];
+    for (message, encoded) in client_messages {
+        assert_eq!(serde_json::to_value(&message).expect("serialize"), encoded);
+        assert_eq!(
+            serde_json::from_value::<ClientToHost>(encoded).expect("deserialize"),
+            message
+        );
+    }
+
+    let host_messages = [
+        (
+            HostToClient::SessionReady {
+                session_id: session_id(),
+            },
+            json!({ "type": "session/ready", "sessionId": "session-1" }),
+        ),
+        (
+            HostToClient::SessionClosed {
+                session_id: session_id(),
+            },
+            json!({ "type": "session/closed", "sessionId": "session-1" }),
+        ),
+    ];
+    for (message, encoded) in host_messages {
+        assert_eq!(serde_json::to_value(&message).expect("serialize"), encoded);
+        assert_eq!(
+            serde_json::from_value::<HostToClient>(encoded).expect("deserialize"),
+            message
+        );
+    }
+}
+
+#[test]
+fn invalid_protocol_states_cannot_be_constructed_or_decoded() {
+    assert!(SessionId::new("").is_err());
+    assert!(Capability::new("   ").is_err());
+    assert!(ProtocolVersion::new(0).is_none());
+    assert!(SupportedProtocolVersions::try_new([]).is_err());
+    assert!(
+        SupportedProtocolVersions::try_new([ProtocolVersion::V1, ProtocolVersion::V1]).is_err()
+    );
+    assert!(CapabilitySet::try_new([capability("same"), capability("same")]).is_err());
+
+    let version_two = ProtocolVersion::new(2).expect("valid protocol version");
+    let versions = SupportedProtocolVersions::try_new([ProtocolVersion::V1, version_two])
+        .expect("valid versions");
+    assert!(versions.contains(ProtocolVersion::V1));
+    assert_eq!(
+        versions.iter().collect::<Vec<_>>(),
+        vec![ProtocolVersion::V1, version_two]
+    );
+
+    let overlapping = capability("overlapping");
+    assert!(
+        ClientHello::new(
+            supported_versions(),
+            CapabilitySet::try_new([overlapping.clone()]).expect("valid required set"),
+            CapabilitySet::try_new([overlapping]).expect("valid optional set"),
+        )
+        .is_err()
+    );
+
+    for invalid in [
+        json!({ "type": "session/open", "sessionId": "" }),
+        json!({
+            "type": "connection/hello",
+            "supportedVersions": [],
+            "requiredCapabilities": [],
+            "optionalCapabilities": [],
+        }),
+        json!({
+            "type": "connection/hello",
+            "supportedVersions": [1],
+            "requiredCapabilities": ["overlapping"],
+            "optionalCapabilities": ["overlapping"],
+        }),
+    ] {
+        assert!(serde_json::from_value::<ClientToHost>(invalid).is_err());
+    }
+}
+
+#[test]
+fn unknown_fields_are_rejected() {
+    assert!(
+        serde_json::from_value::<ClientToHost>(json!({
+            "type": "session/open",
+            "sessionId": "session-1",
+            "unexpected": true,
+        }))
+        .is_err()
+    );
+    assert!(
+        serde_json::from_value::<HostToClient>(json!({
+            "type": "session/ready",
+            "sessionId": "session-1",
+            "unexpected": true,
+        }))
+        .is_err()
+    );
+}

--- a/codex-rs/code-mode-protocol/src/host/message.rs
+++ b/codex-rs/code-mode-protocol/src/host/message.rs
@@ -1,0 +1,142 @@
+use std::fmt;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use super::Capability;
+use super::CapabilitySet;
+use super::HandshakeRejectReason;
+use super::ProtocolVersion;
+use super::SessionId;
+use super::SupportedProtocolVersions;
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientHello {
+    supported_versions: SupportedProtocolVersions,
+    required_capabilities: CapabilitySet,
+    optional_capabilities: CapabilitySet,
+}
+
+impl ClientHello {
+    pub fn new(
+        supported_versions: SupportedProtocolVersions,
+        required_capabilities: CapabilitySet,
+        optional_capabilities: CapabilitySet,
+    ) -> Result<Self, ClientHelloError> {
+        if let Some(capability) = required_capabilities
+            .iter()
+            .find(|capability| optional_capabilities.contains(capability))
+        {
+            return Err(ClientHelloError::OverlappingCapability(capability.clone()));
+        }
+        Ok(Self {
+            supported_versions,
+            required_capabilities,
+            optional_capabilities,
+        })
+    }
+
+    pub fn supported_versions(&self) -> &SupportedProtocolVersions {
+        &self.supported_versions
+    }
+
+    pub fn required_capabilities(&self) -> &CapabilitySet {
+        &self.required_capabilities
+    }
+
+    pub fn optional_capabilities(&self) -> &CapabilitySet {
+        &self.optional_capabilities
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct ClientHelloWire {
+    supported_versions: SupportedProtocolVersions,
+    required_capabilities: CapabilitySet,
+    optional_capabilities: CapabilitySet,
+}
+
+impl<'de> Deserialize<'de> for ClientHello {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = ClientHelloWire::deserialize(deserializer)?;
+        Self::new(
+            wire.supported_versions,
+            wire.required_capabilities,
+            wire.optional_capabilities,
+        )
+        .map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ClientHelloError {
+    OverlappingCapability(Capability),
+}
+
+impl fmt::Display for ClientHelloError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::OverlappingCapability(capability) => write!(
+                formatter,
+                "capability `{capability}` cannot be both required and optional"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ClientHelloError {}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct HostHello {
+    selected_version: ProtocolVersion,
+    capabilities: CapabilitySet,
+}
+
+impl HostHello {
+    pub fn new(selected_version: ProtocolVersion, capabilities: CapabilitySet) -> Self {
+        Self {
+            selected_version,
+            capabilities,
+        }
+    }
+
+    pub fn selected_version(&self) -> ProtocolVersion {
+        self.selected_version
+    }
+
+    pub fn capabilities(&self) -> &CapabilitySet {
+        &self.capabilities
+    }
+}
+
+/// Messages sent from a client to the code-mode host.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, tag = "type", rename_all_fields = "camelCase")]
+pub enum ClientToHost {
+    #[serde(rename = "connection/hello")]
+    ClientHello(ClientHello),
+    #[serde(rename = "session/open")]
+    OpenSession { session_id: SessionId },
+    #[serde(rename = "session/close")]
+    CloseSession { session_id: SessionId },
+}
+
+/// Messages sent from the code-mode host to a client.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, tag = "type", rename_all_fields = "camelCase")]
+pub enum HostToClient {
+    #[serde(rename = "connection/ready")]
+    HostHello(HostHello),
+    #[serde(rename = "connection/rejected")]
+    HandshakeRejected { reason: HandshakeRejectReason },
+    #[serde(rename = "session/ready")]
+    SessionReady { session_id: SessionId },
+    #[serde(rename = "session/closed")]
+    SessionClosed { session_id: SessionId },
+}

--- a/codex-rs/code-mode-protocol/src/host/mod.rs
+++ b/codex-rs/code-mode-protocol/src/host/mod.rs
@@ -1,0 +1,29 @@
+//! Transport-neutral messages for the callback-only code-mode host boundary.
+//!
+//! Protocol version 1 relies on ordered framing and connection-scoped
+//! fail-stop behavior rather than message sequence numbers. It defines no
+//! optional capabilities yet; capability names provide an extension point for
+//! later versions without weakening the v1 decoder.
+
+mod error;
+mod message;
+mod types;
+
+pub use error::HandshakeRejectReason;
+pub use message::ClientHello;
+pub use message::ClientHelloError;
+pub use message::ClientToHost;
+pub use message::HostHello;
+pub use message::HostToClient;
+pub use types::Capability;
+pub use types::CapabilitySet;
+pub use types::DuplicateCapability;
+pub use types::InvalidIdentifier;
+pub use types::InvalidSupportedProtocolVersions;
+pub use types::ProtocolVersion;
+pub use types::SessionId;
+pub use types::SupportedProtocolVersions;
+
+#[cfg(test)]
+#[path = "host_tests.rs"]
+mod tests;

--- a/codex-rs/code-mode-protocol/src/host/types.rs
+++ b/codex-rs/code-mode-protocol/src/host/types.rs
@@ -1,0 +1,226 @@
+use std::collections::BTreeSet;
+use std::fmt;
+use std::num::NonZeroU32;
+
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+use serde::de::Error as _;
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct ProtocolVersion(NonZeroU32);
+
+impl ProtocolVersion {
+    pub const V1: Self = Self(NonZeroU32::MIN);
+
+    pub const fn new(value: u32) -> Option<Self> {
+        match NonZeroU32::new(value) {
+            Some(value) => Some(Self(value)),
+            None => None,
+        }
+    }
+
+    pub const fn get(self) -> u32 {
+        self.0.get()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct InvalidIdentifier;
+
+impl fmt::Display for InvalidIdentifier {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("identifier must not be empty")
+    }
+}
+
+impl std::error::Error for InvalidIdentifier {}
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+struct NonEmptyString(String);
+
+impl NonEmptyString {
+    fn new(value: impl Into<String>) -> Result<Self, InvalidIdentifier> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            Err(InvalidIdentifier)
+        } else {
+            Ok(Self(value))
+        }
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Serialize for NonEmptyString {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for NonEmptyString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::new(String::deserialize(deserializer)?).map_err(D::Error::custom)
+    }
+}
+
+/// A named protocol feature advertised during connection negotiation.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct Capability(NonEmptyString);
+
+impl Capability {
+    pub fn new(value: impl Into<String>) -> Result<Self, InvalidIdentifier> {
+        NonEmptyString::new(value).map(Self)
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl fmt::Display for Capability {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Identifies one logical code-mode session on a connection.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(transparent)]
+pub struct SessionId(NonEmptyString);
+
+impl SessionId {
+    pub fn new(value: impl Into<String>) -> Result<Self, InvalidIdentifier> {
+        NonEmptyString::new(value).map(Self)
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl fmt::Display for SessionId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct CapabilitySet(BTreeSet<Capability>);
+
+impl CapabilitySet {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    pub fn try_new(
+        capabilities: impl IntoIterator<Item = Capability>,
+    ) -> Result<Self, DuplicateCapability> {
+        let mut unique = BTreeSet::new();
+        for capability in capabilities {
+            if !unique.insert(capability.clone()) {
+                return Err(DuplicateCapability { capability });
+            }
+        }
+        Ok(Self(unique))
+    }
+
+    pub fn contains(&self, capability: &Capability) -> bool {
+        self.0.contains(capability)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &Capability> {
+        self.0.iter()
+    }
+}
+
+impl<'de> Deserialize<'de> for CapabilitySet {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::try_new(Vec::<Capability>::deserialize(deserializer)?).map_err(D::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DuplicateCapability {
+    capability: Capability,
+}
+
+impl fmt::Display for DuplicateCapability {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "duplicate capability `{}`", self.capability)
+    }
+}
+
+impl std::error::Error for DuplicateCapability {}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct SupportedProtocolVersions(BTreeSet<ProtocolVersion>);
+
+impl SupportedProtocolVersions {
+    pub fn try_new(
+        versions: impl IntoIterator<Item = ProtocolVersion>,
+    ) -> Result<Self, InvalidSupportedProtocolVersions> {
+        let mut unique = BTreeSet::new();
+        for version in versions {
+            if !unique.insert(version) {
+                return Err(InvalidSupportedProtocolVersions::Duplicate(version));
+            }
+        }
+        if unique.is_empty() {
+            return Err(InvalidSupportedProtocolVersions::Empty);
+        }
+        Ok(Self(unique))
+    }
+
+    pub fn contains(&self, version: ProtocolVersion) -> bool {
+        self.0.contains(&version)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = ProtocolVersion> + '_ {
+        self.0.iter().copied()
+    }
+}
+
+impl<'de> Deserialize<'de> for SupportedProtocolVersions {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::try_new(Vec::<ProtocolVersion>::deserialize(deserializer)?).map_err(D::Error::custom)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InvalidSupportedProtocolVersions {
+    Empty,
+    Duplicate(ProtocolVersion),
+}
+
+impl fmt::Display for InvalidSupportedProtocolVersions {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => formatter.write_str("at least one protocol version is required"),
+            Self::Duplicate(version) => {
+                write!(formatter, "duplicate protocol version {}", version.get())
+            }
+        }
+    }
+}
+
+impl std::error::Error for InvalidSupportedProtocolVersions {}

--- a/codex-rs/code-mode-protocol/src/lib.rs
+++ b/codex-rs/code-mode-protocol/src/lib.rs
@@ -1,4 +1,5 @@
 mod description;
+pub mod host;
 mod response;
 mod runtime;
 mod session;

--- a/codex-rs/code-mode/src/continuing_cell/mod.rs
+++ b/codex-rs/code-mode/src/continuing_cell/mod.rs
@@ -1,0 +1,261 @@
+mod types;
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use codex_code_mode_protocol::DEFAULT_IMAGE_DETAIL;
+use codex_code_mode_protocol::FunctionCallOutputContentItem;
+use serde_json::Value as JsonValue;
+use tokio::sync::mpsc;
+
+pub use self::types::ActorError;
+pub use self::types::ActorErrorKind;
+pub use self::types::CellClosed;
+use self::types::CellCommand;
+pub use self::types::CellEvent;
+pub use self::types::CellHandle;
+pub use self::types::CellRequest;
+pub use self::types::CellTask;
+pub use self::types::InvalidCellRequest;
+pub use self::types::PreparedCell;
+pub use self::types::StartError;
+pub use self::types::ToolCallOutcome;
+use crate::runtime::PendingRuntimeMode;
+use crate::runtime::RuntimeCommand;
+use crate::runtime::RuntimeControlCommand;
+use crate::runtime::RuntimeEvent;
+use crate::runtime::spawn_owned_runtime;
+
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// A callback-only cell actor that continues through runtime checkpoints.
+pub struct CellActor;
+
+impl CellActor {
+    /// Prepares a cell without spawning its actor task.
+    ///
+    /// The returned future must be polled by the owning session.
+    pub fn prepare(
+        request: CellRequest,
+        stored_values: HashMap<String, JsonValue>,
+    ) -> Result<PreparedCell, StartError> {
+        let (runtime_event_tx, runtime_event_rx) = mpsc::unbounded_channel();
+        let (runtime_tx, runtime_control_tx, runtime_terminate_handle, runtime_thread) =
+            spawn_owned_runtime(
+                stored_values,
+                request.into_runtime_request(),
+                runtime_event_tx,
+                PendingRuntimeMode::Continue,
+            )
+            .map_err(StartError::new)?;
+        let (command_tx, command_rx) = mpsc::unbounded_channel();
+        let (event_tx, event_rx) = mpsc::unbounded_channel();
+        let task = Box::pin(run_cell(
+            RuntimeHandle {
+                command_tx: runtime_tx,
+                control_tx: runtime_control_tx,
+                terminator: RuntimeTerminator::Isolate(runtime_terminate_handle),
+                thread: Some(runtime_thread),
+            },
+            runtime_event_rx,
+            command_rx,
+            event_tx,
+            SHUTDOWN_TIMEOUT,
+        ));
+        Ok((CellHandle { command_tx }, event_rx, task))
+    }
+}
+
+struct RuntimeHandle {
+    command_tx: std::sync::mpsc::Sender<RuntimeCommand>,
+    control_tx: std::sync::mpsc::Sender<RuntimeControlCommand>,
+    terminator: RuntimeTerminator,
+    thread: Option<crate::runtime::RuntimeThread>,
+}
+
+enum RuntimeTerminator {
+    Isolate(v8::IsolateHandle),
+    #[cfg(test)]
+    Noop,
+}
+
+impl RuntimeHandle {
+    fn terminate(&self) {
+        let _ = self.control_tx.send(RuntimeControlCommand::Terminate);
+        let _ = self.command_tx.send(RuntimeCommand::Terminate);
+        match &self.terminator {
+            RuntimeTerminator::Isolate(terminate_handle) => {
+                terminate_handle.terminate_execution();
+            }
+            #[cfg(test)]
+            RuntimeTerminator::Noop => {}
+        }
+    }
+}
+
+impl Drop for RuntimeHandle {
+    fn drop(&mut self) {
+        if self
+            .thread
+            .as_ref()
+            .is_some_and(crate::runtime::RuntimeThread::join_pending)
+        {
+            self.terminate();
+        }
+    }
+}
+
+async fn run_cell(
+    runtime: RuntimeHandle,
+    mut runtime_event_rx: mpsc::UnboundedReceiver<RuntimeEvent>,
+    mut command_rx: mpsc::UnboundedReceiver<CellCommand>,
+    event_tx: mpsc::UnboundedSender<CellEvent>,
+    shutdown_timeout: Duration,
+) -> Result<(), ActorError> {
+    let mut started = false;
+    let mut command_channel_open = true;
+    let outcome = loop {
+        tokio::select! {
+            biased;
+            command = command_rx.recv(), if command_channel_open => {
+                match command {
+                    Some(CellCommand::FinishToolCall { id, outcome }) => {
+                        let command = tool_call_command(id, outcome);
+                        // The runtime may have already emitted its terminal event and
+                        // closed this receiver. Preserve that outcome instead of
+                        // synthesizing explicit termination.
+                        let _ = runtime.command_tx.send(command);
+                    }
+                    Some(CellCommand::Terminate) => {
+                        runtime.terminate();
+                        break ShutdownOutcome::Terminal(CellEvent::Terminated);
+                    }
+                    None => command_channel_open = false,
+                }
+            }
+            event = runtime_event_rx.recv() => {
+                let Some(event) = event else {
+                    break ShutdownOutcome::Fault(ActorErrorKind::RuntimeClosedUnexpectedly);
+                };
+                match event {
+                    RuntimeEvent::Started => {
+                        if started {
+                            runtime.terminate();
+                            break ShutdownOutcome::Fault(
+                                ActorErrorKind::RuntimeClosedUnexpectedly,
+                            );
+                        }
+                        started = true;
+                        let _ = event_tx.send(CellEvent::Started);
+                    }
+                    RuntimeEvent::Result {
+                        stored_value_writes,
+                        error_text,
+                    } => {
+                        break ShutdownOutcome::Terminal(CellEvent::Completed {
+                            stored_value_writes,
+                            error_text,
+                        });
+                    }
+                    _event if !started => {
+                        runtime.terminate();
+                        break ShutdownOutcome::Fault(ActorErrorKind::RuntimeClosedUnexpectedly);
+                    }
+                    RuntimeEvent::Pending => {}
+                    RuntimeEvent::ContentItem(item) => send_output(&event_tx, item),
+                    RuntimeEvent::YieldRequested => {
+                        let _ = event_tx.send(CellEvent::YieldRequested);
+                    }
+                    RuntimeEvent::Notify { call_id, text } => {
+                        let _ = event_tx.send(CellEvent::Notification { call_id, text });
+                    }
+                    RuntimeEvent::ToolCall {
+                        id,
+                        name,
+                        kind,
+                        input,
+                    } => {
+                        let _ = event_tx.send(CellEvent::ToolCallRequested {
+                            id,
+                            name,
+                            kind,
+                            input,
+                        });
+                    }
+                }
+            }
+        }
+    };
+    drop(command_rx);
+    drop(runtime_event_rx);
+    finish_shutdown(
+        runtime,
+        outcome,
+        &event_tx,
+        tokio::time::Instant::now() + shutdown_timeout,
+    )
+    .await
+}
+
+enum ShutdownOutcome {
+    Terminal(CellEvent),
+    Fault(ActorErrorKind),
+}
+
+async fn finish_shutdown(
+    mut runtime: RuntimeHandle,
+    outcome: ShutdownOutcome,
+    event_tx: &mpsc::UnboundedSender<CellEvent>,
+    shutdown_deadline: tokio::time::Instant,
+) -> Result<(), ActorError> {
+    let Some(runtime_thread) = runtime.thread.as_mut() else {
+        return Err(ActorError::new(ActorErrorKind::RuntimeClosedUnexpectedly));
+    };
+    let runtime_finished = tokio::select! {
+        biased;
+        _ = tokio::time::sleep_until(shutdown_deadline) => false,
+        _ = runtime_thread.wait() => true,
+    };
+    if !runtime_finished {
+        runtime.terminate();
+        let Some(runtime_thread) = runtime.thread.take() else {
+            return Err(ActorError::new(ActorErrorKind::RuntimeClosedUnexpectedly));
+        };
+        return Err(ActorError::cleanup_timeout(runtime_thread));
+    }
+    let Some(runtime_thread) = runtime.thread.as_mut() else {
+        return Err(ActorError::new(ActorErrorKind::RuntimeClosedUnexpectedly));
+    };
+    if runtime_thread.join_finished().is_err() {
+        return Err(ActorError::new(ActorErrorKind::RuntimeThreadPanicked));
+    }
+
+    match outcome {
+        ShutdownOutcome::Terminal(terminal) => {
+            let _ = event_tx.send(terminal);
+            Ok(())
+        }
+        ShutdownOutcome::Fault(kind) => Err(ActorError::new(kind)),
+    }
+}
+
+fn tool_call_command(id: String, outcome: ToolCallOutcome) -> RuntimeCommand {
+    match outcome {
+        ToolCallOutcome::Result(result) => RuntimeCommand::ToolResponse { id, result },
+        ToolCallOutcome::Error(error_text) => RuntimeCommand::ToolError { id, error_text },
+    }
+}
+
+fn send_output(event_tx: &mpsc::UnboundedSender<CellEvent>, item: FunctionCallOutputContentItem) {
+    let _ = event_tx.send(match item {
+        FunctionCallOutputContentItem::InputText { text } => CellEvent::OutputText { text },
+        FunctionCallOutputContentItem::InputImage { image_url, detail } => CellEvent::OutputImage {
+            image_url,
+            detail: detail.unwrap_or(DEFAULT_IMAGE_DETAIL),
+        },
+    });
+}
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;

--- a/codex-rs/code-mode/src/continuing_cell/tests.rs
+++ b/codex-rs/code-mode/src/continuing_cell/tests.rs
@@ -1,0 +1,567 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::mpsc as std_mpsc;
+use std::time::Duration;
+
+use codex_code_mode_protocol::CodeModeToolKind;
+use codex_code_mode_protocol::DEFAULT_IMAGE_DETAIL;
+use codex_code_mode_protocol::ToolDefinition;
+use codex_protocol::ToolName;
+use pretty_assertions::assert_eq;
+use serde_json::json;
+use tokio::sync::mpsc;
+
+use super::*;
+use crate::runtime::RuntimeEvent;
+use crate::runtime::spawn_runtime_thread;
+
+struct CellHarness {
+    handle: CellHandle,
+    events: mpsc::UnboundedReceiver<CellEvent>,
+    task: tokio::task::JoinHandle<Result<(), ActorError>>,
+}
+
+fn spawn_cell(source: &str, enabled_tools: Vec<ToolDefinition>) -> CellHarness {
+    let request = CellRequest::new("call-1", enabled_tools, source).expect("valid cell request");
+    let (handle, events, task) = CellActor::prepare(request, HashMap::new()).expect("prepare cell");
+    CellHarness {
+        handle,
+        events,
+        task: tokio::spawn(task),
+    }
+}
+
+fn echo_tool() -> ToolDefinition {
+    ToolDefinition {
+        name: "echo".to_string(),
+        tool_name: ToolName::plain("echo"),
+        description: String::new(),
+        kind: CodeModeToolKind::Function,
+        input_schema: None,
+        output_schema: None,
+    }
+}
+
+async fn next_event(events: &mut mpsc::UnboundedReceiver<CellEvent>) -> CellEvent {
+    tokio::time::timeout(Duration::from_secs(2), events.recv())
+        .await
+        .expect("cell event timeout")
+        .expect("cell event channel closed")
+}
+
+async fn assert_closed(mut harness: CellHarness) {
+    assert_eq!(
+        tokio::time::timeout(Duration::from_secs(2), harness.events.recv())
+            .await
+            .expect("cell close timeout"),
+        None
+    );
+    tokio::time::timeout(Duration::from_secs(2), harness.task)
+        .await
+        .expect("cell task timeout")
+        .expect("cell task panicked")
+        .expect("cell actor failed");
+}
+
+struct ControlledCell {
+    handle: CellHandle,
+    events: mpsc::UnboundedReceiver<CellEvent>,
+    runtime_events: mpsc::UnboundedSender<RuntimeEvent>,
+    runtime_commands: Option<std_mpsc::Receiver<RuntimeCommand>>,
+    _runtime_controls: std_mpsc::Receiver<RuntimeControlCommand>,
+    release_runtime: std_mpsc::Sender<()>,
+    runtime_active: Arc<AtomicBool>,
+    task: tokio::task::JoinHandle<Result<(), ActorError>>,
+}
+
+fn controlled_cell(shutdown_timeout: Duration) -> ControlledCell {
+    let (runtime_events, runtime_event_rx) = mpsc::unbounded_channel();
+    let (runtime_command_tx, runtime_commands) = std_mpsc::channel();
+    let (runtime_control_tx, runtime_controls) = std_mpsc::channel();
+    let (release_runtime, release_runtime_rx) = std_mpsc::channel();
+    let (runtime_started_tx, runtime_started_rx) = std_mpsc::sync_channel(/*bound*/ 1);
+    let runtime_active = Arc::new(AtomicBool::new(false));
+    let thread_runtime_active = Arc::clone(&runtime_active);
+    let runtime_thread = spawn_runtime_thread(move || {
+        thread_runtime_active.store(true, Ordering::Release);
+        runtime_started_tx.send(()).expect("report runtime start");
+        let _ = release_runtime_rx.recv();
+        thread_runtime_active.store(false, Ordering::Release);
+    });
+    runtime_started_rx.recv().expect("runtime thread started");
+    let (command_tx, command_rx) = mpsc::unbounded_channel();
+    let (event_tx, events) = mpsc::unbounded_channel();
+    let handle = CellHandle { command_tx };
+    let task = tokio::spawn(run_cell(
+        RuntimeHandle {
+            command_tx: runtime_command_tx,
+            control_tx: runtime_control_tx,
+            terminator: RuntimeTerminator::Noop,
+            thread: Some(runtime_thread),
+        },
+        runtime_event_rx,
+        command_rx,
+        event_tx,
+        shutdown_timeout,
+    ));
+    ControlledCell {
+        handle,
+        events,
+        runtime_events,
+        runtime_commands: Some(runtime_commands),
+        _runtime_controls: runtime_controls,
+        release_runtime,
+        runtime_active,
+        task,
+    }
+}
+
+async fn start_controlled(cell: &mut ControlledCell) {
+    cell.runtime_events
+        .send(RuntimeEvent::Started)
+        .expect("queue runtime start");
+    assert_eq!(next_event(&mut cell.events).await, CellEvent::Started);
+}
+
+async fn actor_result(
+    task: tokio::task::JoinHandle<Result<(), ActorError>>,
+) -> Result<(), ActorError> {
+    tokio::time::timeout(Duration::from_secs(2), task)
+        .await
+        .expect("cell task timeout")
+        .expect("cell task panicked")
+}
+
+#[tokio::test]
+async fn synchronous_execution_emits_granular_events_in_actor_order() {
+    let mut harness = spawn_cell(
+        r#"
+text("before");
+image("data:image/png;base64,AAA");
+notify("notice");
+yield_control();
+yield_control();
+text("after");
+store("answer", 42);
+"#,
+        Vec::new(),
+    );
+
+    let mut events = Vec::new();
+    loop {
+        let event = next_event(&mut harness.events).await;
+        let terminal = matches!(event, CellEvent::Completed { .. } | CellEvent::Terminated);
+        events.push(event);
+        if terminal {
+            break;
+        }
+    }
+    assert_eq!(
+        events,
+        vec![
+            CellEvent::Started,
+            CellEvent::OutputText {
+                text: "before".to_string(),
+            },
+            CellEvent::OutputImage {
+                image_url: "data:image/png;base64,AAA".to_string(),
+                detail: DEFAULT_IMAGE_DETAIL,
+            },
+            CellEvent::Notification {
+                call_id: "call-1".to_string(),
+                text: "notice".to_string(),
+            },
+            CellEvent::YieldRequested,
+            CellEvent::YieldRequested,
+            CellEvent::OutputText {
+                text: "after".to_string(),
+            },
+            CellEvent::Completed {
+                stored_value_writes: HashMap::from([("answer".to_string(), json!(42))]),
+                error_text: None,
+            },
+        ]
+    );
+    assert_closed(harness).await;
+}
+
+#[tokio::test]
+async fn termination_queued_before_actor_start_emits_direct_terminal() {
+    let request = CellRequest::new("call-1", Vec::new(), "await new Promise(() => {});")
+        .expect("valid cell request");
+    let (handle, mut events, task) =
+        CellActor::prepare(request, HashMap::new()).expect("prepare cell");
+    handle.terminate().expect("queue termination before start");
+    let task = tokio::spawn(task);
+
+    assert_eq!(next_event(&mut events).await, CellEvent::Terminated);
+    assert_closed(CellHarness {
+        handle,
+        events,
+        task,
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn termination_before_started_uses_the_cleanup_deadline() {
+    let mut cell = controlled_cell(Duration::ZERO);
+    cell.handle
+        .terminate()
+        .expect("queue termination during startup");
+
+    let error = actor_result(cell.task)
+        .await
+        .expect_err("stalled cleanup should fault at the termination deadline");
+    assert_eq!(error.kind(), ActorErrorKind::RuntimeCleanupTimedOut);
+    assert!(cell.runtime_active.load(Ordering::Acquire));
+    assert_eq!(cell.events.recv().await, None);
+
+    drop(error);
+    cell.release_runtime
+        .send(())
+        .expect("release detached runtime");
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while cell.runtime_active.load(Ordering::Acquire) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("detached runtime did not exit");
+}
+
+#[tokio::test]
+async fn completion_before_started_emits_direct_terminal() {
+    let mut cell = controlled_cell(Duration::from_secs(2));
+    cell.runtime_events
+        .send(RuntimeEvent::Result {
+            stored_value_writes: HashMap::from([("committed".to_string(), json!(true))]),
+            error_text: Some("initialization failed".to_string()),
+        })
+        .expect("queue direct completion");
+    cell.release_runtime
+        .send(())
+        .expect("release runtime thread");
+
+    assert_eq!(
+        next_event(&mut cell.events).await,
+        CellEvent::Completed {
+            stored_value_writes: HashMap::from([("committed".to_string(), json!(true))]),
+            error_text: Some("initialization failed".to_string()),
+        }
+    );
+    actor_result(cell.task)
+        .await
+        .expect("directly completed actor should close cleanly");
+}
+
+#[tokio::test]
+async fn nonterminal_event_before_started_faults_the_actor() {
+    let mut cell = controlled_cell(Duration::from_secs(2));
+    cell.runtime_events
+        .send(RuntimeEvent::YieldRequested)
+        .expect("queue invalid pre-start event");
+    cell.release_runtime
+        .send(())
+        .expect("release runtime thread");
+
+    let error = actor_result(cell.task)
+        .await
+        .expect_err("pre-start nonterminal event should fault the actor");
+    assert_eq!(error.kind(), ActorErrorKind::RuntimeClosedUnexpectedly);
+    assert_eq!(cell.events.recv().await, None);
+}
+
+#[tokio::test]
+async fn callback_send_failure_preserves_queued_natural_completion() {
+    let mut cell = controlled_cell(Duration::from_secs(2));
+    start_controlled(&mut cell).await;
+    cell.runtime_events
+        .send(RuntimeEvent::ToolCall {
+            id: "tool-1".to_string(),
+            name: ToolName::plain("echo"),
+            kind: CodeModeToolKind::Function,
+            input: Some(json!({ "value": "ignored" })),
+        })
+        .expect("queue tool call");
+    assert!(matches!(
+        next_event(&mut cell.events).await,
+        CellEvent::ToolCallRequested { .. }
+    ));
+
+    drop(cell.runtime_commands.take());
+    cell.handle
+        .finish_tool_call("tool-1", ToolCallOutcome::Result(json!("late")))
+        .expect("queue late tool result");
+    cell.runtime_events
+        .send(RuntimeEvent::Result {
+            stored_value_writes: HashMap::from([("committed".to_string(), json!(true))]),
+            error_text: None,
+        })
+        .expect("queue natural completion");
+    cell.release_runtime
+        .send(())
+        .expect("release runtime thread");
+
+    assert_eq!(
+        next_event(&mut cell.events).await,
+        CellEvent::Completed {
+            stored_value_writes: HashMap::from([("committed".to_string(), json!(true))]),
+            error_text: None,
+        }
+    );
+    actor_result(cell.task)
+        .await
+        .expect("naturally completed actor should close cleanly");
+}
+
+#[tokio::test]
+async fn callback_send_failure_followed_by_runtime_close_faults_the_actor() {
+    let mut cell = controlled_cell(Duration::from_secs(2));
+    start_controlled(&mut cell).await;
+    cell.runtime_events
+        .send(RuntimeEvent::ToolCall {
+            id: "tool-1".to_string(),
+            name: ToolName::plain("echo"),
+            kind: CodeModeToolKind::Function,
+            input: None,
+        })
+        .expect("queue tool call");
+    assert!(matches!(
+        next_event(&mut cell.events).await,
+        CellEvent::ToolCallRequested { .. }
+    ));
+
+    drop(cell.runtime_commands.take());
+    cell.handle
+        .finish_tool_call("tool-1", ToolCallOutcome::Result(json!("late")))
+        .expect("queue late tool result");
+    drop(cell.runtime_events);
+    cell.release_runtime
+        .send(())
+        .expect("release runtime thread");
+
+    let error = actor_result(cell.task)
+        .await
+        .expect_err("missing runtime terminal event should fault the actor");
+    assert_eq!(error.kind(), ActorErrorKind::RuntimeClosedUnexpectedly);
+    assert_eq!(cell.events.recv().await, None);
+}
+
+#[tokio::test]
+async fn termination_and_completion_each_win_when_processed_first() {
+    let mut terminated = controlled_cell(Duration::from_secs(2));
+    start_controlled(&mut terminated).await;
+    terminated.handle.terminate().expect("queue termination");
+    terminated
+        .runtime_events
+        .send(RuntimeEvent::Result {
+            stored_value_writes: HashMap::from([("ignored".to_string(), json!(true))]),
+            error_text: None,
+        })
+        .expect("queue completion after termination");
+    terminated
+        .release_runtime
+        .send(())
+        .expect("release terminated runtime");
+    assert_eq!(
+        next_event(&mut terminated.events).await,
+        CellEvent::Terminated
+    );
+    actor_result(terminated.task)
+        .await
+        .expect("terminated actor should close cleanly");
+
+    let mut completed = controlled_cell(Duration::from_secs(2));
+    start_controlled(&mut completed).await;
+    completed
+        .runtime_events
+        .send(RuntimeEvent::Result {
+            stored_value_writes: HashMap::from([("kept".to_string(), json!(true))]),
+            error_text: None,
+        })
+        .expect("queue completion");
+    tokio::time::timeout(Duration::from_secs(2), completed.runtime_events.closed())
+        .await
+        .expect("actor did not claim completion");
+    assert!(matches!(completed.handle.terminate(), Err(CellClosed)));
+    completed
+        .release_runtime
+        .send(())
+        .expect("release completed runtime");
+    assert_eq!(
+        next_event(&mut completed.events).await,
+        CellEvent::Completed {
+            stored_value_writes: HashMap::from([("kept".to_string(), json!(true))]),
+            error_text: None,
+        }
+    );
+    actor_result(completed.task)
+        .await
+        .expect("completed actor should close cleanly");
+}
+
+#[tokio::test]
+async fn expired_cleanup_deadline_preempts_backlog_and_retains_runtime_owner() {
+    let mut cell = controlled_cell(Duration::ZERO);
+    start_controlled(&mut cell).await;
+    cell.runtime_events
+        .send(RuntimeEvent::Result {
+            stored_value_writes: HashMap::new(),
+            error_text: None,
+        })
+        .expect("queue runtime completion");
+    for _ in 0..10_000 {
+        cell.runtime_events
+            .send(RuntimeEvent::YieldRequested)
+            .expect("queue runtime backlog");
+    }
+    let error = actor_result(cell.task)
+        .await
+        .expect_err("cleanup deadline should fault the actor");
+    assert_eq!(error.kind(), ActorErrorKind::RuntimeCleanupTimedOut);
+    assert!(cell.runtime_active.load(Ordering::Acquire));
+    assert_eq!(cell.events.recv().await, None);
+
+    drop(error);
+    cell.release_runtime
+        .send(())
+        .expect("release retained runtime");
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while cell.runtime_active.load(Ordering::Acquire) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("detached runtime did not exit");
+}
+
+#[tokio::test]
+async fn concurrent_callbacks_accept_results_and_errors_in_any_completion_order() {
+    let mut harness = spawn_cell(
+        r#"
+const [first, second] = await Promise.all([
+  tools.echo({ value: "first" }).catch((error) => error),
+  tools.echo({ value: "second" }),
+]);
+text(JSON.stringify([first, second]));
+"#,
+        vec![echo_tool()],
+    );
+
+    assert_eq!(next_event(&mut harness.events).await, CellEvent::Started);
+    let first = next_event(&mut harness.events).await;
+    let second = next_event(&mut harness.events).await;
+    let CellEvent::ToolCallRequested {
+        id: first_id,
+        input: first_input,
+        ..
+    } = first
+    else {
+        panic!("expected first tool call");
+    };
+    let CellEvent::ToolCallRequested {
+        id: second_id,
+        input: second_input,
+        ..
+    } = second
+    else {
+        panic!("expected second tool call");
+    };
+    assert_eq!(
+        [first_input, second_input],
+        [
+            Some(json!({ "value": "first" })),
+            Some(json!({ "value": "second" })),
+        ]
+    );
+
+    harness
+        .handle
+        .finish_tool_call(second_id, ToolCallOutcome::Result(json!("second")))
+        .expect("finish second tool call");
+    harness
+        .handle
+        .finish_tool_call(first_id, ToolCallOutcome::Error("first failed".to_string()))
+        .expect("finish first tool call");
+
+    assert_eq!(
+        next_event(&mut harness.events).await,
+        CellEvent::OutputText {
+            text: r#"["first failed","second"]"#.to_string(),
+        }
+    );
+    assert_eq!(
+        next_event(&mut harness.events).await,
+        CellEvent::Completed {
+            stored_value_writes: HashMap::new(),
+            error_text: None,
+        }
+    );
+    assert_closed(harness).await;
+}
+
+#[tokio::test]
+async fn termination_wins_after_yield_and_cleans_up_a_pending_timer() {
+    let mut harness = spawn_cell(
+        r#"
+yield_control();
+setTimeout(() => text("late"), 60_000);
+await new Promise(() => {});
+"#,
+        Vec::new(),
+    );
+
+    assert_eq!(next_event(&mut harness.events).await, CellEvent::Started);
+    assert_eq!(
+        next_event(&mut harness.events).await,
+        CellEvent::YieldRequested
+    );
+    harness.handle.terminate().expect("terminate cell");
+    assert_eq!(next_event(&mut harness.events).await, CellEvent::Terminated);
+    assert_closed(harness).await;
+}
+
+#[tokio::test]
+async fn script_failure_preserves_writes_and_does_not_poison_the_next_isolate() {
+    let mut failed = spawn_cell(
+        r#"
+store("beforeFailure", true);
+throw new Error("boom");
+"#,
+        Vec::new(),
+    );
+    assert_eq!(next_event(&mut failed.events).await, CellEvent::Started);
+    let CellEvent::Completed {
+        stored_value_writes,
+        error_text: Some(error_text),
+    } = next_event(&mut failed.events).await
+    else {
+        panic!("expected failed completion");
+    };
+    assert_eq!(
+        stored_value_writes,
+        HashMap::from([("beforeFailure".to_string(), json!(true))])
+    );
+    assert!(error_text.contains("boom"));
+    assert_closed(failed).await;
+
+    let mut healthy = spawn_cell(r#"text("healthy");"#, Vec::new());
+    assert_eq!(next_event(&mut healthy.events).await, CellEvent::Started);
+    assert_eq!(
+        next_event(&mut healthy.events).await,
+        CellEvent::OutputText {
+            text: "healthy".to_string(),
+        }
+    );
+    assert_eq!(
+        next_event(&mut healthy.events).await,
+        CellEvent::Completed {
+            stored_value_writes: HashMap::new(),
+            error_text: None,
+        }
+    );
+    assert_closed(healthy).await;
+}

--- a/codex-rs/code-mode/src/continuing_cell/types.rs
+++ b/codex-rs/code-mode/src/continuing_cell/types.rs
@@ -1,0 +1,248 @@
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+
+use codex_code_mode_protocol::CodeModeToolKind;
+use codex_code_mode_protocol::ExecuteRequest;
+use codex_code_mode_protocol::ImageDetail;
+use codex_code_mode_protocol::ToolDefinition;
+use codex_protocol::ToolName;
+use serde_json::Value as JsonValue;
+use tokio::sync::mpsc;
+
+use crate::runtime::RuntimeThread;
+
+/// Owned future that runs one prepared continuing cell.
+pub type CellTask = Pin<Box<dyn Future<Output = Result<(), ActorError>> + Send + 'static>>;
+
+/// Handle, event stream, and unspawned actor task for one admitted cell.
+pub type PreparedCell = (CellHandle, mpsc::UnboundedReceiver<CellEvent>, CellTask);
+
+/// Input required to start a callback-only continuing cell.
+pub struct CellRequest {
+    tool_call_id: String,
+    enabled_tools: Vec<ToolDefinition>,
+    source: String,
+}
+
+impl CellRequest {
+    pub fn new(
+        tool_call_id: impl Into<String>,
+        enabled_tools: Vec<ToolDefinition>,
+        source: impl Into<String>,
+    ) -> Result<Self, InvalidCellRequest> {
+        let tool_call_id = tool_call_id.into();
+        if tool_call_id.trim().is_empty() {
+            return Err(InvalidCellRequest::EmptyToolCallId);
+        }
+        let source = source.into();
+        if source.trim().is_empty() {
+            return Err(InvalidCellRequest::EmptySource);
+        }
+        Ok(Self {
+            tool_call_id,
+            enabled_tools,
+            source,
+        })
+    }
+
+    pub(super) fn into_runtime_request(self) -> ExecuteRequest {
+        ExecuteRequest {
+            tool_call_id: self.tool_call_id,
+            enabled_tools: self.enabled_tools,
+            source: self.source,
+            yield_time_ms: None,
+            max_output_tokens: None,
+        }
+    }
+}
+
+/// Why a continuing cell request could not be constructed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InvalidCellRequest {
+    EmptyToolCallId,
+    EmptySource,
+}
+
+impl fmt::Display for InvalidCellRequest {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyToolCallId => formatter.write_str("cell tool call ID must not be empty"),
+            Self::EmptySource => formatter.write_str("cell source must not be empty"),
+        }
+    }
+}
+
+impl std::error::Error for InvalidCellRequest {}
+
+/// Failure to initialize the V8 runtime for a continuing cell.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StartError(String);
+
+impl StartError {
+    pub(super) fn new(message: String) -> Self {
+        Self(message)
+    }
+}
+
+impl fmt::Display for StartError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for StartError {}
+
+/// A cell-actor fault that cannot be represented as a normal cell terminal event.
+pub struct ActorError {
+    kind: ActorErrorKind,
+    runtime_thread: Option<RuntimeThread>,
+}
+
+impl ActorError {
+    pub fn kind(&self) -> ActorErrorKind {
+        self.kind
+    }
+
+    pub(super) fn new(kind: ActorErrorKind) -> Self {
+        Self {
+            kind,
+            runtime_thread: None,
+        }
+    }
+
+    pub(super) fn cleanup_timeout(runtime_thread: RuntimeThread) -> Self {
+        Self::retained_runtime(ActorErrorKind::RuntimeCleanupTimedOut, runtime_thread)
+    }
+
+    fn retained_runtime(kind: ActorErrorKind, runtime_thread: RuntimeThread) -> Self {
+        Self {
+            kind,
+            runtime_thread: Some(runtime_thread),
+        }
+    }
+}
+
+impl fmt::Debug for ActorError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ActorError")
+            .field("kind", &self.kind)
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for ActorError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.kind {
+            ActorErrorKind::RuntimeClosedUnexpectedly => {
+                formatter.write_str("continuing cell runtime closed without a terminal event")
+            }
+            ActorErrorKind::RuntimeThreadPanicked => {
+                formatter.write_str("continuing cell runtime thread panicked")
+            }
+            ActorErrorKind::RuntimeCleanupTimedOut => {
+                formatter.write_str("continuing cell runtime cleanup timed out")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ActorError {}
+
+impl Drop for ActorError {
+    fn drop(&mut self) {
+        drop(self.runtime_thread.take());
+    }
+}
+
+/// Actor-task faults for the session supervisor; these are not wire reasons.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ActorErrorKind {
+    RuntimeClosedUnexpectedly,
+    RuntimeThreadPanicked,
+    RuntimeCleanupTimedOut,
+}
+
+/// One ordered event emitted by a continuing cell actor.
+#[derive(Clone, Debug, PartialEq)]
+pub enum CellEvent {
+    Started,
+    OutputText {
+        text: String,
+    },
+    OutputImage {
+        image_url: String,
+        detail: ImageDetail,
+    },
+    Notification {
+        call_id: String,
+        text: String,
+    },
+    YieldRequested,
+    ToolCallRequested {
+        id: String,
+        name: ToolName,
+        kind: CodeModeToolKind,
+        input: Option<JsonValue>,
+    },
+    Completed {
+        stored_value_writes: std::collections::HashMap<String, JsonValue>,
+        error_text: Option<String>,
+    },
+    Terminated,
+}
+
+/// Result supplied for a previously emitted tool callback request.
+#[derive(Debug)]
+pub enum ToolCallOutcome {
+    Result(JsonValue),
+    Error(String),
+}
+
+/// A handle for sending callback results or termination to a cell actor.
+#[derive(Clone)]
+pub struct CellHandle {
+    pub(super) command_tx: mpsc::UnboundedSender<CellCommand>,
+}
+
+impl CellHandle {
+    pub fn finish_tool_call(
+        &self,
+        id: impl Into<String>,
+        outcome: ToolCallOutcome,
+    ) -> Result<(), CellClosed> {
+        self.command_tx
+            .send(CellCommand::FinishToolCall {
+                id: id.into(),
+                outcome,
+            })
+            .map_err(|_| CellClosed)
+    }
+
+    pub fn terminate(&self) -> Result<(), CellClosed> {
+        self.command_tx
+            .send(CellCommand::Terminate)
+            .map_err(|_| CellClosed)
+    }
+}
+
+/// Returned when a command targets an actor that has already closed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CellClosed;
+
+impl fmt::Display for CellClosed {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("continuing cell is closed")
+    }
+}
+
+impl std::error::Error for CellClosed {}
+
+pub(super) enum CellCommand {
+    FinishToolCall {
+        id: String,
+        outcome: ToolCallOutcome,
+    },
+    Terminate,
+}

--- a/codex-rs/code-mode/src/lib.rs
+++ b/codex-rs/code-mode/src/lib.rs
@@ -1,4 +1,5 @@
 mod cell_actor;
+pub mod continuing_cell;
 mod runtime;
 mod service;
 mod session_runtime;

--- a/codex-rs/code-mode/src/runtime/mod.rs
+++ b/codex-rs/code-mode/src/runtime/mod.rs
@@ -33,10 +33,6 @@ pub(crate) enum RuntimeCommand {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum PendingRuntimeMode {
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "used by the stacked continuing cell actor")
-    )]
     Continue,
     PauseUntilResumed,
 }
@@ -76,18 +72,10 @@ pub(crate) struct RuntimeThread {
 }
 
 impl RuntimeThread {
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "used by the stacked continuing cell actor")
-    )]
     pub(crate) async fn wait(&mut self) {
         let _ = (&mut self.completion_rx).await;
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "used by the stacked continuing cell actor")
-    )]
     pub(crate) fn join_finished(&mut self) -> Result<(), RuntimeThreadError> {
         let Some(join_handle) = self.join_handle.take() else {
             return Ok(());
@@ -95,10 +83,6 @@ impl RuntimeThread {
         join_handle.join().map_err(|_| RuntimeThreadError::Panicked)
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "used by the stacked continuing cell actor")
-    )]
     pub(crate) fn join_pending(&self) -> bool {
         self.join_handle.is_some()
     }

--- a/codex-rs/code-mode/src/runtime/mod.rs
+++ b/codex-rs/code-mode/src/runtime/mod.rs
@@ -5,6 +5,7 @@ mod timers;
 mod value;
 
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::OnceLock;
 use std::sync::mpsc as std_mpsc;
 use std::thread;
@@ -17,6 +18,7 @@ use codex_code_mode_protocol::enabled_tool_metadata;
 use codex_protocol::ToolName;
 use serde_json::Value as JsonValue;
 use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 
 const EXIT_SENTINEL: &str = "__codex_code_mode_exit__";
 
@@ -31,7 +33,10 @@ pub(crate) enum RuntimeCommand {
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) enum PendingRuntimeMode {
-    #[cfg(test)]
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "used by the stacked continuing cell actor")
+    )]
     Continue,
     PauseUntilResumed,
 }
@@ -65,6 +70,81 @@ pub(crate) enum RuntimeEvent {
     },
 }
 
+pub(crate) struct RuntimeThread {
+    completion_rx: oneshot::Receiver<()>,
+    join_handle: Option<thread::JoinHandle<()>>,
+}
+
+impl RuntimeThread {
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "used by the stacked continuing cell actor")
+    )]
+    pub(crate) async fn wait(&mut self) {
+        let _ = (&mut self.completion_rx).await;
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "used by the stacked continuing cell actor")
+    )]
+    pub(crate) fn join_finished(&mut self) -> Result<(), RuntimeThreadError> {
+        let Some(join_handle) = self.join_handle.take() else {
+            return Ok(());
+        };
+        join_handle.join().map_err(|_| RuntimeThreadError::Panicked)
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "used by the stacked continuing cell actor")
+    )]
+    pub(crate) fn join_pending(&self) -> bool {
+        self.join_handle.is_some()
+    }
+
+    pub(crate) fn detach(mut self) {
+        drop(self.join_handle.take());
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum RuntimeThreadError {
+    Panicked,
+}
+
+impl fmt::Display for RuntimeThreadError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Panicked => formatter.write_str("code mode runtime thread panicked"),
+        }
+    }
+}
+
+impl std::error::Error for RuntimeThreadError {}
+
+struct RuntimeCompletionGuard(Option<oneshot::Sender<()>>);
+
+impl Drop for RuntimeCompletionGuard {
+    fn drop(&mut self) {
+        if let Some(completion_tx) = self.0.take() {
+            let _ = completion_tx.send(());
+        }
+    }
+}
+
+pub(crate) fn spawn_runtime_thread(run: impl FnOnce() + Send + 'static) -> RuntimeThread {
+    let (completion_tx, completion_rx) = oneshot::channel();
+    let join_handle = thread::spawn(move || {
+        let _completion_guard = RuntimeCompletionGuard(Some(completion_tx));
+        run();
+    });
+    RuntimeThread {
+        completion_rx,
+        join_handle: Some(join_handle),
+    }
+}
+
 pub(crate) fn spawn_runtime(
     stored_values: HashMap<String, JsonValue>,
     request: ExecuteRequest,
@@ -75,6 +155,26 @@ pub(crate) fn spawn_runtime(
         std_mpsc::Sender<RuntimeCommand>,
         std_mpsc::Sender<RuntimeControlCommand>,
         v8::IsolateHandle,
+    ),
+    String,
+> {
+    let (command_tx, control_tx, isolate_handle, runtime_thread) =
+        spawn_owned_runtime(stored_values, request, event_tx, pending_mode)?;
+    runtime_thread.detach();
+    Ok((command_tx, control_tx, isolate_handle))
+}
+
+pub(crate) fn spawn_owned_runtime(
+    stored_values: HashMap<String, JsonValue>,
+    request: ExecuteRequest,
+    event_tx: mpsc::UnboundedSender<RuntimeEvent>,
+    pending_mode: PendingRuntimeMode,
+) -> Result<
+    (
+        std_mpsc::Sender<RuntimeCommand>,
+        std_mpsc::Sender<RuntimeControlCommand>,
+        v8::IsolateHandle,
+        RuntimeThread,
     ),
     String,
 > {
@@ -96,22 +196,24 @@ pub(crate) fn spawn_runtime(
         stored_values,
     };
 
-    thread::spawn(move || {
+    let runtime_thread = spawn_runtime_thread(move || {
         run_runtime(
             config,
-            event_tx,
-            command_rx,
-            control_rx,
+            RuntimeChannels {
+                event_tx,
+                command_rx,
+                control_rx,
+                isolate_handle_tx,
+                runtime_command_tx,
+            },
             pending_mode,
-            isolate_handle_tx,
-            runtime_command_tx,
         );
     });
 
     let isolate_handle = isolate_handle_rx
         .recv()
         .map_err(|_| "failed to initialize code mode runtime".to_string())?;
-    Ok((command_tx, control_tx, isolate_handle))
+    Ok((command_tx, control_tx, isolate_handle, runtime_thread))
 }
 
 #[derive(Clone)]
@@ -120,6 +222,14 @@ struct RuntimeConfig {
     enabled_tools: Vec<EnabledToolMetadata>,
     source: String,
     stored_values: HashMap<String, JsonValue>,
+}
+
+struct RuntimeChannels {
+    event_tx: mpsc::UnboundedSender<RuntimeEvent>,
+    command_rx: std_mpsc::Receiver<RuntimeCommand>,
+    control_rx: std_mpsc::Receiver<RuntimeControlCommand>,
+    isolate_handle_tx: std_mpsc::SyncSender<v8::IsolateHandle>,
+    runtime_command_tx: std_mpsc::Sender<RuntimeCommand>,
 }
 
 pub(super) struct RuntimeState {
@@ -160,15 +270,14 @@ fn initialize_v8() -> Result<(), String> {
     }
 }
 
-fn run_runtime(
-    config: RuntimeConfig,
-    event_tx: mpsc::UnboundedSender<RuntimeEvent>,
-    command_rx: std_mpsc::Receiver<RuntimeCommand>,
-    control_rx: std_mpsc::Receiver<RuntimeControlCommand>,
-    pending_mode: PendingRuntimeMode,
-    isolate_handle_tx: std_mpsc::SyncSender<v8::IsolateHandle>,
-    runtime_command_tx: std_mpsc::Sender<RuntimeCommand>,
-) {
+fn run_runtime(config: RuntimeConfig, channels: RuntimeChannels, pending_mode: PendingRuntimeMode) {
+    let RuntimeChannels {
+        event_tx,
+        command_rx,
+        control_rx,
+        isolate_handle_tx,
+        runtime_command_tx,
+    } = channels;
     let isolate = &mut v8::Isolate::new(v8::CreateParams::default());
     let isolate_handle = isolate.thread_safe_handle();
     if isolate_handle_tx.send(isolate_handle).is_err() {
@@ -287,7 +396,6 @@ fn next_runtime_command(
 
         let _ = event_tx.send(RuntimeEvent::Pending);
         match pending_mode {
-            #[cfg(test)]
             PendingRuntimeMode::Continue => return command_rx.recv().ok(),
             PendingRuntimeMode::PauseUntilResumed => match control_rx.recv().ok()? {
                 RuntimeControlCommand::Continue => return command_rx.recv().ok(),
@@ -335,6 +443,7 @@ mod tests {
     use super::RuntimeCommand;
     use super::RuntimeControlCommand;
     use super::RuntimeEvent;
+    use super::spawn_owned_runtime;
     use super::spawn_runtime;
     use crate::FunctionCallOutputContentItem;
 
@@ -346,6 +455,37 @@ mod tests {
             yield_time_ms: Some(1),
             max_output_tokens: None,
         }
+    }
+
+    #[tokio::test]
+    async fn owned_runtime_joins_after_completion() {
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let (_runtime_tx, _runtime_control_tx, _runtime_terminate_handle, mut runtime_thread) =
+            spawn_owned_runtime(
+                HashMap::new(),
+                execute_request(r#"text("runtime output");"#),
+                event_tx,
+                PendingRuntimeMode::Continue,
+            )
+            .unwrap();
+
+        assert!(matches!(event_rx.recv().await, Some(RuntimeEvent::Started)));
+        assert!(runtime_thread.join_pending());
+        assert!(matches!(
+            event_rx.recv().await,
+            Some(RuntimeEvent::ContentItem(
+                FunctionCallOutputContentItem::InputText { .. }
+            ))
+        ));
+        assert!(matches!(
+            event_rx.recv().await,
+            Some(RuntimeEvent::Result { .. })
+        ));
+        assert!(event_rx.recv().await.is_none());
+
+        runtime_thread.wait().await;
+        assert_eq!(runtime_thread.join_finished(), Ok(()));
+        assert!(!runtime_thread.join_pending());
     }
 
     #[tokio::test]

--- a/codex-rs/code-mode/src/runtime/timers.rs
+++ b/codex-rs/code-mode/src/runtime/timers.rs
@@ -1,5 +1,10 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 use std::thread;
+use std::thread::JoinHandle;
 use std::time::Duration;
+use std::time::Instant;
 
 use super::RuntimeCommand;
 use super::RuntimeState;
@@ -7,6 +12,22 @@ use super::value::value_to_error_text;
 
 pub(super) struct ScheduledTimeout {
     callback: v8::Global<v8::Function>,
+    timer: TimerThread,
+}
+
+struct TimerThread {
+    cancelled: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl Drop for TimerThread {
+    fn drop(&mut self) {
+        self.cancelled.store(true, Ordering::Release);
+        if let Some(handle) = self.handle.take() {
+            handle.thread().unpark();
+            let _ = handle.join();
+        }
+    }
 }
 
 pub(super) fn schedule_timeout(
@@ -33,13 +54,30 @@ pub(super) fn schedule_timeout(
     let timeout_id = state.next_timeout_id;
     state.next_timeout_id = state.next_timeout_id.saturating_add(1);
     let runtime_command_tx = state.runtime_command_tx.clone();
-    state
-        .pending_timeouts
-        .insert(timeout_id, ScheduledTimeout { callback });
-    thread::spawn(move || {
-        thread::sleep(Duration::from_millis(delay_ms));
-        let _ = runtime_command_tx.send(RuntimeCommand::TimeoutFired { id: timeout_id });
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let thread_cancelled = Arc::clone(&cancelled);
+    let delay = Duration::from_millis(delay_ms);
+    let handle = thread::spawn(move || {
+        let started_at = Instant::now();
+        while !thread_cancelled.load(Ordering::Acquire) {
+            let remaining = delay.saturating_sub(started_at.elapsed());
+            if remaining.is_zero() {
+                let _ = runtime_command_tx.send(RuntimeCommand::TimeoutFired { id: timeout_id });
+                break;
+            }
+            thread::park_timeout(remaining);
+        }
     });
+    state.pending_timeouts.insert(
+        timeout_id,
+        ScheduledTimeout {
+            callback,
+            timer: TimerThread {
+                cancelled,
+                handle: Some(handle),
+            },
+        },
+    );
 
     Ok(timeout_id)
 }
@@ -69,13 +107,17 @@ pub(super) fn invoke_timeout_callback(
             .ok_or_else(|| "runtime state unavailable".to_string())?;
         state.pending_timeouts.remove(&timeout_id)
     };
-    let Some(callback) = callback else {
+    let Some(ScheduledTimeout {
+        callback,
+        timer: _timer,
+    }) = callback
+    else {
         return Ok(());
     };
 
     let tc = std::pin::pin!(v8::TryCatch::new(scope));
     let mut tc = tc.init();
-    let callback = v8::Local::new(&tc, &callback.callback);
+    let callback = v8::Local::new(&tc, &callback);
     let receiver = v8::undefined(&tc).into();
     let _ = callback.call(&tc, receiver, &[]);
     if tc.has_caught() {


### PR DESCRIPTION
## Summary

- add a callback-only continuing cell actor beside the legacy actor
- emit ordered started, output, notification, yield, callback, and terminal events
- allow termination or runtime initialization failure to produce a direct terminal event before `CellEvent::Started`
- reject nonterminal runtime events before `CellEvent::Started`
- accept callback results, callback errors, and explicit termination
- arbitrate completion, termination, and cleanup races with one absolute deadline
- preserve stored-value write extraction and keep actor faults out of the wire vocabulary
- add deterministic behavior tests for callback, terminal, cleanup, startup, and failure races

## Why

Provide and test the new callback focused ContinuingCellActor.  This purposely is a standalone actor that does not impact the current legacy actor that we use for the tools currently.

## Stack

- Parent: #29565
- This PR: continuing cell actor

## Validation

- `just test -p codex-code-mode` (60 tests)
- `just fix -p codex-code-mode`
- `just fmt`

The legacy `cell_actor` source remains unchanged.