### PR TITLE
[codex] Define schema breakage violations

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -3844,6 +3844,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "pretty_assertions",
+ "serde",
  "serde_json",
 ]
 

--- a/codex-rs/schema-evolution/Cargo.toml
+++ b/codex-rs/schema-evolution/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 
 [dev-dependencies]

--- a/codex-rs/schema-evolution/src/lib.rs
+++ b/codex-rs/schema-evolution/src/lib.rs
@@ -1,5 +1,6 @@
 mod model;
 mod parse;
+mod violation;
 
 pub use model::ApiSchema;
 pub(crate) use model::Arguments;
@@ -14,3 +15,5 @@ pub(crate) use model::TypeSet;
 pub(crate) use model::UnionKind;
 pub(crate) use model::UnionSchema;
 pub(crate) use model::ValueSet;
+pub use violation::SchemaBreakage;
+pub use violation::ViolationKind;

--- a/codex-rs/schema-evolution/src/violation.rs
+++ b/codex-rs/schema-evolution/src/violation.rs
@@ -1,0 +1,26 @@
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Value;
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum ViolationKind {
+    AdditionalPropertiesNarrowed,
+    ConstraintChanged,
+    EnumNarrowed,
+    MethodRemoved,
+    PropertyRemoved,
+    RequiredPropertyAdded,
+    TypeNarrowed,
+    UnionVariantRemoved,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaBreakage {
+    pub kind: ViolationKind,
+    pub method: String,
+    pub path: String,
+    pub before: Value,
+    pub after: Value,
+}


### PR DESCRIPTION
Intent: define the stable vocabulary emitted when request compatibility checks find breakage.

Implementation: add serializable violation kinds and schema breakage records without detector policy.

Manual validation: `just test -p codex-schema-evolution`; `just fix -p codex-schema-evolution`; `just fmt`.
