### PR TITLE
[Codex] [1/2] Add store-owned thread catalog changes

### DIFF
--- a/codex-rs/thread-store/src/in_memory.rs
+++ b/codex-rs/thread-store/src/in_memory.rs
@@ -17,6 +17,7 @@ use codex_protocol::protocol::SessionMetaLine;
 use codex_protocol::protocol::ThreadHistoryMode;
 use codex_protocol::protocol::ThreadMemoryMode;
 use codex_rollout::persisted_rollout_items;
+use tokio::sync::broadcast;
 
 use crate::AppendThreadItemsParams;
 use crate::ArchiveThreadParams;
@@ -29,6 +30,7 @@ use crate::ReadThreadParams;
 use crate::ResumeThreadParams;
 use crate::StoredThread;
 use crate::StoredThreadHistory;
+use crate::ThreadCatalogChange;
 use crate::ThreadMetadataPatch;
 use crate::ThreadPage;
 use crate::ThreadRelationFilter;
@@ -58,6 +60,7 @@ mod tests {
     use crate::ThreadSortKey;
     use codex_protocol::models::BaseInstructions;
     use codex_protocol::protocol::SessionSource;
+    use pretty_assertions::assert_eq;
 
     #[tokio::test]
     async fn default_turn_pagination_methods_return_unsupported() {
@@ -348,6 +351,87 @@ mod tests {
             }
         ));
     }
+
+    #[tokio::test]
+    async fn catalog_changes_follow_successful_mutations() {
+        let store = InMemoryThreadStore::default();
+        let mut changes = store.subscribe_catalog_changes();
+        let thread_id = ThreadId::default();
+
+        ThreadStore::create_thread(
+            &store,
+            create_thread_params(thread_id, ThreadHistoryMode::Legacy),
+        )
+        .await
+        .expect("create thread");
+        assert_eq!(
+            changes.recv().await.expect("create change"),
+            ThreadCatalogChange::Upsert { thread_id }
+        );
+
+        store
+            .read_thread(ReadThreadParams {
+                thread_id,
+                include_archived: false,
+                include_history: false,
+            })
+            .await
+            .expect("read thread");
+        ThreadStore::update_thread_metadata(
+            &store,
+            UpdateThreadMetadataParams {
+                thread_id,
+                patch: ThreadMetadataPatch::default(),
+                include_archived: false,
+            },
+        )
+        .await
+        .expect("apply empty metadata patch");
+        assert!(matches!(
+            changes.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
+        ));
+
+        ThreadStore::update_thread_metadata(
+            &store,
+            UpdateThreadMetadataParams {
+                thread_id,
+                patch: ThreadMetadataPatch {
+                    name: Some(Some("renamed".to_string())),
+                    ..Default::default()
+                },
+                include_archived: false,
+            },
+        )
+        .await
+        .expect("update metadata");
+        store
+            .archive_thread(ArchiveThreadParams { thread_id })
+            .await
+            .expect("archive thread");
+        store
+            .unarchive_thread(ArchiveThreadParams { thread_id })
+            .await
+            .expect("unarchive thread");
+        ThreadStore::delete_thread(&store, DeleteThreadParams { thread_id })
+            .await
+            .expect("delete thread");
+
+        assert_eq!(
+            [
+                ThreadCatalogChange::Upsert { thread_id },
+                ThreadCatalogChange::Upsert { thread_id },
+                ThreadCatalogChange::Upsert { thread_id },
+                ThreadCatalogChange::Delete { thread_id },
+            ],
+            [
+                changes.recv().await.expect("metadata change"),
+                changes.recv().await.expect("archive change"),
+                changes.recv().await.expect("unarchive change"),
+                changes.recv().await.expect("delete change"),
+            ]
+        );
+    }
 }
 
 fn stores_guard() -> MutexGuard<'static, HashMap<String, Arc<InMemoryThreadStore>>> {
