### PR TITLE
Relax hooks.json top-level metadata validation

### DIFF
--- a/codex-rs/config/src/hook_config.rs
+++ b/codex-rs/config/src/hook_config.rs
@@ -10,6 +10,8 @@ use serde::Serialize;
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct HooksFile {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
     #[serde(default)]
     pub hooks: HookEventsToml,
 }

--- a/codex-rs/config/src/hooks_tests.rs
+++ b/codex-rs/config/src/hooks_tests.rs
@@ -13,6 +13,7 @@ use super::MatcherGroup;
 fn hooks_file_deserializes_existing_json_shape() {
     let parsed: HooksFile = serde_json::from_str(
         r#"{
+  "description": "Optional stop-time review gate for Codex Companion.",
   "hooks": {
     "PreToolUse": [
       {
@@ -35,6 +36,7 @@ fn hooks_file_deserializes_existing_json_shape() {
     assert_eq!(
         parsed,
         HooksFile {
+            description: Some("Optional stop-time review gate for Codex Companion.".to_string()),
             hooks: HookEventsToml {
                 pre_tool_use: vec![MatcherGroup {
                     matcher: Some("^Bash$".to_string()),


### PR DESCRIPTION
## Summary
- Allow a top-level `description` string in `hooks.json`.
- Continue rejecting unknown top-level keys and root-level hook events; events must remain under `hooks`.

## Testing
- `just test -p codex-config`