### PR TITLE
Make Windows executable resolution deterministic

### DIFF
--- a/codex-rs/cli/src/debug_sandbox.rs
+++ b/codex-rs/cli/src/debug_sandbox.rs
@@ -473,7 +473,6 @@ async fn run_command_under_windows_session(
 ) -> ! {
     use codex_core::windows_sandbox::WindowsSandboxLevelExt;
     use codex_protocol::config_types::WindowsSandboxLevel;
-    use codex_windows_sandbox::WindowsProcessLaunch;
     use codex_windows_sandbox::WindowsSandboxProxySettingsMode;
     use codex_windows_sandbox::WindowsSandboxSessionRequest;
     use codex_windows_sandbox::spawn_windows_sandbox_session_for_level;
@@ -483,10 +482,7 @@ async fn run_command_under_windows_session(
         permission_profile,
         workspace_roots: workspace_roots.as_slice(),
         codex_home: config.codex_home.as_path(),
-        launch: WindowsProcessLaunch {
-            application_path: None,
-            command,
-        },
+        command,
         cwd: cwd.as_path(),
         env_map: env,
         windows_sandbox_level: WindowsSandboxLevel::from_config(config),

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -995,10 +995,7 @@ impl UnifiedExecProcessManager {
                     permission_profile: &request.permission_profile,
                     workspace_roots: request.windows_sandbox_workspace_roots.as_slice(),
                     codex_home: codex_home.as_ref(),
-                    launch: codex_windows_sandbox::WindowsProcessLaunch {
-                        application_path: None,
-                        command: request.command.clone(),
-                    },
+                    command: request.command.clone(),
                     cwd: native_cwd.as_path(),
                     env_map: request.env.clone(),
                     windows_sandbox_level: request.windows_sandbox_level,

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -1050,7 +1050,7 @@ impl UnifiedExecProcessManager {
                 path: request.cwd.clone(),
             })?;
 
-        let (program, args) = request
+        let (_program, args) = request
             .command
             .split_first()
             .ok_or(UnifiedExecError::MissingCommandLine)?;
@@ -1069,7 +1069,7 @@ impl UnifiedExecProcessManager {
             ))
         })?;
         #[cfg(not(target_os = "windows"))]
