### PR TITLE
[codex] Fix stale approval policy in MCP test

### DIFF
--- a/codex-rs/codex-mcp/src/connection_manager_tests.rs
+++ b/codex-rs/codex-mcp/src/connection_manager_tests.rs
@@ -1031,7 +1031,7 @@ async fn shutdown_continues_after_caller_is_aborted() {
     }
     .boxed()
     .shared();
-    let approval_policy = Constrained::allow_any(AskForApproval::OnFailure);
+    let approval_policy = Constrained::allow_any(AskForApproval::OnRequest);
     let permission_profile = Constrained::allow_any(PermissionProfile::default());
     let mut manager = McpConnectionManager::new_uninitialized(
         &approval_policy,


### PR DESCRIPTION
## Summary

- replace the stale `AskForApproval::OnFailure` reference in the MCP connection manager test with `AskForApproval::OnRequest`
- restore `codex-mcp` test compilation after `OnFailure` was removed in #28418

## Root cause

The test was added on main after the approval-policy removal branch had already updated the other references, so the newly added call site was missed when #28418 merged.

## Validation

- `just test -p codex-mcp` (90 passed)
- `just fmt`
