### PR TITLE
[codex] Apply managed new-thread defaults in TUI

### DIFF
--- a/codex-rs/tui/src/app/session_lifecycle.rs
+++ b/codex-rs/tui/src/app/session_lifecycle.rs
@@ -724,7 +724,12 @@ impl App {
     }
 
     pub(super) fn fresh_session_config(&self) -> Config {
-        let mut config = self.config.clone();
+        let mut config =
+            crate::managed_new_thread_defaults::config_with_managed_new_thread_defaults(
+                self.config.clone(),
+                &self.cli_kv_overrides,
+                &self.harness_overrides,
+            );
         config.service_tier = self.chat_widget.configured_service_tier();
         config
     }

--- a/codex-rs/tui/src/app/tests.rs
+++ b/codex-rs/tui/src/app/tests.rs
@@ -4980,6 +4980,30 @@ async fn fresh_session_config_uses_current_service_tier() {
 }
 
 #[tokio::test]
+async fn fresh_session_config_uses_managed_new_thread_model_default() {
+    let mut app = make_test_app().await;
+    app.config.model = Some("user-model".to_string());
+    app.config.config_layer_stack = codex_config::ConfigLayerStack::new(
+        Vec::new(),
+        codex_config::ConfigRequirements::default(),
+        codex_config::ConfigRequirementsToml {
+            models: Some(codex_config::ModelsRequirementsToml {
+                new_thread: Some(codex_config::NewThreadModelDefaultsToml {
+                    model: Some("managed-model".to_string()),
+                    ..codex_config::NewThreadModelDefaultsToml::default()
+                }),
+            }),
+            ..codex_config::ConfigRequirementsToml::default()
+        },
+    )
+    .expect("managed requirements stack");
+
+    let config = app.fresh_session_config();
+
+    assert_eq!(config.model.as_deref(), Some("managed-model"));
+}
+
+#[tokio::test]
 async fn backtrack_selection_with_duplicate_history_targets_unique_turn() {
     let (mut app, _app_event_rx, mut op_rx) = make_test_app_with_channels().await;
 

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -129,6 +129,7 @@ mod history_cell;
 mod hooks_rpc;
 mod ide_context;
 pub(crate) mod insert_history;
+mod managed_new_thread_defaults;
 pub use insert_history::insert_history_lines;
 mod key_hint;
 mod keymap;
@@ -1680,6 +1681,16 @@ async fn run_ratatui_app(
         }
         _ => config,
     };
+    if matches!(
+        &session_selection,
+        resume_picker::SessionSelection::StartFresh
+    ) {
+        config = managed_new_thread_defaults::config_with_managed_new_thread_defaults(
+            config,
+            &cli_kv_overrides,
+            &overrides,
+        );
+    }
 
     // Configure syntax highlighting theme from the final config — onboarding
     // and resume/fork can both reload config with a different tui_theme, so

--- a/codex-rs/tui/src/managed_new_thread_defaults.rs
+++ b/codex-rs/tui/src/managed_new_thread_defaults.rs
@@ -1,0 +1,52 @@
+use crate::legacy_core::config::Config;
+use crate::legacy_core::config::ConfigOverrides;
+use codex_config::TomlValue;
+use codex_protocol::config_types::ServiceTier;
+
+pub(crate) fn config_with_managed_new_thread_defaults(
+    mut config: Config,
+    cli_overrides: &[(String, TomlValue)],
+    harness_overrides: &ConfigOverrides,
+) -> Config {
+    // `Config` has already merged persisted defaults with launch overrides. Consult the original
+    // override inputs so an explicit TUI launch choice still wins over the managed default.
+    let has_cli_override = |key: &str| cli_overrides.iter().any(|(path, _)| path == key);
+    let Some(defaults) = config
+        .config_layer_stack
+        .requirements_toml()
+        .models
+        .as_ref()
+        .and_then(|models| models.new_thread.as_ref())
+        .cloned()
+    else {
+        return config;
+    };
+
+    if harness_overrides.model.is_none()
+        && !has_cli_override("model")
+        && let Some(model) = defaults.model
+    {
+        config.model = Some(model);
+    }
+    if !has_cli_override("model_reasoning_effort")
+        && let Some(reasoning_effort) = defaults.model_reasoning_effort
+    {
+        config.model_reasoning_effort = Some(reasoning_effort);
+    }
+    if harness_overrides.service_tier.is_none()
+        && !has_cli_override("service_tier")
+        && let Some(service_tier) = defaults.service_tier
+    {
+        config.service_tier = Some(
+            ServiceTier::from_request_value(&service_tier)
+                .map(|tier| tier.request_value().to_string())
+                .unwrap_or(service_tier),
+        );
+    }
+
+    config
+}
+
+#[cfg(test)]
+#[path = "managed_new_thread_defaults_tests.rs"]
+mod tests;

