### PR TITLE
Rank tool_search results with field-aware identity metadata

### DIFF
--- a/codex-rs/core/src/tools/handlers/mcp.rs
+++ b/codex-rs/core/src/tools/handlers/mcp.rs
@@ -19,6 +19,7 @@ use codex_mcp::ToolInfo;
 use codex_tools::ResponsesApiNamespace;
 use codex_tools::ResponsesApiNamespaceTool;
 use codex_tools::ToolName;
+use codex_tools::ToolSearchIdentity;
 use codex_tools::ToolSearchInfo;
 use codex_tools::ToolSearchSourceInfo;
 use codex_tools::ToolSpec;
@@ -105,10 +106,11 @@ impl ToolExecutor<ToolInvocation> for McpHandler {
                 .map(str::to_string),
         });
 
-        ToolSearchInfo::from_spec(
+        ToolSearchInfo::from_spec_with_identity(
             build_mcp_search_text(&self.tool_info),
             self.spec(),
             source_info,
+            build_mcp_search_identity(&self.tool_info),
         )
     }
 
@@ -264,7 +266,6 @@ fn mcp_hook_tool_input(raw_arguments: &str) -> Value {
 }
 
 fn build_mcp_search_text(info: &ToolInfo) -> String {
-    let tool_name = info.canonical_tool_name();
     let mut schema_properties = info
         .tool
         .input_schema
@@ -273,33 +274,49 @@ fn build_mcp_search_text(info: &ToolInfo) -> String {
         .map(|map| map.keys().cloned().collect::<Vec<_>>())
         .unwrap_or_default();
     schema_properties.sort();
-    let mut parts = vec![
-        flat_tool_name(&tool_name).into_owned(),
-        info.callable_name.clone(),
-        info.tool.name.to_string(),
-        info.server_name.clone(),
-    ];
-    if let Some(title) = info.tool.title.as_deref().map(str::trim)
-        && !title.is_empty()
-    {
-        parts.push(title.to_string());
-    }
+    let mut parts = Vec::new();
     if let Some(description) = info.tool.description.as_deref().map(str::trim)
         && !description.is_empty()
     {
         parts.push(description.to_string());
-    }
-    if let Some(connector_name) = info.connector_name.as_deref().map(str::trim)
-        && !connector_name.is_empty()
-    {
-        parts.push(connector_name.to_string());
     }
     if let Some(namespace_description) = info.namespace_description.as_deref().map(str::trim)
         && !namespace_description.is_empty()
     {
         parts.push(namespace_description.to_string());
     }
-    parts.extend(
+    parts.extend(schema_properties);
+    parts.join(" ")
+}
+
+fn build_mcp_search_identity(info: &ToolInfo) -> ToolSearchIdentity {
+    let tool_name = info.canonical_tool_name();
+    let mut identity = ToolSearchIdentity::default();
+    identity
+        .canonical_aliases
+        .push(flat_tool_name(&tool_name).into_owned());
+    identity.canonical_aliases.push(format!(
+        "{}.{}",
+        info.callable_namespace, info.callable_name
+    ));
+    identity.canonical_aliases.push(format!(
+        "{}__{}",
+        info.callable_namespace, info.callable_name
+    ));
+    identity.tool_aliases.push(info.callable_name.clone());
+    identity.tool_aliases.push(info.tool.name.to_string());
+    if let Some(title) = info.tool.title.as_deref().map(str::trim)
+        && !title.is_empty()
+    {
+        identity.tool_aliases.push(title.to_string());
+    }
+    identity.source_aliases.push(info.server_name.clone());
+    if let Some(connector_name) = info.connector_name.as_deref().map(str::trim)
+        && !connector_name.is_empty()
+    {
+        identity.source_aliases.push(connector_name.to_string());
+    }
+    identity.source_aliases.extend(
         info.plugin_display_names
             .iter()
             .map(String::as_str)
@@ -307,8 +324,7 @@ fn build_mcp_search_text(info: &ToolInfo) -> String {
             .filter(|display_name| !display_name.is_empty())
             .map(str::to_string),
     );
-    parts.extend(schema_properties);
-    parts.join(" ")
+    identity
 }
 
 #[cfg(test)]

--- a/codex-rs/core/src/tools/handlers/mcp_search_tests.rs
+++ b/codex-rs/core/src/tools/handlers/mcp_search_tests.rs
@@ -11,7 +11,28 @@ fn search_info_uses_mcp_tool_metadata_and_parameter_names() {
 
     assert_eq!(
         search_info.entry.search_text,
-        "mcp__calendar___create_event _create_event createEvent codex-apps Create event Create a calendar event. Calendar Plan events. Calendar plugin attendees start_time"
+        "Create a calendar event. Plan events. attendees start_time"
+    );
+    assert_eq!(
+        search_info.entry.identity,
+        ToolSearchIdentity {
+            canonical_aliases: vec![
+                "mcp__calendar___create_event".to_string(),
+                "mcp__calendar__._create_event".to_string(),
+                "mcp__calendar_____create_event".to_string(),
+            ],
+            tool_aliases: vec![
+                "_create_event".to_string(),
+                "createEvent".to_string(),
+                "Create event".to_string(),
+            ],
+            source_aliases: vec![
+                "codex-apps".to_string(),
+                "Calendar".to_string(),
+                "Calendar plugin".to_string(),
+                "mcp__calendar__".to_string(),
+            ],
+        }
     );
     assert_eq!(
         search_info.source_info,

--- a/codex-rs/core/src/tools/handlers/tool_search.rs
+++ b/codex-rs/core/src/tools/handlers/tool_search.rs
@@ -28,6 +28,21 @@ pub struct ToolSearchHandler {
     search_engine: SearchEngine<usize>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) enum ToolSearchIdentityTier {
+    None,
+    SourceAlias,
+    ToolAlias,
+    CanonicalAlias,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct ToolSearchScore {
+    pub(crate) index: usize,
+    pub(crate) identity_tier: ToolSearchIdentityTier,
+    pub(crate) bm25_score: f32,
+}
+
 #[derive(Default)]
 pub(crate) struct ToolSearchHandlerCache {
     cached: Mutex<Option<Arc<ToolSearchHandler>>>,
@@ -160,14 +175,52 @@ impl ToolSearchHandler {
         query: &str,
         limit: usize,
     ) -> Result<Vec<LoadableToolSpec>, FunctionCallError> {
-        let results = self
-            .search_engine
-            .search(query, limit)
-            .into_iter()
-            .map(|result| result.document.id)
-            .filter_map(|id| self.search_infos.get(id))
-            .map(|search_info| &search_info.entry);
-        self.search_output_tools(results)
+        let results = self.search_ranked(query).into_iter().take(limit);
+        self.search_output_tools(
+            results
+                .map(|result| result.index)
+                .filter_map(|id| self.search_infos.get(id))
+                .map(|search_info| &search_info.entry),
+        )
+    }
+
+    pub(crate) fn search_ranked(&self, query: &str) -> Vec<ToolSearchScore> {
+        let mut bm25_scores = vec![None; self.search_infos.len()];
+        for result in self.search_engine.search(query, None) {
+            if let Some(score) = bm25_scores.get_mut(result.document.id) {
+                *score = Some(result.score);
+            }
+        }
+
+        let mut results = self
+            .search_infos
+            .iter()
+            .enumerate()
+            .filter_map(|(index, search_info)| {
+                let identity_tier = identity_tier(query, &search_info.entry);
+                let bm25_score = bm25_scores[index].unwrap_or(0.0);
+                (identity_tier != ToolSearchIdentityTier::None || bm25_scores[index].is_some())
+                    .then_some(ToolSearchScore {
+                        index,
+                        identity_tier,
+                        bm25_score,
+                    })
+            })
+            .collect::<Vec<_>>();
+
+        results.sort_by(|left, right| {
+            right
+                .identity_tier
+                .cmp(&left.identity_tier)
+                .then_with(|| {
+                    right
+                        .bm25_score
+                        .partial_cmp(&left.bm25_score)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                })
+                .then_with(|| left.index.cmp(&right.index))
+        });
+        results
     }
 
     fn search_output_tools<'a>(
@@ -178,6 +231,38 @@ impl ToolSearchHandler {
             results.into_iter().map(|entry| entry.output.clone()),
         ))
     }
+}
+
+fn identity_tier(query: &str, entry: &ToolSearchEntry) -> ToolSearchIdentityTier {
+    let query = normalized_identifier(query);
+    if query.is_empty() {
+        return ToolSearchIdentityTier::None;
+    }
+
+    if has_alias_match(&entry.identity.canonical_aliases, &query) {
+        return ToolSearchIdentityTier::CanonicalAlias;
+    }
+    if has_alias_match(&entry.identity.tool_aliases, &query) {
+        return ToolSearchIdentityTier::ToolAlias;
+    }
+    if has_alias_match(&entry.identity.source_aliases, &query) {
+        return ToolSearchIdentityTier::SourceAlias;
+    }
+    ToolSearchIdentityTier::None
+}
+
+fn has_alias_match(aliases: &[String], normalized_query: &str) -> bool {
+    aliases
+        .iter()
+        .any(|alias| normalized_identifier(alias) == normalized_query)
+}
+
+fn normalized_identifier(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| ch.is_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
 }
 
 #[cfg(test)]
@@ -191,6 +276,7 @@ mod tests {
     use codex_tools::ResponsesApiNamespace;
     use codex_tools::ResponsesApiNamespaceTool;
     use codex_tools::ResponsesApiTool;
+    use codex_tools::ToolSearchSourceInfo;
     use pretty_assertions::assert_eq;
     use rmcp::model::Tool;
     use std::sync::Arc;
@@ -323,6 +409,286 @@ mod tests {
                 }),
             ],
         );
+    }
+
+    #[test]
+    fn identity_match_enters_limited_results_ahead_of_description_distractors() {
+        let mut search_infos = (0..10)
+            .map(|index| {
+                namespace_search_info(
+                    &format!("distractor_{index}"),
+                    "semantic_match",
+                    "OpenAI Topics list topics semantic overlap",
+                    "OpenAI Topics list topics semantic overlap",
+                    /*source_info*/ None,
+                )
+            })
+            .collect::<Vec<_>>();
+        search_infos.push(namespace_search_info(
+            "openai_topics",
+            "list_topics",
+            "List OpenAI topic metadata.",
+            "metadata",
+            Some(ToolSearchSourceInfo {
+                name: "OpenAI Topics".to_string(),
+                description: None,
+            }),
+        ));
+        let handler = ToolSearchHandler::new(search_infos);
+
+        let tools = handler
+            .search("OpenAI Topics list topics", TOOL_SEARCH_DEFAULT_LIMIT)
+            .expect("tool search should serialize");
+
+        assert!(
+            namespace_tool_names(&tools, "openai_topics").contains(&"list_topics".to_string()),
+            "identity target should enter the default top 8 before description distractors: {tools:?}"
+        );
+    }
+
+    #[test]
+    fn separator_variants_rank_canonical_tool_first() {
+        let handler = ToolSearchHandler::new(vec![
+            namespace_search_info(
+                "openai_topics",
+                "list_topics",
+                "List OpenAI topic metadata.",
+                "metadata",
+                /*source_info*/ None,
+            ),
+            namespace_search_info(
+                "openai_topics",
+                "create_topic",
+                "Create OpenAI topic metadata.",
+                "metadata",
+                /*source_info*/ None,
+            ),
+        ]);
+
+        for query in [
+            "openai_topics.list_topics",
+            "openai_topics__list_topics",
+            "OpenAI Topics list topics",
+        ] {
+            let first = handler
+                .search_ranked(query)
+                .into_iter()
+                .next()
+                .expect("identity query should match");
+            assert_eq!(
+                first,
+                ToolSearchScore {
+                    index: 0,
+                    identity_tier: ToolSearchIdentityTier::CanonicalAlias,
+                    bm25_score: 0.0,
+                },
+                "query {query:?} should rank list_topics first",
+            );
+        }
+    }
+
+    #[test]
+    fn tool_and_source_identity_outrank_description_only_matches() {
+        let target = namespace_search_info(
+            "openai_topics",
+            "list_topics",
+            "List OpenAI topic metadata.",
+            "metadata",
+            Some(ToolSearchSourceInfo {
+                name: "OpenAI Topics".to_string(),
+                description: None,
+            }),
+        );
+        let description_match = namespace_search_info(
+            "notes",
+            "read_note",
+            "Description repeats list_topics and OpenAI Topics.",
+            "list_topics OpenAI Topics OpenAI Topics",
+            /*source_info*/ None,
+        );
+        let handler = ToolSearchHandler::new(vec![description_match, target]);
+
+        assert_eq!(handler.search_ranked("list_topics")[0].index, 1);
+        assert_eq!(
+            handler.search_ranked("list_topics")[0].identity_tier,
+            ToolSearchIdentityTier::ToolAlias
+        );
+        assert_eq!(handler.search_ranked("OpenAI Topics")[0].index, 1);
+        assert_eq!(
+            handler.search_ranked("OpenAI Topics")[0].identity_tier,
+            ToolSearchIdentityTier::SourceAlias
+        );
+    }
+
+    #[test]
+    fn plugin_display_name_is_source_identity() {
+        let mut cortex_tool = tool_info("openai_topics", "list_topics", "List topics");
+        cortex_tool.connector_name = Some("OpenAI Topics".to_string());
+        cortex_tool.plugin_display_names = vec!["Cortex".to_string()];
+        let handler = ToolSearchHandler::new(vec![
+            namespace_search_info(
+                "notes",
+                "read_note",
+                "Description repeats Cortex.",
+                "Cortex Cortex",
+                /*source_info*/ None,
+            ),
+            McpHandler::new(cortex_tool)
+                .expect("MCP tool should convert")
+                .search_info()
+                .expect("MCP handler should return search info"),
+        ]);
+
+        let first = handler.search_ranked("Cortex")[0];
+
+        assert_eq!(first.index, 1);
+        assert_eq!(first.identity_tier, ToolSearchIdentityTier::SourceAlias);
+    }
+
+    #[test]
+    fn description_only_queries_retain_bm25_ordering() {
+        let handler = ToolSearchHandler::new(vec![
+            namespace_search_info(
+                "calendar",
+                "create_event",
+                "Create calendar events.",
+                "calendar event",
+                /*source_info*/ None,
+            ),
+            namespace_search_info(
+                "docs",
+                "extract_text",
+                "Extract text from uploaded documents.",
+                "uploaded document uploaded document",
+                /*source_info*/ None,
+            ),
+        ]);
+
+        let results = handler.search_ranked("uploaded document");
+
+        assert_eq!(results[0].index, 1);
+        assert_eq!(results[0].identity_tier, ToolSearchIdentityTier::None);
+        assert!(results[0].bm25_score > 0.0);
+    }
+
+    #[test]
+    fn limit_applies_before_namespace_coalescing() {
+        let handler = ToolSearchHandler::new(vec![
+            namespace_search_info(
+                "calendar",
+                "create_event",
+                "Calendar semantic match.",
+                "calendar",
+                /*source_info*/ None,
+            ),
+            namespace_search_info(
+                "calendar",
+                "list_events",
+                "Calendar semantic match.",
+                "calendar",
+                /*source_info*/ None,
+            ),
+            namespace_search_info(
+                "docs",
+                "extract_text",
+                "Calendar semantic match.",
+                "calendar",
+                /*source_info*/ None,
+            ),
+        ]);
+
+        let tools = handler
+            .search("calendar", /*limit*/ 2)
+            .expect("tool search should serialize");
+
+        assert_eq!(
+            namespace_tool_names(&tools, "calendar"),
+            vec!["create_event".to_string(), "list_events".to_string()]
+        );
+        assert_eq!(tools.len(), 1);
+    }
+
+    #[test]
+    fn identity_ties_preserve_original_search_info_order() {
+        let source = Some(ToolSearchSourceInfo {
+            name: "OpenAI Topics".to_string(),
+            description: None,
+        });
+        let handler = ToolSearchHandler::new(vec![
+            namespace_search_info(
+                "openai_topics",
+                "list_topics",
+                "List topics.",
+                "metadata",
+                source.clone(),
+            ),
+            namespace_search_info(
+                "openai_topics",
+                "create_topic",
+                "Create topic.",
+                "metadata",
+                source,
+            ),
+        ]);
+
+        let indexes = handler
+            .search_ranked("OpenAI Topics")
+            .into_iter()
+            .map(|result| result.index)
+            .collect::<Vec<_>>();
+
+        assert_eq!(indexes, vec![0, 1]);
+    }
+
+    fn namespace_search_info(
+        namespace: &str,
+        tool_name: &str,
+        description: &str,
+        search_text: &str,
+        source_info: Option<ToolSearchSourceInfo>,
+    ) -> ToolSearchInfo {
+        ToolSearchInfo::from_spec(
+            search_text.to_string(),
+            ToolSpec::Namespace(ResponsesApiNamespace {
+                name: namespace.to_string(),
+                description: format!("Tools in {namespace}."),
+                tools: vec![ResponsesApiNamespaceTool::Function(ResponsesApiTool {
+                    name: tool_name.to_string(),
+                    description: description.to_string(),
+                    strict: false,
+                    defer_loading: None,
+                    parameters: codex_tools::JsonSchema::object(
+                        Default::default(),
+                        /*required*/ None,
+                        Some(false.into()),
+                    ),
+                    output_schema: None,
+                })],
+            }),
+            source_info,
+        )
+        .expect("namespace tool should be searchable")
+    }
+
+    fn namespace_tool_names(tools: &[LoadableToolSpec], namespace: &str) -> Vec<String> {
+        tools
+            .iter()
+            .filter_map(|tool| match tool {
+                LoadableToolSpec::Namespace(namespace_tool) if namespace_tool.name == namespace => {
+                    Some(
+                        namespace_tool
+                            .tools
+                            .iter()
+                            .map(|tool| match tool {
+                                ResponsesApiNamespaceTool::Function(tool) => tool.name.clone(),
+                            })
+                            .collect::<Vec<_>>(),
+                    )
+                }
+                LoadableToolSpec::Function(_) | LoadableToolSpec::Namespace(_) => None,
+            })
+            .flatten()
+            .collect()
     }
 
     fn tool_info(server_name: &str, tool_name: &str, description_prefix: &str) -> ToolInfo {

--- a/codex-rs/tools/src/lib.rs
+++ b/codex-rs/tools/src/lib.rs
@@ -100,6 +100,7 @@ pub use tool_output::JsonToolOutput;
 pub use tool_output::ToolOutput;
 pub use tool_payload::ToolPayload;
 pub use tool_search::ToolSearchEntry;
+pub use tool_search::ToolSearchIdentity;
 pub use tool_search::ToolSearchInfo;
 pub use tool_spec::ResponsesApiWebSearchFilters;
 pub use tool_spec::ResponsesApiWebSearchUserLocation;

--- a/codex-rs/tools/src/tool_search.rs
+++ b/codex-rs/tools/src/tool_search.rs
@@ -9,6 +9,7 @@ use crate::default_namespace_description;
 #[derive(Clone, PartialEq)]
 pub struct ToolSearchEntry {
     pub search_text: String,
+    pub identity: ToolSearchIdentity,
     pub output: LoadableToolSpec,
 }
 
@@ -16,6 +17,13 @@ pub struct ToolSearchEntry {
 pub struct ToolSearchInfo {
     pub entry: ToolSearchEntry,
     pub source_info: Option<ToolSearchSourceInfo>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ToolSearchIdentity {
+    pub canonical_aliases: Vec<String>,
+    pub tool_aliases: Vec<String>,
+    pub source_aliases: Vec<String>,
 }
 
 impl ToolSearchInfo {
@@ -31,6 +39,20 @@ impl ToolSearchInfo {
         search_text: String,
         spec: ToolSpec,
         source_info: Option<ToolSearchSourceInfo>,
+    ) -> Option<Self> {
+        Self::from_spec_with_identity(
+            search_text,
+            spec,
+            source_info,
+            ToolSearchIdentity::default(),
+        )
+    }
+
+    pub fn from_spec_with_identity(
+        search_text: String,
+        spec: ToolSpec,
+        source_info: Option<ToolSearchSourceInfo>,
+        identity: ToolSearchIdentity,
     ) -> Option<Self> {
         let output = match spec {
             ToolSpec::Function(mut tool) => {
@@ -54,10 +76,12 @@ impl ToolSearchInfo {
             | ToolSpec::WebSearch { .. }
             | ToolSpec::Freeform(_) => return None,
         };
+        let identity = build_identity(&output, source_info.as_ref(), identity);
 
         Some(Self {
             entry: ToolSearchEntry {
                 search_text,
+                identity,
                 output,
             },
             source_info,
@@ -71,7 +95,6 @@ fn default_tool_search_text(spec: &ToolSpec) -> String {
     match spec {
         ToolSpec::Function(tool) => append_function_search_text(tool, &mut parts),
         ToolSpec::Namespace(namespace) => {
-            push_search_part(&mut parts, namespace.name.clone());
             push_search_part(&mut parts, namespace.description.clone());
             for tool in &namespace.tools {
                 let ResponsesApiNamespaceTool::Function(tool) = tool;
@@ -98,16 +121,11 @@ fn default_tool_search_text(spec: &ToolSpec) -> String {
 }
 
 fn append_function_search_text(tool: &ResponsesApiTool, parts: &mut Vec<String>) {
-    push_search_part(parts, tool.name.clone());
-    push_search_part(parts, tool.name.replace('_', " "));
     push_search_part(parts, tool.description.clone());
     append_schema_search_text(&tool.parameters, parts);
 }
 
 fn append_schema_search_text(schema: &JsonSchema, parts: &mut Vec<String>) {
-    if let Some(description) = &schema.description {
-        push_search_part(parts, description.clone());
-    }
     if let Some(properties) = &schema.properties {
         for (name, schema) in properties {
             push_search_part(parts, name.clone());
@@ -121,6 +139,52 @@ fn append_schema_search_text(schema: &JsonSchema, parts: &mut Vec<String>) {
         for variant in variants {
             append_schema_search_text(variant, parts);
         }
+    }
+}
+
+fn build_identity(
+    output: &LoadableToolSpec,
+    source_info: Option<&ToolSearchSourceInfo>,
+    mut identity: ToolSearchIdentity,
+) -> ToolSearchIdentity {
+    append_output_identity(output, &mut identity);
+    if let Some(source_info) = source_info {
+        push_unique_alias(&mut identity.source_aliases, &source_info.name);
+    }
+    identity
+}
+
+fn append_output_identity(output: &LoadableToolSpec, identity: &mut ToolSearchIdentity) {
+    match output {
+        LoadableToolSpec::Function(tool) => {
+            push_unique_alias(&mut identity.canonical_aliases, &tool.name);
+            push_unique_alias(&mut identity.tool_aliases, &tool.name);
+        }
+        LoadableToolSpec::Namespace(namespace) => {
+            push_unique_alias(&mut identity.source_aliases, &namespace.name);
+            for tool in &namespace.tools {
+                let ResponsesApiNamespaceTool::Function(tool) = tool;
+                push_namespaced_aliases(
+                    &mut identity.canonical_aliases,
+                    &namespace.name,
+                    &tool.name,
+                );
+                push_unique_alias(&mut identity.tool_aliases, &tool.name);
+            }
+        }
+    }
+}
+
+fn push_namespaced_aliases(aliases: &mut Vec<String>, namespace: &str, name: &str) {
+    push_unique_alias(aliases, &format!("{namespace}.{name}"));
+    push_unique_alias(aliases, &format!("{namespace}__{name}"));
+    push_unique_alias(aliases, &format!("{namespace}{name}"));
+}
+
+fn push_unique_alias(aliases: &mut Vec<String>, alias: &str) {
+    let alias = alias.trim();
+    if !alias.is_empty() && !aliases.iter().any(|existing| existing == alias) {
+        aliases.push(alias.to_string());
     }
 }
 

--- a/codex-rs/tools/src/tool_search_tests.rs
+++ b/codex-rs/tools/src/tool_search_tests.rs
@@ -3,7 +3,7 @@ use pretty_assertions::assert_eq;
 use std::collections::BTreeMap;
 
 #[test]
-fn default_search_text_uses_model_visible_namespace_metadata_once() {
+fn default_search_text_uses_descriptions_and_schema_property_names() {
     let mut schedule_schema = JsonSchema::object(
         BTreeMap::from([(
             "timezone".to_string(),
@@ -43,6 +43,18 @@ fn default_search_text_uses_model_visible_namespace_metadata_once() {
 
     assert_eq!(
         search_info.entry.search_text,
-        "codex_app Manage Codex automations. automation_update automation update Create or update automations. Automation options. mode Update mode. schedule Schedule settings. timezone IANA timezone."
+        "Manage Codex automations. Create or update automations. mode schedule timezone"
+    );
+    assert_eq!(
+        search_info.entry.identity,
+        ToolSearchIdentity {
+            canonical_aliases: vec![
+                "codex_app.automation_update".to_string(),
+                "codex_app__automation_update".to_string(),
+                "codex_appautomation_update".to_string(),
+            ],
+            tool_aliases: vec!["automation_update".to_string()],
+            source_aliases: vec!["codex_app".to_string()],
+        }
     );
 }


### PR DESCRIPTION
[Codex Thread 019ed1ea-8c0a-7862-9895-17b77fa68352](https://codex-thread-link.openai.chatgpt-team.site/thread/019ed1ea-8c0a-7862-9895-17b77fa68352)

## Summary
- Add structured tool/search identity metadata for canonical aliases, tool aliases, and source aliases instead of relying on repeated BM25 text.
- Rank the full non-zero BM25 candidate set plus exact identity matches before applying the requested/default limit.
- Preserve output protocol, deferred inventory filtering, default limit semantics, and namespace coalescing after final rank/limit selection.
- Keep MCP connector/plugin/server provenance as source identity, including plugin display names such as Cortex -> OpenAI Topics.

## Validation
- `UV_CACHE_DIR=/tmp/codex-uv-cache just fmt`
- `just test -p codex-tools`
- `just test -p codex-core tools::handlers::tool_search`
- `just fix -p codex-tools`
- `just fix -p codex-core`
- `git diff --check`

## Notes
- `just test -p codex-core tool_search` ran 30 filtered tests: 27 passed, 3 local stdio RMCP integration tests failed before any model-server request with `PATH aliases: Read-only file system`; the focused handler tests and app-backed search integration passed.
- A future debug inspector can reuse the internal `search_ranked` / `ToolSearchScore` breakdown. No protocol or UI expansion is included here.