@@ -383,9 +467,19 @@ pub struct InMemoryThreadStoreCalls {
 /// Test and debug configs can select this store by id, letting tests exercise
 /// config-driven non-local persistence without requiring the real remote gRPC
 /// service.
-#[derive(Default)]
 pub struct InMemoryThreadStore {
     state: tokio::sync::Mutex<InMemoryThreadStoreState>,
+    catalog_changes_tx: broadcast::Sender<ThreadCatalogChange>,
+}
+
+impl Default for InMemoryThreadStore {
+    fn default() -> Self {
+        let (catalog_changes_tx, _) = broadcast::channel(256);
+        Self {
+            state: tokio::sync::Mutex::new(InMemoryThreadStoreState::default()),
+            catalog_changes_tx,
+        }
+    }
 }
 
 #[derive(Default)]
@@ -417,6 +511,10 @@ impl InMemoryThreadStore {
     /// Returns the calls observed by this store.
     pub async fn calls(&self) -> InMemoryThreadStoreCalls {
         self.state.lock().await.calls.clone()
+    }
+
+    fn publish_catalog_change(&self, change: ThreadCatalogChange) {
+        let _ = self.catalog_changes_tx.send(change);
     }
 
     async fn create_thread(&self, params: CreateThreadParams) -> ThreadStoreResult<()> {
@@ -608,8 +706,17 @@ impl ThreadStore for InMemoryThreadStore {
         self
     }
 
+    fn subscribe_catalog_changes(&self) -> broadcast::Receiver<ThreadCatalogChange> {
+        self.catalog_changes_tx.subscribe()
+    }
+
     fn create_thread(&self, params: CreateThreadParams) -> ThreadStoreFuture<'_, ()> {
-        Box::pin(InMemoryThreadStore::create_thread(self, params))
+        let thread_id = params.thread_id;
+        Box::pin(async move {
+            InMemoryThreadStore::create_thread(self, params).await?;
+            self.publish_catalog_change(ThreadCatalogChange::Upsert { thread_id });
+            Ok(())
+        })
     }
 
     fn resume_thread(&self, params: ResumeThreadParams) -> ThreadStoreFuture<'_, ()> {
@@ -707,26 +814,46 @@ impl ThreadStore for InMemoryThreadStore {
         &self,
         params: UpdateThreadMetadataParams,
     ) -> ThreadStoreFuture<'_, StoredThread> {
-        Box::pin(InMemoryThreadStore::update_thread_metadata(self, params))
+        let thread_id = params.thread_id;
+        let changed = !params.patch.is_empty();
+        Box::pin(async move {
+            let thread = InMemoryThreadStore::update_thread_metadata(self, params).await?;
+            if changed {
+                self.publish_catalog_change(ThreadCatalogChange::Upsert { thread_id });
+            }
+            Ok(thread)
+        })
     }
 
-    fn archive_thread(&self, _params: ArchiveThreadParams) -> ThreadStoreFuture<'_, ()> {
+    fn archive_thread(&self, params: ArchiveThreadParams) -> ThreadStoreFuture<'_, ()> {
+        let thread_id = params.thread_id;
         Box::pin(async move {
             self.state.lock().await.calls.archive_thread += 1;
+            self.publish_catalog_change(ThreadCatalogChange::Upsert { thread_id });
             Ok(())
         })
     }
 
     fn unarchive_thread(&self, params: ArchiveThreadParams) -> ThreadStoreFuture<'_, StoredThread> {
+        let thread_id = params.thread_id;
         Box::pin(async move {
             let mut state = self.state.lock().await;
             state.calls.unarchive_thread += 1;
-            stored_thread_from_state(&state, params.thread_id, /*include_history*/ false)
+            let thread =
+                stored_thread_from_state(&state, thread_id, /*include_history*/ false)?;
+            drop(state);
+            self.publish_catalog_change(ThreadCatalogChange::Upsert { thread_id });
+            Ok(thread)
         })
     }
 
     fn delete_thread(&self, params: DeleteThreadParams) -> ThreadStoreFuture<'_, ()> {
-        Box::pin(InMemoryThreadStore::delete_thread(self, params))
+        let thread_id = params.thread_id;
+        Box::pin(async move {
+            InMemoryThreadStore::delete_thread(self, params).await?;
+            self.publish_catalog_change(ThreadCatalogChange::Delete { thread_id });
+            Ok(())
+        })
     }
 }
 

--- a/codex-rs/thread-store/src/in_memory.rs
+++ b/codex-rs/thread-store/src/in_memory.rs
@@ -431,6 +431,15 @@ mod tests {
                 changes.recv().await.expect("delete change"),
             ]
         );
