### PR TITLE
fix(tui): clear completed safety buffering prompt

### DIFF
--- a/codex-rs/tui/src/chatwidget/safety_buffering.rs
+++ b/codex-rs/tui/src/chatwidget/safety_buffering.rs
@@ -5,7 +5,7 @@ use codex_app_server_protocol::ModelSafetyBufferingUpdatedNotification;
 
 const SAFETY_BUFFERING_PROMPT_VIEW_ID: &str = "safety-buffering-prompt";
 
-const SAFETY_BUFFERING_MESSAGE_WITH_RETRY: &str = "This request requires additional safety checks, which can take extra time. You can retry with a faster model for a quicker response, though it may be less capable of handling complex requests.";
+const SAFETY_BUFFERING_MESSAGE_WITH_RETRY: &str = "This request requires additional safety checks, which can take extra time. Hang tight or retry with a faster model for a quicker response, though it may be less capable of handling complex requests.";
 const SAFETY_BUFFERING_MESSAGE_WITHOUT_RETRY: &str =
     "This request requires additional safety checks, which can take extra time.";
 

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__safety_buffering_retry_prompt.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__safety_buffering_retry_prompt.snap
@@ -4,8 +4,8 @@ expression: popup
 ---
   Additional safety checks
   This request requires additional safety checks, which can take extra time.
-  You can retry with a faster model for a quicker response, though it may be
-  less capable of handling complex requests.
+  Hang tight or retry with a faster model for a quicker response, though it
+  may be less capable of handling complex requests.
 
 › 1. Retry with a faster model
   2. Keep waiting

--- a/codex-rs/tui/src/chatwidget/tests/app_server.rs
+++ b/codex-rs/tui/src/chatwidget/tests/app_server.rs
@@ -146,7 +146,7 @@ async fn safety_buffering_offers_one_retry_with_app_wording() {
 }
 
 #[tokio::test]
-async fn safety_buffering_stops_retrying_after_agent_message_starts() {
+async fn safety_buffering_remains_visible_until_turn_completes() {
     let (mut chat, _rx, mut op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
     let (thread_id, turn_id, _) = start_safety_buffering_test_turn(&mut chat, &mut op_rx);
     chat.handle_server_notification(
@@ -162,6 +162,11 @@ async fn safety_buffering_stops_retrying_after_agent_message_starts() {
     chat.on_agent_message_delta("Visible response".to_string());
 
     assert!(!chat.can_retry_safety_buffered_turn(turn_id));
+    assert!(render_bottom_popup(&chat, /*width*/ 80).contains("Additional safety checks"));
+
+    handle_turn_completed(&mut chat, turn_id, /*duration_ms*/ None);
+
+    assert!(!render_bottom_popup(&chat, /*width*/ 80).contains("Additional safety checks"));
 }
 
 #[tokio::test]

--- a/codex-rs/tui/src/chatwidget/turn_runtime.rs
+++ b/codex-rs/tui/src/chatwidget/turn_runtime.rs
@@ -170,6 +170,7 @@ impl ChatWidget {
         self.input_queue.user_turn_pending_start = false;
         self.clear_active_hook_cell();
         self.turn_lifecycle.finish();
+        self.clear_safety_buffering();
         self.update_task_running_state();
         self.running_commands.clear();
         self.suppressed_exec_calls.clear();


### PR DESCRIPTION
## Why

The safety-buffering prompt is a modal TUI view, but the normal successful-turn path only hid the running status indicator. If the turn completed while the prompt was open, the stale modal remained over the composer until the user dismissed it or another turn started.

This aligns the TUI with the app behavior: keep the safety notice visible while the turn is active, then remove it when the turn becomes terminal. It also prevents the stale retry action from changing the model and reasoning effort for a future turn after the buffered turn has already completed.

| New copy |
|---|
| <img width="1014" height="313" alt="CleanShot 2026-06-28 at 20 27 18" src="https://github.com/user-attachments/assets/f0f37359-5d77-442f-add2-9d1874bdc422" /> |

## What changed

- Clear the active safety-buffering view and retry state when a turn completes successfully.
- Update the retry-capable message to say “Hang tight or retry with a faster model”.
- Extend the safety-buffering regression coverage to verify that the prompt remains visible after assistant output starts and disappears when the turn completes.
- Update the TUI snapshot for the revised copy.

This is a follow-up to #29919.

## How to Test

1. Start a TUI turn that receives `model/safetyBuffering/updated` with `showBufferingUi: true` and a `fasterModel`.
2. Confirm the prompt says “Hang tight or retry with a faster model”.
3. Let the turn continue and confirm the prompt remains visible while the turn is active.
4. Let the turn finish successfully and confirm the prompt disappears and the composer is restored without requiring an extra keypress.
5. Confirm a buffering update without a faster model still shows the shorter non-retry message.

Targeted automated coverage:

- `just test -p codex-tui safety_buffering` — 4 passed.
- `just test -p codex-tui` — 2,951 passed; two unrelated Guardian feature-flag tests failed identically on `main` in this environment.

The argument-comment lint was also audited manually. The workspace Bazel invocation was blocked by a missing external LLVM `compiler-rt` BUILD file, and the packaged per-crate fallback uses a nightly older than the current `sqlx` minimum Rust version.
