### PR TITLE
path-uri: normalize parent segments in absolute joins

### DIFF
--- a/codex-rs/utils/path-uri/src/absolute_path_normalization.rs
+++ b/codex-rs/utils/path-uri/src/absolute_path_normalization.rs
@@ -33,7 +33,9 @@ pub(super) fn path_uri_from_segments<'a>(
             }
         }
     }
-    if has_trailing_separator {
+    if has_trailing_separator
+        || (convention == PathConvention::Windows && host.is_none() && depth == anchor_depth)
+    {
         normalized_segments.push("");
     }
     {

--- a/codex-rs/utils/path-uri/src/absolute_path_normalization.rs
+++ b/codex-rs/utils/path-uri/src/absolute_path_normalization.rs
@@ -1,0 +1,44 @@
+use crate::PathConvention;
+use crate::PathUri;
+use url::Url;
+
+pub(super) fn path_uri_from_segments<'a>(
+    convention: PathConvention,
+    host: Option<&str>,
+    segments: impl Iterator<Item = &'a str>,
+) -> Option<PathUri> {
+    let mut url = Url::parse("file:///").ok()?;
+    if let Some(host) = host {
+        url.set_host(Some(host)).ok()?;
+    }
+    let anchor_depth = usize::from(convention == PathConvention::Windows);
+    let mut depth = 0;
+    let mut normalized_segments = Vec::new();
+    let mut has_trailing_separator = false;
+    for segment in segments {
+        match segment {
+            "" => has_trailing_separator = true,
+            "." => has_trailing_separator = false,
+            ".." => {
+                has_trailing_separator = false;
+                if depth > anchor_depth {
+                    normalized_segments.pop();
+                    depth -= 1;
+                }
+            }
+            segment => {
+                normalized_segments.push(segment);
+                depth += 1;
+                has_trailing_separator = false;
+            }
+        }
+    }
+    if has_trailing_separator {
+        normalized_segments.push("");
+    }
+    {
+        let mut url_segments = url.path_segments_mut().ok()?;
+        url_segments.clear().extend(normalized_segments);
+    }
+    PathUri::try_from(url).ok()
+}

--- a/codex-rs/utils/path-uri/src/api_path_string_tests.rs
+++ b/codex-rs/utils/path-uri/src/api_path_string_tests.rs
@@ -467,23 +467,6 @@ fn converts_absolute_api_paths_using_the_inferred_convention() {
 }
 
 #[test]
-fn posix_double_slash_root_round_trips_through_path_uri() {
-    let path = LegacyAppPathString("//server/share/file.rs".to_string());
-    let uri = path
-        .to_path_uri(PathConvention::Posix)
-        .expect("double-slash POSIX path should convert");
-
-    assert_eq!(
-        uri.opaque_fallback_bytes().as_deref(),
-        Some(path.as_str().as_bytes())
-    );
-    assert_eq!(
-        LegacyAppPathString::from_path_uri(&uri, PathConvention::Posix),
-        Ok(path)
-    );
-}
-
-#[test]
 fn converts_native_api_path_to_inferred_absolute_path() {
     #[cfg(windows)]
     let raw_path = r"C:\workspace\file.rs";

--- a/codex-rs/utils/path-uri/src/api_path_string_tests.rs
+++ b/codex-rs/utils/path-uri/src/api_path_string_tests.rs
@@ -467,6 +467,23 @@ fn converts_absolute_api_paths_using_the_inferred_convention() {
 }
 
 #[test]
+fn posix_double_slash_root_round_trips_through_path_uri() {
+    let path = LegacyAppPathString("//server/share/file.rs".to_string());
+    let uri = path
+        .to_path_uri(PathConvention::Posix)
+        .expect("double-slash POSIX path should convert");
+
+    assert_eq!(
+        uri.opaque_fallback_bytes().as_deref(),
+        Some(path.as_str().as_bytes())
+    );
+    assert_eq!(
+        LegacyAppPathString::from_path_uri(&uri, PathConvention::Posix),
+        Ok(path)
+    );
+}
+
+#[test]
 fn converts_native_api_path_to_inferred_absolute_path() {
     #[cfg(windows)]
     let raw_path = r"C:\workspace\file.rs";

--- a/codex-rs/utils/path-uri/src/lib.rs
+++ b/codex-rs/utils/path-uri/src/lib.rs
@@ -589,7 +589,7 @@ fn parse_posix_path(path: &str) -> Option<PathUri> {
             format!("/{path}").as_bytes(),
         ));
     }
-    path_uri_from_segments(/*host*/ None, path.split('/'))
+    path_uri_from_segments(PathConvention::Posix, /*host*/ None, path.split('/'))
 }
 
 fn parse_windows_path(path: &str) -> Option<PathUri> {
@@ -612,6 +612,7 @@ fn parse_windows_path(path: &str) -> Option<PathUri> {
             if drive.is_ascii_alphabetic() && is_windows_separator_byte(*separator)
     ) {
         return path_uri_from_segments(
+            PathConvention::Windows,
             /*host*/ None,
             std::iter::once(&path[..2]).chain(path[3..].split(is_windows_separator_char)),
         );
@@ -623,14 +624,19 @@ fn parse_windows_path(path: &str) -> Option<PathUri> {
         let mut components = path[2..].split(is_windows_separator_char);
         let host = components.next().filter(|host| !host.is_empty())?;
         let share = components.next().filter(|share| !share.is_empty())?;
-        return path_uri_from_segments(Some(host), std::iter::once(share).chain(components))
-            .or_else(|| Some(windows_opaque_path_uri(path)));
+        return path_uri_from_segments(
+            PathConvention::Windows,
+            Some(host),
+            std::iter::once(share).chain(components),
+        )
+        .or_else(|| Some(windows_opaque_path_uri(path)));
     }
 
     None
 }
 
 fn path_uri_from_segments<'a>(
+    convention: PathConvention,
     host: Option<&str>,
     segments: impl Iterator<Item = &'a str>,
 ) -> Option<PathUri> {
@@ -638,12 +644,30 @@ fn path_uri_from_segments<'a>(
     if let Some(host) = host {
         url.set_host(Some(host)).ok()?;
     }
+    let anchor_depth = usize::from(convention == PathConvention::Windows);
+    let mut depth = 0;
+    let mut normalized_segments = Vec::new();
+    for segment in segments {
+        match segment {
+            "." => {}
+            ".." => {
+                while normalized_segments.last() == Some(&"") {
+                    normalized_segments.pop();
+                }
+                if depth > anchor_depth {
+                    normalized_segments.pop();
+                    depth -= 1;
+                }
+            }
+            segment => {
+                normalized_segments.push(segment);
+                depth += usize::from(!segment.is_empty());
+            }
+        }
+    }
     {
         let mut url_segments = url.path_segments_mut().ok()?;
-        url_segments.clear();
-        for segment in segments {
-            url_segments.push(segment);
-        }
+        url_segments.clear().extend(normalized_segments);
     }
     PathUri::try_from(url).ok()
 }

