### PR TITLE
Decouple plugin manifest path resolution

### DIFF
--- a/codex-rs/core-plugins/src/manifest.rs
+++ b/codex-rs/core-plugins/src/manifest.rs
@@ -1,10 +1,11 @@
 use codex_config::HooksFile;
 use codex_utils_absolute_path::AbsolutePathBuf;
+use codex_utils_path_uri::PathConvention;
+use codex_utils_path_uri::PathUri;
 use codex_utils_plugins::find_plugin_manifest_path;
 use serde::Deserialize;
 use serde_json::Value as JsonValue;
 use std::fs;
-use std::path::Component;
 use std::path::Path;
 const MAX_DEFAULT_PROMPT_COUNT: usize = 3;
 const MAX_DEFAULT_PROMPT_LEN: usize = 128;
@@ -15,6 +16,8 @@ pub type PluginManifestInterface = codex_plugin::manifest::PluginManifestInterfa
 pub type PluginManifestMcpServers =
     codex_plugin::manifest::PluginManifestMcpServers<AbsolutePathBuf>;
 pub type PluginManifestPaths = codex_plugin::manifest::PluginManifestPaths<AbsolutePathBuf>;
+
+pub(crate) type UriPluginManifest = codex_plugin::manifest::PluginManifest<PathUri>;
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -141,58 +144,19 @@ pub(crate) fn parse_plugin_manifest(
     manifest_path: &Path,
     contents: &str,
 ) -> Result<PluginManifest, serde_json::Error> {
-    let resolver = HostManifestResourceResolver {
-        plugin_root,
-        manifest_path,
-    };
-    parse_plugin_manifest_with_resolver(&resolver, contents)
+    let plugin_root_uri =
+        PathUri::from_host_native_path(plugin_root).map_err(serde_json::Error::io)?;
+    let manifest_path_uri =
+        PathUri::from_host_native_path(manifest_path).map_err(serde_json::Error::io)?;
+    parse_plugin_manifest_uri(&plugin_root_uri, &manifest_path_uri, contents)?
+        .try_map_resources(|path| path.to_abs_path().map_err(serde_json::Error::io))
 }
 