--- a/codex-rs/tui/src/managed_new_thread_defaults_tests.rs
+++ b/codex-rs/tui/src/managed_new_thread_defaults_tests.rs
@@ -1,0 +1,112 @@
+use super::*;
+use crate::legacy_core::config::ConfigBuilder;
+use codex_config::ConfigLayerStack;
+use codex_config::ConfigRequirements;
+use codex_config::ConfigRequirementsToml;
+use codex_config::ModelsRequirementsToml;
+use codex_config::NewThreadModelDefaultsToml;
+use codex_protocol::config_types::ServiceTier;
+use codex_protocol::openai_models::ReasoningEffort;
+use insta::assert_debug_snapshot;
+use pretty_assertions::assert_eq;
+use tempfile::TempDir;
+
+async fn config_with_user_and_managed_defaults() -> Config {
+    let codex_home = TempDir::new().expect("temporary Codex home");
+    let mut config = ConfigBuilder::default()
+        .codex_home(codex_home.path().to_path_buf())
+        .build()
+        .await
+        .expect("config");
+    config.model = Some("user-model".to_string());
+    config.model_reasoning_effort = Some(ReasoningEffort::Low);
+    config.service_tier = Some("flex".to_string());
+    config.config_layer_stack = ConfigLayerStack::new(
+        Vec::new(),
+        ConfigRequirements::default(),
+        ConfigRequirementsToml {
+            models: Some(ModelsRequirementsToml {
+                new_thread: Some(NewThreadModelDefaultsToml {
+                    model: Some("managed-model".to_string()),
+                    model_reasoning_effort: Some(ReasoningEffort::Medium),
+                    service_tier: Some("fast".to_string()),
+                }),
+            }),
+            ..ConfigRequirementsToml::default()
+        },
+    )
+    .expect("managed requirements stack");
+    config
+}
+
+#[tokio::test]
+async fn managed_defaults_override_persisted_user_defaults() {
+    let config = config_with_user_and_managed_defaults().await;
+    let mut expected = config.clone();
+    expected.model = Some("managed-model".to_string());
+    expected.model_reasoning_effort = Some(ReasoningEffort::Medium);
+    expected.service_tier = Some(ServiceTier::Fast.request_value().to_string());
+
+    let actual = config_with_managed_new_thread_defaults(config, &[], &ConfigOverrides::default());
+
+    assert_eq!(actual, expected);
+    assert_debug_snapshot!(
+        "managed_new_thread_defaults",
+        (
+            actual.model,
+            actual.model_reasoning_effort,
+            actual.service_tier,
+        )
+    );
+}
+
+#[tokio::test]
+async fn explicit_tui_launch_overrides_win_over_managed_defaults() {
+    let mut config = config_with_user_and_managed_defaults().await;
+    config.model = Some("cli-model".to_string());
+    config.model_reasoning_effort = Some(ReasoningEffort::High);
+    config.service_tier = Some("flex".to_string());
+    let expected = config.clone();
+    let cli_overrides = vec![(
+        "model_reasoning_effort".to_string(),
+        TomlValue::String("high".to_string()),
+    )];
+    let harness_overrides = ConfigOverrides {
+        model: Some("cli-model".to_string()),
+        service_tier: Some(Some("flex".to_string())),
+        ..ConfigOverrides::default()
+    };
+
+    let actual =
+        config_with_managed_new_thread_defaults(config, &cli_overrides, &harness_overrides);
+
+    assert_eq!(actual, expected);
+}
+
+#[tokio::test]
+async fn explicit_config_flags_win_over_managed_defaults() {
+    let config = config_with_user_and_managed_defaults().await;
+    let expected = config.clone();
+    let cli_overrides = vec![
+        (
+            "model".to_string(),
+            TomlValue::String("user-model".to_string()),
+        ),
+        (
+            "model_reasoning_effort".to_string(),
+            TomlValue::String("low".to_string()),
+        ),
+        (
+            "service_tier".to_string(),
+            TomlValue::String("flex".to_string()),
+        ),
+    ];
+
+    let actual = config_with_managed_new_thread_defaults(
+        config,
+        &cli_overrides,
+        &ConfigOverrides::default(),
+    );
+
+    assert_eq!(actual, expected);
+}

--- a/codex-rs/tui/src/snapshots/codex_tui__managed_new_thread_defaults__tests__managed_new_thread_defaults.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__managed_new_thread_defaults__tests__managed_new_thread_defaults.snap
@@ -1,0 +1,15 @@
+---
+source: tui/src/managed_new_thread_defaults_tests.rs
+expression: "(actual.model, actual.model_reasoning_effort, actual.service_tier,)"
+---
+(
+    Some(
+        "managed-model",
+    ),
+    Some(
+        Medium,
+    ),
+    Some(
+        "priority",
+    ),
+)


### PR DESCRIPTION
## Summary

- apply `models.new_thread` defaults before rendering and starting fresh TUI threads
- preserve explicit `codex --model` and `-c` launch overrides
- reapply managed defaults for `/new` while leaving resume and fork flows unchanged

## Why

The TUI starts from an already merged `Config`, so a model persisted in `config.toml` was forwarded through `thread/start` as though it were an explicit per-thread choice. That prevented the managed new-thread default from becoming the initial TUI selection.

This keeps the precedence explicit launch choice > managed new-thread default > persisted user default, matching the App behavior.

Depends on #29683.

## Validation

- `just test -p codex-tui managed_new_thread_defaults::tests`
- `just test -p codex-tui fresh_session_config_uses_managed_new_thread_model_default`
- `just test -p codex-tui fresh_session_config_uses_current_service_tier`
- `just test -p codex-tui` — 2,939 passed; two unrelated guardian feature-flag tests failed identically on the base branch
- `just fix -p codex-tui`
- `just fmt`
