### PR TITLE
[codex] Handle additional tools in rollout persistence metrics

### DIFF
--- a/codex-rs/rollout/src/persistence_metrics.rs
+++ b/codex-rs/rollout/src/persistence_metrics.rs
@@ -256,6 +256,7 @@ fn turn_item_type(item: &TurnItem) -> &'static str {
 fn response_item_type(item: &ResponseItem) -> &'static str {
     match item {
         ResponseItem::Message { .. } => "response.message",
+        ResponseItem::AdditionalTools { .. } => "response.additional_tools",
         ResponseItem::AgentMessage { .. } => "response.agent_message",
         ResponseItem::Reasoning { .. } => "response.reasoning",
         ResponseItem::LocalShellCall { .. } => "response.local_shell_call",


### PR DESCRIPTION
## Summary

Handle `ResponseItem::AdditionalTools` in rollout persistence metrics.

The persistence metrics match was added after the `AdditionalTools` variant and omitted it, causing release builds to fail with a non-exhaustive pattern error. This assigns the item the `response.additional_tools` metrics label.

Release failure: https://github.com/openai/codex/actions/runs/28043786727/job/83016608475

## Validation

- `just fmt`
- `just test -p codex-rollout` (76 passed)
