### PR TITLE
Handle additional tools in image URL validation

### DIFF
--- a/codex-rs/app-server/src/request_processors/turn_processor.rs
+++ b/codex-rs/app-server/src/request_processors/turn_processor.rs
@@ -58,6 +58,7 @@ fn validate_response_item_image_urls(items: &[ResponseItem]) -> Result<(), JSONR
         | ResponseItem::Compaction { .. }
         | ResponseItem::CompactionTrigger { .. }
         | ResponseItem::ContextCompaction { .. }
+        | ResponseItem::AdditionalTools { .. }
         | ResponseItem::Other => false,
     }) {
         return Err(invalid_request(REMOTE_IMAGE_URL_ERROR));


### PR DESCRIPTION
## Why

`ResponseItem::AdditionalTools` was added without updating app-server image URL validation. The exhaustive match therefore prevents app-server and downstream targets from compiling on `main`.

## What changed

Treat `AdditionalTools` like the other response items that cannot contain input-image URLs.