### PR TITLE
path-uri: add lexical containment

### DIFF
--- a/codex-rs/utils/path-uri/src/lib.rs
+++ b/codex-rs/utils/path-uri/src/lib.rs
@@ -247,6 +247,33 @@ impl PathUri {
         std::iter::successors(Some(self.clone()), Self::parent)
     }
 
+    /// Returns true when this URI is lexically equal to or below `base`.
+    ///
+    /// Containment is computed using URI authority and path-segment boundaries,
+    /// without consulting the host filesystem. Percent-encoded path separators
+    /// fail closed because native path conversion may interpret them as segment
+    /// boundaries. Opaque fallback URIs created by [`Self::from_abs_path`] only
+    /// contain themselves.
+    pub fn starts_with(&self, base: &Self) -> bool {
+        if self == base {
+            return true;
+        }
+        if decode_bad_path_uri(&self.0).is_some() || decode_bad_path_uri(&base.0).is_some() {
+            return false;
+        }
+        if self.0.host_str() != base.0.host_str() {
+            return false;
+        }
+
+        let Some(path_segments) = containment_path_segments(&self.0) else {
+            return false;
+        };
+        let Some(base_segments) = containment_path_segments(&base.0) else {
+            return false;
+        };
+        path_segments.starts_with(&base_segments)
+    }
+
     /// Lexically resolves native absolute or relative path text against this URI.
     ///
     /// Path text is interpreted using the POSIX or Windows convention inferred
@@ -540,6 +567,19 @@ fn decode_bad_path_uri(url: &Url) -> Option<Vec<u8>> {
 
 fn is_windows_drive_uri_segment(segment: &str) -> bool {
     matches!(segment.as_bytes(), [drive, b':'] if drive.is_ascii_alphabetic())
+}
+
+fn containment_path_segments(url: &Url) -> Option<Vec<&str>> {
+    let segments = url
+        .path_segments()?
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+    (!segments.iter().any(|segment| {
+        urlencoding::decode_binary(segment.as_bytes())
+            .iter()
+            .any(|byte| matches!(*byte, b'/' | b'\\'))
+    }))
+    .then_some(segments)
 }
 
 fn infer_opaque_path_convention(path_bytes: &[u8]) -> Option<PathConvention> {

--- a/codex-rs/utils/path-uri/src/tests.rs
+++ b/codex-rs/utils/path-uri/src/tests.rs
@@ -283,9 +283,16 @@ fn structurally_valid_bad_path_uri_with_invalid_native_payload_fails_conversion(
 fn bad_path_uris_are_opaque_to_lexical_operations() {
     let uri = PathUri::parse("file:///%00/bad/path/YQ")
         .expect("canonical base64 fallback URI should parse");
+    let other = PathUri::parse("file:///%00/bad/path/Yg")
+        .expect("canonical base64 fallback URI should parse");
+    let root = PathUri::parse("file:///").expect("valid root URI");
 
     assert_eq!(uri.basename(), None);
     assert_eq!(uri.parent(), None);
+    assert!(uri.starts_with(&uri));
+    assert!(!uri.starts_with(&root));
+    assert!(!uri.starts_with(&other));
+    assert!(!other.starts_with(&uri));
     assert_eq!(uri.join(""), Ok(uri.clone()));
     assert_eq!(
         uri.join("child"),
@@ -695,6 +702,58 @@ fn join_uses_the_base_uri_path_convention() {
         let base = PathUri::parse(base).expect("valid base URI");
         let expected = PathUri::parse(expected).expect("valid expected URI");
         assert_eq!(base.join(path), Ok(expected), "joining {path}");
+    }
+}
+
+#[test]
+fn starts_with_uses_uri_segment_boundaries() {
+    for (path, base, expected) in [
+        ("file:///workspace/plugin", "file:///", true),
+        ("file:///workspace/plugin", "file:///workspace/plugin", true),
+        (
+            "file:///workspace/plugin/assets/icon.svg",
+            "file:///workspace/plugin",
+            true,
+        ),
+        (
+            "file:///workspace/plugin-other/icon.svg",
+            "file:///workspace/plugin",
+            false,
+        ),
+        (
+            "file:///C:/plugins/foo/assets/icon.svg",
+            "file:///C:/plugins/foo",
+            true,
+        ),
+        (
+            "file:///C:/plugins/foo2/assets/icon.svg",
+            "file:///C:/plugins/foo",
+            false,
+        ),
+        (
+            "file://server/share/plugins/foo/icon.svg",
+            "file://server/share/plugins/foo",
+            true,
+        ),
+        (
+            "file://other/share/plugins/foo/icon.svg",
+            "file://server/share/plugins/foo",
+            false,
+        ),
+        (
+            "file:///workspace/plugin/%2F..%2Foutside",
+            "file:///workspace/plugin",
+            false,
+        ),
+        (
+            "file:///workspace/plugin/%5C..%5Coutside",
+            "file:///workspace/plugin",
+            false,
+        ),
+    ] {
+        let path = PathUri::parse(path).expect("valid path URI");
+        let base = PathUri::parse(base).expect("valid base URI");
+        assert_eq!(path.starts_with(&base), expected);
     }
 }
 


### PR DESCRIPTION
## Why

Executor-owned paths must remain portable while the orchestrator validates them. Converting a Windows or remote path into the orchestrator host's native `Path` just to check containment applies the wrong filesystem rules.

This PR adds the lexical containment primitive needed by the URI-native plugin stack.

## What changed

- Add `PathUri::starts_with` for lexical equality and containment.
- Compare URI authorities and complete path segments, so `plugin-other` is not treated as a child of `plugin`.
- Fail closed for encoded native path separators.
- Treat opaque fallback URIs as containing only themselves.
- Cover POSIX, Windows drive, UNC, authority, segment-boundary, encoded-separator, and opaque URI cases.

```text
file:///C:/plugins/foo/assets/icon.svg
  is below file:///C:/plugins/foo

file:///C:/plugins/foo2/icon.svg
  is not below file:///C:/plugins/foo
```

## Stack

1. **This PR** — add lexical `PathUri` containment.
2. #29620 — make manifest path resolution URI-native through one shared parser.
3. #28918 — keep selected plugin roots and resources URI-native.
4. #29626 — load executor skills without host path conversion.
5. #29628 — resolve executor MCP working directories without host path conversion.