+
+        store
+            .archive_thread(ArchiveThreadParams { thread_id })
+            .await
+            .expect_err("deleted thread should not archive");
+        assert!(matches!(
+            changes.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
+        ));
     }
 }
 
@@ -828,7 +837,10 @@ impl ThreadStore for InMemoryThreadStore {
     fn archive_thread(&self, params: ArchiveThreadParams) -> ThreadStoreFuture<'_, ()> {
         let thread_id = params.thread_id;
         Box::pin(async move {
-            self.state.lock().await.calls.archive_thread += 1;
+            let mut state = self.state.lock().await;
+            state.calls.archive_thread += 1;
+            stored_thread_from_state(&state, thread_id, /*include_history*/ false)?;
+            drop(state);
             self.publish_catalog_change(ThreadCatalogChange::Upsert { thread_id });
             Ok(())
         })

--- a/codex-rs/thread-store/src/in_memory.rs
+++ b/codex-rs/thread-store/src/in_memory.rs
@@ -420,14 +420,10 @@ mod tests {
         assert_eq!(
             [
                 ThreadCatalogChange::Upsert { thread_id },
-                ThreadCatalogChange::Upsert { thread_id },
-                ThreadCatalogChange::Upsert { thread_id },
                 ThreadCatalogChange::Delete { thread_id },
             ],
             [
                 changes.recv().await.expect("metadata change"),
-                changes.recv().await.expect("archive change"),
-                changes.recv().await.expect("unarchive change"),
                 changes.recv().await.expect("delete change"),
             ]
         );
@@ -840,8 +836,6 @@ impl ThreadStore for InMemoryThreadStore {
             let mut state = self.state.lock().await;
             state.calls.archive_thread += 1;
             stored_thread_from_state(&state, thread_id, /*include_history*/ false)?;
-            drop(state);
-            self.publish_catalog_change(ThreadCatalogChange::Upsert { thread_id });
             Ok(())
         })
     }
@@ -853,8 +847,6 @@ impl ThreadStore for InMemoryThreadStore {
             state.calls.unarchive_thread += 1;
             let thread =
                 stored_thread_from_state(&state, thread_id, /*include_history*/ false)?;
-            drop(state);
-            self.publish_catalog_change(ThreadCatalogChange::Upsert { thread_id });
             Ok(thread)
         })
     }

--- a/codex-rs/thread-store/src/lib.rs
+++ b/codex-rs/thread-store/src/lib.rs
@@ -47,6 +47,7 @@ pub use types::StoredTurn;
 pub use types::StoredTurnError;
 pub use types::StoredTurnItemsView;
 pub use types::StoredTurnStatus;
+pub use types::ThreadCatalogChange;
 pub use types::ThreadMetadataPatch;
 pub use types::ThreadPage;
 pub use types::ThreadPersistenceMetadata;

--- a/codex-rs/thread-store/src/local/mod.rs
+++ b/codex-rs/thread-store/src/local/mod.rs
@@ -18,6 +18,7 @@ use codex_rollout::RolloutRecorder;
 use codex_rollout::StateDbHandle;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
