### PR TITLE
[rmcp-client] Retain OAuth credentials after persistence failure

### DIFF
--- a/codex-rs/rmcp-client/src/oauth.rs
+++ b/codex-rs/rmcp-client/src/oauth.rs
@@ -1290,6 +1290,85 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unpersisted_refresh_does_not_reinstall_unchanged_durable_credentials() -> Result<()> {
+        let _env = TempCodexHome::new();
+        let server = MockServer::start().await;
+        mount_oauth_metadata(&server).await;
+        Mock::given(method("POST"))
+            .and(path("/oauth/token"))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let failing_store = MockKeyringStore::default();
+        let mut initial_tokens = sample_tokens();
+        initial_tokens.url = format!("{}/mcp", server.uri());
+        super::save_oauth_tokens_with_keyring_store(
+            &failing_store,
+            &initial_tokens.server_name,
+            &initial_tokens,
+            OAuthCredentialsStoreMode::Keyring,
+            AuthKeyringBackendKind::Direct,
+        )?;
+
+        let mut unpersisted_tokens = initial_tokens.clone();
+        unpersisted_tokens
+            .token_response
+            .0
+            .set_access_token(AccessToken::new("unpersisted-access-token".to_string()));
+        let manager = authorization_manager_for(&unpersisted_tokens).await?;
+        let persistor = OAuthPersistor::new(
+            initial_tokens.server_name.clone(),
+            initial_tokens.url.clone(),
+            manager.clone(),
+            ResolvedOAuthCredentialStore::Keyring(AuthKeyringBackendKind::Direct),
+            Some(initial_tokens.clone()),
+        );
+        let key = super::compute_store_key(&initial_tokens.server_name, &initial_tokens.url)?;
+        failing_store.set_error(&key, KeyringError::Invalid("error".into(), "save".into()));
+        persistor
+            .persist_if_needed_with_keyring_store(&failing_store)
+            .await
+            .expect_err("the refreshed credential should remain unpersisted");
+
+        let unchanged_store = MockKeyringStore::default();
+        super::save_oauth_tokens_with_keyring_store(
+            &unchanged_store,
+            &initial_tokens.server_name,
+            &initial_tokens,
+            OAuthCredentialsStoreMode::Keyring,
+            AuthKeyringBackendKind::Direct,
+        )?;
+        let mut subsequent_tokens = unpersisted_tokens.clone();
+        subsequent_tokens
+            .token_response
+            .0
+            .set_access_token(AccessToken::new("subsequent-access-token".to_string()));
+        install_tokens_in_manager(&manager, &subsequent_tokens).await?;
+
+        persistor
+            .persist_if_needed_locked_with_keyring_store(&unchanged_store)
+            .await?;
+
+        let manager_tokens = tokens_from_manager(&manager).await?;
+        assert_eq!(
+            manager_tokens.token_response,
+            subsequent_tokens.token_response
+        );
+        let stored = super::load_oauth_tokens_from_keyring(
+            &unchanged_store,
+            AuthKeyringBackendKind::Direct,
+            &subsequent_tokens.server_name,
+            &subsequent_tokens.url,
+        )?
+        .expect("the subsequent credentials should replace the unchanged stale snapshot");
+        assert_eq!(stored.token_response, subsequent_tokens.token_response);
+        server.verify().await;
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn resolved_secrets_write_does_not_cleanup_fallback_file() -> Result<()> {
         let _env = TempCodexHome::new();
         let server = MockServer::start().await;

--- a/codex-rs/rmcp-client/src/oauth/persistor.rs
+++ b/codex-rs/rmcp-client/src/oauth/persistor.rs
@@ -56,10 +56,37 @@ struct CredentialState {
     current: Option<StoredOAuthTokens>,
     // A successful provider response becomes authoritative for this client before the fallible
     // durable write. We intentionally do not retry that write in this stack: healthy in-memory
-    // credentials may keep serving this process, while any later refresh that would reread the
-    // older durable token fails closed. The persistence warning is the signal for deciding whether
-    // a bounded retry policy is warranted in a follow-up.
-    has_unpersisted_refresh: bool,
+    // credentials may keep serving this process. If they later need refresh, retain the durable
+    // snapshot that preceded the failed write: an unchanged snapshot is stale and fails closed,
+    // while a genuinely changed login, logout, or concurrent refresh remains authoritative.
+    // The persistence warning is the signal for deciding whether a bounded retry policy is
+    // warranted in a follow-up.
+    unpersisted_refresh: Option<UnpersistedRefresh>,
+}
+
+#[derive(Clone)]
+struct UnpersistedRefresh {
+    previously_persisted: Option<StoredOAuthTokens>,
+}
+
+fn durable_credentials_match_snapshot(
+    latest: &Option<StoredOAuthTokens>,
+    snapshot: &Option<StoredOAuthTokens>,
+) -> bool {
+    match (latest, snapshot) {
+        (Some(latest), Some(snapshot)) => {
+            // `expires_in` is reconstructed from the durable `expires_at` timestamp on every
+            // load, so elapsed time alone must not look like a concurrent credential change.
+            let mut comparable_latest = latest.clone();
+            comparable_latest
+                .token_response
+                .0
+                .set_expires_in(snapshot.token_response.0.expires_in().as_ref());
+            comparable_latest == *snapshot
+        }
+        (None, None) => true,
+        (Some(_), None) | (None, Some(_)) => false,
+    }
 }
 
 impl OAuthPersistor {
@@ -78,7 +105,7 @@ impl OAuthPersistor {
                 credential_store,
                 credential_state: Mutex::new(CredentialState {
                     current: initial_credentials,
-                    has_unpersisted_refresh: false,
+                    unpersisted_refresh: None,
                 }),
             }),
         }
@@ -97,9 +124,9 @@ impl OAuthPersistor {
         &self,
         keyring_store: &K,
     ) -> Result<()> {
-        let snapshot = {
+        let (snapshot, unpersisted_refresh) = {
             let state = self.inner.credential_state.lock().await;
-            state.current.clone()
+            (state.current.clone(), state.unpersisted_refresh.clone())
         };
         let (client_id, current_credentials) = self.manager_credentials().await?;
         let manager_changed = match (&snapshot, current_credentials.as_ref()) {
@@ -119,20 +146,13 @@ impl OAuthPersistor {
                 .await?;
         let latest = self.load_resolved_credentials(keyring_store)?;
 
-        let latest_matches_snapshot = match (&latest, &snapshot) {
-            (Some(latest), Some(snapshot)) => {
-                // `expires_in` is reconstructed from the durable `expires_at` timestamp on every
-                // load, so elapsed time alone must not look like a concurrent credential change.
-                let mut comparable_latest = latest.clone();
-                comparable_latest
-                    .token_response
-                    .0
-                    .set_expires_in(snapshot.token_response.0.expires_in().as_ref());
-                comparable_latest == *snapshot
-            }
-            (None, None) => true,
-            (Some(_), None) | (None, Some(_)) => false,
-        };
+        let latest_matches_snapshot = durable_credentials_match_snapshot(&latest, &snapshot)
+            || unpersisted_refresh.as_ref().is_some_and(|pending| {
+                // The failed write never changed durable authority. If storage still contains the
+                // last known durable snapshot, persist the manager's newer result instead of
+                // adopting and replaying that stale snapshot.
+                durable_credentials_match_snapshot(&latest, &pending.previously_persisted)
+            });
 
         if !latest_matches_snapshot {
             // A completed login or logout is authoritative over tokens refreshed inside an RMCP
@@ -144,7 +164,7 @@ impl OAuthPersistor {
                     self.clear_manager_credentials().await;
                     let mut state = self.inner.credential_state.lock().await;
                     state.current = None;
-                    state.has_unpersisted_refresh = false;
+                    state.unpersisted_refresh = None;
                 }
             }
             return Ok(());
@@ -226,8 +246,18 @@ impl OAuthPersistor {
                     // The provider may already have consumed the old rotating refresh token. Make
                     // B authoritative in this process before the fallible save so a later public
                     // operation cannot reinstall A from the last snapshot.
+                    // Preserve the last snapshot known to be durable across repeated in-memory
+                    // changes. Using the immediately preceding in-memory token here could make an
+                    // unchanged stale store look like an external login or refresh.
+                    let previously_persisted = state
+                        .unpersisted_refresh
+                        .take()
+                        .map(|pending| pending.previously_persisted)
+                        .unwrap_or_else(|| state.current.clone());
                     state.current = Some(stored.clone());
-                    state.has_unpersisted_refresh = true;
+                    state.unpersisted_refresh = Some(UnpersistedRefresh {
+                        previously_persisted,
+                    });
                     debug!("persisting refreshed MCP OAuth credentials to the resolved store");
                     let persistence_started_at = Instant::now();
                     let persistence_result = match self.inner.credential_store {
@@ -249,7 +279,7 @@ impl OAuthPersistor {
                         );
                         return Err(error);
                     }
-                    state.has_unpersisted_refresh = false;
+                    state.unpersisted_refresh = None;
                     debug!(
                         persistence_elapsed_ms = persistence_started_at.elapsed().as_millis(),
                         "persisted refreshed MCP OAuth credentials"
@@ -287,7 +317,7 @@ impl OAuthPersistor {
                         self.inner.server_name
                     );
                 }
-                state.has_unpersisted_refresh = false;
+                state.unpersisted_refresh = None;
             }
         }
 
@@ -381,9 +411,9 @@ impl OAuthPersistor {
             "acquired the MCP OAuth credential transaction lock"
         );
 
-        {
+        let unpersisted_refresh = {
             let state = self.inner.credential_state.lock().await;
-            if state.has_unpersisted_refresh {
+            if let Some(unpersisted_refresh) = state.unpersisted_refresh.as_ref() {
                 if state
                     .current
                     .as_ref()
@@ -394,17 +424,31 @@ impl OAuthPersistor {
                     );
                     return Ok(());
                 }
-                anyhow::bail!(
-                    "refusing to refresh MCP OAuth credentials for server {} because the previous refresh succeeded but its credentials were not persisted",
-                    self.inner.server_name
-                );
+                Some(unpersisted_refresh.clone())
+            } else {
+                None
             }
-        }
+        };
         // The refresh transaction must stay on the store that supplied its snapshot. Falling back
         // here could replay an older rotating refresh token from the other store. We assume store
         // availability is stable for this client lifecycle and surface violations of that
         // assumption instead of switching stores.
         let latest = self.load_resolved_credentials(keyring_store)?;
+
+        if let Some(unpersisted_refresh) = unpersisted_refresh {
+            if durable_credentials_match_snapshot(
+                &latest,
+                &unpersisted_refresh.previously_persisted,
+            ) {
+                anyhow::bail!(
+                    "refusing to refresh MCP OAuth credentials for server {} because the previous refresh succeeded but its credentials were not persisted",
+                    self.inner.server_name
+                );
+            }
+            debug!(
+                "the resolved store changed after refresh persistence failed; adopting the serialized login, logout, or concurrent refresh"
+            );
+        }
 
         // The pre-lock snapshot only decides whether a refresh transaction might be needed. Once
         // the lock is held, this reread is authoritative: adopt it before deciding whether to
@@ -413,7 +457,7 @@ impl OAuthPersistor {
             self.clear_manager_credentials().await;
             let mut state = self.inner.credential_state.lock().await;
             state.current = None;
-            state.has_unpersisted_refresh = false;
+            state.unpersisted_refresh = None;
             anyhow::bail!(
                 "OAuth tokens for server {} were removed before refresh; authorization required",
                 self.inner.server_name
@@ -487,7 +531,7 @@ impl OAuthPersistor {
         install_tokens_in_manager(&self.inner.authorization_manager, &tokens).await?;
         let mut state = self.inner.credential_state.lock().await;
         state.current = Some(tokens);
-        state.has_unpersisted_refresh = false;
+        state.unpersisted_refresh = None;
         Ok(())
     }
 


### PR DESCRIPTION
[Codex Thread 019edd6d-6f14-74e2-853c-345d1803d4a6](https://codex-thread-link.openai.chatgpt-team.site/thread/019edd6d-6f14-74e2-853c-345d1803d4a6)

<!-- superseded-by-mcp-oauth-stack-30292 -->
> [!IMPORTANT]
> **This PR belongs to the superseded MCP OAuth stack.** Please review and merge the replacement stack beginning with [openai/codex#30292](https://github.com/openai/codex/pull/30292). This PR remains available only as historical/reference context.
>
> Replacement review order:
> 1. [openai/codex#30292](https://github.com/openai/codex/pull/30292) — shared File/Secrets store locking
> 2. [openai/codex#30293](https://github.com/openai/codex/pull/30293) — authoritative serialized refresh
> 3. [openai/codex#30294](https://github.com/openai/codex/pull/30294) — Codex-owned transport refresh and one-shot 401 recovery
> 4. [openai/codex#30295](https://github.com/openai/codex/pull/30295) — login/logout transaction serialization
> 5. [openai/codex#30296](https://github.com/openai/codex/pull/30296) — diagnostic-only Auto store drift reporting


This is part 5 of an eight-PR stack that prevents concurrent MCP OAuth refreshers from replaying a rotating refresh token or overwriting newer credentials.

## Review order

1. [openai/codex#29017](https://github.com/openai/codex/pull/29017) — refresh transaction and lifecycle-local store pinning
2. [openai/codex#29020](https://github.com/openai/codex/pull/29020) — authoritative reread after lock acquisition
3. [openai/codex#29019](https://github.com/openai/codex/pull/29019) — serialize login and logout with refresh
4. [openai/codex#29021](https://github.com/openai/codex/pull/29021) — lock aggregate File and Secrets stores
5. **[openai/codex#30090](https://github.com/openai/codex/pull/30090) — retain refreshed credentials after a persistence failure (this PR)**
6. [openai/codex#30091](https://github.com/openai/codex/pull/30091) — add Codex-owned proactive and 401 recovery
7. [openai/codex#29018](https://github.com/openai/codex/pull/29018) — make Codex the exclusive refresh owner for all RMCP traffic
8. [openai/codex#30089](https://github.com/openai/codex/pull/30089) — end-to-end transport recovery coverage

## Why this layer exists

After the provider successfully rotates A to B, B is the only potentially usable credential even if durable persistence fails. Reinstalling durable A on the next operation would discard B and replay an already-consumed refresh token.

## What changes

- Make refreshed B authoritative in the authorization manager and the persistor's in-memory state before attempting the durable write.
- Record that B has not been persisted and retain the last credential snapshot known to be durable.
- Keep healthy access-token requests on B for the current process.
- On B's next refresh, reread under the transaction lock only to reconcile authority: unchanged durable A fails closed, while a serialized login, logout, or concurrent refresh that replaced A is adopted.
- Add structured stage and timing logs for provider refresh and persistence failures.

## Decisions reviewers should preserve across the stack

- A successful provider response transfers in-process authority to B before persistence.
- This stack intentionally does not retry persistence, in the foreground or background. The error is logged and returned so telemetry can tell us whether a retry policy is needed.
- A healthy B may continue serving requests without polling durable storage on every operation. When B itself needs refresh, unchanged durable A returns the pending-persistence error; a credential that changed under the shared transaction lock is authoritative and may be adopted.
- Provider timeout is different: no B was received, so the outcome remains unknown and a later serialized retry is allowed.
- `Auto` remains lifecycle-local and never hot-switches after construction.
- The original [openai/codex#28647](https://github.com/openai/codex/pull/28647) and its branch are untouched.

## Review focus

Review the authority transition around the fallible save, the retained last-known-durable snapshot, and the distinction between “provider response succeeded, persistence failed” and “provider outcome unknown.” No transport ownership changes occur in this layer.

## Non-goals

- Retrying failed persistence.
- Quarantining credentials after provider timeout.
- Durable `Auto` selection or backend migration.

## Validation

- `just test -p codex-rmcp-client`: 108 passed, 5 skipped.
- Regression coverage proves an unchanged stale durable snapshot is never reinstalled after a failed save.