### PR TITLE
fix(tui): clear dismissed update prompt

### DIFF
--- a/codex-rs/tui/src/update_prompt.rs
+++ b/codex-rs/tui/src/update_prompt.rs
@@ -70,11 +70,13 @@ pub(crate) async fn run_update_prompt_if_needed(
         }
     }
 
+    // The prompt owns the full frame while it is visible. Clear it before
+    // startup continues so slower initialization cannot leave stale prompt
+    // contents on screen after any dismissal path.
+    tui.terminal.clear()?;
+
     match screen.selection() {
-        Some(UpdateSelection::UpdateNow) => {
-            tui.terminal.clear()?;
-            Ok(UpdatePromptOutcome::RunUpdate(update_action))
-        }
+        Some(UpdateSelection::UpdateNow) => Ok(UpdatePromptOutcome::RunUpdate(update_action)),
         Some(UpdateSelection::NotNow) | None => Ok(UpdatePromptOutcome::Continue),
         Some(UpdateSelection::DontRemind) => {
             if let Err(err) = updates::dismiss_version(config, screen.latest_version()).await {


### PR DESCRIPTION
## Summary
- clear the full-frame update prompt after every rendered selection path
- prevent Skip, Escape, Ctrl-C, and Skip until next version from leaving stale prompt contents during slower startup

Fixes https://github.com/openai/codex/issues/30205

## Testing
- `cargo test -p codex-tui update_prompt_ --release -- --skip update_prompt_snapshot`
- `git diff --check`

Note: the existing `update_prompt_snapshot` currently differs from its checked-in snapshot on main and generates a `.snap.new`; this PR leaves that unrelated snapshot unchanged.