### PR TITLE
[codex] Propagate traces through exec-server HTTP

### DIFF
--- a/codex-rs/exec-server/src/client/reqwest_http_client.rs
+++ b/codex-rs/exec-server/src/client/reqwest_http_client.rs
@@ -18,6 +18,7 @@ use reqwest::Url;
 use reqwest::header::HeaderMap;
 use reqwest::header::HeaderName;
 use reqwest::header::HeaderValue;
+use tracing::Instrument;
 
 use super::HttpResponseBodyStream;
 use super::response_body_stream::send_body_delta;
@@ -146,15 +147,26 @@ impl ReqwestHttpRequestRunner {
             }
         }
 
-        let headers = Self::build_headers(params.headers)?;
+        let request_span = tracing::info_span!(
+            "codex.exec_server.http_request",
+            otel.kind = "client",
+            http.request.method = method.as_str(),
+            server.address = url.host_str().unwrap_or_default(),
+            server.port = u64::from(url.port_or_known_default().unwrap_or_default()),
+            http.response.status_code = tracing::field::Empty,
+            error.type = tracing::field::Empty,
+        );
+        let mut headers = Self::build_headers(params.headers)?;
+        codex_otel::inject_span_w3c_trace_headers(&request_span, &mut headers);
         let mut request = self.client.request(method.clone(), url).headers(headers);
         if let Some(body) = params.body {
             request = request.body(body.into_inner());
         }
 