--- a/codex-rs/utils/path-uri/src/lib.rs
+++ b/codex-rs/utils/path-uri/src/lib.rs
@@ -18,7 +18,10 @@ use thiserror::Error;
 use ts_rs::TS;
 use url::Url;
 
+mod absolute_path_normalization;
 mod api_path_string;
+
+use absolute_path_normalization::path_uri_from_segments;
 
 pub use api_path_string::LegacyAppPathString;
 pub use api_path_string::LegacyAppPathStringError;
@@ -32,8 +35,7 @@ const BAD_PATH_URI_PREFIX: &str = "file:///%00/bad/path/";
 /// URL, and the URI cannot be mutated after construction. [`Self::basename`],
 /// [`Self::parent`], and [`Self::join`] operate on URI path segments without
 /// interpreting them using the operating system running Codex. Fallback URIs
-/// used for native paths without a lossless canonical URL representation are
-/// opaque to these lexical operations.
+/// created by [`Self::from_abs_path`] are opaque to these lexical operations.
 ///
 /// `file:` paths retain their URI spelling so they can be parsed independently
 /// of the current host. A local POSIX `file:` URI can also retain
@@ -209,7 +211,7 @@ impl PathUri {
     /// Returns the lexical parent without crossing the inferred native path root.
     ///
     /// POSIX `/`, Windows drive roots, Windows UNC share roots, and opaque fallback
-    /// URIs have no parent.
+    /// URIs created by [`Self::from_abs_path`] have no parent.
     pub fn parent(&self) -> Option<Self> {
         if decode_bad_path_uri(&self.0).is_some() {
             return None;
@@ -249,7 +251,8 @@ impl PathUri {
     /// Containment is computed using URI authority and path-segment boundaries,
     /// without consulting the host filesystem. Percent-encoded native path
     /// separators fail closed because native path conversion may interpret them
-    /// as segment boundaries. Opaque fallback URIs only contain themselves.
+    /// as segment boundaries. Opaque fallback URIs created by
+    /// [`Self::from_abs_path`] only contain themselves.
     pub fn starts_with(&self, base: &Self) -> bool {
         if self == base {
             return true;
@@ -289,8 +292,8 @@ impl PathUri {
     /// `%`, `?`, and `#` characters are percent-encoded as filename text. Paths
     /// containing a null character are rejected because they cannot be safely
     /// converted to native paths.
-    /// Opaque fallback base URIs reject non-empty relative joins; absolute paths
-    /// replace them normally.
+    /// Opaque fallback URIs created by [`Self::from_abs_path`] reject non-empty
+    /// joins.
     pub fn join(&self, path: &str) -> Result<Self, PathUriParseError> {
         if path.contains('\0') {
             return Err(PathUriParseError::InvalidFileUriPath {
@@ -633,59 +636,6 @@ fn parse_windows_path(path: &str) -> Option<PathUri> {
     }
 
     None
-}
-
-fn path_uri_from_segments<'a>(
-    convention: PathConvention,
-    host: Option<&str>,
-    segments: impl Iterator<Item = &'a str>,
-) -> Option<PathUri> {
-    let mut url = Url::parse("file:///").ok()?;
-    if let Some(host) = host {
-        url.set_host(Some(host)).ok()?;
-    }
-    let segments = segments.collect::<Vec<_>>();
-    let preserve_posix_double_slash = convention == PathConvention::Posix
-        && host.is_none()
-        && (segments.as_slice() == ["", ""]
-            || matches!(segments.as_slice(), ["", segment, ..] if !segment.is_empty()));
-    let anchor_depth = usize::from(convention == PathConvention::Windows);
-    let mut depth = 0;
-    let mut normalized_segments = Vec::new();
-    let mut has_trailing_separator = false;
-    for segment in segments
-        .into_iter()
-        .skip(usize::from(preserve_posix_double_slash))
-    {
-        match segment {
-            "" => has_trailing_separator = true,
-            "." => has_trailing_separator = false,
-            ".." => {
-                has_trailing_separator = false;
-                if depth > anchor_depth {
-                    normalized_segments.pop();
-                    depth -= 1;
-                }
-            }
-            segment => {
-                normalized_segments.push(segment);
-                depth += 1;
-                has_trailing_separator = false;
-            }
-        }
-    }
-    if has_trailing_separator {
-        normalized_segments.push("");
-    }
-    if preserve_posix_double_slash {
-        let path = format!("//{}", normalized_segments.join("/"));
-        return Some(PathUri::from_opaque_path_bytes(path.as_bytes()));
-    }
-    {
-        let mut url_segments = url.path_segments_mut().ok()?;
-        url_segments.clear().extend(normalized_segments);
-    }
-    PathUri::try_from(url).ok()
 }
 
 fn windows_opaque_path_uri(path: &str) -> PathUri {

--- a/codex-rs/utils/path-uri/src/lib.rs
+++ b/codex-rs/utils/path-uri/src/lib.rs
@@ -647,13 +647,13 @@ fn path_uri_from_segments<'a>(
     let anchor_depth = usize::from(convention == PathConvention::Windows);
     let mut depth = 0;
     let mut normalized_segments = Vec::new();
+    let mut has_trailing_separator = false;
     for segment in segments {
         match segment {
-            "." => {}
+            "" => has_trailing_separator = true,
+            "." => has_trailing_separator = false,
             ".." => {
-                while normalized_segments.last() == Some(&"") {
-                    normalized_segments.pop();
-                }
+                has_trailing_separator = false;
                 if depth > anchor_depth {
                     normalized_segments.pop();
                     depth -= 1;
@@ -661,9 +661,13 @@ fn path_uri_from_segments<'a>(
             }
             segment => {
                 normalized_segments.push(segment);
-                depth += usize::from(!segment.is_empty());
+                depth += 1;
+                has_trailing_separator = false;
             }
         }
+    }
+    if has_trailing_separator {
+        normalized_segments.push("");
     }
     {
         let mut url_segments = url.path_segments_mut().ok()?;

--- a/codex-rs/utils/path-uri/src/lib.rs
+++ b/codex-rs/utils/path-uri/src/lib.rs
@@ -32,7 +32,8 @@ const BAD_PATH_URI_PREFIX: &str = "file:///%00/bad/path/";
 /// URL, and the URI cannot be mutated after construction. [`Self::basename`],
 /// [`Self::parent`], and [`Self::join`] operate on URI path segments without
 /// interpreting them using the operating system running Codex. Fallback URIs
-/// created by [`Self::from_abs_path`] are opaque to these lexical operations.
+/// used for native paths without a lossless canonical URL representation are
+/// opaque to these lexical operations.
 ///
 /// `file:` paths retain their URI spelling so they can be parsed independently
 /// of the current host. A local POSIX `file:` URI can also retain
@@ -208,7 +209,7 @@ impl PathUri {
     /// Returns the lexical parent without crossing the inferred native path root.
     ///
     /// POSIX `/`, Windows drive roots, Windows UNC share roots, and opaque fallback
-    /// URIs created by [`Self::from_abs_path`] have no parent.
+    /// URIs have no parent.
     pub fn parent(&self) -> Option<Self> {
         if decode_bad_path_uri(&self.0).is_some() {
             return None;
@@ -248,8 +249,7 @@ impl PathUri {
     /// Containment is computed using URI authority and path-segment boundaries,
     /// without consulting the host filesystem. Percent-encoded native path
     /// separators fail closed because native path conversion may interpret them
-    /// as segment boundaries. Opaque fallback URIs created by
-    /// [`Self::from_abs_path`] only contain themselves.
+    /// as segment boundaries. Opaque fallback URIs only contain themselves.
     pub fn starts_with(&self, base: &Self) -> bool {
         if self == base {
             return true;
@@ -289,8 +289,8 @@ impl PathUri {
     /// `%`, `?`, and `#` characters are percent-encoded as filename text. Paths
     /// containing a null character are rejected because they cannot be safely
     /// converted to native paths.
-    /// Opaque fallback URIs created by [`Self::from_abs_path`] reject non-empty
-    /// joins.
+    /// Opaque fallback base URIs reject non-empty relative joins; absolute paths
+    /// replace them normally.
     pub fn join(&self, path: &str) -> Result<Self, PathUriParseError> {
         if path.contains('\0') {
             return Err(PathUriParseError::InvalidFileUriPath {
@@ -644,11 +644,19 @@ fn path_uri_from_segments<'a>(
     if let Some(host) = host {
         url.set_host(Some(host)).ok()?;
     }
+    let segments = segments.collect::<Vec<_>>();
+    let preserve_posix_double_slash = convention == PathConvention::Posix
+        && host.is_none()
+        && (segments.as_slice() == ["", ""]
+            || matches!(segments.as_slice(), ["", segment, ..] if !segment.is_empty()));
     let anchor_depth = usize::from(convention == PathConvention::Windows);
     let mut depth = 0;
     let mut normalized_segments = Vec::new();
     let mut has_trailing_separator = false;
-    for segment in segments {
+    for segment in segments
+        .into_iter()
+        .skip(usize::from(preserve_posix_double_slash))
+    {
         match segment {
             "" => has_trailing_separator = true,
             "." => has_trailing_separator = false,
@@ -668,6 +676,10 @@ fn path_uri_from_segments<'a>(
     }
     if has_trailing_separator {
         normalized_segments.push("");
+    }
+    if preserve_posix_double_slash {
+        let path = format!("//{}", normalized_segments.join("/"));
+        return Some(PathUri::from_opaque_path_bytes(path.as_bytes()));
     }
     {
         let mut url_segments = url.path_segments_mut().ok()?;

--- a/codex-rs/utils/path-uri/src/tests.rs
+++ b/codex-rs/utils/path-uri/src/tests.rs
@@ -627,6 +627,8 @@ fn join_normalizes_absolute_parent_segments() {
             r"\\server\share\a\..\b",
             "file://server/share/b",
         ),
+        ("file:///workspace", "/tmp//a/../b", "file:///tmp/b"),
+        ("file:///workspace", "/tmp/a/..//b", "file:///tmp/b"),
         ("file:///workspace", "/tmp/a///../b", "file:///tmp/b"),
         (
             "file:///C:/workspace",
@@ -670,6 +672,30 @@ fn join_absolute_parent_segments_stop_at_native_path_roots() {
             "file:///C:/workspace",
             r"\\server\share\\\..\b",
             "file://server/share/b",
+        ),
+    ] {
+        let base = PathUri::parse(base).expect("valid base URI");
+        let expected = PathUri::parse(expected).expect("valid expected URI");
+        assert_eq!(base.join(path), Ok(expected), "joining {path}");
+    }
+}
+
+#[test]
+fn join_collapses_redundant_absolute_separators() {
+    for (base, path, expected) in [
+        ("file:///workspace", "/tmp///", "file:///tmp/"),
+        ("file:///workspace", "///", "file:///"),
+        ("file:///C:/workspace", r"D:\tmp\\\", "file:///D:/tmp/"),
+        ("file:///C:/workspace", r"D:\\\", "file:///D:/"),
+        (
+            "file:///C:/workspace",
+            r"\\server\share\tmp\\\",
+            "file://server/share/tmp/",
+        ),
+        (
+            "file:///C:/workspace",
+            r"\\server\share\\\",
+            "file://server/share/",
         ),
     ] {
         let base = PathUri::parse(base).expect("valid base URI");

--- a/codex-rs/utils/path-uri/src/tests.rs
+++ b/codex-rs/utils/path-uri/src/tests.rs
@@ -685,6 +685,11 @@ fn join_collapses_redundant_absolute_separators() {
     for (base, path, expected) in [
         ("file:///workspace", "/tmp///", "file:///tmp/"),
         ("file:///workspace", "///", "file:///"),
+        (
+            "file:///workspace",
+            "///server/share///",
+            "file:///server/share/",
+        ),
         ("file:///C:/workspace", r"D:\tmp\\\", "file:///D:/tmp/"),
         ("file:///C:/workspace", r"D:\\\", "file:///D:/"),
         (
@@ -701,6 +706,28 @@ fn join_collapses_redundant_absolute_separators() {
         let base = PathUri::parse(base).expect("valid base URI");
         let expected = PathUri::parse(expected).expect("valid expected URI");
         assert_eq!(base.join(path), Ok(expected), "joining {path}");
+    }
+}
+
+#[test]
+fn join_preserves_posix_double_slash_roots() {
+    let base = PathUri::parse("file:///workspace").expect("valid base URI");
+
+    for (path, expected) in [
+        ("//server//share/a/../b", "//server/share/b"),
+        ("//server/share///", "//server/share/"),
+        ("//", "//"),
+        ("//../../b", "//b"),
+    ] {
+        let joined = base.join(path).expect("absolute path should join");
+        let expected = serde_json::from_value::<LegacyAppPathString>(serde_json::json!(expected))
+            .expect("expected path should deserialize");
+
+        assert_eq!(
+            LegacyAppPathString::from_path_uri(&joined, PathConvention::Posix),
+            Ok(expected),
+            "joining {path}"
+        );
     }
 }
 

--- a/codex-rs/utils/path-uri/src/tests.rs
+++ b/codex-rs/utils/path-uri/src/tests.rs
@@ -618,6 +618,34 @@ fn join_replaces_posix_absolute_path() {
 }
 
 #[test]
+fn join_keeps_canonicalized_posix_double_slash_paths_hierarchical() {
+    let base = PathUri::parse("file:///workspace").expect("valid base URI");
+    let cwd = base
+        .join("//server/share/project")
+        .expect("valid absolute path");
+
+    assert_eq!(
+        cwd,
+        PathUri::parse("file:///server/share/project").expect("valid canonical URI")
+    );
+    assert_eq!(
+        cwd.parent(),
+        Some(PathUri::parse("file:///server/share").expect("valid parent URI"))
+    );
+    assert_eq!(
+        cwd.join("AGENTS.md"),
+        Ok(PathUri::parse("file:///server/share/project/AGENTS.md").expect("valid child URI"))
+    );
+    #[cfg(unix)]
+    assert_eq!(
+        cwd.to_abs_path()
+            .expect("cwd should convert to a native path"),
+        AbsolutePathBuf::try_from("/server/share/project")
+            .expect("expected native path should be absolute")
+    );
+}
+
+#[test]
 fn join_normalizes_absolute_parent_segments() {
     for (base, path, expected) in [
         ("file:///workspace", "/tmp/a/../b", "file:///tmp/b"),
@@ -706,28 +734,6 @@ fn join_collapses_redundant_absolute_separators() {
         let base = PathUri::parse(base).expect("valid base URI");
         let expected = PathUri::parse(expected).expect("valid expected URI");
         assert_eq!(base.join(path), Ok(expected), "joining {path}");
-    }
-}
-
-#[test]
-fn join_preserves_posix_double_slash_roots() {
-    let base = PathUri::parse("file:///workspace").expect("valid base URI");
-
-    for (path, expected) in [
-        ("//server//share/a/../b", "//server/share/b"),
-        ("//server/share///", "//server/share/"),
-        ("//", "//"),
-        ("//../../b", "//b"),
-    ] {
-        let joined = base.join(path).expect("absolute path should join");
-        let expected = serde_json::from_value::<LegacyAppPathString>(serde_json::json!(expected))
-            .expect("expected path should deserialize");
-
-        assert_eq!(
-            LegacyAppPathString::from_path_uri(&joined, PathConvention::Posix),
-            Ok(expected),
-            "joining {path}"
-        );
     }
 }
 

--- a/codex-rs/utils/path-uri/src/tests.rs
+++ b/codex-rs/utils/path-uri/src/tests.rs
@@ -689,6 +689,13 @@ fn join_normalizes_absolute_parent_segments() {
 #[test]
 fn join_absolute_parent_segments_stop_at_native_path_roots() {
     for (base, path, expected) in [
+        ("file:///workspace", "/a/..", "file:///"),
+        ("file:///C:/workspace", r"D:\a\..", "file:///D:/"),
+        (
+            "file:///C:/workspace",
+            r"\\server\share\a\..",
+            "file://server/share",
+        ),
         ("file:///workspace", "/../../b", "file:///b"),
         ("file:///C:/workspace", r"D:\..\..\b", "file:///D:/b"),
         (

--- a/codex-rs/utils/path-uri/src/tests.rs
+++ b/codex-rs/utils/path-uri/src/tests.rs
@@ -618,6 +618,67 @@ fn join_replaces_posix_absolute_path() {
 }
 
 #[test]
+fn join_normalizes_absolute_parent_segments() {
+    for (base, path, expected) in [
+        ("file:///workspace", "/tmp/a/../b", "file:///tmp/b"),
+        ("file:///C:/workspace", r"D:\tmp\a\..\b", "file:///D:/tmp/b"),
+        (
+            "file:///C:/workspace",
+            r"\\server\share\a\..\b",
+            "file://server/share/b",
+        ),
+        ("file:///workspace", "/tmp/a///../b", "file:///tmp/b"),
+        (
+            "file:///C:/workspace",
+            r"D:\tmp\a\\\..\b",
+            "file:///D:/tmp/b",
+        ),
+        (
+            "file:///C:/workspace",
+            r"\\server\share\a\\\..\b",
+            "file://server/share/b",
+        ),
+        ("file:///workspace", "/tmp/a///b/../..", "file:///tmp"),
+        (
+            "file:///C:/workspace",
+            r"D:\tmp\a\\\b\..\..",
+            "file:///D:/tmp",
+        ),
+        (
+            "file:///C:/workspace",
+            r"\\server\share\a\\\b\..\..",
+            "file://server/share",
+        ),
+    ] {
+        let base = PathUri::parse(base).expect("valid base URI");
+        let expected = PathUri::parse(expected).expect("valid expected URI");
+        assert_eq!(base.join(path), Ok(expected), "joining {path}");
+    }
+}
+
+#[test]
+fn join_absolute_parent_segments_stop_at_native_path_roots() {
+    for (base, path, expected) in [
+        ("file:///workspace", "/../../b", "file:///b"),
+        ("file:///C:/workspace", r"D:\..\..\b", "file:///D:/b"),
+        (
+            "file:///C:/workspace",
+            r"\\server\share\..\..\b",
+            "file://server/share/b",
+        ),
+        (
+            "file:///C:/workspace",
+            r"\\server\share\\\..\b",
+            "file://server/share/b",
+        ),
+    ] {
+        let base = PathUri::parse(base).expect("valid base URI");
+        let expected = PathUri::parse(expected).expect("valid expected URI");
+        assert_eq!(base.join(path), Ok(expected), "joining {path}");
+    }
+}
+
+#[test]
 fn join_replaces_windows_absolute_path() {
     let base = PathUri::parse("file:///C:/workspace/src").expect("valid base URI");
 


### PR DESCRIPTION
## Why

`PathUri::join` normalized `..` for relative paths, but its absolute-path branch rebuilt URIs through `url::PathSegmentsMut::push`, which skips dot segments. `/tmp/a/../b` therefore resolved to `/tmp/a/b` instead of `/tmp/b`.

## What changed

Normalize absolute native path segments before constructing the file URI. Parent traversal now clamps at POSIX roots, Windows drive roots, and UNC share roots, including paths with repeated separators.

Add platform-independent coverage for POSIX, drive, UNC, root-clamping, and repeated-separator cases.

## Manual validation

- `just test -p codex-utils-path-uri`