### PR TITLE
[codex] Add core schema evolution model

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -3839,6 +3839,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-schema-evolution"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "pretty_assertions",
+ "serde_json",
+]
+
+[[package]]
 name = "codex-secrets"
 version = "0.0.0"
 dependencies = [

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -82,6 +82,7 @@ members = [
     "responses-api-proxy",
     "response-debug-context",
     "sandboxing",
+    "schema-evolution",
     "stdio-to-uds",
     "otel",
     "tui",
@@ -217,6 +218,7 @@ codex-rmcp-client = { path = "rmcp-client" }
 codex-rollout = { path = "rollout" }
 codex-rollout-trace = { path = "rollout-trace" }
 codex-sandboxing = { path = "sandboxing" }
+codex-schema-evolution = { path = "schema-evolution" }
 codex-secrets = { path = "secrets" }
 codex-shell-command = { path = "shell-command" }
 codex-shell-escalation = { path = "shell-escalation" }

--- a/codex-rs/schema-evolution/BUILD.bazel
+++ b/codex-rs/schema-evolution/BUILD.bazel
@@ -1,0 +1,6 @@
+load("//:defs.bzl", "codex_rust_crate")
+
+codex_rust_crate(
+    name = "schema-evolution",
+    crate_name = "codex_schema_evolution",
+)

--- a/codex-rs/schema-evolution/Cargo.toml
+++ b/codex-rs/schema-evolution/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "codex-schema-evolution"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+name = "codex_schema_evolution"
+path = "src/lib.rs"
+doctest = false
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }

--- a/codex-rs/schema-evolution/src/lib.rs
+++ b/codex-rs/schema-evolution/src/lib.rs
@@ -1,0 +1,12 @@
+mod model;
+mod parse;
+
+pub use model::ApiSchema;
+pub(crate) use model::Arguments;
+pub(crate) use model::JsonType;
+pub(crate) use model::ObjectSchema;
+pub(crate) use model::SchemaId;
+pub(crate) use model::SchemaNode;
+pub(crate) use model::SchemaRules;
+pub(crate) use model::TypeSet;
+pub(crate) use model::ValueSet;

--- a/codex-rs/schema-evolution/src/model.rs
+++ b/codex-rs/schema-evolution/src/model.rs
@@ -1,0 +1,113 @@
+mod method;
+mod object;
+mod value;
+
+#[cfg(test)]
+pub(crate) use method::Argument;
+pub(crate) use method::Arguments;
+pub(crate) use method::Method;
+pub(crate) use object::ObjectSchema;
+pub(crate) use value::JsonType;
+pub(crate) use value::TypeSet;
+pub(crate) use value::ValueSet;
+
+use crate::parse::Parser;
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct SchemaId(pub(crate) usize);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ApiSchema {
+    pub(crate) methods: BTreeMap<String, Method>,
+    pub(crate) nodes: Vec<SchemaNode>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SchemaNode {
+    Any,
+    Never,
+    Reference(SchemaId),
+    Rules(Box<SchemaRules>),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SchemaRules {
+    pub types: Option<TypeSet>,
+    pub values: Option<ValueSet>,
+    pub object: Option<ObjectSchema>,
+}
+
+impl ApiSchema {
+    /// Parses a generated client-request JSON Schema into the representation used for comparison.
+    pub fn parse(root: &Value) -> Result<Self> {
+        let definitions = root
+            .get("definitions")
+            .map(|value| {
+                value
+                    .as_object()
+                    .ok_or_else(|| anyhow!("ClientRequest definitions must be an object"))
+            })
+            .transpose()?
+            .cloned()
+            .unwrap_or_default();
+        let mut schema = Self {
+            methods: BTreeMap::new(),
+            nodes: vec![SchemaNode::Any; definitions.len()],
+        };
+        let references = definitions
+            .keys()
+            .enumerate()
+            .map(|(index, name)| {
+                (
+                    format!("#/definitions/{}", pointer_escape(name)),
+                    SchemaId(index),
+                )
+            })
+            .collect();
+        let definition_ids = (0..definitions.len()).map(SchemaId).collect::<Vec<_>>();
+        let mut parser = Parser::new(&mut schema, references);
+        for ((name, value), id) in definitions.iter().zip(&definition_ids) {
+            parser.schema.nodes[id.0] = parser
+                .parse_node(value)
+                .with_context(|| format!("parse JSON Schema definition {name}"))?;
+        }
+        for id in definition_ids {
+            parser.schema.resolve(id)?;
+        }
+        parser.schema.methods = Method::parse_all(&mut parser, root)?;
+        Ok(schema)
+    }
+
+    pub(crate) fn push(&mut self, node: SchemaNode) -> SchemaId {
+        let id = SchemaId(self.nodes.len());
+        self.nodes.push(node);
+        id
+    }
+
+    pub(crate) fn resolve(&self, mut id: SchemaId) -> Result<(SchemaId, &SchemaNode)> {
+        let mut seen = BTreeSet::new();
+        loop {
+            if !seen.insert(id) {
+                return Err(anyhow!("cyclic direct JSON Schema reference"));
+            }
+            match self
+                .nodes
+                .get(id.0)
+                .ok_or_else(|| anyhow!("invalid schema node {}", id.0))?
+            {
+                SchemaNode::Reference(target) => id = *target,
+                node => return Ok((id, node)),
+            }
+        }
+    }
+}
+
+fn pointer_escape(value: &str) -> String {
+    value.replace('~', "~0").replace('/', "~1")
+}

--- a/codex-rs/schema-evolution/src/model/method.rs
+++ b/codex-rs/schema-evolution/src/model/method.rs
@@ -1,0 +1,122 @@
+use crate::JsonType;
+use crate::SchemaId;
+use crate::SchemaNode;
+use crate::parse::Parser;
+use anyhow::Result;
+use anyhow::anyhow;
+use anyhow::bail;
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Method {
+    pub name: String,
+    pub arguments: Arguments,
+    pub request: SchemaId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Arguments {
+    None,
+    Map(Argument),
+    Value(Argument),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Argument {
+    pub required: bool,
+    pub schema: SchemaId,
+}
+
+impl Method {
+    pub(crate) fn parse_all(
+        parser: &mut Parser<'_>,
+        root: &Value,
+    ) -> Result<BTreeMap<String, Self>> {
+        let variants = root
+            .get("oneOf")
+            .and_then(Value::as_array)
+            .ok_or_else(|| anyhow!("ClientRequest schema must contain a oneOf array"))?;
+        let mut methods = BTreeMap::new();
+        for variant in variants {
+            let request_id = parser.parse_schema(variant)?;
+            let (_, request) = parser.schema.resolve(request_id)?;
+            let SchemaNode::Rules(request) = request else {
+                bail!("ClientRequest variant must be an object schema");
+            };
+            if request
+                .types
+                .as_ref()
+                .is_some_and(|types| !types.accepted_types().contains(&JsonType::Object))
+            {
+                bail!("ClientRequest variant must accept objects");
+            }
+            let request_object = request
+                .object
+                .as_ref()
+                .ok_or_else(|| anyhow!("ClientRequest variant must contain properties"))?;
+            let method_property = request_object
+                .properties
+                .get("method")
+                .ok_or_else(|| anyhow!("ClientRequest variant is missing method"))?;
+            let method = singleton_string(parser, method_property.schema, "ClientRequest method")?;
+
+            let arguments = match request_object.properties.get("params") {
+                Some(property) => Arguments::classify(
+                    parser,
+                    Argument {
+                        required: request_object.required.contains("params"),
+                        schema: property.schema,
+                    },
+                )?,
+                None => Arguments::None,
+            };
+            if methods
+                .insert(
+                    method.clone(),
+                    Self {
+                        name: method.clone(),
+                        arguments,
+                        request: request_id,
+                    },
+                )
+                .is_some()
+            {
+                bail!("ClientRequest contains duplicate method {method}");
+            }
+        }
+        Ok(methods)
+    }
+}
+
+impl Arguments {
+    fn classify(parser: &Parser<'_>, argument: Argument) -> Result<Self> {
+        let (_, node) = parser.schema.resolve(argument.schema)?;
+        let SchemaNode::Rules(rules) = node else {
+            return Ok(Self::Value(argument));
+        };
+        if rules.object.is_some() {
+            Ok(Self::Map(argument))
+        } else {
+            Ok(Self::Value(argument))
+        }
+    }
+}
+
+fn singleton_string(parser: &Parser<'_>, id: SchemaId, label: &str) -> Result<String> {
+    let (_, node) = parser.schema.resolve(id)?;
+    let SchemaNode::Rules(rules) = node else {
+        bail!("{label} must use enum or const");
+    };
+    let values = rules
+        .values
+        .as_ref()
+        .ok_or_else(|| anyhow!("{label} must use enum or const"))?;
+    let [value] = values.values.as_slice() else {
+        bail!("{label} must contain exactly one value");
+    };
+    value
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| anyhow!("{label} must be a string"))
+}

--- a/codex-rs/schema-evolution/src/model/object.rs
+++ b/codex-rs/schema-evolution/src/model/object.rs
@@ -1,0 +1,94 @@
+use crate::SchemaId;
+use crate::TypeSet;
+use crate::parse::Parser;
+use anyhow::Result;
+use anyhow::anyhow;
+use anyhow::bail;
+use serde_json::Map;
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ObjectSchema {
+    pub properties: BTreeMap<String, Property>,
+    pub required: BTreeSet<String>,
+    pub additional_properties: AdditionalProperties,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Property {
+    pub schema: SchemaId,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AdditionalProperties {
+    Any,
+    Forbidden,
+    Schema(SchemaId),
+}
+
+impl ObjectSchema {
+    pub(crate) fn parse(
+        parser: &mut Parser<'_>,
+        object: &Map<String, Value>,
+        types: Option<&TypeSet>,
+    ) -> Result<Option<Self>> {
+        let properties = object
+            .get("properties")
+            .map(|value| {
+                value
+                    .as_object()
+                    .ok_or_else(|| anyhow!("JSON Schema properties must be an object"))
+            })
+            .transpose()?;
+        let required = parse_string_set(object.get("required"), "required")?;
+        let has_object_keywords = properties.is_some()
+            || object.contains_key("required")
+            || object.contains_key("additionalProperties");
+        if !has_object_keywords
+            && !types.is_some_and(|types| types.declared.contains(&crate::JsonType::Object))
+        {
+            return Ok(None);
+        }
+        let properties = properties
+            .into_iter()
+            .flatten()
+            .map(|(name, value)| {
+                parser
+                    .parse_schema(value)
+                    .map(|schema| (name.clone(), Property { schema }))
+            })
+            .collect::<Result<_>>()?;
+        let additional_properties = match object.get("additionalProperties") {
+            None | Some(Value::Bool(true)) => AdditionalProperties::Any,
+            Some(Value::Bool(false)) => AdditionalProperties::Forbidden,
+            Some(value @ Value::Object(_)) => {
+                AdditionalProperties::Schema(parser.parse_schema(value)?)
+            }
+            Some(_) => bail!("JSON Schema additionalProperties must be a boolean or object"),
+        };
+        Ok(Some(Self {
+            properties,
+            required,
+            additional_properties,
+        }))
+    }
+}
+
+fn parse_string_set(value: Option<&Value>, keyword: &str) -> Result<BTreeSet<String>> {
+    let Some(value) = value else {
+        return Ok(BTreeSet::new());
+    };
+    value
+        .as_array()
+        .ok_or_else(|| anyhow!("JSON Schema {keyword} must be an array"))?
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::to_string)
+                .ok_or_else(|| anyhow!("JSON Schema {keyword} values must be strings"))
+        })
+        .collect()
+}

--- a/codex-rs/schema-evolution/src/model/value.rs
+++ b/codex-rs/schema-evolution/src/model/value.rs
@@ -1,0 +1,99 @@
+use anyhow::Result;
+use anyhow::anyhow;
+use anyhow::bail;
+use serde_json::Map;
+use serde_json::Value;
+use std::collections::BTreeSet;
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum JsonType {
+    Array,
+    Boolean,
+    Integer,
+    Null,
+    Number,
+    Object,
+    String,
+}
+
+impl JsonType {
+    fn parse(value: &str) -> Result<Self> {
+        match value {
+            "array" => Ok(Self::Array),
+            "boolean" => Ok(Self::Boolean),
+            "integer" => Ok(Self::Integer),
+            "null" => Ok(Self::Null),
+            "number" => Ok(Self::Number),
+            "object" => Ok(Self::Object),
+            "string" => Ok(Self::String),
+            _ => Err(anyhow!("unsupported JSON Schema type {value}")),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TypeSet {
+    pub declared: BTreeSet<JsonType>,
+}
+
+impl TypeSet {
+    pub(crate) fn parse(value: Option<&Value>) -> Result<Option<Self>> {
+        let Some(value) = value else {
+            return Ok(None);
+        };
+        let declared = match value {
+            Value::String(value) => [JsonType::parse(value)?].into_iter().collect(),
+            Value::Array(values) => values
+                .iter()
+                .map(|value| {
+                    value
+                        .as_str()
+                        .ok_or_else(|| anyhow!("JSON Schema types must be strings"))
+                        .and_then(JsonType::parse)
+                })
+                .collect::<Result<_>>()?,
+            _ => bail!("JSON Schema type must be a string or array"),
+        };
+        Ok(Some(Self { declared }))
+    }
+
+    pub(crate) fn accepted_types(&self) -> BTreeSet<JsonType> {
+        let mut accepted = self.declared.clone();
+        if accepted.contains(&JsonType::Number) {
+            accepted.insert(JsonType::Integer);
+        }
+        accepted
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ValueSet {
+    pub values: Vec<Value>,
+}
+
+impl ValueSet {
+    pub(crate) fn parse(object: &Map<String, Value>) -> Result<Option<Self>> {
+        let values = object
+            .get("enum")
+            .map(|values| {
+                values
+                    .as_array()
+                    .cloned()
+                    .ok_or_else(|| anyhow!("JSON Schema enum must be an array"))
+            })
+            .transpose()?;
+        let constant = object.get("const");
+        let mut values = match (values, constant) {
+            (None, None) => return Ok(None),
+            (None, Some(value)) => vec![value.clone()],
+            (Some(values), None) => values,
+            (Some(mut values), Some(constant)) => {
+                values.retain(|value| value == constant);
+                values
+            }
+        };
+        values.sort_by_key(|value| serde_json::to_string(value).unwrap_or_default());
+        values.dedup();
+        Ok(Some(Self { values }))
+    }
+}

--- a/codex-rs/schema-evolution/src/parse.rs
+++ b/codex-rs/schema-evolution/src/parse.rs
@@ -1,0 +1,108 @@
+use crate::ApiSchema;
+use crate::ObjectSchema;
+use crate::SchemaId;
+use crate::SchemaNode;
+use crate::SchemaRules;
+use crate::TypeSet;
+use crate::ValueSet;
+use anyhow::Result;
+use anyhow::anyhow;
+use anyhow::bail;
+use serde_json::Map;
+use serde_json::Value;
+use std::collections::BTreeMap;
+
+pub(crate) struct Parser<'a> {
+    pub(crate) schema: &'a mut ApiSchema,
+    references: BTreeMap<String, SchemaId>,
+}
+
+impl<'a> Parser<'a> {
+    pub(crate) fn new(schema: &'a mut ApiSchema, references: BTreeMap<String, SchemaId>) -> Self {
+        Self { schema, references }
+    }
+
+    pub(crate) fn parse_schema(&mut self, value: &Value) -> Result<SchemaId> {
+        let node = self.parse_node(value)?;
+        Ok(self.schema.push(node))
+    }
+
+    pub(crate) fn parse_node(&mut self, value: &Value) -> Result<SchemaNode> {
+        match value {
+            Value::Bool(true) => return Ok(SchemaNode::Any),
+            Value::Bool(false) => return Ok(SchemaNode::Never),
+            Value::Object(object) => {
+                if let Some(reference) = object.get("$ref") {
+                    return self.parse_reference(reference);
+                }
+                if let Some(alias) = single_all_of(object)? {
+                    return Ok(SchemaNode::Reference(self.parse_schema(alias)?));
+                }
+                if object.contains_key("allOf") {
+                    bail!("only single-branch JSON Schema allOf aliases are supported");
+                }
+            }
+            _ => bail!("JSON Schema must be a boolean or object"),
+        }
+        let object = value
+            .as_object()
+            .ok_or_else(|| anyhow!("JSON Schema must be a boolean or object"))?;
+        let types = TypeSet::parse(object.get("type"))?;
+        let values = ValueSet::parse(object)?;
+        let object_schema = ObjectSchema::parse(self, object, types.as_ref())?;
+        Ok(SchemaNode::Rules(Box::new(SchemaRules {
+            types,
+            values,
+            object: object_schema,
+        })))
+    }
+
+    fn parse_reference(&self, value: &Value) -> Result<SchemaNode> {
+        let reference = value
+            .as_str()
+            .ok_or_else(|| anyhow!("JSON Schema $ref must be a string"))?;
+        let target =
+            self.references.get(reference).copied().ok_or_else(|| {
+                anyhow!("unsupported or missing JSON Schema reference {reference}")
+            })?;
+        Ok(SchemaNode::Reference(target))
+    }
+}
+
+fn single_all_of(object: &Map<String, Value>) -> Result<Option<&Value>> {
+    let Some(value) = object.get("allOf") else {
+        return Ok(None);
+    };
+    let branches = value
+        .as_array()
+        .ok_or_else(|| anyhow!("JSON Schema allOf must be an array"))?;
+    Ok(
+        (branches.len() == 1 && object.keys().all(|key| key == "allOf" || annotation(key)))
+            .then(|| &branches[0]),
+    )
+}
+
+fn annotation(keyword: &str) -> bool {
+    matches!(
+        keyword,
+        "$comment"
+            | "$id"
+            | "$schema"
+            | "default"
+            | "deprecated"
+            | "description"
+            | "examples"
+            | "readOnly"
+            | "title"
+            | "writeOnly"
+    )
+}
+
+#[cfg(test)]
+use crate::Arguments;
+#[cfg(test)]
+use crate::model::Argument;
+
+#[cfg(test)]
+#[path = "parse_tests.rs"]
+mod tests;

--- a/codex-rs/schema-evolution/src/parse_tests.rs
+++ b/codex-rs/schema-evolution/src/parse_tests.rs
@@ -1,0 +1,107 @@
+use super::*;
+use pretty_assertions::assert_eq;
+use serde_json::json;
+
+#[test]
+fn parses_methods_into_typed_argument_shapes() -> Result<()> {
+    let schema = json!({
+        "oneOf": [
+            request("map", json!({ "properties": { "value": { "type": "string" } }, "type": "object" }), /*required*/ true),
+            request("value", json!({ "type": "null" }), /*required*/ false),
+            {
+                "properties": { "method": { "const": "none" } },
+                "required": ["method"],
+                "type": "object"
+            }
+        ]
+    });
+    let parsed = ApiSchema::parse(&schema)?;
+
+    assert!(matches!(parsed.methods["map"].arguments, Arguments::Map(_)));
+    assert!(matches!(
+        parsed.methods["value"].arguments,
+        Arguments::Value(Argument {
+            required: false,
+            ..
+        })
+    ));
+    assert_eq!(parsed.methods["none"].arguments, Arguments::None);
+    let (_, request) = parsed.resolve(parsed.methods["map"].request)?;
+    let SchemaNode::Rules(request) = request else {
+        panic!("method request should contain rules");
+    };
+    let request = request.object.as_ref().unwrap();
+    assert!(request.properties.contains_key("id"));
+    assert!(request.properties.contains_key("method"));
+    assert!(request.properties.contains_key("params"));
+    Ok(())
+}
+
+#[test]
+fn keeps_refs_typed_without_expanding_recursive_definitions() -> Result<()> {
+    let mut schema = request_schema(json!({ "$ref": "#/definitions/Params" }));
+    schema["definitions"] = json!({
+        "Params": {
+            "properties": {
+                "child": { "$ref": "#/definitions/Params" },
+                "name": { "allOf": [{ "$ref": "#/definitions/Name" }], "description": "alias" }
+            },
+            "type": "object"
+        },
+        "Name": { "type": "string" }
+    });
+
+    let parsed = ApiSchema::parse(&schema)?;
+    assert!(matches!(
+        parsed.methods["test/method"].arguments,
+        Arguments::Map(_)
+    ));
+    Ok(())
+}
+
+#[test]
+fn rejects_malformed_protocol_shapes_and_direct_ref_cycles() {
+    let duplicate = json!({
+        "oneOf": [
+            request("same", json!(null), /*required*/ true),
+            request("same", json!(null), /*required*/ true)
+        ]
+    });
+    assert!(ApiSchema::parse(&duplicate).is_err());
+
+    let mut missing_ref = request_schema(json!({ "$ref": "#/definitions/Missing" }));
+    missing_ref["definitions"] = json!({});
+    assert!(ApiSchema::parse(&missing_ref).is_err());
+
+    let mut cycle = request_schema(json!({ "$ref": "#/definitions/A" }));
+    cycle["definitions"] = json!({
+        "A": { "$ref": "#/definitions/B" },
+        "B": { "$ref": "#/definitions/A" }
+    });
+    assert!(ApiSchema::parse(&cycle).is_err());
+
+    let unsupported_all_of = request_schema(json!({
+        "allOf": [{ "type": "string" }, { "minLength": 1 }]
+    }));
+    assert!(ApiSchema::parse(&unsupported_all_of).is_err());
+}
+
+fn request_schema(params: serde_json::Value) -> serde_json::Value {
+    json!({ "oneOf": [request("test/method", params, /*required*/ true)] })
+}
+
+fn request(method: &str, params: serde_json::Value, required: bool) -> serde_json::Value {
+    let mut required_fields = vec![json!("id"), json!("method")];
+    if required {
+        required_fields.push(json!("params"));
+    }
+    json!({
+        "properties": {
+            "id": { "type": "string" },
+            "method": { "enum": [method] },
+            "params": params
+        },
+        "required": required_fields,
+        "type": "object"
+    })
+}


### PR DESCRIPTION
Intent: establish an auditable typed representation for generated request schemas.

Implementation: add the `codex-schema-evolution` crate with method, argument, object, and scalar schema parsing.

Manual validation: `just test -p codex-schema-evolution`; `just fix -p codex-schema-evolution`; `just fmt`.
