### PR TITLE
[codex] Add plugin list force refetch

### DIFF
--- a/codex-rs/app-server-protocol/schema/json/ClientRequest.json
+++ b/codex-rs/app-server-protocol/schema/json/ClientRequest.json
@@ -1905,6 +1905,10 @@
             "null"
           ]
         },
+        "forceRefetch": {
+          "description": "When true, bypass app/tool caches that can stay stale after external app re-auth.",
+          "type": "boolean"
+        },
         "marketplaceKinds": {
           "description": "Optional marketplace kind filter. When omitted, only local marketplaces are queried, plus the default remote catalog when enabled by feature flag.",
           "items": {

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -13525,6 +13525,10 @@
               "null"
             ]
           },
+          "forceRefetch": {
+            "description": "When true, bypass app/tool caches that can stay stale after external app re-auth.",
+            "type": "boolean"
+          },
           "marketplaceKinds": {
             "description": "Optional marketplace kind filter. When omitted, only local marketplaces are queried, plus the default remote catalog when enabled by feature flag.",
             "items": {

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.v2.schemas.json
@@ -9929,6 +9929,10 @@
             "null"
           ]
         },
+        "forceRefetch": {
+          "description": "When true, bypass app/tool caches that can stay stale after external app re-auth.",
+          "type": "boolean"
+        },
         "marketplaceKinds": {
           "description": "Optional marketplace kind filter. When omitted, only local marketplaces are queried, plus the default remote catalog when enabled by feature flag.",
           "items": {

--- a/codex-rs/app-server-protocol/schema/json/v2/PluginListParams.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/PluginListParams.json
@@ -27,6 +27,10 @@
         "null"
       ]
     },
+    "forceRefetch": {
+      "description": "When true, bypass app/tool caches that can stay stale after external app re-auth.",
+      "type": "boolean"
+    },
     "marketplaceKinds": {
       "description": "Optional marketplace kind filter. When omitted, only local marketplaces are queried, plus the default remote catalog when enabled by feature flag.",
       "items": {

--- a/codex-rs/app-server-protocol/schema/typescript/v2/PluginListParams.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/PluginListParams.ts
@@ -14,4 +14,8 @@ cwds?: Array<AbsolutePathBuf> | null,
  * Optional marketplace kind filter. When omitted, only local marketplaces are queried, plus
  * the default remote catalog when enabled by feature flag.
  */
-marketplaceKinds?: Array<PluginListMarketplaceKind> | null, };
+marketplaceKinds?: Array<PluginListMarketplaceKind> | null,
+/**
+ * When true, bypass app/tool caches that can stay stale after external app re-auth.
+ */
+forceRefetch?: boolean, };

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -1875,6 +1875,7 @@ mod tests {
             params: v2::PluginListParams {
                 cwds: None,
                 marketplace_kinds: None,
+                force_refetch: false,
             },
         };
         assert_eq!(plugin_list.serialization_scope(), None);

--- a/codex-rs/app-server-protocol/src/protocol/v2/plugin.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2/plugin.rs
@@ -135,6 +135,9 @@ pub struct PluginListParams {
     /// the default remote catalog when enabled by feature flag.
     #[ts(optional = nullable)]
     pub marketplace_kinds: Option<Vec<PluginListMarketplaceKind>>,
+    /// When true, bypass app/tool caches that can stay stale after external app re-auth.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub force_refetch: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]

--- a/codex-rs/app-server-protocol/src/protocol/v2/tests.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2/tests.rs
@@ -3032,6 +3032,7 @@ fn plugin_list_params_ignore_removed_force_remote_sync_field() {
         PluginListParams {
             cwds: None,
             marketplace_kinds: None,
+            force_refetch: false,
         },
     );
 }
@@ -3048,6 +3049,7 @@ fn plugin_list_params_serializes_marketplace_kind_filter() {
                 PluginListMarketplaceKind::SharedWithMe,
                 PluginListMarketplaceKind::CreatedByMeRemote,
             ]),
