### PR TITLE
Fix app-server attestation subscription race

### DIFF
--- a/codex-rs/app-server/src/attestation.rs
+++ b/codex-rs/app-server/src/attestation.rs
@@ -10,7 +10,9 @@ use codex_core::AttestationProvider;
 use codex_core::GenerateAttestationFuture;
 use serde::Serialize;
 use tokio::time::Duration;
-use tokio::time::timeout;
+use tokio::time::Instant;
+use tokio::time::timeout_at;
+use tracing::debug;
 use tracing::warn;
 
 use crate::outgoing_message::OutgoingMessageSender;
@@ -44,7 +46,16 @@ impl std::fmt::Debug for AppServerAttestationProvider {
 impl AttestationProvider for AppServerAttestationProvider {
     fn header_for_request(&self, context: AttestationContext) -> GenerateAttestationFuture<'_> {
         let Some(outgoing) = self.outgoing.upgrade() else {
-            return Box::pin(async { None });
+            return Box::pin(async move {
+                warn!(
+                    thread_id = %context.thread_id,
+                    stage = "provider",
+                    reason = "outgoing_unavailable",
+                    outcome = "omitted",
+                    "app-server attestation provider is unavailable"
+                );
+                None
+            });
         };
         let thread_state_manager = self.thread_state_manager.clone();
         Box::pin(async move {
@@ -55,7 +66,20 @@ impl AttestationProvider for AppServerAttestationProvider {
                 ATTESTATION_GENERATE_TIMEOUT,
             )
             .await
-            .and_then(|value| HeaderValue::from_bytes(value.as_bytes()).ok())
+            .and_then(|value| match HeaderValue::from_bytes(value.as_bytes()) {
+                Ok(value) => Some(value),
+                Err(err) => {
+                    warn!(
+                        thread_id = %context.thread_id,
+                        stage = "header_serialize",
+                        reason = "invalid_header_value",
+                        outcome = "omitted",
+                        error = %err,
+                        "failed to build app-server attestation header"
+                    );
+                    None
+                }
+            })
         })
     }
 }
