### PR TITLE
windows: contain elevated unified exec sessions

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -4429,6 +4429,7 @@ dependencies = [
  "codex-otel",
  "codex-protocol",
  "codex-utils-absolute-path",
+ "codex-utils-cargo-bin",
  "codex-utils-pty",
  "codex-utils-string",
  "dirs-next",

--- a/codex-rs/windows-sandbox-rs/BUILD.bazel
+++ b/codex-rs/windows-sandbox-rs/BUILD.bazel
@@ -6,4 +6,8 @@ codex_rust_crate(
         "codex-windows-sandbox-setup.manifest",
     ],
     crate_name = "codex_windows_sandbox",
+    test_data_extra = [
+        ":codex-command-runner",
+        ":codex-windows-sandbox-setup",
+    ],
 )

--- a/codex-rs/windows-sandbox-rs/Cargo.toml
+++ b/codex-rs/windows-sandbox-rs/Cargo.toml
@@ -93,4 +93,5 @@ features = [
 version = "0.52"
 
 [dev-dependencies]
+codex-utils-cargo-bin = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/codex-rs/windows-sandbox-rs/src/bin/command_runner/win.rs
+++ b/codex-rs/windows-sandbox-rs/src/bin/command_runner/win.rs
@@ -13,16 +13,18 @@ mod cwd_junction;
 
 use anyhow::Context;
 use anyhow::Result;
+use codex_utils_pty::JobProcess;
+use codex_utils_pty::KillOnCloseJob;
 use codex_windows_sandbox::ErrorPayload;
 use codex_windows_sandbox::ErrorStage;
 use codex_windows_sandbox::ExitPayload;
 use codex_windows_sandbox::FramedMessage;
 use codex_windows_sandbox::IPC_PROTOCOL_VERSION;
+use codex_windows_sandbox::JobPipeSpawnHandles;
 use codex_windows_sandbox::LocalSid;
 use codex_windows_sandbox::Message;
 use codex_windows_sandbox::OutputPayload;
 use codex_windows_sandbox::OutputStream;
-use codex_windows_sandbox::PipeSpawnHandles;
 use codex_windows_sandbox::ResizePayload;
 use codex_windows_sandbox::SpawnReady;
 use codex_windows_sandbox::SpawnRequest;
@@ -39,7 +41,7 @@ use codex_windows_sandbox::hide_current_user_profile_dir;
 use codex_windows_sandbox::log_note;
 use codex_windows_sandbox::read_frame;
 use codex_windows_sandbox::read_handle_loop;
-use codex_windows_sandbox::spawn_process_with_pipes;
+use codex_windows_sandbox::spawn_job_process_with_pipes;
 use codex_windows_sandbox::to_wide;
 use codex_windows_sandbox::token_mode_for_permission_profile;
 use codex_windows_sandbox::write_frame;
@@ -62,38 +64,43 @@ use windows_sys::Win32::Storage::FileSystem::FILE_GENERIC_WRITE;
 use windows_sys::Win32::Storage::FileSystem::OPEN_EXISTING;
 use windows_sys::Win32::System::Console::COORD;
 use windows_sys::Win32::System::Console::ResizePseudoConsole;
-use windows_sys::Win32::System::JobObjects::AssignProcessToJobObject;
-use windows_sys::Win32::System::JobObjects::CreateJobObjectW;
-use windows_sys::Win32::System::JobObjects::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-use windows_sys::Win32::System::JobObjects::JOBOBJECT_EXTENDED_LIMIT_INFORMATION;
-use windows_sys::Win32::System::JobObjects::JobObjectExtendedLimitInformation;
-use windows_sys::Win32::System::JobObjects::SetInformationJobObject;
 use windows_sys::Win32::System::Threading::GetExitCodeProcess;
-use windows_sys::Win32::System::Threading::GetProcessId;
 use windows_sys::Win32::System::Threading::INFINITE;
 use windows_sys::Win32::System::Threading::MUTEX_ALL_ACCESS;
 use windows_sys::Win32::System::Threading::OpenMutexW;
-use windows_sys::Win32::System::Threading::PROCESS_INFORMATION;
-use windows_sys::Win32::System::Threading::TerminateProcess;
 use windows_sys::Win32::System::Threading::WaitForSingleObject;
 
 const READ_ACL_MUTEX_NAME: &str = "Local\\CodexSandboxReadAcl";
 const WAIT_TIMEOUT: u32 = 0x0000_0102;
 
+/// Terminates the runner's child job when the parent control transport closes or requests it.
+///
+/// Production uses the shared kill-on-close job controller. Tests implement this boundary to
+/// verify that transport failure is fail-closed without launching a real sandbox account.
+trait RunnerJobController: Send + 'static {
+    fn terminate_job(&self);
+}
+
+impl RunnerJobController for KillOnCloseJob {
+    fn terminate_job(&self) {
+        let _ = self.terminate_and_close(1);
+    }
+}
+
 struct IpcSpawnedProcess {
     log_dir: PathBuf,
-    pi: PROCESS_INFORMATION,
+    process: JobProcess,
     stdout_handle: HANDLE,
     stderr_handle: HANDLE,
     stdin_handle: Option<HANDLE>,
     conpty_owner: Option<codex_windows_sandbox::ConptyInstance>,
     hpc_handle: Option<HANDLE>,
-    _pipe_handles: Option<PipeSpawnHandles>,
+    _pipe_desktop: Option<codex_windows_sandbox::LaunchDesktop>,
 }
 
 /// Small RAII wrapper for raw Win32 handles.
 ///
