### PR TITLE
[app-server] increase currentTime/read timeout

### DIFF
--- a/codex-rs/app-server/src/current_time.rs
+++ b/codex-rs/app-server/src/current_time.rs
@@ -22,7 +22,7 @@ use crate::outgoing_message::ConnectionId;
 use crate::outgoing_message::OutgoingMessageSender;
 use crate::thread_state::ThreadStateManager;
 
-const CURRENT_TIME_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+const CURRENT_TIME_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 const CURRENT_TIME_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
 pub(crate) fn app_server_time_provider(


### PR DESCRIPTION
## Summary

Increase the external currentTime/read request timeout from 5 seconds to 10 seconds.

## Validation

- just fmt
- Focused app-server test build was stopped to defer validation to CI.