### PR TITLE
code-mode: Rename codex_code_mode::CodeModeService

### DIFF
--- a/codex-rs/code-mode/src/lib.rs
+++ b/codex-rs/code-mode/src/lib.rs
@@ -4,6 +4,6 @@ mod service;
 mod session_runtime;
 
 pub use codex_code_mode_protocol::*;
-pub use service::CodeModeService;
+pub use service::InProcessCodeModeSession;
 pub use service::InProcessCodeModeSessionProvider;
 pub use service::NoopCodeModeSessionDelegate;

--- a/codex-rs/code-mode/src/service.rs
+++ b/codex-rs/code-mode/src/service.rs
@@ -66,17 +66,17 @@ impl CodeModeSessionProvider for InProcessCodeModeSessionProvider {
     ) -> CodeModeSessionProviderFuture<'a> {
         Box::pin(async move {
             let session: Arc<dyn CodeModeSession> =
-                Arc::new(CodeModeService::with_delegate(delegate));
+                Arc::new(InProcessCodeModeSession::with_delegate(delegate));
             Ok(session)
         })
     }
 }
 
-pub struct CodeModeService {
+pub struct InProcessCodeModeSession {
     runtime: SessionRuntime<ProtocolDelegate>,
 }
 
-impl CodeModeService {
+impl InProcessCodeModeSession {
     pub fn new() -> Self {
         Self::with_delegate(Arc::new(NoopCodeModeSessionDelegate))
     }
@@ -209,13 +209,13 @@ impl CodeModeService {
     }
 }
 
-impl Default for CodeModeService {
+impl Default for InProcessCodeModeSession {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl CodeModeSession for CodeModeService {
+impl CodeModeSession for InProcessCodeModeSession {
     fn is_alive(&self) -> bool {
         self.runtime.is_alive()
     }
@@ -224,19 +224,19 @@ impl CodeModeSession for CodeModeService {
         &'a self,
         request: ExecuteRequest,
     ) -> CodeModeSessionResultFuture<'a, StartedCell> {
-        Box::pin(CodeModeService::execute(self, request))
+        Box::pin(InProcessCodeModeSession::execute(self, request))
     }
 
     fn wait<'a>(&'a self, request: WaitRequest) -> CodeModeSessionResultFuture<'a, WaitOutcome> {
-        Box::pin(CodeModeService::wait(self, request))
+        Box::pin(InProcessCodeModeSession::wait(self, request))
     }
 
     fn terminate<'a>(&'a self, cell_id: CellId) -> CodeModeSessionResultFuture<'a, WaitOutcome> {
-        Box::pin(CodeModeService::terminate(self, cell_id))
+        Box::pin(InProcessCodeModeSession::terminate(self, cell_id))
     }
 
     fn shutdown<'a>(&'a self) -> CodeModeSessionResultFuture<'a, ()> {
-        Box::pin(CodeModeService::shutdown(self))
+        Box::pin(InProcessCodeModeSession::shutdown(self))
     }
 }
 

