### PR TITLE
Parallelize environment skill loading

### DIFF
--- a/codex-rs/core-skills/src/loader/environment.rs
+++ b/codex-rs/core-skills/src/loader/environment.rs
@@ -10,6 +10,7 @@ use codex_utils_path_uri::PathUri;
 use codex_utils_plugins::DISCOVERABLE_PLUGIN_MANIFEST_PATHS;
 use codex_utils_plugins::plugin_namespace_for_root_uri;
 use codex_utils_plugins::plugin_namespace_for_skill_uri;
+use futures::StreamExt;
 use futures::future::join_all;
 
 use crate::model::SkillDependencies;
@@ -31,6 +32,7 @@ use super::sanitize_single_line;
 use super::validate_len;
 
 const MAX_SKILLS_ENTRIES_PER_ROOT: usize = 20_000;
+const MAX_CONCURRENT_SKILL_LOADS: usize = 16;
 
 /// URI-native metadata for one skill owned by an execution environment.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -220,26 +222,29 @@ pub async fn load_environment_skills_from_root(
         .filter_map(|(plugin_root, namespace)| namespace.map(|namespace| (plugin_root, namespace)))
         .collect::<HashMap<_, _>>();
 
-    // Remote executors can multiplex these independent per-skill reads, so polling them together
-    // allows the I/O for each skill and its metadata to happen concurrently.
-    let skill_results = join_all(discovery.skill_files.into_iter().map(|path| {
-        let mut ancestor = path.parent();
-        let plugin_namespace = loop {
-            let Some(current) = ancestor else {
-                break None;
+    // Remote executors can multiplex these independent per-skill reads, so polling a bounded
+    // number together allows the I/O for each skill and its metadata to happen concurrently.
+    let skill_results = futures::stream::iter(discovery.skill_files)
+        .map(|path| {
+            let mut ancestor = path.parent();
+            let plugin_namespace = loop {
+                let Some(current) = ancestor else {
+                    break None;
+                };
+                if let Some(namespace) = plugin_namespaces.get(&current) {
+                    break Some(namespace.as_str());
+                }
+                ancestor = current.parent();
             };
-            if let Some(namespace) = plugin_namespaces.get(&current) {
-                break Some(namespace.as_str());
+            async move {
+                let result =
+                    EnvironmentSkillMetadata::parse(file_system, &path, plugin_namespace).await;
+                (path, result)
             }
-            ancestor = current.parent();
-        };
-        async move {
-            let result =
-                EnvironmentSkillMetadata::parse(file_system, &path, plugin_namespace).await;
-            (path, result)
-        }
-    }))
-    .await;
+        })
+        .buffered(MAX_CONCURRENT_SKILL_LOADS)
+        .collect::<Vec<_>>()
+        .await;
 
     for (path, result) in skill_results {
         match result {

--- a/codex-rs/core-skills/src/loader/environment.rs
+++ b/codex-rs/core-skills/src/loader/environment.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::future::Future;
 use std::io;
 
 use codex_exec_server::ExecutorFileSystem;
@@ -32,7 +33,7 @@ use super::sanitize_single_line;
 use super::validate_len;
 
 const MAX_SKILLS_ENTRIES_PER_ROOT: usize = 20_000;
-const MAX_CONCURRENT_SKILL_LOADS: usize = 256;
+const MAX_CONCURRENT_SKILL_LOADS: usize = 64;
 
 /// URI-native metadata for one skill owned by an execution environment.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -70,10 +71,11 @@ impl EnvironmentSkillMetadata {
         path: &PathUri,
         plugin_namespace: Option<&str>,
     ) -> Result<Self, String> {
-        let contents = file_system
-            .read_file_text(path, /*sandbox*/ None)
-            .await
-            .map_err(|err| format!("failed to read file: {err}"))?;
+        let contents = retry_once_on_broken_pipe(|| {
+            file_system.read_file_text(path, /*sandbox*/ None)
+        })
+        .await
+        .map_err(|err| format!("failed to read file: {err}"))?;
         let ParsedSkillFrontmatter {
             name: base_name,
             description,
@@ -279,9 +281,10 @@ async fn load_skill_metadata(
     else {
         return (None, None);
     };
-    match file_system
-        .get_metadata(&metadata_path, /*sandbox*/ None)
-        .await
+    match retry_once_on_broken_pipe(|| {
+        file_system.get_metadata(&metadata_path, /*sandbox*/ None)
+    })
+    .await
     {
         Ok(metadata) if metadata.is_file => {}
         Ok(_) => return (None, None),
@@ -291,9 +294,10 @@ async fn load_skill_metadata(
             return (None, None);
         }
     }
-    let contents = match file_system
-        .read_file_text(&metadata_path, /*sandbox*/ None)
-        .await
+    let contents = match retry_once_on_broken_pipe(|| {
+        file_system.read_file_text(&metadata_path, /*sandbox*/ None)
+    })
+    .await
     {
         Ok(contents) => contents,
         Err(error) => {
@@ -313,6 +317,17 @@ async fn load_skill_metadata(
         resolve_dependencies(parsed.dependencies),
         resolve_policy(parsed.policy),
     )
+}
+
+async fn retry_once_on_broken_pipe<T, F, Fut>(mut operation: F) -> io::Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = io::Result<T>>,
+{
+    match operation().await {
+        Err(error) if error.kind() == io::ErrorKind::BrokenPipe => operation().await,
+        result => result,
+    }
 }
 
 fn default_skill_name(path: &PathUri) -> String {

--- a/codex-rs/core-skills/src/loader/environment.rs
+++ b/codex-rs/core-skills/src/loader/environment.rs
@@ -220,7 +220,9 @@ pub async fn load_environment_skills_from_root(
         .filter_map(|(plugin_root, namespace)| namespace.map(|namespace| (plugin_root, namespace)))
         .collect::<HashMap<_, _>>();
 
-    for path in discovery.skill_files {
+    // Remote executors can multiplex these independent per-skill reads, so polling them together
+    // allows the I/O for each skill and its metadata to happen concurrently.
+    let skill_results = join_all(discovery.skill_files.into_iter().map(|path| {
         let mut ancestor = path.parent();
         let plugin_namespace = loop {
             let Some(current) = ancestor else {
@@ -231,13 +233,16 @@ pub async fn load_environment_skills_from_root(
             }
             ancestor = current.parent();
         };
-        match EnvironmentSkillMetadata::parse(
-            file_system,
-            &path,
-            /*plugin_namespace*/ plugin_namespace,
-        )
-        .await
-        {
+        async move {
+            let result =
+                EnvironmentSkillMetadata::parse(file_system, &path, plugin_namespace).await;
+            (path, result)
+        }
+    }))
+    .await;
+
+    for (path, result) in skill_results {
+        match result {
             Ok(skill) if skill.matches_product_restriction(restriction_product) => {
                 outcome.skills.push(skill);
             }

--- a/codex-rs/core-skills/src/loader/environment.rs
+++ b/codex-rs/core-skills/src/loader/environment.rs
@@ -10,6 +10,7 @@ use codex_utils_path_uri::PathUri;
 use codex_utils_plugins::DISCOVERABLE_PLUGIN_MANIFEST_PATHS;
 use codex_utils_plugins::plugin_namespace_for_root_uri;
 use codex_utils_plugins::plugin_namespace_for_skill_uri;
+use futures::StreamExt;
 use futures::future::join_all;
 
 use crate::model::SkillDependencies;
@@ -31,6 +32,7 @@ use super::sanitize_single_line;
 use super::validate_len;
 
 const MAX_SKILLS_ENTRIES_PER_ROOT: usize = 20_000;
+const MAX_CONCURRENT_SKILL_LOADS: usize = 256;
 
 /// URI-native metadata for one skill owned by an execution environment.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -220,26 +222,29 @@ pub async fn load_environment_skills_from_root(
         .filter_map(|(plugin_root, namespace)| namespace.map(|namespace| (plugin_root, namespace)))
         .collect::<HashMap<_, _>>();
 
-    // Remote executors can multiplex these independent per-skill reads, so polling them together
-    // allows the I/O for each skill and its metadata to happen concurrently.
-    let skill_results = join_all(discovery.skill_files.into_iter().map(|path| {
-        let mut ancestor = path.parent();
-        let plugin_namespace = loop {
-            let Some(current) = ancestor else {
-                break None;
+    // Remote executors can multiplex these independent per-skill reads, so polling a bounded
+    // number together allows the I/O for each skill and its metadata to happen concurrently.
+    let skill_results = futures::stream::iter(discovery.skill_files)
+        .map(|path| {
+            let mut ancestor = path.parent();
+            let plugin_namespace = loop {
+                let Some(current) = ancestor else {
+                    break None;
+                };
+                if let Some(namespace) = plugin_namespaces.get(&current) {
+                    break Some(namespace.as_str());
+                }
+                ancestor = current.parent();
             };
-            if let Some(namespace) = plugin_namespaces.get(&current) {
-                break Some(namespace.as_str());
+            async move {
+                let result =
+                    EnvironmentSkillMetadata::parse(file_system, &path, plugin_namespace).await;
+                (path, result)
             }
-            ancestor = current.parent();
-        };
-        async move {
-            let result =
-                EnvironmentSkillMetadata::parse(file_system, &path, plugin_namespace).await;
-            (path, result)
-        }
-    }))
-    .await;
+        })
+        .buffered(MAX_CONCURRENT_SKILL_LOADS)
+        .collect::<Vec<_>>()
+        .await;
 
     for (path, result) in skill_results {
         match result {

--- a/codex-rs/core-skills/src/loader/environment.rs
+++ b/codex-rs/core-skills/src/loader/environment.rs
@@ -10,7 +10,6 @@ use codex_utils_path_uri::PathUri;
 use codex_utils_plugins::DISCOVERABLE_PLUGIN_MANIFEST_PATHS;
 use codex_utils_plugins::plugin_namespace_for_root_uri;
 use codex_utils_plugins::plugin_namespace_for_skill_uri;
-use futures::StreamExt;
 use futures::future::join_all;
 
 use crate::model::SkillDependencies;
@@ -32,7 +31,6 @@ use super::sanitize_single_line;
 use super::validate_len;
 
 const MAX_SKILLS_ENTRIES_PER_ROOT: usize = 20_000;
-const MAX_CONCURRENT_SKILL_LOADS: usize = 16;
 
 /// URI-native metadata for one skill owned by an execution environment.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -222,29 +220,26 @@ pub async fn load_environment_skills_from_root(
         .filter_map(|(plugin_root, namespace)| namespace.map(|namespace| (plugin_root, namespace)))
         .collect::<HashMap<_, _>>();
 
-    // Remote executors can multiplex these independent per-skill reads, so polling a bounded
-    // number together allows the I/O for each skill and its metadata to happen concurrently.
-    let skill_results = futures::stream::iter(discovery.skill_files)
-        .map(|path| {
-            let mut ancestor = path.parent();
-            let plugin_namespace = loop {
-                let Some(current) = ancestor else {
-                    break None;
-                };
-                if let Some(namespace) = plugin_namespaces.get(&current) {
-                    break Some(namespace.as_str());
-                }
-                ancestor = current.parent();
+    // Remote executors can multiplex these independent per-skill reads, so polling them together
+    // allows the I/O for each skill and its metadata to happen concurrently.
+    let skill_results = join_all(discovery.skill_files.into_iter().map(|path| {
+        let mut ancestor = path.parent();
+        let plugin_namespace = loop {
+            let Some(current) = ancestor else {
+                break None;
             };
-            async move {
-                let result =
-                    EnvironmentSkillMetadata::parse(file_system, &path, plugin_namespace).await;
-                (path, result)
+            if let Some(namespace) = plugin_namespaces.get(&current) {
+                break Some(namespace.as_str());
             }
-        })
-        .buffered(MAX_CONCURRENT_SKILL_LOADS)
-        .collect::<Vec<_>>()
-        .await;
+            ancestor = current.parent();
+        };
+        async move {
+            let result =
+                EnvironmentSkillMetadata::parse(file_system, &path, plugin_namespace).await;
+            (path, result)
+        }
+    }))
+    .await;
 
     for (path, result) in skill_results {
         match result {

--- a/codex-rs/core-skills/src/loader/environment.rs
+++ b/codex-rs/core-skills/src/loader/environment.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::future::Future;
 use std::io;
 
 use codex_exec_server::ExecutorFileSystem;
@@ -71,11 +70,10 @@ impl EnvironmentSkillMetadata {
         path: &PathUri,
         plugin_namespace: Option<&str>,
     ) -> Result<Self, String> {
-        let contents = retry_once_on_broken_pipe(|| {
-            file_system.read_file_text(path, /*sandbox*/ None)
-        })
-        .await
-        .map_err(|err| format!("failed to read file: {err}"))?;
+        let contents = file_system
+            .read_file_text(path, /*sandbox*/ None)
+            .await
+            .map_err(|err| format!("failed to read file: {err}"))?;
         let ParsedSkillFrontmatter {
             name: base_name,
             description,
@@ -281,10 +279,9 @@ async fn load_skill_metadata(
     else {
         return (None, None);
     };
-    match retry_once_on_broken_pipe(|| {
-        file_system.get_metadata(&metadata_path, /*sandbox*/ None)
-    })
-    .await
+    match file_system
+        .get_metadata(&metadata_path, /*sandbox*/ None)
+        .await
     {
         Ok(metadata) if metadata.is_file => {}
         Ok(_) => return (None, None),
@@ -294,10 +291,9 @@ async fn load_skill_metadata(
             return (None, None);
         }
     }
-    let contents = match retry_once_on_broken_pipe(|| {
-        file_system.read_file_text(&metadata_path, /*sandbox*/ None)
-    })
-    .await
+    let contents = match file_system
+        .read_file_text(&metadata_path, /*sandbox*/ None)
+        .await
     {
         Ok(contents) => contents,
         Err(error) => {
@@ -317,17 +313,6 @@ async fn load_skill_metadata(
         resolve_dependencies(parsed.dependencies),
         resolve_policy(parsed.policy),
     )
-}
-
-async fn retry_once_on_broken_pipe<T, F, Fut>(mut operation: F) -> io::Result<T>
-where
-    F: FnMut() -> Fut,
-    Fut: Future<Output = io::Result<T>>,
-{
-    match operation().await {
-        Err(error) if error.kind() == io::ErrorKind::BrokenPipe => operation().await,
-        result => result,
-    }
 }
 
 fn default_skill_name(path: &PathUri) -> String {


### PR DESCRIPTION
## Why

Avoid a request waterfall for loading lots of skills at once by hiding latency in concurrent tasks.

## What changed

Poll the per-skill parse futures concurrently with an order-preserving stream capped at 64 in-flight loads. Results retain discovery order, and the existing filtering, warnings, and final catalog sorting are unchanged.