-        let response = match request.send().await {
+        let response = match request.send().instrument(request_span.clone()).await {
             Ok(response) => response,
             Err(error) => {
+                request_span.record("error.type", "request");
                 let error_message = error.to_string();
                 log_send_error(&method, error);
                 return Err(internal_error(format!(
@@ -163,6 +175,7 @@ impl ReqwestHttpRequestRunner {
             }
         };
         let status = response.status().as_u16();
+        request_span.record("http.response.status_code", u64::from(status));
         let headers = Self::response_headers(response.headers());
 
         if params.stream_response {

--- a/codex-rs/exec-server/src/server/processor.rs
+++ b/codex-rs/exec-server/src/server/processor.rs
@@ -238,6 +238,7 @@ mod tests {
     use codex_exec_server_protocol::RequestId;
     use codex_utils_path_uri::PathUri;
     use opentelemetry::trace::SpanId;
+    use opentelemetry::trace::TraceContextExt;
     use opentelemetry::trace::TraceId;
     use opentelemetry::trace::TracerProvider as _;
     use opentelemetry_sdk::trace::InMemorySpanExporter;
@@ -255,6 +256,11 @@ mod tests {
     use tokio::time::timeout;
     use tracing_subscriber::filter::filter_fn;
     use tracing_subscriber::prelude::*;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
 
     use super::request_span;
     use super::run_connection;
@@ -268,6 +274,10 @@ mod tests {
     use crate::protocol::EnvironmentInfo;
     use crate::protocol::ExecParams;
     use crate::protocol::ExecResponse;
+    use crate::protocol::HTTP_REQUEST_METHOD;
+    use crate::protocol::HttpRedirectPolicy;
+    use crate::protocol::HttpRequestParams;
+    use crate::protocol::HttpRequestResponse;
     use crate::protocol::INITIALIZE_METHOD;
     use crate::protocol::INITIALIZED_METHOD;
     use crate::protocol::InitializeParams;
@@ -326,6 +336,122 @@ mod tests {
         );
         assert_eq!(request_span.span_context.trace_id(), trace_id);
         assert_eq!(request_span.parent_span_id, parent_span_id);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn request_dispatch_continues_trace_through_http_egress() {
+        let span_exporter = InMemorySpanExporter::default();
+        let tracer_provider = SdkTracerProvider::builder()
+            .with_simple_exporter(span_exporter.clone())
+            .build();
+        let tracer = tracer_provider.tracer("exec-server-test");
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_opentelemetry::layer()
+                .with_tracer(tracer)
+                .with_filter(filter_fn(codex_otel::OtelProvider::trace_export_filter)),
+        );
+        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+        tracing::callsite::rebuild_interest_cache();
+
+        let provider = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/mcp"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"ok"))
+            .expect(1)
+            .mount(&provider)
+            .await;
+
+        let registry = SessionRegistry::new();
+        let (mut writer, mut lines, task) = spawn_test_connection(registry, "traced-http");
+        send_request(
+            &mut writer,
+            /*id*/ 1,
+            INITIALIZE_METHOD,
+            &InitializeParams {
+                client_name: "exec-server-test".to_string(),
+                resume_session_id: None,
+            },
+        )
+        .await;
+        let _: InitializeResponse = read_response(&mut lines, /*expected_id*/ 1).await;
+        send_notification(&mut writer, INITIALIZED_METHOD, &()).await;
+
+        let trace_id = TraceId::from_hex("00000000000000000000000000000011").expect("trace id");
+        let parent_span_id = SpanId::from_hex("0000000000000022").expect("span id");
+        send_request_with_trace(
+            &mut writer,
+            /*id*/ 2,
+            HTTP_REQUEST_METHOD,
+            &HttpRequestParams {
+                method: "GET".to_string(),
+                url: format!("{}/mcp", provider.uri()),
+                headers: Vec::new(),
+                body: None,
+                timeout_ms: None,
+                redirect_policy: HttpRedirectPolicy::Follow,
+                request_id: "request-1".to_string(),
+                stream_response: false,
+            },
+            Some(codex_protocol::protocol::W3cTraceContext {
+                traceparent: Some(format!("00-{trace_id}-{parent_span_id}-01")),
+                tracestate: None,
+            }),
+        )
+        .await;
+        let response: HttpRequestResponse = read_response(&mut lines, /*expected_id*/ 2).await;
+        assert_eq!(response.status, 200);
+
+        drop(writer);
+        drop(lines);
+        timeout(Duration::from_secs(1), task)
+            .await
+            .expect("processor should exit")
+            .expect("processor should join");
+
+        let requests = provider
+            .received_requests()
+            .await
+            .expect("wiremock should retain requests");
+        let request = requests.first().expect("provider request");
+        let outbound_context = codex_otel::context_from_w3c_trace_context(
+            &codex_protocol::protocol::W3cTraceContext {
+                traceparent: request
+                    .headers
+                    .get("traceparent")
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_string),
+                tracestate: request
+                    .headers
+                    .get("tracestate")
+                    .and_then(|value| value.to_str().ok())
+                    .map(str::to_string),
+            },
+        )
+        .expect("provider request should carry valid W3C context");
+        let outbound_span_context = outbound_context.span().span_context().clone();
+
+        tracer_provider.force_flush().expect("flush traces");
+        let spans = span_exporter.get_finished_spans().expect("span export");
+        let request_span = spans
+            .iter()
+            .find(|span| span.name.as_ref() == HTTP_REQUEST_METHOD)
+            .expect("executor request span");
+        let http_span = spans
+            .iter()
+            .find(|span| span.name.as_ref() == "codex.exec_server.http_request")
+            .expect("HTTP client span");
+        assert_eq!(request_span.span_context.trace_id(), trace_id);
+        assert_eq!(request_span.parent_span_id, parent_span_id);
+        assert_eq!(http_span.span_context.trace_id(), trace_id);
+        assert_eq!(
+            http_span.parent_span_id,
+            request_span.span_context.span_id()
+        );
+        assert_eq!(outbound_span_context.trace_id(), trace_id);
+        assert_eq!(
+            outbound_span_context.span_id(),
+            http_span.span_context.span_id()
+        );
     }
 
     #[tokio::test]
@@ -476,13 +602,23 @@ mod tests {
         method: &str,
         params: &P,
     ) {
+        send_request_with_trace(writer, id, method, params, None).await;
+    }
+
+    async fn send_request_with_trace<P: Serialize>(
+        writer: &mut DuplexStream,
+        id: i64,
+        method: &str,
+        params: &P,
+        trace: Option<codex_protocol::protocol::W3cTraceContext>,
+    ) {
         write_message(
             writer,
             &JSONRPCMessage::Request(JSONRPCRequest {
                 id: RequestId::Integer(id),
                 method: method.to_string(),
                 params: Some(serde_json::to_value(params).expect("serialize params")),
-                trace: None,
+                trace,
             }),
         )
         .await;

--- a/codex-rs/exec-server/src/server/processor.rs
+++ b/codex-rs/exec-server/src/server/processor.rs
@@ -602,7 +602,7 @@ mod tests {
         method: &str,
         params: &P,
     ) {
-        send_request_with_trace(writer, id, method, params, None).await;
+        send_request_with_trace(writer, id, method, params, /*trace*/ None).await;
     }
 
     async fn send_request_with_trace<P: Serialize>(

--- a/codex-rs/exec-server/src/server/processor.rs
+++ b/codex-rs/exec-server/src/server/processor.rs
@@ -238,7 +238,6 @@ mod tests {
     use codex_exec_server_protocol::RequestId;
     use codex_utils_path_uri::PathUri;
     use opentelemetry::trace::SpanId;
-    use opentelemetry::trace::TraceContextExt;
     use opentelemetry::trace::TraceId;
     use opentelemetry::trace::TracerProvider as _;
     use opentelemetry_sdk::trace::InMemorySpanExporter;
@@ -256,11 +255,6 @@ mod tests {
     use tokio::time::timeout;
     use tracing_subscriber::filter::filter_fn;
     use tracing_subscriber::prelude::*;
-    use wiremock::Mock;
-    use wiremock::MockServer;
-    use wiremock::ResponseTemplate;
-    use wiremock::matchers::method;
-    use wiremock::matchers::path;
 
     use super::request_span;
     use super::run_connection;
@@ -274,10 +268,6 @@ mod tests {
     use crate::protocol::EnvironmentInfo;
     use crate::protocol::ExecParams;
     use crate::protocol::ExecResponse;
-    use crate::protocol::HTTP_REQUEST_METHOD;
-    use crate::protocol::HttpRedirectPolicy;
-    use crate::protocol::HttpRequestParams;
-    use crate::protocol::HttpRequestResponse;
     use crate::protocol::INITIALIZE_METHOD;
     use crate::protocol::INITIALIZED_METHOD;
     use crate::protocol::InitializeParams;
@@ -336,122 +326,6 @@ mod tests {
         );
         assert_eq!(request_span.span_context.trace_id(), trace_id);
         assert_eq!(request_span.parent_span_id, parent_span_id);
-    }
-
-    #[tokio::test(flavor = "current_thread")]
-    async fn request_dispatch_continues_trace_through_http_egress() {
-        let span_exporter = InMemorySpanExporter::default();
-        let tracer_provider = SdkTracerProvider::builder()
-            .with_simple_exporter(span_exporter.clone())
-            .build();
-        let tracer = tracer_provider.tracer("exec-server-test");
-        let subscriber = tracing_subscriber::registry().with(
-            tracing_opentelemetry::layer()
-                .with_tracer(tracer)
-                .with_filter(filter_fn(codex_otel::OtelProvider::trace_export_filter)),
-        );
-        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
-        tracing::callsite::rebuild_interest_cache();
-
-        let provider = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/mcp"))
-            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"ok"))
-            .expect(1)
-            .mount(&provider)
-            .await;
-
-        let registry = SessionRegistry::new();
-        let (mut writer, mut lines, task) = spawn_test_connection(registry, "traced-http");
-        send_request(
-            &mut writer,
-            /*id*/ 1,
-            INITIALIZE_METHOD,
-            &InitializeParams {
-                client_name: "exec-server-test".to_string(),
-                resume_session_id: None,
-            },
-        )
-        .await;
-        let _: InitializeResponse = read_response(&mut lines, /*expected_id*/ 1).await;
-        send_notification(&mut writer, INITIALIZED_METHOD, &()).await;
-
-        let trace_id = TraceId::from_hex("00000000000000000000000000000011").expect("trace id");
-        let parent_span_id = SpanId::from_hex("0000000000000022").expect("span id");
-        send_request_with_trace(
-            &mut writer,
-            /*id*/ 2,
-            HTTP_REQUEST_METHOD,
-            &HttpRequestParams {
-                method: "GET".to_string(),
-                url: format!("{}/mcp", provider.uri()),
-                headers: Vec::new(),
-                body: None,
-                timeout_ms: None,
-                redirect_policy: HttpRedirectPolicy::Follow,
-                request_id: "request-1".to_string(),
-                stream_response: false,
-            },
-            Some(codex_protocol::protocol::W3cTraceContext {
-                traceparent: Some(format!("00-{trace_id}-{parent_span_id}-01")),
-                tracestate: None,
-            }),
-        )
-        .await;
-        let response: HttpRequestResponse = read_response(&mut lines, /*expected_id*/ 2).await;
-        assert_eq!(response.status, 200);
-
-        drop(writer);
-        drop(lines);
-        timeout(Duration::from_secs(1), task)
-            .await
-            .expect("processor should exit")
-            .expect("processor should join");
-
-        let requests = provider
-            .received_requests()
-            .await
-            .expect("wiremock should retain requests");
-        let request = requests.first().expect("provider request");
-        let outbound_context = codex_otel::context_from_w3c_trace_context(
-            &codex_protocol::protocol::W3cTraceContext {
-                traceparent: request
-                    .headers
-                    .get("traceparent")
-                    .and_then(|value| value.to_str().ok())
-                    .map(str::to_string),
-                tracestate: request
-                    .headers
-                    .get("tracestate")
-                    .and_then(|value| value.to_str().ok())
-                    .map(str::to_string),
-            },
-        )
-        .expect("provider request should carry valid W3C context");
-        let outbound_span_context = outbound_context.span().span_context().clone();
-
-        tracer_provider.force_flush().expect("flush traces");
-        let spans = span_exporter.get_finished_spans().expect("span export");
-        let request_span = spans
-            .iter()
-            .find(|span| span.name.as_ref() == HTTP_REQUEST_METHOD)
-            .expect("executor request span");
-        let http_span = spans
-            .iter()
-            .find(|span| span.name.as_ref() == "codex.exec_server.http_request")
-            .expect("HTTP client span");
-        assert_eq!(request_span.span_context.trace_id(), trace_id);
-        assert_eq!(request_span.parent_span_id, parent_span_id);
-        assert_eq!(http_span.span_context.trace_id(), trace_id);
-        assert_eq!(
-            http_span.parent_span_id,
-            request_span.span_context.span_id()
-        );
-        assert_eq!(outbound_span_context.trace_id(), trace_id);
-        assert_eq!(
-            outbound_span_context.span_id(),
-            http_span.span_context.span_id()
-        );
     }
 
     #[tokio::test]
@@ -602,23 +476,13 @@ mod tests {
         method: &str,
         params: &P,
     ) {
-        send_request_with_trace(writer, id, method, params, /*trace*/ None).await;
-    }
-
-    async fn send_request_with_trace<P: Serialize>(
-        writer: &mut DuplexStream,
-        id: i64,
-        method: &str,
-        params: &P,
-        trace: Option<codex_protocol::protocol::W3cTraceContext>,
-    ) {
         write_message(
             writer,
             &JSONRPCMessage::Request(JSONRPCRequest {
                 id: RequestId::Integer(id),
                 method: method.to_string(),
                 params: Some(serde_json::to_value(params).expect("serialize params")),
-                trace,
+                trace: None,
             }),
         )
         .await;

--- a/codex-rs/otel/src/lib.rs
+++ b/codex-rs/otel/src/lib.rs
@@ -29,6 +29,7 @@ pub use crate::provider::OtelProvider;
 pub use crate::trace_context::context_from_w3c_trace_context;
 pub use crate::trace_context::current_span_trace_id;
 pub use crate::trace_context::current_span_w3c_trace_context;
+pub use crate::trace_context::inject_span_w3c_trace_headers;
 pub use crate::trace_context::set_parent_from_context;
 pub use crate::trace_context::set_parent_from_w3c_trace_context;
 pub use crate::trace_context::span_w3c_trace_context;

--- a/codex-rs/otel/src/trace_context.rs
+++ b/codex-rs/otel/src/trace_context.rs
@@ -336,7 +336,6 @@ mod tests {
     use super::context_from_trace_headers;
     use super::context_from_w3c_trace_context;
     use super::current_span_trace_id;
-    use super::inject_span_w3c_trace_headers;
     use codex_protocol::protocol::W3cTraceContext;
     use opentelemetry::trace::SpanId;
     use opentelemetry::trace::TraceContextExt;
@@ -401,39 +400,5 @@ mod tests {
         assert_eq!(trace_id.len(), 32);
         assert!(trace_id.chars().all(|ch| ch.is_ascii_hexdigit()));
         assert_ne!(trace_id, "00000000000000000000000000000000");
-    }
-
-    #[test]
-    fn inject_span_w3c_trace_headers_replaces_existing_context() {
-        let provider = SdkTracerProvider::builder().build();
-        let tracer = provider.tracer("codex-otel-tests");
-        let subscriber =
-            tracing_subscriber::registry().with(tracing_opentelemetry::layer().with_tracer(tracer));
-        let _guard = subscriber.set_default();
-        let span = trace_span!("test_span");
-        let expected = super::span_w3c_trace_context(&span).expect("trace context");
-        let mut headers = http::HeaderMap::new();
-        headers.insert(
-            "traceparent",
-            http::HeaderValue::from_static(
-                "00-00000000000000000000000000000033-0000000000000044-01",
-            ),
-        );
-        headers.insert("tracestate", http::HeaderValue::from_static("stale=value"));
-
-        assert!(inject_span_w3c_trace_headers(&span, &mut headers));
-
-        assert_eq!(
-            headers
-                .get("traceparent")
-                .and_then(|value| value.to_str().ok()),
-            expected.traceparent.as_deref()
-        );
-        assert_eq!(
-            headers
-                .get("tracestate")
-                .and_then(|value| value.to_str().ok()),
-            expected.tracestate.as_deref()
-        );
     }
 }

--- a/codex-rs/otel/src/trace_context.rs
+++ b/codex-rs/otel/src/trace_context.rs
@@ -49,6 +49,38 @@ pub fn span_w3c_trace_context(span: &Span) -> Option<W3cTraceContext> {
     })
 }
 
+/// Injects the W3C trace context for `span` into HTTP headers.
+///
+/// Existing `traceparent` and `tracestate` values are replaced so callers can
+/// safely reuse a request header map while keeping the supplied span as the
+/// source of truth.
+pub fn inject_span_w3c_trace_headers(span: &Span, headers: &mut http::HeaderMap) -> bool {
+    let Some(trace) = span_w3c_trace_context(span) else {
+        return false;
+    };
+    match trace.traceparent {
+        Some(traceparent) => {
+            if let Ok(value) = http::HeaderValue::from_str(&traceparent) {
+                headers.insert("traceparent", value);
+            }
+        }
+        None => {
+            headers.remove("traceparent");
+        }
+    }
+    match trace.tracestate {
+        Some(tracestate) => {
+            if let Ok(value) = http::HeaderValue::from_str(&tracestate) {
+                headers.insert("tracestate", value);
+            }
+        }
+        None => {
+            headers.remove("tracestate");
+        }
+    }
+    true
+}
+
 pub(crate) fn set_tracestate_entries(
     entries: BTreeMap<String, BTreeMap<String, String>>,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -304,6 +336,7 @@ mod tests {
     use super::context_from_trace_headers;
     use super::context_from_w3c_trace_context;
     use super::current_span_trace_id;
+    use super::inject_span_w3c_trace_headers;
     use codex_protocol::protocol::W3cTraceContext;
     use opentelemetry::trace::SpanId;
     use opentelemetry::trace::TraceContextExt;
@@ -368,5 +401,39 @@ mod tests {
         assert_eq!(trace_id.len(), 32);
         assert!(trace_id.chars().all(|ch| ch.is_ascii_hexdigit()));
         assert_ne!(trace_id, "00000000000000000000000000000000");
+    }
+
+    #[test]
+    fn inject_span_w3c_trace_headers_replaces_existing_context() {
+        let provider = SdkTracerProvider::builder().build();
+        let tracer = provider.tracer("codex-otel-tests");
+        let subscriber =
+            tracing_subscriber::registry().with(tracing_opentelemetry::layer().with_tracer(tracer));
+        let _guard = subscriber.set_default();
+        let span = trace_span!("test_span");
+        let expected = super::span_w3c_trace_context(&span).expect("trace context");
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            "traceparent",
+            http::HeaderValue::from_static(
+                "00-00000000000000000000000000000033-0000000000000044-01",
+            ),
+        );
+        headers.insert("tracestate", http::HeaderValue::from_static("stale=value"));
+
+        assert!(inject_span_w3c_trace_headers(&span, &mut headers));
+
+        assert_eq!(
+            headers
+                .get("traceparent")
+                .and_then(|value| value.to_str().ok()),
+            expected.traceparent.as_deref()
+        );
+        assert_eq!(
+            headers
+                .get("tracestate")
+                .and_then(|value| value.to_str().ok()),
+            expected.tracestate.as_deref()
+        );
     }
 }


### PR DESCRIPTION
Fixes distributed trace continuity across exec-server JSON-RPC HTTP egress by adding an executor client span and injecting its W3C context through a reusable `codex-otel` helper.

This preserves the caller trace across core/tool → executor → provider/MCP instead of dropping parentage at raw reqwest.

Note that this doesn't include the websocket path, which is needed to really get the full story but at least we cover the basic http path with this change.