@@ -66,9 +90,46 @@ async fn request_attestation_header_value_with_timeout(
     thread_id: codex_protocol::ThreadId,
     timeout_duration: Duration,
 ) -> Option<String> {
-    let connection_id = thread_state_manager
-        .first_attestation_capable_connection_for_thread(thread_id)
-        .await?;
+    let deadline = Instant::now() + timeout_duration;
+    let connection_id = match timeout_at(
+        deadline,
+        thread_state_manager.wait_for_attestation_capable_connection_for_thread(thread_id),
+    )
+    .await
+    {
+        Ok(Some(connection_id)) => connection_id,
+        Ok(None) => {
+            let subscriber_count = thread_state_manager
+                .subscribed_connection_ids(thread_id)
+                .await
+                .len();
+            debug!(
+                thread_id = %thread_id,
+                stage = "capability_lookup",
+                reason = "no_live_capable_connection",
+                outcome = "omitted",
+                subscriber_count,
+                "no live client supports attestation generation"
+            );
+            return None;
+        }
+        Err(_) => {
+            let subscriber_count = thread_state_manager
+                .subscribed_connection_ids(thread_id)
+                .await
+                .len();
+            warn!(
+                thread_id = %thread_id,
+                stage = "capability_lookup",
+                reason = "no_capable_thread_subscriber",
+                outcome = "omitted",
+                subscriber_count,
+                timeout_ms = timeout_duration.as_millis(),
+                "timed out waiting for an attestation-capable client to subscribe"
+            );
+            return None;
+        }
+    };
 
     let connection_ids = [connection_id];
     let (request_id, rx) = outgoing
@@ -78,11 +139,25 @@ async fn request_attestation_header_value_with_timeout(
             /*thread_id*/ None,
         )
         .await;
+    debug!(
+        thread_id = %thread_id,
+        connection_id = connection_id.0,
+        request_id = ?request_id,
+        stage = "rpc_dispatch",
+        reason = "capable_connection_selected",
+        "dispatched attestation generation request"
+    );
 
-    let result = match timeout(timeout_duration, rx).await {
+    let result = match timeout_at(deadline, rx).await {
         Ok(Ok(Ok(result))) => result,
         Ok(Ok(Err(err))) => {
             warn!(
+                thread_id = %thread_id,
+                connection_id = connection_id.0,
+                request_id = ?request_id,
+                stage = "rpc_response",
+                reason = "request_failed",
+                outcome = "error_header",
                 code = err.code,
                 message = %err.message,
                 "attestation generation request failed"
@@ -93,7 +168,16 @@ async fn request_attestation_header_value_with_timeout(
             );
         }
         Ok(Err(err)) => {
-            warn!("attestation generation request canceled: {err}");
+            warn!(
+                thread_id = %thread_id,
+                connection_id = connection_id.0,
+                request_id = ?request_id,
+                stage = "rpc_response",
+                reason = "request_canceled",
+                outcome = "error_header",
+                error = %err,
+                "attestation generation request canceled"
+            );
             return app_server_attestation_header_value(
                 AppServerAttestationStatus::RequestCanceled,
                 /*token*/ None,
@@ -102,7 +186,13 @@ async fn request_attestation_header_value_with_timeout(
         Err(_) => {
             let _canceled = outgoing.cancel_request(&request_id).await;
             warn!(
-                timeout_seconds = timeout_duration.as_secs(),
+                thread_id = %thread_id,
+                connection_id = connection_id.0,
+                request_id = ?request_id,
+                stage = "rpc_response",
+                reason = "timeout",
+                outcome = "error_header",
+                timeout_ms = timeout_duration.as_millis(),
                 "attestation generation request timed out"
             );
             return app_server_attestation_header_value(
@@ -113,12 +203,32 @@ async fn request_attestation_header_value_with_timeout(
     };
 
     match serde_json::from_value::<AttestationGenerateResponse>(result) {
-        Ok(response) => app_server_attestation_header_value(
-            AppServerAttestationStatus::Ok,
-            Some(&response.token),
-        ),
+        Ok(response) => {
+            debug!(
+                thread_id = %thread_id,
+                connection_id = connection_id.0,
+                request_id = ?request_id,
+                stage = "rpc_response",
+                reason = "ok",
+                outcome = "header",
+                "received attestation generation response"
+            );
+            app_server_attestation_header_value(
+                AppServerAttestationStatus::Ok,
+                Some(&response.token),
+            )
+        }
         Err(err) => {
-            warn!("failed to deserialize attestation generation response: {err}");
+            warn!(
+                thread_id = %thread_id,
+                connection_id = connection_id.0,
+                request_id = ?request_id,
+                stage = "rpc_response",
+                reason = "malformed_response",
+                outcome = "error_header",
+                error = %err,
+                "failed to deserialize attestation generation response"
+            );
             app_server_attestation_header_value(
                 AppServerAttestationStatus::MalformedResponse,
                 /*token*/ None,
@@ -165,7 +275,15 @@ fn app_server_attestation_header_value(
         s: status.code(),
         t: token,
     })
-    .map_err(|err| warn!("failed to serialize app-server attestation envelope: {err}"))
+    .map_err(|err| {
+        warn!(
+            stage = "header_serialize",
+            reason = "json_serialize_failed",
+            outcome = "omitted",
+            error = %err,
+            "failed to serialize app-server attestation envelope"
+        )
+    })
     .ok()
 }
 
@@ -173,7 +291,22 @@ fn app_server_attestation_header_value(
 mod tests {
     use super::AppServerAttestationStatus;
     use super::app_server_attestation_header_value;
+    use super::app_server_attestation_provider;
+    use super::request_attestation_header_value_with_timeout;
+    use crate::outgoing_message::ConnectionId;
+    use crate::outgoing_message::OutgoingEnvelope;
+    use crate::outgoing_message::OutgoingMessage;
+    use crate::outgoing_message::OutgoingMessageSender;
+    use crate::thread_state::ConnectionCapabilities;
+    use crate::thread_state::ThreadStateManager;
+    use codex_app_server_protocol::ServerRequest;
+    use codex_core::AttestationContext;
+    use codex_protocol::ThreadId;
     use pretty_assertions::assert_eq;
+    use std::sync::Arc;
+    use tokio::sync::mpsc;
+    use tokio::time::Duration;
+    use tokio::time::timeout;
 
     #[test]
     fn app_server_attestation_header_value_wraps_opaque_client_payloads() {
@@ -216,5 +349,199 @@ mod tests {
             ),
             Some(r#"{"v":1,"s":4}"#.to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn unavailable_provider_is_omitted() {
+        let (outgoing_tx, _outgoing_rx) = mpsc::channel(1);
+        let provider = app_server_attestation_provider(
+            Arc::new(OutgoingMessageSender::new(
+                outgoing_tx,
+                codex_analytics::AnalyticsEventsClient::disabled(),
+            )),
+            ThreadStateManager::new(),
+        );
+
+        let header = provider
+            .header_for_request(AttestationContext {
+                thread_id: ThreadId::new(),
+            })
+            .await;
+
+        assert_eq!(header, None);
+    }
+
+    #[tokio::test]
+    async fn attestation_without_thread_subscriber_is_omitted() {
+        let (outgoing_tx, _outgoing_rx) = mpsc::channel(1);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            outgoing_tx,
+            codex_analytics::AnalyticsEventsClient::disabled(),
+        ));
+        let thread_state_manager = ThreadStateManager::new();
+        let thread_id = ThreadId::new();
+
+        let header = request_attestation_header_value_with_timeout(
+            outgoing,
+            thread_state_manager,
+            thread_id,
+            Duration::from_millis(1),
+        )
+        .await;
+
+        assert_eq!(header, None);
+    }
+
+    #[tokio::test]
+    async fn attestation_waits_for_capable_thread_subscriber() {
+        let (outgoing_tx, mut outgoing_rx) = mpsc::channel(1);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            outgoing_tx,
+            codex_analytics::AnalyticsEventsClient::disabled(),
+        ));
+        let thread_state_manager = ThreadStateManager::new();
+        let thread_id = ThreadId::new();
+        let connection_id = ConnectionId(7);
+        thread_state_manager
+            .connection_initialized(
+                connection_id,
+                ConnectionCapabilities {
+                    request_attestation: true,
+                },
+            )
+            .await;
+
+        let request_header = request_attestation_header_value_with_timeout(
+            Arc::clone(&outgoing),
+            thread_state_manager.clone(),
+            thread_id,
+            Duration::from_secs(1),
+        );
+        let respond = attach_capable_connection_and_respond(
+            &thread_state_manager,
+            thread_id,
+            connection_id,
+            outgoing.as_ref(),
+            &mut outgoing_rx,
+        );
+
+        let (header, ()) = tokio::join!(request_header, respond);
+        assert_eq!(
+            header,
+            Some(r#"{"v":1,"s":0,"t":"v1.integration-test"}"#.to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn attestation_waits_past_unsupported_subscriber_for_capable_subscriber() {
+        let (outgoing_tx, mut outgoing_rx) = mpsc::channel(1);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            outgoing_tx,
+            codex_analytics::AnalyticsEventsClient::disabled(),
+        ));
+        let thread_state_manager = ThreadStateManager::new();
+        let thread_id = ThreadId::new();
+        let unsupported_connection_id = ConnectionId(7);
+        let capable_connection_id = ConnectionId(8);
+        thread_state_manager
+            .connection_initialized(unsupported_connection_id, ConnectionCapabilities::default())
+            .await;
+        thread_state_manager
+            .connection_initialized(
+                capable_connection_id,
+                ConnectionCapabilities {
+                    request_attestation: true,
+                },
+            )
+            .await;
+        assert!(
+            thread_state_manager
+                .try_add_connection_to_thread(thread_id, unsupported_connection_id)
+                .await
+        );
+
+        let request_header = request_attestation_header_value_with_timeout(
+            Arc::clone(&outgoing),
+            thread_state_manager.clone(),
+            thread_id,
+            Duration::from_secs(1),
+        );
+        let respond = attach_capable_connection_and_respond(
+            &thread_state_manager,
+            thread_id,
+            capable_connection_id,
+            outgoing.as_ref(),
+            &mut outgoing_rx,
+        );
+
+        let (header, ()) = tokio::join!(request_header, respond);
+        assert_eq!(
+            header,
+            Some(r#"{"v":1,"s":0,"t":"v1.integration-test"}"#.to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn attestation_with_unsupported_thread_subscriber_is_omitted() {
+        let (outgoing_tx, _outgoing_rx) = mpsc::channel(1);
+        let outgoing = Arc::new(OutgoingMessageSender::new(
+            outgoing_tx,
+            codex_analytics::AnalyticsEventsClient::disabled(),
+        ));
+        let thread_state_manager = ThreadStateManager::new();
+        let thread_id = ThreadId::new();
+        let connection_id = ConnectionId(7);
+        thread_state_manager
+            .connection_initialized(connection_id, ConnectionCapabilities::default())
+            .await;
+        assert!(
+            thread_state_manager
+                .try_add_connection_to_thread(thread_id, connection_id)
+                .await
+        );
+
+        let header = request_attestation_header_value_with_timeout(
+            outgoing,
+            thread_state_manager,
+            thread_id,
+            Duration::from_secs(1),
+        )
+        .await;
+
+        assert_eq!(header, None);
+    }
+
+    async fn attach_capable_connection_and_respond(
+        thread_state_manager: &ThreadStateManager,
+        thread_id: ThreadId,
+        connection_id: ConnectionId,
+        outgoing: &OutgoingMessageSender,
+        outgoing_rx: &mut mpsc::Receiver<OutgoingEnvelope>,
+    ) {
+        tokio::task::yield_now().await;
+        assert!(
+            thread_state_manager
+                .try_add_connection_to_thread(thread_id, connection_id)
+                .await
+        );
+        let envelope = timeout(Duration::from_secs(1), outgoing_rx.recv())
+            .await
+            .expect("timed out waiting for attestation request")
+            .expect("outgoing channel closed before attestation request");
+        let OutgoingEnvelope::ToConnection {
+            connection_id: target_connection_id,
+            message: OutgoingMessage::Request(ServerRequest::AttestationGenerate { request_id, .. }),
+            ..
+        } = envelope
+        else {
+            panic!("expected targeted attestation request");
+        };
+        assert_eq!(target_connection_id, connection_id);
+        outgoing
+            .notify_client_response(
+                request_id,
+                serde_json::json!({ "token": "v1.integration-test" }),
+            )
+            .await;
     }
 }

--- a/codex-rs/app-server/src/thread_state.rs
+++ b/codex-rs/app-server/src/thread_state.rs
@@ -251,6 +251,7 @@ struct ThreadEntry {
     state: Arc<Mutex<ThreadState>>,
     connection_ids: HashSet<ConnectionId>,
     has_connections_watcher: watch::Sender<bool>,
+    connections_changed_watcher: watch::Sender<u64>,
 }
 
 impl Default for ThreadEntry {
@@ -259,17 +260,20 @@ impl Default for ThreadEntry {
             state: Arc::new(Mutex::new(ThreadState::default())),
             connection_ids: HashSet::new(),
             has_connections_watcher: watch::channel(false).0,
+            connections_changed_watcher: watch::channel(0).0,
         }
     }
 }
 
 impl ThreadEntry {
-    fn update_has_connections(&self) {
+    fn update_connections(&self) {
         let _ = self.has_connections_watcher.send_if_modified(|current| {
             let prev = *current;
             *current = !self.connection_ids.is_empty();
             prev != *current
         });
+        self.connections_changed_watcher
+            .send_modify(|generation| *generation = generation.wrapping_add(1));
     }
 }
 
@@ -329,6 +333,39 @@ impl ThreadStateManager {
                     .then_some(*connection_id)
             })
             .min_by_key(|connection_id| connection_id.0)
+    }
+
+    pub(crate) async fn wait_for_attestation_capable_connection_for_thread(
+        &self,
+        thread_id: ThreadId,
+    ) -> Option<ConnectionId> {
+        let mut connections_changed = {
+            let mut state = self.state.lock().await;
+            if !state
+                .live_connections
+                .values()
+                .any(|capabilities| capabilities.request_attestation)
+            {
+                return None;
+            }
+            state
+                .threads
+                .entry(thread_id)
+                .or_default()
+                .connections_changed_watcher
+                .subscribe()
+        };
+        loop {
+            if let Some(connection_id) = self
+                .first_attestation_capable_connection_for_thread(thread_id)
+                .await
+            {
+                return Some(connection_id);
+            }
+            if connections_changed.changed().await.is_err() {
+                return None;
+            }
+        }
     }
 
     pub(crate) async fn wait_for_thread_subscriber(&self, thread_id: ThreadId) {
@@ -470,7 +507,7 @@ impl ThreadStateManager {
             }
             if let Some(thread_entry) = state.threads.get_mut(&thread_id) {
                 thread_entry.connection_ids.remove(&connection_id);
-                thread_entry.update_has_connections();
+                thread_entry.update_connections();
             }
         };
 
@@ -505,7 +542,7 @@ impl ThreadStateManager {
                 .insert(thread_id);
             let thread_entry = state.threads.entry(thread_id).or_default();
             thread_entry.connection_ids.insert(connection_id);
-            thread_entry.update_has_connections();
+            thread_entry.update_connections();
             thread_entry.state.clone()
         };
         {
@@ -533,7 +570,7 @@ impl ThreadStateManager {
             .insert(thread_id);
         let thread_entry = state.threads.entry(thread_id).or_default();
         thread_entry.connection_ids.insert(connection_id);
-        thread_entry.update_has_connections();
+        thread_entry.update_connections();
         true
     }
 
@@ -548,7 +585,7 @@ impl ThreadStateManager {
             for thread_id in &thread_ids {
                 if let Some(thread_entry) = state.threads.get_mut(thread_id) {
                     thread_entry.connection_ids.remove(&connection_id);
-                    thread_entry.update_has_connections();
+                    thread_entry.update_connections();
                 }
             }
             thread_ids


### PR DESCRIPTION
### Summary

Codex Desktop startup and mixed-client attachment can race app-server's first attestation-bearing request, leaving eligible requests without `x-oai-attestation`. This makes app-server wait within the existing 100 ms budget for an attestation-capable subscriber while preserving omission for clients that do not advertise support.

### Details

- Wait for an exact-thread capable subscription only when a live client has advertised attestation support.
- Preserve omission semantics for unsupported clients, detached threads, and provider teardown.
- Add structured `stage`, `reason`, and `outcome` logs across capability lookup, RPC dispatch/result, serialization, and timeout paths.
- Add regression coverage for late attachment and mixed capable/incapable subscribers.

### Testing

- `just test -p codex-app-server attestation` (9 passed)
- `just fix -p codex-app-server`
- `just fmt`
- `just test -p codex-app-server` (910 passed; 8 unrelated environment failures caused by local shell-profile stderr and a missing `target/debug/codex` fixture binary)
- Native Codex review: no actionable findings

### Post-deployment validation

Compare `invalid.missing_attestation_header` rows against the new `capability_lookup` reason logs for Codex Desktop prewarm traffic.
