### PR TITLE
ci: publish versioned bash fork artifacts

### DIFF
--- a/.github/dotslash-bash-config.json
+++ b/.github/dotslash-bash-config.json
@@ -1,0 +1,32 @@
+{
+  "outputs": {
+    "codex-bash": {
+      "platforms": {
+        "macos-aarch64": {
+          "name": "codex-bash-aarch64-apple-darwin.tar.gz",
+          "format": "tar.gz",
+          "hash": "sha256",
+          "path": "codex-bash/bin/bash"
+        },
+        "macos-x86_64": {
+          "name": "codex-bash-x86_64-apple-darwin.tar.gz",
+          "format": "tar.gz",
+          "hash": "sha256",
+          "path": "codex-bash/bin/bash"
+        },
+        "linux-x86_64": {
+          "name": "codex-bash-x86_64-unknown-linux-musl.tar.gz",
+          "format": "tar.gz",
+          "hash": "sha256",
+          "path": "codex-bash/bin/bash"
+        },
+        "linux-aarch64": {
+          "name": "codex-bash-aarch64-unknown-linux-musl.tar.gz",
+          "format": "tar.gz",
+          "hash": "sha256",
+          "path": "codex-bash/bin/bash"
+        }
+      }
+    }
+  }
+}

--- a/.github/scripts/build-bash-release-artifact.sh
+++ b/.github/scripts/build-bash-release-artifact.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" -ne 1 ]]; then
+  echo "usage: $0 <archive-path>" >&2
+  exit 1
+fi
+
+archive_path="$1"
+workspace="${GITHUB_WORKSPACE:?missing GITHUB_WORKSPACE}"
+bash_commit="${BASH_COMMIT:?missing BASH_COMMIT}"
+bash_patch="${BASH_PATCH:?missing BASH_PATCH}"
+temp_root="${RUNNER_TEMP:-/tmp}"
+work_root="$(mktemp -d "${temp_root%/}/codex-bash-release.XXXXXX")"
+trap 'rm -rf "$work_root"' EXIT
+
+source_root="${work_root}/bash"
+package_root="${work_root}/codex-bash"
+wrapper_path="${work_root}/exec-wrapper"
+stdout_path="${work_root}/stdout.txt"
+wrapper_log_path="${work_root}/wrapper.log"
+socket_probe_path="${work_root}/socket-probe.txt"
+
+git clone https://git.savannah.gnu.org/git/bash "$source_root"
+cd "$source_root"
+git checkout "$bash_commit"
+git apply "${workspace}/${bash_patch}"
+
+configure_args=(--without-bash-malloc)
+if [[ -n "${BASH_HOST:-}" ]]; then
+  configure_args+=(
+    --host="$BASH_HOST"
+    --disable-nls
+    --disable-readline
+    --enable-static-link
+  )
+fi
+if [[ -n "${MACOSX_DEPLOYMENT_TARGET:-}" ]]; then
+  # The macOS 15 SDK exposes strchrnul even though it is unavailable on our
+  # minimum supported macOS version. Use Bash's bundled implementation.
+  export bash_cv_func_strchrnul_works=no
+fi
+./configure "${configure_args[@]}"
+
+cores="$(command -v nproc >/dev/null 2>&1 && nproc || getconf _NPROCESSORS_ONLN)"
+make -j"${cores}"
+
+# Stand in for codex-execve-wrapper: record each intercepted executable and
+# prove that the inherited escalation-socket descriptor is still open.
+cat > "$wrapper_path" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${CODEX_WRAPPER_LOG:?missing CODEX_WRAPPER_LOG}"
+: "${EXEC_WRAPPER:?missing EXEC_WRAPPER}"
+: "${CODEX_ESCALATE_SOCKET:?missing CODEX_ESCALATE_SOCKET}"
+printf 'socket-open\n' >&"${CODEX_ESCALATE_SOCKET}"
+printf '%s\n' "$@" >> "$CODEX_WRAPPER_LOG"
+file="$1"
+shift
+if [[ "$#" -eq 0 ]]; then
+  exec "$file"
+fi
+arg0="$1"
+shift
+exec -a "$arg0" "$file" "$@"
+EOF
+chmod +x "$wrapper_path"
+
+# The nested bash and /bin/echo should each pass through EXEC_WRAPPER while
+# retaining the same inherited descriptor.
+CODEX_WRAPPER_LOG="$wrapper_log_path" \
+CODEX_ESCALATE_SOCKET=9 \
+EXEC_WRAPPER="$wrapper_path" \
+"${source_root}/bash" \
+  -c "\"${source_root}/bash\" -c '/bin/echo smoke-bash'" \
+  > "$stdout_path" \
+  9> "$socket_probe_path"
+
+grep -Fx "smoke-bash" "$stdout_path"
+grep -Fx "${source_root}/bash" "$wrapper_log_path"
+grep -Fx "/bin/echo" "$wrapper_log_path"
+[[ "$(grep -Fxc "socket-open" "$socket_probe_path")" -eq 2 ]]
+
+if [[ -n "${BASH_HOST:-}" ]]; then
+  file "${source_root}/bash" | grep -F "statically linked"
+  if readelf -l "${source_root}/bash" | grep -q "INTERP"; then
+    echo "bash contains an ELF interpreter despite requesting a static build" >&2
+    exit 1
+  fi
+fi
+
+if [[ -n "${MACOSX_DEPLOYMENT_TARGET:-}" ]]; then
+  minos="$(otool -l "${source_root}/bash" | awk '$1 == "minos" { print $2; exit }')"
+  if [[ "$minos" != "$MACOSX_DEPLOYMENT_TARGET" ]]; then
+    echo "bash has minimum macOS version ${minos}, expected ${MACOSX_DEPLOYMENT_TARGET}" >&2
+    exit 1
+  fi
+  if nm -u "${source_root}/bash" | grep -Eq '[[:space:]]_?strchrnul$'; then
+    echo "bash references strchrnul, which is unavailable on macOS 12" >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "$package_root/bin" "$(dirname "${workspace}/${archive_path}")"
+cp "${source_root}/bash" "$package_root/bin/bash"
+chmod +x "$package_root/bin/bash"
+
+(cd "$work_root" && tar -czf "${workspace}/${archive_path}" codex-bash)

