### PR TITLE
ci: narrow Windows test skips

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -107,8 +107,9 @@ common:ci-bazel --config=ci
 common:ci-bazel --build_metadata=TAG_workflow=bazel
 # Keep code-mode integration cases out of ordinary Bazel legs. The
 # Windows-cross config below re-enables them after generating its Windows V8
-# snapshot on the Windows runner.
-common:ci-bazel --test_env=CODEX_BAZEL_TEST_SKIP_FILTERS=suite::code_mode::
+# snapshot on the Windows runner. Also skip the ConPTY Ctrl-C integration test
+# until Windows Bazel CI can reliably interrupt foreground processes.
+common:ci-bazel --test_env=CODEX_BAZEL_TEST_SKIP_FILTERS=suite::code_mode::,tests::windows_tests::conpty_ctrl_c_interrupts_powershell_foreground_child
 
 # Shared config for Bazel-backed Rust linting.
 build:clippy --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
@@ -194,8 +195,9 @@ common:ci-windows-cross --test_env=RUST_TEST_THREADS=1
 # Native Windows CI still covers the PowerShell parser-process tests. The
 # cross-built gnullvm binaries currently hang in those tests when run on the
 # Windows runner. Keep V8-backed code-mode tests enabled except for the hidden
-# dynamic-tool callback test, which currently times out on Windows.
-common:ci-windows-cross --test_env=CODEX_BAZEL_TEST_SKIP_FILTERS=command_safety::powershell_parser::tests::,suite::code_mode::code_mode_can_call_hidden_dynamic_tools
+# dynamic-tool callback test, which currently times out on Windows. This config
+# replaces the base skip list, so repeat the exact ConPTY Ctrl-C test exclusion.
+common:ci-windows-cross --test_env=CODEX_BAZEL_TEST_SKIP_FILTERS=command_safety::powershell_parser::tests::,suite::code_mode::code_mode_can_call_hidden_dynamic_tools,tests::windows_tests::conpty_ctrl_c_interrupts_powershell_foreground_child
 common:ci-windows-cross --platforms=//:windows_x86_64_gnullvm
 common:ci-windows-cross --extra_execution_platforms=//:rbe,//:windows_x86_64_msvc
 common:ci-windows-cross --extra_toolchains=//:windows_gnullvm_tests_on_msvc_host_toolchain

--- a/.bazelrc
+++ b/.bazelrc
@@ -191,11 +191,11 @@ common:ci-windows-cross --strategy=TestRunner=local
 common:ci-windows-cross --strategy=V8Mksnapshot=local
 common:ci-windows-cross --local_test_jobs=4
 common:ci-windows-cross --test_env=RUST_TEST_THREADS=1
-# Native Windows CI still covers the PowerShell tests. The cross-built gnullvm
-# binaries currently hang in PowerShell AST parser tests when those binaries are
-# run on the Windows runner. Keep V8-backed code-mode tests enabled except for
-# the hidden dynamic-tool callback test, which currently times out on Windows.
-common:ci-windows-cross --test_env=CODEX_BAZEL_TEST_SKIP_FILTERS=powershell,suite::code_mode::code_mode_can_call_hidden_dynamic_tools
+# Native Windows CI still covers the PowerShell parser-process tests. The
+# cross-built gnullvm binaries currently hang in those tests when run on the
+# Windows runner. Keep V8-backed code-mode tests enabled except for the hidden
+# dynamic-tool callback test, which currently times out on Windows.
+common:ci-windows-cross --test_env=CODEX_BAZEL_TEST_SKIP_FILTERS=command_safety::powershell_parser::tests::,suite::code_mode::code_mode_can_call_hidden_dynamic_tools
 common:ci-windows-cross --platforms=//:windows_x86_64_gnullvm
 common:ci-windows-cross --extra_execution_platforms=//:rbe,//:windows_x86_64_msvc
 common:ci-windows-cross --extra_toolchains=//:windows_gnullvm_tests_on_msvc_host_toolchain


### PR DESCRIPTION
## Why

The Windows cross-build skip used the broad `powershell` substring, which hid unrelated Windows tests. Narrowing it exposed the same ConPTY Ctrl-C timeout that is breaking `main`; that test is not reliable in either cross-built or native Windows Bazel CI yet.

## What changed

- scope the cross-build PowerShell carve-out to the dedicated parser-process test module
- exclude the exact ConPTY Ctrl-C test from Bazel CI while leaving local Windows runs enabled
- repeat the exact exclusion in the cross-build config because it replaces the base skip list

## Manual validation

- `just test-github-scripts`
- queried the PTY test target under both `ci-windows` and `ci-windows-cross`
- verified the matcher excludes parser-process and ConPTY tests without excluding unrelated PowerShell tests
- [Windows shard 4/4](https://github.com/openai/codex/actions/runs/28204844286/job/83553063859) reproduced the `main` ConPTY timeout before the exact CI-only exclusion was applied