### PR TITLE
Read retry_model from safety buffering events

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/mod.rs
+++ b/codex-rs/app-server/tests/suite/v2/mod.rs
@@ -57,6 +57,7 @@ mod request_permissions;
 mod request_user_input;
 mod request_validation;
 mod review;
+mod safety_buffering;
 mod safety_check_downgrade;
 #[cfg(not(target_os = "windows"))]
 mod selected_capability_stack;

--- a/codex-rs/app-server/tests/suite/v2/safety_buffering.rs
+++ b/codex-rs/app-server/tests/suite/v2/safety_buffering.rs
@@ -29,7 +29,7 @@ async fn direct_websocket_safety_buffering_reaches_app_server_notification() -> 
     buffering_event["safety_buffering"] = json!({
         "use_cases": ["cyber"],
         "reasons": ["user_risk"],
-        "faster_model": FASTER_MODEL,
+        "retry_model": FASTER_MODEL,
     });
     let websocket_server = responses::start_websocket_server(vec![vec![
         vec![

--- a/codex-rs/app-server/tests/suite/v2/safety_buffering.rs
+++ b/codex-rs/app-server/tests/suite/v2/safety_buffering.rs
@@ -1,0 +1,133 @@
+use anyhow::Result;
+use app_test_support::TestAppServer;
+use app_test_support::to_response;
+use codex_app_server_protocol::JSONRPCResponse;
+use codex_app_server_protocol::ModelSafetyBufferingUpdatedNotification;
+use codex_app_server_protocol::RequestId;
+use codex_app_server_protocol::ThreadStartParams;
+use codex_app_server_protocol::ThreadStartResponse;
+use codex_app_server_protocol::TurnStartParams;
+use codex_app_server_protocol::TurnStartResponse;
+use codex_app_server_protocol::UserInput;
+use core_test_support::responses;
+use core_test_support::skip_if_no_network;
+use pretty_assertions::assert_eq;
+use serde_json::json;
+use std::path::Path;
+use tempfile::TempDir;
+use tokio::time::Duration;
+use tokio::time::timeout;
+
+const DEFAULT_READ_TIMEOUT: Duration = Duration::from_secs(20);
+const FASTER_MODEL: &str = "gpt-fast-wire";
+
+#[tokio::test]
+async fn direct_websocket_safety_buffering_reaches_app_server_notification() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let mut buffering_event = responses::ev_response_created("resp-1");
+    buffering_event["safety_buffering"] = json!({
+        "use_cases": ["cyber"],
+        "reasons": ["user_risk"],
+        "faster_model": FASTER_MODEL,
+    });
+    let websocket_server = responses::start_websocket_server(vec![vec![
+        vec![
+            json!({
+                "type": "codex.response.metadata",
+                "headers": {"x-codex-safety-buffering-enabled": "false"},
+            }),
+            responses::ev_response_created("warm-1"),
+            responses::ev_completed("warm-1"),
+        ],
+        vec![
+            buffering_event,
+            responses::ev_assistant_message("msg-1", "Done"),
+            responses::ev_completed("resp-1"),
+        ],
+    ]])
+    .await;
+
+    let codex_home = TempDir::new()?;
+    create_websocket_config(
+        codex_home.path(),
+        &websocket_server.uri().replacen("ws://", "http://", 1),
+    )?;
+    let mut mcp = TestAppServer::new_with_auto_env(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let thread_request = mcp
+        .send_thread_start_request_with_auto_env(ThreadStartParams::default())
+        .await?;
+    let thread_response: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(thread_request)),
+    )
+    .await??;
+    let ThreadStartResponse { thread, .. } = to_response(thread_response)?;
+
+    let turn_request = mcp
+        .send_turn_start_request(TurnStartParams {
+            thread_id: thread.id.clone(),
+            client_user_message_id: None,
+            input: vec![UserInput::Text {
+                text: "Check this request".to_string(),
+                text_elements: Vec::new(),
+            }],
+            ..Default::default()
+        })
+        .await?;
+    let turn_response: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(turn_request)),
+    )
+    .await??;
+    let TurnStartResponse { turn } = to_response(turn_response)?;
+
+    let notification = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_notification_message("model/safetyBuffering/updated"),
+    )
+    .await??;
+    let notification: ModelSafetyBufferingUpdatedNotification =
+        serde_json::from_value(notification.params.expect("notification params"))?;
+
+    assert_eq!(notification.thread_id, thread.id);
+    assert_eq!(notification.turn_id, turn.id);
+    assert_eq!(notification.model, "mock-model");
+    assert_eq!(notification.use_cases, ["cyber"]);
+    assert_eq!(notification.reasons, ["user_risk"]);
+    assert!(notification.show_buffering_ui);
+    assert_eq!(notification.faster_model.as_deref(), Some(FASTER_MODEL));
+
+    timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_notification_message("turn/completed"),
+    )
+    .await??;
+    websocket_server.shutdown().await;
+    Ok(())
+}
+
+fn create_websocket_config(codex_home: &Path, server_uri: &str) -> std::io::Result<()> {
+    std::fs::write(
+        codex_home.join("config.toml"),
+        format!(
+            r#"
+model = "mock-model"
+approval_policy = "never"
+sandbox_mode = "read-only"
+
+model_provider = "mock_provider"
+
+[model_providers.mock_provider]
+name = "Mock provider for test"
+base_url = "{server_uri}/v1"
+wire_api = "responses"
+request_max_retries = 0
+stream_max_retries = 0
+supports_websockets = true
+"#
+        ),
+    )
+}