--- a/.github/scripts/build-zsh-release-artifact.sh
+++ b/.github/scripts/build-zsh-release-artifact.sh
@@ -20,6 +20,7 @@ package_root="${work_root}/codex-zsh"
 wrapper_path="${work_root}/exec-wrapper"
 stdout_path="${work_root}/stdout.txt"
 wrapper_log_path="${work_root}/wrapper.log"
+socket_probe_path="${work_root}/socket-probe.txt"
 
 git clone https://git.code.sf.net/p/zsh/code "$source_root"
 cd "$source_root"
@@ -31,11 +32,16 @@ git apply "${workspace}/${zsh_patch}"
 cores="$(command -v nproc >/dev/null 2>&1 && nproc || getconf _NPROCESSORS_ONLN)"
 make -j"${cores}"
 
+# Stand in for codex-execve-wrapper: record each intercepted executable and
+# prove that the inherited escalation-socket descriptor is still open.
 cat > "$wrapper_path" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 : "${CODEX_WRAPPER_LOG:?missing CODEX_WRAPPER_LOG}"
-printf '%s\n' "$@" > "$CODEX_WRAPPER_LOG"
+: "${EXEC_WRAPPER:?missing EXEC_WRAPPER}"
+: "${CODEX_ESCALATE_SOCKET:?missing CODEX_ESCALATE_SOCKET}"
+printf 'socket-open\n' >&"${CODEX_ESCALATE_SOCKET}"
+printf '%s\n' "$@" >> "$CODEX_WRAPPER_LOG"
 file="$1"
 shift
 if [[ "$#" -eq 0 ]]; then
@@ -47,12 +53,20 @@ exec -a "$arg0" "$file" "$@"
 EOF
 chmod +x "$wrapper_path"
 
