### PR TITLE
core tests: use current automatic environment builder

### DIFF
--- a/codex-rs/core/tests/suite/rmcp_client.rs
+++ b/codex-rs/core/tests/suite/rmcp_client.rs
@@ -2339,7 +2339,7 @@ async fn streamable_http_chatgpt_auth_respects_configured_authorization() -> any
                 },
             );
         })
-        .build_with_remote_env(&server)
+        .build_with_auto_env(&server)
         .await?;
     wait_for_mcp_server(&chatgpt_auth_fixture.codex, "chatgpt_auth").await?;
     drop(chatgpt_auth_fixture);
@@ -2379,7 +2379,7 @@ async fn streamable_http_chatgpt_auth_respects_configured_authorization() -> any
                 },
             );
         })
-        .build_with_remote_env(&server)
+        .build_with_auto_env(&server)
         .await?;
 
     wait_for_mcp_server(&configured_auth_fixture.codex, "configured_auth").await?;


### PR DESCRIPTION
## Why

#29728 renamed `build_with_remote_env` to `build_with_auto_env`. #29733 subsequently added two calls using the old name, leaving current `main` unable to compile the core integration-test target and blocking CI for dependent PRs.

## What

Update both MCP auth test fixtures to call the renamed `build_with_auto_env` helper.

## Testing

- `cargo test -p codex-core --test all streamable_http_chatgpt_auth_respects_configured_authorization --no-run`