--- a/codex-rs/codex-api/src/common.rs
+++ b/codex-rs/codex-api/src/common.rs
@@ -121,14 +121,17 @@ pub struct SafetyBuffering {
     pub reasons: Vec<String>,
     #[serde(skip)]
     pub show_buffering_ui: bool,
-    #[serde(skip)]
     pub faster_model: Option<String>,
 }
 
 impl SafetyBuffering {
-    pub(crate) fn with_treatment(mut self, treatment: &SafetyBufferingTreatment) -> Self {
-        self.show_buffering_ui = treatment.show_buffering_ui;
-        self.faster_model.clone_from(&treatment.faster_model);
+    pub(crate) fn with_treatment(mut self, treatment: Option<&SafetyBufferingTreatment>) -> Self {
+        if let Some(treatment) = treatment {
+            self.show_buffering_ui = treatment.show_buffering_ui;
+            self.faster_model.clone_from(&treatment.faster_model);
+        } else {
+            self.show_buffering_ui = true;
+        }
         self
     }
 }

--- a/codex-rs/codex-api/src/common.rs
+++ b/codex-rs/codex-api/src/common.rs
@@ -10,6 +10,7 @@ use codex_protocol::protocol::TurnModerationMetadataEvent;
 use codex_protocol::protocol::W3cTraceContext;
 use futures::Stream;
 use serde::Deserialize;
+use serde::Deserializer;
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -121,6 +122,9 @@ pub struct SafetyBuffering {
     pub reasons: Vec<String>,
     #[serde(skip)]
     pub show_buffering_ui: bool,
+    #[serde(rename = "retry_model", default)]
+    pub(crate) wire_retry_model: WireRetryModel,
+    #[serde(skip)]
     pub faster_model: Option<String>,
 }
 
@@ -131,8 +135,27 @@ impl SafetyBuffering {
             self.faster_model.clone_from(&treatment.faster_model);
         } else {
             self.show_buffering_ui = true;
+            if let WireRetryModel::Value(retry_model) = &self.wire_retry_model {
+                self.faster_model.clone_from(retry_model);
+            }
         }
         self
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) enum WireRetryModel {
+    #[default]
+    Missing,
+    Value(Option<String>),
+}
+
+impl<'de> Deserialize<'de> for WireRetryModel {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<String>::deserialize(deserializer).map(Self::Value)
     }
 }
 