-/// Separates manifest decoding from filesystem-specific resource resolution.
-///
-/// Implementations interpret manifest-relative paths using the convention of
-/// the filesystem that owns the plugin root. They must reject paths that are
-/// invalid for that convention or lexically escape the plugin root, and supply
-/// source-appropriate values for fallback naming and diagnostics.
-trait ManifestResourceResolver {
-    type Resource;
-
-    fn plugin_name_fallback(&self) -> Option<String>;
-    fn manifest_path_for_warning(&self) -> String;
-    fn resolve_path(&self, field: &'static str, path: Option<&str>) -> Option<Self::Resource>;
-}
-
-struct HostManifestResourceResolver<'a> {
-    plugin_root: &'a Path,
-    manifest_path: &'a Path,
-}
-
-impl ManifestResourceResolver for HostManifestResourceResolver<'_> {
-    type Resource = AbsolutePathBuf;
-
-    fn plugin_name_fallback(&self) -> Option<String> {
-        self.plugin_root
-            .file_name()
-            .and_then(|entry| entry.to_str())
-            .map(str::to_string)
-    }
-
-    fn manifest_path_for_warning(&self) -> String {
-        self.manifest_path.display().to_string()
-    }
-
-    fn resolve_path(&self, field: &'static str, path: Option<&str>) -> Option<Self::Resource> {
-        resolve_manifest_path(self.plugin_root, field, path)
-    }
-}
-
-fn parse_plugin_manifest_with_resolver<R>(
-    resolver: &R,
+pub(crate) fn parse_plugin_manifest_uri(
+    plugin_root: &PathUri,
+    manifest_path: &PathUri,
     contents: &str,
-) -> Result<codex_plugin::manifest::PluginManifest<R::Resource>, serde_json::Error>
-where
-    R: ManifestResourceResolver,
-{
+) -> Result<UriPluginManifest, serde_json::Error> {
     let RawPluginManifest {
         name: raw_name,
         version,
@@ -204,11 +168,11 @@ where
         hooks,
         interface,
     } = serde_json::from_str::<RawPluginManifest>(contents)?;
-    let name = resolver
-        .plugin_name_fallback()
+    let name = plugin_root
+        .basename()
         .filter(|_| raw_name.trim().is_empty())
         .unwrap_or(raw_name);
-    let manifest_path_for_warning = resolver.manifest_path_for_warning();
+    let manifest_path_for_warning = manifest_path.to_string();
     let version = version.and_then(|version| {
         let version = version.trim();
         (!version.is_empty()).then(|| version.to_string())
@@ -248,13 +212,13 @@ where
             ),
             brand_color,
             composer_icon: resolve_interface_asset_path(
-                resolver,
+                plugin_root,
                 "interface.composerIcon",
                 composer_icon.as_deref(),
             ),
-            logo: resolve_interface_asset_path(resolver, "interface.logo", logo.as_deref()),
+            logo: resolve_interface_asset_path(plugin_root, "interface.logo", logo.as_deref()),
             logo_dark: resolve_interface_asset_path(
-                resolver,
+                plugin_root,
                 "interface.logoDark",
                 logo_dark.as_deref(),
             ),
@@ -262,7 +226,7 @@ where
                 .iter()
                 .filter_map(|screenshot| {
                     resolve_interface_asset_path(
-                        resolver,
+                        plugin_root,
                         "interface.screenshots",
                         Some(screenshot),
                     )
@@ -294,30 +258,28 @@ where
         description,
         keywords,
         paths: codex_plugin::manifest::PluginManifestPaths {
-            skills: resolve_manifest_paths(resolver, "skills", skills.as_ref()),
-            mcp_servers: resolve_manifest_mcp_servers(resolver, mcp_servers),
-            apps: resolver.resolve_path("apps", apps.as_deref()),
-            hooks: resolve_manifest_hooks(resolver, hooks),
+            skills: resolve_manifest_paths(plugin_root, "skills", skills.as_ref()),
+            mcp_servers: resolve_manifest_mcp_servers(plugin_root, mcp_servers),
+            apps: resolve_manifest_path(plugin_root, "apps", apps.as_deref()),
+            hooks: resolve_manifest_hooks(plugin_root, hooks),
         },
         interface,
     })
 }
 
-fn resolve_manifest_hooks<R>(
-    resolver: &R,
+fn resolve_manifest_hooks(
+    plugin_root: &PathUri,
     hooks: Option<RawPluginManifestHooks>,
-) -> Option<codex_plugin::manifest::PluginManifestHooks<R::Resource>>
-where
-    R: ManifestResourceResolver,
-{
+) -> Option<codex_plugin::manifest::PluginManifestHooks<PathUri>> {
     match hooks? {
-        RawPluginManifestHooks::Path(path) => resolver
-            .resolve_path("hooks", Some(&path))
-            .map(|path| codex_plugin::manifest::PluginManifestHooks::Paths(vec![path])),
+        RawPluginManifestHooks::Path(path) => {
+            resolve_manifest_path(plugin_root, "hooks", Some(&path))
+                .map(|path| codex_plugin::manifest::PluginManifestHooks::Paths(vec![path]))
+        }
         RawPluginManifestHooks::Paths(paths) => {
             let hooks = paths
                 .iter()
-                .filter_map(|path| resolver.resolve_path("hooks", Some(path)))
+                .filter_map(|path| resolve_manifest_path(plugin_root, "hooks", Some(path)))
                 .collect::<Vec<_>>();
             (!hooks.is_empty()).then_some(codex_plugin::manifest::PluginManifestHooks::Paths(hooks))
         }
@@ -338,17 +300,15 @@ where
     }
 }
 
-fn resolve_manifest_mcp_servers<R>(
-    resolver: &R,
+fn resolve_manifest_mcp_servers(
+    plugin_root: &PathUri,
     mcp_servers: Option<RawPluginManifestMcpServers>,
-) -> Option<codex_plugin::manifest::PluginManifestMcpServers<R::Resource>>
-where
-    R: ManifestResourceResolver,
-{
+) -> Option<codex_plugin::manifest::PluginManifestMcpServers<PathUri>> {
     match mcp_servers? {
-        RawPluginManifestMcpServers::Path(path) => resolver
-            .resolve_path("mcpServers", Some(&path))
-            .map(codex_plugin::manifest::PluginManifestMcpServers::Path),
+        RawPluginManifestMcpServers::Path(path) => {
+            resolve_manifest_path(plugin_root, "mcpServers", Some(&path))
+                .map(codex_plugin::manifest::PluginManifestMcpServers::Path)
+        }
         RawPluginManifestMcpServers::Object(servers) => match serde_json::to_string(&servers) {
             Ok(servers) => Some(codex_plugin::manifest::PluginManifestMcpServers::Object(
                 servers,
@@ -368,15 +328,12 @@ where
     }
 }
 
-fn resolve_interface_asset_path<R>(
-    resolver: &R,
+fn resolve_interface_asset_path(
+    plugin_root: &PathUri,
     field: &'static str,
     path: Option<&str>,
-) -> Option<R::Resource>
-where
-    R: ManifestResourceResolver,
-{
-    resolver.resolve_path(field, path)
+) -> Option<PathUri> {
+    resolve_manifest_path(plugin_root, field, path)
 }
 
 fn resolve_default_prompts(
@@ -468,22 +425,20 @@ fn json_value_type(value: &JsonValue) -> &'static str {
     }
 }
 
-fn resolve_manifest_paths<R>(
-    resolver: &R,
+fn resolve_manifest_paths(
+    plugin_root: &PathUri,
     field: &'static str,
     paths: Option<&RawPluginManifestPaths>,
-) -> Vec<R::Resource>
-where
-    R: ManifestResourceResolver,
-{
+) -> Vec<PathUri> {
     match paths {
-        Some(RawPluginManifestPaths::Path(path)) => resolver
-            .resolve_path(field, Some(path))
-            .map(|path| vec![path])
-            .unwrap_or_default(),
+        Some(RawPluginManifestPaths::Path(path)) => {
+            resolve_manifest_path(plugin_root, field, Some(path))
+                .map(|path| vec![path])
+                .unwrap_or_default()
+        }
         Some(RawPluginManifestPaths::Paths(paths)) => paths
             .iter()
-            .filter_map(|path| resolver.resolve_path(field, Some(path)))
+            .filter_map(|path| resolve_manifest_path(plugin_root, field, Some(path)))
             .collect(),
         Some(RawPluginManifestPaths::Invalid(value)) => {
             tracing::warn!(
@@ -497,12 +452,10 @@ where
 }
 
 fn resolve_manifest_path(
-    plugin_root: &Path,
+    plugin_root: &PathUri,
     field: &'static str,
     path: Option<&str>,
-) -> Option<AbsolutePathBuf> {
-    // `plugin.json` paths are required to be relative to the plugin root and we return the
-    // normalized absolute path to the rest of the system.
+) -> Option<PathUri> {
     let path = path?;
     if path.is_empty() {
         return None;
@@ -516,27 +469,40 @@ fn resolve_manifest_path(
         return None;
     }
 
-    let mut normalized = std::path::PathBuf::new();
-    for component in Path::new(relative_path).components() {
-        match component {
-            Component::Normal(component) => normalized.push(component),
-            Component::ParentDir => {
-                tracing::warn!("ignoring {field}: path must not contain '..'");
-                return None;
-            }
-            _ => {
-                tracing::warn!("ignoring {field}: path must stay within the plugin root");
-                return None;
-            }
+    let convention = plugin_root.infer_path_convention();
+    let has_parent_component = match convention {
+        Some(PathConvention::Windows) => relative_path
+            .split(['/', '\\'])
+            .any(|component| component == ".."),
+        Some(PathConvention::Posix) | None => {
+            relative_path.split('/').any(|component| component == "..")
         }
+    };
+    if has_parent_component {
+        tracing::warn!("ignoring {field}: path must not contain '..'");
+        return None;
     }
 
-    AbsolutePathBuf::try_from(plugin_root.join(normalized))
-        .map_err(|err| {
-            tracing::warn!("ignoring {field}: path must resolve to an absolute path: {err}");
-            err
-        })
-        .ok()
+    let has_windows_root = convention == Some(PathConvention::Windows)
+        && (relative_path.starts_with('\\')
+            || matches!(relative_path.as_bytes(), [drive, b':', ..] if drive.is_ascii_alphabetic()));
+    if relative_path.starts_with('/') || has_windows_root {
+        tracing::warn!("ignoring {field}: path must stay within the plugin root");
+        return None;
+    }
+
+    let resolved = match plugin_root.join(relative_path) {
+        Ok(resolved) => resolved,
+        Err(err) => {
+            tracing::warn!("ignoring {field}: path must resolve under plugin root: {err}");
+            return None;
+        }
+    };
+    if !resolved.starts_with(plugin_root) {
+        tracing::warn!("ignoring {field}: path must stay within the plugin root");
+        return None;
+    }
+    Some(resolved)
 }
 
 #[cfg(test)]
@@ -551,6 +517,7 @@ mod tests {
     use codex_protocol::capabilities::CapabilityRootLocation;
     use codex_protocol::capabilities::SelectedCapabilityRoot;
     use codex_utils_absolute_path::AbsolutePathBuf;
+    use codex_utils_path_uri::PathUri;
     use pretty_assertions::assert_eq;
     use std::fs;
     use std::path::Path;
@@ -758,6 +725,46 @@ mod tests {
                 .and_then(|interface| interface.display_name.as_deref()),
             Some("Fallback Plugin")
         );
+    }
+
+    #[test]
+    fn uri_manifest_uses_the_root_path_convention() {
+        let windows_root =
+            PathUri::parse("file:///C:/plugins/demo-plugin").expect("Windows plugin root URI");
+        let posix_root =
+            PathUri::parse("file:///plugins/demo-plugin").expect("POSIX plugin root URI");
+        let composer_icon = r"./assets\..\icon.svg";
+
+        assert_eq!(parse_uri_composer_icon(&windows_root, composer_icon), None);
+        assert_eq!(
+            parse_uri_composer_icon(&posix_root, composer_icon),
+            Some(
+                posix_root
+                    .join(r"assets\..\icon.svg")
+                    .expect("composer icon URI")
+            )
+        );
+    }
+
+    fn parse_uri_composer_icon(plugin_root: &PathUri, composer_icon: &str) -> Option<PathUri> {
+        let manifest_path = plugin_root
+            .join(".codex-plugin/plugin.json")
+            .expect("manifest URI");
+        let composer_icon_json =
+            serde_json::to_string(composer_icon).expect("serialize composer icon");
+        let contents = format!(
+            r#"{{
+  "name": "demo-plugin",
+  "interface": {{
+    "displayName": "Demo Plugin",
+    "composerIcon": {composer_icon_json}
+  }}
+}}"#
+        );
+        super::parse_plugin_manifest_uri(plugin_root, &manifest_path, &contents)
+            .expect("URI manifest")
+            .interface
+            .and_then(|interface| interface.composer_icon)
     }
 
     #[tokio::test]

--- a/codex-rs/core-plugins/src/manifest.rs
+++ b/codex-rs/core-plugins/src/manifest.rs
@@ -148,6 +148,12 @@ pub(crate) fn parse_plugin_manifest(
     parse_plugin_manifest_with_resolver(&resolver, contents)
 }
 
+/// Separates manifest decoding from filesystem-specific resource resolution.
+///
+/// Implementations interpret manifest-relative paths using the convention of
+/// the filesystem that owns the plugin root. They must reject paths that are
+/// invalid for that convention or lexically escape the plugin root, and supply
+/// source-appropriate values for fallback naming and diagnostics.
 trait ManifestResourceResolver {
     type Resource;
 

--- a/codex-rs/core-plugins/src/manifest.rs
+++ b/codex-rs/core-plugins/src/manifest.rs
@@ -454,7 +454,7 @@ fn resolve_default_prompt_str(manifest_path: &str, field: &str, prompt: &str) ->
 }
 
 fn warn_invalid_default_prompt(manifest_path: &str, field: &str, message: &str) {
-    tracing::warn!(path = manifest_path, "ignoring {field}: {message}");
+    tracing::warn!(path = %manifest_path, "ignoring {field}: {message}");
 }
 
 fn json_value_type(value: &JsonValue) -> &'static str {

--- a/codex-rs/core-plugins/src/manifest.rs
+++ b/codex-rs/core-plugins/src/manifest.rs
@@ -141,6 +141,52 @@ pub(crate) fn parse_plugin_manifest(
     manifest_path: &Path,
     contents: &str,
 ) -> Result<PluginManifest, serde_json::Error> {
+    let resolver = HostManifestResourceResolver {
+        plugin_root,
+        manifest_path,
+    };
+    parse_plugin_manifest_with_resolver(&resolver, contents)
+}
+
+trait ManifestResourceResolver {
+    type Resource;
+
+    fn plugin_name_fallback(&self) -> Option<String>;
+    fn manifest_path_for_warning(&self) -> String;
+    fn resolve_path(&self, field: &'static str, path: Option<&str>) -> Option<Self::Resource>;
+}
+
+struct HostManifestResourceResolver<'a> {
+    plugin_root: &'a Path,
+    manifest_path: &'a Path,
+}
+
+impl ManifestResourceResolver for HostManifestResourceResolver<'_> {
+    type Resource = AbsolutePathBuf;
+
+    fn plugin_name_fallback(&self) -> Option<String> {
+        self.plugin_root
+            .file_name()
+            .and_then(|entry| entry.to_str())
+            .map(str::to_string)
+    }
+
+    fn manifest_path_for_warning(&self) -> String {
+        self.manifest_path.display().to_string()
+    }
+
+    fn resolve_path(&self, field: &'static str, path: Option<&str>) -> Option<Self::Resource> {
+        resolve_manifest_path(self.plugin_root, field, path)
+    }
+}
+
+fn parse_plugin_manifest_with_resolver<R>(
+    resolver: &R,
+    contents: &str,
+) -> Result<codex_plugin::manifest::PluginManifest<R::Resource>, serde_json::Error>
+where
+    R: ManifestResourceResolver,
+{
     let RawPluginManifest {
         name: raw_name,
         version,
@@ -152,12 +198,11 @@ pub(crate) fn parse_plugin_manifest(
         hooks,
         interface,
     } = serde_json::from_str::<RawPluginManifest>(contents)?;
-    let name = plugin_root
-        .file_name()
-        .and_then(|entry| entry.to_str())
+    let name = resolver
+        .plugin_name_fallback()
         .filter(|_| raw_name.trim().is_empty())
-        .unwrap_or(&raw_name)
-        .to_string();
+        .unwrap_or(raw_name);
+    let manifest_path_for_warning = resolver.manifest_path_for_warning();
     let version = version.and_then(|version| {
         let version = version.trim();
         (!version.is_empty()).then(|| version.to_string())
@@ -181,7 +226,7 @@ pub(crate) fn parse_plugin_manifest(
             screenshots,
         } = interface;
 
-        let interface = PluginManifestInterface {
+        let interface = codex_plugin::manifest::PluginManifestInterface {
             display_name,
             short_description,
             long_description,
@@ -191,16 +236,19 @@ pub(crate) fn parse_plugin_manifest(
             website_url,
             privacy_policy_url,
             terms_of_service_url,
-            default_prompt: resolve_default_prompts(manifest_path, default_prompt.as_ref()),
+            default_prompt: resolve_default_prompts(
+                &manifest_path_for_warning,
+                default_prompt.as_ref(),
+            ),
             brand_color,
             composer_icon: resolve_interface_asset_path(
-                plugin_root,
+                resolver,
                 "interface.composerIcon",
                 composer_icon.as_deref(),
             ),
-            logo: resolve_interface_asset_path(plugin_root, "interface.logo", logo.as_deref()),
+            logo: resolve_interface_asset_path(resolver, "interface.logo", logo.as_deref()),
             logo_dark: resolve_interface_asset_path(
-                plugin_root,
+                resolver,
                 "interface.logoDark",
                 logo_dark.as_deref(),
             ),
@@ -208,7 +256,7 @@ pub(crate) fn parse_plugin_manifest(
                 .iter()
                 .filter_map(|screenshot| {
                     resolve_interface_asset_path(
-                        plugin_root,
+                        resolver,
                         "interface.screenshots",
                         Some(screenshot),
                     )
@@ -234,41 +282,46 @@ pub(crate) fn parse_plugin_manifest(
 
         has_fields.then_some(interface)
     });
-    Ok(PluginManifest {
+    Ok(codex_plugin::manifest::PluginManifest {
         name,
         version,
         description,
         keywords,
-        paths: PluginManifestPaths {
-            skills: resolve_manifest_paths(plugin_root, "skills", skills.as_ref()),
-            mcp_servers: resolve_manifest_mcp_servers(plugin_root, mcp_servers),
-            apps: resolve_manifest_path(plugin_root, "apps", apps.as_deref()),
-            hooks: resolve_manifest_hooks(plugin_root, hooks),
+        paths: codex_plugin::manifest::PluginManifestPaths {
+            skills: resolve_manifest_paths(resolver, "skills", skills.as_ref()),
+            mcp_servers: resolve_manifest_mcp_servers(resolver, mcp_servers),
+            apps: resolver.resolve_path("apps", apps.as_deref()),
+            hooks: resolve_manifest_hooks(resolver, hooks),
         },
         interface,
     })
 }
 
-fn resolve_manifest_hooks(
-    plugin_root: &Path,
+fn resolve_manifest_hooks<R>(
+    resolver: &R,
     hooks: Option<RawPluginManifestHooks>,
-) -> Option<PluginManifestHooks> {
+) -> Option<codex_plugin::manifest::PluginManifestHooks<R::Resource>>
+where
+    R: ManifestResourceResolver,
+{
     match hooks? {
-        RawPluginManifestHooks::Path(path) => {
-            resolve_manifest_path(plugin_root, "hooks", Some(&path))
-                .map(|path| PluginManifestHooks::Paths(vec![path]))
-        }
+        RawPluginManifestHooks::Path(path) => resolver
+            .resolve_path("hooks", Some(&path))
+            .map(|path| codex_plugin::manifest::PluginManifestHooks::Paths(vec![path])),
         RawPluginManifestHooks::Paths(paths) => {
             let hooks = paths
                 .iter()
-                .filter_map(|path| resolve_manifest_path(plugin_root, "hooks", Some(path)))
+                .filter_map(|path| resolver.resolve_path("hooks", Some(path)))
                 .collect::<Vec<_>>();
-            (!hooks.is_empty()).then_some(PluginManifestHooks::Paths(hooks))
+            (!hooks.is_empty()).then_some(codex_plugin::manifest::PluginManifestHooks::Paths(hooks))
         }
-        RawPluginManifestHooks::Inline(hooks) => Some(PluginManifestHooks::Inline(vec![hooks])),
-        RawPluginManifestHooks::InlineList(hooks) => {
-            (!hooks.is_empty()).then_some(PluginManifestHooks::Inline(hooks))
+        RawPluginManifestHooks::Inline(hooks) => {
+            Some(codex_plugin::manifest::PluginManifestHooks::Inline(vec![
+                hooks,
+            ]))
         }
+        RawPluginManifestHooks::InlineList(hooks) => (!hooks.is_empty())
+            .then_some(codex_plugin::manifest::PluginManifestHooks::Inline(hooks)),
         RawPluginManifestHooks::Invalid(value) => {
             tracing::warn!(
                 "ignoring hooks: expected a string, string array, object, or object array; found {}",
@@ -279,17 +332,21 @@ fn resolve_manifest_hooks(
     }
 }
 
-fn resolve_manifest_mcp_servers(
-    plugin_root: &Path,
+fn resolve_manifest_mcp_servers<R>(
+    resolver: &R,
     mcp_servers: Option<RawPluginManifestMcpServers>,
-) -> Option<PluginManifestMcpServers> {
+) -> Option<codex_plugin::manifest::PluginManifestMcpServers<R::Resource>>
+where
+    R: ManifestResourceResolver,
+{
     match mcp_servers? {
-        RawPluginManifestMcpServers::Path(path) => {
-            resolve_manifest_path(plugin_root, "mcpServers", Some(&path))
-                .map(PluginManifestMcpServers::Path)
-        }
+        RawPluginManifestMcpServers::Path(path) => resolver
+            .resolve_path("mcpServers", Some(&path))
+            .map(codex_plugin::manifest::PluginManifestMcpServers::Path),
         RawPluginManifestMcpServers::Object(servers) => match serde_json::to_string(&servers) {
-            Ok(servers) => Some(PluginManifestMcpServers::Object(servers)),
+            Ok(servers) => Some(codex_plugin::manifest::PluginManifestMcpServers::Object(
+                servers,
+            )),
             Err(err) => {
                 tracing::warn!("ignoring mcpServers: failed to serialize object: {err}");
                 None
@@ -305,16 +362,19 @@ fn resolve_manifest_mcp_servers(
     }
 }
 
-fn resolve_interface_asset_path(
-    plugin_root: &Path,
+fn resolve_interface_asset_path<R>(
+    resolver: &R,
     field: &'static str,
     path: Option<&str>,
-) -> Option<AbsolutePathBuf> {
-    resolve_manifest_path(plugin_root, field, path)
+) -> Option<R::Resource>
+where
+    R: ManifestResourceResolver,
+{
+    resolver.resolve_path(field, path)
 }
 
 fn resolve_default_prompts(
-    manifest_path: &Path,
+    manifest_path: &str,
     value: Option<&RawPluginManifestDefaultPrompt>,
 ) -> Option<Vec<String>> {
     match value? {
@@ -370,7 +430,7 @@ fn resolve_default_prompts(
     }
 }
 
-fn resolve_default_prompt_str(manifest_path: &Path, field: &str, prompt: &str) -> Option<String> {
+fn resolve_default_prompt_str(manifest_path: &str, field: &str, prompt: &str) -> Option<String> {
     let prompt = prompt.split_whitespace().collect::<Vec<_>>().join(" ");
     if prompt.is_empty() {
         warn_invalid_default_prompt(manifest_path, field, "prompt must not be empty");
@@ -387,11 +447,8 @@ fn resolve_default_prompt_str(manifest_path: &Path, field: &str, prompt: &str) -
     Some(prompt)
 }
 
-fn warn_invalid_default_prompt(manifest_path: &Path, field: &str, message: &str) {
-    tracing::warn!(
-        path = %manifest_path.display(),
-        "ignoring {field}: {message}"
-    );
+fn warn_invalid_default_prompt(manifest_path: &str, field: &str, message: &str) {
+    tracing::warn!(path = manifest_path, "ignoring {field}: {message}");
 }
 
 fn json_value_type(value: &JsonValue) -> &'static str {
@@ -405,20 +462,22 @@ fn json_value_type(value: &JsonValue) -> &'static str {
     }
 }
 
-fn resolve_manifest_paths(
-    plugin_root: &Path,
+fn resolve_manifest_paths<R>(
+    resolver: &R,
     field: &'static str,
     paths: Option<&RawPluginManifestPaths>,
-) -> Vec<AbsolutePathBuf> {
+) -> Vec<R::Resource>
+where
+    R: ManifestResourceResolver,
+{
     match paths {
-        Some(RawPluginManifestPaths::Path(path)) => {
-            resolve_manifest_path(plugin_root, field, Some(path))
-                .map(|path| vec![path])
-                .unwrap_or_default()
-        }
+        Some(RawPluginManifestPaths::Path(path)) => resolver
+            .resolve_path(field, Some(path))
+            .map(|path| vec![path])
+            .unwrap_or_default(),
         Some(RawPluginManifestPaths::Paths(paths)) => paths
             .iter()
-            .filter_map(|path| resolve_manifest_path(plugin_root, field, Some(path)))
+            .filter_map(|path| resolver.resolve_path(field, Some(path)))
             .collect(),
         Some(RawPluginManifestPaths::Invalid(value)) => {
             tracing::warn!(

--- a/codex-rs/core-plugins/src/marketplace.rs
+++ b/codex-rs/core-plugins/src/marketplace.rs
@@ -86,11 +86,12 @@ impl MarketplacePluginManifestFallback {
     }
 
     pub(crate) fn parse_for_listing(&self) -> Option<crate::manifest::PluginManifest> {
-        // Git sources have no plugin root before install. Parse against a synthetic absolute root,
-        // then discard path-bearing fields so listings expose metadata only.
+        // Git sources have no plugin root before install. Parse against a host-native synthetic
+        // absolute root, then discard path-bearing fields so listings expose metadata only.
+        let plugin_root = Path::new(if cfg!(windows) { r"C:\" } else { "/" });
         let mut manifest = crate::manifest::parse_plugin_manifest(
-            Path::new("/"),
-            Path::new("/.codex-plugin/plugin.json"),
+            plugin_root,
+            &fallback_plugin_manifest_path(plugin_root),
             &self.contents,
         )
         .ok()?;

--- a/codex-rs/plugin/src/manifest.rs
+++ b/codex-rs/plugin/src/manifest.rs
@@ -90,7 +90,8 @@ impl<Resource> PluginManifest<Resource> {
             .unwrap_or(&self.name)
     }
 
-    pub(crate) fn try_map_resources<Mapped, Error>(
+    /// Maps every path-bearing resource in the manifest.
+    pub fn try_map_resources<Mapped, Error>(
         self,
         mut map: impl FnMut(Resource) -> Result<Mapped, Error>,
     ) -> Result<PluginManifest<Mapped>, Error> {

--- a/codex-rs/utils/path-uri/src/lib.rs
+++ b/codex-rs/utils/path-uri/src/lib.rs
@@ -247,6 +247,33 @@ impl PathUri {
         std::iter::successors(Some(self.clone()), Self::parent)
     }
 
+    /// Returns true when this URI is lexically equal to or below `base`.
+    ///
+    /// Containment is computed using URI authority and path-segment boundaries,
+    /// without consulting the host filesystem. Percent-encoded path separators
+    /// fail closed because native path conversion may interpret them as segment
+    /// boundaries. Opaque fallback URIs created by [`Self::from_abs_path`] only
+    /// contain themselves.
+    pub fn starts_with(&self, base: &Self) -> bool {
+        if self == base {
+            return true;
+        }
+        if decode_bad_path_uri(&self.0).is_some() || decode_bad_path_uri(&base.0).is_some() {
+            return false;
+        }
+        if self.0.host_str() != base.0.host_str() {
+            return false;
+        }
+
+        let Some(path_segments) = containment_path_segments(&self.0) else {
+            return false;
+        };
+        let Some(base_segments) = containment_path_segments(&base.0) else {
+            return false;
+        };
+        path_segments.starts_with(&base_segments)
+    }
+
     /// Lexically resolves native absolute or relative path text against this URI.
     ///
     /// Path text is interpreted using the POSIX or Windows convention inferred
@@ -540,6 +567,19 @@ fn decode_bad_path_uri(url: &Url) -> Option<Vec<u8>> {
 
 fn is_windows_drive_uri_segment(segment: &str) -> bool {
     matches!(segment.as_bytes(), [drive, b':'] if drive.is_ascii_alphabetic())
+}
+
+fn containment_path_segments(url: &Url) -> Option<Vec<&str>> {
+    let segments = url
+        .path_segments()?
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+    (!segments.iter().any(|segment| {
+        urlencoding::decode_binary(segment.as_bytes())
+            .iter()
+            .any(|byte| matches!(*byte, b'/' | b'\\'))
+    }))
+    .then_some(segments)
 }
 
 fn infer_opaque_path_convention(path_bytes: &[u8]) -> Option<PathConvention> {

--- a/codex-rs/utils/path-uri/src/lib.rs
+++ b/codex-rs/utils/path-uri/src/lib.rs
@@ -265,10 +265,18 @@ impl PathUri {
             return false;
         }
 
-        let Some(path_segments) = containment_path_segments(&self.0) else {
+        let Some(path_segments) = containment_path_segments(
+            &self.0,
+            self.infer_path_convention()
+                .unwrap_or(PathConvention::Posix),
+        ) else {
             return false;
         };
-        let Some(base_segments) = containment_path_segments(&base.0) else {
+        let Some(base_segments) = containment_path_segments(
+            &base.0,
+            base.infer_path_convention()
+                .unwrap_or(PathConvention::Posix),
+        ) else {
             return false;
         };
         path_segments.starts_with(&base_segments)
@@ -569,7 +577,7 @@ fn is_windows_drive_uri_segment(segment: &str) -> bool {
     matches!(segment.as_bytes(), [drive, b':'] if drive.is_ascii_alphabetic())
 }
 
-fn containment_path_segments(url: &Url) -> Option<Vec<&str>> {
+fn containment_path_segments(url: &Url, convention: PathConvention) -> Option<Vec<&str>> {
     let segments = url
         .path_segments()?
         .filter(|segment| !segment.is_empty())
@@ -577,7 +585,7 @@ fn containment_path_segments(url: &Url) -> Option<Vec<&str>> {
     (!segments.iter().any(|segment| {
         urlencoding::decode_binary(segment.as_bytes())
             .iter()
-            .any(|byte| matches!(*byte, b'/' | b'\\'))
+            .any(|byte| *byte == b'/' || (convention == PathConvention::Windows && *byte == b'\\'))
     }))
     .then_some(segments)
 }

--- a/codex-rs/utils/path-uri/src/tests.rs
+++ b/codex-rs/utils/path-uri/src/tests.rs
@@ -283,9 +283,16 @@ fn structurally_valid_bad_path_uri_with_invalid_native_payload_fails_conversion(
 fn bad_path_uris_are_opaque_to_lexical_operations() {
     let uri = PathUri::parse("file:///%00/bad/path/YQ")
         .expect("canonical base64 fallback URI should parse");
+    let other = PathUri::parse("file:///%00/bad/path/Yg")
+        .expect("canonical base64 fallback URI should parse");
+    let root = PathUri::parse("file:///").expect("valid root URI");
 
     assert_eq!(uri.basename(), None);
     assert_eq!(uri.parent(), None);
+    assert!(uri.starts_with(&uri));
+    assert!(!uri.starts_with(&root));
+    assert!(!uri.starts_with(&other));
+    assert!(!other.starts_with(&uri));
     assert_eq!(uri.join(""), Ok(uri.clone()));
     assert_eq!(
         uri.join("child"),
@@ -695,6 +702,58 @@ fn join_uses_the_base_uri_path_convention() {
         let base = PathUri::parse(base).expect("valid base URI");
         let expected = PathUri::parse(expected).expect("valid expected URI");
         assert_eq!(base.join(path), Ok(expected), "joining {path}");
+    }
+}
+
+#[test]
+fn starts_with_uses_uri_segment_boundaries() {
+    for (path, base, expected) in [
+        ("file:///workspace/plugin", "file:///", true),
+        ("file:///workspace/plugin", "file:///workspace/plugin", true),
+        (
+            "file:///workspace/plugin/assets/icon.svg",
+            "file:///workspace/plugin",
+            true,
+        ),
+        (
+            "file:///workspace/plugin-other/icon.svg",
+            "file:///workspace/plugin",
+            false,
+        ),
+        (
+            "file:///C:/plugins/foo/assets/icon.svg",
+            "file:///C:/plugins/foo",
+            true,
+        ),
+        (
+            "file:///C:/plugins/foo2/assets/icon.svg",
+            "file:///C:/plugins/foo",
+            false,
+        ),
+        (
+            "file://server/share/plugins/foo/icon.svg",
+            "file://server/share/plugins/foo",
+            true,
+        ),
+        (
+            "file://other/share/plugins/foo/icon.svg",
+            "file://server/share/plugins/foo",
+            false,
+        ),
+        (
+            "file:///workspace/plugin/%2F..%2Foutside",
+            "file:///workspace/plugin",
+            false,
+        ),
+        (
+            "file:///workspace/plugin/%5C..%5Coutside",
+            "file:///workspace/plugin",
+            false,
+        ),
+    ] {
+        let path = PathUri::parse(path).expect("valid path URI");
+        let base = PathUri::parse(base).expect("valid base URI");
+        assert_eq!(path.starts_with(&base), expected);
     }
 }
 

--- a/codex-rs/utils/path-uri/src/tests.rs
+++ b/codex-rs/utils/path-uri/src/tests.rs
@@ -748,6 +748,11 @@ fn starts_with_uses_uri_segment_boundaries() {
         (
             "file:///workspace/plugin/%5C..%5Coutside",
             "file:///workspace/plugin",
+            true,
+        ),
+        (
+            "file:///C:/plugins/foo/%5C..%5Coutside",
+            "file:///C:/plugins/foo",
             false,
         ),
     ] {


### PR DESCRIPTION
## Why

Plugin manifests use the same schema whether the package lives on the host or in an executor. Only the path representation differs: host callers need native `Path` inputs and `AbsolutePathBuf` outputs, while executor callers need `PathUri` throughout.

Maintaining separate parsing or resolver implementations would duplicate the manifest rules and allow them to drift. This PR instead makes URI-native resolution the single parsing path and keeps host conversion at the boundary.

## What changed

- Make `parse_plugin_manifest_uri` the shared manifest parser and resolve every path-bearing field as `PathUri`.
- Keep the existing host entrypoint as a thin adapter: convert its native root and manifest path to `PathUri`, run the shared parser, then map resources back to `AbsolutePathBuf`.
- Expose `PluginManifest::try_map_resources` so callers can convert the generic resource type without duplicating manifest construction.
- Resolve relative manifest paths using the root URI's convention: backslashes are separators for Windows roots and ordinary filename characters for POSIX roots.
- Apply lexical containment after URI resolution, rejecting absolute paths and parent traversal outside the plugin root.
- Make encoded backslashes fail containment only for Windows URIs; encoded `/` remains unsafe for every convention.
- Use a host-native synthetic root for marketplace fallback manifests so the host adapter also works on Windows.

```text
host Path --------> PathUri --\
                              +--> one manifest parser --> PluginManifest<PathUri>
executor PathUri -------------/

host result: PluginManifest<PathUri> --> PluginManifest<AbsolutePathBuf>
```

Existing host manifest behavior is preserved; #28918 is the first executor consumer.

## Verification

- `just test -p codex-utils-path-uri`
- `just test -p codex-plugin`
- `just test -p codex-core-plugins`

## Stack

1. #29614 — add lexical `PathUri` containment.
2. **This PR** — share URI-native manifest path resolution.
3. #28918 — keep selected plugin roots and resources URI-native.
4. #29626 — load executor skills without host path conversion.
5. #29628 — resolve executor MCP working directories without host path conversion.