+# The nested zsh and /bin/echo should each pass through EXEC_WRAPPER while
+# retaining the same inherited descriptor.
 CODEX_WRAPPER_LOG="$wrapper_log_path" \
+CODEX_ESCALATE_SOCKET=9 \
 EXEC_WRAPPER="$wrapper_path" \
-"${source_root}/Src/zsh" -fc '/bin/echo smoke-zsh' > "$stdout_path"
+"${source_root}/Src/zsh" \
+  -fc "\"${source_root}/Src/zsh\" -fc '/bin/echo smoke-zsh'" \
+  > "$stdout_path" \
+  9> "$socket_probe_path"
 
 grep -Fx "smoke-zsh" "$stdout_path"
+grep -Fx "${source_root}/Src/zsh" "$wrapper_log_path"
 grep -Fx "/bin/echo" "$wrapper_log_path"
+[[ "$(grep -Fxc "socket-open" "$socket_probe_path")" -eq 2 ]]
 
 mkdir -p "$package_root/bin" "$(dirname "${workspace}/${archive_path}")"
 cp "${source_root}/Src/zsh" "$package_root/bin/zsh"

--- a/.github/scripts/test-shell-exec-wrapper-chain.sh
+++ b/.github/scripts/test-shell-exec-wrapper-chain.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" -ne 2 ]]; then
+  echo "usage: $0 <bash-path> <zsh-path>" >&2
+  exit 1
+fi
+
+bash_path="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+zsh_path="$(cd "$(dirname "$2")" && pwd)/$(basename "$2")"
+temp_root="${RUNNER_TEMP:-/tmp}"
+work_root="$(mktemp -d "${temp_root%/}/codex-shell-chain.XXXXXX")"
+trap 'rm -rf "$work_root"' EXIT
+
+wrapper_path="${work_root}/exec-wrapper"
+
+# Stand in for codex-execve-wrapper: record each intercepted executable and
+# prove that the inherited escalation-socket descriptor is still open.
+cat > "$wrapper_path" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${CODEX_WRAPPER_LOG:?missing CODEX_WRAPPER_LOG}"
+: "${EXEC_WRAPPER:?missing EXEC_WRAPPER}"
+: "${CODEX_ESCALATE_SOCKET:?missing CODEX_ESCALATE_SOCKET}"
+printf 'socket-open\n' >&"${CODEX_ESCALATE_SOCKET}"
+printf '%s\n' "$@" >> "$CODEX_WRAPPER_LOG"
+file="$1"
+shift
+if [[ "$#" -eq 0 ]]; then
+  exec "$file"
+fi
+arg0="$1"
+shift
+exec -a "$arg0" "$file" "$@"
+EOF
+chmod +x "$wrapper_path"
+
+run_chain() {
+  local outer_shell="$1"
+  local outer_flag="$2"
+  local inner_shell="$3"
+  local inner_flag="$4"
+  local marker="$5"
+  local wrapper_log="${work_root}/${marker}-wrapper.log"
+  local socket_probe="${work_root}/${marker}-socket.log"
+  local stdout="${work_root}/${marker}-stdout.txt"
+  local command
+  command="\"${inner_shell}\" ${inner_flag} '/bin/echo ${marker}'"
+
+  # The inner shell and /bin/echo should each pass through EXEC_WRAPPER while
+  # retaining the same inherited descriptor.
+  CODEX_WRAPPER_LOG="$wrapper_log" \
+  CODEX_ESCALATE_SOCKET=9 \
+  EXEC_WRAPPER="$wrapper_path" \
+  "$outer_shell" "$outer_flag" "$command" > "$stdout" 9> "$socket_probe"
+
+  grep -Fx "$marker" "$stdout"
+  grep -Fx "$inner_shell" "$wrapper_log"
+  grep -Fx "/bin/echo" "$wrapper_log"
+  [[ "$(grep -Fxc "socket-open" "$socket_probe")" -eq 2 ]]
+}
+
+# Either patched shell may launch the other, so exercise both directions.
+run_chain "$bash_path" -c "$zsh_path" -fc bash-zsh-chain
+run_chain "$zsh_path" -fc "$bash_path" -c zsh-bash-chain

