### PR TITLE
Recognize Work web and mobile thread originators

### DIFF
--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -195,8 +195,10 @@ pub struct StartThreadOptions {
 
 fn originator_from_service_name(service_name: Option<&str>) -> Option<String> {
     let service_name = service_name?.trim();
-    if service_name.eq_ignore_ascii_case("codex_work_desktop") {
-        return Some("codex_work_desktop".to_string());
+    for originator in ["codex_work_desktop", "codex_work_web", "codex_work_mobile"] {
+        if service_name.eq_ignore_ascii_case(originator) {
+            return Some(originator.to_string());
+        }
     }
     None
 }

--- a/codex-rs/core/src/thread_manager_tests.rs
+++ b/codex-rs/core/src/thread_manager_tests.rs
@@ -121,6 +121,18 @@ fn effective_originator_prefers_thread_scoped_sources_before_env_originator() {
             "codex_work_desktop",
         ),
         (
+            Some("codex_work_web"),
+            Some("persisted_originator"),
+            Some("inherited_originator"),
+            "codex_work_web",
+        ),
+        (
+            Some("codex_work_mobile"),
+            Some("persisted_originator"),
+            Some("inherited_originator"),
+            "codex_work_mobile",
+        ),
+        (
             None,
             Some("persisted_originator"),
             Some("inherited_originator"),


### PR DESCRIPTION
## Summary

- recognize `codex_work_web` and `codex_work_mobile` as supported `thread/start.serviceName` values
- use the recognized value as the thread-scoped originator, with the same persistence and request propagation added for `codex_work_desktop`
- cover precedence over persisted and inherited originators

This is the Codex consumer for the service names introduced by [openai/openai#1073178](https://github.com/openai/openai/pull/1073178).

## Rollout / Compatibility

The producer is ChatGPT's app-server integration in openai/openai#1073178. This PR is the Codex app-server consumer that converts those service names into the outgoing per-thread `originator`.

Until this change is deployed, the new service names are ignored and Codex continues using its fallback originator. Deploy this mapper and the matching codex-backend compatibility change in [openai/openai#1073594](https://github.com/openai/openai/pull/1073594) while the existing Flora egress overwrite remains in place. Remove that overwrite in [openai/openai#1073197](https://github.com/openai/openai/pull/1073197) only after both consumers are deployed.

## Validation

- `just test -p codex-core effective_originator_prefers_thread_scoped_sources_before_env_originator`
- `just fix -p codex-core`
- `just fmt`