--- a/codex-rs/code-mode/src/service_contract_tests.rs
+++ b/codex-rs/code-mode/src/service_contract_tests.rs
@@ -184,7 +184,7 @@ async fn next_event(events_rx: &mut mpsc::UnboundedReceiver<DelegateEvent>) -> D
 
 #[tokio::test]
 async fn yields_and_resumes() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
     let cell = service
         .execute(ExecuteRequest {
             source: r#"text("before"); yield_control(); text("after");"#.to_string(),
@@ -224,7 +224,7 @@ async fn yields_and_resumes() {
 #[tokio::test]
 async fn returns_and_resumes_from_the_pending_frontier() {
     let (delegate, mut events_rx) = BlockingDelegate::new();
-    let service = CodeModeService::with_delegate(delegate.clone());
+    let service = InProcessCodeModeSession::with_delegate(delegate.clone());
 
     assert_eq!(
         service
@@ -271,7 +271,7 @@ text("after");
 
 #[tokio::test]
 async fn observed_natural_completion_wins_over_termination() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
     let cell = service
         .execute(execute_request(
             r#"yield_control(); store("finished", true); text("done");"#,
@@ -328,7 +328,7 @@ async fn observed_natural_completion_wins_over_termination() {
 #[tokio::test]
 async fn termination_cancels_pending_callbacks_before_responding() {
     let (delegate, mut events_rx) = BlockingDelegate::new();
-    let service = CodeModeService::with_delegate(delegate.clone());
+    let service = InProcessCodeModeSession::with_delegate(delegate.clone());
     let cell = service
         .execute(execute_request(
             r#"notify("pending"); await new Promise(() => {});"#,
@@ -368,7 +368,7 @@ async fn termination_cancels_pending_callbacks_before_responding() {
 #[tokio::test]
 async fn shutdown_cancels_notifications_while_natural_completion_is_draining() {
     let (delegate, mut events_rx) = HeldNotificationDelegate::new();
-    let service = Arc::new(CodeModeService::with_delegate(delegate.clone()));
+    let service = Arc::new(InProcessCodeModeSession::with_delegate(delegate.clone()));
     service
         .execute(execute_request(r#"notify("pending");"#))
         .await
@@ -398,7 +398,7 @@ async fn shutdown_cancels_notifications_while_natural_completion_is_draining() {
 #[tokio::test]
 async fn repeated_termination_is_rejected_while_callback_cleanup_is_pending() {
     let (delegate, mut events_rx) = HeldNotificationDelegate::new();
-    let service = Arc::new(CodeModeService::with_delegate(delegate.clone()));
+    let service = Arc::new(InProcessCodeModeSession::with_delegate(delegate.clone()));
     let cell = service
         .execute(execute_request(
             r#"notify("pending"); await new Promise(() => {});"#,
@@ -448,7 +448,7 @@ async fn repeated_termination_is_rejected_while_callback_cleanup_is_pending() {
 
 #[tokio::test]
 async fn second_observer_is_rejected_without_displacing_the_first() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
     let cell = service
         .execute(execute_request("await new Promise(() => {});"))
         .await
@@ -496,7 +496,7 @@ async fn second_observer_is_rejected_without_displacing_the_first() {
 #[tokio::test]
 async fn natural_completion_cleans_up_callbacks_before_responding() {
     let (delegate, mut events_rx) = BlockingDelegate::new();
-    let service = CodeModeService::with_delegate(delegate.clone());
+    let service = InProcessCodeModeSession::with_delegate(delegate.clone());
     let cell = service
         .execute(ExecuteRequest {
             enabled_tools: vec![blocking_tool()],

--- a/codex-rs/code-mode/src/service_tests.rs
+++ b/codex-rs/code-mode/src/service_tests.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use super::CellId;
 use super::CodeModeNestedToolCall;
-use super::CodeModeService;
 use super::CodeModeSessionDelegate;
+use super::InProcessCodeModeSession;
 use super::NotificationFuture;
 use super::RuntimeResponse;
 use super::ToolInvocationFuture;
@@ -86,7 +86,7 @@ fn echo_tool() -> ToolDefinition {
     }
 }
 
-async fn execute(service: &CodeModeService, request: ExecuteRequest) -> RuntimeResponse {
+async fn execute(service: &InProcessCodeModeSession, request: ExecuteRequest) -> RuntimeResponse {
     service
         .execute(request)
         .await
@@ -98,7 +98,7 @@ async fn execute(service: &CodeModeService, request: ExecuteRequest) -> RuntimeR
 
 #[tokio::test]
 async fn synchronous_exit_returns_successfully() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
 
     let response = execute(
         &service,
@@ -124,8 +124,8 @@ async fn synchronous_exit_returns_successfully() {
 
 #[tokio::test]
 async fn stored_values_are_shared_between_cells_but_not_sessions() {
-    let first_session = CodeModeService::new();
-    let second_session = CodeModeService::new();
+    let first_session = InProcessCodeModeSession::new();
+    let second_session = InProcessCodeModeSession::new();
 
     let write_response = execute(
         &first_session,
@@ -188,7 +188,7 @@ async fn stored_values_are_shared_between_cells_but_not_sessions() {
 
 #[tokio::test]
 async fn shutdown_interrupts_cpu_bound_cells() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
 
     let cell = service
         .execute(ExecuteRequest {
@@ -213,7 +213,7 @@ async fn shutdown_interrupts_cpu_bound_cells() {
 
 #[tokio::test]
 async fn start_cell_rejects_new_cell_after_shutdown_begins() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
     service.shutdown().await.unwrap();
 
     let error = service
@@ -227,7 +227,7 @@ async fn start_cell_rejects_new_cell_after_shutdown_begins() {
 
 #[tokio::test]
 async fn execute_to_pending_returns_completed_for_synchronous_results() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
 
     let response = service
         .execute_to_pending(ExecuteRequest {
@@ -252,7 +252,7 @@ async fn execute_to_pending_returns_completed_for_synchronous_results() {
 
 #[tokio::test]
 async fn execute_to_pending_returns_once_the_runtime_is_quiescent() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
 
     let response = tokio::time::timeout(
         Duration::from_secs(1),
@@ -290,7 +290,7 @@ async fn execute_to_pending_returns_once_the_runtime_is_quiescent() {
 
 #[tokio::test]
 async fn execute_to_pending_identifies_tool_calls_in_paused_frontier() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
 
     let response = service
         .execute_to_pending(ExecuteRequest {
@@ -330,7 +330,7 @@ await Promise.all([
 
 #[tokio::test]
 async fn execute_to_pending_excludes_delayed_timeout_tool_calls_until_wait() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
 
     let initial_response = service
         .execute_to_pending(ExecuteRequest {
@@ -395,7 +395,7 @@ await Promise.all([
 #[tokio::test]
 async fn wait_to_pending_returns_after_resumed_runtime_becomes_quiescent_again() {
     let delegate = Arc::new(ReleasableToolDelegate::default());
-    let service = CodeModeService::with_delegate(delegate.clone());
+    let service = InProcessCodeModeSession::with_delegate(delegate.clone());
 
     let initial_response = service
         .execute_to_pending(ExecuteRequest {
@@ -458,7 +458,7 @@ await new Promise(() => {});
 #[tokio::test]
 async fn wait_to_pending_returns_completed_after_resumed_runtime_finishes() {
     let delegate = Arc::new(ReleasableToolDelegate::default());
-    let service = CodeModeService::with_delegate(delegate.clone());
+    let service = InProcessCodeModeSession::with_delegate(delegate.clone());
 
     let initial_response = service
         .execute_to_pending(ExecuteRequest {
@@ -511,7 +511,7 @@ text("done");
 
 #[tokio::test]
 async fn v8_console_is_not_exposed_on_global_this() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
 
     let response = execute(
         &service,
@@ -537,7 +537,7 @@ async fn v8_console_is_not_exposed_on_global_this() {
 
 #[tokio::test]
 async fn date_locale_string_formats_with_icu_data() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
 
     let response = execute(
         &service,
@@ -577,7 +577,7 @@ text(value);
 
 #[tokio::test]
 async fn intl_date_time_format_formats_with_icu_data() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
 
     let response = execute(
         &service,
@@ -616,7 +616,7 @@ text(formatter.format(new Date("2025-01-02T03:04:05Z")));
 
 #[tokio::test]
 async fn output_helpers_return_undefined() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
 
     let response = execute(
         &service,
@@ -659,7 +659,7 @@ text(JSON.stringify(returnsUndefined));
 
 #[tokio::test]
 async fn image_helper_accepts_raw_mcp_image_block_with_original_detail() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
 
     let response = execute(
             &service,
@@ -694,7 +694,7 @@ image({
 
 #[tokio::test]
 async fn generated_image_helper_appends_image_and_output_hint() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
 
     let response = execute(
         &service,
@@ -732,7 +732,7 @@ generatedImage({
 
 #[tokio::test]
 async fn image_helper_second_arg_overrides_explicit_object_detail() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
 
     let response = execute(
         &service,
@@ -768,7 +768,7 @@ image(
 
 #[tokio::test]
 async fn image_helper_second_arg_overrides_raw_mcp_image_detail() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
 
     let response = execute(
             &service,
@@ -806,7 +806,7 @@ image(
 
 #[tokio::test]
 async fn image_helper_accepts_low_detail() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
 
     let response = execute(
         &service,
@@ -847,7 +847,7 @@ async fn image_helpers_reject_remote_urls() {
             format!("image({image_url:?});"),
             format!("generatedImage({{ image_url: {image_url:?} }});"),
         ] {
-            let service = CodeModeService::new();
+            let service = InProcessCodeModeSession::new();
 
             let response = execute(
                 &service,
@@ -875,7 +875,7 @@ async fn image_helpers_reject_remote_urls() {
 
 #[tokio::test]
 async fn image_helper_rejects_unsupported_detail() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
 
     let response = execute(
         &service,
@@ -905,7 +905,7 @@ image({
 
 #[tokio::test]
 async fn image_helper_rejects_raw_mcp_result_container() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
 
     let response = execute(
             &service,
@@ -944,7 +944,7 @@ image({
 
 #[tokio::test]
 async fn wait_reports_missing_cell_separately_from_runtime_results() {
-    let service = CodeModeService::new();
+    let service = InProcessCodeModeSession::new();
 
     let response = service
         .wait(WaitRequest {

--- a/codex-rs/core/src/tools/code_mode/mod.rs
+++ b/codex-rs/core/src/tools/code_mode/mod.rs
@@ -12,6 +12,7 @@ use codex_code_mode::CellId;
 use codex_code_mode::CodeModeNestedToolCall;
 use codex_code_mode::CodeModeSession;
 use codex_code_mode::CodeModeToolKind;
+use codex_code_mode::InProcessCodeModeSession;
 use codex_code_mode::RuntimeResponse;
 use codex_protocol::models::FunctionCallOutputContentItem;
 use serde_json::Value as JsonValue;
@@ -68,7 +69,7 @@ impl CodeModeService {
     pub(crate) fn new() -> Self {
         let dispatch_broker = Arc::new(CodeModeDispatchBroker::new());
         Self {
-            session: Some(Arc::new(codex_code_mode::CodeModeService::with_delegate(
+            session: Some(Arc::new(InProcessCodeModeSession::with_delegate(
                 dispatch_broker.clone(),
             ))),
             dispatch_broker,


### PR DESCRIPTION
Mechanical rename of CodeModeService => InProcessCodeModeSession

This already implements a CodeModeSession as its prime interface to Core.  The name was vestigial _and_ confusing af when embedded inside core::tools::code_mode::CodeModeService