--- a/.github/workflows/rust-release-bash.yml
+++ b/.github/workflows/rust-release-bash.yml
@@ -1,0 +1,243 @@
+name: rust-release-bash
+
+on:
+  push:
+    tags:
+      - "codex-bash-v*.*.*"
+  pull_request:
+    paths:
+      - ".github/dotslash-bash-config.json"
+      - ".github/scripts/build-bash-release-artifact.sh"
+      - ".github/scripts/test-shell-exec-wrapper-chain.sh"
+      - ".github/workflows/rust-release-bash.yml"
+      - "codex-rs/shell-escalation/patches/bash-exec-wrapper.patch"
+
+env:
+  BASH_COMMIT: a8a1c2fac029404d3f42cd39f5a20f24b6e4fe4b
+  BASH_PATCH: codex-rs/shell-escalation/patches/bash-exec-wrapper.patch
+  ZSH_FORK_RELEASE_TAG: codex-zsh-v0.1.0
+
+concurrency:
+  group: ${{ github.workflow }}::${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  metadata:
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.release_tag.outputs.release_tag }}
+
+    steps:
+      - name: Validate release tag
+        if: github.event_name == 'push'
+        id: release_tag
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${RELEASE_TAG}" =~ ^codex-bash-v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag ${RELEASE_TAG} does not match codex-bash-vX.Y.Z." >&2
+            exit 1
+          fi
+
+          echo "release_tag=${RELEASE_TAG}" >> "${GITHUB_OUTPUT}"
+
+      - name: Ensure release does not exist
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release_tag.outputs.release_tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" > /dev/null 2>&1; then
+            echo "Release ${RELEASE_TAG} already exists; publish changed artifacts under a new tag." >&2
+            exit 1
+          fi
+
+  linux:
+    name: Build bash (Linux) - ${{ matrix.variant }} - ${{ matrix.target }}
+    needs: metadata
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    container:
+      image: ${{ matrix.image }}
+    env:
+      BASH_HOST: ${{ matrix.host }}
+      CC: musl-gcc
+      LDFLAGS: -static
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+            host: x86_64-linux-musl
+            variant: ubuntu-24.04
+            image: ubuntu:24.04
+            archive_name: codex-bash-x86_64-unknown-linux-musl.tar.gz
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            host: aarch64-linux-musl
+            variant: ubuntu-24.04
+            image: arm64v8/ubuntu:24.04
+            archive_name: codex-bash-aarch64-unknown-linux-musl.tar.gz
+
+    steps:
+      - name: Install build prerequisites
+        shell: bash
+        run: |
+          set -euo pipefail
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            autoconf \
+            bison \
+            binutils \
+            build-essential \
+            ca-certificates \
+            file \
+            gettext \
+            git \
+            musl-tools
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Build, smoke-test, and stage bash artifact
+        shell: bash
+        run: |
+          "${GITHUB_WORKSPACE}/.github/scripts/build-bash-release-artifact.sh" \
+            "dist/bash/${{ matrix.target }}/${{ matrix.archive_name }}"
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: codex-bash-${{ matrix.target }}
+          path: dist/bash/${{ matrix.target }}/*
+          if-no-files-found: error
+
+  darwin:
+    name: Build bash (macOS) - ${{ matrix.variant }} - ${{ matrix.target }}
+    needs: metadata
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15-large
+            target: x86_64-apple-darwin
+            variant: macos-15
+            archive_name: codex-bash-x86_64-apple-darwin.tar.gz
+          - runner: macos-15-xlarge
+            target: aarch64-apple-darwin
+            variant: macos-15
+            archive_name: codex-bash-aarch64-apple-darwin.tar.gz
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Build, smoke-test, and stage bash artifact
+        shell: bash
+        run: |
+          "${GITHUB_WORKSPACE}/.github/scripts/build-bash-release-artifact.sh" \
+            "dist/bash/${{ matrix.target }}/${{ matrix.archive_name }}"
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: codex-bash-${{ matrix.target }}
+          path: dist/bash/${{ matrix.target }}/*
+          if-no-files-found: error
+
+  cross-shell-smoke:
+    name: Smoke test bash and zsh fork chain
+    needs:
+      - linux
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download bash artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: codex-bash-x86_64-unknown-linux-musl
+          path: dist/bash
+
+      - name: Download zsh fork artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist/zsh
+          gh release download "${ZSH_FORK_RELEASE_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern codex-zsh-x86_64-unknown-linux-musl.tar.gz \
+            --dir dist/zsh
+
+      - name: Test nested shell forks
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist/extracted/bash dist/extracted/zsh
+          tar -xzf dist/bash/codex-bash-x86_64-unknown-linux-musl.tar.gz \
+            -C dist/extracted/bash
+          tar -xzf dist/zsh/codex-zsh-x86_64-unknown-linux-musl.tar.gz \
+            -C dist/extracted/zsh
+          .github/scripts/test-shell-exec-wrapper-chain.sh \
+            dist/extracted/bash/codex-bash/bin/bash \
+            dist/extracted/zsh/codex-zsh/bin/zsh
+
+  publish-release:
+    if: github.event_name == 'push'
+    needs:
+      - metadata
+      - linux
+      - darwin
+      - cross-shell-smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: dist
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+        with:
+          tag_name: ${{ needs.metadata.outputs.release_tag }}
+          name: ${{ needs.metadata.outputs.release_tag }}
+          files: dist/**
+          # Keep bash artifact releases out of Codex's normal "latest release" channel.
+          prerelease: true
+
+      - name: Publish DotSlash manifest
+        uses: facebook/dotslash-publish-release@9c9ec027515c34db9282a09a25a9cab5880b2c52 # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag: ${{ needs.metadata.outputs.release_tag }}
+          config: .github/dotslash-bash-config.json

--- a/codex-rs/shell-escalation/README.md
+++ b/codex-rs/shell-escalation/README.md
@@ -15,6 +15,31 @@ decision to the shell-escalation protocol over a shared file descriptor (specifi
 - `Deny`: the server has declared the proposed command to be forbidden, so
   `codex-execve-wrapper` prints an error to `stderr` and exits with `1`.
 
+Both patched shells use `EXEC_WRAPPER` to locate `codex-execve-wrapper` and
+preserve `CODEX_ESCALATE_SOCKET` as the inherited escalation socket file
+descriptor. This shared environment contract lets intercepted commands pass
+through trees containing either shell without losing the escalation session.
+
+## Patched bash
+
+We carry a small patch to `execute_cmd.c` (see
+`patches/bash-exec-wrapper.patch`) that adds support for `EXEC_WRAPPER`. The
+patch applies to `a8a1c2fac029404d3f42cd39f5a20f24b6e4fe4b` from
+https://git.savannah.gnu.org/git/bash. To rebuild manually:
+
+```bash
+git clone https://git.savannah.gnu.org/git/bash
+git checkout a8a1c2fac029404d3f42cd39f5a20f24b6e4fe4b
+git apply /path/to/patches/bash-exec-wrapper.patch
+./configure --without-bash-malloc
+make -j"$(nproc)"
+```
+
+Release artifacts are built by `.github/workflows/rust-release-bash.yml` when
+a `codex-bash-vX.Y.Z` tag is pushed. Linux artifacts are statically linked
+against musl, and macOS artifacts target macOS 12 or newer. When the bash
+commit or patch changes, publish the next version tag.
+
 ## Patched zsh
 
 We carry a small patch to `Src/exec.c` (see `patches/zsh-exec-wrapper.patch`) that adds support for `EXEC_WRAPPER`. The patch applies to `77045ef899e53b9598bebc5a41db93a548a40ca6` from https://git.code.sf.net/p/zsh/code. To rebuild manually:

--- a/codex-rs/shell-escalation/patches/bash-exec-wrapper.patch
+++ b/codex-rs/shell-escalation/patches/bash-exec-wrapper.patch
@@ -1,0 +1,25 @@
+diff --git a/execute_cmd.c b/execute_cmd.c
+index 070f5119..5fd984a7 100644
+--- a/execute_cmd.c
++++ b/execute_cmd.c
+@@ -6129,6 +6129,20 @@ shell_execve (char *command, char **args, char **env)
+   char sample[HASH_BANG_BUFSIZ];
+   size_t larray;
+ 
++  char *exec_wrapper = getenv("EXEC_WRAPPER");
++  if (exec_wrapper && *exec_wrapper && !whitespace (*exec_wrapper))
++    {
++      char *orig_command = command;
++
++      larray = strvec_len (args);
++      args = strvec_resize (args, larray + 3);
++
++      memmove (args + 2, args, (larray + 1) * sizeof (char *));
++      args[0] = exec_wrapper;
++      args[1] = orig_command;
++      command = exec_wrapper;
++    }
++
+   SETOSTYPE (0);		/* Some systems use for USG/POSIX semantics */
+   execve (command, args, env);
+   i = errno;			/* error from execve() */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,24 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  '@modelcontextprotocol/sdk': 1.26.0
-  braces: ^3.0.3
-  esbuild: 0.28.1
-  fast-uri: 3.1.1
-  flatted: 3.4.2
-  glob@10.4.5: 10.5.0
-  handlebars: 4.7.9
-  hono: 4.12.25
-  micromatch: ^4.0.8
-  minimatch@3.1.2: 3.1.4
-  minimatch@9.0.5: 9.0.7
-  path-to-regexp: 8.4.0
-  picomatch@2.3.1: 2.3.2
-  picomatch@4.0.3: 4.0.4
-  rollup: 4.59.0
-  semver: ^7.7.1
-
 importers:
 
   .:
@@ -37,7 +19,7 @@ importers:
   sdk/typescript:
     devDependencies:
       '@modelcontextprotocol/sdk':
-        specifier: 1.26.0
+        specifier: ^1.24.0
         version: 1.26.0(zod@3.25.76)
       '@types/jest':
         specifier: ^29.5.14
@@ -65,10 +47,10 @@ importers:
         version: 3.6.2
       ts-jest:
         specifier: ^29.3.4
-        version: 29.4.4(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.28.1)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.18)(ts-node@10.9.2(@types/node@20.19.18)(typescript@5.9.2)))(typescript@5.9.2)
+        version: 29.4.4(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.18)(ts-node@10.9.2(@types/node@20.19.18)(typescript@5.9.2)))(typescript@5.9.2)
       ts-jest-mock-import-meta:
         specifier: ^1.3.1
-        version: 1.3.1(ts-jest@29.4.4(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.28.1)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.18)(ts-node@10.9.2(@types/node@20.19.18)(typescript@5.9.2)))(typescript@5.9.2))
+        version: 1.3.1(ts-jest@29.4.4(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.18)(ts-node@10.9.2(@types/node@20.19.18)(typescript@5.9.2)))(typescript@5.9.2))
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.19.18)(typescript@5.9.2)
@@ -259,158 +241,158 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@esbuild/aix-ppc64@0.28.1':
-    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.28.1':
-    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.28.1':
-    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.28.1':
-    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.28.1':
-    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.28.1':
-    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.28.1':
-    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.28.1':
-    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.28.1':
-    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.28.1':
-    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.28.1':
-    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.28.1':
-    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.28.1':
-    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.28.1':
-    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.28.1':
-    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.28.1':
-    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.28.1':
-    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.28.1':
-    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.28.1':
-    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.28.1':
-    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.28.1':
-    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.28.1':
-    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.28.1':
-    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.28.1':
-    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.28.1':
-    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.28.1':
-    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -457,7 +439,7 @@ packages:
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: 4.12.25
+      hono: ^4
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1003,7 +985,7 @@ packages:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
-      esbuild: 0.28.1
+      esbuild: '>=0.18'
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -1204,8 +1186,8 @@ packages:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
 
