### PR TITLE
[codex] Update bundled skill installer guidance

### DIFF
--- a/codex-rs/skills/src/assets/samples/skill-installer/SKILL.md
+++ b/codex-rs/skills/src/assets/samples/skill-installer/SKILL.md
@@ -27,7 +27,7 @@ Skills from {repo}:
 Which ones would you like installed?
 """
 
-After installing a skill, tell the user: "Restart Codex to pick up new skills."
+After installing a skill, tell the user it will be available on their next turn.
 
 ## Scripts
 


### PR DESCRIPTION
## Summary

- Update the bundled skill installer's post-install guidance to say the skill will be available on the user's next turn.
- Remove the obsolete instruction to restart Codex.

## Why

Codex refreshes its skill catalog between turns. The existing bundled instruction predates that behavior and causes the model to recommend an unnecessary restart.

## Impact

Released Codex builds will materialize accurate post-install guidance for the bundled system skill.

## Related

- Canonical skill change: https://github.com/openai/skills/pull/507

## Validation

- `just fmt`
- `git diff --check`
- `just test -p codex-app-server skills_changed_notification_is_emitted_after_skill_change` (passed during investigation)

No test code was added because the existing live-refresh path and focused integration test already verify that skill changes are picked up without restarting.