### PR TITLE
fix(tui): avoid duplicate unicode keyboard input

### DIFF
--- a/codex-rs/tui/src/tui/keyboard_modes.rs
+++ b/codex-rs/tui/src/tui/keyboard_modes.rs
@@ -126,10 +126,12 @@ pub(super) fn enable_keyboard_enhancement() {
     let _ = execute!(
         stdout(),
         DisableModifyOtherKeys,
+        // Some Kitty-protocol terminals emit duplicate non-ASCII text when
+        // alternate keycodes are requested. Codex does not consume alternate
+        // keycodes, so keep only the enhancements needed for key routing.
         PushKeyboardEnhancementFlags(
             KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
                 | KeyboardEnhancementFlags::REPORT_EVENT_TYPES
-                | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
         )
     );
 


### PR DESCRIPTION
## Summary
- stop requesting Kitty alternate-key reporting that Codex does not consume
- retain escape disambiguation and key event type reporting for existing key routing
- avoid duplicate non-ASCII input observed in Windows Terminal and Warp

Fixes https://github.com/openai/codex/issues/16170

## Testing
- `cargo test -p codex-tui non_ascii_char_inserts_immediately_without_burst_state`
- `cargo check -p codex-tui`
- `git diff --check`