### PR TITLE
Let Codex consult user-level code-review-* skills.

### DIFF
--- a/.codex/skills/code-review/SKILL.md
+++ b/.codex/skills/code-review/SKILL.md
@@ -3,7 +3,7 @@ name: code-review
 description: Run a final code review on a pull request
 ---
 
-Use subagents to review code using all code-review-* skills in this repository other than this orchestrator. One subagent per skill. Pass full skill path to subagents. Use xhigh reasoning.
+Use subagents to review code using all code-review-* skills other than this orchestrator. One subagent per skill. Pass full skill path to subagents. Use xhigh reasoning.
 
 You must return every single issue from every subagent. You can return an unlimited number of findings.
 Use raw Markdown to report findings.


### PR DESCRIPTION
## Why

I use the `$code-review` skill a lot and it'd be nice to add my own additional review criteria in `$CODEX_HOME/skills/code-review-*`.

## What

Removes phrasing about "code-review-* skills in this repository" which in practice seems like enough to get Codex to consult my user-level code review skills in addition to the repo-level ones.