-  esbuild@0.28.1:
-    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1356,7 +1338,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: 4.0.4
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -1453,7 +1435,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -2093,10 +2075,6 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
-    engines: {node: '>=0.6'}
-
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
@@ -2169,6 +2147,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
@@ -2584,7 +2566,7 @@ snapshots:
       debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 7.7.2
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
@@ -2602,7 +2584,7 @@ snapshots:
       '@babel/helper-validator-option': 7.27.1
       browserslist: 4.26.2
       lru-cache: 5.1.1
-      semver: 7.7.2
+      semver: 6.3.1
 
   '@babel/helper-globals@7.28.0': {}
 
@@ -2753,82 +2735,82 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
-  '@esbuild/aix-ppc64@0.28.1':
+  '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/android-arm64@0.28.1':
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
-  '@esbuild/android-arm@0.28.1':
+  '@esbuild/android-arm@0.25.12':
     optional: true
 
-  '@esbuild/android-x64@0.28.1':
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-arm64@0.28.1':
+  '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-x64@0.28.1':
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.28.1':
+  '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-x64@0.28.1':
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm64@0.28.1':
+  '@esbuild/linux-arm64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm@0.28.1':
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
-  '@esbuild/linux-ia32@0.28.1':
+  '@esbuild/linux-ia32@0.25.12':
     optional: true
 
