### PR TITLE
core: raise token budget message limits

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -2889,12 +2889,12 @@
         },
         "guidance_message": {
           "description": "Guidance appended to the context-window metadata in a developer message.",
-          "maxLength": 1000,
+          "maxLength": 2000,
           "type": "string"
         },
         "reminder_message_template": {
           "description": "Reminder template. `{n_remaining}` is replaced with the tokens remaining before auto-compaction.",
-          "maxLength": 1000,
+          "maxLength": 2000,
           "minLength": 1,
           "type": "string"
         },

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -1088,8 +1088,8 @@ pub(crate) const DEFAULT_TOKEN_BUDGET_REMINDER_MESSAGE_TEMPLATE: &str = concat!(
     "Your context window is nearly exhausted (only {n_remaining} tokens remaining) and will be automatically reset for you soon. ",
     "Once reset, message items in current context window will be cleared in the new window, but notes and history items will be persistent across windows."
 );
-const TOKEN_BUDGET_REMINDER_MESSAGE_TEMPLATE_MAX_BYTES: usize = 1000;
-const TOKEN_BUDGET_GUIDANCE_MESSAGE_MAX_BYTES: usize = 1000;
+const TOKEN_BUDGET_REMINDER_MESSAGE_TEMPLATE_MAX_BYTES: usize = 2000;
+const TOKEN_BUDGET_GUIDANCE_MESSAGE_MAX_BYTES: usize = 2000;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct TokenBudgetConfig {

--- a/codex-rs/features/src/feature_configs.rs
+++ b/codex-rs/features/src/feature_configs.rs
@@ -86,11 +86,11 @@ pub struct TokenBudgetConfigToml {
     /// Reminder template. `{n_remaining}` is replaced with the tokens remaining before
     /// auto-compaction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(length(min = 1, max = 1000))]
+    #[schemars(length(min = 1, max = 2000))]
     pub reminder_message_template: Option<String>,
     /// Guidance appended to the context-window metadata in a developer message.
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(length(max = 1000))]
+    #[schemars(length(max = 2000))]
     pub guidance_message: Option<String>,
 }
 


### PR DESCRIPTION
## Why

Token-budget reminder and guidance messages can require more than 1,000 bytes to provide useful model-facing instructions. At the same time, these strings are injected into model-visible context, so their size must remain tightly bounded in response to the P0 context-growth concern. A 2,000-byte runtime cap provides additional room without allowing the substantially larger context growth of a 4 KiB limit.

## What changed

- raises the runtime byte limits for token-budget reminder templates and guidance messages from 1,000 to 2,000
- raises the corresponding JSON Schema `maxLength` values to 2,000
- regenerates `codex-rs/core/config.schema.json`

## Testing

- `just test -p codex-features`
- `just test -p codex-core load_config_resolves_token_budget_config load_config_rejects_invalid_token_budget_reminder_template`

The full `codex-core` test run completed 2,858 tests successfully and encountered seven unrelated environment-sensitive failures involving Seatbelt/network environment assertions, MCP capability setup, and abort timing.