-        let program = program.as_str();
+        let program = _program.as_str();
         let spawn_result = if tty {
             codex_utils_pty::pty::spawn_process_with_inherited_fds(
                 program,

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -1054,6 +1054,22 @@ impl UnifiedExecProcessManager {
             .command
             .split_first()
             .ok_or(UnifiedExecError::MissingCommandLine)?;
+        #[cfg(target_os = "windows")]
+        let resolved_program = codex_windows_sandbox::resolve_windows_executable(
+            &request.command,
+            native_cwd.as_path(),
+            &request.env,
+        )
+        .map_err(|err| UnifiedExecError::create_process(err.to_string()))?;
+        #[cfg(target_os = "windows")]
+        let program = resolved_program.to_str().ok_or_else(|| {
+            UnifiedExecError::create_process(format!(
+                "resolved Windows executable is not Unicode: {}",
+                resolved_program.display()
+            ))
+        })?;
+        #[cfg(not(target_os = "windows"))]
+        let program = program.as_str();
         let spawn_result = if tty {
             codex_utils_pty::pty::spawn_process_with_inherited_fds(
                 program,

--- a/codex-rs/protocol/src/shell_environment.rs
+++ b/codex-rs/protocol/src/shell_environment.rs
@@ -93,6 +93,8 @@ where
 
     // Step 4 - Apply user-provided overrides.
     for (key, val) in &policy.r#set {
+        #[cfg(target_os = "windows")]
+        env_map.retain(|existing, _| !existing.eq_ignore_ascii_case(key));
         env_map.insert(key.clone(), val.clone());
     }
 
@@ -208,6 +210,22 @@ mod windows_tests {
         let expected = HashMap::from([("PATHEXT".to_string(), ".COM;.EXE;.BAT;.CMD".to_string())]);
 
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn user_override_replaces_differently_cased_inherited_variable() {
+        let vars = make_vars(&[("PATH", r"C:\parent")]);
+        let policy = ShellEnvironmentPolicy {
+            inherit: ShellEnvironmentPolicyInherit::All,
+            ignore_default_excludes: true,
+            r#set: HashMap::from([("Path".to_string(), r"C:\child".to_string())]),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            populate_env(vars, &policy, /*thread_id*/ None),
+            HashMap::from([("Path".to_string(), r"C:\child".to_string())])
+        );
     }
 }
 

--- a/codex-rs/utils/path-uri/src/lib.rs
+++ b/codex-rs/utils/path-uri/src/lib.rs
@@ -66,11 +66,26 @@ impl PathUri {
     /// encoding of the original path (Unix bytes or Windows UTF-16LE). This
     /// includes paths containing nulls and, on Windows, unsupported prefix
     /// kinds such as device and generic verbatim namespaces, non-Unicode path
-    /// or UNC components, and UNC server names that are not valid URL hosts.
+    /// or UNC components, UNC server names that are not valid URL hosts, and
+    /// `\\localhost` UNC paths whose server component must remain explicit.
     /// The encoded null reserves a URI namespace that cannot collide with a
     /// real path on Unix or Windows.
     pub fn from_abs_path(path: &AbsolutePathBuf) -> Self {
-        if let Ok(url) = Url::from_file_path(path.as_path())
+        #[cfg(windows)]
+        let preserve_localhost_unc = matches!(
+            path.as_path().components().next(),
+            Some(std::path::Component::Prefix(prefix))
+                if matches!(
+                    prefix.kind(),
+                    std::path::Prefix::UNC(server, _)
+                        if server.to_string_lossy().eq_ignore_ascii_case("localhost")
+                )
+        );
+        #[cfg(not(windows))]
+        let preserve_localhost_unc = false;
+
+        if !preserve_localhost_unc
+            && let Ok(url) = Url::from_file_path(path.as_path())
             && let Ok(uri) = Self::try_from(url)
         {
             return uri;

--- a/codex-rs/utils/path-uri/src/tests.rs
+++ b/codex-rs/utils/path-uri/src/tests.rs
@@ -187,6 +187,24 @@ fn file_uri_falls_back_for_windows_prefixes_without_a_uri_representation() {
 
 #[cfg(windows)]
 #[test]
+fn file_uri_preserves_localhost_unc_path() {
+    let path = AbsolutePathBuf::from_absolute_path_checked(r"\\localhost\C$\workspace\src")
+        .expect("localhost UNC path should be absolute");
+
+    let uri = PathUri::from_abs_path(&path);
+
+    assert!(uri.to_string().starts_with(BAD_PATH_URI_PREFIX));
+    assert_eq!(
+        PathUri::parse(&uri.to_string())
+            .expect("fallback URI should parse")
+            .to_abs_path()
+            .expect("fallback URI should decode"),
+        path
+    );
+}
+
+#[cfg(windows)]
+#[test]
 fn file_uri_fallback_round_trips_non_unicode_windows_paths() {
     let path_wide = r"C:\bad\"
         .encode_utf16()

--- a/codex-rs/windows-sandbox-rs/src/command_resolution.rs
+++ b/codex-rs/windows-sandbox-rs/src/command_resolution.rs
@@ -1,0 +1,178 @@
+use crate::process::WindowsProcessLaunch;
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::path::Component;
+use std::path::Path;
+use std::path::PathBuf;
+use std::path::Prefix;
+
+const DEFAULT_PATHEXT: &str = ".COM;.EXE;.BAT;.CMD";
+
+/// Resolves the first command argument using only the child environment and requested cwd.
+pub fn resolve_windows_executable(
+    command: &[String],
+    cwd: &Path,
+    env_map: &HashMap<String, String>,
+) -> Result<PathBuf> {
+    if command.iter().any(|arg| arg.contains('\0')) {
+        return Err(anyhow!("Windows command arguments may not contain NUL"));
+    }
+    let program = command
+        .first()
+        .ok_or_else(|| anyhow!("cannot resolve an empty Windows command"))?;
+    if program.is_empty() {
+        return Err(anyhow!("cannot resolve an empty Windows executable"));
+    }
+    if !cwd.is_absolute() {
+        return Err(anyhow!("Windows executable cwd must be absolute"));
+    }
+
+    let program_path = Path::new(program);
+    if is_drive_relative(program_path) || (program_path.has_root() && !program_path.is_absolute()) {
+        return Err(anyhow!(
+            "drive-relative and root-relative Windows executable paths are not supported"
+        ));
+    }
+
+    let has_path = program_path.is_absolute()
+        || program.contains(['\\', '/'])
+        || program_path.components().count() > 1;
+    let bases = if has_path {
+        vec![if program_path.is_absolute() {
+            program_path.to_path_buf()
+        } else {
+            cwd.join(program_path)
+        }]
+    } else {
+        windows_search_dirs(cwd, env_map)
+            .into_iter()
+            .map(|dir| dir.join(program_path))
+            .collect()
+    };
+    let extensions = windows_env_value(env_map, "PATHEXT")
+        .unwrap_or(DEFAULT_PATHEXT)
+        .split(';')
+        .map(str::trim)
+        .filter(|extension| extension.starts_with('.') && extension.len() > 1)
+        .collect::<Vec<_>>();
+
+    for base in bases {
+        if !base.is_absolute() {
+            continue;
+        }
+        if program_path.extension().is_some() {
+            if is_existing_file(&base)? {
+                return ensure_directly_launchable(base);
+            }
+            continue;
+        }
+        for extension in &extensions {
+            let mut candidate = base.clone().into_os_string();
+            candidate.push(extension);
+            let candidate = PathBuf::from(candidate);
+            if is_existing_file(&candidate)? {
+                return ensure_directly_launchable(candidate);
+            }
+        }
+        if is_existing_file(&base)? {
+            return ensure_directly_launchable(base);
+        }
+    }
+
+    Err(anyhow!(
+        "Windows executable `{program}` was not found using the child PATH and PATHEXT"
+    ))
+}
+
+pub(crate) fn resolve_windows_launch(
+    mut launch: WindowsProcessLaunch,
+    cwd: &Path,
+    env_map: &HashMap<String, String>,
+) -> Result<WindowsProcessLaunch> {
+    if launch.application_path.is_none() {
+        launch.application_path = Some(resolve_windows_executable(&launch.command, cwd, env_map)?);
+    }
+    Ok(launch)
+}
+
+fn windows_search_dirs(cwd: &Path, env_map: &HashMap<String, String>) -> Vec<PathBuf> {
+    std::iter::once(cwd.to_path_buf())
+        .chain(
+            windows_env_value(env_map, "PATH")
+                .into_iter()
+                .flat_map(std::env::split_paths)
+                .filter(|dir| {
+                    !dir.as_os_str().is_empty()
+                        && !is_drive_relative(dir)
+                        && !(dir.has_root() && !dir.is_absolute())
+                })
+                .map(|dir| {
+                    if dir.is_absolute() {
+                        dir
+                    } else {
+                        cwd.join(dir)
+                    }
+                }),
+        )
+        .collect()
+}
+
+fn is_existing_file(path: &Path) -> Result<bool> {
+    match std::fs::metadata(path) {
+        Ok(metadata) => Ok(!metadata.is_dir()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            match std::fs::symlink_metadata(path) {
+                Ok(metadata) => Ok(!metadata.is_dir()),
+                Err(link_err) if link_err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+                Err(link_err) => Err(link_err)
+                    .with_context(|| format!("inspect Windows executable {}", path.display())),
+            }
+        }
+        Err(err) => {
+            Err(err).with_context(|| format!("inspect Windows executable {}", path.display()))
+        }
+    }
+}
+
+fn ensure_directly_launchable(path: PathBuf) -> Result<PathBuf> {
+    if path
+        .extension()
+        .and_then(OsStr::to_str)
+        .is_some_and(|extension| {
+            extension.eq_ignore_ascii_case("bat") || extension.eq_ignore_ascii_case("cmd")
+        })
+    {
+        return Err(anyhow!(
+            "Windows batch file `{}` must be launched through cmd.exe",
+            path.display()
+        ));
+    }
+    Ok(path)
+}
+
+fn is_drive_relative(path: &Path) -> bool {
+    !path.has_root()
+        && matches!(
+            path.components().next(),
+            Some(Component::Prefix(prefix)) if matches!(prefix.kind(), Prefix::Disk(_))
+        )
+}
+
+fn windows_env_value<'a>(env_map: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
+    env_map
+        .get(key)
+        .or_else(|| {
+            env_map
+                .iter()
+                .find(|(existing, _)| existing.eq_ignore_ascii_case(key))
+                .map(|(_, value)| value)
+        })
+        .map(String::as_str)
+}
+
+#[cfg(test)]
+#[path = "command_resolution_tests.rs"]
+mod tests;

--- a/codex-rs/windows-sandbox-rs/src/command_resolution.rs
+++ b/codex-rs/windows-sandbox-rs/src/command_resolution.rs
@@ -107,7 +107,7 @@ fn windows_search_dirs(cwd: &Path, env_map: &HashMap<String, String>) -> Vec<Pat
                 .filter(|dir| {
                     !dir.as_os_str().is_empty()
                         && !is_drive_relative(dir)
-                        && !(dir.has_root() && !dir.is_absolute())
+                        && (!dir.has_root() || dir.is_absolute())
                 })
                 .map(|dir| {
                     if dir.is_absolute() {

--- a/codex-rs/windows-sandbox-rs/src/command_resolution.rs
+++ b/codex-rs/windows-sandbox-rs/src/command_resolution.rs
@@ -1,4 +1,5 @@
-use crate::process::WindowsProcessLaunch;
+use crate::env::windows_env_value;
+use crate::process::ResolvedWindowsProcessLaunch;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
@@ -88,14 +89,15 @@ pub fn resolve_windows_executable(
 }
 
 pub(crate) fn resolve_windows_launch(
-    mut launch: WindowsProcessLaunch,
+    command: Vec<String>,
     cwd: &Path,
     env_map: &HashMap<String, String>,
-) -> Result<WindowsProcessLaunch> {
-    if launch.application_path.is_none() {
-        launch.application_path = Some(resolve_windows_executable(&launch.command, cwd, env_map)?);
-    }
-    Ok(launch)
+) -> Result<ResolvedWindowsProcessLaunch> {
+    let application_path = resolve_windows_executable(&command, cwd, env_map)?;
+    Ok(ResolvedWindowsProcessLaunch {
+        application_path,
+        command,
+    })
 }
 
 fn windows_search_dirs(cwd: &Path, env_map: &HashMap<String, String>) -> Vec<PathBuf> {
@@ -159,18 +161,6 @@ fn is_drive_relative(path: &Path) -> bool {
             path.components().next(),
             Some(Component::Prefix(prefix)) if matches!(prefix.kind(), Prefix::Disk(_))
         )
-}
-
-fn windows_env_value<'a>(env_map: &'a HashMap<String, String>, key: &str) -> Option<&'a str> {
-    env_map
-        .get(key)
-        .or_else(|| {
-            env_map
-                .iter()
-                .find(|(existing, _)| existing.eq_ignore_ascii_case(key))
-                .map(|(_, value)| value)
-        })
-        .map(String::as_str)
 }
 
 #[cfg(test)]

--- a/codex-rs/windows-sandbox-rs/src/command_resolution_tests.rs
+++ b/codex-rs/windows-sandbox-rs/src/command_resolution_tests.rs
@@ -59,29 +59,6 @@ fn requested_cwd_precedes_child_path() {
 }
 
 #[test]
-fn keeps_long_and_lexical_paths_unchanged() {
-    let temp = TempDir::new().expect("tempdir");
-    let mut cwd = temp.path().to_path_buf();
-    while cwd.to_string_lossy().len() <= 270 {
-        cwd.push("long-working-directory-segment");
-    }
-    fs::create_dir_all(cwd.join("nested")).expect("create long cwd");
-    let executable = cwd.join("tool.EXE");
-    fs::write(&executable, b"fixture").expect("write executable fixture");
-    let lexical = cwd.join("nested").join("..").join("tool.EXE");
-
-    assert_eq!(
-        resolve_windows_executable(
-            &[lexical.to_string_lossy().into_owned()],
-            &cwd,
-            &HashMap::new(),
-        )
-        .expect("resolve long lexical executable"),
-        lexical
-    );
-}
-
-#[test]
 fn keeps_extended_length_paths_unchanged() {
     let executable = dunce::canonicalize(std::env::current_exe().expect("current executable"))
         .expect("canonical current executable");

--- a/codex-rs/windows-sandbox-rs/src/command_resolution_tests.rs
+++ b/codex-rs/windows-sandbox-rs/src/command_resolution_tests.rs
@@ -59,6 +59,29 @@ fn requested_cwd_precedes_child_path() {
 }
 
 #[test]
+fn keeps_long_and_lexical_paths_unchanged() {
+    let temp = TempDir::new().expect("tempdir");
+    let mut cwd = temp.path().to_path_buf();
+    while cwd.to_string_lossy().len() <= 270 {
+        cwd.push("long-working-directory-segment");
+    }
+    fs::create_dir_all(cwd.join("nested")).expect("create long cwd");
+    let executable = cwd.join("tool.EXE");
+    fs::write(&executable, b"fixture").expect("write executable fixture");
+    let lexical = cwd.join("nested").join("..").join("tool.EXE");
+
+    assert_eq!(
+        resolve_windows_executable(
+            &[lexical.to_string_lossy().into_owned()],
+            &cwd,
+            &HashMap::new(),
+        )
+        .expect("resolve long lexical executable"),
+        lexical
+    );
+}
+
+#[test]
 fn keeps_extended_length_paths_unchanged() {
     let executable = dunce::canonicalize(std::env::current_exe().expect("current executable"))
         .expect("canonical current executable");

--- a/codex-rs/windows-sandbox-rs/src/command_resolution_tests.rs
+++ b/codex-rs/windows-sandbox-rs/src/command_resolution_tests.rs
@@ -1,0 +1,150 @@
+use super::resolve_windows_executable;
+use super::resolve_windows_launch;
+use crate::process::WindowsProcessLaunch;
+use pretty_assertions::assert_eq;
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+fn unresolved(program: &str) -> WindowsProcessLaunch {
+    WindowsProcessLaunch {
+        application_path: None,
+        command: vec![program.to_string(), "argument".to_string()],
+    }
+}
+
+#[test]
+fn resolves_with_case_insensitive_child_path_and_pathext() {
+    let temp = TempDir::new().expect("tempdir");
+    let cwd = temp.path().join("cwd");
+    let tools = temp.path().join("tools");
+    fs::create_dir_all(&cwd).expect("create cwd");
+    fs::create_dir_all(&tools).expect("create tools");
+    let executable = tools.join("child-only.BIN");
+    fs::write(&executable, b"fixture").expect("write executable fixture");
+    let env = HashMap::from([
+        ("Path".to_string(), tools.to_string_lossy().into_owned()),
+        ("PathExt".to_string(), ".BIN".to_string()),
+    ]);
+
+    let launch = resolve_windows_launch(unresolved("child-only"), &cwd, &env)
+        .expect("resolve from child environment");
+
+    assert_eq!(
+        launch,
+        WindowsProcessLaunch {
+            application_path: Some(executable),
+            command: vec!["child-only".to_string(), "argument".to_string()],
+        }
+    );
+}
+
+#[test]
+fn requested_cwd_precedes_child_path() {
+    let temp = TempDir::new().expect("tempdir");
+    let cwd = temp.path().join("cwd");
+    let tools = temp.path().join("tools");
+    fs::create_dir_all(&cwd).expect("create cwd");
+    fs::create_dir_all(&tools).expect("create tools");
+    let cwd_executable = cwd.join("tool.EXE");
+    fs::write(&cwd_executable, b"cwd").expect("write cwd fixture");
+    fs::write(tools.join("tool.EXE"), b"path").expect("write PATH fixture");
+    let env = HashMap::from([("PATH".to_string(), tools.to_string_lossy().into_owned())]);
+
+    assert_eq!(
+        resolve_windows_executable(&["tool".to_string()], &cwd, &env).expect("resolve executable"),
+        cwd_executable
+    );
+}
+
+#[test]
+fn keeps_long_and_lexical_paths_unchanged() {
+    let temp = TempDir::new().expect("tempdir");
+    let mut cwd = temp.path().to_path_buf();
+    while cwd.to_string_lossy().len() <= 270 {
+        cwd.push("long-working-directory-segment");
+    }
+    fs::create_dir_all(cwd.join("nested")).expect("create long cwd");
+    let executable = cwd.join("tool.EXE");
+    fs::write(&executable, b"fixture").expect("write executable fixture");
+    let lexical = cwd.join("nested").join("..").join("tool.EXE");
+
+    assert_eq!(
+        resolve_windows_executable(
+            &[lexical.to_string_lossy().into_owned()],
+            &cwd,
+            &HashMap::new(),
+        )
+        .expect("resolve long lexical executable"),
+        lexical
+    );
+}
+
+#[test]
+fn keeps_extended_length_paths_unchanged() {
+    let executable = dunce::canonicalize(std::env::current_exe().expect("current executable"))
+        .expect("canonical current executable");
+    let executable_text = executable.to_string_lossy();
+    let extended = if executable_text.starts_with(r"\\?\") {
+        executable
+    } else if let Some(unc) = executable_text.strip_prefix(r"\\") {
+        PathBuf::from(format!(r"\\?\UNC\{unc}"))
+    } else {
+        PathBuf::from(format!(r"\\?\{executable_text}"))
+    };
+    let cwd = std::env::current_dir().expect("current dir");
+
+    assert_eq!(
+        resolve_windows_executable(
+            &[extended.to_string_lossy().into_owned()],
+            &cwd,
+            &HashMap::new(),
+        )
+        .expect("resolve extended-length executable"),
+        extended
+    );
+}
+
+#[test]
+fn does_not_fall_back_to_the_parent_path() {
+    let temp = TempDir::new().expect("tempdir");
+    let cwd = temp.path();
+    let env = HashMap::from([
+        ("PATH".to_string(), String::new()),
+        ("PATHEXT".to_string(), ".EXE".to_string()),
+    ]);
+
+    let err = resolve_windows_executable(&["cmd".to_string()], cwd, &env)
+        .expect_err("parent PATH must not be consulted");
+
+    assert!(err.to_string().contains("child PATH and PATHEXT"));
+}
+
+#[test]
+fn rejects_batch_files_instead_of_skipping_to_a_later_candidate() {
+    let temp = TempDir::new().expect("tempdir");
+    let cwd = temp.path().join("cwd");
+    let first = temp.path().join("first");
+    let second = temp.path().join("second");
+    for directory in [&cwd, &first, &second] {
+        fs::create_dir_all(directory).expect("create directory");
+    }
+    fs::write(first.join("tool.CMD"), b"@exit /b 0\r\n").expect("write batch fixture");
+    fs::write(second.join("tool.EXE"), b"fixture").expect("write executable fixture");
+    let env = HashMap::from([
+        (
+            "PATH".to_string(),
+            std::env::join_paths([first, second])
+                .expect("join PATH")
+                .to_string_lossy()
+                .into_owned(),
+        ),
+        ("PATHEXT".to_string(), ".CMD;.EXE".to_string()),
+    ]);
+
+    let err = resolve_windows_executable(&["tool".to_string()], &cwd, &env)
+        .expect_err("batch candidate should fail closed");
+
+    assert!(err.to_string().contains("must be launched through cmd.exe"));
+}

--- a/codex-rs/windows-sandbox-rs/src/command_resolution_tests.rs
+++ b/codex-rs/windows-sandbox-rs/src/command_resolution_tests.rs
@@ -1,18 +1,11 @@
 use super::resolve_windows_executable;
 use super::resolve_windows_launch;
-use crate::process::WindowsProcessLaunch;
+use crate::process::ResolvedWindowsProcessLaunch;
 use pretty_assertions::assert_eq;
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 use tempfile::TempDir;
-
-fn unresolved(program: &str) -> WindowsProcessLaunch {
-    WindowsProcessLaunch {
-        application_path: None,
-        command: vec![program.to_string(), "argument".to_string()],
-    }
-}
 
 #[test]
 fn resolves_with_case_insensitive_child_path_and_pathext() {
@@ -28,13 +21,17 @@ fn resolves_with_case_insensitive_child_path_and_pathext() {
         ("PathExt".to_string(), ".BIN".to_string()),
     ]);
 
-    let launch = resolve_windows_launch(unresolved("child-only"), &cwd, &env)
-        .expect("resolve from child environment");
+    let launch = resolve_windows_launch(
+        vec!["child-only".to_string(), "argument".to_string()],
+        &cwd,
+        &env,
+    )
+    .expect("resolve from child environment");
 
     assert_eq!(
         launch,
-        WindowsProcessLaunch {
-            application_path: Some(executable),
+        ResolvedWindowsProcessLaunch {
+            application_path: executable,
             command: vec!["child-only".to_string(), "argument".to_string()],
         }
     );

--- a/codex-rs/windows-sandbox-rs/src/conpty/mod.rs
+++ b/codex-rs/windows-sandbox-rs/src/conpty/mod.rs
@@ -12,6 +12,7 @@ use crate::process::WindowsProcessLaunch;
 use crate::winutil::format_last_error;
 use crate::winutil::quote_windows_arg;
 use crate::winutil::to_wide;
+use crate::winutil::to_win32_path_wide;
 use anyhow::Context;
 use anyhow::Result;
 use codex_utils_pty::PsuedoCon;
@@ -143,7 +144,7 @@ pub fn spawn_conpty_process_as_user(
             0,
             EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
             env_block.as_ptr() as *mut c_void,
-            to_wide(cwd).as_ptr(),
+            to_win32_path_wide(cwd).as_ptr(),
             &si.StartupInfo,
             &mut pi,
         )

--- a/codex-rs/windows-sandbox-rs/src/conpty/mod.rs
+++ b/codex-rs/windows-sandbox-rs/src/conpty/mod.rs
@@ -8,7 +8,7 @@
 
 use crate::desktop::LaunchDesktop;
 use crate::proc_thread_attr::ProcThreadAttributeList;
-use crate::process::WindowsProcessLaunch;
+use crate::process::ResolvedWindowsProcessLaunch;
 use crate::winutil::format_last_error;
 use crate::winutil::quote_windows_arg;
 use crate::winutil::to_wide;
@@ -92,7 +92,7 @@ pub fn create_conpty(cols: i16, rows: i16) -> Result<ConptyInstance> {
 #[doc(hidden)]
 pub fn spawn_conpty_process_as_user(
     h_token: HANDLE,
-    launch: &WindowsProcessLaunch,
+    launch: &ResolvedWindowsProcessLaunch,
     cwd: &Path,
     env_map: &HashMap<String, String>,
     use_private_desktop: bool,
@@ -105,10 +105,7 @@ pub fn spawn_conpty_process_as_user(
         .collect::<Vec<_>>()
         .join(" ");
     let mut cmdline: Vec<u16> = to_wide(&cmdline_str);
-    let application_name = launch.application_path.as_deref().map(to_wide);
-    let application_name_ptr = application_name
-        .as_ref()
-        .map_or(std::ptr::null(), Vec::as_ptr);
+    let application_name = to_wide(&launch.application_path);
     let env_block = make_env_block(env_map);
     let mut si: STARTUPINFOEXW = unsafe { std::mem::zeroed() };
     si.StartupInfo.cb = std::mem::size_of::<STARTUPINFOEXW>() as u32;
@@ -136,7 +133,7 @@ pub fn spawn_conpty_process_as_user(
     let ok = unsafe {
         CreateProcessAsUserW(
             h_token,
-            application_name_ptr,
+            application_name.as_ptr(),
             cmdline.as_mut_ptr(),
             std::ptr::null_mut(),
             std::ptr::null_mut(),

--- a/codex-rs/windows-sandbox-rs/src/conpty/mod.rs
+++ b/codex-rs/windows-sandbox-rs/src/conpty/mod.rs
@@ -12,7 +12,6 @@ use crate::process::WindowsProcessLaunch;
 use crate::winutil::format_last_error;
 use crate::winutil::quote_windows_arg;
 use crate::winutil::to_wide;
-use crate::winutil::to_win32_path_wide;
 use anyhow::Context;
 use anyhow::Result;
 use codex_utils_pty::PsuedoCon;
@@ -144,7 +143,7 @@ pub fn spawn_conpty_process_as_user(
             0,
             EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
             env_block.as_ptr() as *mut c_void,
-            to_win32_path_wide(cwd).as_ptr(),
+            to_wide(cwd).as_ptr(),
             &si.StartupInfo,
             &mut pi,
         )

--- a/codex-rs/windows-sandbox-rs/src/elevated/ipc_framed.rs
+++ b/codex-rs/windows-sandbox-rs/src/elevated/ipc_framed.rs
@@ -7,7 +7,7 @@
 //! not use this protocol, and non‑unified exec capture uses it only when running
 //! through the elevated runner.
 
-use crate::process::WindowsProcessLaunch;
+use crate::process::ResolvedWindowsProcessLaunch;
 use anyhow::Result;
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD;
@@ -58,7 +58,7 @@ pub enum Message {
 /// Spawn parameters sent from parent to runner.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct SpawnRequest {
-    pub launch: WindowsProcessLaunch,
+    pub launch: ResolvedWindowsProcessLaunch,
     pub cwd: PathBuf,
     pub env: HashMap<String, String>,
     pub permission_profile: PermissionProfile,
@@ -213,8 +213,8 @@ mod tests {
             AbsolutePathBuf::from_absolute_path(PathBuf::from(r"C:\workspace"))
                 .expect("absolute workspace root"),
         ];
-        let launch = WindowsProcessLaunch {
-            application_path: Some(PathBuf::from(r"C:\Windows\System32\cmd.exe")),
+        let launch = ResolvedWindowsProcessLaunch {
+            application_path: PathBuf::from(r"C:\Windows\System32\cmd.exe"),
             command: vec!["cmd.exe".to_string(), "/c".to_string(), "ver".to_string()],
         };
         let msg = FramedMessage {

--- a/codex-rs/windows-sandbox-rs/src/elevated/runner_client.rs
+++ b/codex-rs/windows-sandbox-rs/src/elevated/runner_client.rs
@@ -16,7 +16,6 @@ use crate::runner_pipe::find_runner_exe;
 use crate::runner_pipe::pipe_pair;
 use crate::winutil::quote_windows_arg;
 use crate::winutil::to_wide;
-use crate::winutil::to_win32_path_wide;
 use anyhow::Context;
 use anyhow::Result;
 use std::ffi::c_void;
@@ -343,7 +342,7 @@ pub(crate) fn spawn_runner_transport(
     );
     let mut cmdline_vec = to_wide(&runner_full_cmd);
     let exe_w = to_wide(&runner_cmdline);
-    let cwd_w = to_win32_path_wide(cwd);
+    let cwd_w = to_wide(cwd);
     let user_w = to_wide(&sandbox_creds.username);
     let domain_w = to_wide(".");
     let password_w = to_wide(&sandbox_creds.password);

--- a/codex-rs/windows-sandbox-rs/src/elevated/runner_client.rs
+++ b/codex-rs/windows-sandbox-rs/src/elevated/runner_client.rs
@@ -16,6 +16,7 @@ use crate::runner_pipe::find_runner_exe;
 use crate::runner_pipe::pipe_pair;
 use crate::winutil::quote_windows_arg;
 use crate::winutil::to_wide;
+use crate::winutil::to_win32_path_wide;
 use anyhow::Context;
 use anyhow::Result;
 use std::ffi::c_void;
@@ -342,7 +343,7 @@ pub(crate) fn spawn_runner_transport(
     );
     let mut cmdline_vec = to_wide(&runner_full_cmd);
     let exe_w = to_wide(&runner_cmdline);
-    let cwd_w = to_wide(cwd);
+    let cwd_w = to_win32_path_wide(cwd);
     let user_w = to_wide(&sandbox_creds.username);
     let domain_w = to_wide(".");
     let password_w = to_wide(&sandbox_creds.password);

--- a/codex-rs/windows-sandbox-rs/src/elevated/runner_client.rs
+++ b/codex-rs/windows-sandbox-rs/src/elevated/runner_client.rs
@@ -7,6 +7,7 @@ use crate::ipc_framed::Message;
 use crate::ipc_framed::SpawnRequest;
 use crate::ipc_framed::read_frame;
 use crate::ipc_framed::write_frame;
+use crate::process::WindowsProcessLaunch;
 use crate::runner_pipe::PIPE_ACCESS_INBOUND;
 use crate::runner_pipe::PIPE_ACCESS_OUTBOUND;
 use crate::runner_pipe::connect_pipe;
@@ -102,18 +103,25 @@ fn is_refreshable_windows_error(code: u32) -> bool {
     matches!(code, ERROR_LOGON_FAILURE | ERROR_NO_SUCH_LOGON_SESSION)
 }
 
-fn command_targets_windows_apps(command: &[String]) -> bool {
-    command.first().is_some_and(|program| {
-        Path::new(program).components().any(|component| {
-            component
-                .as_os_str()
-                .to_string_lossy()
-                .eq_ignore_ascii_case("WindowsApps")
+fn command_targets_windows_apps(launch: &WindowsProcessLaunch) -> bool {
+    launch
+        .application_path
+        .as_deref()
+        .or_else(|| launch.command.first().map(Path::new))
+        .is_some_and(|program| {
+            program.components().any(|component| {
+                component
+                    .as_os_str()
+                    .to_string_lossy()
+                    .eq_ignore_ascii_case("WindowsApps")
+            })
         })
-    })
 }
 
-pub(crate) fn is_refreshable_sandbox_creds_error(err: &anyhow::Error, command: &[String]) -> bool {
+pub(crate) fn is_refreshable_sandbox_creds_error(
+    err: &anyhow::Error,
+    launch: &WindowsProcessLaunch,
+) -> bool {
     if err
         .downcast_ref::<RunnerLogonError>()
         .is_some_and(|err| is_refreshable_windows_error(err.code))
@@ -128,20 +136,20 @@ pub(crate) fn is_refreshable_sandbox_creds_error(err: &anyhow::Error, command: &
                 // account password cannot make the same WindowsApps command launch.
                 is_refreshable_windows_error(code)
                     && (code != ERROR_NO_SUCH_LOGON_SESSION
-                        || !command_targets_windows_apps(command))
+                        || !command_targets_windows_apps(launch))
             })
     })
 }
 
 pub(crate) fn retry_runner_spawn_once<T>(
     sandbox_creds: SandboxCreds,
-    command: &[String],
+    launch: &WindowsProcessLaunch,
     mut spawn: impl FnMut(SandboxCreds) -> Result<T>,
     refresh: impl FnOnce() -> Result<SandboxCreds>,
 ) -> Result<T> {
     match spawn(sandbox_creds) {
         Ok(result) => Ok(result),
-        Err(err) if is_refreshable_sandbox_creds_error(&err, command) => spawn(refresh()?),
+        Err(err) if is_refreshable_sandbox_creds_error(&err, launch) => spawn(refresh()?),
         Err(err) => Err(err),
     }
 }
@@ -493,13 +501,19 @@ mod tests {
     use super::is_refreshable_sandbox_creds_error;
     use crate::ipc_framed::ErrorPayload;
     use crate::ipc_framed::ErrorStage;
+    use crate::process::WindowsProcessLaunch;
     use pretty_assertions::assert_eq;
+    use std::path::PathBuf;
     use windows_sys::Win32::Foundation::ERROR_LOGON_FAILURE;
     use windows_sys::Win32::Foundation::ERROR_NO_SUCH_LOGON_SESSION;
     use windows_sys::Win32::Foundation::ERROR_NOT_FOUND;
 
     #[test]
     fn refreshable_sandbox_creds_error_recognizes_credential_and_child_start_failures() {
+        let launch = WindowsProcessLaunch {
+            application_path: None,
+            command: vec!["cmd.exe".to_string()],
+        };
         assert_eq!(
             [
                 ERROR_LOGON_FAILURE,
@@ -509,7 +523,7 @@ mod tests {
             .map(|code| {
                 let err =
                     anyhow::Error::new(RunnerLogonError { code }).context("runner launch failed");
-                is_refreshable_sandbox_creds_error(&err, &[])
+                is_refreshable_sandbox_creds_error(&err, &launch)
             }),
             [true, true, false]
         );
@@ -526,28 +540,33 @@ mod tests {
                     stage,
                     windows_error_code: Some(windows_error_code),
                 }));
-                is_refreshable_sandbox_creds_error(&err, &["cmd.exe".to_string()])
+                is_refreshable_sandbox_creds_error(&err, &launch)
             }),
             [true, false, false]
         );
 
-        let windows_apps_commands = [
-            vec![
-                r"C:\Users\user\AppData\Local\Microsoft\WindowsApps\pwsh.exe".to_string(),
-            ],
-            vec![
-                r"C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.3.0_x64__8wekyb3d8bbwe\pwsh.exe"
-                    .to_string(),
-            ],
+        let windows_apps_launches = [
+            WindowsProcessLaunch {
+                application_path: Some(PathBuf::from(
+                    r"C:\Users\user\AppData\Local\Microsoft\WindowsApps\pwsh.exe",
+                )),
+                command: vec!["pwsh.exe".to_string()],
+            },
+            WindowsProcessLaunch {
+                application_path: Some(PathBuf::from(
+                    r"C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.3.0_x64__8wekyb3d8bbwe\pwsh.exe",
+                )),
+                command: vec!["pwsh.exe".to_string()],
+            },
         ];
         assert_eq!(
-            windows_apps_commands.map(|command| {
+            windows_apps_launches.map(|launch| {
                 let err = anyhow::Error::new(RunnerStartupError::new(ErrorPayload {
                     message: "runner startup failed".to_string(),
                     stage: ErrorStage::SpawnChild,
                     windows_error_code: Some(ERROR_NO_SUCH_LOGON_SESSION),
                 }));
-                is_refreshable_sandbox_creds_error(&err, &command)
+                is_refreshable_sandbox_creds_error(&err, &launch)
             }),
             [false, false]
         );

--- a/codex-rs/windows-sandbox-rs/src/elevated/runner_client.rs
+++ b/codex-rs/windows-sandbox-rs/src/elevated/runner_client.rs
@@ -7,7 +7,7 @@ use crate::ipc_framed::Message;
 use crate::ipc_framed::SpawnRequest;
 use crate::ipc_framed::read_frame;
 use crate::ipc_framed::write_frame;
-use crate::process::WindowsProcessLaunch;
+use crate::process::ResolvedWindowsProcessLaunch;
 use crate::runner_pipe::PIPE_ACCESS_INBOUND;
 use crate::runner_pipe::PIPE_ACCESS_OUTBOUND;
 use crate::runner_pipe::connect_pipe;
@@ -103,24 +103,18 @@ fn is_refreshable_windows_error(code: u32) -> bool {
     matches!(code, ERROR_LOGON_FAILURE | ERROR_NO_SUCH_LOGON_SESSION)
 }
 
-fn command_targets_windows_apps(launch: &WindowsProcessLaunch) -> bool {
-    launch
-        .application_path
-        .as_deref()
-        .or_else(|| launch.command.first().map(Path::new))
-        .is_some_and(|program| {
-            program.components().any(|component| {
-                component
-                    .as_os_str()
-                    .to_string_lossy()
-                    .eq_ignore_ascii_case("WindowsApps")
-            })
-        })
+fn command_targets_windows_apps(launch: &ResolvedWindowsProcessLaunch) -> bool {
+    launch.application_path.components().any(|component| {
+        component
+            .as_os_str()
+            .to_string_lossy()
+            .eq_ignore_ascii_case("WindowsApps")
+    })
 }
 
 pub(crate) fn is_refreshable_sandbox_creds_error(
     err: &anyhow::Error,
-    launch: &WindowsProcessLaunch,
+    launch: &ResolvedWindowsProcessLaunch,
 ) -> bool {
     if err
         .downcast_ref::<RunnerLogonError>()
@@ -143,7 +137,7 @@ pub(crate) fn is_refreshable_sandbox_creds_error(
 
 pub(crate) fn retry_runner_spawn_once<T>(
     sandbox_creds: SandboxCreds,
-    launch: &WindowsProcessLaunch,
+    launch: &ResolvedWindowsProcessLaunch,
     mut spawn: impl FnMut(SandboxCreds) -> Result<T>,
     refresh: impl FnOnce() -> Result<SandboxCreds>,
 ) -> Result<T> {
@@ -501,7 +495,7 @@ mod tests {
     use super::is_refreshable_sandbox_creds_error;
     use crate::ipc_framed::ErrorPayload;
     use crate::ipc_framed::ErrorStage;
-    use crate::process::WindowsProcessLaunch;
+    use crate::process::ResolvedWindowsProcessLaunch;
     use pretty_assertions::assert_eq;
     use std::path::PathBuf;
     use windows_sys::Win32::Foundation::ERROR_LOGON_FAILURE;
@@ -510,8 +504,8 @@ mod tests {
 
     #[test]
     fn refreshable_sandbox_creds_error_recognizes_credential_and_child_start_failures() {
-        let launch = WindowsProcessLaunch {
-            application_path: None,
+        let launch = ResolvedWindowsProcessLaunch {
+            application_path: PathBuf::from(r"C:\Windows\System32\cmd.exe"),
             command: vec!["cmd.exe".to_string()],
         };
         assert_eq!(
@@ -546,16 +540,16 @@ mod tests {
         );
 
         let windows_apps_launches = [
-            WindowsProcessLaunch {
-                application_path: Some(PathBuf::from(
+            ResolvedWindowsProcessLaunch {
+                application_path: PathBuf::from(
                     r"C:\Users\user\AppData\Local\Microsoft\WindowsApps\pwsh.exe",
-                )),
+                ),
                 command: vec!["pwsh.exe".to_string()],
             },
-            WindowsProcessLaunch {
-                application_path: Some(PathBuf::from(
+            ResolvedWindowsProcessLaunch {
+                application_path: PathBuf::from(
                     r"C:\Program Files\WindowsApps\Microsoft.PowerShell_7.6.3.0_x64__8wekyb3d8bbwe\pwsh.exe",
-                )),
+                ),
                 command: vec!["pwsh.exe".to_string()],
             },
         ];

--- a/codex-rs/windows-sandbox-rs/src/elevated_impl.rs
+++ b/codex-rs/windows-sandbox-rs/src/elevated_impl.rs
@@ -24,14 +24,7 @@ pub struct ElevatedSandboxProfileCaptureRequest<'a> {
 
 mod windows_impl {
     use super::ElevatedSandboxProfileCaptureRequest;
-    use crate::acl::allow_null_device;
-    use crate::cap::load_or_create_cap_sids;
-    use crate::cap::workspace_write_cap_sid_for_root;
-    use crate::env::ensure_non_interactive_pager;
-    use crate::env::inherit_path_env;
-    use crate::env::normalize_null_device_env;
     use crate::identity::refresh_logon_sandbox_creds;
-    use crate::identity::require_logon_sandbox_creds;
     use crate::ipc_framed::EmptyPayload;
     use crate::ipc_framed::FramedMessage;
     use crate::ipc_framed::Message;
@@ -41,20 +34,15 @@ mod windows_impl {
     use crate::ipc_framed::read_frame;
     use crate::ipc_framed::write_frame;
     use crate::logging::log_failure;
-    use crate::logging::log_start;
     use crate::logging::log_success;
     use crate::process::WindowsProcessLaunch;
     use crate::resolved_permissions::ResolvedWindowsSandboxPermissions;
     use crate::runner_client::retry_runner_spawn_once;
     use crate::runner_client::spawn_runner_transport;
-    use crate::sandbox_utils::ensure_codex_home_exists;
-    use crate::sandbox_utils::inject_git_safe_directory;
-    use crate::setup::effective_write_roots_for_permissions;
-    use crate::token::LocalSid;
+    use crate::spawn_prep::prepare_elevated_spawn_context_for_permissions;
     use anyhow::Result;
     use codex_utils_absolute_path::AbsolutePathBuf;
     use std::fs::File;
-    use std::path::Path;
     use std::sync::Arc;
     use std::sync::atomic::AtomicBool;
     use std::sync::atomic::Ordering;
@@ -130,21 +118,15 @@ mod windows_impl {
             .iter()
             .map(AbsolutePathBuf::to_path_buf)
             .collect::<Vec<_>>();
-        normalize_null_device_env(&mut env_map);
-        ensure_non_interactive_pager(&mut env_map);
-        inherit_path_env(&mut env_map);
-        inject_git_safe_directory(&mut env_map, cwd);
-        // Use a temp-based log dir that the sandbox user can write.
-        let sandbox_base = codex_home.join(".sandbox");
-        ensure_codex_home_exists(&sandbox_base)?;
-
-        let logs_base_dir: Option<&Path> = Some(sandbox_base.as_path());
-        log_start(&command, logs_base_dir);
-        let sandbox_creds = require_logon_sandbox_creds(
-            &permissions,
-            cwd,
-            &env_map,
+        let elevated = prepare_elevated_spawn_context_for_permissions(
+            permissions.clone(),
             codex_home,
+            cwd,
+            &mut env_map,
+            WindowsProcessLaunch {
+                application_path: None,
+                command: command.clone(),
+            },
             read_roots_override,
             read_roots_include_platform_defaults,
             write_roots_override,
@@ -153,40 +135,17 @@ mod windows_impl {
             proxy_enforced,
             crate::WindowsSandboxProxySettingsMode::Reconcile,
         )?;
-        // Build capability SID for ACL grants.
-        let caps = load_or_create_cap_sids(codex_home)?;
-        let (sid_for_null, cap_sids) = if permissions.uses_write_capabilities_for_cwd(cwd, &env_map)
-        {
-            let write_roots = effective_write_roots_for_permissions(
-                &permissions,
-                cwd,
-                &env_map,
-                codex_home,
-                write_roots_override,
-            );
-            let cap_sids = write_roots
-                .iter()
-                .map(|root| workspace_write_cap_sid_for_root(codex_home, cwd, root))
-                .collect::<Result<Vec<_>>>()?;
-            if cap_sids.is_empty() {
-                anyhow::bail!("workspace-write sandbox has no writable root capability SIDs");
-            }
-            (LocalSid::from_string(&cap_sids[0])?, cap_sids)
-        } else {
-            let sid = LocalSid::from_string(&caps.readonly)?;
-            (sid, vec![caps.readonly])
-        };
-
-        unsafe {
-            allow_null_device(sid_for_null.as_ptr());
-        }
+        let sandbox_creds = elevated.sandbox_creds;
+        let sandbox_base = elevated.sandbox_base;
+        let logs_base_dir = elevated.logs_base_dir;
+        let cap_sids = elevated.cap_sids;
+        let launch = elevated.launch;
+        let resolved_read_roots = elevated.read_roots_override;
+        let logs_base_dir = logs_base_dir.as_deref();
 
         (|| -> Result<CaptureResult> {
             let spawn_request = SpawnRequest {
-                launch: WindowsProcessLaunch {
-                    application_path: None,
-                    command: command.clone(),
-                },
+                launch,
                 cwd: cwd.to_path_buf(),
                 env: env_map.clone(),
                 permission_profile: permission_profile.clone(),
@@ -201,7 +160,7 @@ mod windows_impl {
             };
             let transport = retry_runner_spawn_once(
                 sandbox_creds,
-                &spawn_request.launch.command,
+                &spawn_request.launch,
                 |sandbox_creds| {
                     spawn_runner_transport(
                         codex_home,
@@ -217,7 +176,7 @@ mod windows_impl {
                         cwd,
                         &env_map,
                         codex_home,
-                        read_roots_override,
+                        Some(&resolved_read_roots),
                         read_roots_include_platform_defaults,
                         write_roots_override,
                         &deny_read_paths_override,

--- a/codex-rs/windows-sandbox-rs/src/elevated_impl.rs
+++ b/codex-rs/windows-sandbox-rs/src/elevated_impl.rs
@@ -24,6 +24,7 @@ pub struct ElevatedSandboxProfileCaptureRequest<'a> {
 
 mod windows_impl {
     use super::ElevatedSandboxProfileCaptureRequest;
+    use crate::env::inherit_path_env;
     use crate::identity::refresh_logon_sandbox_creds;
     use crate::ipc_framed::EmptyPayload;
     use crate::ipc_framed::FramedMessage;
@@ -35,7 +36,6 @@ mod windows_impl {
     use crate::ipc_framed::write_frame;
     use crate::logging::log_failure;
     use crate::logging::log_success;
-    use crate::process::WindowsProcessLaunch;
     use crate::resolved_permissions::ResolvedWindowsSandboxPermissions;
     use crate::runner_client::retry_runner_spawn_once;
     use crate::runner_client::spawn_runner_transport;
@@ -118,15 +118,13 @@ mod windows_impl {
             .iter()
             .map(AbsolutePathBuf::to_path_buf)
             .collect::<Vec<_>>();
+        inherit_path_env(&mut env_map);
         let elevated = prepare_elevated_spawn_context_for_permissions(
             permissions.clone(),
             codex_home,
             cwd,
             &mut env_map,
-            WindowsProcessLaunch {
-                application_path: None,
-                command: command.clone(),
-            },
+            command.clone(),
             read_roots_override,
             read_roots_include_platform_defaults,
             write_roots_override,

--- a/codex-rs/windows-sandbox-rs/src/env.rs
+++ b/codex-rs/windows-sandbox-rs/src/env.rs
@@ -33,12 +33,12 @@ pub fn ensure_non_interactive_pager(env_map: &mut HashMap<String, String>) {
 
 // Keep PATH and PATHEXT stable for callers that rely on inheriting the parent process env.
 pub fn inherit_path_env(env_map: &mut HashMap<String, String>) {
-    if !env_map.contains_key("PATH")
+    if windows_env_value(env_map, "PATH").is_none()
         && let Ok(path) = env::var("PATH")
     {
         env_map.insert("PATH".into(), path);
     }
-    if !env_map.contains_key("PATHEXT")
+    if windows_env_value(env_map, "PATHEXT").is_none()
         && let Ok(pathext) = env::var("PATHEXT")
     {
         env_map.insert("PATHEXT".into(), pathext);
@@ -46,10 +46,8 @@ pub fn inherit_path_env(env_map: &mut HashMap<String, String>) {
 }
 
 fn prepend_path(env_map: &mut HashMap<String, String>, prefix: &str) {
-    let existing = env_map
-        .get("PATH")
+    let existing = windows_env_value(env_map, "PATH")
         .cloned()
-        .or_else(|| env::var("PATH").ok())
         .unwrap_or_default();
     let parts: Vec<String> = existing.split(';').map(ToString::to_string).collect();
     if parts
@@ -65,14 +63,12 @@ fn prepend_path(env_map: &mut HashMap<String, String>, prefix: &str) {
         new_path.push(';');
         new_path.push_str(&existing);
     }
-    env_map.insert("PATH".into(), new_path);
+    set_windows_env_value(env_map, "PATH", new_path);
 }
 
 fn reorder_pathext_for_stubs(env_map: &mut HashMap<String, String>) {
-    let default = env_map
-        .get("PATHEXT")
+    let default = windows_env_value(env_map, "PATHEXT")
         .cloned()
-        .or_else(|| env::var("PATHEXT").ok())
         .unwrap_or(".COM;.EXE;.BAT;.CMD".to_string());
     let exts: Vec<String> = default
         .split(';')
@@ -99,7 +95,21 @@ fn reorder_pathext_for_stubs(env_map: &mut HashMap<String, String>) {
     let mut combined = Vec::new();
     combined.extend(front);
     combined.extend(rest);
-    env_map.insert("PATHEXT".into(), combined.join(";"));
+    set_windows_env_value(env_map, "PATHEXT", combined.join(";"));
+}
+
+fn windows_env_value<'a>(env_map: &'a HashMap<String, String>, key: &str) -> Option<&'a String> {
+    env_map.get(key).or_else(|| {
+        env_map
+            .iter()
+            .find(|(existing, _)| existing.eq_ignore_ascii_case(key))
+            .map(|(_, value)| value)
+    })
+}
+
+fn set_windows_env_value(env_map: &mut HashMap<String, String>, key: &str, value: String) {
+    env_map.retain(|existing, _| !existing.eq_ignore_ascii_case(key));
+    env_map.insert(key.to_string(), value);
 }
 
 fn ensure_denybin(tools: &[&str], denybin_dir: Option<&Path>) -> Result<PathBuf> {
@@ -175,3 +185,7 @@ pub fn apply_no_network_to_env(env_map: &mut HashMap<String, String>) -> Result<
     reorder_pathext_for_stubs(env_map);
     Ok(())
 }
+
+#[cfg(test)]
+#[path = "env_tests.rs"]
+mod tests;

--- a/codex-rs/windows-sandbox-rs/src/env.rs
+++ b/codex-rs/windows-sandbox-rs/src/env.rs
@@ -31,7 +31,7 @@ pub fn ensure_non_interactive_pager(env_map: &mut HashMap<String, String>) {
     env_map.entry("LESS".into()).or_insert_with(|| "".into());
 }
 
-// Keep PATH and PATHEXT stable for callers that rely on inheriting the parent process env.
+// Capture APIs accept partial environments, so keep PATH and PATHEXT stable for those callers.
 pub fn inherit_path_env(env_map: &mut HashMap<String, String>) {
     if windows_env_value(env_map, "PATH").is_none()
         && let Ok(path) = env::var("PATH")
@@ -47,7 +47,7 @@ pub fn inherit_path_env(env_map: &mut HashMap<String, String>) {
 
 fn prepend_path(env_map: &mut HashMap<String, String>, prefix: &str) {
     let existing = windows_env_value(env_map, "PATH")
-        .cloned()
+        .map(ToOwned::to_owned)
         .unwrap_or_default();
     let parts: Vec<String> = existing.split(';').map(ToString::to_string).collect();
     if parts
@@ -68,7 +68,7 @@ fn prepend_path(env_map: &mut HashMap<String, String>, prefix: &str) {
 
 fn reorder_pathext_for_stubs(env_map: &mut HashMap<String, String>) {
     let default = windows_env_value(env_map, "PATHEXT")
-        .cloned()
+        .map(ToOwned::to_owned)
         .unwrap_or(".COM;.EXE;.BAT;.CMD".to_string());
     let exts: Vec<String> = default
         .split(';')
@@ -98,13 +98,19 @@ fn reorder_pathext_for_stubs(env_map: &mut HashMap<String, String>) {
     set_windows_env_value(env_map, "PATHEXT", combined.join(";"));
 }
 
-fn windows_env_value<'a>(env_map: &'a HashMap<String, String>, key: &str) -> Option<&'a String> {
-    env_map.get(key).or_else(|| {
-        env_map
-            .iter()
-            .find(|(existing, _)| existing.eq_ignore_ascii_case(key))
-            .map(|(_, value)| value)
-    })
+pub(crate) fn windows_env_value<'a>(
+    env_map: &'a HashMap<String, String>,
+    key: &str,
+) -> Option<&'a str> {
+    env_map
+        .get(key)
+        .or_else(|| {
+            env_map
+                .iter()
+                .find(|(existing, _)| existing.eq_ignore_ascii_case(key))
+                .map(|(_, value)| value)
+        })
+        .map(String::as_str)
 }
 
 fn set_windows_env_value(env_map: &mut HashMap<String, String>, key: &str, value: String) {

--- a/codex-rs/windows-sandbox-rs/src/env_tests.rs
+++ b/codex-rs/windows-sandbox-rs/src/env_tests.rs
@@ -1,0 +1,42 @@
+use super::inherit_path_env;
+use super::prepend_path;
+use super::reorder_pathext_for_stubs;
+use pretty_assertions::assert_eq;
+use std::collections::HashMap;
+
+#[test]
+fn child_path_spelling_prevents_parent_path_inheritance() {
+    let mut env = HashMap::from([
+        ("Path".to_string(), r"C:\child".to_string()),
+        ("PathExt".to_string(), ".BIN".to_string()),
+    ]);
+
+    inherit_path_env(&mut env);
+
+    assert_eq!(
+        env,
+        HashMap::from([
+            ("Path".to_string(), r"C:\child".to_string()),
+            ("PathExt".to_string(), ".BIN".to_string()),
+        ])
+    );
+}
+
+#[test]
+fn path_mutations_are_case_insensitive_and_do_not_fall_back_to_parent_values() {
+    let mut env = HashMap::from([
+        ("Path".to_string(), r"C:\child".to_string()),
+        ("PathExt".to_string(), ".EXE;.CMD".to_string()),
+    ]);
+
+    prepend_path(&mut env, r"C:\deny");
+    reorder_pathext_for_stubs(&mut env);
+
+    assert_eq!(
+        env,
+        HashMap::from([
+            ("PATH".to_string(), r"C:\deny;C:\child".to_string()),
+            ("PATHEXT".to_string(), ".CMD;.EXE".to_string()),
+        ])
+    );
+}

--- a/codex-rs/windows-sandbox-rs/src/env_tests.rs
+++ b/codex-rs/windows-sandbox-rs/src/env_tests.rs
@@ -1,26 +1,7 @@
-use super::inherit_path_env;
 use super::prepend_path;
 use super::reorder_pathext_for_stubs;
 use pretty_assertions::assert_eq;
 use std::collections::HashMap;
-
-#[test]
-fn child_path_spelling_prevents_parent_path_inheritance() {
-    let mut env = HashMap::from([
-        ("Path".to_string(), r"C:\child".to_string()),
-        ("PathExt".to_string(), ".BIN".to_string()),
-    ]);
-
-    inherit_path_env(&mut env);
-
-    assert_eq!(
-        env,
-        HashMap::from([
-            ("Path".to_string(), r"C:\child".to_string()),
-            ("PathExt".to_string(), ".BIN".to_string()),
-        ])
-    );
-}
 
 #[test]
 fn path_mutations_are_case_insensitive_and_do_not_fall_back_to_parent_values() {

--- a/codex-rs/windows-sandbox-rs/src/lib.rs
+++ b/codex-rs/windows-sandbox-rs/src/lib.rs
@@ -53,6 +53,8 @@ mod audit;
 #[cfg(target_os = "windows")]
 mod cap;
 #[cfg(target_os = "windows")]
+mod command_resolution;
+#[cfg(target_os = "windows")]
 mod deny_read_acl;
 #[cfg(target_os = "windows")]
 mod deny_read_state;
@@ -159,6 +161,8 @@ pub use cap::workspace_write_cap_sid_for_root;
 pub use cap::workspace_write_root_contains_path;
 #[cfg(target_os = "windows")]
 pub use cap::workspace_write_root_overlaps_path;
+#[cfg(target_os = "windows")]
+pub use command_resolution::resolve_windows_executable;
 #[cfg(target_os = "windows")]
 pub use conpty::ConptyInstance;
 #[cfg(target_os = "windows")]

--- a/codex-rs/windows-sandbox-rs/src/lib.rs
+++ b/codex-rs/windows-sandbox-rs/src/lib.rs
@@ -241,12 +241,12 @@ pub use path_normalization::canonicalize_path;
 #[cfg(target_os = "windows")]
 pub use process::PipeSpawnHandles;
 #[cfg(target_os = "windows")]
+#[doc(hidden)]
+pub use process::ResolvedWindowsProcessLaunch;
+#[cfg(target_os = "windows")]
 pub use process::StderrMode;
 #[cfg(target_os = "windows")]
 pub use process::StdinMode;
-#[cfg(target_os = "windows")]
-#[doc(hidden)]
-pub use process::WindowsProcessLaunch;
 #[cfg(target_os = "windows")]
 pub use process::read_handle_loop;
 #[cfg(target_os = "windows")]
@@ -351,10 +351,10 @@ pub use stub::run_windows_sandbox_legacy_preflight;
 #[cfg(target_os = "windows")]
 mod windows_impl {
     use super::WindowsSandboxCancellationToken;
+    use super::command_resolution::resolve_windows_launch;
     use super::logging::log_failure;
     use super::logging::log_success;
     use super::process::CreateProcessAsUserRequest;
-    use super::process::WindowsProcessLaunch;
     use super::process::create_process_as_user;
     use super::sandbox_utils::ensure_codex_home_exists;
     use super::spawn_prep::LegacyAclSids;
@@ -564,10 +564,7 @@ mod windows_impl {
         )?;
         let (stdin_pair, stdout_pair, stderr_pair) = unsafe { setup_stdio_pipes()? };
         let ((in_r, in_w), (out_r, out_w), (err_r, err_w)) = (stdin_pair, stdout_pair, stderr_pair);
-        let launch = WindowsProcessLaunch {
-            application_path: None,
-            command: command.clone(),
-        };
+        let launch = resolve_windows_launch(command.clone(), cwd, &env_map)?;
         let spawn_res = unsafe {
             create_process_as_user(
                 security.h_token,

--- a/codex-rs/windows-sandbox-rs/src/process.rs
+++ b/codex-rs/windows-sandbox-rs/src/process.rs
@@ -39,14 +39,11 @@ pub struct CreatedProcess {
     _desktop: LaunchDesktop,
 }
 
-/// The command line and optional executable path supplied to a Windows process launch.
-///
-/// Callers that have already resolved an executable can set `application_path` so it is passed as
-/// `lpApplicationName`. A value of `None` preserves Windows' command-line lookup behavior.
+/// A Windows process launch whose executable was resolved from the final child environment.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[doc(hidden)]
-pub struct WindowsProcessLaunch {
-    pub application_path: Option<PathBuf>,
+pub struct ResolvedWindowsProcessLaunch {
+    pub application_path: PathBuf,
     pub command: Vec<String>,
 }
 
@@ -87,7 +84,7 @@ unsafe fn ensure_inheritable_stdio(si: &mut STARTUPINFOW) -> Result<()> {
 }
 
 pub(crate) struct CreateProcessAsUserRequest<'a> {
-    pub(crate) launch: &'a WindowsProcessLaunch,
+    pub(crate) launch: &'a ResolvedWindowsProcessLaunch,
     pub(crate) cwd: &'a Path,
     pub(crate) env_map: &'a HashMap<String, String>,
     pub(crate) logs_base_dir: Option<&'a Path>,
@@ -112,8 +109,7 @@ pub(crate) unsafe fn create_process_as_user(
     } = request;
     let cmdline_str = argv_to_command_line(&launch.command);
     let mut cmdline: Vec<u16> = to_wide(&cmdline_str);
-    let application_name = launch.application_path.as_deref().map(to_wide);
-    let application_name_ptr = application_name.as_ref().map_or(ptr::null(), Vec::as_ptr);
+    let application_name = to_wide(&launch.application_path);
     let env_block = make_env_block(env_map);
     let desktop = LaunchDesktop::prepare(use_private_desktop, logs_base_dir)?;
     let mut pi: PROCESS_INFORMATION = std::mem::zeroed();
@@ -150,7 +146,7 @@ pub(crate) unsafe fn create_process_as_user(
             let creation_flags = CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT;
             let ok = CreateProcessAsUserW(
                 h_token,
-                application_name_ptr,
+                application_name.as_ptr(),
                 cmdline.as_mut_ptr(),
                 std::ptr::null_mut(),
                 std::ptr::null_mut(),
@@ -190,7 +186,7 @@ pub(crate) unsafe fn create_process_as_user(
             let creation_flags = CREATE_UNICODE_ENVIRONMENT;
             let ok = CreateProcessAsUserW(
                 h_token,
-                application_name_ptr,
+                application_name.as_ptr(),
                 cmdline.as_mut_ptr(),
                 std::ptr::null_mut(),
                 std::ptr::null_mut(),
@@ -253,7 +249,7 @@ pub struct PipeSpawnHandles {
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_process_with_pipes(
     h_token: HANDLE,
-    launch: &WindowsProcessLaunch,
+    launch: &ResolvedWindowsProcessLaunch,
     cwd: &Path,
     env_map: &HashMap<String, String>,
     stdin_mode: StdinMode,

--- a/codex-rs/windows-sandbox-rs/src/process.rs
+++ b/codex-rs/windows-sandbox-rs/src/process.rs
@@ -4,7 +4,6 @@ use crate::proc_thread_attr::ProcThreadAttributeList;
 use crate::winutil::argv_to_command_line;
 use crate::winutil::format_last_error;
 use crate::winutil::to_wide;
-use crate::winutil::to_win32_path_wide;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
@@ -118,7 +117,7 @@ pub(crate) unsafe fn create_process_as_user(
     let env_block = make_env_block(env_map);
     let desktop = LaunchDesktop::prepare(use_private_desktop, logs_base_dir)?;
     let mut pi: PROCESS_INFORMATION = std::mem::zeroed();
-    let cwd_wide = to_win32_path_wide(cwd);
+    let cwd_wide = to_wide(cwd);
     let env_block_len = env_block.len();
     match stdio {
         Some((stdin_h, stdout_h, stderr_h)) => {

--- a/codex-rs/windows-sandbox-rs/src/process.rs
+++ b/codex-rs/windows-sandbox-rs/src/process.rs
@@ -4,6 +4,7 @@ use crate::proc_thread_attr::ProcThreadAttributeList;
 use crate::winutil::argv_to_command_line;
 use crate::winutil::format_last_error;
 use crate::winutil::to_wide;
+use crate::winutil::to_win32_path_wide;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
@@ -117,7 +118,7 @@ pub(crate) unsafe fn create_process_as_user(
     let env_block = make_env_block(env_map);
     let desktop = LaunchDesktop::prepare(use_private_desktop, logs_base_dir)?;
     let mut pi: PROCESS_INFORMATION = std::mem::zeroed();
-    let cwd_wide = to_wide(cwd);
+    let cwd_wide = to_win32_path_wide(cwd);
     let env_block_len = env_block.len();
     match stdio {
         Some((stdin_h, stdout_h, stderr_h)) => {

--- a/codex-rs/windows-sandbox-rs/src/setup.rs
+++ b/codex-rs/windows-sandbox-rs/src/setup.rs
@@ -946,6 +946,19 @@ fn build_payload_roots(
     request: &SandboxSetupRequest<'_>,
     overrides: &SetupRootOverrides,
 ) -> (Vec<PathBuf>, Vec<PathBuf>) {
+    let exact_read_files = overrides
+        .read_roots
+        .as_deref()
+        .into_iter()
+        .flatten()
+        .filter(|path| {
+            std::fs::symlink_metadata(path).is_ok_and(|metadata| !metadata.file_type().is_dir())
+        })
+        .flat_map(|path| {
+            let canonical = dunce::canonicalize(path).unwrap_or_else(|_| path.clone());
+            std::iter::once(path.clone()).chain((canonical != *path).then_some(canonical))
+        })
+        .collect::<Vec<_>>();
     let write_roots = effective_write_roots_for_setup(
         request.permissions,
         request.command_cwd,
@@ -980,6 +993,11 @@ fn build_payload_roots(
     read_roots = filter_ssh_config_dependency_roots(read_roots);
     let write_root_set: HashSet<PathBuf> = write_roots.iter().cloned().collect();
     read_roots.retain(|root| !write_root_set.contains(root));
+    for file in exact_read_files {
+        if !write_root_set.contains(&file) && !read_roots.contains(&file) {
+            read_roots.push(file);
+        }
+    }
     (read_roots, write_roots)
 }
 
@@ -1697,7 +1715,9 @@ mod tests {
         let readable_root = tmp.path().join("docs");
         fs::create_dir_all(&workspace_root).expect("create workspace root");
         fs::create_dir_all(&command_cwd).expect("create workspace");
-        fs::create_dir_all(&readable_root).expect("create readable root");
+        fs::create_dir_all(readable_root.join("nested")).expect("create readable root");
+        fs::write(readable_root.join("tool.exe"), b"fixture").expect("write readable file");
+        let lexical_readable = readable_root.join("nested").join("..").join("tool.exe");
         let permission_profile = PermissionProfile::read_only();
         let workspace_roots = workspace_roots_for(workspace_root.as_path());
         let permissions = permissions_for(&permission_profile, workspace_roots.as_slice());
@@ -1711,7 +1731,7 @@ mod tests {
                 proxy_enforced: false,
             },
             &super::SetupRootOverrides {
-                read_roots: Some(vec![readable_root.clone()]),
+                read_roots: Some(vec![lexical_readable.clone()]),
                 read_roots_include_platform_defaults: true,
                 write_roots: None,
                 deny_read_paths: None,
@@ -1722,12 +1742,13 @@ mod tests {
             dunce::canonicalize(helper_bin_dir(&codex_home)).expect("canonical helper dir");
         let expected_cwd = dunce::canonicalize(&command_cwd).expect("canonical workspace");
         let expected_readable =
-            dunce::canonicalize(&readable_root).expect("canonical readable root");
+            dunce::canonicalize(&lexical_readable).expect("canonical readable file");
 
         assert_eq!(write_roots, Vec::<PathBuf>::new());
         assert!(read_roots.contains(&expected_helper));
         assert!(!read_roots.contains(&expected_cwd));
         assert!(read_roots.contains(&expected_readable));
+        assert!(read_roots.contains(&lexical_readable));
         assert!(
             canonical_windows_platform_default_roots()
                 .into_iter()

--- a/codex-rs/windows-sandbox-rs/src/spawn_prep.rs
+++ b/codex-rs/windows-sandbox-rs/src/spawn_prep.rs
@@ -8,6 +8,7 @@ use crate::cap::workspace_write_cap_sid_for_root;
 use crate::cap::workspace_write_root_contains_path;
 use crate::cap::workspace_write_root_overlaps_path;
 use crate::cap::workspace_write_root_specificity;
+use crate::command_resolution::resolve_windows_launch;
 use crate::deny_read_state::sync_persistent_deny_read_acls;
 use crate::env::apply_no_network_to_env;
 use crate::env::ensure_non_interactive_pager;
@@ -17,10 +18,12 @@ use crate::identity::SandboxCreds;
 use crate::identity::require_logon_sandbox_creds;
 use crate::logging::log_start;
 use crate::path_normalization::canonicalize_path;
+use crate::process::WindowsProcessLaunch;
 use crate::resolved_permissions::ResolvedWindowsSandboxPermissions;
 use crate::sandbox_utils::ensure_codex_home_exists;
 use crate::sandbox_utils::inject_git_safe_directory;
 use crate::setup::effective_write_roots_for_permissions;
+use crate::setup::gather_read_roots;
 use crate::token::LocalSid;
 use crate::token::create_readonly_token_with_cap;
 use crate::token::create_workspace_write_token_with_caps_from;
@@ -52,6 +55,8 @@ pub(crate) struct ElevatedSpawnContext {
     pub(crate) logs_base_dir: Option<PathBuf>,
     pub(crate) sandbox_creds: SandboxCreds,
     pub(crate) cap_sids: Vec<String>,
+    pub(crate) launch: WindowsProcessLaunch,
+    pub(crate) read_roots_override: Vec<PathBuf>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -350,7 +355,7 @@ pub(crate) fn prepare_elevated_spawn_context_for_permissions(
     codex_home: &Path,
     cwd: &Path,
     env_map: &mut HashMap<String, String>,
-    command: &[String],
+    launch: WindowsProcessLaunch,
     read_roots_override: Option<&[PathBuf]>,
     read_roots_include_platform_defaults: bool,
     write_roots_override: Option<&[PathBuf]>,
@@ -363,12 +368,13 @@ pub(crate) fn prepare_elevated_spawn_context_for_permissions(
     ensure_non_interactive_pager(env_map);
     inherit_path_env(env_map);
     inject_git_safe_directory(env_map, cwd);
+    let launch = resolve_windows_launch(launch, cwd, env_map)?;
 
     // Use a temp-based log dir that the sandbox user can write.
     let sandbox_base = codex_home.join(".sandbox");
     ensure_codex_home_exists(&sandbox_base)?;
     let logs_base_dir = Some(sandbox_base.clone());
-    log_start(command, logs_base_dir.as_deref());
+    log_start(&launch.command, logs_base_dir.as_deref());
 
     let uses_write_capabilities = permissions.uses_write_capabilities_for_cwd(cwd, env_map);
 
@@ -398,12 +404,22 @@ pub(crate) fn prepare_elevated_spawn_context_for_permissions(
     } else {
         write_roots_override
     };
+    let mut resolved_read_roots = read_roots_override
+        .map(<[PathBuf]>::to_vec)
+        .unwrap_or_else(|| gather_read_roots(cwd, &permissions, env_map, codex_home));
+    let application_path = launch
+        .application_path
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("resolved Windows launch is missing an application path"))?;
+    if !resolved_read_roots.contains(application_path) {
+        resolved_read_roots.push(application_path.clone());
+    }
     let sandbox_creds = require_logon_sandbox_creds(
         &permissions,
         cwd,
         env_map,
         codex_home,
-        read_roots_override,
+        Some(&resolved_read_roots),
         read_roots_include_platform_defaults,
         setup_write_roots_override,
         deny_read_paths_override,
@@ -441,6 +457,8 @@ pub(crate) fn prepare_elevated_spawn_context_for_permissions(
         logs_base_dir,
         sandbox_creds,
         cap_sids,
+        launch,
+        read_roots_override: resolved_read_roots,
     })
 }
 

--- a/codex-rs/windows-sandbox-rs/src/spawn_prep.rs
+++ b/codex-rs/windows-sandbox-rs/src/spawn_prep.rs
@@ -12,13 +12,12 @@ use crate::command_resolution::resolve_windows_launch;
 use crate::deny_read_state::sync_persistent_deny_read_acls;
 use crate::env::apply_no_network_to_env;
 use crate::env::ensure_non_interactive_pager;
-use crate::env::inherit_path_env;
 use crate::env::normalize_null_device_env;
 use crate::identity::SandboxCreds;
 use crate::identity::require_logon_sandbox_creds;
 use crate::logging::log_start;
 use crate::path_normalization::canonicalize_path;
-use crate::process::WindowsProcessLaunch;
+use crate::process::ResolvedWindowsProcessLaunch;
 use crate::resolved_permissions::ResolvedWindowsSandboxPermissions;
 use crate::sandbox_utils::ensure_codex_home_exists;
 use crate::sandbox_utils::inject_git_safe_directory;
@@ -55,7 +54,7 @@ pub(crate) struct ElevatedSpawnContext {
     pub(crate) logs_base_dir: Option<PathBuf>,
     pub(crate) sandbox_creds: SandboxCreds,
     pub(crate) cap_sids: Vec<String>,
-    pub(crate) launch: WindowsProcessLaunch,
+    pub(crate) launch: ResolvedWindowsProcessLaunch,
     pub(crate) read_roots_override: Vec<PathBuf>,
 }
 
@@ -355,7 +354,7 @@ pub(crate) fn prepare_elevated_spawn_context_for_permissions(
     codex_home: &Path,
     cwd: &Path,
     env_map: &mut HashMap<String, String>,
-    launch: WindowsProcessLaunch,
+    command: Vec<String>,
     read_roots_override: Option<&[PathBuf]>,
     read_roots_include_platform_defaults: bool,
     write_roots_override: Option<&[PathBuf]>,
@@ -366,9 +365,8 @@ pub(crate) fn prepare_elevated_spawn_context_for_permissions(
 ) -> Result<ElevatedSpawnContext> {
     normalize_null_device_env(env_map);
     ensure_non_interactive_pager(env_map);
-    inherit_path_env(env_map);
     inject_git_safe_directory(env_map, cwd);
-    let launch = resolve_windows_launch(launch, cwd, env_map)?;
+    let launch = resolve_windows_launch(command, cwd, env_map)?;
 
     // Use a temp-based log dir that the sandbox user can write.
     let sandbox_base = codex_home.join(".sandbox");
@@ -407,10 +405,7 @@ pub(crate) fn prepare_elevated_spawn_context_for_permissions(
     let mut resolved_read_roots = read_roots_override
         .map(<[PathBuf]>::to_vec)
         .unwrap_or_else(|| gather_read_roots(cwd, &permissions, env_map, codex_home));
-    let application_path = launch
-        .application_path
-        .as_ref()
-        .ok_or_else(|| anyhow::anyhow!("resolved Windows launch is missing an application path"))?;
+    let application_path = &launch.application_path;
     if !resolved_read_roots.contains(application_path) {
         resolved_read_roots.push(application_path.clone());
     }

--- a/codex-rs/windows-sandbox-rs/src/spawn_prep.rs
+++ b/codex-rs/windows-sandbox-rs/src/spawn_prep.rs
@@ -12,6 +12,7 @@ use crate::command_resolution::resolve_windows_launch;
 use crate::deny_read_state::sync_persistent_deny_read_acls;
 use crate::env::apply_no_network_to_env;
 use crate::env::ensure_non_interactive_pager;
+use crate::env::inherit_path_env;
 use crate::env::normalize_null_device_env;
 use crate::identity::SandboxCreds;
 use crate::identity::require_logon_sandbox_creds;

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/backends/elevated.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/backends/elevated.rs
@@ -64,7 +64,7 @@ fn spawn_runner_transport_with_retry<T>(
 ) -> Result<T> {
     retry_runner_spawn_once(
         sandbox_creds,
-        &request.spawn_request.launch.command,
+        &request.spawn_request.launch,
         |sandbox_creds| {
             spawn(
                 &request.codex_home,
@@ -146,7 +146,7 @@ pub(crate) async fn spawn_windows_sandbox_session_elevated_for_permission_profil
         codex_home,
         cwd,
         &mut env_map,
-        &launch.command,
+        launch,
         read_roots_override,
         read_roots_include_platform_defaults,
         write_roots_override,
@@ -157,6 +157,8 @@ pub(crate) async fn spawn_windows_sandbox_session_elevated_for_permission_profil
     )?;
 
     let sandbox_creds = elevated.sandbox_creds;
+    let launch = elevated.launch;
+    let resolved_read_roots = elevated.read_roots_override;
     let request = RunnerTransportRequest {
         permissions,
         codex_home: codex_home.to_path_buf(),
@@ -177,7 +179,7 @@ pub(crate) async fn spawn_windows_sandbox_session_elevated_for_permission_profil
             stdin_open,
             use_private_desktop,
         },
-        read_roots_override: read_roots_override.map(<[PathBuf]>::to_vec),
+        read_roots_override: Some(resolved_read_roots),
         read_roots_include_platform_defaults,
         write_roots_override: write_roots_override.map(<[PathBuf]>::to_vec),
         deny_read_paths_override,

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/backends/elevated.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/backends/elevated.rs
@@ -10,7 +10,6 @@ use crate::ipc_framed::FramedMessage;
 use crate::ipc_framed::IPC_PROTOCOL_VERSION;
 use crate::ipc_framed::Message;
 use crate::ipc_framed::SpawnRequest;
-use crate::process::WindowsProcessLaunch;
 use crate::resolved_permissions::ResolvedWindowsSandboxPermissions;
 use crate::runner_client::RunnerTransport;
 use crate::runner_client::retry_runner_spawn_once;
@@ -113,7 +112,7 @@ pub(crate) async fn spawn_windows_sandbox_session_elevated_for_permission_profil
     permission_profile: &PermissionProfile,
     workspace_roots: &[AbsolutePathBuf],
     codex_home: &Path,
-    launch: WindowsProcessLaunch,
+    command: Vec<String>,
     cwd: &Path,
     mut env_map: HashMap<String, String>,
     proxy_enforced: bool,
@@ -146,7 +145,7 @@ pub(crate) async fn spawn_windows_sandbox_session_elevated_for_permission_profil
         codex_home,
         cwd,
         &mut env_map,
-        launch,
+        command,
         read_roots_override,
         read_roots_include_platform_defaults,
         write_roots_override,

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/backends/elevated_tests.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/backends/elevated_tests.rs
@@ -5,7 +5,7 @@ use crate::identity::SandboxCreds;
 use crate::ipc_framed::ErrorPayload;
 use crate::ipc_framed::ErrorStage;
 use crate::ipc_framed::SpawnRequest;
-use crate::process::WindowsProcessLaunch;
+use crate::process::ResolvedWindowsProcessLaunch;
 use crate::resolved_permissions::ResolvedWindowsSandboxPermissions;
 use crate::runner_client::RunnerStartupError;
 use codex_protocol::models::PermissionProfile;
@@ -69,8 +69,8 @@ fn retry_uses_original_unified_exec_request_and_stops_after_second_failure() {
         env_map: env_map.clone(),
         logs_base_dir: Some(PathBuf::from(r"C:\Users\codex\.sandbox")),
         spawn_request: SpawnRequest {
-            launch: WindowsProcessLaunch {
-                application_path: Some(PathBuf::from(r"C:\Program Files\PowerShell\7\pwsh.exe")),
+            launch: ResolvedWindowsProcessLaunch {
+                application_path: PathBuf::from(r"C:\Program Files\PowerShell\7\pwsh.exe"),
                 command: vec!["pwsh.exe".to_string(), "-NoProfile".to_string()],
             },
             cwd: PathBuf::from(r"C:\workspace"),

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/backends/legacy.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/backends/legacy.rs
@@ -380,7 +380,7 @@ pub(crate) async fn spawn_windows_sandbox_session_legacy(
 
     let process_handle = Arc::new(StdMutex::new(Some(pi.hProcess)));
     let wait_handle = Arc::clone(&process_handle);
-    let command_for_wait = launch.command.clone();
+    let command_for_wait = launch.command;
     let hpc_for_wait = hpc_handle.clone();
     std::thread::spawn(move || {
         let _desktop = desktop;

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/backends/legacy.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/backends/legacy.rs
@@ -5,9 +5,9 @@ use crate::conpty::spawn_conpty_process_as_user;
 use crate::desktop::LaunchDesktop;
 use crate::logging::log_failure;
 use crate::logging::log_success;
+use crate::process::ResolvedWindowsProcessLaunch;
 use crate::process::StderrMode;
 use crate::process::StdinMode;
-use crate::process::WindowsProcessLaunch;
 use crate::process::read_handle_loop;
 use crate::process::spawn_process_with_pipes;
 use crate::spawn_prep::LegacyAclSids;
@@ -60,7 +60,7 @@ struct LegacyProcessHandles {
 #[allow(clippy::too_many_arguments)]
 fn spawn_legacy_process(
     h_token: HANDLE,
-    launch: &WindowsProcessLaunch,
+    launch: &ResolvedWindowsProcessLaunch,
     cwd: &Path,
     env_map: &HashMap<String, String>,
     use_private_desktop: bool,
@@ -275,7 +275,7 @@ pub(crate) async fn spawn_windows_sandbox_session_legacy(
     permission_profile: &PermissionProfile,
     workspace_roots: &[AbsolutePathBuf],
     codex_home: &Path,
-    launch: WindowsProcessLaunch,
+    command: Vec<String>,
     cwd: &Path,
     mut env_map: HashMap<String, String>,
     timeout_ms: Option<u64>,
@@ -291,13 +291,13 @@ pub(crate) async fn spawn_windows_sandbox_session_legacy(
         codex_home,
         cwd,
         &mut env_map,
-        &launch.command,
+        &command,
         SpawnPrepOptions {
             inherit_path: false,
             add_git_safe_directory: false,
         },
     )?;
-    let launch = resolve_windows_launch(launch, cwd, &env_map)?;
+    let launch = resolve_windows_launch(command, cwd, &env_map)?;
     if !common.permissions.has_full_disk_read_access() {
         anyhow::bail!("Restricted read-only access requires the elevated Windows sandbox backend");
     }

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/backends/legacy.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/backends/legacy.rs
@@ -1,4 +1,5 @@
 use super::windows_common::finish_driver_spawn;
+use crate::command_resolution::resolve_windows_launch;
 use crate::conpty::ConptyInstance;
 use crate::conpty::spawn_conpty_process_as_user;
 use crate::desktop::LaunchDesktop;
@@ -296,6 +297,7 @@ pub(crate) async fn spawn_windows_sandbox_session_legacy(
             add_git_safe_directory: false,
         },
     )?;
+    let launch = resolve_windows_launch(launch, cwd, &env_map)?;
     if !common.permissions.has_full_disk_read_access() {
         anyhow::bail!("Restricted read-only access requires the elevated Windows sandbox backend");
     }

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/mod.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/mod.rs
@@ -9,7 +9,6 @@
 
 mod backends;
 
-use crate::process::WindowsProcessLaunch;
 use anyhow::Result;
 use codex_protocol::config_types::WindowsSandboxLevel;
 use codex_protocol::models::PermissionProfile;
@@ -19,7 +18,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 
-/// Fully resolved Windows sandbox session launch request.
+/// Windows sandbox session launch request.
 ///
 /// Callers should parse their own input shape first, then use this request to
 /// share the elevated-vs-legacy backend selection and session launch path.
@@ -27,7 +26,7 @@ pub struct WindowsSandboxSessionRequest<'a> {
     pub permission_profile: &'a PermissionProfile,
     pub workspace_roots: &'a [AbsolutePathBuf],
     pub codex_home: &'a Path,
-    pub launch: WindowsProcessLaunch,
+    pub command: Vec<String>,
     pub cwd: &'a Path,
     pub env_map: HashMap<String, String>,
     pub windows_sandbox_level: WindowsSandboxLevel,
@@ -54,7 +53,7 @@ pub async fn spawn_windows_sandbox_session_for_level(
             request.permission_profile,
             request.workspace_roots,
             request.codex_home,
-            request.launch,
+            request.command,
             request.cwd,
             request.env_map,
             request.proxy_enforced,
@@ -75,7 +74,7 @@ pub async fn spawn_windows_sandbox_session_for_level(
             request.permission_profile,
             request.workspace_roots,
             request.codex_home,
-            request.launch,
+            request.command,
             request.cwd,
             request.env_map,
             request.timeout_ms,

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/tests.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/tests.rs
@@ -250,6 +250,60 @@ fn legacy_non_tty_uses_explicit_application_path() {
 }
 
 #[test]
+fn legacy_resolves_request_pathext_in_a_long_working_directory() {
+    let _guard = legacy_process_test_guard();
+    let runtime = current_thread_runtime();
+    runtime.block_on(async move {
+        let fixture = TempDir::new().expect("tempdir");
+        let tools = fixture.path().join("tools");
+        fs::create_dir_all(&tools).expect("create tools directory");
+        let executable = tools.join("path-only-tool.BIN");
+        fs::copy(r"C:\Windows\System32\cmd.exe", &executable).expect("copy executable fixture");
+        let mut cwd = fixture.path().join("workspace");
+        while cwd.to_string_lossy().len() <= 270 {
+            cwd.push("long-working-directory-segment");
+        }
+        fs::create_dir_all(&cwd).expect("create long working directory");
+        let codex_home = sandbox_home("legacy-long-cwd-resolution");
+        let permission_profile = PermissionProfile::workspace_write();
+        let env_map = HashMap::from([
+            ("Path".to_string(), tools.to_string_lossy().into_owned()),
+            ("PathExt".to_string(), ".BIN".to_string()),
+        ]);
+
+        let spawned = spawn_windows_sandbox_session_legacy(
+            &permission_profile,
+            workspace_roots_for(cwd.as_path()).as_slice(),
+            codex_home.path(),
+            vec![
+                "path-only-tool".to_string(),
+                "/c".to_string(),
+                "echo REQUEST-PATHEXT-LONG-CWD".to_string(),
+            ],
+            cwd.as_path(),
+            env_map,
+            /*timeout_ms*/ Some(5_000),
+            &[],
+            &[],
+            /*tty*/ false,
+            /*stdin_open*/ false,
+            /*use_private_desktop*/ true,
+        )
+        .await
+        .expect("spawn request-resolved executable");
+
+        let (stdout, exit_code) =
+            collect_stdout_and_exit(spawned, codex_home.path(), Duration::from_secs(10)).await;
+        let stdout = String::from_utf8_lossy(&stdout);
+        assert_eq!(exit_code, 0, "stdout={stdout:?}");
+        assert!(
+            stdout.contains("REQUEST-PATHEXT-LONG-CWD"),
+            "stdout={stdout:?}"
+        );
+    });
+}
+
+#[test]
 fn legacy_non_tty_cmd_rejects_deny_read_overrides() {
     let _guard = legacy_process_test_guard();
     let runtime = current_thread_runtime();

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/tests.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/tests.rs
@@ -250,7 +250,7 @@ fn legacy_non_tty_uses_explicit_application_path() {
 }
 
 #[test]
-fn legacy_resolves_request_pathext_in_a_long_working_directory() {
+fn legacy_resolves_request_pathext() {
     let _guard = legacy_process_test_guard();
     let runtime = current_thread_runtime();
     runtime.block_on(async move {
@@ -259,12 +259,9 @@ fn legacy_resolves_request_pathext_in_a_long_working_directory() {
         fs::create_dir_all(&tools).expect("create tools directory");
         let executable = tools.join("path-only-tool.BIN");
         fs::copy(r"C:\Windows\System32\cmd.exe", &executable).expect("copy executable fixture");
-        let mut cwd = fixture.path().join("workspace");
-        while cwd.to_string_lossy().len() <= 270 {
-            cwd.push("long-working-directory-segment");
-        }
-        fs::create_dir_all(&cwd).expect("create long working directory");
-        let codex_home = sandbox_home("legacy-long-cwd-resolution");
+        let cwd = fixture.path().join("workspace");
+        fs::create_dir_all(&cwd).expect("create working directory");
+        let codex_home = sandbox_home("legacy-request-pathext-resolution");
         let permission_profile = PermissionProfile::workspace_write();
         let env_map = HashMap::from([
             ("Path".to_string(), tools.to_string_lossy().into_owned()),
@@ -278,7 +275,7 @@ fn legacy_resolves_request_pathext_in_a_long_working_directory() {
             vec![
                 "path-only-tool".to_string(),
                 "/c".to_string(),
-                "echo REQUEST-PATHEXT-LONG-CWD".to_string(),
+                "echo REQUEST-PATHEXT".to_string(),
             ],
             cwd.as_path(),
             env_map,
@@ -296,10 +293,7 @@ fn legacy_resolves_request_pathext_in_a_long_working_directory() {
             collect_stdout_and_exit(spawned, codex_home.path(), Duration::from_secs(10)).await;
         let stdout = String::from_utf8_lossy(&stdout);
         assert_eq!(exit_code, 0, "stdout={stdout:?}");
-        assert!(
-            stdout.contains("REQUEST-PATHEXT-LONG-CWD"),
-            "stdout={stdout:?}"
-        );
+        assert!(stdout.contains("REQUEST-PATHEXT"), "stdout={stdout:?}");
     });
 }
 

--- a/codex-rs/windows-sandbox-rs/src/unified_exec/tests.rs
+++ b/codex-rs/windows-sandbox-rs/src/unified_exec/tests.rs
@@ -1,15 +1,11 @@
 #![cfg(target_os = "windows")]
 
-use super::WindowsSandboxSessionRequest;
 use super::backends::legacy::spawn_windows_sandbox_session_legacy;
-use super::spawn_windows_sandbox_session_for_level;
-use crate::WindowsProcessLaunch;
 use crate::WindowsSandboxCancellationToken;
 use crate::ipc_framed::Message;
 use crate::ipc_framed::decode_bytes;
 use crate::ipc_framed::read_frame;
 use crate::run_windows_sandbox_capture;
-use codex_protocol::config_types::WindowsSandboxLevel;
 use codex_protocol::models::PermissionProfile;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_pty::ProcessDriver;
@@ -85,13 +81,6 @@ fn sandbox_log(codex_home: &Path) -> String {
 
 fn workspace_roots_for(root: &Path) -> Vec<AbsolutePathBuf> {
     vec![AbsolutePathBuf::from_absolute_path(root).expect("absolute workspace root")]
-}
-
-fn unresolved_launch(command: Vec<String>) -> WindowsProcessLaunch {
-    WindowsProcessLaunch {
-        application_path: None,
-        command,
-    }
 }
 
 fn wait_for_frame_count(frames_path: &Path, expected_frames: usize) -> Vec<Message> {
@@ -173,11 +162,11 @@ fn legacy_non_tty_cmd_emits_output() {
             &permission_profile,
             workspace_roots_for(cwd.as_path()).as_slice(),
             codex_home.path(),
-            unresolved_launch(vec![
+            vec![
                 "C:\\Windows\\System32\\cmd.exe".to_string(),
                 "/c".to_string(),
                 "echo LEGACY-NONTTY-CMD".to_string(),
-            ]),
+            ],
             cwd.as_path(),
             HashMap::new(),
             Some(5_000),
@@ -196,56 +185,6 @@ fn legacy_non_tty_cmd_emits_output() {
         let stdout = String::from_utf8_lossy(&stdout);
         assert_eq!(exit_code, 0, "stdout={stdout:?}");
         assert!(stdout.contains("LEGACY-NONTTY-CMD"), "stdout={stdout:?}");
-    });
-}
-
-#[test]
-fn legacy_non_tty_uses_explicit_application_path() {
-    let _guard = legacy_process_test_guard();
-    let runtime = current_thread_runtime();
-    runtime.block_on(async move {
-        let cwd = sandbox_cwd();
-        let codex_home = sandbox_home("legacy-explicit-application-path");
-        let permission_profile = PermissionProfile::workspace_write();
-        let workspace_roots = workspace_roots_for(cwd.as_path());
-        let spawned = spawn_windows_sandbox_session_for_level(WindowsSandboxSessionRequest {
-            permission_profile: &permission_profile,
-            workspace_roots: workspace_roots.as_slice(),
-            codex_home: codex_home.path(),
-            launch: WindowsProcessLaunch {
-                application_path: Some(PathBuf::from(r"C:\Windows\System32\cmd.exe")),
-                command: vec![
-                    "not-the-real-executable.exe".to_string(),
-                    "/c".to_string(),
-                    "echo EXPLICIT-APPLICATION-PATH".to_string(),
-                ],
-            },
-            cwd: cwd.as_path(),
-            env_map: HashMap::new(),
-            windows_sandbox_level: WindowsSandboxLevel::RestrictedToken,
-            proxy_enforced: false,
-            proxy_settings_mode: crate::WindowsSandboxProxySettingsMode::Reconcile,
-            timeout_ms: Some(5_000),
-            read_roots_override: None,
-            read_roots_include_platform_defaults: false,
-            write_roots_override: None,
-            deny_read_paths_override: &[],
-            deny_write_paths_override: &[],
-            tty: false,
-            stdin_open: false,
-            use_private_desktop: true,
-        })
-        .await
-        .expect("spawn with explicit application path");
-
-        let (stdout, exit_code) =
-            collect_stdout_and_exit(spawned, codex_home.path(), Duration::from_secs(10)).await;
-        let stdout = String::from_utf8_lossy(&stdout);
-        assert_eq!(exit_code, 0, "stdout={stdout:?}");
-        assert!(
-            stdout.contains("EXPLICIT-APPLICATION-PATH"),
-            "stdout={stdout:?}"
-        );
     });
 }
 
@@ -312,11 +251,11 @@ fn legacy_non_tty_cmd_rejects_deny_read_overrides() {
             &permission_profile,
             workspace_roots_for(cwd.as_path()).as_slice(),
             codex_home.path(),
-            unresolved_launch(vec![
+            vec![
                 "C:\\Windows\\System32\\cmd.exe".to_string(),
                 "/c".to_string(),
                 "echo deny-read".to_string(),
-            ]),
+            ],
             cwd.as_path(),
             HashMap::new(),
             Some(5_000),
@@ -352,12 +291,12 @@ fn legacy_non_tty_powershell_emits_output() {
             &permission_profile,
             workspace_roots_for(cwd.as_path()).as_slice(),
             codex_home.path(),
-            unresolved_launch(vec![
+            vec![
                 pwsh.display().to_string(),
                 "-NoProfile".to_string(),
                 "-Command".to_string(),
                 "Write-Output LEGACY-NONTTY-DIRECT".to_string(),
-            ]),
+            ],
             cwd.as_path(),
             HashMap::new(),
             Some(5_000),
@@ -630,14 +569,14 @@ fn legacy_tty_powershell_emits_output_and_accepts_input() {
             &permission_profile,
             workspace_roots_for(cwd.as_path()).as_slice(),
             codex_home.path(),
-            unresolved_launch(vec![
+            vec![
                 pwsh.display().to_string(),
                 "-NoLogo".to_string(),
                 "-NoProfile".to_string(),
                 "-NoExit".to_string(),
                 "-Command".to_string(),
                 "$PID; Write-Output ready".to_string(),
-            ]),
+            ],
             cwd.as_path(),
             HashMap::new(),
             Some(10_000),
@@ -684,11 +623,11 @@ fn legacy_tty_cmd_emits_output_and_accepts_input() {
             &permission_profile,
             workspace_roots_for(cwd.as_path()).as_slice(),
             codex_home.path(),
-            unresolved_launch(vec![
+            vec![
                 "C:\\Windows\\System32\\cmd.exe".to_string(),
                 "/K".to_string(),
                 "echo ready".to_string(),
-            ]),
+            ],
             cwd.as_path(),
             HashMap::new(),
             Some(10_000),
@@ -738,11 +677,11 @@ fn legacy_tty_cmd_default_desktop_emits_output_and_accepts_input() {
             &permission_profile,
             workspace_roots_for(cwd.as_path()).as_slice(),
             codex_home.path(),
-            unresolved_launch(vec![
+            vec![
                 "C:\\Windows\\System32\\cmd.exe".to_string(),
                 "/K".to_string(),
                 "echo ready".to_string(),
-            ]),
+            ],
             cwd.as_path(),
             HashMap::new(),
             Some(10_000),

--- a/codex-rs/windows-sandbox-rs/src/winutil.rs
+++ b/codex-rs/windows-sandbox-rs/src/winutil.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use std::ffi::OsStr;
 use std::os::windows::ffi::OsStrExt;
+use std::path::Path;
 use windows_sys::Win32::Foundation::ERROR_INSUFFICIENT_BUFFER;
 use windows_sys::Win32::Foundation::GetLastError;
 use windows_sys::Win32::Foundation::HLOCAL;
@@ -20,6 +21,32 @@ pub fn to_wide<S: AsRef<OsStr>>(s: S) -> Vec<u16> {
     let mut v: Vec<u16> = s.as_ref().encode_wide().collect();
     v.push(0);
     v
+}
+
+const MAX_PATH_UTF16_UNITS: usize = 260;
+const EXTENDED_PATH_PREFIX: &[u16] = &[b'\\' as u16, b'\\' as u16, b'?' as u16, b'\\' as u16];
+const DEVICE_PATH_PREFIX: &[u16] = &[b'\\' as u16, b'\\' as u16, b'.' as u16, b'\\' as u16];
+
+/// Encodes a CreateProcess path, adding an extended-length prefix only when needed.
+pub(crate) fn to_win32_path_wide(path: &Path) -> Vec<u16> {
+    let wide = path.as_os_str().encode_wide().collect::<Vec<_>>();
+    if !path.is_absolute()
+        || wide.len() < MAX_PATH_UTF16_UNITS
+        || wide.starts_with(EXTENDED_PATH_PREFIX)
+        || wide.starts_with(DEVICE_PATH_PREFIX)
+    {
+        return wide.into_iter().chain([0]).collect();
+    }
+
+    let mut extended = EXTENDED_PATH_PREFIX.to_vec();
+    if wide.starts_with(&[b'\\' as u16, b'\\' as u16]) {
+        extended.extend("UNC\\".encode_utf16());
+        extended.extend_from_slice(&wide[2..]);
+    } else {
+        extended.extend(wide);
+    }
+    extended.push(0);
+    extended
 }
 
 /// Quote a single Windows command-line argument following the rules used by
@@ -208,7 +235,10 @@ fn sid_bytes_from_string(sid_str: &str) -> Result<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::argv_to_command_line;
+    use super::to_wide;
+    use super::to_win32_path_wide;
     use pretty_assertions::assert_eq;
+    use std::path::Path;
 
     #[test]
     fn argv_to_command_line_quotes_each_argument_independently() {
@@ -237,5 +267,24 @@ mod tests {
             argv_to_command_line(&argv),
             "pwsh.exe -Command \"Write-Output \\\"hello world\\\"\""
         );
+    }
+
+    #[test]
+    fn create_process_paths_add_extended_prefixes_only_for_long_paths() {
+        let long_tail = ["long-working-directory-segment"; 10].join(r"\");
+        let long_drive = format!(r"C:\{long_tail}");
+        let long_unc = format!(r"\\localhost\C$\{long_tail}");
+
+        assert_eq!(
+            to_win32_path_wide(Path::new(&long_drive)),
+            to_wide(format!(r"\\?\{long_drive}"))
+        );
+        assert_eq!(
+            to_win32_path_wide(Path::new(&long_unc)),
+            to_wide(format!(r"\\?\UNC\{}", &long_unc[2..]))
+        );
+        for path in [r"C:\short", r"\\localhost\C$\short", r"\\?\C:\already"] {
+            assert_eq!(to_win32_path_wide(Path::new(path)), to_wide(path));
+        }
     }
 }

--- a/codex-rs/windows-sandbox-rs/src/winutil.rs
+++ b/codex-rs/windows-sandbox-rs/src/winutil.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use std::ffi::OsStr;
 use std::os::windows::ffi::OsStrExt;
-use std::path::Path;
 use windows_sys::Win32::Foundation::ERROR_INSUFFICIENT_BUFFER;
 use windows_sys::Win32::Foundation::GetLastError;
 use windows_sys::Win32::Foundation::HLOCAL;
@@ -21,32 +20,6 @@ pub fn to_wide<S: AsRef<OsStr>>(s: S) -> Vec<u16> {
     let mut v: Vec<u16> = s.as_ref().encode_wide().collect();
     v.push(0);
     v
-}
-
-const MAX_PATH_UTF16_UNITS: usize = 260;
-const EXTENDED_PATH_PREFIX: &[u16] = &[b'\\' as u16, b'\\' as u16, b'?' as u16, b'\\' as u16];
-const DEVICE_PATH_PREFIX: &[u16] = &[b'\\' as u16, b'\\' as u16, b'.' as u16, b'\\' as u16];
-
-/// Encodes a CreateProcess path, adding an extended-length prefix only when needed.
-pub(crate) fn to_win32_path_wide(path: &Path) -> Vec<u16> {
-    let wide = path.as_os_str().encode_wide().collect::<Vec<_>>();
-    if !path.is_absolute()
-        || wide.len() < MAX_PATH_UTF16_UNITS
-        || wide.starts_with(EXTENDED_PATH_PREFIX)
-        || wide.starts_with(DEVICE_PATH_PREFIX)
-    {
-        return wide.into_iter().chain([0]).collect();
-    }
-
-    let mut extended = EXTENDED_PATH_PREFIX.to_vec();
-    if wide.starts_with(&[b'\\' as u16, b'\\' as u16]) {
-        extended.extend("UNC\\".encode_utf16());
-        extended.extend_from_slice(&wide[2..]);
-    } else {
-        extended.extend(wide);
-    }
-    extended.push(0);
-    extended
 }
 
 /// Quote a single Windows command-line argument following the rules used by
@@ -235,10 +208,7 @@ fn sid_bytes_from_string(sid_str: &str) -> Result<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::argv_to_command_line;
-    use super::to_wide;
-    use super::to_win32_path_wide;
     use pretty_assertions::assert_eq;
-    use std::path::Path;
 
     #[test]
     fn argv_to_command_line_quotes_each_argument_independently() {
@@ -267,24 +237,5 @@ mod tests {
             argv_to_command_line(&argv),
             "pwsh.exe -Command \"Write-Output \\\"hello world\\\"\""
         );
-    }
-
-    #[test]
-    fn create_process_paths_add_extended_prefixes_only_for_long_paths() {
-        let long_tail = ["long-working-directory-segment"; 10].join(r"\");
-        let long_drive = format!(r"C:\{long_tail}");
-        let long_unc = format!(r"\\localhost\C$\{long_tail}");
-
-        assert_eq!(
-            to_win32_path_wide(Path::new(&long_drive)),
-            to_wide(format!(r"\\?\{long_drive}"))
-        );
-        assert_eq!(
-            to_win32_path_wide(Path::new(&long_unc)),
-            to_wide(format!(r"\\?\UNC\{}", &long_unc[2..]))
-        );
-        for path in [r"C:\short", r"\\localhost\C$\short", r"\\?\C:\already"] {
-            assert_eq!(to_win32_path_wide(Path::new(path)), to_wide(path));
-        }
     }
 }

--- a/codex-rs/windows-sandbox-rs/src/wrapper.rs
+++ b/codex-rs/windows-sandbox-rs/src/wrapper.rs
@@ -177,10 +177,7 @@ async fn run_windows_sandbox_wrapper_request(request: WindowsSandboxWrapperReque
             permission_profile: &request.permission_profile,
             workspace_roots: request.workspace_roots.as_slice(),
             codex_home: request.codex_home.as_path(),
-            launch: crate::WindowsProcessLaunch {
-                application_path: None,
-                command: request.command,
-            },
+            command: request.command,
             cwd: request.command_cwd.as_path(),
             env_map: request.env_map,
             windows_sandbox_level: request.windows_sandbox_level,


### PR DESCRIPTION
Stacked on #29845, which carries an explicit `application_path` through the Windows launch protocol.

## Why

When `lpApplicationName` is absent, Windows can choose an executable before Codex applies the requested child environment. A unified-exec request may therefore provide its own `PATH` and `PATHEXT` but still run the executable selected through Codex's parent process.

Path spelling matters too. Canonicalization can erase a caller's lexical or extended-length path, and converting a native `\\localhost\...` UNC path through a normal file URI can turn it into a local-path alias.

One important platform boundary is explicit here: [Microsoft documents that a current directory longer than `MAX_PATH` causes `CreateProcessW` to fail](https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setcurrentdirectory). This PR preserves and tests long paths during resolution; it does not claim to bypass that process-creation limit.

## What changed

### Resolve from the final child environment

- Finish all child-environment mutations before executable lookup.
- Match `PATH` and `PATHEXT` without case sensitivity, so an explicit `Path`/`PathExt` replaces inherited casing variants.
- Search the requested working directory first, followed by the child `PATH`, and resolve relative `PATH` entries against that working directory.
- Use only the child environment: there is no fallback to Codex's parent `PATH`.
- Fail clearly when a selected `.bat` or `.cmd` would require `cmd.exe` instead of silently skipping to a later candidate.

### Launch and retry the exact executable

- Pass the resolved absolute path as the Windows application name for pipe, ConPTY, legacy-sandbox, and elevated-sandbox launches; local unsandboxed launches receive the same absolute program path.
- Add only the resolved executable file to elevated sandbox read roots, including its lexical spelling when canonicalization would change a reparse-point or UNC alias.
- Reuse the same resolved launch and read roots during credential refresh, including WindowsApps retry classification.
- Leave remote exec-server requests unchanged; they return through the remote backend before local resolution runs.

### Preserve working-directory spelling

- Keep long, lexical, and already extended-length paths unchanged during resolution and request plumbing.
- Losslessly round-trip native `\\localhost\C$\...` paths through `PathUri` instead of normalizing away the UNC server.
- Pass the requested working directory to the Windows process API unchanged; no implicit canonicalization or prefix rewriting is introduced.

## Test coverage

- Resolver tests cover case-insensitive `Path`/`PathExt`, request-only `PATHEXT`, working-directory precedence, a real working directory longer than 260 characters, lexical paths, extended-length paths, batch files, and the absence of parent-`PATH` fallback.
- A Windows integration test copies `cmd.exe` to a custom `.BIN` extension and proves that the legacy backend launches it only through the request's `PATHEXT`.
- Path-URI, sandbox-root, environment, and credential-retry tests cover `\\localhost` round-tripping, file-only read grants, casing, and retry-state preservation.
