### PR TITLE
[codex] fix CreateThreadParams test initializer

### DIFF
--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -9178,6 +9178,7 @@ async fn attach_in_memory_thread_store(
             originator: "test_originator".to_string(),
             base_instructions: BaseInstructions::default(),
             dynamic_tools: Vec::new(),
+            selected_capability_roots: Vec::new(),
             multi_agent_version: None,
             initial_window_id: Uuid::now_v7().to_string(),
             metadata: ThreadPersistenceMetadata {


### PR DESCRIPTION
## Summary

- initialize `selected_capability_roots` in the new `attach_in_memory_thread_store` test helper
- restore `codex-core` test compilation on `main`

## Root cause

[#30144](https://github.com/openai/codex/pull/30144) added the helper from commit `0c3d0742`, whose parent was `c38b2e9b`. That branch was based before [#29856](https://github.com/openai/codex/pull/29856) added `selected_capability_roots` as a required field on `CreateThreadParams`.

The PR's Rust and Bazel workflows both passed against the stale branch head `0c3d0742`. When #30144 was squashed onto newer `main`, its initializer was integrated alongside the required field from #29856, producing `E0063` in `core/src/session/tests.rs`. Because those workflows tested the branch head rather than the integrated merge result, they did not see the version-skew failure before merge.

## Impact

Any job that compiles the `codex-core` library tests fails, which turned the main-branch `rust-ci-full` and `Bazel` workflows red across platforms and blocks unrelated focused core tests. This change only completes the test initializer; it does not alter production behavior or workflow configuration.

## Validation

- `just fmt`
- `just test -p codex-core turn_complete_flushes_terminal_event_after_delivery` (1 passed, 2909 skipped)
- `git diff --check`