+use std::future::Future;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -117,6 +118,26 @@ impl LocalThreadStore {
 
     fn publish_catalog_change(&self, change: ThreadCatalogChange) {
         let _ = self.catalog_changes_tx.send(change);
+    }
+
+    async fn track_catalog_visibility<T>(
+        &self,
+        thread_id: ThreadId,
+        operation: impl Future<Output = ThreadStoreResult<T>>,
+    ) -> ThreadStoreResult<T> {
+        let rollout_path = live_writer::rollout_path(self, thread_id).await?;
+        let was_visible = codex_rollout::existing_rollout_path(&rollout_path)
+            .await
+            .is_some();
+        let result = operation.await?;
+        if !was_visible
+            && codex_rollout::existing_rollout_path(&rollout_path)
+                .await
+                .is_some()
+        {
+            self.publish_catalog_change(ThreadCatalogChange::Upsert { thread_id });
+        }
+        Ok(result)
     }
 
     /// Return the state DB handle used by local rollout writers.
@@ -264,23 +285,26 @@ impl ThreadStore for LocalThreadStore {
     }
 
     fn append_items(&self, params: AppendThreadItemsParams) -> ThreadStoreFuture<'_, ()> {
-        Box::pin(async move { live_writer::append_items(self, params).await })
+        let thread_id = params.thread_id;
+        Box::pin(self.track_catalog_visibility(thread_id, live_writer::append_items(self, params)))
     }
 
     fn persist_thread(&self, thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
-        Box::pin(async move {
-            live_writer::persist_thread(self, thread_id).await?;
-            self.publish_catalog_change(ThreadCatalogChange::Upsert { thread_id });
-            Ok(())
-        })
+        Box::pin(
+            self.track_catalog_visibility(thread_id, live_writer::persist_thread(self, thread_id)),
+        )
     }
 
     fn flush_thread(&self, thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
-        Box::pin(async move { live_writer::flush_thread(self, thread_id).await })
+        Box::pin(
+            self.track_catalog_visibility(thread_id, live_writer::flush_thread(self, thread_id)),
+        )
     }
 
     fn shutdown_thread(&self, thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
-        Box::pin(async move { live_writer::shutdown_thread(self, thread_id).await })
+        Box::pin(
+            self.track_catalog_visibility(thread_id, live_writer::shutdown_thread(self, thread_id)),
+        )
     }
 
     fn discard_thread(&self, thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
@@ -413,14 +437,14 @@ mod tests {
             })
             .await
             .expect("append live item");
+        assert_eq!(
+            catalog_changes.recv().await.expect("creation change"),
+            ThreadCatalogChange::Upsert { thread_id }
+        );
         store
             .persist_thread(thread_id)
             .await
             .expect("persist live thread");
-        assert_eq!(
-            catalog_changes.recv().await.expect("persist change"),
-            ThreadCatalogChange::Upsert { thread_id }
-        );
         store
             .flush_thread(thread_id)
             .await
