### PR TITLE
[codex] Add schema evolution CLI

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -3843,6 +3843,7 @@ name = "codex-schema-evolution"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "codex-utils-cargo-bin",
  "pretty_assertions",
  "serde",
  "serde_json",

--- a/codex-rs/schema-evolution/Cargo.toml
+++ b/codex-rs/schema-evolution/Cargo.toml
@@ -9,6 +9,10 @@ name = "codex_schema_evolution"
 path = "src/lib.rs"
 doctest = false
 
+[[bin]]
+name = "codex-schema-evolution"
+path = "src/bin/schema_evolution.rs"
+
 [lints]
 workspace = true
 
@@ -19,4 +23,5 @@ serde_json = { workspace = true }
 toml = { workspace = true }
 
 [dev-dependencies]
+codex-utils-cargo-bin = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/codex-rs/schema-evolution/src/bin/schema_evolution.rs
+++ b/codex-rs/schema-evolution/src/bin/schema_evolution.rs
@@ -1,0 +1,43 @@
+use anyhow::Context;
+use anyhow::Result;
+use codex_schema_evolution::ApiSchema;
+use codex_schema_evolution::KnownBreakageLog;
+use codex_schema_evolution::check_request_narrowing;
+use serde::Deserialize;
+use serde_json::Value;
+use std::io::Read;
+use std::process::ExitCode;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct LintInput {
+    before: Value,
+    after: Value,
+    before_known_breakages: String,
+    after_known_breakages: String,
+}
+
+fn main() -> Result<ExitCode> {
+    let mut input = String::new();
+    std::io::stdin()
+        .read_to_string(&mut input)
+        .context("read lint input from stdin")?;
+    let input: LintInput =
+        serde_json::from_str(&input).context("parse lint input JSON from stdin")?;
+    let before = ApiSchema::parse(&input.before).context("parse before schema")?;
+    let after = ApiSchema::parse(&input.after).context("parse after schema")?;
+    let before_log = KnownBreakageLog::parse(&input.before_known_breakages, "before")?;
+    let after_log = KnownBreakageLog::parse(&input.after_known_breakages, "after")?;
+    let breakages = check_request_narrowing(&before, &after, &before_log, &after_log)?;
+
+    if breakages.is_empty() {
+        println!("request schema does not narrow the baseline");
+        Ok(ExitCode::SUCCESS)
+    } else {
+        println!(
+            "{} request schema breakage(s) recorded in the known-breakage log",
+            breakages.len()
+        );
+        Ok(ExitCode::FAILURE)
+    }
+}