+            force_refetch: false,
         })
         .unwrap(),
         json!({
@@ -3059,6 +3061,23 @@ fn plugin_list_params_serializes_marketplace_kind_filter() {
                 "shared-with-me",
                 "created-by-me-remote",
             ],
+        }),
+    );
+}
+
+#[test]
+fn plugin_list_params_serializes_force_refetch_when_enabled() {
+    assert_eq!(
+        serde_json::to_value(PluginListParams {
+            cwds: None,
+            marketplace_kinds: None,
+            force_refetch: true,
+        })
+        .unwrap(),
+        json!({
+            "cwds": null,
+            "marketplaceKinds": null,
+            "forceRefetch": true,
         }),
     );
 }

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -212,10 +212,24 @@ Example with notification opt-out:
 - `marketplace/add` — add a remote plugin marketplace from an HTTP(S) Git URL, SSH Git URL, or GitHub `owner/repo` shorthand, then persist it into the user marketplace config. Returns the installed root path plus whether the marketplace was already present.
 - `marketplace/remove` — remove a configured marketplace by name from the user marketplace config, and delete its installed marketplace root when one exists.
 - `marketplace/upgrade` — upgrade all configured Git plugin marketplaces, or one named marketplace when `marketplaceName` is provided. Returns selected marketplace names, upgraded roots, and per-marketplace errors.
-- `plugin/list` — list discovered plugin marketplaces and plugin state, including effective marketplace install/auth policy metadata, plugin `availability` (`AVAILABLE` by default or `DISABLED_BY_ADMIN` for remote plugins blocked upstream), fail-open `marketplaceLoadErrors` entries for marketplace files that could not be parsed or loaded, and best-effort `featuredPluginIds` for the official curated marketplace. Clients can explicitly request the remote `workspace-directory`, `shared-with-me`, or `created-by-me-remote` marketplace kinds. `interface.category` uses the marketplace category when present; otherwise it falls back to the plugin manifest category (**under development; do not call from production clients yet**).
+- `plugin/list` — list discovered plugin marketplaces and plugin state, including effective marketplace install/auth policy metadata, plugin `availability` (`AVAILABLE` by default or `DISABLED_BY_ADMIN` for remote plugins blocked upstream), fail-open `marketplaceLoadErrors` entries for marketplace files that could not be parsed or loaded, and best-effort `featuredPluginIds` for the official curated marketplace. Clients can explicitly request the remote `workspace-directory`, `shared-with-me`, or `created-by-me-remote` marketplace kinds. Pass `forceRefetch: true` for user-initiated refreshes that should bypass app/tool caches and schedule a fresh remote installed-plugin cache load after external app authentication changes. `interface.category` uses the marketplace category when present; otherwise it falls back to the plugin manifest category (**under development; do not call from production clients yet**).
 - `plugin/installed` — list installed plugin rows plus any explicitly requested local install-suggestion plugin names, without fetching the broader remote catalog. Mention surfaces can use this narrower view when they need plugin mention payloads rather than plugin-page discovery data (**under development; do not call from production clients yet**).
 - `plugin/read` — read one plugin by `marketplacePath` plus `pluginName`, returning marketplace info, a list-style `summary`, manifest descriptions/interface metadata, and bundled skills/hooks/apps/MCP server names. Remote plugin details expose the canonical `shareUrl` supplied by the remote catalog when available; it is `null` for local plugins or when the catalog omits it. This field is separate from `summary.shareContext`, which continues to describe user and workspace sharing state. Returned plugin skills include their current `enabled` state after local config filtering; bundled hooks are returned as lightweight declaration summaries keyed for correlation with `hooks/list`. Use `plugin/install`'s `appsNeedingAuth` to drive post-install authentication and `app/list`'s `isAccessible` to determine current connector accessibility (**under development; do not call from production clients yet**).
 - `plugin/skill/read` — read remote plugin skill markdown on demand by `remoteMarketplaceName`, `remotePluginId`, and `skillName`. This lets clients preview uninstalled remote plugin skills without downloading the plugin bundle.
+
+Example `plugin/list` refresh request after external app authentication changes:
+
+```json
+{
+  "method": "plugin/list",
+  "id": 41,
+  "params": {
+    "marketplaceKinds": ["workspace-directory"],
+    "forceRefetch": true
+  }
+}
+```
+
 - `skills/changed` — notification emitted when watched local skill files change.
 - `app/list` — list available apps.
 - `remoteControl/enable` — experimental; enable remote control for the current app-server process and return the current remote-control status snapshot. By default, any missing enrollment is completed before the response and the preference is persisted for the current app-server client scope. Pass `ephemeral: true` to enable remote control only for the current process without changing the persisted preference.

