### PR TITLE
fix(tui): preserve transcript on viewport growth

### DIFF
--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -912,11 +912,10 @@ impl Tui {
             let mut area = terminal.viewport_area;
             area.height = height.min(size.height);
             area.width = size.width;
-            // If the viewport has expanded, scroll everything else up to make room.
+            // Keep the viewport bottom-aligned as it grows. The next frame
+            // redraws the expanded viewport, so scrolling rows above it here
+            // would permanently discard visible transcript lines.
             if area.bottom() > size.height {
-                terminal
-                    .backend_mut()
-                    .scroll_region_up(0..area.top(), area.bottom() - size.height)?;
                 area.y = size.height - area.height;
             }
             if area != terminal.viewport_area {


### PR DESCRIPTION
## Summary
- keep the inline viewport bottom-aligned when the composer grows
- avoid scrolling rows above the viewport before the next frame redraws the expanded area
- preserve visible transcript lines during multiline composer growth and streaming redraws

Fixes https://github.com/openai/codex/issues/5538

## Testing
- `cargo test -p codex-tui first_viewport_change_clears_from_new_viewport_when_old_viewport_is_empty`
- `cargo check -p codex-tui`
- `git diff --check`