--- a/codex-rs/schema-evolution/tests/cli.rs
+++ b/codex-rs/schema-evolution/tests/cli.rs
@@ -1,0 +1,127 @@
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::ensure;
+use serde_json::Value;
+use serde_json::json;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Output;
+use std::process::Stdio;
+
+#[test]
+fn compatible_schema_passes_end_to_end() -> Result<()> {
+    let output = run_lint(
+        "before.json",
+        "compatible-after.json",
+        "empty-known-breakages.toml",
+        "empty-known-breakages.toml",
+    )?;
+
+    ensure!(
+        output.status.success(),
+        "compatible schema failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    ensure!(
+        String::from_utf8_lossy(&output.stdout)
+            .contains("request schema does not narrow the baseline")
+    );
+    Ok(())
+}
+
+#[test]
+fn breaking_schema_prints_the_known_breakage_to_append() -> Result<()> {
+    let output = run_lint(
+        "before.json",
+        "breaking-after.json",
+        "empty-known-breakages.toml",
+        "empty-known-breakages.toml",
+    )?;
+
+    ensure!(!output.status.success(), "unrecorded breakage should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    for expected in [
+        "RequiredPropertyAdded",
+        "params.value",
+        "[[breakages]]",
+        "id = 1",
+    ] {
+        ensure!(
+            stderr.contains(expected),
+            "missing {expected:?} in {stderr}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn matching_new_known_breakage_still_fails_and_history_cannot_be_deleted() -> Result<()> {
+    let recorded = run_lint(
+        "before.json",
+        "breaking-after.json",
+        "empty-known-breakages.toml",
+        "known-required-property.toml",
+    )?;
+    ensure!(
+        !recorded.status.success(),
+        "detected breakage should return a failing status"
+    );
+    ensure!(
+        String::from_utf8_lossy(&recorded.stdout)
+            .contains("1 request schema breakage(s) recorded in the known-breakage log")
+    );
+
+    let deleted = run_lint(
+        "before.json",
+        "before.json",
+        "known-required-property.toml",
+        "empty-known-breakages.toml",
+    )?;
+    ensure!(!deleted.status.success(), "deleting history should fail");
+    ensure!(
+        String::from_utf8_lossy(&deleted.stderr)
+            .contains("known breakage 1 was deleted; existing entries are append-only")
+    );
+    Ok(())
+}
+
+fn run_lint(
+    before_schema: &str,
+    after_schema: &str,
+    before_known_breakages: &str,
+    after_known_breakages: &str,
+) -> Result<Output> {
+    let input = json!({
+        "before": read_json(before_schema)?,
+        "after": read_json(after_schema)?,
+        "beforeKnownBreakages": read_fixture(before_known_breakages)?,
+        "afterKnownBreakages": read_fixture(after_known_breakages)?,
+    });
+    let mut child = Command::new(codex_utils_cargo_bin::cargo_bin("codex-schema-evolution")?)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("spawn schema-evolution CLI")?;
+    child
+        .stdin
+        .take()
+        .context("schema-evolution CLI stdin should be piped")?
+        .write_all(&serde_json::to_vec(&input)?)?;
+    child.wait_with_output().context("run schema-evolution CLI")
+}
+
+fn read_json(name: &str) -> Result<Value> {
+    serde_json::from_str(&read_fixture(name)?).with_context(|| format!("parse fixture {name}"))
+}
+
+fn read_fixture(name: &str) -> Result<String> {
+    let path = fixture_path(name)?;
+    std::fs::read_to_string(&path).with_context(|| format!("read fixture {}", path.display()))
+}
+
+fn fixture_path(name: &str) -> Result<PathBuf> {
+    let relative_path = format!("tests/fixtures/{name}");
+    codex_utils_cargo_bin::find_resource!(relative_path).map_err(Into::into)
+}

--- a/codex-rs/schema-evolution/tests/fixtures/before.json
+++ b/codex-rs/schema-evolution/tests/fixtures/before.json
@@ -1,0 +1,22 @@
+{
+  "oneOf": [
+    {
+      "properties": {
+        "method": {
+          "const": "test/method",
+          "type": "string"
+        },
+        "params": {
+          "properties": {
+            "value": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": ["method", "params"],
+      "type": "object"
+    }
+  ]
+}

--- a/codex-rs/schema-evolution/tests/fixtures/breaking-after.json
+++ b/codex-rs/schema-evolution/tests/fixtures/breaking-after.json
@@ -1,0 +1,23 @@
+{
+  "oneOf": [
+    {
+      "properties": {
+        "method": {
+          "const": "test/method",
+          "type": "string"
+        },
+        "params": {
+          "properties": {
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": ["value"],
+          "type": "object"
+        }
+      },
+      "required": ["method", "params"],
+      "type": "object"
+    }
+  ]
+}

--- a/codex-rs/schema-evolution/tests/fixtures/compatible-after.json
+++ b/codex-rs/schema-evolution/tests/fixtures/compatible-after.json
@@ -1,0 +1,25 @@
+{
+  "oneOf": [
+    {
+      "properties": {
+        "method": {
+          "const": "test/method",
+          "type": "string"
+        },
+        "params": {
+          "properties": {
+            "other": {
+              "type": "boolean"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": ["method", "params"],
+      "type": "object"
+    }
+  ]
+}

--- a/codex-rs/schema-evolution/tests/fixtures/empty-known-breakages.toml
+++ b/codex-rs/schema-evolution/tests/fixtures/empty-known-breakages.toml
@@ -1,0 +1,1 @@
+version = 1

--- a/codex-rs/schema-evolution/tests/fixtures/known-required-property.toml
+++ b/codex-rs/schema-evolution/tests/fixtures/known-required-property.toml
@@ -1,0 +1,10 @@
+version = 1
+
+[[breakages]]
+id = 1
+kind = "requiredPropertyAdded"
+method = "test/method"
+path = "params.value"
+before_json = "false"
+after_json = "true"
+justification = "Accepts the documented wire-format compatibility tradeoff."


### PR DESCRIPTION
Intent: expose the schema compatibility library through a small CI-friendly executable.

Implementation: add a stdin JSON CLI plus Cargo/Bazel end-to-end tests and minimal schema/log fixtures.

Manual validation: `just test -p codex-schema-evolution` (30 tests); Bazel unit and CLI integration targets; `just bazel-lock-update`; `just fix -p codex-schema-evolution`; `just fmt`.