--- a/codex-rs/app-server/src/request_processors/plugins.rs
+++ b/codex-rs/app-server/src/request_processors/plugins.rs
@@ -738,11 +738,8 @@ impl PluginRequestProcessor {
                 }
             }
         }
-        if include_local
-            || include_created_by_me_remote
-            || include_shared_with_me
-            || include_global_remote
-        {
+        let include_remote_sources = !remote_sources.is_empty();
+        if include_local || include_remote_sources {
             let on_effective_plugins_changed = Some(self.effective_plugins_changed_callback());
             plugins_manager.maybe_start_plugin_list_background_tasks_for_config(
                 &plugins_input,

--- a/codex-rs/app-server/src/request_processors/plugins.rs
+++ b/codex-rs/app-server/src/request_processors/plugins.rs
@@ -533,6 +533,7 @@ impl PluginRequestProcessor {
         let PluginListParams {
             cwds,
             marketplace_kinds,
+            force_refetch,
         } = params;
         let roots = cwds.unwrap_or_default();
         let explicit_marketplace_kinds = marketplace_kinds.is_some();
@@ -560,6 +561,10 @@ impl PluginRequestProcessor {
         let auth_mode = auth.as_ref().map(CodexAuth::api_auth_mode);
         plugins_manager.set_auth_mode(auth_mode);
         let plugins_input = config.plugins_config_input();
+        if force_refetch {
+            self.force_refresh_app_caches_for_plugin_list(&config, auth.as_ref())
+                .await;
+        }
         let include_shared_with_me =
             marketplace_kinds.contains(&PluginListMarketplaceKind::SharedWithMe);
         let include_created_by_me_remote = marketplace_kinds
@@ -738,6 +743,7 @@ impl PluginRequestProcessor {
             || include_shared_with_me
             || include_global_remote
         {
+            let on_effective_plugins_changed = Some(self.effective_plugins_changed_callback());
             plugins_manager.maybe_start_plugin_list_background_tasks_for_config(
                 &plugins_input,
                 auth.clone(),
@@ -745,8 +751,15 @@ impl PluginRequestProcessor {
                 PluginListBackgroundTaskOptions {
                     refresh_global_remote_catalog_cache,
                 },
-                Some(self.effective_plugins_changed_callback()),
+                on_effective_plugins_changed.clone(),
             );
+            if force_refetch {
+                plugins_manager.maybe_start_remote_installed_plugins_cache_refresh_after_mutation(
+                    &plugins_input,
+                    auth.clone(),
+                    on_effective_plugins_changed,
+                );
+            }
         }
 
         let featured_plugin_ids = if data.iter().any(|marketplace| {
@@ -775,6 +788,64 @@ impl PluginRequestProcessor {
             marketplace_load_errors,
             featured_plugin_ids,
         })
+    }
+
+    async fn force_refresh_app_caches_for_plugin_list(
+        &self,
+        config: &Config,
+        auth: Option<&CodexAuth>,
+    ) {
+        if !config
+            .features
+            .apps_enabled_for_auth(auth.is_some_and(CodexAuth::uses_codex_backend))
+        {
+            return;
+        }
+
+        let plugins_manager = self.thread_manager.plugins_manager();
+        let plugin_apps = plugins_manager
+            .plugins_for_config(&config.plugins_config_input())
+            .await
+            .effective_apps();
+        let environment_manager = self.thread_manager.environment_manager();
+        let (all_connectors_result, accessible_connectors_result) = tokio::join!(
+            connectors::list_all_connectors_with_options(
+                config,
+                /*force_refetch*/ true,
+                &plugin_apps,
+            ),
+            connectors::list_accessible_connectors_from_mcp_tools_with_mcp_manager(
+                config,
+                /*force_refetch*/ true,
+                Arc::clone(&environment_manager),
+                self.thread_manager.mcp_manager(),
+            ),
+        );
+
+        match all_connectors_result {
+            Ok(_) => {}
+            Err(err) => {
+                warn!("plugin/list forceRefetch failed to refresh app directory cache: {err:#}");
+            }
+        }
+        let mut refreshed_codex_apps_tools_cache = false;
+        match accessible_connectors_result {
+            Ok(status) => {
+                refreshed_codex_apps_tools_cache = true;
+                if !status.codex_apps_ready {
+                    warn!(
+                        "plugin/list forceRefetch refreshed Codex Apps cache before codex-apps was ready"
+                    );
+                }
+            }
+            Err(err) => {
+                warn!("plugin/list forceRefetch failed to refresh Codex Apps tools cache: {err:#}");
+            }
+        }
+
+        if refreshed_codex_apps_tools_cache {
+            self.on_effective_plugins_changed();
+        }
     }
 
     async fn plugin_installed_response(

--- a/codex-rs/app-server/tests/suite/v2/app_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/app_list.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use anyhow::Result;
@@ -29,6 +31,8 @@ use codex_app_server_protocol::AppsListParams;
 use codex_app_server_protocol::AppsListResponse;
 use codex_app_server_protocol::JSONRPCError;
 use codex_app_server_protocol::JSONRPCResponse;
+use codex_app_server_protocol::PluginListParams;
+use codex_app_server_protocol::PluginListResponse;
 use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ServerNotification;
 use codex_app_server_protocol::ThreadStartParams;
@@ -1383,6 +1387,84 @@ async fn list_apps_force_refetch_patches_updates_from_cached_snapshots() -> Resu
     Ok(())
 }
 
+#[tokio::test]
+async fn plugin_list_force_refetch_refreshes_codex_apps_tools() -> Result<()> {
+    let connectors = vec![AppInfo {
+        id: "beta".to_string(),
+        name: "Beta App".to_string(),
+        description: Some("Beta connector".to_string()),
+        logo_url: None,
+        logo_url_dark: None,
+        distribution_channel: None,
+        branding: None,
+        app_metadata: None,
+        labels: None,
+        install_url: None,
+        is_accessible: false,
+        is_enabled: true,
+        plugin_display_names: Vec::new(),
+    }];
+    let tools = vec![connector_tool("beta", "Beta App")?];
+    let (server_url, server_handle, server_control) = start_apps_server_with_delays_and_control(
+        connectors,
+        tools,
+        Duration::ZERO,
+        Duration::ZERO,
+    )
+    .await?;
+
+    let codex_home = TempDir::new()?;
+    write_connectors_and_plugins_config(codex_home.path(), &server_url)?;
+    write_chatgpt_auth(
+        codex_home.path(),
+        ChatGptAuthFixture::new("chatgpt-token")
+            .account_id("account-123")
+            .chatgpt_user_id("user-123")
+            .chatgpt_account_id("account-123"),
+        AuthCredentialsStoreMode::File,
+    )?;
+
+    let mut mcp = TestAppServer::new(codex_home.path()).await?;
+    timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;
+
+    let cached_request = mcp
+        .send_plugin_list_request(PluginListParams {
+            cwds: None,
+            marketplace_kinds: None,
+            force_refetch: false,
+        })
+        .await?;
+    let cached_response: JSONRPCResponse = timeout(
+        DEFAULT_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(cached_request)),
+    )
+    .await??;
+    let _cached_response: PluginListResponse = to_response(cached_response)?;
+    let calls_before_force_refetch = server_control.tool_list_calls();
+
+    let refetch_request = mcp
+        .send_plugin_list_request(PluginListParams {
+            cwds: None,
+            marketplace_kinds: None,
+            force_refetch: true,
+        })
+        .await?;
+    let refetch_response: JSONRPCResponse = timeout(
+        DEFAULT_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(refetch_request)),
+    )
+    .await??;
+    let _refetch_response: PluginListResponse = to_response(refetch_response)?;
+
+    assert!(
+        server_control.tool_list_calls() > calls_before_force_refetch,
+        "expected plugin/list forceRefetch to hard-refresh Codex Apps tools"
+    );
+
+    server_handle.abort();
+    Ok(())
+}
+
 async fn read_app_list_updated_notification(
     mcp: &mut TestAppServer,
 ) -> Result<AppListUpdatedNotification> {
@@ -1411,11 +1493,20 @@ struct AppsServerState {
 struct AppListMcpServer {
     tools: Arc<StdMutex<Vec<Tool>>>,
     tools_delay: Duration,
+    tool_list_calls: Arc<AtomicUsize>,
 }
 
 impl AppListMcpServer {
-    fn new(tools: Arc<StdMutex<Vec<Tool>>>, tools_delay: Duration) -> Self {
-        Self { tools, tools_delay }
+    fn new(
+        tools: Arc<StdMutex<Vec<Tool>>>,
+        tools_delay: Duration,
+        tool_list_calls: Arc<AtomicUsize>,
+    ) -> Self {
+        Self {
+            tools,
+            tools_delay,
+            tool_list_calls,
+        }
     }
 }
 
@@ -1423,6 +1514,7 @@ impl AppListMcpServer {
 struct AppsServerControl {
     response: Arc<StdMutex<serde_json::Value>>,
     tools: Arc<StdMutex<Vec<Tool>>>,
+    tool_list_calls: Arc<AtomicUsize>,
 }
 
 impl AppsServerControl {
@@ -1441,6 +1533,10 @@ impl AppsServerControl {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         *tools_guard = tools;
     }
+
+    fn tool_list_calls(&self) -> usize {
+        self.tool_list_calls.load(Ordering::SeqCst)
+    }
 }
 
 impl ServerHandler for AppListMcpServer {
@@ -1456,7 +1552,9 @@ impl ServerHandler for AppListMcpServer {
     {
         let tools = self.tools.clone();
         let tools_delay = self.tools_delay;
+        let tool_list_calls = self.tool_list_calls.clone();
         async move {
+            tool_list_calls.fetch_add(1, Ordering::SeqCst);
             if tools_delay > Duration::ZERO {
                 tokio::time::sleep(tools_delay).await;
             }
@@ -1529,6 +1627,7 @@ async fn start_apps_server_with_delays_and_control_inner(
         json!({ "apps": connectors, "next_token": null }),
     ));
     let tools = Arc::new(StdMutex::new(tools));
+    let tool_list_calls = Arc::new(AtomicUsize::new(0));
     let state = AppsServerState {
         expected_bearer: "Bearer chatgpt-token".to_string(),
         expected_account_id: "account-123".to_string(),
@@ -1540,6 +1639,7 @@ async fn start_apps_server_with_delays_and_control_inner(
     let server_control = AppsServerControl {
         response,
         tools: tools.clone(),
+        tool_list_calls: tool_list_calls.clone(),
     };
 
     let listener = TcpListener::bind("127.0.0.1:0").await?;
@@ -1548,7 +1648,14 @@ async fn start_apps_server_with_delays_and_control_inner(
     let mcp_service = StreamableHttpService::new(
         {
             let tools = tools.clone();
-            move || Ok(AppListMcpServer::new(tools.clone(), tools_delay))
+            let tool_list_calls = tool_list_calls.clone();
+            move || {
+                Ok(AppListMcpServer::new(
+                    tools.clone(),
+                    tools_delay,
+                    tool_list_calls.clone(),
+                ))
+            }
         },
         Arc::new(LocalSessionManager::default()),
         StreamableHttpServerConfig::default(),

--- a/codex-rs/app-server/tests/suite/v2/external_agent_config.rs
+++ b/codex-rs/app-server/tests/suite/v2/external_agent_config.rs
@@ -504,6 +504,7 @@ async fn external_agent_config_import_sends_completion_notification_for_local_pl
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
     let response: JSONRPCResponse = timeout(

--- a/codex-rs/app-server/tests/suite/v2/plugin_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_list.rs
@@ -97,6 +97,7 @@ async fn plugin_list_skips_invalid_marketplace_file_and_reports_error() -> Resul
         .send_plugin_list_request(PluginListParams {
             cwds: Some(vec![AbsolutePathBuf::try_from(repo_root.path())?]),
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
 
@@ -417,6 +418,7 @@ async fn plugin_list_keeps_valid_marketplaces_when_another_marketplace_fails_to_
                 AbsolutePathBuf::try_from(invalid_repo_root.path())?,
             ]),
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
 
@@ -531,6 +533,7 @@ async fn plugin_list_returns_empty_when_workspace_codex_plugins_disabled() -> Re
         .send_plugin_list_request(PluginListParams {
             cwds: Some(vec![AbsolutePathBuf::try_from(repo_root.path())?]),
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
 
@@ -623,6 +626,7 @@ async fn plugin_list_reuses_cached_workspace_codex_plugins_setting() -> Result<(
             .send_plugin_list_request(PluginListParams {
                 cwds: Some(vec![AbsolutePathBuf::try_from(repo_root.path())?]),
                 marketplace_kinds: None,
+                force_refetch: false,
             })
             .await?;
 
@@ -707,6 +711,7 @@ async fn plugin_list_uses_alternate_discoverable_manifest_and_keeps_undiscoverab
         .send_plugin_list_request(PluginListParams {
             cwds: Some(vec![AbsolutePathBuf::try_from(repo_root.path())?]),
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
 
@@ -822,6 +827,7 @@ async fn plugin_list_accepts_omitted_cwds() -> Result<()> {
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
 
@@ -875,6 +881,7 @@ async fn plugin_list_returns_share_context_for_shared_local_plugin() -> Result<(
         .send_plugin_list_request(PluginListParams {
             cwds: Some(vec![AbsolutePathBuf::try_from(repo_root.path())?]),
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
 
@@ -967,6 +974,7 @@ enabled = false
         .send_plugin_list_request(PluginListParams {
             cwds: Some(vec![AbsolutePathBuf::try_from(repo_root.path())?]),
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
 
@@ -1124,6 +1132,7 @@ enabled = false
                 AbsolutePathBuf::try_from(workspace_default.path())?,
             ]),
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
 
@@ -1208,6 +1217,7 @@ async fn plugin_list_returns_plugin_interface_with_absolute_asset_paths() -> Res
         .send_plugin_list_request(PluginListParams {
             cwds: Some(vec![AbsolutePathBuf::try_from(repo_root.path())?]),
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
 
@@ -1321,6 +1331,7 @@ async fn plugin_list_accepts_legacy_string_default_prompt() -> Result<()> {
         .send_plugin_list_request(PluginListParams {
             cwds: Some(vec![AbsolutePathBuf::try_from(repo_root.path())?]),
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
 
@@ -1409,6 +1420,7 @@ enabled = true
         .send_plugin_list_request(PluginListParams {
             cwds: Some(vec![AbsolutePathBuf::try_from(repo_root.path())?]),
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
 
@@ -1599,6 +1611,7 @@ async fn plugin_list_sync_upgrades_and_removes_remote_installed_plugin_bundles()
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
     let response: JSONRPCResponse = timeout(
@@ -1779,6 +1792,7 @@ async fn plugin_list_includes_remote_marketplaces_when_remote_plugin_enabled() -
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
 
@@ -1922,6 +1936,7 @@ async fn plugin_list_uses_cached_global_remote_catalog_and_refreshes_it() -> Res
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
     let response: PluginListResponse = to_response(
@@ -1955,6 +1970,7 @@ async fn plugin_list_uses_cached_global_remote_catalog_and_refreshes_it() -> Res
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
     let response: PluginListResponse = to_response(
@@ -2036,6 +2052,7 @@ async fn plugin_list_includes_openai_curated_remote_collection_when_requested() 
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: Some(vec![PluginListMarketplaceKind::Vertical]),
+            force_refetch: false,
         })
         .await?;
     let response: JSONRPCResponse = timeout(
@@ -2124,6 +2141,7 @@ async fn plugin_list_propagates_explicit_openai_curated_remote_collection_errors
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: Some(vec![PluginListMarketplaceKind::Vertical]),
+            force_refetch: false,
         })
         .await?;
     let err = timeout(
@@ -2163,6 +2181,7 @@ async fn plugin_list_skips_explicit_openai_curated_remote_collection_for_api_aut
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: Some(vec![PluginListMarketplaceKind::Vertical]),
+            force_refetch: false,
         })
         .await?;
     let response: JSONRPCResponse = timeout(
@@ -2202,6 +2221,7 @@ async fn plugin_list_includes_api_curated_marketplace_for_api_auth_when_remote_p
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
     let response: JSONRPCResponse = timeout(
@@ -2257,6 +2277,7 @@ async fn plugin_list_does_not_query_openai_curated_remote_collection_by_default(
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
     let response: JSONRPCResponse = timeout(
@@ -2310,6 +2331,7 @@ async fn plugin_list_vertical_kind_noops_when_remote_plugin_enabled() -> Result<
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: Some(vec![PluginListMarketplaceKind::Vertical]),
+            force_refetch: false,
         })
         .await?;
     let response: JSONRPCResponse = timeout(
@@ -2364,6 +2386,7 @@ async fn plugin_list_does_not_append_global_remote_when_marketplace_kinds_are_ex
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: Some(vec![PluginListMarketplaceKind::Local]),
+            force_refetch: false,
         })
         .await?;
 
@@ -2785,6 +2808,7 @@ async fn plugin_list_fetches_workspace_directory_kind_without_remote_plugin_flag
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: Some(vec![PluginListMarketplaceKind::WorkspaceDirectory]),
+            force_refetch: false,
         })
         .await?;
 
@@ -2912,6 +2936,7 @@ plugin_sharing = false
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: Some(vec![PluginListMarketplaceKind::CreatedByMeRemote]),
+            force_refetch: false,
         })
         .await?;
 
@@ -3039,6 +3064,7 @@ async fn plugin_list_fetches_shared_with_me_kind() -> Result<()> {
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: Some(vec![PluginListMarketplaceKind::SharedWithMe]),
+            force_refetch: false,
         })
         .await?;
 
@@ -3196,6 +3222,7 @@ plugin_sharing = false
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: Some(vec![PluginListMarketplaceKind::SharedWithMe]),
+            force_refetch: false,
         })
         .await?;
 
@@ -3256,6 +3283,7 @@ plugin_sharing = true
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: Some(vec![PluginListMarketplaceKind::CreatedByMeRemote]),
+            force_refetch: false,
         })
         .await?;
 
@@ -3386,6 +3414,7 @@ async fn plugin_list_marks_remote_plugin_disabled_by_admin() -> Result<()> {
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
 
@@ -3446,6 +3475,7 @@ remote_plugin = true
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
 
@@ -3482,6 +3512,7 @@ async fn plugin_list_fetches_featured_plugin_ids_without_chatgpt_auth() -> Resul
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
 
@@ -3522,6 +3553,7 @@ async fn plugin_list_uses_warmed_featured_plugin_ids_cache_on_first_request() ->
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
 

--- a/codex-rs/app-server/tests/suite/v2/plugin_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_list.rs
@@ -2856,6 +2856,68 @@ async fn plugin_list_fetches_workspace_directory_kind_without_remote_plugin_flag
 }
 
 #[tokio::test]
+async fn plugin_list_force_refetch_refreshes_installed_cache_for_workspace_directory() -> Result<()>
+{
+    let codex_home = TempDir::new()?;
+    let server = MockServer::start().await;
+    write_plugins_enabled_config_with_base_url(
+        codex_home.path(),
+        &format!("{}/backend-api/", server.uri()),
+    )?;
+    write_chatgpt_auth(
+        codex_home.path(),
+        ChatGptAuthFixture::new("chatgpt-token")
+            .account_id("account-123")
+            .chatgpt_user_id("user-123")
+            .chatgpt_account_id("account-123"),
+        AuthCredentialsStoreMode::File,
+    )?;
+
+    let workspace_plugin_body = workspace_remote_plugin_page_body(
+        "plugins~Plugin_11111111111111111111111111111111",
+        "workspace-linear",
+        "Workspace Linear",
+        "LISTED",
+        /*enabled*/ None,
+    );
+    let workspace_installed_body = workspace_remote_plugin_page_body(
+        "plugins~Plugin_11111111111111111111111111111111",
+        "workspace-linear",
+        "Workspace Linear",
+        "LISTED",
+        /*enabled*/ Some(true),
+    );
+    mount_remote_plugin_list(&server, "WORKSPACE", &workspace_plugin_body).await;
+    mount_remote_installed_plugins(&server, "GLOBAL", empty_remote_installed_plugins_body()).await;
+    mount_remote_installed_plugins(&server, "WORKSPACE", &workspace_installed_body).await;
+    mount_empty_user_installed_plugins(&server).await;
+
+    let mut mcp = TestAppServer::new(codex_home.path()).await?;
+    timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;
+
+    let request_id = mcp
+        .send_plugin_list_request(PluginListParams {
+            cwds: None,
+            marketplace_kinds: Some(vec![PluginListMarketplaceKind::WorkspaceDirectory]),
+            force_refetch: true,
+        })
+        .await?;
+
+    let response: PluginListResponse = to_response(
+        timeout(
+            DEFAULT_TIMEOUT,
+            mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+        )
+        .await??,
+    )?;
+    assert_eq!(response.marketplaces.len(), 1);
+    assert_eq!(response.marketplaces[0].name, "workspace-directory");
+
+    wait_for_remote_installed_scope_request_count_at_least(&server, "WORKSPACE", 2).await?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn plugin_list_fetches_user_plugins_in_created_by_me_remote_marketplace() -> Result<()> {
     let codex_home = TempDir::new()?;
     let server = MockServer::start().await;
@@ -3631,6 +3693,37 @@ async fn wait_for_remote_installed_scope_request(server: &MockServer, scope: &st
                         .query_pairs()
                         .any(|(name, value)| name == "scope" && value == scope)
             }) {
+                return Ok::<(), anyhow::Error>(());
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await??;
+    Ok(())
+}
+
+async fn wait_for_remote_installed_scope_request_count_at_least(
+    server: &MockServer,
+    scope: &str,
+    expected_count: usize,
+) -> Result<()> {
+    timeout(DEFAULT_TIMEOUT, async {
+        loop {
+            let Some(requests) = server.received_requests().await else {
+                bail!("wiremock did not record requests");
+            };
+            let request_count = requests
+                .iter()
+                .filter(|request| {
+                    request.method == "GET"
+                        && request.url.path().ends_with("/ps/plugins/installed")
+                        && request
+                            .url
+                            .query_pairs()
+                            .any(|(name, value)| name == "scope" && value == scope)
+                })
+                .count();
+            if request_count >= expected_count {
                 return Ok::<(), anyhow::Error>(());
             }
             tokio::time::sleep(Duration::from_millis(10)).await;

--- a/codex-rs/app-server/tests/suite/v2/plugin_share.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_share.rs
@@ -719,6 +719,7 @@ async fn plugin_share_checkout_adds_personal_marketplace_entry() -> Result<()> {
             marketplace_kinds: Some(vec![
                 codex_app_server_protocol::PluginListMarketplaceKind::Local,
             ]),
+            force_refetch: false,
         })
         .await?;
     let response: JSONRPCResponse = timeout(

--- a/codex-rs/app-server/tests/suite/v2/skills_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/skills_list.rs
@@ -390,6 +390,7 @@ async fn skills_list_loads_remote_installed_plugin_skills_from_cache() -> Result
         .send_plugin_list_request(PluginListParams {
             cwds: None,
             marketplace_kinds: None,
+            force_refetch: false,
         })
         .await?;
     let plugin_list_response: JSONRPCResponse = timeout(

--- a/codex-rs/tui/src/app/background_requests.rs
+++ b/codex-rs/tui/src/app/background_requests.rs
@@ -1031,6 +1031,7 @@ async fn request_plugin_list_with_marketplace_kinds(
             params: PluginListParams {
                 cwds: Some(vec![cwd]),
                 marketplace_kinds,
+                force_refetch: false,
             },
         })
         .await


### PR DESCRIPTION
## Why

External app re-auth can refresh Codex Apps link/tool state outside Codex, but the Plugins page refresh only asks `plugin/list` for catalog data today. When the local Codex Apps tools, accessible-connectors cache, or remote installed-plugin cache stays stale, users may need a full Codex restart after re-auth before workspace plugin tools are visible again.

This complements #29742, which mitigates transient remote catalog GET failures.

## What changed

- Add an optional `forceRefetch` flag to `plugin/list`.
- When `forceRefetch` is set, refresh the app directory cache and hard-refresh Codex Apps tools / accessible connector state.
- After a forced plugin-list refresh that includes remote marketplaces, queue remote installed-plugin cache refresh with an after-success notification so active plugin/tool state can be reloaded even when the installed set is unchanged.
- Include `workspace-directory` in that forced installed-plugin cache refresh path, so a client refreshing only the workspace directory can still update installed/enabled/tool state.
- Keep default plugin-list callers on `forceRefetch: false`, including the TUI plugin-list caller.
- Regenerate the app-server protocol schema fixtures and TypeScript types.
- Document `plugin/list.forceRefetch` in the app-server README with an example refresh request.

## Review Notes

- Addressed @codex feedback:
  - documented the new `plugin/list.forceRefetch` request flag
  - included `workspace-directory` in the forced remote installed-plugin cache refresh path

## Verification

- `just write-app-server-schema`
- `cargo test -p codex-app-server-protocol plugin_list_params --lib`
- `cargo test -p codex-app-server plugin_list_accepts_omitted_cwds`
- `just test -p codex-app-server plugin_list_force_refetch_refreshes_codex_apps_tools`
- `just test -p codex-app-server plugin_list_force_refetch_refreshes_installed_cache_for_workspace_directory`
- `just test -p codex-app-server plugin_list_fetches_workspace_directory_kind_without_remote_plugin_flag`
- `just test -p codex-tui plugins_popup_refreshes_installed_counts_after_install`
