### PR TITLE
[codex] assign IDs to normalized prompt outputs

### DIFF
--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -253,6 +253,7 @@ async fn run_compact_task_inner_impl(
         let turn_input = history
             .clone()
             .for_prompt(&turn_context.model_info.input_modalities);
+        let turn_input = Session::assign_missing_prompt_item_ids(turn_context.as_ref(), turn_input);
         let turn_input_len = turn_input.len();
         let prompt = Prompt {
             input: turn_input,

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -224,6 +224,7 @@ async fn run_remote_compact_task_inner_impl(
     // request, whose prompt will repeat current developer/context prefix items.
     let trace_input_history = history.raw_items().to_vec();
     let prompt_input = history.for_prompt(&turn_context.model_info.input_modalities);
+    let prompt_input = Session::assign_missing_prompt_item_ids(turn_context.as_ref(), prompt_input);
     let tool_router = built_tools(
         sess.as_ref(),
         step_context.as_ref(),

--- a/codex-rs/core/src/compact_remote_v2.rs
+++ b/codex-rs/core/src/compact_remote_v2.rs
@@ -232,6 +232,7 @@ async fn run_remote_compact_task_inner_impl(
 
     let trace_input_history = history.raw_items().to_vec();
     let prompt_input = history.for_prompt(&turn_context.model_info.input_modalities);
+    let prompt_input = Session::assign_missing_prompt_item_ids(turn_context.as_ref(), prompt_input);
     let tool_router = built_tools(
         sess.as_ref(),
         step_context.as_ref(),

--- a/codex-rs/core/src/prompt_debug.rs
+++ b/codex-rs/core/src/prompt_debug.rs
@@ -88,10 +88,7 @@ pub(crate) async fn build_prompt_input_from_session(
             .await;
     }
 
-    let prompt_input = sess
-        .clone_history()
-        .await
-        .for_prompt(&turn_context.model_info.input_modalities);
+    let prompt_input = sess.prompt_input_from_history(turn_context.as_ref()).await;
     let router = built_tools(sess, step_context.as_ref(), &CancellationToken::new()).await?;
     let base_instructions = sess.get_base_instructions().await;
     let prompt = build_prompt(

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -2729,6 +2729,31 @@ impl Session {
         }
     }
 
+    /// Returns normalized history for a model request. When item IDs are
+    /// enabled, this also assigns IDs to prompt-only items synthesized during
+    /// normalization.
+    pub(crate) async fn prompt_input_from_history(
+        &self,
+        turn_context: &TurnContext,
+    ) -> Vec<ResponseItem> {
+        let items = self
+            .clone_history()
+            .await
+            .for_prompt(&turn_context.model_info.input_modalities);
+        Self::assign_missing_prompt_item_ids(turn_context, items)
+    }
+
+    pub(crate) fn assign_missing_prompt_item_ids(
+        turn_context: &TurnContext,
+        items: Vec<ResponseItem>,
+    ) -> Vec<ResponseItem> {
+        if turn_context.config.features.enabled(Feature::ItemIds) {
+            Self::assign_missing_response_item_ids(Cow::Owned(items)).into_owned()
+        } else {
+            items
+        }
+    }
+
     fn assign_missing_response_item_ids(items: Cow<'_, [ResponseItem]>) -> Cow<'_, [ResponseItem]> {
         if items.iter().all(|item| item.id().is_some()) {
             return items;

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -268,13 +268,10 @@ pub(crate) async fn run_turn(
             }
 
             // Construct the input that we will send to the model.
-            let sampling_request_input: Vec<ResponseItem> = async {
-                sess.clone_history()
-                    .await
-                    .for_prompt(&turn_context.model_info.input_modalities)
-            }
-            .instrument(trace_span!("run_turn.prepare_sampling_request_input"))
-            .await;
+            let sampling_request_input: Vec<ResponseItem> =
+                async { sess.prompt_input_from_history(turn_context.as_ref()).await }
+                    .instrument(trace_span!("run_turn.prepare_sampling_request_input"))
+                    .await;
 
             let responses_metadata = turn_context.turn_metadata_state.to_responses_metadata(
                 sess.installation_id.clone(),
@@ -1104,9 +1101,7 @@ async fn run_sampling_request(
         let prompt_input = if let Some(input) = initial_input.take() {
             input
         } else {
-            sess.clone_history()
-                .await
-                .for_prompt(&turn_context.model_info.input_modalities)
+            sess.prompt_input_from_history(turn_context.as_ref()).await
         };
         let prompt = build_prompt(
             prompt_input,

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -364,6 +364,73 @@ async fn response_item_ids_persist_across_resume_and_preserve_server_ids() -> an
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn normalized_call_outputs_receive_item_ids() -> anyhow::Result<()> {
+    let function_call_id = "missing-output-call";
+    let thread_id = ThreadId::default();
+    let rollout = vec![
+        RolloutLine {
+            timestamp: "2024-01-01T00:00:00.000Z".to_string(),
+            item: RolloutItem::SessionMeta(SessionMetaLine {
+                meta: SessionMeta {
+                    session_id: thread_id.into(),
+                    id: thread_id,
+                    parent_thread_id: None,
+                    timestamp: "2024-01-01T00:00:00Z".to_string(),
+                    cwd: ".".into(),
+                    originator: "test_originator".to_string(),
+                    cli_version: "test_version".to_string(),
+                    model_provider: Some("test-provider".to_string()),
+                    ..Default::default()
+                },
+                git: None,
+            }),
+        },
+        RolloutLine {
+            timestamp: "2024-01-01T00:00:01.000Z".to_string(),
+            item: RolloutItem::ResponseItem(ResponseItem::FunctionCall {
+                id: Some("fc_existing".to_string()),
+                name: "do_it".to_string(),
+                namespace: None,
+                arguments: "{}".to_string(),
+                call_id: function_call_id.to_string(),
+                internal_chat_message_metadata_passthrough: None,
+            }),
+        },
+    ];
+    let tmpdir = TempDir::new().unwrap();
+    let session_path = tmpdir.path().join("normalized-call-output-item-id.jsonl");
+    let mut file = std::fs::File::create(&session_path).unwrap();
+    for line in rollout {
+        writeln!(file, "{}", serde_json::to_string(&line).unwrap()).unwrap();
+    }
+
+    let server = MockServer::start().await;
+    let response_mock = mount_sse_once(
+        &server,
+        sse(vec![ev_response_created("resp-1"), ev_completed("resp-1")]),
+    )
+    .await;
+    let codex_home = Arc::new(TempDir::new().unwrap());
+    let mut builder = test_codex().with_config(|config| {
+        let _ = config.features.enable(Feature::ItemIds);
+    });
+    let test = builder.resume(&server, codex_home, session_path).await?;
+
+    test.submit_turn("after resume").await?;
+
+    let output = response_mock
+        .single_request()
+        .function_call_output(function_call_id);
+    let output_id = output
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .expect("normalized output should have an item ID");
+    assert!(output_id.starts_with("fco_"));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn response_item_ids_are_sent_for_all_remote_v2_compaction_requests() -> anyhow::Result<()> {
     let server = MockServer::start().await;
     let response_mock = mount_sse_sequence(


### PR DESCRIPTION
## Summary

- Run the existing response-item ID allocator after `ContextManager::for_prompt` normalization.
- Route regular turns, retry rebuilds, prompt debug, and local/remote compaction prompts through that finalization step.
- Add integration coverage for a resumed call whose missing output is synthesized during normalization.

## Root cause

`item_ids` assigns IDs at the durable history-recording boundary. Later, `for_prompt` can synthesize an `"aborted"` call output for an unmatched call. That prompt-only output bypassed the allocation boundary and serialized without an ID, which breaks consumers that require IDs for every rendered response item.

This keeps the existing feature gate and type-specific UUIDv7 allocator instead of weakening the downstream invariant. Related: #28814.

## Validation

- `just test -p codex-core --test all normalized_call_outputs_receive_item_ids`
- `cargo fmt --check`
- Attempted `just test -p codex-core`; currently blocked on `main` by the unrelated `CreateThreadParams` initializer missing `history_mode` in `core/src/session/tests.rs:7006`.