-/// The elevated runner has a few early-return paths where we acquire a token, job, or pipe
+/// The elevated runner has a few early-return paths where we acquire a token or pipe
 /// handle and then may fail while preparing the child. Keeping those handles in a guard makes
 /// the error paths read more directly and closes the gaps that were previously leaking them.
 struct OwnedWinHandle(HANDLE);
@@ -124,25 +131,6 @@ impl Drop for OwnedWinHandle {
             }
         }
     }
-}
-
-unsafe fn create_job_kill_on_close() -> Result<HANDLE> {
-    let h_job = OwnedWinHandle::new(CreateJobObjectW(std::ptr::null_mut(), std::ptr::null()));
-    if h_job.raw() == 0 {
-        return Err(anyhow::anyhow!("CreateJobObjectW failed"));
-    }
-    let mut limits: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
-    limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-    let ok = SetInformationJobObject(
-        h_job.raw(),
-        JobObjectExtendedLimitInformation,
-        &mut limits as *mut _ as *mut _,
-        std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
-    );
-    if ok == 0 {
-        return Err(anyhow::anyhow!("SetInformationJobObject failed"));
-    }
-    Ok(h_job.into_raw())
 }
 
 /// Open a named pipe created by the parent process.
@@ -298,9 +286,9 @@ fn spawn_ipc_process(req: &SpawnRequest) -> Result<IpcSpawnedProcess> {
 
     let mut conpty_owner = None;
     let mut hpc_handle: Option<HANDLE> = None;
-    let mut pipe_handles = None;
-    let (pi, stdout_handle, stderr_handle, stdin_handle) = if req.tty {
-        let (pi, mut conpty) = codex_windows_sandbox::spawn_conpty_process_as_user(
+    let mut pipe_desktop = None;
+    let (process, stdout_handle, stderr_handle, stdin_handle) = if req.tty {
+        let (process, mut conpty) = codex_windows_sandbox::spawn_job_conpty_process_as_user(
             h_token.raw(),
             &req.command,
             &effective_cwd,
@@ -321,7 +309,7 @@ fn spawn_ipc_process(req: &SpawnRequest) -> Result<IpcSpawnedProcess> {
             None
         };
         (
-            pi,
+            process,
             output_read,
             windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE,
             stdin_handle,
@@ -332,7 +320,7 @@ fn spawn_ipc_process(req: &SpawnRequest) -> Result<IpcSpawnedProcess> {
         } else {
             StdinMode::Closed
         };
-        let spawned_pipes: PipeSpawnHandles = spawn_process_with_pipes(
+        let spawned_pipes: JobPipeSpawnHandles = spawn_job_process_with_pipes(
             h_token.raw(),
             &req.command,
             &effective_cwd,
@@ -342,24 +330,27 @@ fn spawn_ipc_process(req: &SpawnRequest) -> Result<IpcSpawnedProcess> {
             req.use_private_desktop,
             Some(log_dir.as_path()),
         )?;
-        let pi = spawned_pipes.process;
-        let stdout_handle = spawned_pipes.stdout_read;
-        let stderr_handle = spawned_pipes
-            .stderr_read
-            .unwrap_or(windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE);
-        let stdin_handle = spawned_pipes.stdin_write;
-        pipe_handles = Some(spawned_pipes);
-        (pi, stdout_handle, stderr_handle, stdin_handle)
+        let JobPipeSpawnHandles {
+            process,
+            stdin_write: stdin_handle,
+            stdout_read: stdout_handle,
+            stderr_read: stderr_handle,
+            desktop,
+        } = spawned_pipes;
+        let stderr_handle =
+            stderr_handle.unwrap_or(windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE);
+        pipe_desktop = Some(desktop);
+        (process, stdout_handle, stderr_handle, stdin_handle)
     };
     Ok(IpcSpawnedProcess {
         log_dir,
-        pi,
+        process,
         stdout_handle,
         stderr_handle,
         stdin_handle,
         conpty_owner,
         hpc_handle,
-        _pipe_handles: pipe_handles,
+        _pipe_desktop: pipe_desktop,
     })
 }
 
@@ -396,7 +387,7 @@ fn spawn_input_loop(
     mut reader: File,
     stdin_handle: Option<HANDLE>,
     hpc_handle: Arc<StdMutex<Option<HANDLE>>>,
-    process_handle: Arc<StdMutex<Option<HANDLE>>>,
+    job: impl RunnerJobController,
     log_dir: Option<PathBuf>,
 ) -> std::thread::JoinHandle<()> {
     std::thread::spawn(move || {
@@ -404,8 +395,22 @@ fn spawn_input_loop(
         loop {
             let msg = match read_frame(&mut reader) {
                 Ok(Some(v)) => v,
-                Ok(None) => break,
-                Err(_) => break,
+                Ok(None) => {
+                    log_note(
+                        "runner control pipe closed; terminating child job",
+                        log_dir.as_deref(),
+                    );
+                    job.terminate_job();
+                    break;
+                }
+                Err(err) => {
+                    log_note(
+                        &format!("runner control pipe read failed: {err}; terminating child job"),
+                        log_dir.as_deref(),
+                    );
+                    job.terminate_job();
+                    break;
+                }
             };
             match msg.message {
                 Message::Stdin { payload } => {
@@ -489,13 +494,7 @@ fn spawn_input_loop(
                     }
                 }
                 Message::Terminate { .. } => {
-                    if let Ok(guard) = process_handle.lock()
-                        && let Some(handle) = guard.as_ref()
-                    {
-                        unsafe {
-                            let _ = TerminateProcess(*handle, 1);
-                        }
-                    }
+                    job.terminate_job();
                 }
                 Message::SpawnRequest { .. } => {}
                 Message::SpawnReady { .. } => {}
@@ -567,27 +566,21 @@ pub fn main() -> Result<()> {
         }
     };
     let log_dir = Some(ipc_spawn.log_dir.as_path());
-    let pi = ipc_spawn.pi;
+    let process = ipc_spawn.process;
+    let process_handle = process.as_raw_handle() as HANDLE;
+    let job = process.controller();
     let stdout_handle = ipc_spawn.stdout_handle;
     let stderr_handle = ipc_spawn.stderr_handle;
     let mut conpty_owner = ipc_spawn.conpty_owner;
+    let pipe_desktop = ipc_spawn._pipe_desktop;
     let stdin_handle = ipc_spawn.stdin_handle;
     let hpc_handle = Arc::new(StdMutex::new(ipc_spawn.hpc_handle));
-
-    let h_job = unsafe { create_job_kill_on_close().ok() };
-    if let Some(job) = h_job {
-        unsafe {
-            let _ = AssignProcessToJobObject(job, pi.hProcess);
-        }
-    }
-
-    let process_handle = Arc::new(StdMutex::new(Some(pi.hProcess)));
 
     let msg = FramedMessage {
         version: IPC_PROTOCOL_VERSION,
         message: Message::SpawnReady {
             payload: SpawnReady {
-                process_id: unsafe { GetProcessId(pi.hProcess) },
+                process_id: process.process_id(),
             },
         },
     };
@@ -626,32 +619,26 @@ pub fn main() -> Result<()> {
         pipe_read,
         stdin_handle,
         Arc::clone(&hpc_handle),
-        Arc::clone(&process_handle),
+        job.clone(),
         log_dir_owned,
     );
 
     let timeout = req.timeout_ms.map(|ms| ms as u32).unwrap_or(INFINITE);
-    let wait_res = unsafe { WaitForSingleObject(pi.hProcess, timeout) };
+    let wait_res = unsafe { WaitForSingleObject(process_handle, timeout) };
     let timed_out = wait_res == WAIT_TIMEOUT;
 
     let exit_code: i32;
     unsafe {
         if timed_out {
-            let _ = TerminateProcess(pi.hProcess, 1);
+            let _ = job.terminate_and_close(1);
             exit_code = 128 + 64;
         } else {
             let mut raw_exit: u32 = 1;
-            GetExitCodeProcess(pi.hProcess, &mut raw_exit);
+            GetExitCodeProcess(process_handle, &mut raw_exit);
             exit_code = raw_exit as i32;
-        }
-        if pi.hThread != 0 {
-            CloseHandle(pi.hThread);
-        }
-        if pi.hProcess != 0 {
-            CloseHandle(pi.hProcess);
-        }
-        if let Some(job) = h_job {
-            CloseHandle(job);
+            // Root exit ends the session. Closing the job before joining readers ensures any
+            // surviving descendants are stopped and release inherited output handles.
+            let _ = job.close();
         }
     }
 
@@ -659,6 +646,7 @@ pub fn main() -> Result<()> {
         let _ = guard.take();
     }
     drop(conpty_owner.take());
+    drop(pipe_desktop);
 
     let _ = out_thread.join();
     if let Some(thread) = err_thread {
@@ -682,3 +670,7 @@ pub fn main() -> Result<()> {
 
     std::process::exit(exit_code);
 }
+
+#[cfg(test)]
+#[path = "win_tests.rs"]
+mod tests;

--- a/codex-rs/windows-sandbox-rs/src/bin/command_runner/win_tests.rs
+++ b/codex-rs/windows-sandbox-rs/src/bin/command_runner/win_tests.rs
@@ -1,0 +1,36 @@
+use super::RunnerJobController;
+use super::spawn_input_loop;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+
+struct RecordingJobController {
+    terminated: Arc<AtomicBool>,
+}
+
+impl RunnerJobController for RecordingJobController {
+    fn terminate_job(&self) {
+        self.terminated.store(true, Ordering::SeqCst);
+    }
+}
+
+#[test]
+fn control_pipe_eof_terminates_child_job() {
+    let terminated = Arc::new(AtomicBool::new(false));
+    let input_thread = spawn_input_loop(
+        tempfile::tempfile().expect("create empty control-pipe stand-in"),
+        /*stdin_handle*/ None,
+        Arc::new(Mutex::new(None)),
+        RecordingJobController {
+            terminated: Arc::clone(&terminated),
+        },
+        /*log_dir*/ None,
+    );
+
+    input_thread.join().expect("join runner input loop");
+    assert!(
+        terminated.load(Ordering::SeqCst),
+        "EOF from the parent transport must terminate the child job"
+    );
+}

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/elevated_job_tests.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/elevated_job_tests.rs
@@ -1,0 +1,298 @@
+#![cfg(target_os = "windows")]
+
+use super::current_thread_runtime;
+use super::job_test_support::SessionEnding;
+use super::job_test_support::SessionMode;
+use super::job_test_support::assert_grandchild_stopped;
+use super::job_test_support::grandchild_fixture;
+use super::job_test_support::wait_for_grandchild;
+use super::job_test_support::windows_powershell_path;
+use super::job_test_support::windows_process_test_guard;
+use super::sandbox_cwd;
+use super::sandbox_log;
+use super::workspace_roots_for;
+use crate::WindowsSandboxProxySettingsMode;
+use crate::ipc_framed::Message;
+use crate::ipc_framed::SpawnRequest;
+use crate::ipc_framed::read_frame;
+use crate::resolved_permissions::ResolvedWindowsSandboxPermissions;
+use crate::runner_client::spawn_runner_transport;
+use crate::spawn_prep::prepare_elevated_spawn_context_for_permissions;
+use crate::unified_exec::spawn_windows_sandbox_session_elevated_for_permission_profile;
+use anyhow::Context;
+use codex_protocol::models::PermissionProfile;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+use std::time::Duration;
+use tokio::time::timeout;
+
+static ELEVATED_TEST_CODEX_HOME: OnceLock<PathBuf> = OnceLock::new();
+
+fn elevated_test_codex_home() -> &'static Path {
+    ELEVATED_TEST_CODEX_HOME
+        .get_or_init(|| {
+            let path = if let Some(test_tmpdir) = std::env::var_os("TEST_TMPDIR") {
+                // Elevated setup provisions machine-local users. Bazel retries reuse the same
+                // Windows VM, so keep CODEX_HOME stable and reconcile its persisted ACL state.
+                PathBuf::from(test_tmpdir).join("elevated-job-lifecycle-codex-home")
+            } else {
+                std::env::temp_dir().join(format!(
+                    "codex-windows-sandbox-elevated-job-lifecycle-{}",
+                    std::process::id()
+                ))
+            };
+            fs::create_dir_all(&path).unwrap_or_else(|err| {
+                panic!(
+                    "create stable elevated test CODEX_HOME {}: {err}",
+                    path.display()
+                )
+            });
+            path
+        })
+        .as_path()
+}
+
+fn stage_windows_sandbox_helpers() -> anyhow::Result<()> {
+    let test_exe = std::env::current_exe().context("resolve current Windows test executable")?;
+    let test_exe_dir = test_exe
+        .parent()
+        .context("Windows test executable should have a parent directory")?;
+    let resources_dir = test_exe_dir.join("codex-resources");
+    match fs::create_dir_all(&resources_dir) {
+        Ok(()) => {}
+        Err(err)
+            if err.kind() == std::io::ErrorKind::PermissionDenied && resources_dir.is_dir() => {}
+        Err(err) => {
+            return Err(err)
+                .with_context(|| format!("create resources dir {}", resources_dir.display()));
+        }
+    }
+    for helper_name in ["codex-windows-sandbox-setup", "codex-command-runner"] {
+        let file_name = Path::new(helper_name).with_extension("exe");
+        let helper = match codex_utils_cargo_bin::cargo_bin(helper_name) {
+            Ok(helper) => helper,
+            Err(cargo_bin_err) if codex_utils_cargo_bin::runfiles_available() => {
+                codex_utils_cargo_bin::resolve_bazel_runfile(
+                    option_env!("BAZEL_PACKAGE"),
+                    &file_name,
+                )
+                .with_context(|| {
+                    format!(
+                        "resolve Bazel runfile for {helper_name} after cargo_bin failed: {cargo_bin_err}"
+                    )
+                })?
+            }
+            Err(err) => return Err(err.into()),
+        };
+        let destination = resources_dir.join(file_name);
+        if let Err(err) = fs::copy(&helper, &destination) {
+            // A runner from a preceding Bazel retry can briefly retain the staged executable.
+            // In that case the existing copy is the binary that retry already launched.
+            if err.kind() == std::io::ErrorKind::PermissionDenied && destination.exists() {
+                continue;
+            }
+            return Err(err).with_context(|| {
+                format!(
+                    "stage Windows sandbox helper {} at {}",
+                    helper.display(),
+                    destination.display()
+                )
+            });
+        }
+    }
+    Ok(())
+}
+
+fn wait_for_runner_exit(mut pipe_read: std::fs::File) -> i32 {
+    let (result_tx, result_rx) = std::sync::mpsc::sync_channel(1);
+    let reader = std::thread::spawn(move || {
+        let result = loop {
+            match read_frame(&mut pipe_read) {
+                Ok(Some(frame)) => match frame.message {
+                    Message::Exit { payload } => break Ok(payload.exit_code),
+                    Message::Error { payload } => {
+                        break Err(anyhow::anyhow!("runner error: {}", payload.message));
+                    }
+                    Message::Output { .. }
+                    | Message::SpawnReady { .. }
+                    | Message::SpawnRequest { .. }
+                    | Message::Stdin { .. }
+                    | Message::CloseStdin { .. }
+                    | Message::Resize { .. }
+                    | Message::Terminate { .. } => {}
+                },
+                Ok(None) => break Err(anyhow::anyhow!("runner pipe closed before exit")),
+                Err(err) => break Err(err.context("read runner exit frame")),
+            }
+        };
+        let _ = result_tx.send(result);
+    });
+    let exit_code = result_rx
+        .recv_timeout(Duration::from_secs(10))
+        .expect("timed out waiting for runner exit after control transport EOF")
+        .expect("runner should report exit after control transport EOF");
+    reader.join().expect("runner output reader should finish");
+    exit_code
+}
+
+fn assert_elevated_session_stops_grandchild(mode: SessionMode, ending: SessionEnding) {
+    let _guard = windows_process_test_guard();
+    stage_windows_sandbox_helpers().expect("stage elevated sandbox helpers");
+    let runtime = current_thread_runtime();
+    runtime.block_on(async move {
+        let cwd = sandbox_cwd();
+        let powershell = windows_powershell_path();
+        let fixture = grandchild_fixture(&cwd, &powershell, ending.root_tail());
+        let codex_home = elevated_test_codex_home();
+        let permission_profile = PermissionProfile::workspace_write();
+        let spawned = spawn_windows_sandbox_session_elevated_for_permission_profile(
+            &permission_profile,
+            workspace_roots_for(cwd.as_path()).as_slice(),
+            codex_home,
+            fixture.command.clone(),
+            cwd.as_path(),
+            HashMap::new(),
+            /*proxy_enforced*/ false,
+            Some(30_000),
+            /*read_roots_override*/ None,
+            /*read_roots_include_platform_defaults*/ false,
+            /*write_roots_override*/ None,
+            &[],
+            &[],
+            /*tty*/ mode.tty(),
+            /*stdin_open*/ mode.tty(),
+            /*use_private_desktop*/ false,
+        )
+        .await
+        .unwrap_or_else(|err| {
+            panic!(
+                "spawn elevated {} grandchild session: {err:#}\n{}",
+                mode.label(),
+                sandbox_log(codex_home)
+            )
+        });
+
+        wait_for_grandchild(&fixture);
+
+        let codex_utils_pty::SpawnedProcess {
+            session,
+            stdout_rx: _stdout_rx,
+            stderr_rx: _stderr_rx,
+            exit_rx,
+        } = spawned;
+        if matches!(ending, SessionEnding::ExplicitTermination) {
+            session.request_terminate();
+        }
+        let exit_code = timeout(Duration::from_secs(10), exit_rx)
+            .await
+            .unwrap_or_else(|_| {
+                panic!(
+                    "timed out waiting for elevated session exit\n{}",
+                    sandbox_log(codex_home)
+                )
+            })
+            .unwrap_or(-1);
+        match ending {
+            SessionEnding::ExplicitTermination => assert_ne!(exit_code, 0),
+            SessionEnding::RootExit => assert_eq!(exit_code, 0),
+        }
+        assert_grandchild_stopped(&fixture);
+    });
+}
+
+#[test]
+fn elevated_non_tty_termination_stops_grandchild() {
+    assert_elevated_session_stops_grandchild(SessionMode::Pipe, SessionEnding::ExplicitTermination);
+}
+
+#[test]
+fn elevated_tty_termination_stops_grandchild() {
+    assert_elevated_session_stops_grandchild(SessionMode::Tty, SessionEnding::ExplicitTermination);
+}
+
+#[test]
+fn elevated_non_tty_root_exit_stops_grandchild() {
+    assert_elevated_session_stops_grandchild(SessionMode::Pipe, SessionEnding::RootExit);
+}
+
+#[test]
+fn elevated_tty_root_exit_stops_grandchild() {
+    assert_elevated_session_stops_grandchild(SessionMode::Tty, SessionEnding::RootExit);
+}
+
+#[test]
+fn elevated_control_transport_eof_stops_grandchild() {
+    let _guard = windows_process_test_guard();
+    stage_windows_sandbox_helpers().expect("stage elevated sandbox helpers");
+    let cwd = sandbox_cwd();
+    let powershell = windows_powershell_path();
+    let fixture = grandchild_fixture(&cwd, &powershell, "Start-Sleep -Seconds 30");
+    let codex_home = elevated_test_codex_home();
+    let permission_profile = PermissionProfile::workspace_write();
+    let workspace_roots = workspace_roots_for(&cwd);
+    let mut env_map = HashMap::new();
+    let permissions =
+        ResolvedWindowsSandboxPermissions::try_from_permission_profile_for_workspace_roots(
+            &permission_profile,
+            &workspace_roots,
+        )
+        .expect("resolve elevated test permissions");
+    let elevated = prepare_elevated_spawn_context_for_permissions(
+        permissions,
+        codex_home,
+        &cwd,
+        &mut env_map,
+        &fixture.command,
+        /*read_roots_override*/ None,
+        /*read_roots_include_platform_defaults*/ false,
+        /*write_roots_override*/ None,
+        &[],
+        &[],
+        /*proxy_enforced*/ false,
+        WindowsSandboxProxySettingsMode::Reconcile,
+    )
+    .unwrap_or_else(|err| {
+        panic!(
+            "prepare elevated transport-drop session: {err:#}\n{}",
+            sandbox_log(codex_home)
+        )
+    });
+    let spawn_request = SpawnRequest {
+        command: fixture.command.clone(),
+        cwd: cwd.clone(),
+        env: env_map,
+        permission_profile,
+        workspace_roots,
+        codex_home: elevated.sandbox_base.clone(),
+        real_codex_home: codex_home.to_path_buf(),
+        cap_sids: elevated.cap_sids.clone(),
+        timeout_ms: Some(30_000),
+        tty: false,
+        stdin_open: false,
+        use_private_desktop: false,
+    };
+    let transport = spawn_runner_transport(
+        codex_home,
+        &cwd,
+        &elevated.sandbox_creds,
+        elevated.logs_base_dir.as_deref(),
+        spawn_request,
+    )
+    .unwrap_or_else(|err| {
+        panic!(
+            "spawn elevated runner transport: {err:#}\n{}",
+            sandbox_log(codex_home)
+        )
+    });
+
+    wait_for_grandchild(&fixture);
+    let (pipe_write, pipe_read) = transport.into_files();
+    drop(pipe_write);
+
+    let exit_code = wait_for_runner_exit(pipe_read);
+    assert_ne!(exit_code, 0);
+    assert_grandchild_stopped(&fixture);
+}

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/tests.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/tests.rs
@@ -36,6 +36,9 @@ static TEST_HOME_COUNTER: AtomicU64 = AtomicU64::new(0);
 #[path = "job_test_support.rs"]
 mod job_test_support;
 
+#[path = "elevated_job_tests.rs"]
+mod elevated_job_tests;
+
 #[path = "restricted_job_tests.rs"]
 mod restricted_job_tests;
 


### PR DESCRIPTION
## Intent

Elevated unified-exec sessions must terminate their child tree when the parent requests termination, a timeout fires, or the parent IPC transport disappears. `SpawnReady` must never describe an uncontained process.

## Implementation

- Remove the runner-local best-effort Job Object helper and ignored late assignment.
- Receive an already-assigned `JobProcess` from both elevated pipe and ConPTY spawn paths.
- Emit `SpawnReady` only after assignment and resume have succeeded.
- Terminate the shared job on `Terminate`, timeout, named-pipe EOF, or control read failure.
- Close the job before output-reader joins on normal root exit while preserving the root exit code.
- Add elevated pipe/TTY lifecycle coverage and a real control-transport EOF test.

## Manual validation

- Built `codex-windows-sandbox` and `codex-command-runner` for Windows gnullvm with Bazel.

## Stack

[1. job primitives](https://github.com/openai/codex/pull/29979) → [2. local ConPTY](https://github.com/openai/codex/pull/29980) → [3. restricted sessions](https://github.com/openai/codex/pull/29981) → **[4. elevated runner](https://github.com/openai/codex/pull/29982)** → [5. command preparation](https://github.com/openai/codex/pull/29983) → [6. raw pipe launcher](https://github.com/openai/codex/pull/29984) → [7. command parity](https://github.com/openai/codex/pull/29985)
