### PR TITLE
test: add bwrap integration-test sandbox

### DIFF
--- a/bazel/rules/testing/bwrap/BUILD.bazel
+++ b/bazel/rules/testing/bwrap/BUILD.bazel
@@ -1,0 +1,57 @@
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
+load(":defs.bzl", "BWRAP_EXEC_PROPERTIES")
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["defs.bzl"])
+
+rust_library(
+    name = "bwrap_test_support",
+    testonly = True,
+    srcs = [
+        "src/lib.rs",
+        "src/lib_tests.rs",
+    ],
+    crate_name = "bwrap_test_support",
+    crate_root = "src/lib.rs",
+    edition = "2024",
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [
+        "//codex-rs/utils/cargo-bin",
+        "@crates//:anyhow",
+        "@crates//:tempfile",
+        "@crates//:tokio",
+    ],
+)
+
+rust_binary(
+    name = "bwrap-smoke",
+    testonly = True,
+    srcs = ["fixtures/bwrap_smoke.rs"],
+    crate_name = "bwrap_smoke",
+    crate_root = "fixtures/bwrap_smoke.rs",
+    edition = "2024",
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//visibility:private"],
+    deps = ["@crates//:anyhow"],
+)
+
+rust_test(
+    name = "bwrap-test-support-smoke-test",
+    crate = ":bwrap_test_support",
+    data = [
+        ":bwrap-smoke",
+        "//codex-rs/bwrap",
+    ],
+    env = {
+        "CARGO_BIN_EXE_bwrap": "$(rlocationpath //codex-rs/bwrap:bwrap)",
+        "CARGO_BIN_EXE_bwrap-smoke": "$(rlocationpath :bwrap-smoke)",
+    },
+    exec_properties = BWRAP_EXEC_PROPERTIES,
+    target_compatible_with = ["@platforms//os:linux"],
+    deps = [
+        "@crates//:futures",
+        "@crates//:libc",
+        "@crates//:pretty_assertions",
+    ],
+)

