### PR TITLE
code-mode: Remove Session::is_alive()

### DIFF
--- a/codex-rs/code-mode-protocol/src/session.rs
+++ b/codex-rs/code-mode-protocol/src/session.rs
@@ -110,12 +110,6 @@ pub trait CodeModeSessionDelegate: Send + Sync {
 /// must keep those values isolated. Implementations may execute cells
 /// in-process or remotely.
 pub trait CodeModeSession: Send + Sync {
-    /// Returns whether the session can still accept requests.
-    ///
-    /// Remote implementations should return `false` after their underlying
-    /// connection fails so callers can create a fresh session for later work.
-    fn is_alive(&self) -> bool;
-
     fn execute<'a>(
         &'a self,
         request: ExecuteRequest,

--- a/codex-rs/code-mode/src/service.rs
+++ b/codex-rs/code-mode/src/service.rs
@@ -216,10 +216,6 @@ impl Default for InProcessCodeModeSession {
 }
 
 impl CodeModeSession for InProcessCodeModeSession {
-    fn is_alive(&self) -> bool {
-        self.runtime.is_alive()
-    }
-
     fn execute<'a>(
         &'a self,
         request: ExecuteRequest,

--- a/codex-rs/code-mode/src/session_runtime/mod.rs
+++ b/codex-rs/code-mode/src/session_runtime/mod.rs
@@ -63,10 +63,6 @@ impl<D: SessionRuntimeDelegate> SessionRuntime<D> {
         }
     }
 
-    pub(crate) fn is_alive(&self) -> bool {
-        !self.inner.shutdown_token.is_cancelled()
-    }
-
     pub(crate) async fn execute(
         &self,
         request: CreateCellRequest,

--- a/codex-rs/code-mode/src/session_runtime/tests.rs
+++ b/codex-rs/code-mode/src/session_runtime/tests.rs
@@ -152,7 +152,6 @@ async fn shutdown_rejects_cell_admission_queued_before_the_registry_lock() {
     })
     .await;
 
-    assert!(!runtime.is_alive());
     drop(cells);
     assert!(matches!(execution.await, Err(Error::ShuttingDown)));
     assert_eq!(shutdown.await, Ok(()));


### PR DESCRIPTION
Remove this unused API.  This API is insidious in that it implies that alive state should be determinable from the caller, and implies that a preflight should indicate routing.  Lets drop this, and handle errors correctly from a failed session in the future.