### PR TITLE
[cli] make thread inventory assertion path-stable

### DIFF
--- a/codex-rs/cli/src/doctor/thread_inventory.rs
+++ b/codex-rs/cli/src/doctor/thread_inventory.rs
@@ -779,11 +779,13 @@ mod tests {
                 .as_deref()
                 .is_some_and(|remedy| remedy.starts_with("Restart Codex"))
         }));
+        let missing_file_name = missing_path.file_name().expect("rollout file name");
         assert!(
             check
                 .details
                 .iter()
-                .any(|detail| detail.contains(missing_path.to_string_lossy().as_ref()))
+                .filter_map(|detail| detail.strip_prefix("rollout DB missing active sample: "))
+                .any(|sample| Path::new(sample).file_name() == Some(missing_file_name))
         );
     }
 


### PR DESCRIPTION
## Summary

- make the thread-inventory warning test compare the missing rollout sample by its exact filename
- preserve the diagnostic label and behavior assertions while avoiding platform-dependent temp-directory spelling

## Failure evidence

This assertion failed in 6/6 inspected recent failed `main` `rust-ci-full` runs on Windows x64 and/or Windows ARM64, including:

- [current Windows x64 shard](https://github.com/openai/codex/actions/runs/28063243910/job/83083851201)
- [current Windows ARM64 shard](https://github.com/openai/codex/actions/runs/28063243910/job/83084137284)
- [completed recurring Windows x64 shard](https://github.com/openai/codex/actions/runs/28061825178/job/83079774177)

Before, `thread_inventory_check_warns_for_missing_stale_and_mismatched_rows` failed at `cli/src/doctor/thread_inventory.rs:782` because the diagnostic's discovered path and the test's constructed temp path could have different textual spellings on Windows. The inventory status, issue counts, and warning category were correct.

After, the test selects the `rollout DB missing active sample:` diagnostic and compares its path's exact filename with the expected rollout filename. This continues to reject the wrong sample while avoiding dependence on the temp root's textual representation.

Authoritative platform results:

- [branch Windows x64 shard 2](https://github.com/openai/codex/actions/runs/28065463395/job/83090663798): full shard passed
- [branch Windows ARM64 shard 2](https://github.com/openai/codex/actions/runs/28065463395/job/83090994716): the doctor test passed; the only terminal failure was the independent `legacy_non_tty_powershell_emits_output` runner-image issue

## Validation

- `just fmt`
- exact nextest filter: pass
- exact nextest filter with `--stress-count 20`: 20/20 pass
- `cargo check -p codex-cli --tests`: pass
- `cargo clippy -p codex-cli --tests --no-deps -- -D warnings`: pass

The separate subagent-resume synchronization race is handled in #29747. PowerShell module-load failures, Linux ARM runner shutdowns, and the Linux remote-environment compatibility failures were classified separately and are not bundled into this change.
