### PR TITLE
[core] stabilize subagent resume mode test

### DIFF
--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -2291,6 +2291,47 @@ async fn resume_thread_subagent_restores_stored_metadata_and_effective_multi_age
         .get_thread(child_thread_id)
         .await
         .expect("child thread should exist");
+    let mut status_rx = harness
+        .control
+        .subscribe_status(child_thread_id)
+        .await
+        .expect("status subscription should succeed");
+    timeout(Duration::from_secs(5), async {
+        while matches!(status_rx.borrow().clone(), AgentStatus::PendingInit) {
+            status_rx
+                .changed()
+                .await
+                .expect("child status should advance past pending init");
+        }
+        if matches!(status_rx.borrow().clone(), AgentStatus::Running) {
+            harness
+                .control
+                .interrupt_agent(child_thread_id)
+                .await
+                .expect("child turn should accept interruption");
+        }
+        while matches!(
+            status_rx.borrow().clone(),
+            AgentStatus::PendingInit | AgentStatus::Running
+        ) {
+            status_rx
+                .changed()
+                .await
+                .expect("child status should reach a terminal state");
+        }
+        while child_thread
+            .codex
+            .session
+            .active_turn
+            .lock()
+            .await
+            .is_some()
+        {
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("child turn should settle before writing resume history");
     let mut child_turn_context = child_thread
         .codex
         .session
@@ -2323,26 +2364,6 @@ async fn resume_thread_subagent_restores_stored_metadata_and_effective_multi_age
         })
         .await
         .expect("change parent multi-agent mode before child resume");
-    let mut status_rx = harness
-        .control
-        .subscribe_status(child_thread_id)
-        .await
-        .expect("status subscription should succeed");
-    if matches!(status_rx.borrow().clone(), AgentStatus::PendingInit) {
-        timeout(Duration::from_secs(5), async {
-            loop {
-                status_rx
-                    .changed()
-                    .await
-                    .expect("child status should advance past pending init");
-                if !matches!(status_rx.borrow().clone(), AgentStatus::PendingInit) {
-                    break;
-                }
-            }
-        })
-        .await
-        .expect("child should initialize before shutdown");
-    }
     let original_snapshot = child_thread.config_snapshot().await;
     let original_nickname = original_snapshot
         .session_source


### PR DESCRIPTION
## Summary

- make the subagent resume-mode test stop its initial spawned turn before writing synthetic resume history
- wait for both the agent status transition and `active_turn` cleanup, so no concurrent task can append a newer `TurnContext`
- preserve the behavioral assertion that resume restores the child's stored `Proactive` mode after the parent changes to `ExplicitRequestOnly`

## Failure evidence

This signature failed on six consecutive inspected `main` runs on Windows ARM64, including:

- [current main run, shard 3](https://github.com/openai/codex/actions/runs/28063243910/job/83084137264)
- [completed anchor run, shard 3](https://github.com/openai/codex/actions/runs/28061825178/job/83080224560)
- [preceding main run, shard 3](https://github.com/openai/codex/actions/runs/28061282339/job/83078592223)

Before:

```text
agent::control::tests::resume_thread_subagent_restores_stored_metadata_and_effective_multi_agent_mode
assertion failed at core/src/agent/control_tests.rs:2414
left:  ExplicitRequestOnly
right: Proactive
```

The test wrote a synthetic `Proactive` turn context while the child task spawned by `spawn_agent` was still active. On slower Windows ARM64 runners, that task appended its own later `ExplicitRequestOnly` turn context, and resume correctly selected the latest context. The test now interrupts and fully drains that task before constructing the history under test.

After:

```text
exact nextest: PASS
20-iteration nextest stress run: 20/20 PASS
Windows ARM64 shard 3: old resume assertion absent; only the independent PowerShell module failures remain
```

Authoritative platform result: [branch Windows ARM64 shard 3](https://github.com/openai/codex/actions/runs/28064997213/job/83089530903). The job's failed-test log contains only `legacy_capture_powershell_emits_output` and `legacy_tty_powershell_emits_output_and_accepts_input`; `resume_thread_subagent_restores_stored_metadata_and_effective_multi_agent_mode` passed.

## Validation

- `just fmt`
- `just test -p codex-core resume_thread_subagent_restores_stored_metadata_and_effective_multi_agent_mode`
- `just test -p codex-core --stress-count 20 resume_thread_subagent_restores_stored_metadata_and_effective_multi_agent_mode`
- `cargo check -p codex-core --tests`
- `cargo clippy -p codex-core --tests --no-deps -- -D warnings`

I also ran the broader `codex-core` nextest suite. The changed test passed; unrelated tests failed because this local sandbox cannot create PATH aliases, lacks runtime helper binaries, and aborts nested sandbox helpers. The draft PR will use the Windows ARM64 matrix as the authoritative platform validation.

## Other failures triaged separately

- Linux ARM64 archive builds: runner shutdown during compilation with no test failure on [branch attempt 1](https://github.com/openai/codex/actions/runs/28064997213/job/83087257643), [direct retry attempt 2](https://github.com/openai/codex/actions/runs/28064997213/job/83092119012), and [direct retry attempt 3 on a different worker](https://github.com/openai/codex/actions/runs/28064997213/job/83092939735)
- [Windows ARM64 PowerShell shard](https://github.com/openai/codex/actions/runs/28063243910/job/83084137264): `Microsoft.PowerShell.Utility` cannot be loaded on the runner image
- [Linux remote shards](https://github.com/openai/codex/actions/runs/28063243910): broad deterministic remote-environment compatibility failures across all four shards, not this race
- [Windows thread-inventory assertion](https://github.com/openai/codex/actions/runs/28063243910/job/83083851201): separate CLI/path test ownership; being handled independently
