### PR TITLE
Fix slash command popup dismissal

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -3592,6 +3592,20 @@ impl ChatComposer {
     /// textarea. This must be called after every modification that can change
     /// the text so the popup is shown/updated/hidden as appropriate.
     fn sync_command_popup(&mut self, allow: bool) {
+        let text = self.draft.textarea.text();
+        let first_line_end = text.find('\n').unwrap_or(text.len());
+        let first_line = &text[..first_line_end];
+        let command_token = slash_input::command_popup_filter_text(first_line, /*cursor*/ 0);
+        if let Some(command_token) = command_token.as_deref()
+            && self.popups.dismissed_command_token.as_deref() == Some(command_token)
+        {
+            if matches!(self.popups.active, ActivePopup::Command(_)) {
+                self.popups.active = ActivePopup::None;
+            }
+            return;
+        }
+        self.popups.dismissed_command_token = None;
+
         if !allow {
             if matches!(self.popups.active, ActivePopup::Command(_)) {
                 self.popups.active = ActivePopup::None;
@@ -3599,9 +3613,6 @@ impl ChatComposer {
             return;
         }
         // Determine whether the caret is inside the initial '/name' token on the first line.
-        let text = self.draft.textarea.text();
-        let first_line_end = text.find('\n').unwrap_or(text.len());
-        let first_line = &text[..first_line_end];
         let cursor = self.draft.textarea.cursor();
         let caret_on_first_line = cursor <= first_line_end;
 

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -3595,13 +3595,11 @@ impl ChatComposer {
         let text = self.draft.textarea.text();
         let first_line_end = text.find('\n').unwrap_or(text.len());
         let first_line = &text[..first_line_end];
+        // Keep an explicitly dismissed popup closed until the command token changes.
         let command_token = slash_input::command_popup_filter_text(first_line, /*cursor*/ 0);
         if let Some(command_token) = command_token.as_deref()
             && self.popups.dismissed_command_token.as_deref() == Some(command_token)
         {
-            if matches!(self.popups.active, ActivePopup::Command(_)) {
-                self.popups.active = ActivePopup::None;
-            }
             return;
         }
         self.popups.dismissed_command_token = None;

--- a/codex-rs/tui/src/bottom_pane/chat_composer/popup_state.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer/popup_state.rs
@@ -9,6 +9,7 @@ use crate::bottom_pane::skill_popup::SkillPopup;
 #[derive(Default)]
 pub(super) struct PopupState {
     pub(super) active: ActivePopup,
+    pub(super) dismissed_command_token: Option<String>,
     pub(super) dismissed_file_token: Option<String>,
     pub(super) current_file_query: Option<String>,
     pub(super) dismissed_mention_token: Option<String>,

--- a/codex-rs/tui/src/bottom_pane/chat_composer/slash_input.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer/slash_input.rs
@@ -19,7 +19,6 @@ use crate::slash_command::SlashCommand;
 use codex_protocol::user_input::ByteRange;
 use codex_protocol::user_input::TextElement;
 
-use super::super::footer::esc_hint_mode;
 use super::super::footer::reset_mode_after_activity;
 use super::ActivePopup;
 use super::ChatComposer;
@@ -215,14 +214,14 @@ impl ChatComposer {
             return (InputResult::None, true);
         }
         if key_event.code == KeyCode::Esc {
-            let next_mode = esc_hint_mode(self.footer.mode, self.is_task_running);
-            if next_mode != self.footer.mode {
-                self.footer.mode = next_mode;
-                return (InputResult::None, true);
-            }
-        } else {
-            self.footer.mode = reset_mode_after_activity(self.footer.mode);
+            // Always dismiss the popup without changing the draft.
+            let first_line = self.draft.textarea.text().lines().next().unwrap_or("");
+            self.popups.dismissed_command_token =
+                command_popup_filter_text(first_line, /*cursor*/ 0);
+            self.popups.active = ActivePopup::None;
+            return (InputResult::None, true);
         }
+        self.footer.mode = reset_mode_after_activity(self.footer.mode);
         let ActivePopup::Command(popup) = &mut self.popups.active else {
             unreachable!();
         };
@@ -249,16 +248,6 @@ impl ChatComposer {
                 ..
             } => {
                 popup.move_down();
-                (InputResult::None, true)
-            }
-            KeyEvent {
-                code: KeyCode::Esc, ..
-            } => {
-                // Dismiss the slash popup; keep the current input untouched.
-                let first_line = self.draft.textarea.text().lines().next().unwrap_or("");
-                self.popups.dismissed_command_token =
-                    command_popup_filter_text(first_line, /*cursor*/ 0);
-                self.popups.active = ActivePopup::None;
                 (InputResult::None, true)
             }
             KeyEvent {
@@ -605,6 +594,17 @@ mod tests {
 
     fn composer_with_draft_tail(prefix: &str, draft: &str) -> ChatComposer {
         composer_with_text_at_cursor(&format!("{prefix}{draft}"), prefix.len())
+    }
+
+    #[test]
+    fn esc_dismisses_slash_popup_while_idle() {
+        let mut composer = composer_with_text_at_cursor("/rev", "/rev".len());
+        assert!(composer.popup_active());
+
+        assert_eq!(press(&mut composer, KeyCode::Esc), InputResult::None);
+
+        assert!(!composer.popup_active());
+        assert_eq!(composer.draft.textarea.text(), "/rev");
     }
 
     #[test]

--- a/codex-rs/tui/src/bottom_pane/chat_composer/slash_input.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer/slash_input.rs
@@ -255,6 +255,9 @@ impl ChatComposer {
                 code: KeyCode::Esc, ..
             } => {
                 // Dismiss the slash popup; keep the current input untouched.
+                let first_line = self.draft.textarea.text().lines().next().unwrap_or("");
+                self.popups.dismissed_command_token =
+                    command_popup_filter_text(first_line, /*cursor*/ 0);
                 self.popups.active = ActivePopup::None;
                 (InputResult::None, true)
             }

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -2666,7 +2666,7 @@ mod tests {
     }
 
     #[test]
-    fn esc_with_slash_command_popup_does_not_interrupt_task() {
+    fn esc_dismisses_slash_command_popup_without_interrupting_task() {
         let (tx_raw, mut rx) = unbounded_channel::<AppEvent>();
         let tx = AppEventSender::new(tx_raw);
         let mut pane = BottomPane::new(BottomPaneParams {
@@ -2682,11 +2682,12 @@ mod tests {
 
         pane.set_task_running(/*running*/ true);
 
-        // Repro: a running task + slash-command popup + Esc should not interrupt the task.
-        pane.insert_str("/");
+        // Repro: a running task + slash-command popup + Esc should dismiss the popup without
+        // interrupting the task.
+        pane.insert_str("/rev");
         assert!(
             pane.composer.popup_active(),
-            "expected command popup after typing `/`"
+            "expected command popup after typing `/rev`"
         );
 
         pane.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
@@ -2697,7 +2698,18 @@ mod tests {
                 "expected Esc to not send Op::Interrupt while command popup is active"
             );
         }
-        assert_eq!(pane.composer_text(), "/");
+        assert!(!pane.composer.popup_active());
+        assert_eq!(pane.composer_text(), "/rev");
+
+        let width = 60;
+        let area = Rect::new(0, 0, width, pane.desired_height(width));
+        assert_snapshot!(
+            "slash_command_popup_dismissed",
+            render_snapshot(&pane, area)
+        );
+
+        pane.insert_str("i");
+        assert!(pane.composer.popup_active());
     }
 
     #[test]

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__tests__slash_command_popup_dismissed.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__tests__slash_command_popup_dismissed.snap
@@ -1,0 +1,10 @@
+---
+source: tui/src/bottom_pane/mod.rs
+expression: "render_snapshot(&pane, area)"
+---
+• Working (0s • esc to interrupt)                           
+                                                            
+                                                            
+› /rev                                                      
+                                                            
+  tab to queue message                   100% context left


### PR DESCRIPTION
## Summary

If you type `/rev`, then hit Escape, it ends up as a no-op. After Escape closes the slash-command popup, the next synchronization pass sees the command text and immediately reopens it.

This change records the dismissed command token and suppresses the popup until the token changes. The slash popup now handles Escape before the idle backtrack hint, so one press dismisses it consistently while idle, during MCP startup, or during an active turn. Editing the command clears the dismissal and allows the popup to open again normally.

All 645 focused bottom-pane tests pass.