--- a/bazel/rules/testing/bwrap/BUILD.bazel
+++ b/bazel/rules/testing/bwrap/BUILD.bazel
@@ -11,6 +11,7 @@ rust_library(
     srcs = [
         "src/lib.rs",
         "src/lib_tests.rs",
+        "src/sandbox_init.rs",
     ],
     crate_name = "bwrap_test_support",
     crate_root = "src/lib.rs",
@@ -19,6 +20,7 @@ rust_library(
     deps = [
         "//codex-rs/utils/cargo-bin",
         "@crates//:anyhow",
+        "@crates//:libc",
         "@crates//:tempfile",
         "@crates//:tokio",
     ],
@@ -33,7 +35,10 @@ rust_binary(
     edition = "2024",
     target_compatible_with = ["@platforms//os:linux"],
     visibility = ["//visibility:private"],
-    deps = ["@crates//:anyhow"],
+    deps = [
+        "@crates//:anyhow",
+        "@crates//:libc",
+    ],
 )
 
 rust_test(

--- a/bazel/rules/testing/bwrap/defs.bzl
+++ b/bazel/rules/testing/bwrap/defs.bzl
@@ -1,0 +1,6 @@
+BWRAP_EXEC_PROPERTIES = {
+    # BuildBuddy's isolated network mode disables loopback, which the runner uses to reach exec-server.
+    "test.network": "external",
+    # A fresh VM isolates the deliberately writable outer namespace and permits nested user namespaces.
+    "test.workload-isolation-type": "firecracker",
+}

--- a/bazel/rules/testing/bwrap/fixtures/bwrap_smoke.rs
+++ b/bazel/rules/testing/bwrap/fixtures/bwrap_smoke.rs
@@ -1,0 +1,205 @@
+#[cfg(not(target_os = "linux"))]
+compile_error!("the bwrap smoke fixture can only run on Linux");
+
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::net::TcpStream;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::Context;
+use anyhow::Result;
+
+const NAMESPACES: &[&str] = &["user", "mnt", "pid", "ipc", "uts", "net"];
+
+fn main() -> Result<()> {
+    let mut args = env::args_os();
+    let _executable = args.next();
+    let mode = args.next().context("missing bwrap smoke fixture mode")?;
+    match mode.to_str() {
+        Some("wait") => wait(),
+        Some("inspect") => inspect(),
+        Some("filesystem") => {
+            let tmp_dir = args.next().context("missing tmp directory")?;
+            let workspace_dir = args.next().context("missing workspace directory")?;
+            let root_target = args.next().context("missing root write target")?;
+            filesystem(
+                Path::new(&tmp_dir),
+                Path::new(&workspace_dir),
+                Path::new(&root_target),
+            )
+        }
+        Some("connect") => {
+            let address = args.next().context("missing listener address")?;
+            connect(address.to_string_lossy().as_ref())
+        }
+        Some("nested") => {
+            let bwrap = args.next().context("missing nested bwrap path")?;
+            let fixture = args.next().context("missing nested fixture path")?;
+            nested(Path::new(&bwrap), Path::new(&fixture))
+        }
+        _ => anyhow::bail!("unknown bwrap smoke fixture mode: {mode:?}"),
+    }
+}
+
+fn wait() -> Result<()> {
+    println!("BWRAP_TEST_READY");
+    std::io::stdout().flush()?;
+    loop {
+        std::thread::park();
+    }
+}
+
+fn inspect() -> Result<()> {
+    for (key, value) in inspection()? {
+        println!("{key}={value}");
+    }
+    Ok(())
+}
+
+fn inspection() -> Result<BTreeMap<String, String>> {
+    let mut values = BTreeMap::new();
+    let status = fs::read_to_string("/proc/self/status").context("read /proc/self/status")?;
+    values.insert(
+        "id.effective_uid".to_string(),
+        status_id(&status, "Uid")?.to_string(),
+    );
+    values.insert(
+        "id.effective_gid".to_string(),
+        status_id(&status, "Gid")?.to_string(),
+    );
+    for (name, field) in [
+        ("effective", "CapEff"),
+        ("permitted", "CapPrm"),
+        ("inheritable", "CapInh"),
+        ("ambient", "CapAmb"),
+    ] {
+        values.insert(
+            format!("cap.{name}"),
+            status_field(&status, field)?.to_string(),
+        );
+    }
+    for namespace in NAMESPACES {
+        values.insert(
+            format!("ns.{namespace}"),
+            namespace_identity("self", namespace)?,
+        );
+    }
+    match namespace_identity("1", "pid") {
+        Ok(namespace) => {
+            values.insert("proc.1.pid_ns".to_string(), namespace);
+        }
+        Err(error) => {
+            values.insert("proc.1.pid_ns.error".to_string(), error.to_string());
+        }
+    }
+    values.insert(
+        "proc.self.pid_ns".to_string(),
+        namespace_identity("self", "pid")?,
+    );
+    for name in ["overflowuid", "overflowgid"] {
+        let value = fs::read_to_string(format!("/proc/sys/kernel/{name}"))
+            .with_context(|| format!("read /proc/sys/kernel/{name}"))?;
+        values.insert(format!("proc.{name}"), value.trim().to_string());
+    }
+    for name in ["HOME", "CODEX_HOME", "XDG_RUNTIME_DIR", "TMPDIR"] {
+        let value = env::var(name).with_context(|| format!("read {name}"))?;
+        values.insert(format!("env.{name}"), value);
+    }
+    Ok(values)
+}
+
+fn namespace_identity(pid: &str, namespace: &str) -> Result<String> {
+    let path = format!("/proc/{pid}/ns/{namespace}");
+    Ok(fs::read_link(&path)
+        .with_context(|| format!("read namespace link {path}"))?
+        .to_string_lossy()
+        .into_owned())
+}
+
+fn status_field<'a>(status: &'a str, name: &str) -> Result<&'a str> {
+    status
+        .lines()
+        .find_map(|line| line.strip_prefix(&format!("{name}:")))
+        .map(str::trim)
+        .with_context(|| format!("/proc/self/status is missing {name}"))
+}
+
+fn status_id(status: &str, name: &str) -> Result<u32> {
+    status_field(status, name)?
+        .split_whitespace()
+        .nth(1)
+        .with_context(|| format!("/proc/self/status field {name} has no effective ID"))?
+        .parse()
+        .with_context(|| format!("parse effective {name}"))
+}
+
+fn filesystem(tmp_dir: &Path, workspace_dir: &Path, root_target: &Path) -> Result<()> {
+    fs::create_dir_all(tmp_dir)
+        .with_context(|| format!("create private tmp fixture {}", tmp_dir.display()))?;
+    println!(
+        "tmp.host_sentinel_visible={}",
+        tmp_dir.join("host-sentinel.txt").exists()
+    );
+    for (name, directory) in [("tmp", tmp_dir), ("workspace", workspace_dir)] {
+        let writable_file = directory.join("round-trip.txt");
+        fs::write(&writable_file, "round-trip")
+            .with_context(|| format!("write {}", writable_file.display()))?;
+        println!("{name}.value={}", fs::read_to_string(&writable_file)?);
+    }
+
+    let error = fs::write(root_target, "must not be written")
+        .expect_err("writing through the read-only root unexpectedly succeeded");
+    println!(
+        "root.write_errno={}",
+        error
+            .raw_os_error()
+            .context("root write error had no errno")?
+    );
+    Ok(())
+}
+
+fn connect(address: &str) -> Result<()> {
+    let mut stream = TcpStream::connect(address)
+        .with_context(|| format!("connect to parent listener at {address}"))?;
+    stream.write_all(b"BWRAP_LOOPBACK")?;
+    Ok(())
+}
+
+fn nested(bwrap: &Path, fixture: &Path) -> Result<()> {
+    for (key, value) in inspection()? {
+        println!("outer.{key}={value}");
+    }
+    let output = Command::new(bwrap)
+        .args([
+            "--new-session",
+            "--die-with-parent",
+            "--ro-bind",
+            "/",
+            "/",
+            "--dev",
+            "/dev",
+            "--unshare-user",
+            "--unshare-pid",
+            "--unshare-net",
+            "--proc",
+            "/proc",
+            "--",
+        ])
+        .arg(fixture)
+        .arg("inspect")
+        .output()
+        .context("run raw nested bwrap")?;
+    anyhow::ensure!(
+        output.status.success(),
+        "raw nested bwrap exited with {}; stderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    for line in String::from_utf8(output.stdout)?.lines() {
+        println!("child.{line}");
+    }
+    Ok(())
+}

--- a/bazel/rules/testing/bwrap/fixtures/bwrap_smoke.rs
+++ b/bazel/rules/testing/bwrap/fixtures/bwrap_smoke.rs
@@ -12,6 +12,12 @@ use std::process::Command;
 use anyhow::Context;
 use anyhow::Result;
 
+/// Namespace classes whose topology is part of this harness's contract.
+///
+/// The outer bwrap isolates user, mount, IPC, and UTS, but deliberately inherits
+/// PID plus writable procfs for nested bwrap setup and network for loopback.
+/// Cgroup and time namespaces stay executor-owned; `*_for_children` entries are
+/// alternate PID/time handles rather than separate namespace classes.
 const NAMESPACES: &[&str] = &["user", "mnt", "pid", "ipc", "uts", "net"];
 
 fn main() -> Result<()> {

--- a/bazel/rules/testing/bwrap/fixtures/bwrap_smoke.rs
+++ b/bazel/rules/testing/bwrap/fixtures/bwrap_smoke.rs
@@ -14,10 +14,11 @@ use anyhow::Result;
 
 /// Namespace classes whose topology is part of this harness's contract.
 ///
-/// The outer bwrap isolates user, mount, IPC, and UTS, but deliberately inherits
-/// PID plus writable procfs for nested bwrap setup and network for loopback.
-/// Cgroup and time namespaces stay executor-owned; `*_for_children` entries are
-/// alternate PID/time handles rather than separate namespace classes.
+/// The outer bwrap isolates user, mount, PID, IPC, and UTS, but deliberately
+/// inherits the VM's writable procfs for nested bwrap setup and its network for
+/// loopback. Cgroup and time namespaces stay executor-owned; `*_for_children`
+/// entries are alternate PID/time handles rather than separate namespace
+/// classes.
 const NAMESPACES: &[&str] = &["user", "mnt", "pid", "ipc", "uts", "net"];
 
 fn main() -> Result<()> {
@@ -26,6 +27,8 @@ fn main() -> Result<()> {
     let mode = args.next().context("missing bwrap smoke fixture mode")?;
     match mode.to_str() {
         Some("wait") => wait(),
+        Some("spawn-detached-descendant") => spawn_detached_descendant(),
+        Some("detached-wait") => detached_wait(),
         Some("inspect") => inspect(),
         Some("filesystem") => {
             let tmp_dir = args.next().context("missing tmp directory")?;
@@ -52,6 +55,34 @@ fn main() -> Result<()> {
 
 fn wait() -> Result<()> {
     println!("BWRAP_TEST_READY");
+    std::io::stdout().flush()?;
+    loop {
+        std::thread::park();
+    }
+}
+
+fn spawn_detached_descendant() -> Result<()> {
+    let _descendant = Command::new(env::current_exe()?)
+        .arg("detached-wait")
+        .spawn()
+        .context("spawn detached descendant")?;
+    loop {
+        std::thread::park();
+    }
+}
+
+fn detached_wait() -> Result<()> {
+    // SAFETY: setsid has no memory-safety preconditions. This fixture is a
+    // forked child and therefore is not already a process-group leader.
+    if unsafe { libc::setsid() } == -1 {
+        return Err(std::io::Error::last_os_error()).context("detach descendant session");
+    }
+    let status = fs::read_to_string("/proc/self/status").context("read detached child status")?;
+    let vm_pid = status_field(&status, "NSpid")?
+        .split_whitespace()
+        .next()
+        .context("detached child status has no VM-visible PID")?;
+    println!("BWRAP_TEST_DETACHED_DESCENDANT_READY={vm_pid}");
     std::io::stdout().flush()?;
     loop {
         std::thread::park();
@@ -156,8 +187,10 @@ fn filesystem(tmp_dir: &Path, workspace_dir: &Path, root_target: &Path) -> Resul
         println!("{name}.value={}", fs::read_to_string(&writable_file)?);
     }
 
-    let error = fs::write(root_target, "must not be written")
-        .expect_err("writing through the read-only root unexpectedly succeeded");
+    let error = match fs::write(root_target, "must not be written") {
+        Ok(()) => anyhow::bail!("writing through the read-only root unexpectedly succeeded"),
+        Err(error) => error,
+    };
     println!(
         "root.write_errno={}",
         error

--- a/bazel/rules/testing/bwrap/src/lib.rs
+++ b/bazel/rules/testing/bwrap/src/lib.rs
@@ -4,13 +4,19 @@ compile_error!("bwrap_test_support can only run on Linux");
 use std::ffi::OsString;
 use std::fs;
 use std::future::Future;
+use std::io;
+use std::io::Read;
 use std::io::Write;
+use std::os::fd::AsRawFd;
 use std::os::unix::fs::PermissionsExt;
+use std::os::unix::net::UnixStream;
+use std::os::unix::process::CommandExt;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command as StdCommand;
 use std::process::Stdio;
 use std::time::Duration;
+use std::time::Instant;
 
 use anyhow::Context;
 use anyhow::Result;
@@ -20,6 +26,13 @@ use tokio::process::Child;
 use tokio::process::ChildStdout;
 use tokio::process::Command as TokioCommand;
 
+use self::sandbox_init::BWRAP_CLEANUP_TIMEOUT;
+use self::sandbox_init::SandboxInit;
+
+const BWRAP_SETUP_TIMEOUT: Duration = Duration::from_secs(10);
+
+mod sandbox_init;
+
 /// Builds a command that runs inside the Linux integration-test namespace.
 pub struct BwrapTestCommand {
     executable: PathBuf,
@@ -27,17 +40,19 @@ pub struct BwrapTestCommand {
     env: Vec<(OsString, OsString)>,
 }
 
-/// Owns a process running inside the Linux integration-test namespace.
+/// Owns a process tree running inside a dedicated PID namespace.
 ///
 /// Call [`Self::scope`] or [`Self::shutdown`] on every successful path. A
 /// normal unguarded drop panics, while a drop during unwinding performs
-/// blocking cleanup without introducing a second panic.
+/// blocking cleanup without introducing a second panic. Teardown signals the
+/// namespace init and waits for it, so detached descendants cannot escape.
 pub struct BwrapTestProcess {
     processes: Option<BwrapProcesses>,
 }
 
 struct BwrapProcesses {
     child: Child,
+    sandbox_init: SandboxInit,
     cleanup_complete: bool,
     environment: TempDir,
 }
@@ -109,14 +124,15 @@ impl BwrapTestCommand {
             },
         )?;
 
-        // Firecracker supplies the host PID boundary, so the outer wrapper
-        // deliberately shares the disposable VM's PID namespace and rebinds
-        // its procfs read-write. Nested unprivileged bwrap writes UID/GID maps
-        // through the caller's /proc before mounting a fresh procfs for its
-        // own PID namespace. Giving the outer wrapper a fresh procfs on this
-        // executor leaves locked child mounts that make the nested proc mount
-        // fail Linux's mount_too_revealing check; making the inherited procfs
-        // read-only instead makes UID/GID map setup fail.
+        // Firecracker supplies the host PID boundary. The outer wrapper adds a
+        // child PID namespace so terminating its init kills every descendant,
+        // but deliberately rebinds the VM's existing procfs read-write. Nested
+        // unprivileged bwrap writes UID/GID maps through the caller's /proc
+        // before mounting a fresh procfs for its own PID namespace. Giving the
+        // outer wrapper a fresh procfs on this executor leaves locked child
+        // mounts that make the nested proc mount fail Linux's
+        // mount_too_revealing check; making the inherited procfs read-only
+        // instead makes UID/GID map setup fail.
         //
         // A private directory backs /tmp so remote fixtures cannot alias files
         // owned by the test runner. The Bazel workspace is the other deliberate
@@ -127,8 +143,25 @@ impl BwrapTestCommand {
         // capabilities. Bubblewrap rejects a non-root caller that already has
         // capabilities, while an unprivileged nested bwrap acquires the setup
         // capabilities it needs inside the user namespace it creates.
+        let (mut info_reader, info_writer) =
+            UnixStream::pair().context("create bwrap info pipe")?;
+        let (block_reader, block_writer) =
+            UnixStream::pair().context("create bwrap startup gate")?;
+        info_reader
+            .set_read_timeout(Some(BWRAP_SETUP_TIMEOUT))
+            .context("set bwrap info timeout")?;
+        let info_writer_fd = info_writer.as_raw_fd();
+        let block_reader_fd = block_reader.as_raw_fd();
+
+        // Hold the sandbox at --block-fd before it forks the payload. This
+        // keeps the reported PID-namespace init alive until its pidfd is open;
+        // dropping block_writer below releases the sandbox with EOF.
         let mut command = StdCommand::new(&runtime.bwrap);
         command
+            .arg("--info-fd")
+            .arg(info_writer_fd.to_string())
+            .arg("--block-fd")
+            .arg(block_reader_fd.to_string())
             .args([
                 "--new-session",
                 "--die-with-parent",
@@ -147,6 +180,7 @@ impl BwrapTestCommand {
             .arg(&workspace)
             .args([
                 "--unshare-user",
+                "--unshare-pid",
                 "--unshare-ipc",
                 "--unshare-uts",
                 "--uid",
@@ -168,15 +202,57 @@ impl BwrapTestCommand {
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit());
 
+        // SAFETY: only async-signal-safe fcntl calls run between fork and exec.
+        // The parent retains both descriptors until spawn completes.
+        unsafe {
+            command.pre_exec(move || {
+                for fd in [info_writer_fd, block_reader_fd] {
+                    let flags = libc::fcntl(fd, libc::F_GETFD);
+                    if flags == -1
+                        || libc::fcntl(fd, libc::F_SETFD, flags & !libc::FD_CLOEXEC) == -1
+                    {
+                        return Err(io::Error::last_os_error());
+                    }
+                }
+                Ok(())
+            });
+        }
+
         let mut command = TokioCommand::from(command);
         command.kill_on_drop(true);
-        let child = command
+        let mut child = command
             .spawn()
             .context("start process inside bwrap test environment")?;
+        // This binding is intentionally declared after child. On an early
+        // return it drops first, releasing the startup gate before
+        // kill_on_drop terminates the launcher. Failures before a pidfd is
+        // acquired ultimately remain contained by the disposable action VM.
+        let startup_gate = block_writer;
+        let launcher_pid = child.id().context("bwrap launcher omitted its PID")?;
+        drop(info_writer);
+        drop(block_reader);
+        let mut bwrap_info = String::new();
+        let startup_result = info_reader
+            .read_to_string(&mut bwrap_info)
+            .context("read bwrap child information")
+            .and_then(|_| SandboxInit::from_bwrap_info(&bwrap_info, launcher_pid));
+        drop(startup_gate);
+        let sandbox_init = match startup_result {
+            Ok(sandbox_init) => sandbox_init,
+            Err(error) => {
+                if let Err(kill_error) = child.start_kill() {
+                    return Err(error.context(format!(
+                        "bwrap startup cleanup could not kill its launcher: {kill_error}"
+                    )));
+                }
+                return Err(error);
+            }
+        };
 
         Ok(BwrapTestProcess {
             processes: Some(BwrapProcesses {
                 child,
+                sandbox_init,
                 cleanup_complete: false,
                 environment,
             }),
@@ -225,7 +301,7 @@ impl BwrapTestProcess {
         }
     }
 
-    /// Kills the isolated process and waits for bwrap to exit.
+    /// Kills the isolated PID namespace and waits for bwrap to exit.
     pub async fn shutdown(mut self) -> Result<()> {
         let Some(processes) = self.processes.as_mut() else {
             anyhow::bail!("bwrap process guard is missing");
@@ -256,21 +332,57 @@ impl BwrapRuntimePaths {
 
 impl BwrapProcesses {
     async fn shutdown(&mut self) -> Result<()> {
-        let (kill_result, check_exit_status) = match self.child.try_wait() {
-            Ok(Some(_)) => (Ok(()), true),
-            Ok(None) => (
-                self.child
-                    .start_kill()
-                    .context("kill process running inside bwrap"),
-                false,
-            ),
-            Err(error) => (Err(error).context("check bwrap process status"), false),
+        let child_status = self.child.try_wait();
+        let sandbox_kill_result = self
+            .sandbox_init
+            .start_kill()
+            .context("kill bwrap PID namespace init");
+        let (mut check_exit_status, status_check_result) = match child_status {
+            Ok(Some(_)) => (true, Ok(())),
+            Ok(None) => (false, Ok(())),
+            Err(error) => (false, Err(error).context("check bwrap process status")),
         };
-        let wait_result = self
-            .child
+        let mut fallback_started = false;
+        let early_fallback_result = if sandbox_kill_result.is_err() {
+            check_exit_status = false;
+            fallback_started = true;
+            self.start_kill_launcher()
+        } else {
+            Ok(())
+        };
+        let sandbox_wait_result = self
+            .sandbox_init
             .wait()
             .await
-            .context("wait for process running inside bwrap")
+            .context("wait for bwrap PID namespace init");
+        let late_fallback_result = if sandbox_wait_result.is_err() && !fallback_started {
+            check_exit_status = false;
+            self.start_kill_launcher()
+        } else {
+            Ok(())
+        };
+        let mut timeout_kill_result = Ok(());
+        let launcher_timeout_result;
+        let launcher_wait_result =
+            match tokio::time::timeout(BWRAP_CLEANUP_TIMEOUT, self.child.wait()).await {
+                Ok(result) => {
+                    launcher_timeout_result = Ok(());
+                    result.context("wait for bwrap launcher")
+                }
+                Err(_) => {
+                    launcher_timeout_result = Err(anyhow::anyhow!(
+                        "timed out waiting for bwrap launcher after {BWRAP_CLEANUP_TIMEOUT:?}"
+                    ));
+                    check_exit_status = false;
+                    timeout_kill_result = self.start_kill_launcher();
+                    match tokio::time::timeout(BWRAP_CLEANUP_TIMEOUT, self.child.wait()).await {
+                        Ok(result) => result.context("wait for killed bwrap launcher"),
+                        Err(_) => Err(anyhow::anyhow!(
+                            "timed out waiting for killed bwrap launcher after {BWRAP_CLEANUP_TIMEOUT:?}"
+                        )),
+                    }
+                }
+            }
             .and_then(|status| {
                 anyhow::ensure!(
                     !check_exit_status || status.success(),
@@ -282,8 +394,24 @@ impl BwrapProcesses {
         // Every cleanup action has been attempted, so an individual error
         // should not cause the blocking fallback to repeat them.
         self.cleanup_complete = true;
-        kill_result?;
-        wait_result
+        status_check_result?;
+        sandbox_kill_result?;
+        early_fallback_result?;
+        sandbox_wait_result?;
+        late_fallback_result?;
+        launcher_timeout_result?;
+        timeout_kill_result?;
+        launcher_wait_result
+    }
+
+    fn start_kill_launcher(&mut self) -> Result<()> {
+        if let Err(kill_error) = self.child.start_kill() {
+            match self.child.try_wait() {
+                Ok(Some(_)) => return Ok(()),
+                Ok(None) | Err(_) => return Err(kill_error).context("kill bwrap launcher"),
+            }
+        }
+        Ok(())
     }
 
     fn shutdown_blocking(&mut self) {
@@ -291,25 +419,48 @@ impl BwrapProcesses {
             "bwrap panic cleanup starting for environment {}",
             self.environment.path().display()
         ));
-        if let Err(error) = self.child.start_kill() {
+        if let Err(error) = self.sandbox_init.start_kill() {
             log_panic_cleanup(format_args!(
-                "bwrap panic cleanup could not kill its child: {error}"
+                "bwrap panic cleanup could not kill its PID namespace init: {error}"
+            ));
+        }
+        if let Err(error) = self.start_kill_launcher() {
+            log_panic_cleanup(format_args!(
+                "bwrap panic cleanup could not kill its launcher: {error}"
             ));
         }
 
-        log_panic_cleanup(format_args!("bwrap panic cleanup waiting for its child"));
+        log_panic_cleanup(format_args!(
+            "bwrap panic cleanup waiting for its PID namespace init"
+        ));
+        if let Err(error) = self.sandbox_init.wait_blocking() {
+            log_panic_cleanup(format_args!(
+                "bwrap panic cleanup could not wait for its PID namespace init: {error}"
+            ));
+        }
+
+        log_panic_cleanup(format_args!("bwrap panic cleanup waiting for its launcher"));
+        let deadline = Instant::now() + BWRAP_CLEANUP_TIMEOUT;
         loop {
             match self.child.try_wait() {
                 Ok(Some(status)) => {
                     log_panic_cleanup(format_args!(
-                        "bwrap panic cleanup child exited with {status}"
+                        "bwrap panic cleanup launcher exited with {status}"
                     ));
                     break;
                 }
-                Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+                Ok(None) => {
+                    if Instant::now() >= deadline {
+                        log_panic_cleanup(format_args!(
+                            "bwrap panic cleanup timed out waiting for its launcher"
+                        ));
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(10));
+                }
                 Err(error) => {
                     log_panic_cleanup(format_args!(
-                        "bwrap panic cleanup could not wait for its child: {error}"
+                        "bwrap panic cleanup could not wait for its launcher: {error}"
                     ));
                     break;
                 }

--- a/bazel/rules/testing/bwrap/src/lib.rs
+++ b/bazel/rules/testing/bwrap/src/lib.rs
@@ -86,7 +86,12 @@ impl BwrapTestCommand {
         fs::create_dir(&private_tmp)
             .with_context(|| format!("create private tmp directory {}", private_tmp.display()))?;
         fs::set_permissions(&private_tmp, fs::Permissions::from_mode(0o1777)).with_context(
-            || format!("set permissions on private tmp directory {}", private_tmp.display()),
+            || {
+                format!(
+                    "set permissions on private tmp directory {}",
+                    private_tmp.display()
+                )
+            },
         )?;
         let home = private_tmp.join("home");
         let codex_home = private_tmp.join("codex-home");
@@ -104,15 +109,19 @@ impl BwrapTestCommand {
             },
         )?;
 
-        // Keep the VM's PID namespace and expose its existing procfs
-        // read-write: a nested bwrap must write UID/GID maps before mounting
-        // the fresh procfs for its own PID namespace. Mounting a fresh procfs
-        // here instead leaves locked child mounts that make the nested mount
-        // fail Linux's mount_too_revealing check. A private directory backs
-        // /tmp so remote fixtures cannot alias files owned by the test runner.
-        // The Bazel workspace is the other deliberate writable carveout:
-        // production bwrap setup needs to materialize missing mount targets
-        // below a writable command cwd.
+        // Firecracker supplies the host PID boundary, so the outer wrapper
+        // deliberately shares the disposable VM's PID namespace and rebinds
+        // its procfs read-write. Nested unprivileged bwrap writes UID/GID maps
+        // through the caller's /proc before mounting a fresh procfs for its
+        // own PID namespace. Giving the outer wrapper a fresh procfs on this
+        // executor leaves locked child mounts that make the nested proc mount
+        // fail Linux's mount_too_revealing check; making the inherited procfs
+        // read-only instead makes UID/GID map setup fail.
+        //
+        // A private directory backs /tmp so remote fixtures cannot alias files
+        // owned by the test runner. The Bazel workspace is the other deliberate
+        // writable carveout: production bwrap setup needs to materialize
+        // missing mount targets below a writable command cwd.
         //
         // Map the caller to a non-root ID and leave the final process with no
         // capabilities. Bubblewrap rejects a non-root caller that already has
@@ -133,11 +142,7 @@ impl BwrapTestCommand {
             ])
             .arg(&private_tmp)
             .arg("/tmp")
-            .args([
-                "--dev",
-                "/dev",
-                "--bind",
-            ])
+            .args(["--dev", "/dev", "--bind"])
             .arg(&workspace)
             .arg(&workspace)
             .args([

--- a/bazel/rules/testing/bwrap/src/lib.rs
+++ b/bazel/rules/testing/bwrap/src/lib.rs
@@ -1,0 +1,335 @@
+#[cfg(not(target_os = "linux"))]
+compile_error!("bwrap_test_support can only run on Linux");
+
+use std::ffi::OsString;
+use std::fs;
+use std::future::Future;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command as StdCommand;
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::Context;
+use anyhow::Result;
+use tempfile::Builder;
+use tempfile::TempDir;
+use tokio::process::Child;
+use tokio::process::ChildStdout;
+use tokio::process::Command as TokioCommand;
+
+/// Builds a command that runs inside the Linux integration-test namespace.
+pub struct BwrapTestCommand {
+    executable: PathBuf,
+    args: Vec<OsString>,
+    env: Vec<(OsString, OsString)>,
+}
+
+/// Owns a process running inside the Linux integration-test namespace.
+///
+/// Call [`Self::scope`] or [`Self::shutdown`] on every successful path. A
+/// normal unguarded drop panics, while a drop during unwinding performs
+/// blocking cleanup without introducing a second panic.
+pub struct BwrapTestProcess {
+    processes: Option<BwrapProcesses>,
+}
+
+struct BwrapProcesses {
+    child: Child,
+    cleanup_complete: bool,
+    environment: TempDir,
+}
+
+struct BwrapRuntimePaths {
+    bwrap: PathBuf,
+}
+
+impl BwrapTestCommand {
+    /// Creates an isolated bwrap command for `executable`.
+    pub fn new(executable: impl Into<PathBuf>) -> Self {
+        Self {
+            executable: executable.into(),
+            args: Vec::new(),
+            env: Vec::new(),
+        }
+    }
+
+    /// Adds an argument passed to the isolated executable.
+    #[must_use]
+    pub fn arg(mut self, arg: impl Into<OsString>) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    /// Adds or overrides an environment variable for the isolated process.
+    #[must_use]
+    pub fn env(mut self, key: impl Into<OsString>, value: impl Into<OsString>) -> Self {
+        self.env.push((key.into(), value.into()));
+        self
+    }
+
+    /// Starts the executable with an isolated filesystem, IPC, and UTS view.
+    pub fn spawn(self) -> Result<BwrapTestProcess> {
+        let runtime = BwrapRuntimePaths::from_runfiles()?;
+        let workspace = std::env::current_dir().context("resolve Bazel test workspace")?;
+        anyhow::ensure!(
+            workspace != Path::new("/"),
+            "refusing to make the filesystem root writable"
+        );
+        let environment = Builder::new()
+            .prefix("codex-bwrap-test-")
+            .tempdir_in("/tmp")
+            .context("create isolated bwrap test environment")?;
+        let private_tmp = environment.path().join("tmp");
+        fs::create_dir(&private_tmp)
+            .with_context(|| format!("create private tmp directory {}", private_tmp.display()))?;
+        fs::set_permissions(&private_tmp, fs::Permissions::from_mode(0o1777)).with_context(
+            || format!("set permissions on private tmp directory {}", private_tmp.display()),
+        )?;
+        let home = private_tmp.join("home");
+        let codex_home = private_tmp.join("codex-home");
+        let xdg_runtime_dir = private_tmp.join("xdg-runtime");
+        for path in [&home, &codex_home, &xdg_runtime_dir] {
+            fs::create_dir(path)
+                .with_context(|| format!("create bwrap test directory {}", path.display()))?;
+        }
+        fs::set_permissions(&xdg_runtime_dir, fs::Permissions::from_mode(0o700)).with_context(
+            || {
+                format!(
+                    "set permissions on bwrap runtime directory {}",
+                    xdg_runtime_dir.display()
+                )
+            },
+        )?;
+
+        // Keep the VM's PID namespace and expose its existing procfs
+        // read-write: a nested bwrap must write UID/GID maps before mounting
+        // the fresh procfs for its own PID namespace. Mounting a fresh procfs
+        // here instead leaves locked child mounts that make the nested mount
+        // fail Linux's mount_too_revealing check. A private directory backs
+        // /tmp so remote fixtures cannot alias files owned by the test runner.
+        // The Bazel workspace is the other deliberate writable carveout:
+        // production bwrap setup needs to materialize missing mount targets
+        // below a writable command cwd.
+        //
+        // Map the caller to a non-root ID and leave the final process with no
+        // capabilities. Bubblewrap rejects a non-root caller that already has
+        // capabilities, while an unprivileged nested bwrap acquires the setup
+        // capabilities it needs inside the user namespace it creates.
+        let mut command = StdCommand::new(&runtime.bwrap);
+        command
+            .args([
+                "--new-session",
+                "--die-with-parent",
+                "--ro-bind",
+                "/",
+                "/",
+                "--bind",
+                "/proc",
+                "/proc",
+                "--bind",
+            ])
+            .arg(&private_tmp)
+            .arg("/tmp")
+            .args([
+                "--dev",
+                "/dev",
+                "--bind",
+            ])
+            .arg(&workspace)
+            .arg(&workspace)
+            .args([
+                "--unshare-user",
+                "--unshare-ipc",
+                "--unshare-uts",
+                "--uid",
+                "1000",
+                "--gid",
+                "1000",
+                "--cap-drop",
+                "ALL",
+                "--",
+            ])
+            .arg(self.executable)
+            .args(self.args)
+            .env("HOME", "/tmp/home")
+            .env("CODEX_HOME", "/tmp/codex-home")
+            .env("XDG_RUNTIME_DIR", "/tmp/xdg-runtime")
+            .env("TMPDIR", "/tmp")
+            .envs(self.env)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+
+        let mut command = TokioCommand::from(command);
+        command.kill_on_drop(true);
+        let child = command
+            .spawn()
+            .context("start process inside bwrap test environment")?;
+
+        Ok(BwrapTestProcess {
+            processes: Some(BwrapProcesses {
+                child,
+                cleanup_complete: false,
+                environment,
+            }),
+        })
+    }
+}
+
+impl BwrapTestProcess {
+    /// Returns the host path containing this process's isolated environment.
+    pub fn environment_path(&self) -> &Path {
+        let Some(processes) = self.processes.as_ref() else {
+            panic!("bwrap process guard is missing");
+        };
+        processes.environment.path()
+    }
+
+    /// Takes the piped standard output of the isolated process.
+    ///
+    /// This may only be called once for a process created by
+    /// [`BwrapTestCommand::spawn`].
+    pub fn take_stdout(&mut self) -> ChildStdout {
+        let Some(processes) = self.processes.as_mut() else {
+            panic!("bwrap process guard is missing");
+        };
+        let Some(stdout) = processes.child.stdout.take() else {
+            panic!("bwrap process stdout has already been taken");
+        };
+        stdout
+    }
+
+    /// Runs `future`, then asynchronously tears down bwrap before returning.
+    ///
+    /// If both the scoped operation and teardown fail, the operation error is
+    /// returned with the teardown error attached as context. A panic in the
+    /// scoped operation triggers the blocking unwind-time fallback instead.
+    pub async fn scope<T>(self, future: impl Future<Output = Result<T>>) -> Result<T> {
+        let scope_result = future.await;
+        let shutdown_result = self.shutdown().await;
+        match (scope_result, shutdown_result) {
+            (Ok(value), Ok(())) => Ok(value),
+            (Err(error), Ok(())) => Err(error),
+            (Ok(_), Err(error)) => Err(error),
+            (Err(error), Err(shutdown_error)) => {
+                Err(error.context(format!("bwrap teardown also failed: {shutdown_error:#}")))
+            }
+        }
+    }
+
+    /// Kills the isolated process and waits for bwrap to exit.
+    pub async fn shutdown(mut self) -> Result<()> {
+        let Some(processes) = self.processes.as_mut() else {
+            anyhow::bail!("bwrap process guard is missing");
+        };
+        let result = processes.shutdown().await;
+        self.processes.take();
+        result
+    }
+}
+
+impl Drop for BwrapTestProcess {
+    fn drop(&mut self) {
+        // Panicking here starts unwinding, after which BwrapProcesses performs
+        // the blocking fallback while its field is dropped.
+        if self.processes.is_some() && !std::thread::panicking() {
+            panic!("BwrapTestProcess dropped without async teardown");
+        }
+    }
+}
+
+impl BwrapRuntimePaths {
+    fn from_runfiles() -> Result<Self> {
+        Ok(Self {
+            bwrap: codex_utils_cargo_bin::cargo_bin("bwrap")?,
+        })
+    }
+}
+
+impl BwrapProcesses {
+    async fn shutdown(&mut self) -> Result<()> {
+        let (kill_result, check_exit_status) = match self.child.try_wait() {
+            Ok(Some(_)) => (Ok(()), true),
+            Ok(None) => (
+                self.child
+                    .start_kill()
+                    .context("kill process running inside bwrap"),
+                false,
+            ),
+            Err(error) => (Err(error).context("check bwrap process status"), false),
+        };
+        let wait_result = self
+            .child
+            .wait()
+            .await
+            .context("wait for process running inside bwrap")
+            .and_then(|status| {
+                anyhow::ensure!(
+                    !check_exit_status || status.success(),
+                    "bwrap process exited with {status}"
+                );
+                Ok(())
+            });
+
+        // Every cleanup action has been attempted, so an individual error
+        // should not cause the blocking fallback to repeat them.
+        self.cleanup_complete = true;
+        kill_result?;
+        wait_result
+    }
+
+    fn shutdown_blocking(&mut self) {
+        log_panic_cleanup(format_args!(
+            "bwrap panic cleanup starting for environment {}",
+            self.environment.path().display()
+        ));
+        if let Err(error) = self.child.start_kill() {
+            log_panic_cleanup(format_args!(
+                "bwrap panic cleanup could not kill its child: {error}"
+            ));
+        }
+
+        log_panic_cleanup(format_args!("bwrap panic cleanup waiting for its child"));
+        loop {
+            match self.child.try_wait() {
+                Ok(Some(status)) => {
+                    log_panic_cleanup(format_args!(
+                        "bwrap panic cleanup child exited with {status}"
+                    ));
+                    break;
+                }
+                Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+                Err(error) => {
+                    log_panic_cleanup(format_args!(
+                        "bwrap panic cleanup could not wait for its child: {error}"
+                    ));
+                    break;
+                }
+            }
+        }
+
+        self.cleanup_complete = true;
+        log_panic_cleanup(format_args!("bwrap panic cleanup complete"));
+    }
+}
+
+impl Drop for BwrapProcesses {
+    fn drop(&mut self) {
+        // Never introduce a second panic while unwinding. Blocking here is
+        // intentional because test failures must not leak bwrap children.
+        if !self.cleanup_complete && std::thread::panicking() {
+            self.shutdown_blocking();
+        }
+    }
+}
+
+fn log_panic_cleanup(args: std::fmt::Arguments<'_>) {
+    let _ = writeln!(std::io::stderr().lock(), "{args}");
+}
+
+#[cfg(test)]
+#[path = "lib_tests.rs"]
+mod tests;

--- a/bazel/rules/testing/bwrap/src/lib.rs
+++ b/bazel/rules/testing/bwrap/src/lib.rs
@@ -11,9 +11,11 @@ use std::os::fd::AsRawFd;
 use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixStream;
 use std::os::unix::process::CommandExt;
+use std::os::unix::process::ExitStatusExt;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command as StdCommand;
+use std::process::ExitStatus;
 use std::process::Stdio;
 use std::time::Duration;
 use std::time::Instant;
@@ -59,6 +61,12 @@ struct BwrapProcesses {
 
 struct BwrapRuntimePaths {
     bwrap: PathBuf,
+}
+
+#[derive(Clone, Copy)]
+enum LauncherExitPolicy {
+    RequireSuccess,
+    AllowTeardownKill,
 }
 
 impl BwrapTestCommand {
@@ -337,14 +345,16 @@ impl BwrapProcesses {
             .sandbox_init
             .start_kill()
             .context("kill bwrap PID namespace init");
-        let (mut check_exit_status, status_check_result) = match child_status {
-            Ok(Some(_)) => (true, Ok(())),
-            Ok(None) => (false, Ok(())),
-            Err(error) => (false, Err(error).context("check bwrap process status")),
+        let (exit_policy, status_check_result) = match child_status {
+            Ok(Some(_)) => (LauncherExitPolicy::RequireSuccess, Ok(())),
+            Ok(None) => (LauncherExitPolicy::AllowTeardownKill, Ok(())),
+            Err(error) => (
+                LauncherExitPolicy::RequireSuccess,
+                Err(error).context("check bwrap process status"),
+            ),
         };
         let mut fallback_started = false;
         let early_fallback_result = if sandbox_kill_result.is_err() {
-            check_exit_status = false;
             fallback_started = true;
             self.start_kill_launcher()
         } else {
@@ -356,7 +366,6 @@ impl BwrapProcesses {
             .await
             .context("wait for bwrap PID namespace init");
         let late_fallback_result = if sandbox_wait_result.is_err() && !fallback_started {
-            check_exit_status = false;
             self.start_kill_launcher()
         } else {
             Ok(())
@@ -373,7 +382,6 @@ impl BwrapProcesses {
                     launcher_timeout_result = Err(anyhow::anyhow!(
                         "timed out waiting for bwrap launcher after {BWRAP_CLEANUP_TIMEOUT:?}"
                     ));
-                    check_exit_status = false;
                     timeout_kill_result = self.start_kill_launcher();
                     match tokio::time::timeout(BWRAP_CLEANUP_TIMEOUT, self.child.wait()).await {
                         Ok(result) => result.context("wait for killed bwrap launcher"),
@@ -383,13 +391,7 @@ impl BwrapProcesses {
                     }
                 }
             }
-            .and_then(|status| {
-                anyhow::ensure!(
-                    !check_exit_status || status.success(),
-                    "bwrap process exited with {status}"
-                );
-                Ok(())
-            });
+            .and_then(|status| ensure_launcher_exit_status(status, exit_policy));
 
         // Every cleanup action has been attempted, so an individual error
         // should not cause the blocking fallback to repeat them.
@@ -480,6 +482,18 @@ impl Drop for BwrapProcesses {
             self.shutdown_blocking();
         }
     }
+}
+
+fn ensure_launcher_exit_status(status: ExitStatus, policy: LauncherExitPolicy) -> Result<()> {
+    // bwrap normalizes a SIGKILL of its PID-namespace init to 128 + SIGKILL.
+    // Killing the launcher directly leaves it signal-terminated instead.
+    let expected_teardown_kill = matches!(policy, LauncherExitPolicy::AllowTeardownKill)
+        && (status.code() == Some(128 + libc::SIGKILL) || status.signal() == Some(libc::SIGKILL));
+    anyhow::ensure!(
+        status.success() || expected_teardown_kill,
+        "bwrap process exited with {status}"
+    );
+    Ok(())
 }
 
 fn log_panic_cleanup(args: std::fmt::Arguments<'_>) {

--- a/bazel/rules/testing/bwrap/src/lib_tests.rs
+++ b/bazel/rules/testing/bwrap/src/lib_tests.rs
@@ -5,9 +5,11 @@ use std::future::Future;
 use std::os::fd::AsRawFd;
 use std::os::fd::FromRawFd;
 use std::os::fd::OwnedFd;
+use std::os::unix::process::ExitStatusExt;
 use std::panic::AssertUnwindSafe;
 use std::path::Path;
 use std::path::PathBuf;
+use std::process::ExitStatus;
 
 use anyhow::Context;
 use anyhow::Result;
@@ -23,6 +25,8 @@ use tokio::time::timeout;
 
 use super::BwrapTestCommand;
 use super::BwrapTestProcess;
+use super::LauncherExitPolicy;
+use super::ensure_launcher_exit_status;
 
 fn smoke_fixture() -> Result<PathBuf> {
     Ok(codex_utils_cargo_bin::cargo_bin("bwrap-smoke")?)
@@ -101,6 +105,53 @@ fn namespace_identity(namespace: &str) -> Result<String> {
     Ok(fs::read_link(format!("/proc/self/ns/{namespace}"))?
         .to_string_lossy()
         .into_owned())
+}
+
+fn exit_status(code: i32) -> ExitStatus {
+    ExitStatus::from_raw(code << 8)
+}
+
+fn signal_status(signal: i32) -> ExitStatus {
+    ExitStatus::from_raw(signal)
+}
+
+#[test]
+fn launcher_exit_status_distinguishes_payload_failures_from_teardown() {
+    let actual = [
+        ensure_launcher_exit_status(exit_status(0), LauncherExitPolicy::RequireSuccess).is_ok(),
+        ensure_launcher_exit_status(exit_status(73), LauncherExitPolicy::RequireSuccess).is_ok(),
+        ensure_launcher_exit_status(
+            exit_status(128 + libc::SIGKILL),
+            LauncherExitPolicy::RequireSuccess,
+        )
+        .is_ok(),
+        ensure_launcher_exit_status(
+            signal_status(libc::SIGKILL),
+            LauncherExitPolicy::RequireSuccess,
+        )
+        .is_ok(),
+        ensure_launcher_exit_status(exit_status(0), LauncherExitPolicy::AllowTeardownKill).is_ok(),
+        ensure_launcher_exit_status(exit_status(73), LauncherExitPolicy::AllowTeardownKill).is_ok(),
+        ensure_launcher_exit_status(
+            exit_status(128 + libc::SIGKILL),
+            LauncherExitPolicy::AllowTeardownKill,
+        )
+        .is_ok(),
+        ensure_launcher_exit_status(
+            signal_status(libc::SIGKILL),
+            LauncherExitPolicy::AllowTeardownKill,
+        )
+        .is_ok(),
+        ensure_launcher_exit_status(
+            signal_status(libc::SIGTERM),
+            LauncherExitPolicy::AllowTeardownKill,
+        )
+        .is_ok(),
+    ];
+    assert_eq!(
+        actual,
+        [true, false, false, false, true, false, true, true, false]
+    );
 }
 
 #[tokio::test]

--- a/bazel/rules/testing/bwrap/src/lib_tests.rs
+++ b/bazel/rules/testing/bwrap/src/lib_tests.rs
@@ -1,0 +1,390 @@
+use std::any::Any;
+use std::collections::BTreeMap;
+use std::fs;
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use anyhow::Result;
+use futures::FutureExt;
+use pretty_assertions::assert_eq;
+use tempfile::Builder;
+use tokio::io::AsyncBufReadExt;
+use tokio::io::AsyncReadExt;
+use tokio::io::BufReader;
+use tokio::net::TcpListener;
+use tokio::time::Duration;
+use tokio::time::timeout;
+
+use super::BwrapTestCommand;
+use super::BwrapTestProcess;
+
+fn smoke_fixture() -> Result<PathBuf> {
+    Ok(codex_utils_cargo_bin::cargo_bin("bwrap-smoke")?)
+}
+
+async fn waiting_smoke_process() -> Result<BwrapTestProcess> {
+    let mut process = BwrapTestCommand::new(smoke_fixture()?)
+        .arg("wait")
+        .spawn()?;
+    let mut lines = BufReader::new(process.take_stdout()).lines();
+    let ready_line = lines
+        .next_line()
+        .await?
+        .context("bwrap smoke process exited before becoming ready")?;
+    assert_eq!(ready_line, "BWRAP_TEST_READY");
+    Ok(process)
+}
+
+fn environment_path(process: &BwrapTestProcess) -> PathBuf {
+    process.environment_path().to_path_buf()
+}
+
+fn assert_environment_removed(path: &Path) {
+    assert!(
+        !path.exists(),
+        "bwrap test environment remains: {}",
+        path.display()
+    );
+}
+
+fn assert_panic_message(panic: Box<dyn Any + Send>, expected: &str) {
+    assert_eq!(panic.downcast_ref::<&str>(), Some(&expected));
+}
+
+async fn assert_future_panics<T>(future: impl Future<Output = T>, expected: &str) {
+    let panic = match AssertUnwindSafe(future).catch_unwind().await {
+        Ok(_) => panic!("future should panic"),
+        Err(panic) => panic,
+    };
+    assert_panic_message(panic, expected);
+}
+
+async fn run_smoke(args: &[&str]) -> Result<BTreeMap<String, String>> {
+    let mut command = BwrapTestCommand::new(smoke_fixture()?);
+    for arg in args {
+        command = command.arg(*arg);
+    }
+    run_smoke_command(command).await
+}
+
+async fn run_smoke_command(command: BwrapTestCommand) -> Result<BTreeMap<String, String>> {
+    let mut process = command.spawn()?;
+    let mut stdout = process.take_stdout();
+    let output = process
+        .scope(async move {
+            let mut output = String::new();
+            stdout.read_to_string(&mut output).await?;
+            Ok(output)
+        })
+        .await?;
+    parse_key_values(&output)
+}
+
+fn parse_key_values(output: &str) -> Result<BTreeMap<String, String>> {
+    output
+        .lines()
+        .map(|line| {
+            line.split_once('=')
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+                .with_context(|| format!("invalid smoke output line: {line:?}"))
+        })
+        .collect()
+}
+
+fn namespace_identity(namespace: &str) -> Result<String> {
+    Ok(fs::read_link(format!("/proc/self/ns/{namespace}"))?
+        .to_string_lossy()
+        .into_owned())
+}
+
+#[tokio::test]
+async fn dropping_without_teardown_panics_and_cleans_up() -> Result<()> {
+    let process = waiting_smoke_process().await?;
+    let environment = environment_path(&process);
+    assert_future_panics(
+        async move { drop(process) },
+        "BwrapTestProcess dropped without async teardown",
+    )
+    .await;
+    assert_environment_removed(&environment);
+    Ok(())
+}
+
+#[tokio::test]
+async fn dropping_while_panicking_does_not_panic_again() -> Result<()> {
+    let process = waiting_smoke_process().await?;
+    let environment = environment_path(&process);
+    assert_future_panics(
+        async move {
+            let _process = process;
+            panic!("sentinel panic");
+        },
+        "sentinel panic",
+    )
+    .await;
+    assert_environment_removed(&environment);
+    Ok(())
+}
+
+#[tokio::test]
+async fn async_teardown_disarms_drop_bomb_and_cleans_up() -> Result<()> {
+    let process = waiting_smoke_process().await?;
+    let environment = environment_path(&process);
+    process.shutdown().await?;
+    assert_environment_removed(&environment);
+    Ok(())
+}
+
+#[tokio::test]
+async fn scope_returns_value_and_cleans_up() -> Result<()> {
+    let process = waiting_smoke_process().await?;
+    let environment = environment_path(&process);
+    let value = process
+        .scope(async { Ok::<_, anyhow::Error>("scope value") })
+        .await?;
+    assert_eq!(value, "scope value");
+    assert_environment_removed(&environment);
+    Ok(())
+}
+
+#[tokio::test]
+async fn outer_namespace_topology_matches_the_exec_server_contract() -> Result<()> {
+    let values = run_smoke(&["inspect"]).await?;
+
+    assert_eq!(
+        values.get("id.effective_uid").map(String::as_str),
+        Some("1000")
+    );
+    assert_eq!(
+        values.get("id.effective_gid").map(String::as_str),
+        Some("1000")
+    );
+    for set in ["effective", "permitted", "inheritable", "ambient"] {
+        assert_eq!(
+            u64::from_str_radix(
+                values
+                    .get(&format!("cap.{set}"))
+                    .with_context(|| format!("missing {set} capabilities"))?,
+                16,
+            )?,
+            0,
+            "the non-root outer process must not carry {set} capabilities"
+        );
+    }
+    assert_ne!(
+        values.get("ns.user"),
+        Some(&namespace_identity("user")?),
+        "outer user namespace should differ from its parent"
+    );
+    for namespace in ["pid", "net"] {
+        assert_eq!(
+            values.get(&format!("ns.{namespace}")),
+            Some(&namespace_identity(namespace)?),
+            "outer {namespace} namespace should deliberately match its parent"
+        );
+    }
+    for namespace in ["mnt", "ipc", "uts"] {
+        assert_ne!(
+            values.get(&format!("ns.{namespace}")),
+            Some(&namespace_identity(namespace)?),
+            "outer {namespace} namespace should differ from its parent"
+        );
+    }
+    if let Some(pid_one_namespace) = values.get("proc.1.pid_ns") {
+        assert_eq!(Some(pid_one_namespace), values.get("proc.self.pid_ns"));
+    } else {
+        assert!(
+            values.contains_key("proc.1.pid_ns.error"),
+            "outer procfs should either expose PID 1 or report why it is unreadable"
+        );
+    }
+    assert_eq!(
+        values.get("proc.self.pid_ns"),
+        Some(&namespace_identity("pid")?),
+        "outer /proc should deliberately expose the parent PID namespace"
+    );
+    for name in ["overflowuid", "overflowgid"] {
+        let value = values
+            .get(&format!("proc.{name}"))
+            .with_context(|| format!("missing {name}"))?;
+        assert!(value.parse::<u32>().is_ok(), "invalid {name}: {value:?}");
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn default_home_and_runtime_directories_use_private_tmp() -> Result<()> {
+    let values = run_smoke(&["inspect"]).await?;
+
+    for (name, expected) in [
+        ("HOME", "/tmp/home"),
+        ("CODEX_HOME", "/tmp/codex-home"),
+        ("XDG_RUNTIME_DIR", "/tmp/xdg-runtime"),
+        ("TMPDIR", "/tmp"),
+    ] {
+        assert_eq!(
+            values.get(&format!("env.{name}")).map(String::as_str),
+            Some(expected)
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn command_environment_overrides_isolated_defaults() -> Result<()> {
+    let overrides = [
+        ("HOME", "/tmp/bwrap-test-home-override"),
+        ("CODEX_HOME", "/tmp/bwrap-test-codex-home-override"),
+        ("XDG_RUNTIME_DIR", "/tmp/bwrap-test-xdg-runtime-override"),
+    ];
+    let mut command = BwrapTestCommand::new(smoke_fixture()?).arg("inspect");
+    for (name, value) in overrides {
+        command = command.env(name, value);
+    }
+    let values = run_smoke_command(command).await?;
+
+    for (name, value) in overrides {
+        assert_eq!(
+            values.get(&format!("env.{name}")).map(String::as_str),
+            Some(value)
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn root_is_read_only_while_tmp_and_workspace_round_trip() -> Result<()> {
+    let tmp_writable = Builder::new()
+        .prefix("bwrap-write-smoke-")
+        .tempdir_in("/tmp")?;
+    fs::write(tmp_writable.path().join("host-sentinel.txt"), "host")?;
+    let workspace = std::env::current_dir()?;
+    let workspace_writable = Builder::new()
+        .prefix("bwrap-workspace-write-smoke-")
+        .tempdir_in(workspace)?;
+    let root_target = format!("/bwrap-test-root-write-{}", std::process::id());
+    let values = run_smoke(&[
+        "filesystem",
+        tmp_writable
+            .path()
+            .to_str()
+            .context("non-UTF-8 temp path")?,
+        workspace_writable
+            .path()
+            .to_str()
+            .context("non-UTF-8 workspace path")?,
+        &root_target,
+    ])
+    .await?;
+
+    assert_eq!(
+        values.get("tmp.value").map(String::as_str),
+        Some("round-trip")
+    );
+    assert_eq!(
+        values.get("tmp.host_sentinel_visible").map(String::as_str),
+        Some("false")
+    );
+    assert_eq!(
+        fs::read_to_string(tmp_writable.path().join("host-sentinel.txt"))?,
+        "host"
+    );
+    assert!(!tmp_writable.path().join("round-trip.txt").exists());
+    assert_eq!(
+        values.get("workspace.value").map(String::as_str),
+        Some("round-trip")
+    );
+    assert_eq!(
+        fs::read_to_string(workspace_writable.path().join("round-trip.txt"))?,
+        "round-trip"
+    );
+    assert_eq!(
+        values.get("root.write_errno").map(String::as_str),
+        Some(libc::EROFS.to_string().as_str())
+    );
+    assert!(!Path::new(&root_target).exists());
+    Ok(())
+}
+
+#[tokio::test]
+async fn outer_loopback_reaches_a_parent_listener() -> Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let address = listener.local_addr()?;
+    let process = BwrapTestCommand::new(smoke_fixture()?)
+        .arg("connect")
+        .arg(address.to_string())
+        .spawn()?;
+
+    let received = process
+        .scope(async move {
+            timeout(Duration::from_secs(10), async move {
+                let (mut stream, _) = listener.accept().await?;
+                let mut received = Vec::new();
+                stream.read_to_end(&mut received).await?;
+                Ok::<_, anyhow::Error>(received)
+            })
+            .await
+            .context("parent listener timed out")?
+        })
+        .await?;
+    assert_eq!(received, b"BWRAP_LOOPBACK");
+    Ok(())
+}
+
+#[tokio::test]
+async fn raw_nested_bwrap_creates_required_namespaces_and_fresh_proc() -> Result<()> {
+    let bwrap = codex_utils_cargo_bin::cargo_bin("bwrap")?;
+    let fixture = smoke_fixture()?;
+    let values = run_smoke(&[
+        "nested",
+        bwrap.to_str().context("non-UTF-8 bwrap path")?,
+        fixture.to_str().context("non-UTF-8 fixture path")?,
+    ])
+    .await?;
+
+    for namespace in ["user", "mnt", "pid", "net"] {
+        assert_ne!(
+            values.get(&format!("outer.ns.{namespace}")),
+            values.get(&format!("child.ns.{namespace}")),
+            "nested {namespace} namespace should differ from the outer namespace"
+        );
+    }
+    assert_eq!(
+        values.get("child.id.effective_uid").map(String::as_str),
+        Some("1000")
+    );
+    assert_eq!(
+        values.get("child.id.effective_gid").map(String::as_str),
+        Some("1000")
+    );
+    for set in ["effective", "permitted", "inheritable", "ambient"] {
+        assert_eq!(
+            u64::from_str_radix(
+                values
+                    .get(&format!("child.cap.{set}"))
+                    .with_context(|| format!("missing nested {set} capabilities"))?,
+                16,
+            )?,
+            0,
+            "the nested command should not retain {set} bwrap setup capabilities"
+        );
+    }
+    assert_eq!(
+        values
+            .get("child.proc.1.pid_ns")
+            .context("nested procfs did not expose PID 1")?,
+        values
+            .get("child.proc.self.pid_ns")
+            .context("nested procfs did not expose self")?
+    );
+    for name in ["overflowuid", "overflowgid"] {
+        let value = values
+            .get(&format!("child.proc.{name}"))
+            .with_context(|| format!("missing nested {name}"))?;
+        assert!(value.parse::<u32>().is_ok(), "invalid {name}: {value:?}");
+    }
+    Ok(())
+}

--- a/bazel/rules/testing/bwrap/src/lib_tests.rs
+++ b/bazel/rules/testing/bwrap/src/lib_tests.rs
@@ -2,6 +2,9 @@ use std::any::Any;
 use std::collections::BTreeMap;
 use std::fs;
 use std::future::Future;
+use std::os::fd::AsRawFd;
+use std::os::fd::FromRawFd;
+use std::os::fd::OwnedFd;
 use std::panic::AssertUnwindSafe;
 use std::path::Path;
 use std::path::PathBuf;
@@ -139,6 +142,61 @@ async fn async_teardown_disarms_drop_bomb_and_cleans_up() -> Result<()> {
 }
 
 #[tokio::test]
+async fn async_teardown_kills_descendants_in_detached_sessions() -> Result<()> {
+    let mut process = BwrapTestCommand::new(smoke_fixture()?)
+        .arg("spawn-detached-descendant")
+        .spawn()?;
+    let mut lines = BufReader::new(process.take_stdout()).lines();
+    let ready_line = timeout(Duration::from_secs(10), lines.next_line())
+        .await
+        .context("detached descendant did not become ready")??
+        .context("detached descendant exited before becoming ready")?;
+    let descendant_pid: libc::pid_t = ready_line
+        .strip_prefix("BWRAP_TEST_DETACHED_DESCENDANT_READY=")
+        .context("invalid detached descendant ready line")?
+        .parse()
+        .context("parse detached descendant PID")?;
+    // SAFETY: pidfd_open does not dereference userspace pointers. The returned
+    // descriptor is uniquely owned when the syscall succeeds.
+    let raw_pidfd = unsafe { libc::syscall(libc::SYS_pidfd_open, descendant_pid, 0) };
+    if raw_pidfd == -1 {
+        return Err(std::io::Error::last_os_error()).context("open detached descendant pidfd");
+    }
+    // SAFETY: a successful pidfd_open returns a new owned descriptor.
+    let descendant_pidfd = unsafe { OwnedFd::from_raw_fd(raw_pidfd as i32) };
+
+    process.shutdown().await?;
+
+    let next_line = match timeout(Duration::from_secs(10), lines.next_line()).await {
+        Ok(result) => result?,
+        Err(timeout_error) => {
+            // SAFETY: pidfd_send_signal only reads the supplied null siginfo
+            // pointer, and descendant_pidfd remains owned for the syscall.
+            let kill_result = unsafe {
+                libc::syscall(
+                    libc::SYS_pidfd_send_signal,
+                    descendant_pidfd.as_raw_fd(),
+                    libc::SIGKILL,
+                    std::ptr::null::<libc::siginfo_t>(),
+                    0,
+                )
+            };
+            if kill_result == -1 {
+                let kill_error = std::io::Error::last_os_error();
+                return Err(anyhow::Error::new(timeout_error).context(format!(
+                    "detached descendant kept stdout open after teardown; \
+                     cleanup kill also failed: {kill_error}"
+                )));
+            }
+            return Err(anyhow::Error::new(timeout_error)
+                .context("detached descendant kept stdout open after teardown"));
+        }
+    };
+    assert_eq!(next_line, None);
+    Ok(())
+}
+
+#[tokio::test]
 async fn scope_returns_value_and_cleans_up() -> Result<()> {
     let process = waiting_smoke_process().await?;
     let environment = environment_path(&process);
@@ -179,13 +237,16 @@ async fn outer_namespace_topology_matches_the_exec_server_contract() -> Result<(
         Some(&namespace_identity("user")?),
         "outer user namespace should differ from its parent"
     );
-    for namespace in ["pid", "net"] {
-        assert_eq!(
-            values.get(&format!("ns.{namespace}")),
-            Some(&namespace_identity(namespace)?),
-            "outer {namespace} namespace should deliberately match its parent"
-        );
-    }
+    assert_eq!(
+        values.get("ns.net"),
+        Some(&namespace_identity("net")?),
+        "outer network namespace should deliberately match its parent"
+    );
+    assert_ne!(
+        values.get("ns.pid"),
+        Some(&namespace_identity("pid")?),
+        "outer pid namespace should differ from its parent"
+    );
     for namespace in ["mnt", "ipc", "uts"] {
         assert_ne!(
             values.get(&format!("ns.{namespace}")),
@@ -194,18 +255,19 @@ async fn outer_namespace_topology_matches_the_exec_server_contract() -> Result<(
         );
     }
     if let Some(pid_one_namespace) = values.get("proc.1.pid_ns") {
-        assert_eq!(Some(pid_one_namespace), values.get("proc.self.pid_ns"));
+        assert_eq!(pid_one_namespace, &namespace_identity("pid")?);
     } else {
         assert!(
             values.contains_key("proc.1.pid_ns.error"),
             "outer procfs should either expose PID 1 or report why it is unreadable"
         );
     }
-    assert_eq!(
+    assert_ne!(
         values.get("proc.self.pid_ns"),
         Some(&namespace_identity("pid")?),
-        "outer /proc should deliberately expose the parent PID namespace"
+        "outer process should run in a private PID namespace"
     );
+    assert_eq!(values.get("proc.self.pid_ns"), values.get("ns.pid"));
     for name in ["overflowuid", "overflowgid"] {
         let value = values
             .get(&format!("proc.{name}"))

--- a/bazel/rules/testing/bwrap/src/sandbox_init.rs
+++ b/bazel/rules/testing/bwrap/src/sandbox_init.rs
@@ -1,0 +1,143 @@
+use std::fs;
+use std::io;
+use std::os::fd::AsRawFd;
+use std::os::fd::FromRawFd;
+use std::os::fd::OwnedFd;
+use std::os::fd::RawFd;
+use std::time::Duration;
+use std::time::Instant;
+
+use anyhow::Context;
+use anyhow::Result;
+
+pub(super) const BWRAP_CLEANUP_TIMEOUT: Duration = Duration::from_secs(10);
+
+pub(super) struct SandboxInit {
+    pidfd: OwnedFd,
+}
+
+impl SandboxInit {
+    pub(super) fn from_bwrap_info(info: &str, launcher_pid: u32) -> Result<Self> {
+        let child_pid: libc::pid_t = info
+            .lines()
+            .find_map(|line| line.trim().strip_prefix("\"child-pid\":"))
+            .map(|value| value.trim().trim_end_matches(',').parse())
+            .transpose()
+            .context("parse bwrap child PID")?
+            .context("bwrap child information omitted child-pid")?;
+        anyhow::ensure!(
+            child_pid > 0,
+            "bwrap reported invalid child PID {child_pid}"
+        );
+
+        // SAFETY: pidfd_open does not dereference userspace pointers. The
+        // returned descriptor is uniquely owned when the syscall succeeds.
+        let raw_pidfd = unsafe { libc::syscall(libc::SYS_pidfd_open, child_pid, 0) };
+        if raw_pidfd == -1 {
+            return Err(io::Error::last_os_error()).context("open bwrap child pidfd");
+        }
+        // SAFETY: a successful pidfd_open returns a new owned descriptor.
+        let pidfd = unsafe { OwnedFd::from_raw_fd(raw_pidfd as i32) };
+        // Validate the numeric PID before retaining the pidfd. If setup failed
+        // and Linux already reused the PID, it cannot still name the launcher's
+        // direct child.
+        let status = fs::read_to_string(format!("/proc/{child_pid}/status"))
+            .context("read bwrap child status")?;
+        let parent_pid: u32 = status
+            .lines()
+            .find_map(|line| line.strip_prefix("PPid:"))
+            .map(str::trim)
+            .context("bwrap child status omitted PPid")?
+            .parse()
+            .context("parse bwrap child parent PID")?;
+        anyhow::ensure!(
+            parent_pid == launcher_pid,
+            "bwrap child PID {child_pid} belongs to parent {parent_pid}, not launcher {launcher_pid}"
+        );
+        Ok(Self { pidfd })
+    }
+
+    pub(super) fn start_kill(&self) -> io::Result<()> {
+        // SAFETY: pidfd_send_signal only reads the supplied null siginfo
+        // pointer, and pidfd remains owned by self for the syscall's duration.
+        let result = unsafe {
+            libc::syscall(
+                libc::SYS_pidfd_send_signal,
+                self.pidfd.as_raw_fd(),
+                libc::SIGKILL,
+                std::ptr::null::<libc::siginfo_t>(),
+                0,
+            )
+        };
+        if result == -1 {
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() != Some(libc::ESRCH) {
+                return Err(error);
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) async fn wait(&self) -> io::Result<()> {
+        let pidfd = self.pidfd.try_clone()?;
+        let wait = tokio::task::spawn_blocking(move || {
+            wait_for_pidfd_exit(pidfd.as_raw_fd(), BWRAP_CLEANUP_TIMEOUT)
+        });
+        match tokio::time::timeout(BWRAP_CLEANUP_TIMEOUT, wait).await {
+            Ok(result) => result.map_err(io::Error::other)?,
+            Err(_) => Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "timed out scheduling wait for bwrap PID namespace init",
+            )),
+        }
+    }
+
+    pub(super) fn wait_blocking(&self) -> io::Result<()> {
+        wait_for_pidfd_exit(self.pidfd.as_raw_fd(), BWRAP_CLEANUP_TIMEOUT)
+    }
+}
+
+fn wait_for_pidfd_exit(pidfd: RawFd, timeout: Duration) -> io::Result<()> {
+    let deadline = Instant::now() + timeout;
+    let mut poll_fd = libc::pollfd {
+        fd: pidfd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "timed out waiting for bwrap PID namespace init",
+            ));
+        }
+        let timeout_millis = remaining.as_millis().clamp(1, i32::MAX as u128) as i32;
+        poll_fd.revents = 0;
+        // SAFETY: poll_fd points to one initialized pollfd for the duration of
+        // the call.
+        let result = unsafe {
+            libc::poll(&mut poll_fd, /*nfds*/ 1, timeout_millis)
+        };
+        if result == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "timed out waiting for bwrap PID namespace init",
+            ));
+        }
+        if result == -1 {
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(error);
+        }
+        if poll_fd.revents & libc::POLLIN != 0 {
+            return Ok(());
+        }
+        return Err(io::Error::other(format!(
+            "unexpected pidfd poll events: {:#x}",
+            poll_fd.revents
+        )));
+    }
+}


### PR DESCRIPTION
## Why

Make it easier for developers and CI to exercise the remote executor flow with a Linux-based app-server and a Linux-based exec-server.

## Why not Docker

These tests will need to run on BuildBuddy's Firecracker microVMs, which also would allow us to run docker containers. Using a Docker container has stronger isolation than this bwrap setup, but has a couple costs:

1. several extra seconds of startup on each test
2. requires deeper changes to the images we use for RBE tests
3. harder to replicate without a blessed RBE setup
4. requires root permissions (could use podman here if this was only concern)

This setup loses Docker's ability to have a totally different filesystem image with alternate dependencies, but that doesn't seem too important for these remote executor tests.

## What

Add the scoped outer bwrap harness, its namespace and filesystem setup, shared execution properties, and smoke coverage for topology, credentials, procfs, loopback, private `/tmp`, and cleanup.

## Validation

Confirmed new test coverage is [running in github actions](https://github.com/openai/codex/actions/runs/28124174967/job/83283575486):

```
//bazel/rules/testing/bwrap:bwrap-test-support-smoke-test (cached) PASSED in 3.0s
```

## Stack

First in the stack. Followed by #29896.