### PR TITLE
release: publish standalone zsh artifacts

### DIFF
--- a/.github/dotslash-zsh-config.json
+++ b/.github/dotslash-zsh-config.json
@@ -5,21 +5,25 @@
         "macos-aarch64": {
           "name": "codex-zsh-aarch64-apple-darwin.tar.gz",
           "format": "tar.gz",
+          "hash": "sha256",
           "path": "codex-zsh/bin/zsh"
         },
         "macos-x86_64": {
           "name": "codex-zsh-x86_64-apple-darwin.tar.gz",
           "format": "tar.gz",
+          "hash": "sha256",
           "path": "codex-zsh/bin/zsh"
         },
         "linux-x86_64": {
           "name": "codex-zsh-x86_64-unknown-linux-musl.tar.gz",
           "format": "tar.gz",
+          "hash": "sha256",
           "path": "codex-zsh/bin/zsh"
         },
         "linux-aarch64": {
           "name": "codex-zsh-aarch64-unknown-linux-musl.tar.gz",
           "format": "tar.gz",
+          "hash": "sha256",
           "path": "codex-zsh/bin/zsh"
         }
       }

--- a/.github/workflows/rust-release-zsh.yml
+++ b/.github/workflows/rust-release-zsh.yml
@@ -1,15 +1,56 @@
 name: rust-release-zsh
 
 on:
-  workflow_call:
+  push:
+    tags:
+      - "codex-zsh-v*.*.*"
 
 env:
   ZSH_COMMIT: 77045ef899e53b9598bebc5a41db93a548a40ca6
   ZSH_PATCH: codex-rs/shell-escalation/patches/zsh-exec-wrapper.patch
 
+concurrency:
+  group: ${{ github.workflow }}::${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
+  metadata:
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.release_tag.outputs.release_tag }}
+
+    steps:
+      - name: Validate release tag
+        id: release_tag
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${RELEASE_TAG}" =~ ^codex-zsh-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag ${RELEASE_TAG} does not match codex-zsh-vX.Y.Z." >&2
+            exit 1
+          fi
+
+          echo "release_tag=${RELEASE_TAG}" >> "${GITHUB_OUTPUT}"
+
+      - name: Ensure release does not exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release_tag.outputs.release_tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" > /dev/null 2>&1; then
+            echo "Release ${RELEASE_TAG} already exists; publish changed artifacts under a new tag." >&2
+            exit 1
+          fi
+
   linux:
     name: Build zsh (Linux) - ${{ matrix.variant }} - ${{ matrix.target }}
+    needs: metadata
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     container:
@@ -62,6 +103,7 @@ jobs:
 
   darwin:
     name: Build zsh (macOS) - ${{ matrix.variant }} - ${{ matrix.target }}
+    needs: metadata
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
 
@@ -101,3 +143,40 @@ jobs:
         with:
           name: codex-zsh-${{ matrix.target }}
           path: dist/zsh/${{ matrix.target }}/*
+
+  publish-release:
+    needs:
+      - metadata
+      - linux
+      - darwin
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: dist
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        with:
+          tag_name: ${{ needs.metadata.outputs.release_tag }}
+          name: ${{ needs.metadata.outputs.release_tag }}
+          files: dist/**
+          # Keep zsh artifact releases out of Codex's normal "latest release" channel.
+          prerelease: true
+
+      - name: Publish DotSlash manifest
+        uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag: ${{ needs.metadata.outputs.release_tag }}
+          config: .github/dotslash-zsh-config.json

--- a/codex-rs/shell-escalation/README.md
+++ b/codex-rs/shell-escalation/README.md
@@ -27,3 +27,8 @@ git apply /path/to/patches/zsh-exec-wrapper.patch
 ./configure
 make -j"$(nproc)"
 ```
+
+Release artifacts are built by `.github/workflows/rust-release-zsh.yml` when a
+`codex-zsh-vX.Y.Z` tag is pushed. When the zsh commit or patch changes, publish
+the next version tag and update the checked-in DotSlash manifests to use the new
+release.


### PR DESCRIPTION
## Why

The patched zsh artifacts rarely change, but `.github/workflows/rust-release-zsh.yml` currently runs as part of every Rust release. Rebuilding the same four binaries for each Codex version wastes release capacity and ties an independently versioned runtime dependency to the main release cadence.

This establishes the producer side of a build-once flow. The existing Rust release workflow remains unchanged until the first standalone artifact release has been published and the checked-in DotSlash manifests can be updated with its URLs and checksums.

## What changed

- Run the zsh release workflow for protected `codex-zsh-vX.Y.Z` tags instead of as a reusable workflow.
- Validate the semantic release tag before starting the platform builds.
- Publish the four zsh archives to a GitHub prerelease so the release never becomes the repository latest release.
- Publish the generated `codex-zsh` DotSlash manifest alongside the archives.
- Document how to publish the next artifact version after changing the pinned zsh commit or patch.

## Tag protection

An active repository tag ruleset named `codex-zsh-v*.*.*` targets `refs/tags/codex-zsh-v*.*.*`. It restricts tag creation, updates, deletion, and non-fast-forward changes; requires linear history; and limits bypass to the configured repository role.

This was verified with:

```shell
gh api repos/openai/codex/rulesets/18140982
```

The response reported `"enforcement":"active"`, the expected tag condition, and the `creation`, `update`, `deletion`, `non_fast_forward`, and `required_linear_history` rules.

## Rollout

After this lands, publish the first `codex-zsh-vX.Y.Z` release. A follow-up can then update the checked-in DotSlash manifests and remove the zsh rebuild from `.github/workflows/rust-release.yml`.



---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/30114).
* #30116
* __->__ #30114