### PR TITLE
cli: rename sandbox permission profile flag

### DIFF
--- a/codex-rs/cli/src/lib.rs
+++ b/codex-rs/cli/src/lib.rs
@@ -53,7 +53,12 @@ pub struct SeatbeltCommand {
     pub sandbox_state: SandboxStateArgs,
 
     /// Named permissions profile to apply from the active configuration stack.
-    #[arg(long = "permissions-profile", short = 'P', value_name = "NAME")]
+    #[arg(
+        long = "permission-profile",
+        alias = "permissions-profile",
+        short = 'P',
+        value_name = "NAME"
+    )]
     pub permissions_profile: Option<String>,
 
     /// Layer $CODEX_HOME/<name>.config.toml on top of the base user config.
@@ -104,7 +109,12 @@ pub struct LandlockCommand {
     pub sandbox_state: SandboxStateArgs,
 
     /// Named permissions profile to apply from the active configuration stack.
-    #[arg(long = "permissions-profile", short = 'P', value_name = "NAME")]
+    #[arg(
+        long = "permission-profile",
+        alias = "permissions-profile",
+        short = 'P',
+        value_name = "NAME"
+    )]
     pub permissions_profile: Option<String>,
 
     /// Layer $CODEX_HOME/<name>.config.toml on top of the base user config.
@@ -142,7 +152,12 @@ pub struct WindowsCommand {
     pub sandbox_state: SandboxStateArgs,
 
     /// Named permissions profile to apply from the active configuration stack.
-    #[arg(long = "permissions-profile", short = 'P', value_name = "NAME")]
+    #[arg(
+        long = "permission-profile",
+        alias = "permissions-profile",
+        short = 'P',
+        value_name = "NAME"
+    )]
     pub permissions_profile: Option<String>,
 
     /// Layer $CODEX_HOME/<name>.config.toml on top of the base user config.

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -2965,7 +2965,28 @@ mod tests {
 
     #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
     #[test]
-    fn sandbox_parses_permissions_profile() {
+    fn sandbox_parses_permission_profile() {
+        let cli = MultitoolCli::try_parse_from([
+            "codex",
+            "sandbox",
+            "--permission-profile",
+            ":workspace",
+            "--",
+            "echo",
+        ])
+        .expect("parse");
+
+        let Some(Subcommand::Sandbox(command)) = cli.subcommand else {
+            panic!("expected sandbox command");
+        };
+
+        assert_eq!(command.permissions_profile.as_deref(), Some(":workspace"));
+        assert_eq!(command.command, vec!["echo"]);
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+    #[test]
+    fn sandbox_parses_legacy_permissions_profile_alias() {
         let cli = MultitoolCli::try_parse_from([
             "codex",
             "sandbox",
@@ -2982,6 +3003,14 @@ mod tests {
 
         assert_eq!(command.permissions_profile.as_deref(), Some(":workspace"));
         assert_eq!(command.command, vec!["echo"]);
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
+    #[test]
+    fn sandbox_help_only_shows_singular_permission_profile() {
+        let help = help_from_args(&["codex", "sandbox", "--help"]);
+        assert!(help.contains("--permission-profile"), "{help}");
+        assert!(!help.contains("--permissions-profile"), "{help}");
     }
 
     #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]

--- a/codex-rs/cli/tests/sandbox_network_proxy.rs
+++ b/codex-rs/cli/tests/sandbox_network_proxy.rs
@@ -35,7 +35,7 @@ mode = "full"
         .env("CODEX_HOME", codex_home.path())
         .args([
             "sandbox",
-            "--permissions-profile",
+            "--permission-profile",
             "network-test",
             "--",
             "curl",


### PR DESCRIPTION
## Why

`codex sandbox` accepts a single named permissions profile, so the existing plural `--permissions-profile` spelling is misleading. The canonical flag and its help text should use the singular form without breaking scripts that already use the old spelling.

## What changed

- Make `--permission-profile` the canonical flag for all sandbox backends.
- Keep `--permissions-profile` as a hidden backwards-compatible alias.
- Cover the canonical spelling, legacy alias, and help visibility with regression tests.

## Testing

Ran `just c sandbox --help` and verified I saw:

```shell
  -P, --permission-profile <NAME>
          Named permissions profile to apply from the active configuration stack
```