### PR TITLE
Allow interrupting MCP startup with composer popups open

### DIFF
--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -1298,6 +1298,14 @@ impl BottomPane {
     }
 
     pub(crate) fn should_interrupt_running_task(&self, key_event: KeyEvent) -> bool {
+        self.should_interrupt_running_task_allowing_composer_popup(key_event)
+            && !self.composer.popup_active()
+    }
+
+    pub(crate) fn should_interrupt_running_task_allowing_composer_popup(
+        &self,
+        key_event: KeyEvent,
+    ) -> bool {
         let is_agent_command = self
             .composer_text()
             .lines()
@@ -1308,7 +1316,7 @@ impl BottomPane {
         self.keymap.chat.interrupt_turn.is_pressed(key_event)
             && self.is_task_running
             && !(is_agent_command && key_event.code == KeyCode::Esc)
-            && self.no_modal_or_popup_active()
+            && self.view_stack.is_empty()
             && !self.composer_should_handle_vim_insert_escape(key_event)
             && self.status.is_some()
     }

--- a/codex-rs/tui/src/chatwidget/interaction.rs
+++ b/codex-rs/tui/src/chatwidget/interaction.rs
@@ -155,6 +155,16 @@ impl ChatWidget {
             return;
         }
 
+        // MCP startup is background work rather than an agent turn. Keep its visible interrupt
+        // hint authoritative even after typing opens a composer popup such as slash completion.
+        if self.mcp_startup_status.is_some()
+            && !self.turn_lifecycle.agent_turn_running
+            && self.chat_keymap.interrupt_turn.is_pressed(key_event)
+        {
+            self.submit_op(AppCommand::interrupt());
+            return;
+        }
+
         if self.handle_plugins_popup_key_event(key_event) {
             return;
         }

--- a/codex-rs/tui/src/chatwidget/interaction.rs
+++ b/codex-rs/tui/src/chatwidget/interaction.rs
@@ -159,7 +159,9 @@ impl ChatWidget {
         // hint authoritative even after typing opens a composer popup such as slash completion.
         if self.mcp_startup_status.is_some()
             && !self.turn_lifecycle.agent_turn_running
-            && self.chat_keymap.interrupt_turn.is_pressed(key_event)
+            && self
+                .bottom_pane
+                .should_interrupt_running_task_allowing_composer_popup(key_event)
         {
             self.submit_op(AppCommand::interrupt());
             return;

--- a/codex-rs/tui/src/chatwidget/tests/mcp_startup.rs
+++ b/codex-rs/tui/src/chatwidget/tests/mcp_startup.rs
@@ -139,6 +139,35 @@ async fn esc_interrupts_mcp_startup_while_slash_popup_is_open() {
 }
 
 #[tokio::test]
+async fn esc_during_mcp_startup_leaves_vim_insert_mode_without_interrupting() {
+    let (mut chat, _rx, mut op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    let esc = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
+    notify_mcp_status(&mut chat, "alpha", McpServerStartupState::Starting);
+    chat.toggle_vim_mode_and_notify();
+    chat.handle_key_event(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE));
+    assert!(chat.should_handle_vim_insert_escape(esc));
+
+    chat.handle_key_event(esc);
+
+    assert!(!chat.should_handle_vim_insert_escape(esc));
+    assert!(op_rx.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn esc_during_mcp_startup_does_not_interrupt_agent_draft() {
+    let (mut chat, _rx, mut op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    notify_mcp_status(&mut chat, "alpha", McpServerStartupState::Starting);
+    chat.bottom_pane
+        .set_composer_text("/agent ".to_string(), Vec::new(), Vec::new());
+    assert!(chat.bottom_pane.no_modal_or_popup_active());
+
+    chat.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+    assert!(op_rx.try_recv().is_err());
+    assert_eq!(chat.bottom_pane.composer_text(), "/agent ");
+}
+
+#[tokio::test]
 async fn mcp_startup_complete_does_not_clear_running_task() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
 

--- a/codex-rs/tui/src/chatwidget/tests/mcp_startup.rs
+++ b/codex-rs/tui/src/chatwidget/tests/mcp_startup.rs
@@ -125,6 +125,20 @@ async fn mcp_startup_header_booting_snapshot() {
 }
 
 #[tokio::test]
+async fn esc_interrupts_mcp_startup_while_slash_popup_is_open() {
+    let (mut chat, _rx, mut op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    notify_mcp_status(&mut chat, "alpha", McpServerStartupState::Starting);
+    chat.bottom_pane
+        .set_composer_text("/review".to_string(), Vec::new(), Vec::new());
+    assert!(!chat.bottom_pane.no_modal_or_popup_active());
+
+    chat.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+    assert_matches!(op_rx.try_recv(), Ok(Op::Interrupt { .. }));
+    assert_eq!(chat.bottom_pane.composer_text(), "/review");
+}
+
+#[tokio::test]
 async fn mcp_startup_complete_does_not_clear_running_task() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
 

--- a/codex-rs/tui/src/chatwidget/tests/mcp_startup.rs
+++ b/codex-rs/tui/src/chatwidget/tests/mcp_startup.rs
@@ -168,6 +168,21 @@ async fn esc_during_mcp_startup_does_not_interrupt_agent_draft() {
 }
 
 #[tokio::test]
+async fn esc_during_mcp_startup_and_agent_turn_does_not_interrupt() {
+    let (mut chat, _rx, mut op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    notify_mcp_status(&mut chat, "alpha", McpServerStartupState::Starting);
+    handle_turn_started(&mut chat, "turn-1");
+    chat.bottom_pane
+        .set_composer_text("/review".to_string(), Vec::new(), Vec::new());
+    assert!(!chat.bottom_pane.no_modal_or_popup_active());
+
+    chat.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+    assert!(op_rx.try_recv().is_err());
+    assert_eq!(chat.bottom_pane.composer_text(), "/review");
+}
+
+#[tokio::test]
 async fn mcp_startup_complete_does_not_clear_running_task() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
 


### PR DESCRIPTION
## Summary

During MCP-only startup, the TUI advertises its interrupt key, but opening a composer popup such as slash completion caused Escape to be consumed locally instead of cancelling startup.

This change reuses the existing running-task interrupt guards while allowing composer popups only for MCP-only startup. Vim insert mode and `/agent` drafts keep ownership of Escape, and active agent turns continue using normal popup routing.

Focused MCP-startup coverage passes (29 tests), and formatting passes. The full TUI suite ran 2,956 tests; two unrelated Guardian feature-flag tests failed in this environment and continued to fail when rerun in isolation.
