### PR TITLE
Fix stale MCP test helper calls

### DIFF
--- a/codex-rs/core/tests/suite/rmcp_client.rs
+++ b/codex-rs/core/tests/suite/rmcp_client.rs
@@ -2339,7 +2339,7 @@ async fn streamable_http_chatgpt_auth_respects_configured_authorization() -> any
                 },
             );
         })
-        .build_with_remote_env(&server)
+        .build_with_auto_env(&server)
         .await?;
     wait_for_mcp_server(&chatgpt_auth_fixture.codex, "chatgpt_auth").await?;
     drop(chatgpt_auth_fixture);
@@ -2379,7 +2379,7 @@ async fn streamable_http_chatgpt_auth_respects_configured_authorization() -> any
                 },
             );
         })
-        .build_with_remote_env(&server)
+        .build_with_auto_env(&server)
         .await?;
 
     wait_for_mcp_server(&configured_auth_fixture.codex, "configured_auth").await?;


### PR DESCRIPTION
## Summary
- update the two MCP auth integration tests added by #29733 to use `build_with_auto_env`, the renamed helper from #29728
- restore `main` compilation after the stale helper calls landed

## Test
- `cargo fmt --check`