### PR TITLE
[codex] Assign response item IDs in forked history

### DIFF
--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -1339,9 +1339,11 @@ impl Session {
             }
             InitialHistory::Forked(mut rollout_items) => {
                 let turn_context = self.new_default_turn().await;
-                for rollout_item in &mut rollout_items {
-                    if let RolloutItem::ResponseItem(response_item) = rollout_item {
-                        Self::assign_missing_response_item_id(response_item);
+                if turn_context.config.features.enabled(Feature::ItemIds) {
+                    for rollout_item in &mut rollout_items {
+                        if let RolloutItem::ResponseItem(response_item) = rollout_item {
+                            Self::assign_missing_response_item_id(response_item);
+                        }
                     }
                 }
                 self.apply_rollout_reconstruction(&turn_context, &rollout_items)

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -2715,7 +2715,11 @@ impl Session {
         for item in items.to_mut() {
             item.set_turn_id_if_missing(&turn_context.sub_id);
         }
-        Self::assign_missing_response_item_ids(items)
+        if turn_context.config.features.enabled(Feature::ItemIds) {
+            Self::assign_missing_response_item_ids(items)
+        } else {
+            items
+        }
     }
 
     fn assign_missing_response_item_ids(items: Cow<'_, [ResponseItem]>) -> Cow<'_, [ResponseItem]> {
@@ -2920,13 +2924,17 @@ impl Session {
 
     pub(crate) async fn replace_compacted_history(
         &self,
-        _turn_context: &TurnContext,
+        turn_context: &TurnContext,
         items: Vec<ResponseItem>,
         reference_context_item: Option<TurnContextItem>,
         world_state_baseline: Option<Arc<WorldState>>,
         compacted_item: CompactedItem,
     ) {
-        let items = Self::assign_missing_response_item_ids(Cow::Owned(items)).into_owned();
+        let items = if turn_context.config.features.enabled(Feature::ItemIds) {
+            Self::assign_missing_response_item_ids(Cow::Owned(items)).into_owned()
+        } else {
+            items
+        };
         let compacted_item = CompactedItem {
             replacement_history: Some(items.clone()),
             ..compacted_item

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -1337,8 +1337,13 @@ impl Session {
                     let _ = self.flush_rollout().await;
                 }
             }
-            InitialHistory::Forked(rollout_items) => {
+            InitialHistory::Forked(mut rollout_items) => {
                 let turn_context = self.new_default_turn().await;
+                for rollout_item in &mut rollout_items {
+                    if let RolloutItem::ResponseItem(response_item) = rollout_item {
+                        Self::assign_missing_response_item_id(response_item);
+                    }
+                }
                 self.apply_rollout_reconstruction(&turn_context, &rollout_items)
                     .await;
 
@@ -2710,11 +2715,7 @@ impl Session {
         for item in items.to_mut() {
             item.set_turn_id_if_missing(&turn_context.sub_id);
         }
-        if turn_context.config.features.enabled(Feature::ItemIds) {
-            Self::assign_missing_response_item_ids(items)
-        } else {
-            items
-        }
+        Self::assign_missing_response_item_ids(items)
     }
 
     fn assign_missing_response_item_ids(items: Cow<'_, [ResponseItem]>) -> Cow<'_, [ResponseItem]> {
@@ -2723,29 +2724,33 @@ impl Session {
         }
         let mut items = items;
         for item in items.to_mut() {
-            if item.id().is_some() {
-                continue;
-            }
-            let prefix = match item {
-                ResponseItem::AdditionalTools { .. } => "at",
-                ResponseItem::Message { .. } => "msg",
-                ResponseItem::Reasoning { .. } => "rs",
-                ResponseItem::LocalShellCall { .. } => "lsh",
-                ResponseItem::FunctionCall { .. } => "fc",
-                ResponseItem::ToolSearchCall { .. } => "tsc",
-                ResponseItem::FunctionCallOutput { .. } => "fco",
-                ResponseItem::CustomToolCall { .. } => "ctc",
-                ResponseItem::CustomToolCallOutput { .. } => "ctco",
-                ResponseItem::ToolSearchOutput { .. } => "tso",
-                ResponseItem::WebSearchCall { .. } => "ws",
-                ResponseItem::ImageGenerationCall { .. } => "ig",
-                ResponseItem::Compaction { .. } | ResponseItem::ContextCompaction { .. } => "cmp",
-                ResponseItem::AgentMessage { .. } => "amsg",
-                ResponseItem::CompactionTrigger { .. } | ResponseItem::Other => continue,
-            };
-            item.set_id(Some(format!("{prefix}_{}", Uuid::now_v7())));
+            Self::assign_missing_response_item_id(item);
         }
         items
+    }
+
+    fn assign_missing_response_item_id(item: &mut ResponseItem) {
+        if item.id().is_some() {
+            return;
+        }
+        let prefix = match item {
+            ResponseItem::AdditionalTools { .. } => "at",
+            ResponseItem::Message { .. } => "msg",
+            ResponseItem::Reasoning { .. } => "rs",
+            ResponseItem::LocalShellCall { .. } => "lsh",
+            ResponseItem::FunctionCall { .. } => "fc",
+            ResponseItem::ToolSearchCall { .. } => "tsc",
+            ResponseItem::FunctionCallOutput { .. } => "fco",
+            ResponseItem::CustomToolCall { .. } => "ctc",
+            ResponseItem::CustomToolCallOutput { .. } => "ctco",
+            ResponseItem::ToolSearchOutput { .. } => "tso",
+            ResponseItem::WebSearchCall { .. } => "ws",
+            ResponseItem::ImageGenerationCall { .. } => "ig",
+            ResponseItem::Compaction { .. } | ResponseItem::ContextCompaction { .. } => "cmp",
+            ResponseItem::AgentMessage { .. } => "amsg",
+            ResponseItem::CompactionTrigger { .. } | ResponseItem::Other => return,
+        };
+        item.set_id(Some(format!("{prefix}_{}", Uuid::now_v7())));
     }
 
     pub(crate) fn response_item_from_user_input(&self, input: Vec<UserInput>) -> ResponseItem {
@@ -2915,17 +2920,13 @@ impl Session {
 
     pub(crate) async fn replace_compacted_history(
         &self,
-        turn_context: &TurnContext,
+        _turn_context: &TurnContext,
         items: Vec<ResponseItem>,
         reference_context_item: Option<TurnContextItem>,
         world_state_baseline: Option<Arc<WorldState>>,
         compacted_item: CompactedItem,
     ) {
-        let items = if turn_context.config.features.enabled(Feature::ItemIds) {
-            Self::assign_missing_response_item_ids(Cow::Owned(items)).into_owned()
-        } else {
-            items
-        };
+        let items = Self::assign_missing_response_item_ids(Cow::Owned(items)).into_owned();
         let compacted_item = CompactedItem {
             replacement_history: Some(items.clone()),
             ..compacted_item

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -1730,10 +1730,11 @@ async fn record_conversation_items_stamps_missing_turn_id_and_preserves_existing
     let mut expected_fresh_item = fresh_item;
     expected_fresh_item.set_turn_id_if_missing(&turn_context.sub_id);
     let expected_items = vec![expected_fresh_item, existing_item];
-    assert_eq!(
-        session.clone_history().await.raw_items(),
-        expected_items.as_slice()
-    );
+    let mut actual_items = session.clone_history().await.into_raw_items();
+    for item in &mut actual_items {
+        item.set_id(/*new_id*/ None);
+    }
+    assert_eq!(actual_items, expected_items);
 }
 
 #[tokio::test]
@@ -1754,8 +1755,14 @@ async fn record_inter_agent_communication_sets_turn_id_in_rollout_and_resume() {
         .record_inter_agent_communication(&turn_context, communication)
         .await;
 
+    let live_history = session.clone_history().await;
+    let [live_item] = live_history.raw_items() else {
+        panic!("expected exactly one live history item");
+    };
+    expected_item.set_id(live_item.id().map(ToString::to_string));
+
     assert_eq!(
-        session.clone_history().await.raw_items(),
+        live_history.raw_items(),
         std::slice::from_ref(&expected_item)
     );
 
@@ -1782,9 +1789,7 @@ async fn record_inter_agent_communication_preserves_item_id_in_rollout_and_resum
     let (mut session, turn_context, _rx) = make_session_and_context_with_auth_and_config_and_rx(
         CodexAuth::from_api_key("Test API Key"),
         Vec::new(),
-        |config| {
-            let _ = config.features.enable(Feature::ItemIds);
-        },
+        |_config| {},
     )
     .await;
     let rollout_path =
@@ -1831,9 +1836,7 @@ async fn record_inter_agent_communication_preserves_item_id_in_rollout_and_resum
         make_session_and_context_with_auth_and_config_and_rx(
             CodexAuth::from_api_key("Test API Key"),
             Vec::new(),
-            |config| {
-                let _ = config.features.enable(Feature::ItemIds);
-            },
+            |_config| {},
         )
         .await;
     resumed_session
@@ -1851,9 +1854,7 @@ async fn prepares_image_failures_before_history_insertion() {
     let (session, turn_context, _rx) = make_session_and_context_with_auth_and_config_and_rx(
         CodexAuth::from_api_key("Test API Key"),
         Vec::new(),
-        |config| {
-            let _ = config.features.enable(Feature::ItemIds);
-        },
+        |_config| {},
     )
     .await;
     let item = ResponseItem::FunctionCallOutput {
@@ -2691,9 +2692,7 @@ async fn start_new_context_window_assigns_and_persists_item_ids() {
     let (mut session, turn_context, _rx) = make_session_and_context_with_auth_and_config_and_rx(
         CodexAuth::from_api_key("Test API Key"),
         Vec::new(),
-        |config| {
-            let _ = config.features.enable(Feature::ItemIds);
-        },
+        |_config| {},
     )
     .await;
     let rollout_path =
@@ -2734,6 +2733,52 @@ async fn start_new_context_window_assigns_and_persists_item_ids() {
         persisted_replacement_history.map(Vec::as_slice),
         Some(live_history.raw_items())
     );
+}
+
+#[tokio::test]
+async fn record_initial_history_assigns_and_persists_id_for_forked_response_item() {
+    let (mut session, _turn_context) = make_session_and_context().await;
+    let rollout_path = attach_thread_persistence(&mut session).await;
+    let response_item = crate::context_manager::updates::build_developer_update_item(vec![
+        "Subagent guidance.".to_string(),
+    ])
+    .expect("developer message");
+    let mut expected_item = response_item.clone();
+
+    session
+        .record_initial_history(InitialHistory::Forked(vec![RolloutItem::ResponseItem(
+            response_item,
+        )]))
+        .await;
+
+    let live_history = session.clone_history().await;
+    let [live_item] = live_history.raw_items() else {
+        panic!("expected one forked response item");
+    };
+    let live_item_id = live_item
+        .id()
+        .expect("forked response item should have an id")
+        .to_string();
+    assert!(live_item_id.starts_with("msg_"));
+    expected_item.set_id(Some(live_item_id.clone()));
+    assert_eq!(live_history.raw_items(), &[expected_item]);
+
+    session.flush_rollout().await.expect("rollout should flush");
+    let InitialHistory::Resumed(resumed) = RolloutRecorder::get_rollout_history(&rollout_path)
+        .await
+        .expect("read rollout history")
+    else {
+        panic!("expected resumed rollout history");
+    };
+    let persisted_item_id = resumed.history.iter().find_map(|item| match item {
+        RolloutItem::ResponseItem(response_item) => response_item.id(),
+        RolloutItem::SessionMeta(_)
+        | RolloutItem::InterAgentCommunication(_)
+        | RolloutItem::Compacted(_)
+        | RolloutItem::TurnContext(_)
+        | RolloutItem::EventMsg(_) => None,
+    });
+    assert_eq!(persisted_item_id, Some(live_item_id.as_str()));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -1730,11 +1730,10 @@ async fn record_conversation_items_stamps_missing_turn_id_and_preserves_existing
     let mut expected_fresh_item = fresh_item;
     expected_fresh_item.set_turn_id_if_missing(&turn_context.sub_id);
     let expected_items = vec![expected_fresh_item, existing_item];
-    let mut actual_items = session.clone_history().await.into_raw_items();
-    for item in &mut actual_items {
-        item.set_id(/*new_id*/ None);
-    }
-    assert_eq!(actual_items, expected_items);
+    assert_eq!(
+        session.clone_history().await.raw_items(),
+        expected_items.as_slice()
+    );
 }
 
 #[tokio::test]
@@ -1755,14 +1754,8 @@ async fn record_inter_agent_communication_sets_turn_id_in_rollout_and_resume() {
         .record_inter_agent_communication(&turn_context, communication)
         .await;
 
-    let live_history = session.clone_history().await;
-    let [live_item] = live_history.raw_items() else {
-        panic!("expected exactly one live history item");
-    };
-    expected_item.set_id(live_item.id().map(ToString::to_string));
-
     assert_eq!(
-        live_history.raw_items(),
+        session.clone_history().await.raw_items(),
         std::slice::from_ref(&expected_item)
     );
 
@@ -1789,7 +1782,9 @@ async fn record_inter_agent_communication_preserves_item_id_in_rollout_and_resum
     let (mut session, turn_context, _rx) = make_session_and_context_with_auth_and_config_and_rx(
         CodexAuth::from_api_key("Test API Key"),
         Vec::new(),
-        |_config| {},
+        |config| {
+            let _ = config.features.enable(Feature::ItemIds);
+        },
     )
     .await;
     let rollout_path =
@@ -1836,7 +1831,9 @@ async fn record_inter_agent_communication_preserves_item_id_in_rollout_and_resum
         make_session_and_context_with_auth_and_config_and_rx(
             CodexAuth::from_api_key("Test API Key"),
             Vec::new(),
-            |_config| {},
+            |config| {
+                let _ = config.features.enable(Feature::ItemIds);
+            },
         )
         .await;
     resumed_session
@@ -1854,7 +1851,9 @@ async fn prepares_image_failures_before_history_insertion() {
     let (session, turn_context, _rx) = make_session_and_context_with_auth_and_config_and_rx(
         CodexAuth::from_api_key("Test API Key"),
         Vec::new(),
-        |_config| {},
+        |config| {
+            let _ = config.features.enable(Feature::ItemIds);
+        },
     )
     .await;
     let item = ResponseItem::FunctionCallOutput {
@@ -2695,7 +2694,9 @@ async fn start_new_context_window_assigns_and_persists_item_ids() {
     let (mut session, turn_context, _rx) = make_session_and_context_with_auth_and_config_and_rx(
         CodexAuth::from_api_key("Test API Key"),
         Vec::new(),
-        |_config| {},
+        |config| {
+            let _ = config.features.enable(Feature::ItemIds);
+        },
     )
     .await;
     let rollout_path =

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -2682,11 +2682,8 @@ async fn record_initial_history_reconstructs_forked_transcript() {
         .record_initial_history(InitialHistory::Forked(rollout_items))
         .await;
 
-    let mut actual = session.state.lock().await.clone_history().into_raw_items();
-    for item in &mut actual {
-        item.set_id(/*new_id*/ None);
-    }
-    assert_eq!(expected, actual);
+    let history = session.state.lock().await.clone_history();
+    assert_eq!(expected, history.raw_items());
 }
 
 #[tokio::test]
@@ -2741,8 +2738,16 @@ async fn start_new_context_window_assigns_and_persists_item_ids() {
 
 #[tokio::test]
 async fn record_initial_history_assigns_and_persists_id_for_forked_response_item() {
-    let (mut session, _turn_context) = make_session_and_context().await;
-    let rollout_path = attach_thread_persistence(&mut session).await;
+    let (mut session, _turn_context, _rx) = make_session_and_context_with_auth_and_config_and_rx(
+        CodexAuth::from_api_key("Test API Key"),
+        Vec::new(),
+        |config| {
+            let _ = config.features.enable(Feature::ItemIds);
+        },
+    )
+    .await;
+    let rollout_path =
+        attach_thread_persistence(Arc::get_mut(&mut session).expect("unique session")).await;
     let response_item = crate::context_manager::updates::build_developer_update_item(vec![
         "Subagent guidance.".to_string(),
     ])

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -2683,8 +2683,11 @@ async fn record_initial_history_reconstructs_forked_transcript() {
         .record_initial_history(InitialHistory::Forked(rollout_items))
         .await;
 
-    let history = session.state.lock().await.clone_history();
-    assert_eq!(expected, history.raw_items());
+    let mut actual = session.state.lock().await.clone_history().into_raw_items();
+    for item in &mut actual {
+        item.set_id(/*new_id*/ None);
+    }
+    assert_eq!(expected, actual);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Why

Fork-specific response items, including the subagent usage hint, are appended directly to `InitialHistory::Forked`. This bypasses the normal history insertion path that assigns missing response item IDs when `Feature::ItemIds` is enabled, so the child could reconstruct and persist those items without IDs.

## What changed

- When `Feature::ItemIds` is enabled, assign missing IDs to top-level `ResponseItem`s while materializing `InitialHistory::Forked`, before both reconstruction and persistence.
- Preserve existing IDs and use the same owned rollout items for live history and persistence.
- Extract the existing single-item ID allocation logic for reuse by the fork path.
- Add coverage that verifies a fork-only developer message receives the same ID in live and persisted history with the feature enabled.

Normal history recording, compacted-history replacement, and fork handling all continue to honor `Feature::ItemIds`. External-agent imports, normal resume, and nested legacy compaction checkpoints are unchanged.

## Testing

- `just test -p codex-core record_initial_history_reconstructs_forked_transcript`
- `just test -p codex-core record_initial_history_assigns_and_persists_id_for_forked_response_item`
