### PR TITLE
[codex] Make MCP requirements atomic across layers

### DIFF
--- a/codex-rs/config/src/config_requirements.rs
+++ b/codex-rs/config/src/config_requirements.rs
@@ -271,7 +271,7 @@ pub enum MarketplaceAllowedSourceKind {
 
 impl PluginRequirementsToml {
     pub fn is_empty(&self) -> bool {
-        self.mcp_servers.as_ref().is_none_or(BTreeMap::is_empty)
+        self.mcp_servers.is_none()
     }
 }
 

--- a/codex-rs/config/src/config_requirements.rs
+++ b/codex-rs/config/src/config_requirements.rs
@@ -271,7 +271,7 @@ pub enum MarketplaceAllowedSourceKind {
 
 impl PluginRequirementsToml {
     pub fn is_empty(&self) -> bool {
-        self.mcp_servers.is_none()
+        self.mcp_servers.as_ref().is_none_or(BTreeMap::is_empty)
     }
 }
 

--- a/codex-rs/config/src/merge.rs
+++ b/codex-rs/config/src/merge.rs
@@ -18,9 +18,8 @@ pub fn merge_toml_values(base: &mut TomlValue, overlay: &TomlValue) {
 /// requirement instead represents one complete requirement, so combining its
 /// internal fields across layers could retain parts of both definitions.
 /// After the regular merge, reapply higher-priority values at the configured
-/// atomic paths so each same-name requirement is replaced as a whole. An
-/// explicitly empty atomic map clears lower-priority entries. A `*` path
-/// segment matches every key at that level.
+/// atomic paths so each same-name requirement is replaced as a whole. A `*`
+/// path segment matches every key at that level.
 pub(crate) fn merge_requirements_toml_values(base: &mut TomlValue, overlay: &TomlValue) {
     merge_toml_values(base, overlay);
     for path in ATOMIC_REQUIREMENT_PATHS {
@@ -62,10 +61,6 @@ fn apply_atomic_override_at_path(base: &mut TomlValue, overlay: &TomlValue, path
     let Some(overlay_table) = overlay.as_table() else {
         return;
     };
-    if *segment == "*" && remaining.is_empty() && overlay_table.is_empty() {
-        *base = overlay.clone();
-        return;
-    }
     let Some(base_table) = base.as_table_mut() else {
         return;
     };

--- a/codex-rs/config/src/merge.rs
+++ b/codex-rs/config/src/merge.rs
@@ -3,9 +3,29 @@ use crate::key_aliases::normalized_with_key_aliases;
 use codex_network_proxy::normalize_host;
 use toml::Value as TomlValue;
 
+const ATOMIC_REQUIREMENT_PATHS: &[&[&str]] =
+    &[&["mcp_servers", "*"], &["plugins", "*", "mcp_servers", "*"]];
+
 /// Merge config `overlay` into `base`, giving `overlay` precedence.
 pub fn merge_toml_values(base: &mut TomlValue, overlay: &TomlValue) {
     merge_toml_values_at_path(base, overlay, &mut Vec::new());
+}
+
+/// Merge a requirements layer while treating selected requirement values as
+/// atomic.
+///
+/// The regular TOML merge recursively combines tables. Each named MCP server
+/// requirement instead represents one complete requirement, so combining its
+/// internal fields across layers could retain parts of both definitions.
+/// After the regular merge, reapply higher-priority values at the configured
+/// atomic paths so each same-name requirement is replaced as a whole. An
+/// explicitly empty atomic map clears lower-priority entries. A `*` path
+/// segment matches every key at that level.
+pub(crate) fn merge_requirements_toml_values(base: &mut TomlValue, overlay: &TomlValue) {
+    merge_toml_values(base, overlay);
+    for path in ATOMIC_REQUIREMENT_PATHS {
+        apply_atomic_override_at_path(base, overlay, path);
+    }
 }
 
 fn merge_toml_values_at_path(base: &mut TomlValue, overlay: &TomlValue, path: &mut Vec<String>) {
@@ -31,6 +51,36 @@ fn merge_toml_values_at_path(base: &mut TomlValue, overlay: &TomlValue, path: &m
         }
     } else {
         *base = normalized_with_key_aliases(overlay, path);
+    }
+}
+
+fn apply_atomic_override_at_path(base: &mut TomlValue, overlay: &TomlValue, path: &[&str]) {
+    let Some((segment, remaining)) = path.split_first() else {
+        *base = overlay.clone();
+        return;
+    };
+    let Some(overlay_table) = overlay.as_table() else {
+        return;
+    };
+    if *segment == "*" && remaining.is_empty() && overlay_table.is_empty() {
+        *base = overlay.clone();
+        return;
+    }
+    let Some(base_table) = base.as_table_mut() else {
+        return;
+    };
+
+    if *segment == "*" {
+        for (key, overlay_value) in overlay_table {
+            let Some(base_value) = base_table.get_mut(key) else {
+                continue;
+            };
+            apply_atomic_override_at_path(base_value, overlay_value, remaining);
+        }
+    } else if let Some(base_value) = base_table.get_mut(*segment)
+        && let Some(overlay_value) = overlay_table.get(*segment)
+    {
+        apply_atomic_override_at_path(base_value, overlay_value, remaining);
     }
 }
 

--- a/codex-rs/config/src/merge_tests.rs
+++ b/codex-rs/config/src/merge_tests.rs
@@ -124,3 +124,44 @@ fn merge_toml_values_normalizes_permission_network_domains_before_overlaying() {
     );
     assert_eq!(base, expected);
 }
+
+#[test]
+fn merge_requirements_toml_values_replaces_named_mcp_requirements_atomically() {
+    let mut base = parse_toml(
+        r#"
+[mcp_servers.proxy.identity]
+command = "legacy-proxy"
+
+[mcp_servers.docs.identity]
+command = "docs-server"
+
+[plugins."sample@test".mcp_servers.proxy.identity]
+command = "legacy-plugin-proxy"
+"#,
+    );
+    let overlay = parse_toml(
+        r#"
+[mcp_servers.proxy.identity]
+url = "https://mcp.example.com/proxy"
+
+[plugins."sample@test".mcp_servers.proxy.identity]
+url = "https://mcp.example.com/plugin-proxy"
+"#,
+    );
+
+    merge_requirements_toml_values(&mut base, &overlay);
+
+    let expected = parse_toml(
+        r#"
+[mcp_servers.proxy.identity]
+url = "https://mcp.example.com/proxy"
+
+[mcp_servers.docs.identity]
+command = "docs-server"
+
+[plugins."sample@test".mcp_servers.proxy.identity]
+url = "https://mcp.example.com/plugin-proxy"
+"#,
+    );
+    assert_eq!(base, expected);
+}

--- a/codex-rs/config/src/requirements_layers/stack.rs
+++ b/codex-rs/config/src/requirements_layers/stack.rs
@@ -10,6 +10,8 @@
 //! - `rules.prefix_rules` append high-priority rules first.
 //! - `hooks` append high-priority event groups first while failing closed on
 //!   active managed-dir conflicts.
+//! - Higher-priority layers replace each named MCP server requirement as an
+//!   atomic value.
 //! - `permissions.filesystem.deny_read` is a high-priority-first union across
 //!   layers.
 
@@ -17,7 +19,7 @@ use crate::ConfigRequirementsToml;
 use crate::ConfigRequirementsWithSources;
 use crate::RequirementSource;
 use crate::Sourced;
-use crate::merge::merge_toml_values;
+use crate::merge::merge_requirements_toml_values;
 use std::cell::OnceCell;
 use std::io;
 use thiserror::Error;
@@ -150,7 +152,7 @@ impl RequirementsLayerStack {
 
         let mut merged_toml = TomlValue::Table(toml::map::Map::new());
         for layer in &layers {
-            merge_toml_values(&mut merged_toml, &layer.regular_toml);
+            merge_requirements_toml_values(&mut merged_toml, &layer.regular_toml);
         }
 
         let requirements: ConfigRequirementsToml =

--- a/codex-rs/config/src/requirements_layers/stack_tests.rs
+++ b/codex-rs/config/src/requirements_layers/stack_tests.rs
@@ -351,7 +351,7 @@ alpha = true
 }
 
 #[test]
-fn mcp_requirements_use_regular_toml_merge() {
+fn higher_priority_mcp_requirements_replace_named_rules() {
     let composed = compose(vec![
         layer(
             "req_low",
@@ -369,7 +369,7 @@ url = "https://low.example.com/mcp"
             "High",
             r#"
 [mcp_servers.shared.identity]
-command = "high-mcp"
+url = "https://high.example.com/mcp"
 "#,
         ),
     ])
@@ -384,7 +384,94 @@ command = "high-mcp"
 url = "https://low.example.com/mcp"
 
 [mcp_servers.shared.identity]
-command = "high-mcp"
+url = "https://high.example.com/mcp"
+"#
+        )
+    );
+}
+
+#[test]
+fn higher_priority_empty_mcp_allowlist_clears_lower_rules() {
+    let composed = compose(vec![
+        layer(
+            "req_low",
+            "Low",
+            r#"
+[mcp_servers.server.identity]
+command = "low-mcp"
+"#,
+        ),
+        layer("req_high", "High", "mcp_servers = {}"),
+    ])
+    .expect("compose requirements")
+    .expect("requirements present");
+
+    assert_eq!(composed, expected_requirements("mcp_servers = {}"));
+}
+
+#[test]
+fn higher_priority_plugin_mcp_requirements_replace_named_rules() {
+    let composed = compose(vec![
+        layer(
+            "req_low",
+            "Low",
+            r#"
+[plugins."sample@test".mcp_servers.shared.identity]
+command = "low-plugin-mcp"
+"#,
+        ),
+        layer(
+            "req_high",
+            "High",
+            r#"
+[plugins."sample@test".mcp_servers.shared.identity]
+url = "https://high.example.com/mcp"
+"#,
+        ),
+    ])
+    .expect("compose requirements")
+    .expect("requirements present");
+
+    assert_eq!(
+        composed,
+        expected_requirements(
+            r#"
+[plugins."sample@test".mcp_servers.shared.identity]
+url = "https://high.example.com/mcp"
+"#
+        )
+    );
+}
+
+#[test]
+fn higher_priority_empty_plugin_mcp_allowlist_clears_lower_rules() {
+    let composed = compose(vec![
+        layer(
+            "req_low",
+            "Low",
+            r#"
+[plugins."sample@test".mcp_servers.server.identity]
+command = "low-plugin-mcp"
+"#,
+        ),
+        layer(
+            "req_high",
+            "High",
+            r#"
+[plugins."sample@test"]
+mcp_servers = {}
+"#,
+        ),
+    ])
+    .expect("compose requirements")
+    .expect("requirements present");
+
+    assert_eq!(
+        composed,
+        expected_requirements(
+            r#"
+[plugins."sample@test"]
+mcp_servers = {}
 "#
         )
     );

--- a/codex-rs/config/src/requirements_layers/stack_tests.rs
+++ b/codex-rs/config/src/requirements_layers/stack_tests.rs
@@ -391,7 +391,7 @@ url = "https://high.example.com/mcp"
 }
 
 #[test]
-fn higher_priority_empty_mcp_allowlist_clears_lower_rules() {
+fn higher_priority_empty_mcp_allowlist_preserves_lower_rules() {
     let composed = compose(vec![
         layer(
             "req_low",
@@ -406,7 +406,15 @@ command = "low-mcp"
     .expect("compose requirements")
     .expect("requirements present");
 
-    assert_eq!(composed, expected_requirements("mcp_servers = {}"));
+    assert_eq!(
+        composed,
+        expected_requirements(
+            r#"
+[mcp_servers.server.identity]
+command = "low-mcp"
+"#
+        )
+    );
 }
 
 #[test]
@@ -444,7 +452,7 @@ url = "https://high.example.com/mcp"
 }
 
 #[test]
-fn higher_priority_empty_plugin_mcp_allowlist_clears_lower_rules() {
+fn higher_priority_empty_plugin_mcp_allowlist_preserves_lower_rules() {
     let composed = compose(vec![
         layer(
             "req_low",
@@ -470,8 +478,8 @@ mcp_servers = {}
         composed,
         expected_requirements(
             r#"
-[plugins."sample@test"]
-mcp_servers = {}
+[plugins."sample@test".mcp_servers.server.identity]
+command = "low-plugin-mcp"
 "#
         )
     );


### PR DESCRIPTION
## Summary

Treat each named MCP server requirement as one atomic value when composing requirements layers.

- a higher-priority `mcp_servers.<name>` requirement replaces the complete lower-priority requirement for that name;
- plugin-qualified `plugins.<plugin>.mcp_servers.<name>` requirements follow the same rule;
- empty MCP maps contribute no entries, preserving the merged lower-layer allowlist; and
- unrelated server names continue to merge normally.

## Merge behavior

| Lower layer | Higher layer | Before #30118 | After #30118 | Explaination |
| --- | --- | --- | --- | --- |
| `[mcp_servers.x.identity]`<br>`command = "a"` | `[mcp_servers.x.identity]`<br>`command = "b"` | `[mcp_servers.x.identity]`<br>`command = "b"` | `[mcp_servers.x.identity]`<br>`command = "b"` | no change |
| `[mcp_servers.x.identity]`<br>`command = "a"` | `[mcp_servers.x.identity]`<br>`url = "https://b"` | `[mcp_servers.x.identity]`<br>`command = "a"` | `[mcp_servers.x.identity]`<br>`url = "https://b"` | before: silently uses serde untagged deserialisation and erroneously uses lower layer |
| `[mcp_servers.a.identity]`<br>`command = "a"` | `[mcp_servers.b.identity]`<br>`url = "https://b"` | `[mcp_servers.a.identity]`<br>`command = "a"`<br><br>`[mcp_servers.b.identity]`<br>`url = "https://b"` | `[mcp_servers.a.identity]`<br>`command = "a"`<br><br>`[mcp_servers.b.identity]`<br>`url = "https://b"` | no change |
| `[mcp_servers.x.identity]`<br>`command = "a"` | `mcp_servers = {}` | `[mcp_servers.x.identity]`<br>`command = "a"` | `[mcp_servers.x.identity]`<br>`command = "a"` | no change |
| `[mcp_servers.x.identity]`<br>`command = "a"` | `[mcp_servers.x.identity]`<br>`command = { executable = "cli", args = [{ match = "exact", value = "b" }] }` | `[mcp_servers.x.identity]`<br>`command = { executable = "cli", args = [{ match = "exact", value = "b" }] }` | `[mcp_servers.x.identity]`<br>`command = { executable = "cli", args = [{ match = "exact", value = "b" }] }` | no change |
| `[mcp_servers.x.identity]`<br>`command = { executable = "cli", args = [{ match = "exact", value = "a" }] }` | `[mcp_servers.x.identity]`<br>`url = { match = "prefix", value = "https://b" }` | `# parse error` | `[mcp_servers.x.identity]`<br>`url = { match = "prefix", value = "https://b" }` | higher layer wins |
| `[mcp_servers.x.identity]`<br>`url = { match = "regex", expression = "a.*" }` | `[mcp_servers.x.identity]`<br>`url = { match = "exact", value = "https://b" }` | `# parse error` | `[mcp_servers.x.identity]`<br>`url = { match = "exact", value = "https://b" }` | higher layer wins |

## Why

The regular TOML merge recursively combines tables. That can retain fields from two different same-name MCP requirements, such as a lower-priority command identity alongside a higher-priority URL identity, instead of applying the higher-priority requirement as a complete rule.

Empty `mcp_servers = {}` maps retain the existing allowlist merge contract: they do not remove lower-layer entries. Atomic replacement applies only when a higher layer provides a same-name requirement.

## Implementation

Requirements composition still uses the established TOML merge for ordinary fields. After that merge, higher-priority values are reapplied only at the two MCP requirement paths:

- `mcp_servers.*`
- `plugins.*.mcp_servers.*`

The standalone merge is based on `main` and does not depend on the matcher work in #29648.

## Validation

- `just fmt`
- `git diff --check`
- `just test -p codex-config` (189 passed)