@@ -432,6 +456,10 @@ mod tests {
             .shutdown_thread(thread_id)
             .await
             .expect("shutdown live thread");
+        assert!(matches!(
+            catalog_changes.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
+        ));
         let err = store
             .append_items(AppendThreadItemsParams {
                 thread_id,
@@ -614,6 +642,7 @@ mod tests {
         .await
         .expect("state db should initialize");
         let store = Arc::new(LocalThreadStore::new(config, Some(runtime.clone())));
+        let mut catalog_changes = store.subscribe_catalog_changes();
         let thread_id = ThreadId::default();
         let live_thread = LiveThread::create(store.clone(), create_thread_params(thread_id))
             .await
@@ -624,6 +653,10 @@ mod tests {
             .expect("live rollout path");
 
         live_thread.shutdown().await.expect("shutdown thread");
+        assert!(matches!(
+            catalog_changes.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
+        ));
 
         assert!(
             !tokio::fs::try_exists(rollout_path.as_path())
@@ -690,6 +723,7 @@ mod tests {
         .await
         .expect("state db should initialize");
         let store = Arc::new(LocalThreadStore::new(config, Some(runtime.clone())));
+        let mut catalog_changes = store.subscribe_catalog_changes();
         let thread_id = ThreadId::default();
         let live_thread = LiveThread::create(store.clone(), create_thread_params(thread_id))
             .await
@@ -709,6 +743,10 @@ mod tests {
             .await
             .expect("append metadata-only item");
         live_thread.shutdown().await.expect("shutdown thread");
+        assert_eq!(
+            catalog_changes.recv().await.expect("creation change"),
+            ThreadCatalogChange::Upsert { thread_id }
+        );
 
         assert!(
             tokio::fs::try_exists(rollout_path.as_path())

--- a/codex-rs/thread-store/src/local/mod.rs
+++ b/codex-rs/thread-store/src/local/mod.rs
@@ -350,7 +350,12 @@ impl ThreadStore for LocalThreadStore {
         let changed = !params.patch.is_empty();
         Box::pin(async move {
             let thread = update_thread_metadata::update_thread_metadata(self, params).await?;
-            if changed {
+            if changed
+                && let Some(rollout_path) = thread.rollout_path.as_ref()
+                && codex_rollout::existing_rollout_path(rollout_path)
+                    .await
+                    .is_some()
+            {
                 self.publish_catalog_change(ThreadCatalogChange::Upsert { thread_id });
             }
             Ok(thread)
@@ -408,6 +413,7 @@ mod tests {
 
     use super::*;
     use crate::LiveThread;
+    use crate::ThreadMetadataPatch;
     use crate::ThreadPersistenceMetadata;
     use crate::local::test_support::test_config;
     use crate::local::test_support::write_archived_session_file;
@@ -683,10 +689,23 @@ mod tests {
         .await
         .expect("state db should initialize");
         let store = Arc::new(LocalThreadStore::new(config, Some(runtime.clone())));
+        let mut catalog_changes = store.subscribe_catalog_changes();
         let thread_id = ThreadId::default();
         let live_thread = LiveThread::create(store.clone(), create_thread_params(thread_id))
             .await
             .expect("create live thread");
+
+        live_thread
+            .update_metadata(
+                ThreadMetadataPatch::default(),
+                /*include_archived*/ false,
+            )
+            .await
+            .expect("flush pending metadata");
+        assert!(matches!(
+            catalog_changes.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
+        ));
 
         live_thread
             .update_memory_mode(ThreadMemoryMode::Disabled, /*include_archived*/ false)

--- a/codex-rs/thread-store/src/local/mod.rs
+++ b/codex-rs/thread-store/src/local/mod.rs
@@ -128,9 +128,14 @@ impl LocalThreadStore {
     }
 
     async fn publish_catalog_upsert_if_visible(&self, thread_id: ThreadId, thread: &StoredThread) {
-        if let Some(rollout_path) = thread.rollout_path.as_ref()
-            && self.rollout_is_catalog_visible(rollout_path).await
-        {
+        let visible = if !thread.preview.is_empty() {
+            true
+        } else if let Some(rollout_path) = thread.rollout_path.as_ref() {
+            self.rollout_is_catalog_visible(rollout_path).await
+        } else {
+            false
+        };
+        if visible {
             self.publish_catalog_change(ThreadCatalogChange::Upsert { thread_id });
         }
     }
@@ -366,6 +371,12 @@ impl ThreadStore for LocalThreadStore {
                 Err(err) => {
                     if changed
                         && may_partially_apply
+                        && !matches!(
+                            &err,
+                            ThreadStoreError::Unsupported {
+                                operation: "paginated_threads"
+                            }
+                        )
                         && let Ok(thread) = read_thread::read_thread(
                             self,
                             ReadThreadParams {

--- a/codex-rs/thread-store/src/local/mod.rs
+++ b/codex-rs/thread-store/src/local/mod.rs
@@ -19,6 +19,7 @@ use codex_rollout::StateDbHandle;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::future::Future;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -120,21 +121,29 @@ impl LocalThreadStore {
         let _ = self.catalog_changes_tx.send(change);
     }
 
+    async fn rollout_is_catalog_visible(&self, rollout_path: &Path) -> bool {
+        read_thread::read_thread_from_rollout_path(self, rollout_path.to_path_buf())
+            .await
+            .is_ok_and(|thread| !thread.preview.is_empty())
+    }
+
+    async fn publish_catalog_upsert_if_visible(&self, thread_id: ThreadId, thread: &StoredThread) {
+        if let Some(rollout_path) = thread.rollout_path.as_ref()
+            && self.rollout_is_catalog_visible(rollout_path).await
+        {
+            self.publish_catalog_change(ThreadCatalogChange::Upsert { thread_id });
+        }
+    }
+
     async fn track_catalog_visibility<T>(
         &self,
         thread_id: ThreadId,
         operation: impl Future<Output = ThreadStoreResult<T>>,
     ) -> ThreadStoreResult<T> {
         let rollout_path = live_writer::rollout_path(self, thread_id).await?;
-        let was_visible = codex_rollout::existing_rollout_path(&rollout_path)
-            .await
-            .is_some();
+        let was_visible = self.rollout_is_catalog_visible(&rollout_path).await;
         let result = operation.await?;
-        if !was_visible
-            && codex_rollout::existing_rollout_path(&rollout_path)
-                .await
-                .is_some()
-        {
+        if !was_visible && self.rollout_is_catalog_visible(&rollout_path).await {
             self.publish_catalog_change(ThreadCatalogChange::Upsert { thread_id });
         }
         Ok(result)
@@ -348,15 +357,34 @@ impl ThreadStore for LocalThreadStore {
     ) -> ThreadStoreFuture<'_, StoredThread> {
         let thread_id = params.thread_id;
         let changed = !params.patch.is_empty();
+        let may_partially_apply =
+            update_thread_metadata::needs_rollout_compatibility_update(&params.patch);
+        let include_archived = params.include_archived;
         Box::pin(async move {
-            let thread = update_thread_metadata::update_thread_metadata(self, params).await?;
-            if changed
-                && let Some(rollout_path) = thread.rollout_path.as_ref()
-                && codex_rollout::existing_rollout_path(rollout_path)
-                    .await
-                    .is_some()
-            {
-                self.publish_catalog_change(ThreadCatalogChange::Upsert { thread_id });
+            let thread = match update_thread_metadata::update_thread_metadata(self, params).await {
+                Ok(thread) => thread,
+                Err(err) => {
+                    if changed
+                        && may_partially_apply
+                        && let Ok(thread) = read_thread::read_thread(
+                            self,
+                            ReadThreadParams {
+                                thread_id,
+                                include_archived,
+                                include_history: false,
+                            },
+                        )
+                        .await
+                    {
+                        self.publish_catalog_upsert_if_visible(thread_id, &thread)
+                            .await;
+                    }
+                    return Err(err);
+                }
+            };
+            if changed {
+                self.publish_catalog_upsert_if_visible(thread_id, &thread)
+                    .await;
             }
             Ok(thread)
         })
@@ -435,6 +463,15 @@ mod tests {
             .live_rollout_path(thread_id)
             .await
             .expect("load rollout path");
+
+        store
+            .persist_thread(thread_id)
+            .await
+            .expect("persist empty thread");
+        assert!(matches!(
+            catalog_changes.try_recv(),
+            Err(broadcast::error::TryRecvError::Empty)
+        ));
 
         store
             .append_items(AppendThreadItemsParams {
@@ -732,7 +769,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn live_thread_shutdown_with_buffered_items_materializes_before_metadata_read() {
+    async fn live_thread_shutdown_with_buffered_user_message_materializes_before_metadata_read() {
         let home = TempDir::new().expect("temp dir");
         let config = test_config(home.path());
         let runtime = codex_state::StateRuntime::init(
@@ -753,14 +790,9 @@ mod tests {
             .expect("live rollout path");
 
         live_thread
-            .append_items(&[RolloutItem::EventMsg(EventMsg::TokenCount(
-                codex_protocol::protocol::TokenCountEvent {
-                    info: None,
-                    rate_limits: None,
-                },
-            ))])
+            .append_items(&[user_message_item("buffered message")])
             .await
-            .expect("append metadata-only item");
+            .expect("append user message");
         live_thread.shutdown().await.expect("shutdown thread");
         assert_eq!(
             catalog_changes.recv().await.expect("creation change"),

--- a/codex-rs/thread-store/src/local/mod.rs
+++ b/codex-rs/thread-store/src/local/mod.rs
@@ -21,6 +21,7 @@ use std::collections::hash_map::Entry;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use tokio::sync::broadcast;
 
 use crate::AppendThreadItemsParams;
 use crate::ArchiveThreadParams;
@@ -34,6 +35,7 @@ use crate::ResumeThreadParams;
 use crate::SearchThreadsParams;
 use crate::StoredThread;
 use crate::StoredThreadHistory;
+use crate::ThreadCatalogChange;
 use crate::ThreadPage;
 use crate::ThreadSearchPage;
 use crate::ThreadStore;
@@ -60,6 +62,7 @@ pub struct LocalThreadStore {
     pub(super) config: LocalThreadStoreConfig,
     live_recorders: Arc<Mutex<HashMap<ThreadId, LiveRecorderEntry>>>,
     state_db: Option<StateDbHandle>,
+    catalog_changes_tx: broadcast::Sender<ThreadCatalogChange>,
 }
 
 struct LiveRecorderEntry {
@@ -103,11 +106,17 @@ impl std::fmt::Debug for LocalThreadStore {
 impl LocalThreadStore {
     /// Create a local store using an already initialized state DB handle.
     pub fn new(config: LocalThreadStoreConfig, state_db: Option<StateDbHandle>) -> Self {
+        let (catalog_changes_tx, _) = broadcast::channel(256);
         Self {
             config,
             live_recorders: Arc::new(Mutex::new(HashMap::new())),
             state_db,
+            catalog_changes_tx,
         }
+    }
+
+    fn publish_catalog_change(&self, change: ThreadCatalogChange) {
+        let _ = self.catalog_changes_tx.send(change);
     }
 
     /// Return the state DB handle used by local rollout writers.
@@ -242,6 +251,10 @@ impl ThreadStore for LocalThreadStore {
         self
     }
 
+    fn subscribe_catalog_changes(&self) -> broadcast::Receiver<ThreadCatalogChange> {
+        self.catalog_changes_tx.subscribe()
+    }
+
     fn create_thread(&self, params: CreateThreadParams) -> ThreadStoreFuture<'_, ()> {
         Box::pin(async move { live_writer::create_thread(self, params).await })
     }
@@ -255,7 +268,11 @@ impl ThreadStore for LocalThreadStore {
     }
 
     fn persist_thread(&self, thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
-        Box::pin(async move { live_writer::persist_thread(self, thread_id).await })
+        Box::pin(async move {
+            live_writer::persist_thread(self, thread_id).await?;
+            self.publish_catalog_change(ThreadCatalogChange::Upsert { thread_id });
+            Ok(())
+        })
     }
 
     fn flush_thread(&self, thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
@@ -305,19 +322,42 @@ impl ThreadStore for LocalThreadStore {
         &self,
         params: UpdateThreadMetadataParams,
     ) -> ThreadStoreFuture<'_, StoredThread> {
-        Box::pin(async move { update_thread_metadata::update_thread_metadata(self, params).await })
+        let thread_id = params.thread_id;
+        let changed = !params.patch.is_empty();
+        Box::pin(async move {
+            let thread = update_thread_metadata::update_thread_metadata(self, params).await?;
+            if changed {
+                self.publish_catalog_change(ThreadCatalogChange::Upsert { thread_id });
+            }
+            Ok(thread)
+        })
     }
 
     fn archive_thread(&self, params: ArchiveThreadParams) -> ThreadStoreFuture<'_, ()> {
-        Box::pin(async move { archive_thread::archive_thread(self, params).await })
+        let thread_id = params.thread_id;
+        Box::pin(async move {
+            archive_thread::archive_thread(self, params).await?;
+            self.publish_catalog_change(ThreadCatalogChange::Upsert { thread_id });
+            Ok(())
+        })
     }
 
     fn unarchive_thread(&self, params: ArchiveThreadParams) -> ThreadStoreFuture<'_, StoredThread> {
-        Box::pin(async move { unarchive_thread::unarchive_thread(self, params).await })
+        let thread_id = params.thread_id;
+        Box::pin(async move {
+            let thread = unarchive_thread::unarchive_thread(self, params).await?;
+            self.publish_catalog_change(ThreadCatalogChange::Upsert { thread_id });
+            Ok(thread)
+        })
     }
 
     fn delete_thread(&self, params: DeleteThreadParams) -> ThreadStoreFuture<'_, ()> {
-        Box::pin(async move { delete_thread::delete_thread(self, params).await })
+        let thread_id = params.thread_id;
+        Box::pin(async move {
+            delete_thread::delete_thread(self, params).await?;
+            self.publish_catalog_change(ThreadCatalogChange::Delete { thread_id });
+            Ok(())
+        })
     }
 }
 
@@ -339,6 +379,7 @@ mod tests {
     use codex_protocol::protocol::TurnCompleteEvent;
     use codex_protocol::protocol::TurnStartedEvent;
     use codex_protocol::protocol::UserMessageEvent;
+    use pretty_assertions::assert_eq;
     use tempfile::TempDir;
 
     use super::*;
@@ -353,6 +394,7 @@ mod tests {
     async fn live_writer_lifecycle_writes_and_closes() {
         let home = TempDir::new().expect("temp dir");
         let store = LocalThreadStore::new(test_config(home.path()), /*state_db*/ None);
+        let mut catalog_changes = store.subscribe_catalog_changes();
         let thread_id = ThreadId::default();
 
         store
@@ -375,6 +417,10 @@ mod tests {
             .persist_thread(thread_id)
             .await
             .expect("persist live thread");
+        assert_eq!(
+            catalog_changes.recv().await.expect("persist change"),
+            ThreadCatalogChange::Upsert { thread_id }
+        );
         store
             .flush_thread(thread_id)
             .await

--- a/codex-rs/thread-store/src/local/read_thread.rs
+++ b/codex-rs/thread-store/src/local/read_thread.rs
@@ -255,7 +255,7 @@ async fn resolve_rollout_path(
     }
 }
 
-async fn read_thread_from_rollout_path(
+pub(super) async fn read_thread_from_rollout_path(
     store: &LocalThreadStore,
     path: std::path::PathBuf,
 ) -> ThreadStoreResult<StoredThread> {

--- a/codex-rs/thread-store/src/local/update_thread_metadata.rs
+++ b/codex-rs/thread-store/src/local/update_thread_metadata.rs
@@ -455,7 +455,7 @@ async fn canonical_history_mode(
     Ok(session_meta.meta.history_mode)
 }
 
-fn needs_rollout_compatibility_update(patch: &ThreadMetadataPatch) -> bool {
+pub(super) fn needs_rollout_compatibility_update(patch: &ThreadMetadataPatch) -> bool {
     if patch.name.is_some() {
         return true;
     }

--- a/codex-rs/thread-store/src/store.rs
+++ b/codex-rs/thread-store/src/store.rs
@@ -19,6 +19,7 @@ use crate::ResumeThreadParams;
 use crate::SearchThreadsParams;
 use crate::StoredThread;
 use crate::StoredThreadHistory;
+use crate::ThreadCatalogChange;
 use crate::ThreadPage;
 use crate::ThreadSearchPage;
 use crate::ThreadStoreError;
@@ -41,6 +42,13 @@ pub trait ThreadStore: Any + Send + Sync {
     fn default_history_mode(&self) -> ThreadHistoryMode {
         ThreadHistoryMode::Legacy
     }
+
+    /// Subscribes to future catalog-row invalidations.
+    ///
+    /// Events are not replayed and do not contain snapshots. Consumers should subscribe before
+    /// reading their initial catalog view, reread the affected thread after each event, and rebuild
+    /// that view if the receiver reports lag.
+    fn subscribe_catalog_changes(&self) -> tokio::sync::broadcast::Receiver<ThreadCatalogChange>;
 
     /// Creates a new live thread.
     fn create_thread(&self, params: CreateThreadParams) -> ThreadStoreFuture<'_, ()>;

--- a/codex-rs/thread-store/src/types.rs
+++ b/codex-rs/thread-store/src/types.rs
@@ -730,6 +730,15 @@ pub struct DeleteThreadParams {
     pub thread_id: ThreadId,
 }
 
+/// Store-owned invalidation for a thread catalog row.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ThreadCatalogChange {
+    /// The row was created or its metadata changed.
+    Upsert { thread_id: ThreadId },
+    /// The row was deleted.
+    Delete { thread_id: ThreadId },
+}
+
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;


### PR DESCRIPTION
## Why

A thread catalog feed is only trustworthy if every catalog-visible mutation crosses one publication boundary. App-server handlers and loaded thread runtimes cannot provide that guarantee: direct store mutations would be missed, and observing metadata should never require loading or resuming a thread.

This is the first PR in a two-PR stack. It establishes the store-owned change boundary consumed by #29902; it does not add an app-server API.

## What changed

`ThreadStore` implementations expose a bounded, future-only stream of `Upsert` and `Delete` invalidations keyed by thread ID. The local and in-memory stores publish after successful creation or materialization, non-empty metadata updates, archive or unarchive, and deletion. Reads, resumes, empty metadata patches, and later history-only appends remain silent.

Local thread creation is lazy, so its first `Upsert` is emitted when append, persist, flush, or shutdown actually materializes the rollout. Empty threads that never become listable emit nothing.

## How it works

Consumers subscribe before taking a catalog snapshot. An `Upsert` tells them to reread the affected row, a `Delete` removes it, and receiver lag requires rebuilding the snapshot. Events contain IDs rather than a second metadata representation, leaving `ThreadStore` as the single source of truth.

**Review focus:** Can any successful catalog-visible mutation remain silent, or can any failed/no-op operation publish a phantom change?

## Verification

All 90 `codex-thread-store` tests pass, including focused coverage for lazy materialization, mutation invalidations, silent reads and no-op updates, duplicate suppression, and missing-thread mutations. Scoped Clippy and formatting also pass.
