### PR TITLE
[codex] Enable remote plugins by default

### DIFF
--- a/codex-rs/app-server-test-client/src/plugin_analytics_mutation_smoke.rs
+++ b/codex-rs/app-server-test-client/src/plugin_analytics_mutation_smoke.rs
@@ -124,7 +124,6 @@ pub(super) fn run_cleanup(
     overrides.extend([
         "analytics.enabled=false".to_string(),
         "features.plugins=true".to_string(),
-        "features.remote_plugin=true".to_string(),
     ]);
     let mut client = CodexClient::spawn_stdio(codex_bin, &overrides)?;
     client.initialize()?;
@@ -199,7 +198,6 @@ fn spawn_client(
     overrides.extend([
         "analytics.enabled=true".to_string(),
         "features.plugins=true".to_string(),
-        "features.remote_plugin=true".to_string(),
     ]);
     let environment = vec![(
         OsString::from(ANALYTICS_CAPTURE_ENV_VAR),

--- a/codex-rs/app-server-test-client/src/plugin_analytics_smoke.rs
+++ b/codex-rs/app-server-test-client/src/plugin_analytics_smoke.rs
@@ -263,7 +263,6 @@ fn smoke_config_overrides(responses_base_url: &str) -> Result<Vec<String>> {
     Ok(vec![
         "analytics.enabled=true".to_string(),
         "features.plugins=true".to_string(),
-        "features.remote_plugin=true".to_string(),
         format!("model={}", quoted(MOCK_MODEL_SLUG)?),
         format!("model_provider={}", quoted(MOCK_PROVIDER_ID)?),
         format!(

--- a/codex-rs/app-server/tests/suite/v2/plugin_install.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_install.rs
@@ -2027,7 +2027,6 @@ chatgpt_base_url = "{base_url}"
 
 [features]
 plugins = true
-remote_plugin = true
 "#
         ),
     )
@@ -2057,7 +2056,6 @@ chatgpt_base_url = "{}/backend-api/"
 
 [features]
 plugins = true
-remote_plugin = true
 connectors = true
 "#,
             server.uri()

--- a/codex-rs/app-server/tests/suite/v2/plugin_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_list.rs
@@ -71,6 +71,23 @@ plugins = true
     )
 }
 
+fn write_remote_plugins_disabled_config_with_base_url(
+    codex_home: &std::path::Path,
+    base_url: &str,
+) -> std::io::Result<()> {
+    std::fs::write(
+        codex_home.join("config.toml"),
+        format!(
+            r#"chatgpt_base_url = "{base_url}"
+
+[features]
+plugins = true
+remote_plugin = false
+"#,
+        ),
+    )
+}
+
 #[tokio::test]
 async fn plugin_list_skips_invalid_marketplace_file_and_reports_error() -> Result<()> {
     let codex_home = TempDir::new()?;
@@ -197,7 +214,6 @@ async fn plugin_installed_prefers_remote_curated_conflicts_when_remote_plugin_en
 
 [features]
 plugins = true
-remote_plugin = true
 plugin_sharing = false
 
 [plugins."linear@openai-curated"]
@@ -1987,10 +2003,11 @@ async fn plugin_list_uses_cached_global_remote_catalog_and_refreshes_it() -> Res
 }
 
 #[tokio::test]
-async fn plugin_list_includes_openai_curated_remote_collection_when_requested() -> Result<()> {
+async fn plugin_list_includes_openai_curated_remote_collection_when_remote_plugin_disabled_and_requested()
+-> Result<()> {
     let codex_home = TempDir::new()?;
     let server = MockServer::start().await;
-    write_plugins_enabled_config_with_base_url(
+    write_remote_plugins_disabled_config_with_base_url(
         codex_home.path(),
         &format!("{}/backend-api/", server.uri()),
     )?;
@@ -2092,10 +2109,11 @@ async fn plugin_list_includes_openai_curated_remote_collection_when_requested() 
 }
 
 #[tokio::test]
-async fn plugin_list_propagates_explicit_openai_curated_remote_collection_errors() -> Result<()> {
+async fn plugin_list_propagates_openai_curated_remote_collection_errors_when_remote_plugin_disabled()
+-> Result<()> {
     let codex_home = TempDir::new()?;
     let server = MockServer::start().await;
-    write_plugins_enabled_config_with_base_url(
+    write_remote_plugins_disabled_config_with_base_url(
         codex_home.path(),
         &format!("{}/backend-api/", server.uri()),
     )?;
@@ -2148,10 +2166,11 @@ async fn plugin_list_propagates_explicit_openai_curated_remote_collection_errors
 }
 
 #[tokio::test]
-async fn plugin_list_skips_explicit_openai_curated_remote_collection_for_api_auth() -> Result<()> {
+async fn plugin_list_skips_openai_curated_remote_collection_for_api_auth_when_remote_plugin_disabled()
+-> Result<()> {
     let codex_home = TempDir::new()?;
     let server = MockServer::start().await;
-    write_plugins_enabled_config_with_base_url(
+    write_remote_plugins_disabled_config_with_base_url(
         codex_home.path(),
         &format!("{}/backend-api/", server.uri()),
     )?;
@@ -2391,7 +2410,8 @@ async fn plugin_list_does_not_append_global_remote_when_marketplace_kinds_are_ex
 }
 
 #[tokio::test]
-async fn plugin_installed_includes_remote_shared_with_me_plugins() -> Result<()> {
+async fn plugin_installed_includes_remote_shared_with_me_plugins_when_remote_plugin_disabled()
+-> Result<()> {
     let codex_home = TempDir::new()?;
     let server = MockServer::start().await;
     std::fs::write(
@@ -2493,7 +2513,8 @@ plugin_sharing = true
 }
 
 #[tokio::test]
-async fn plugin_installed_includes_workspace_directory_without_plugin_sharing() -> Result<()> {
+async fn plugin_installed_includes_workspace_directory_without_plugin_sharing_when_remote_plugin_disabled()
+-> Result<()> {
     let codex_home = TempDir::new()?;
     let server = MockServer::start().await;
     std::fs::write(
@@ -2590,7 +2611,6 @@ async fn plugin_installed_includes_created_by_me_when_remote_plugins_enabled() -
 
 [features]
 plugins = true
-remote_plugin = true
 plugin_sharing = false
 "#,
             server.uri()
@@ -2681,7 +2701,6 @@ async fn plugin_installed_starts_remote_installed_bundle_sync() -> Result<()> {
 
 [features]
 plugins = true
-remote_plugin = true
 plugin_sharing = false
 "#,
             server.uri()
@@ -2750,10 +2769,10 @@ plugin_sharing = false
 }
 
 #[tokio::test]
-async fn plugin_list_fetches_workspace_directory_kind_without_remote_plugin_flag() -> Result<()> {
+async fn plugin_list_fetches_workspace_directory_kind_when_remote_plugin_disabled() -> Result<()> {
     let codex_home = TempDir::new()?;
     let server = MockServer::start().await;
-    write_plugins_enabled_config_with_base_url(
+    write_remote_plugins_disabled_config_with_base_url(
         codex_home.path(),
         &format!("{}/backend-api/", server.uri()),
     )?;
@@ -2848,7 +2867,6 @@ async fn plugin_list_fetches_user_plugins_in_created_by_me_remote_marketplace() 
 
 [features]
 plugins = true
-remote_plugin = true
 plugin_sharing = false
 "#,
             server.uri()
@@ -4032,7 +4050,6 @@ chatgpt_base_url = "{base_url}"
 
 [features]
 plugins = true
-remote_plugin = true
 "#
         ),
     )

--- a/codex-rs/app-server/tests/suite/v2/plugin_read.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_read.rs
@@ -2132,7 +2132,6 @@ chatgpt_base_url = "{base_url}"
 
 [features]
 plugins = true
-remote_plugin = true
 "#
         ),
     )

--- a/codex-rs/app-server/tests/suite/v2/plugin_share.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_share.rs
@@ -344,7 +344,6 @@ chatgpt_base_url = "{}/backend-api"
 
 [features]
 plugins = true
-remote_plugin = true
 plugin_sharing = false
 "#,
             server.uri()
@@ -1050,7 +1049,6 @@ chatgpt_base_url = "{}/backend-api"
 
 [features]
 plugins = true
-remote_plugin = true
 plugin_sharing = false
 "#,
             server.uri()
@@ -1204,7 +1202,6 @@ chatgpt_base_url = "{base_url}"
 
 [features]
 plugins = true
-remote_plugin = true
 "#
         ),
     )

--- a/codex-rs/app-server/tests/suite/v2/plugin_uninstall.rs
+++ b/codex-rs/app-server/tests/suite/v2/plugin_uninstall.rs
@@ -622,7 +622,6 @@ chatgpt_base_url = "{base_url}"
 
 [features]
 plugins = true
-remote_plugin = true
 "#
         ),
     )

--- a/codex-rs/app-server/tests/suite/v2/recommended_plugins.rs
+++ b/codex-rs/app-server/tests/suite/v2/recommended_plugins.rs
@@ -68,9 +68,7 @@ async fn first_turn_after_external_login_waits_for_recommended_plugins() -> Resu
     let config = std::fs::read_to_string(&config_path)?;
     std::fs::write(
         config_path,
-        format!(
-            "{config}\n[features]\napps = true\nplugins = true\nremote_plugin = true\ntool_suggest = true\n"
-        ),
+        format!("{config}\n[features]\napps = true\nplugins = true\ntool_suggest = true\n"),
     )?;
 
     let sqlite_home = codex_home.path().to_string_lossy();

--- a/codex-rs/app-server/tests/suite/v2/skills_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/skills_list.rs
@@ -79,23 +79,6 @@ plugins = true
     )
 }
 
-fn write_remote_plugins_enabled_config_with_base_url(
-    codex_home: &std::path::Path,
-    base_url: &str,
-) -> std::io::Result<()> {
-    std::fs::write(
-        codex_home.join("config.toml"),
-        format!(
-            r#"chatgpt_base_url = "{base_url}"
-
-[features]
-plugins = true
-remote_plugin = true
-"#,
-        ),
-    )
-}
-
 fn write_plugin_with_skill(
     repo_root: &std::path::Path,
     plugin_name: &str,
@@ -175,7 +158,7 @@ fn write_cached_local_curated_plugin_with_skill(codex_home: &std::path::Path) ->
 }
 
 #[tokio::test]
-async fn runtime_remote_plugin_enablement_excludes_local_curated_plugin_skills() -> Result<()> {
+async fn runtime_remote_plugin_toggle_updates_local_curated_plugin_skills() -> Result<()> {
     let codex_home = TempDir::new()?;
     let cwd = TempDir::new()?;
     let server = MockServer::start().await;
@@ -205,6 +188,18 @@ enabled = true
 
     let mut mcp = TestAppServer::new(codex_home.path()).await?;
     timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;
+
+    let disablement_request_id = mcp
+        .send_experimental_feature_enablement_set_request(ExperimentalFeatureEnablementSetParams {
+            enablement: BTreeMap::from([("remote_plugin".to_string(), false)]),
+        })
+        .await?;
+    let disablement_response: JSONRPCResponse = timeout(
+        DEFAULT_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(disablement_request_id)),
+    )
+    .await??;
+    let _: ExperimentalFeatureEnablementSetResponse = to_response(disablement_response)?;
 
     let initial_skills_list_request_id = mcp
         .send_skills_list_request(SkillsListParams {
@@ -266,7 +261,7 @@ async fn skills_list_loads_remote_installed_plugin_skills_from_cache() -> Result
     let server = MockServer::start().await;
     let expected_skill_path =
         std::fs::canonicalize(write_cached_remote_plugin_with_skill(codex_home.path())?)?;
-    write_remote_plugins_enabled_config_with_base_url(
+    write_plugins_enabled_config_with_base_url(
         codex_home.path(),
         &format!("{}/backend-api/", server.uri()),
     )?;

--- a/codex-rs/core-plugins/src/discoverable_tests.rs
+++ b/codex-rs/core-plugins/src/discoverable_tests.rs
@@ -37,6 +37,13 @@ use wiremock::matchers::query_param;
 #[tokio::test]
 async fn returns_fallback_plugins_when_remote_disabled_for_codex_auth() {
     let codex_home = tempdir().expect("tempdir should succeed");
+    write_file(
+        &codex_home.path().join(CONFIG_TOML_FILE),
+        r#"[features]
+plugins = true
+remote_plugin = false
+"#,
+    );
     let curated_root = curated_plugins_repo_path(codex_home.path());
     write_openai_curated_marketplace(&curated_root, &["sample", "slack", "openai-developers"]);
 
@@ -69,8 +76,7 @@ async fn returns_api_curated_fallback_plugins_for_direct_provider_auth() {
     let curated_root = curated_plugins_repo_path(codex_home.path());
     write_openai_api_curated_marketplace(&curated_root, &["sample", "slack", "openai-developers"]);
 
-    let mut plugins = load_plugins_config(codex_home.path(), codex_home.path()).await;
-    plugins.remote_plugin_enabled = true;
+    let plugins = load_plugins_config(codex_home.path(), codex_home.path()).await;
     let plugins_manager = PluginsManager::new(codex_home.path().to_path_buf());
     plugins_manager.set_auth_mode(Some(AuthMode::ApiKey));
     let auth = CodexAuth::from_api_key("test-api-key");
@@ -153,7 +159,6 @@ async fn omits_openai_curated_but_keeps_configured_marketplaces_for_remote_codex
         &format!(
             r#"[features]
 plugins = true
-remote_plugin = true
 
 [marketplaces.{bundled_marketplace_name}]
 source_type = "git"
@@ -188,8 +193,7 @@ async fn includes_openai_curated_when_remote_enabled_without_auth() {
     let curated_root = curated_plugins_repo_path(codex_home.path());
     write_openai_curated_marketplace(&curated_root, &["slack"]);
 
-    let mut plugins = load_plugins_config(codex_home.path(), codex_home.path()).await;
-    plugins.remote_plugin_enabled = true;
+    let plugins = load_plugins_config(codex_home.path(), codex_home.path()).await;
     let plugins_manager = PluginsManager::new(codex_home.path().to_path_buf());
     let discoverable_plugins = list_discoverable_plugins(
         &plugins_manager,
@@ -788,7 +792,6 @@ async fn expands_cached_remote_plugins_by_loaded_apps() {
         &codex_home.path().join(CONFIG_TOML_FILE),
         r#"[features]
 plugins = true
-remote_plugin = true
 "#,
     );
 

--- a/codex-rs/core-plugins/src/manager_tests.rs
+++ b/codex-rs/core-plugins/src/manager_tests.rs
@@ -871,7 +871,6 @@ async fn remote_installed_cache_ignores_plugins_missing_local_cache() {
         &codex_home.path().join(CONFIG_TOML_FILE),
         r#"[features]
 plugins = true
-remote_plugin = true
 "#,
     );
 
@@ -1105,7 +1104,6 @@ async fn remote_global_catalog_ignores_local_curated_plugins() {
         &codex_home.path().join(CONFIG_TOML_FILE),
         r#"[features]
 plugins = true
-remote_plugin = true
 
 [plugins."linear@openai-curated"]
 enabled = true
@@ -1156,7 +1154,6 @@ async fn remote_plugin_feature_keeps_local_curated_without_codex_backend() {
         &codex_home.path().join(CONFIG_TOML_FILE),
         r#"[features]
 plugins = true
-remote_plugin = true
 
 [plugins."linear@openai-curated"]
 enabled = true
@@ -4679,7 +4676,6 @@ async fn remote_plugin_caches_refresh_warms_recommended_plugins_cache() {
         &tmp.path().join(CONFIG_TOML_FILE),
         r#"[features]
 plugins = true
-remote_plugin = true
 "#,
     );
 
@@ -4740,7 +4736,6 @@ async fn recommended_plugins_mode_deduplicates_concurrent_cache_misses() {
         &tmp.path().join(CONFIG_TOML_FILE),
         r#"[features]
 plugins = true
-remote_plugin = true
 "#,
     );
 
@@ -4818,7 +4813,6 @@ async fn recommended_plugin_candidates_filter_installed_and_disabled_plugins() {
         &tmp.path().join(CONFIG_TOML_FILE),
         r#"[features]
 plugins = true
-remote_plugin = true
 "#,
     );
     let server = MockServer::start().await;
@@ -4891,7 +4885,6 @@ async fn recommended_plugins_mode_caches_explicit_false() {
         &tmp.path().join(CONFIG_TOML_FILE),
         r#"[features]
 plugins = true
-remote_plugin = true
 "#,
     );
 
@@ -4931,7 +4924,6 @@ async fn recommended_plugins_mode_retries_after_fetch_failure() {
         &tmp.path().join(CONFIG_TOML_FILE),
         r#"[features]
 plugins = true
-remote_plugin = true
 "#,
     );
 

--- a/codex-rs/core-plugins/src/test_support.rs
+++ b/codex-rs/core-plugins/src/test_support.rs
@@ -149,7 +149,7 @@ pub(crate) async fn load_plugins_config(codex_home: &Path, cwd: &Path) -> Plugin
         feature_enabled(
             &effective_config,
             "remote_plugin",
-            /*default_enabled*/ false,
+            /*default_enabled*/ true,
         ),
         "https://chatgpt.com/backend-api/".to_string(),
     )

--- a/codex-rs/core/src/plugins/discoverable_tests.rs
+++ b/codex-rs/core/src/plugins/discoverable_tests.rs
@@ -69,7 +69,6 @@ async fn list_tool_suggest_discoverable_plugins_includes_cached_remote_global_pl
         &codex_home.path().join(crate::config::CONFIG_TOML_FILE),
         r#"[features]
 plugins = true
-remote_plugin = true
 "#,
     );
 
@@ -306,7 +305,6 @@ remote_plugin = true
         &codex_home.path().join(crate::config::CONFIG_TOML_FILE),
         r#"[features]
 plugins = true
-remote_plugin = true
 
 [tool_suggest]
 disabled_tools = [

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -190,7 +190,7 @@ pub enum Feature {
     ///
     /// Requirements-only gate: this should be set from requirements, not user config.
     ComputerUse,
-    /// Temporary internal-only flag for PS-backed remote plugin catalog development.
+    /// Enable the PS-backed remote plugin catalog.
     RemotePlugin,
     /// Enable remote plugin sharing flows.
     PluginSharing,
@@ -1145,8 +1145,8 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::RemotePlugin,
         key: "remote_plugin",
-        stage: Stage::UnderDevelopment,
-        default_enabled: false,
+        stage: Stage::Stable,
+        default_enabled: true,
     },
     FeatureSpec {
         id: Feature::PluginSharing,

--- a/codex-rs/tui/src/chatwidget/tests/popups_and_settings.rs
+++ b/codex-rs/tui/src/chatwidget/tests/popups_and_settings.rs
@@ -1200,9 +1200,10 @@ async fn plugins_popup_admin_disabled_available_plugin_has_view_only_hint() {
 }
 
 #[tokio::test]
-async fn plugins_popup_remote_section_fallback_states_snapshot() {
+async fn plugins_popup_remote_section_fallback_states_when_remote_plugin_disabled_snapshot() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
     chat.set_feature_enabled(Feature::Plugins, /*enabled*/ true);
+    chat.set_feature_enabled(Feature::RemotePlugin, /*enabled*/ false);
 
     let select_tab_containing = |chat: &mut ChatWidget, visible_text: &str| -> String {
         for _ in 0..8 {
@@ -1266,7 +1267,6 @@ async fn plugins_popup_remote_section_fallback_states_snapshot() {
 
     let (mut remote_chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
     remote_chat.set_feature_enabled(Feature::Plugins, /*enabled*/ true);
-    remote_chat.set_feature_enabled(Feature::RemotePlugin, /*enabled*/ true);
     remote_chat.add_plugins_output();
     let remote_cwd = remote_chat.config.cwd.clone();
     remote_chat.on_plugins_loaded(


### PR DESCRIPTION
## Summary

- enable the remote plugin feature by default
- promote the remote plugin feature from under development to stable
- preserve the existing `features.remote_plugin` override for explicitly disabling it
- keep legacy disabled-path coverage explicit in TUI and app-server tests

## Impact

Remote plugin functionality is enabled by default for configurations that do not set the feature flag. The existing Codex backend authentication gate still applies.

## Validation

- `just fmt`
- `just test -p codex-features`
- `just test -p codex-tui plugins_popup_remote_section_fallback_states_snapshot`
- targeted `codex-app-server` plugin-list and skills-list tests
- `git diff --check`

The full TUI and app-server suites were also exercised locally. All remote-plugin-related coverage passed; unrelated local sandbox/test-binary failures remain outside this change.
