### PR TITLE
[codex] Fix stale approval policy in MCP test

### DIFF
--- a/codex-rs/codex-mcp/src/connection_manager_tests.rs
+++ b/codex-rs/codex-mcp/src/connection_manager_tests.rs
@@ -1031,7 +1031,7 @@ async fn shutdown_continues_after_caller_is_aborted() {
     }
     .boxed()
     .shared();
-    let approval_policy = Constrained::allow_any(AskForApproval::OnFailure);
+    let approval_policy = Constrained::allow_any(AskForApproval::OnRequest);
     let permission_profile = Constrained::allow_any(PermissionProfile::default());
     let mut manager = McpConnectionManager::new_uninitialized(
         &approval_policy,


### PR DESCRIPTION
## Summary

- replace the removed `AskForApproval::OnFailure` variant in the MCP shutdown test with `OnRequest`

## Why

`OnFailure` was removed from `AskForApproval`, but this test fixture still referenced it, causing Rust and Clippy compilation failures.

## Validation

- `just test -p codex-mcp shutdown_continues_after_caller_is_aborted`
- `just fmt`
