### PR TITLE
[codex] Ensure app-server listener before proxying

### DIFF
--- a/codex-rs/app-server-daemon/src/lib.rs
+++ b/codex-rs/app-server-daemon/src/lib.rs
@@ -192,6 +192,15 @@ pub async fn run(command: LifecycleCommand) -> Result<LifecycleOutput> {
     Daemon::from_environment()?.run(command).await
 }
 
+/// Ensures the CODEX_HOME app-server listener is healthy, starting it with the
+/// currently running Codex executable when needed.
+pub async fn ensure_listener_started_with_current_exe() -> Result<()> {
+    ensure_supported_platform()?;
+    Daemon::from_environment()?
+        .ensure_listener_started_with_current_exe()
+        .await
+}
+
 pub async fn bootstrap(options: BootstrapOptions) -> Result<BootstrapOutput> {
     ensure_supported_platform()?;
     Daemon::from_environment()?.bootstrap(options).await
@@ -291,6 +300,25 @@ impl Daemon {
         }
     }
 
+    async fn ensure_listener_started_with_current_exe(&self) -> Result<()> {
+        let _operation_lock = self.acquire_operation_lock().await?;
+        let settings = self.load_settings().await?;
+        if client::probe(&self.socket_path).await.is_ok() {
+            return Ok(());
+        }
+
+        if self.running_backend_instance(&settings).await?.is_some() {
+            self.wait_until_ready().await?;
+            return Ok(());
+        }
+
+        let current_exe =
+            std::env::current_exe().context("failed to resolve the current Codex executable")?;
+        self.start_backend_with_bin(&settings, &current_exe).await?;
+        self.wait_until_ready().await?;
+        Ok(())
+    }
+
     async fn start(&self) -> Result<LifecycleOutput> {
         let settings = self.load_settings().await?;
         if let Ok(info) = client::probe(&self.socket_path).await {
@@ -381,7 +409,7 @@ impl Daemon {
                 RestartDecision::Restart => {
                     backend.stop().await?;
                     let _ = self
-                        .start_managed_backend_with_bin(&settings, managed_codex_bin)
+                        .start_backend_with_bin(&settings, managed_codex_bin)
                         .await?;
                     self.wait_until_ready().await?;
                     RestartIfRunningOutcome::Restarted
@@ -642,11 +670,11 @@ impl Daemon {
     }
 
     async fn start_managed_backend(&self, settings: &DaemonSettings) -> Result<Option<u32>> {
-        self.start_managed_backend_with_bin(settings, &self.managed_codex_bin)
+        self.start_backend_with_bin(settings, &self.managed_codex_bin)
             .await
     }
 
-    async fn start_managed_backend_with_bin(
+    async fn start_backend_with_bin(
         &self,
         settings: &DaemonSettings,
         managed_codex_bin: &Path,

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -645,6 +645,10 @@ struct AppServerProxyCommand {
     /// Path to the app-server Unix domain socket to connect to.
     #[arg(long = "sock", value_name = "SOCKET_PATH", value_parser = parse_socket_path)]
     socket_path: Option<AbsolutePathBuf>,
+
+    /// Start the CODEX_HOME app-server listener if it is not healthy before proxying.
+    #[arg(long = "ensure-listener")]
+    ensure_listener: bool,
 }
 
 #[derive(Debug, Args)]
@@ -1192,6 +1196,15 @@ async fn cli_main(
                             codex_app_server::app_server_control_socket_path(&codex_home)?
                         }
                     };
+                    if proxy_cli.ensure_listener {
+                        let codex_home = find_codex_home()?;
+                        let default_socket_path =
+                            codex_app_server::app_server_control_socket_path(&codex_home)?;
+                        if socket_path != default_socket_path {
+                            anyhow::bail!("--ensure-listener only supports the CODEX_HOME socket");
+                        }
+                        codex_app_server_daemon::ensure_listener_started_with_current_exe().await?;
+                    }
                     codex_stdio_to_uds::run(socket_path.as_path()).await?;
                 }
                 Some(AppServerSubcommand::GenerateTs(gen_cli)) => {
@@ -3742,7 +3755,43 @@ mod tests {
         assert!(matches!(
             app_server.subcommand,
             Some(AppServerSubcommand::Proxy(AppServerProxyCommand {
-                socket_path: None
+                socket_path: None,
+                ensure_listener: false,
+            }))
+        ));
+    }
+
+    #[test]
+    fn app_server_proxy_ensure_listener_flag_parses() {
+        let app_server =
+            app_server_from_args(["codex", "app-server", "proxy", "--ensure-listener"].as_ref());
+        assert!(matches!(
+            app_server.subcommand,
+            Some(AppServerSubcommand::Proxy(AppServerProxyCommand {
+                socket_path: None,
+                ensure_listener: true,
+            }))
+        ));
+    }
+
+    #[test]
+    fn app_server_proxy_ensure_listener_accepts_sock() {
+        let app_server = app_server_from_args(
+            [
+                "codex",
+                "app-server",
+                "proxy",
+                "--ensure-listener",
+                "--sock",
+                "/tmp/codex.sock",
+            ]
+            .as_ref(),
+        );
+        assert!(matches!(
+            app_server.subcommand,
+            Some(AppServerSubcommand::Proxy(AppServerProxyCommand {
+                socket_path: Some(_),
+                ensure_listener: true,
             }))
         ));
     }
@@ -3829,7 +3878,10 @@ mod tests {
 
     #[test]
     fn reject_remote_auth_token_env_for_app_server_proxy() {
-        let subcommand = AppServerSubcommand::Proxy(AppServerProxyCommand { socket_path: None });
+        let subcommand = AppServerSubcommand::Proxy(AppServerProxyCommand {
+            socket_path: None,
+            ensure_listener: false,
+        });
         let err = reject_remote_mode_for_app_server_subcommand(
             /*remote*/ None,
             Some("CODEX_REMOTE_AUTH_TOKEN"),

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -1200,7 +1200,11 @@ async fn cli_main(
                         let codex_home = find_codex_home()?;
                         let default_socket_path =
                             codex_app_server::app_server_control_socket_path(&codex_home)?;
-                        if socket_path != default_socket_path {
+                        if !is_default_app_server_socket(
+                            socket_path.as_path(),
+                            default_socket_path.as_path(),
+                            codex_home.as_path(),
+                        ) {
                             anyhow::bail!("--ensure-listener only supports the CODEX_HOME socket");
                         }
                         codex_app_server_daemon::ensure_listener_started_with_current_exe().await?;
@@ -1684,6 +1688,33 @@ fn profile_v2_for_subcommand<'a>(
             "--profile only applies to runtime commands and `codex mcp`: `codex`, `codex exec`, `codex review`, `codex resume`, `codex archive`, `codex delete`, `codex unarchive`, `codex fork`, `codex mcp`, `codex sandbox`, and `codex debug prompt-input`."
         ),
     }
+}
+
+fn is_default_app_server_socket(
+    socket_path: &std::path::Path,
+    default_socket_path: &std::path::Path,
+    codex_home: &std::path::Path,
+) -> bool {
+    if socket_path == default_socket_path {
+        return true;
+    }
+
+    let Some(socket_dir) = socket_path.parent() else {
+        return false;
+    };
+    let Some(default_socket_dir) = default_socket_path.parent() else {
+        return false;
+    };
+    if socket_path.file_name() != default_socket_path.file_name()
+        || socket_dir.file_name() != default_socket_dir.file_name()
+    {
+        return false;
+    }
+
+    socket_dir
+        .parent()
+        .and_then(|candidate_home| candidate_home.canonicalize().ok())
+        .is_some_and(|candidate_home| candidate_home == codex_home)
 }
 
 async fn run_exec_server_command(

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -647,6 +647,7 @@ struct AppServerProxyCommand {
     socket_path: Option<AbsolutePathBuf>,
 
     /// Start the CODEX_HOME app-server listener if it is not healthy before proxying.
+    #[cfg(unix)]
     #[arg(long = "ensure-listener")]
     ensure_listener: bool,
 }
@@ -1196,6 +1197,7 @@ async fn cli_main(
                             codex_app_server::app_server_control_socket_path(&codex_home)?
                         }
                     };
+                    #[cfg(unix)]
                     if proxy_cli.ensure_listener {
                         let codex_home = find_codex_home()?;
                         let default_socket_path =
@@ -1690,6 +1692,7 @@ fn profile_v2_for_subcommand<'a>(
     }
 }
 
+#[cfg(unix)]
 fn is_default_app_server_socket(
     socket_path: &std::path::Path,
     default_socket_path: &std::path::Path,
@@ -3787,11 +3790,13 @@ mod tests {
             app_server.subcommand,
             Some(AppServerSubcommand::Proxy(AppServerProxyCommand {
                 socket_path: None,
+                #[cfg(unix)]
                 ensure_listener: false,
             }))
         ));
     }
 
+    #[cfg(unix)]
     #[test]
     fn app_server_proxy_ensure_listener_flag_parses() {
         let app_server =
@@ -3805,6 +3810,7 @@ mod tests {
         ));
     }
 
+    #[cfg(unix)]
     #[test]
     fn app_server_proxy_ensure_listener_accepts_sock() {
         let app_server = app_server_from_args(
@@ -3825,6 +3831,15 @@ mod tests {
                 ensure_listener: true,
             }))
         ));
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn app_server_proxy_ensure_listener_flag_is_unavailable() {
+        let err =
+            MultitoolCli::try_parse_from(["codex", "app-server", "proxy", "--ensure-listener"])
+                .expect_err("--ensure-listener should be Unix-only");
+        assert_eq!(err.kind(), clap::error::ErrorKind::UnknownArgument);
     }
 
     #[test]
@@ -3911,6 +3926,7 @@ mod tests {
     fn reject_remote_auth_token_env_for_app_server_proxy() {
         let subcommand = AppServerSubcommand::Proxy(AppServerProxyCommand {
             socket_path: None,
+            #[cfg(unix)]
             ensure_listener: false,
         });
         let err = reject_remote_mode_for_app_server_subcommand(

--- a/codex-rs/cli/tests/app_server.rs
+++ b/codex-rs/cli/tests/app_server.rs
@@ -96,3 +96,35 @@ fn proxy_ensure_listener_rejects_a_non_default_socket() -> Result<()> {
     );
     Ok(())
 }
+
+
+#[cfg(unix)]
+#[test]
+fn proxy_ensure_listener_accepts_default_socket_through_symlinked_codex_home() -> Result<()> {
+    use std::os::unix::fs::symlink;
+
+    let real_home = TempDir::new()?;
+    let link_parent = TempDir::new()?;
+    let linked_home = link_parent.path().join("linked-codex-home");
+    symlink(real_home.path(), &linked_home)?;
+
+    let socket_path = linked_home.join("app-server-control/app-server-control.sock");
+    let mut proxy = codex_command(&linked_home)?;
+    proxy
+        .args([
+            "app-server",
+            "proxy",
+            "--ensure-listener",
+            "--sock",
+            socket_path.to_str().expect("temp path should be UTF-8"),
+        ])
+        .assert()
+        .success();
+
+    let mut stop = codex_command(&linked_home)?;
+    stop.args(["app-server", "daemon", "stop"])
+        .assert()
+        .success();
+
+    Ok(())
+}

--- a/codex-rs/cli/tests/app_server.rs
+++ b/codex-rs/cli/tests/app_server.rs
@@ -28,3 +28,71 @@ foo = "bar"
 
     Ok(())
 }
+
+#[cfg(unix)]
+#[test]
+fn proxy_ensure_listener_recovers_a_stale_socket_and_reuses_the_listener() -> Result<()> {
+    use std::os::unix::net::UnixListener;
+
+    let codex_home = TempDir::new()?;
+    let socket_dir = codex_home.path().join("app-server-control");
+    let socket_path = socket_dir.join("app-server-control.sock");
+    std::fs::create_dir_all(&socket_dir)?;
+
+    let stale_listener = UnixListener::bind(&socket_path)?;
+    drop(stale_listener);
+
+    let mut first_proxy = codex_command(codex_home.path())?;
+    first_proxy
+        .args(["app-server", "proxy", "--ensure-listener"])
+        .assert()
+        .success();
+
+    let pid_file = codex_home.path().join("app-server-daemon/app-server.pid");
+    let first_pid_record = std::fs::read_to_string(&pid_file)?;
+
+    let mut second_proxy = codex_command(codex_home.path())?;
+    second_proxy
+        .args(["app-server", "proxy", "--ensure-listener"])
+        .assert()
+        .success();
+
+    let second_pid_record = std::fs::read_to_string(pid_file)?;
+
+    let mut stop = codex_command(codex_home.path())?;
+    stop.args(["app-server", "daemon", "stop"])
+        .assert()
+        .success();
+
+    assert_eq!(first_pid_record, second_pid_record);
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn proxy_ensure_listener_rejects_a_non_default_socket() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    let other_socket = codex_home.path().join("other.sock");
+    let mut proxy = codex_command(codex_home.path())?;
+    let output = proxy
+        .args([
+            "app-server",
+            "proxy",
+            "--ensure-listener",
+            "--sock",
+            other_socket.to_str().expect("temp path should be UTF-8"),
+        ])
+        .output()?;
+
+    let mut stop = codex_command(codex_home.path())?;
+    stop.args(["app-server", "daemon", "stop"])
+        .assert()
+        .success();
+
+    assert!(!output.status.success());
+    assert!(
+        String::from_utf8_lossy(&output.stderr)
+            .contains("--ensure-listener only supports the CODEX_HOME socket")
+    );
+    Ok(())
+}

--- a/codex-rs/cli/tests/app_server.rs
+++ b/codex-rs/cli/tests/app_server.rs
@@ -97,7 +97,6 @@ fn proxy_ensure_listener_rejects_a_non_default_socket() -> Result<()> {
     Ok(())
 }
 
-
 #[cfg(unix)]
 #[test]
 fn proxy_ensure_listener_accepts_default_socket_through_symlinked_codex_home() -> Result<()> {


### PR DESCRIPTION
## Summary

Add an opt-in Unix-only `codex app-server proxy --ensure-listener` mode that makes one native command ensure the CODEX_HOME app-server listener and then proxy stdio to it.

The ensure path reuses the existing daemon lifecycle: a protocol-level Unix-socket probe, operation locking, detached PID management with process-start identity, stale socket recovery in app-server startup, bounded readiness polling, and daemon stop support. It starts the listener with the current Codex executable, so remote CODEX_HOME directories do not require the separately managed standalone install.

`--ensure-listener --sock <path>` is accepted only when the path is the CODEX_HOME default socket. Existing `app-server proxy` behavior is unchanged when the flag is absent.

## Why

A dead app-server can leave a Unix socket inode behind. Callers that treat the inode as listener health retry the same refused endpoint forever. This gives restricted transports a narrow native primitive with the same connect-based health decision already used by the daemon.

## Testing

- CLI parsing, socket guardrail coverage, and symlinked `CODEX_HOME` normalization
- End-to-end stale Unix socket recovery through the built `codex` binary
- Repeated ensure calls reuse one listener and PID record
- Full `codex-app-server-daemon` test suite
- Targeted Clippy/fix passes for the daemon and CLI crates
- Rust formatting