-  '@esbuild/linux-loong64@0.28.1':
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
-  '@esbuild/linux-mips64el@0.28.1':
+  '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
-  '@esbuild/linux-ppc64@0.28.1':
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/linux-riscv64@0.28.1':
+  '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
-  '@esbuild/linux-s390x@0.28.1':
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
-  '@esbuild/linux-x64@0.28.1':
+  '@esbuild/linux-x64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.28.1':
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-x64@0.28.1':
+  '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.28.1':
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-x64@0.28.1':
+  '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.28.1':
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
-  '@esbuild/sunos-x64@0.28.1':
+  '@esbuild/sunos-x64@0.25.12':
     optional: true
 
-  '@esbuild/win32-arm64@0.28.1':
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
-  '@esbuild/win32-ia32@0.28.1':
+  '@esbuild/win32-ia32@0.25.12':
     optional: true
 
-  '@esbuild/win32-x64@0.28.1':
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.36.0)':
@@ -3544,9 +3526,9 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
-  bundle-require@5.1.0(esbuild@0.28.1):
+  bundle-require@5.1.0(esbuild@0.25.12):
     dependencies:
-      esbuild: 0.28.1
+      esbuild: 0.25.12
       load-tsconfig: 0.2.5
 
   bytes@3.1.2: {}
@@ -3700,34 +3682,34 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
 
-  esbuild@0.28.1:
+  esbuild@0.25.12:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.28.1
-      '@esbuild/android-arm': 0.28.1
-      '@esbuild/android-arm64': 0.28.1
-      '@esbuild/android-x64': 0.28.1
-      '@esbuild/darwin-arm64': 0.28.1
-      '@esbuild/darwin-x64': 0.28.1
-      '@esbuild/freebsd-arm64': 0.28.1
-      '@esbuild/freebsd-x64': 0.28.1
-      '@esbuild/linux-arm': 0.28.1
-      '@esbuild/linux-arm64': 0.28.1
-      '@esbuild/linux-ia32': 0.28.1
-      '@esbuild/linux-loong64': 0.28.1
-      '@esbuild/linux-mips64el': 0.28.1
-      '@esbuild/linux-ppc64': 0.28.1
-      '@esbuild/linux-riscv64': 0.28.1
-      '@esbuild/linux-s390x': 0.28.1
-      '@esbuild/linux-x64': 0.28.1
-      '@esbuild/netbsd-arm64': 0.28.1
-      '@esbuild/netbsd-x64': 0.28.1
-      '@esbuild/openbsd-arm64': 0.28.1
-      '@esbuild/openbsd-x64': 0.28.1
-      '@esbuild/openharmony-arm64': 0.28.1
-      '@esbuild/sunos-x64': 0.28.1
-      '@esbuild/win32-arm64': 0.28.1
-      '@esbuild/win32-ia32': 0.28.1
-      '@esbuild/win32-x64': 0.28.1
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   escalade@3.2.0: {}
 
