### PR TITLE
Handle additional tools in rollout persistence metrics

### DIFF
--- a/codex-rs/rollout/src/persistence_metrics.rs
+++ b/codex-rs/rollout/src/persistence_metrics.rs
@@ -255,6 +255,7 @@ fn turn_item_type(item: &TurnItem) -> &'static str {
 
 fn response_item_type(item: &ResponseItem) -> &'static str {
     match item {
+        ResponseItem::AdditionalTools { .. } => "response.additional_tools",
         ResponseItem::Message { .. } => "response.message",
         ResponseItem::AgentMessage { .. } => "response.agent_message",
         ResponseItem::Reasoning { .. } => "response.reasoning",


### PR DESCRIPTION
## Why

The rollout persistence metrics added on current `main` exhaustively match `ResponseItem`, but omit `ResponseItem::AdditionalTools`. That prevents `codex-rollout` and downstream targets from compiling across Cargo and Bazel builds.

## What

Map `ResponseItem::AdditionalTools` to the `response.additional_tools` metric label, consistent with the existing exact-variant labels.

## Validation

- `just test -p codex-rollout` (76 passed)
- `just fix -p codex-rollout`