--- a/codex-rs/codex-api/src/endpoint/responses_websocket.rs
+++ b/codex-rs/codex-api/src/endpoint/responses_websocket.rs
@@ -635,7 +635,7 @@ async fn run_websocket_response_stream(
     turn_state: Option<&OnceLock<String>>,
 ) -> Result<(), ApiError> {
     let mut last_server_model: Option<String> = None;
-    let mut safety_buffering_treatment = SafetyBufferingTreatment::default();
+    let mut safety_buffering_treatment: Option<SafetyBufferingTreatment> = None;
     send_websocket_request(
         ws_stream,
         request_text,
@@ -689,17 +689,10 @@ async fn run_websocket_response_stream(
                 {
                     let _ = turn_state.set(response_turn_state);
                 }
-                if let Some(headers) = event.headers.as_ref().and_then(Value::as_object)
-                    && let Some(treatment) =
-                        treatment_from_headers(&json_headers_to_http_headers(headers))
-                {
-                    safety_buffering_treatment = treatment;
-                }
                 let model_verifications = event.model_verifications();
                 let turn_moderation_metadata = event.turn_moderation_metadata();
-                let safety_buffering = event
-                    .safety_buffering()
-                    .map(|buffering| buffering.with_treatment(&safety_buffering_treatment));
+                let safety_buffering =
+                    safety_buffering_for_event(&event, &mut safety_buffering_treatment);
                 if event.kind() == "codex.rate_limits" {
                     if let Some(snapshot) = parse_rate_limit_event(&text) {
                         let _ = tx_event.send(Ok(ResponseEvent::RateLimits(snapshot))).await;
@@ -772,6 +765,21 @@ async fn run_websocket_response_stream(
     }
 
     Ok(())
+}
+
+fn safety_buffering_for_event(
+    event: &ResponsesStreamEvent,
+    treatment: &mut Option<SafetyBufferingTreatment>,
+) -> Option<crate::common::SafetyBuffering> {
+    if let Some(headers) = event.headers.as_ref().and_then(Value::as_object)
+        && let Some(updated_treatment) =
+            treatment_from_headers(&json_headers_to_http_headers(headers))
+    {
+        *treatment = Some(updated_treatment);
+    }
+    event
+        .safety_buffering()
+        .map(|buffering| buffering.with_treatment(treatment.as_ref()))
 }
 
 async fn send_websocket_request(
@@ -1038,5 +1046,116 @@ mod tests {
             merged.get("x-default-only"),
             Some(&HeaderValue::from_static("default-only"))
         );
+    }
+
+    #[test]
+    fn direct_websocket_safety_buffering_uses_wire_faster_model() {
+        let event: ResponsesStreamEvent = serde_json::from_value(json!({
+            "type": "response.output_text.delta",
+            "safety_buffering": {
+                "use_cases": ["cyber"],
+                "reasons": ["user_risk"],
+                "faster_model": "gpt-fast-wire"
+            }
+        }))
+        .expect("deserialize safety buffering event");
+        let mut treatment = None;
+
+        let buffering = safety_buffering_for_event(&event, &mut treatment)
+            .expect("expected safety buffering payload");
+
+        assert!(buffering.show_buffering_ui);
+        assert_eq!(buffering.faster_model.as_deref(), Some("gpt-fast-wire"));
+    }
+
+    #[test]
+    fn websocket_safety_buffering_treatment_metadata_overrides_wire_values() {
+        let metadata: ResponsesStreamEvent = serde_json::from_value(json!({
+            "type": "codex.response.metadata",
+            "headers": {
+                "x-codex-safety-buffering-enabled": "true",
+                "x-codex-safety-buffering-faster-model": "gpt-fast-header"
+            }
+        }))
+        .expect("deserialize treatment metadata");
+        let event: ResponsesStreamEvent = serde_json::from_value(json!({
+            "type": "response.output_text.delta",
+            "safety_buffering": {
+                "use_cases": ["cyber"],
+                "reasons": ["user_risk"],
+                "faster_model": "gpt-fast-wire"
+            }
+        }))
+        .expect("deserialize safety buffering event");
+        let mut treatment = None;
+
+        assert!(safety_buffering_for_event(&metadata, &mut treatment).is_none());
+        let buffering = safety_buffering_for_event(&event, &mut treatment)
+            .expect("expected safety buffering payload");
+
+        assert!(buffering.show_buffering_ui);
+        assert_eq!(buffering.faster_model.as_deref(), Some("gpt-fast-header"));
+    }
+
+    #[test]
+    fn websocket_safety_buffering_treatment_can_clear_wire_values() {
+        for (headers, expected_show_buffering_ui) in [
+            (json!({"x-codex-safety-buffering-enabled": "true"}), true),
+            (
+                json!({
+                    "x-codex-safety-buffering-enabled": "false",
+                    "x-codex-safety-buffering-faster-model": "ignored-header-model"
+                }),
+                false,
+            ),
+        ] {
+            let metadata: ResponsesStreamEvent = serde_json::from_value(json!({
+                "type": "codex.response.metadata",
+                "headers": headers
+            }))
+            .expect("deserialize treatment metadata");
+            let event: ResponsesStreamEvent = serde_json::from_value(json!({
+                "type": "response.output_text.delta",
+                "safety_buffering": {
+                    "use_cases": ["cyber"],
+                    "reasons": ["user_risk"],
+                    "faster_model": "gpt-fast-wire"
+                }
+            }))
+            .expect("deserialize safety buffering event");
+            let mut treatment = None;
+
+            assert!(safety_buffering_for_event(&metadata, &mut treatment).is_none());
+            let buffering = safety_buffering_for_event(&event, &mut treatment)
+                .expect("expected safety buffering payload");
+
+            assert_eq!(buffering.show_buffering_ui, expected_show_buffering_ui);
+            assert_eq!(buffering.faster_model, None);
+        }
+    }
+
+    #[test]
+    fn direct_websocket_safety_buffering_accepts_missing_and_null_faster_model() {
+        for faster_model in [None, Some(Value::Null)] {
+            let mut payload = json!({
+                "type": "response.output_text.delta",
+                "safety_buffering": {
+                    "use_cases": ["cyber"],
+                    "reasons": ["user_risk"]
+                }
+            });
+            if let Some(faster_model) = faster_model {
+                payload["safety_buffering"]["faster_model"] = faster_model;
+            }
+            let event: ResponsesStreamEvent =
+                serde_json::from_value(payload).expect("deserialize safety buffering event");
+            let mut treatment = None;
+
+            let buffering = safety_buffering_for_event(&event, &mut treatment)
+                .expect("expected safety buffering payload");
+
+            assert!(buffering.show_buffering_ui);
+            assert_eq!(buffering.faster_model, None);
+        }
     }
 }

--- a/codex-rs/codex-api/src/endpoint/responses_websocket.rs
+++ b/codex-rs/codex-api/src/endpoint/responses_websocket.rs
@@ -3,6 +3,7 @@ use crate::common::ResponseEvent;
 use crate::common::ResponseStream;
 use crate::common::ResponsesWsRequest;
 use crate::common::SafetyBufferingTreatment;
+use crate::common::WireRetryModel;
 use crate::error::ApiError;
 use crate::provider::Provider;
 use crate::rate_limits::parse_rate_limit_event;
@@ -636,6 +637,7 @@ async fn run_websocket_response_stream(
 ) -> Result<(), ApiError> {
     let mut last_server_model: Option<String> = None;
     let mut safety_buffering_treatment: Option<SafetyBufferingTreatment> = None;
+    let mut wire_retry_model: Option<String> = None;
     send_websocket_request(
         ws_stream,
         request_text,
@@ -691,8 +693,11 @@ async fn run_websocket_response_stream(
                 }
                 let model_verifications = event.model_verifications();
                 let turn_moderation_metadata = event.turn_moderation_metadata();
-                let safety_buffering =
-                    safety_buffering_for_event(&event, &mut safety_buffering_treatment);
+                let safety_buffering = safety_buffering_for_event(
+                    &event,
+                    &mut safety_buffering_treatment,
+                    &mut wire_retry_model,
+                );
                 if event.kind() == "codex.rate_limits" {
                     if let Some(snapshot) = parse_rate_limit_event(&text) {
                         let _ = tx_event.send(Ok(ResponseEvent::RateLimits(snapshot))).await;
@@ -770,6 +775,7 @@ async fn run_websocket_response_stream(
 fn safety_buffering_for_event(
     event: &ResponsesStreamEvent,
     treatment: &mut Option<SafetyBufferingTreatment>,
+    wire_retry_model: &mut Option<String>,
 ) -> Option<crate::common::SafetyBuffering> {
     if let Some(headers) = event.headers.as_ref().and_then(Value::as_object)
         && let Some(updated_treatment) =
@@ -777,9 +783,19 @@ fn safety_buffering_for_event(
     {
         *treatment = Some(updated_treatment);
     }
-    event
-        .safety_buffering()
-        .map(|buffering| buffering.with_treatment(treatment.as_ref()))
+    event.safety_buffering().map(|mut buffering| {
+        if treatment.is_none() {
+            match &buffering.wire_retry_model {
+                WireRetryModel::Value(retry_model) => {
+                    wire_retry_model.clone_from(retry_model);
+                }
+                WireRetryModel::Missing => {
+                    buffering.wire_retry_model = WireRetryModel::Value(wire_retry_model.clone());
+                }
+            }
+        }
+        buffering.with_treatment(treatment.as_ref())
+    })
 }
 
 async fn send_websocket_request(
@@ -1049,19 +1065,20 @@ mod tests {
     }
 
     #[test]
-    fn direct_websocket_safety_buffering_uses_wire_faster_model() {
+    fn direct_websocket_safety_buffering_uses_wire_retry_model() {
         let event: ResponsesStreamEvent = serde_json::from_value(json!({
             "type": "response.output_text.delta",
             "safety_buffering": {
                 "use_cases": ["cyber"],
                 "reasons": ["user_risk"],
-                "faster_model": "gpt-fast-wire"
+                "retry_model": "gpt-fast-wire"
             }
         }))
         .expect("deserialize safety buffering event");
         let mut treatment = None;
+        let mut wire_retry_model = None;
 
-        let buffering = safety_buffering_for_event(&event, &mut treatment)
+        let buffering = safety_buffering_for_event(&event, &mut treatment, &mut wire_retry_model)
             .expect("expected safety buffering payload");
 
         assert!(buffering.show_buffering_ui);
@@ -1083,14 +1100,17 @@ mod tests {
             "safety_buffering": {
                 "use_cases": ["cyber"],
                 "reasons": ["user_risk"],
-                "faster_model": "gpt-fast-wire"
+                "retry_model": "gpt-fast-wire"
             }
         }))
         .expect("deserialize safety buffering event");
         let mut treatment = None;
+        let mut wire_retry_model = None;
 
-        assert!(safety_buffering_for_event(&metadata, &mut treatment).is_none());
-        let buffering = safety_buffering_for_event(&event, &mut treatment)
+        assert!(
+            safety_buffering_for_event(&metadata, &mut treatment, &mut wire_retry_model).is_none()
+        );
+        let buffering = safety_buffering_for_event(&event, &mut treatment, &mut wire_retry_model)
             .expect("expected safety buffering payload");
 
         assert!(buffering.show_buffering_ui);
@@ -1119,15 +1139,20 @@ mod tests {
                 "safety_buffering": {
                     "use_cases": ["cyber"],
                     "reasons": ["user_risk"],
-                    "faster_model": "gpt-fast-wire"
+                    "retry_model": "gpt-fast-wire"
                 }
             }))
             .expect("deserialize safety buffering event");
             let mut treatment = None;
+            let mut wire_retry_model = None;
 
-            assert!(safety_buffering_for_event(&metadata, &mut treatment).is_none());
-            let buffering = safety_buffering_for_event(&event, &mut treatment)
-                .expect("expected safety buffering payload");
+            assert!(
+                safety_buffering_for_event(&metadata, &mut treatment, &mut wire_retry_model)
+                    .is_none()
+            );
+            let buffering =
+                safety_buffering_for_event(&event, &mut treatment, &mut wire_retry_model)
+                    .expect("expected safety buffering payload");
 
             assert_eq!(buffering.show_buffering_ui, expected_show_buffering_ui);
             assert_eq!(buffering.faster_model, None);
@@ -1135,8 +1160,8 @@ mod tests {
     }
 
     #[test]
-    fn direct_websocket_safety_buffering_accepts_missing_and_null_faster_model() {
-        for faster_model in [None, Some(Value::Null)] {
+    fn direct_websocket_safety_buffering_accepts_missing_and_null_retry_model() {
+        for retry_model in [None, Some(Value::Null)] {
             let mut payload = json!({
                 "type": "response.output_text.delta",
                 "safety_buffering": {
@@ -1144,18 +1169,91 @@ mod tests {
                     "reasons": ["user_risk"]
                 }
             });
-            if let Some(faster_model) = faster_model {
-                payload["safety_buffering"]["faster_model"] = faster_model;
+            if let Some(retry_model) = retry_model {
+                payload["safety_buffering"]["retry_model"] = retry_model;
             }
             let event: ResponsesStreamEvent =
                 serde_json::from_value(payload).expect("deserialize safety buffering event");
             let mut treatment = None;
+            let mut wire_retry_model = None;
 
-            let buffering = safety_buffering_for_event(&event, &mut treatment)
-                .expect("expected safety buffering payload");
+            let buffering =
+                safety_buffering_for_event(&event, &mut treatment, &mut wire_retry_model)
+                    .expect("expected safety buffering payload");
 
             assert!(buffering.show_buffering_ui);
             assert_eq!(buffering.faster_model, None);
         }
+    }
+
+    #[test]
+    fn direct_websocket_safety_buffering_preserves_wire_retry_model() {
+        let event_with_retry: ResponsesStreamEvent = serde_json::from_value(json!({
+            "type": "response.output_text.delta",
+            "safety_buffering": {
+                "use_cases": ["cyber"],
+                "reasons": ["user_risk"],
+                "retry_model": "gpt-fast-wire"
+            }
+        }))
+        .expect("deserialize safety buffering event");
+        let event_without_retry: ResponsesStreamEvent = serde_json::from_value(json!({
+            "type": "response.output_text.delta",
+            "safety_buffering": {
+                "use_cases": ["cyber"],
+                "reasons": ["user_risk"]
+            }
+        }))
+        .expect("deserialize safety buffering event");
+        let mut treatment = None;
+        let mut wire_retry_model = None;
+
+        let first =
+            safety_buffering_for_event(&event_with_retry, &mut treatment, &mut wire_retry_model)
+                .expect("expected first safety buffering payload");
+        let second =
+            safety_buffering_for_event(&event_without_retry, &mut treatment, &mut wire_retry_model)
+                .expect("expected second safety buffering payload");
+
+        assert_eq!(first.faster_model.as_deref(), Some("gpt-fast-wire"));
+        assert_eq!(second.faster_model.as_deref(), Some("gpt-fast-wire"));
+    }
+
+    #[test]
+    fn direct_websocket_safety_buffering_null_clears_wire_retry_model() {
+        let event_with_retry: ResponsesStreamEvent = serde_json::from_value(json!({
+            "type": "response.output_text.delta",
+            "safety_buffering": {
+                "use_cases": ["cyber"],
+                "reasons": ["user_risk"],
+                "retry_model": "gpt-fast-wire"
+            }
+        }))
+        .expect("deserialize safety buffering event");
+        let event_with_null_retry: ResponsesStreamEvent = serde_json::from_value(json!({
+            "type": "response.output_text.delta",
+            "safety_buffering": {
+                "use_cases": ["cyber"],
+                "reasons": ["user_risk"],
+                "retry_model": null
+            }
+        }))
+        .expect("deserialize safety buffering event");
+        let mut treatment = None;
+        let mut wire_retry_model = None;
+
+        let first =
+            safety_buffering_for_event(&event_with_retry, &mut treatment, &mut wire_retry_model)
+                .expect("expected first safety buffering payload");
+        let second = safety_buffering_for_event(
+            &event_with_null_retry,
+            &mut treatment,
+            &mut wire_retry_model,
+        )
+        .expect("expected second safety buffering payload");
+
+        assert_eq!(first.faster_model.as_deref(), Some("gpt-fast-wire"));
+        assert_eq!(second.faster_model, None);
+        assert_eq!(wire_retry_model, None);
     }
 }

--- a/codex-rs/codex-api/src/sse/responses.rs
+++ b/codex-rs/codex-api/src/sse/responses.rs
@@ -1355,7 +1355,7 @@ mod tests {
                 "safety_buffering": {
                     "use_cases": ["cyber"],
                     "reasons": ["user_risk"],
-                    "faster_model": "unexpected-wire-model"
+                    "retry_model": "unexpected-wire-model"
                 }
             }),
             json!({

--- a/codex-rs/codex-api/src/sse/responses.rs
+++ b/codex-rs/codex-api/src/sse/responses.rs
@@ -517,7 +517,7 @@ async fn process_sse_with_treatment(
         let turn_moderation_metadata = event.turn_moderation_metadata();
         let safety_buffering = event
             .safety_buffering()
-            .map(|buffering| buffering.with_treatment(&safety_buffering_treatment));
+            .map(|buffering| buffering.with_treatment(Some(&safety_buffering_treatment)));
 
         if let Some(model) = event.response_model()
             && last_server_model.as_deref() != Some(model.as_str())
@@ -1354,7 +1354,8 @@ mod tests {
                 "delta": "hello",
                 "safety_buffering": {
                     "use_cases": ["cyber"],
-                    "reasons": ["user_risk"]
+                    "reasons": ["user_risk"],
+                    "faster_model": "unexpected-wire-model"
                 }
             }),
             json!({
@@ -1381,7 +1382,10 @@ mod tests {
         assert_matches!(
             &events[1],
             ResponseEvent::SafetyBuffering(buffering)
-                if buffering.use_cases == ["cyber"] && buffering.reasons == ["user_risk"]
+                if buffering.use_cases == ["cyber"]
+                    && buffering.reasons == ["user_risk"]
+                    && !buffering.show_buffering_ui
+                    && buffering.faster_model.is_none()
         );
         assert_matches!(&events[2], ResponseEvent::OutputTextDelta(delta) if delta == "hello");
         assert_matches!(


### PR DESCRIPTION
## Summary

Direct Codex third-party traffic receives safety-buffering metadata from the Responses WebSocket without Codex first-party treatment headers. This change reads the new optional `safety_buffering.retry_model` wire field, forwards it through the existing internal/app-server `fasterModel` notification, and leaves the explicit user retry flow unchanged.

API review: https://app.notion.com/p/38c8e50b62b081308e4ae4719443db6b

Paired Responses API producer: https://github.com/openai/openai/pull/1082770

## Behavior

- With no first-party treatment metadata, an object-valued safety-buffering signal is visible and uses the wire `retry_model` value.
- On repeated buffering updates in one response, an omitted field preserves the prior retry target and explicit `null` clears it.
- First-party treatment headers remain authoritative for both visibility and retry target, including explicit disabled and enabled-without-target treatments.
- Treatment and cached wire state reset for every `response.create`, even when the WebSocket connection is reused.
- Missing and explicit `null` on the first object remain compatible and produce no retry target.
- SSE behavior is unchanged: its existing first-party treatment headers remain authoritative, and Responses does not emit this public field on SSE.

The retry remains explicit and user initiated. It creates an ordinary request with the selected model; all ordinary access, safety, and rate-limit checks still apply.

## Validation

- `just test -p codex-api`: 136 passed, including direct WebSocket string, missing, null, repeated omission, explicit-null clearing, and 1P treatment precedence.
- `just test -p codex-app-server --test all direct_websocket_safety_buffering_reaches_app_server_notification`: passed. This uses a mock WebSocket server and proves `retry_model` reaches the real `model/safetyBuffering/updated` notification as `fasterModel` without leaking a disabled warmup treatment across responses on the same connection.
- `just test -p codex-tui safety_buffering_offers_one_retry_with_app_wording`: passed and proves the exact model becomes the existing `RetrySafetyBufferedTurn` action.
- `just fix -p codex-api`, `just fix -p codex-app-server`, and `just fmt`: passed.
- Paired Responses producer validation exercised the real WebSocket route/emitter under mocked auth, Statsig, and Protection Client boundaries for configured string, explicit null, and disabled/omitted cases; the unshipped draft wire name `faster_model` was absent.