@@ -3882,7 +3864,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.0
+      qs: 6.15.1
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.0
@@ -4133,7 +4115,7 @@ snapshots:
       '@babel/parser': 7.28.4
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
-      semver: 7.7.2
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
@@ -4769,10 +4751,6 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
-  qs@6.14.0:
-    dependencies:
-      side-channel: 1.1.0
-
   qs@6.15.1:
     dependencies:
       side-channel: 1.1.0
@@ -4862,6 +4840,8 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  semver@6.3.1: {}
 
   semver@7.7.2: {}
 
@@ -5050,11 +5030,11 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest-mock-import-meta@1.3.1(ts-jest@29.4.4(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.28.1)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.18)(ts-node@10.9.2(@types/node@20.19.18)(typescript@5.9.2)))(typescript@5.9.2)):
+  ts-jest-mock-import-meta@1.3.1(ts-jest@29.4.4(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.18)(ts-node@10.9.2(@types/node@20.19.18)(typescript@5.9.2)))(typescript@5.9.2)):
     dependencies:
-      ts-jest: 29.4.4(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.28.1)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.18)(ts-node@10.9.2(@types/node@20.19.18)(typescript@5.9.2)))(typescript@5.9.2)
+      ts-jest: 29.4.4(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.18)(ts-node@10.9.2(@types/node@20.19.18)(typescript@5.9.2)))(typescript@5.9.2)
 
-  ts-jest@29.4.4(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.28.1)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.18)(ts-node@10.9.2(@types/node@20.19.18)(typescript@5.9.2)))(typescript@5.9.2):
+  ts-jest@29.4.4(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.25.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.18)(ts-node@10.9.2(@types/node@20.19.18)(typescript@5.9.2)))(typescript@5.9.2):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -5072,7 +5052,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.28.4)
-      esbuild: 0.28.1
+      esbuild: 0.25.12
       jest-util: 29.7.0
 
   ts-node@10.9.2(@types/node@20.19.18)(typescript@5.9.2):
@@ -5095,12 +5075,12 @@ snapshots:
 
   tsup@8.5.0(postcss@8.5.6)(typescript@5.9.2)(yaml@2.8.1):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.28.1)
+      bundle-require: 5.1.0(esbuild@0.25.12)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.28.1
+      esbuild: 0.25.12
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1


### PR DESCRIPTION
## Why

Bash fork support was removed in #15644, but bringing it back should not require rebuilding an effectively unchanged patched shell for every Rust release. Following the zsh artifact split in #30114, this establishes the same independently versioned, prerelease artifact pipeline for Bash. A later change can consume these artifacts from the Codex package.

Bash and zsh also need one shared wrapper contract so an escalation socket remains usable through a process tree containing either patched shell.

## What changed

- Add a `rust-release-bash` workflow triggered by immutable `codex-bash-vX.Y.Z` tags.
- Build and smoke-test patched Bash artifacts for Linux and macOS on x86_64 and AArch64, then publish them as a prerelease with a SHA-256 DotSlash manifest.
- Restore the Bash `EXEC_WRAPPER` patch and document its pinned upstream commit and release process.
- Exercise recursive `EXEC_WRAPPER` interception while preserving the inherited `CODEX_ESCALATE_SOCKET` file descriptor in both Bash and zsh artifact builds.
- Add a cross-shell workflow test for Bash → zsh and zsh → Bash process trees using the existing `codex-zsh-v0.1.0` release.

## Tag protection

Verified with `gh api repos/openai/codex/rulesets/{id}` that the repository rulesets for both `codex-bash-v*.*.*` and `codex-zsh-v*.*.*` are active. Both protect creation, updates, deletion, force-pushes, and linear history, with matching repository-admin and organization-admin bypasses.

## Testing

- Built the patched Bash and zsh shells locally and passed their recursive exec-wrapper smoke tests.
- Passed the alternating Bash → zsh and zsh → Bash wrapper-chain test with a live inherited escalation-socket file descriptor.
