### PR TITLE
Add explicit agent communication logging

### DIFF
--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -157,7 +157,7 @@ serial_test = { workspace = true }
 tempfile = { workspace = true }
 test-log = { workspace = true }
 tracing-opentelemetry = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["json"] }
 tracing-test = { workspace = true, features = ["no-env-filter"] }
 walkdir = { workspace = true }
 wiremock = { workspace = true }

--- a/codex-rs/core/src/agent/control.rs
+++ b/codex-rs/core/src/agent/control.rs
@@ -24,6 +24,7 @@ use codex_protocol::error::Result as CodexResult;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::MessagePhase;
 use codex_protocol::models::ResponseItem;
+use codex_protocol::protocol::AgentCommunicationKind;
 use codex_protocol::protocol::InitialHistory;
 use codex_protocol::protocol::InterAgentCommunication;
 use codex_protocol::protocol::MultiAgentVersion;
@@ -473,12 +474,23 @@ impl AgentControl {
                 ) else {
                     return;
                 };
-                let communication = InterAgentCommunication::new(
+                let mut communication = InterAgentCommunication::new(
                     child_agent_path,
                     parent_agent_path,
                     Vec::new(),
                     message,
                     /*trigger_turn*/ false,
+                );
+                communication.agent_communication_metadata = Some(
+                    crate::agent_communication::new_agent_communication_metadata(
+                        AgentCommunicationKind::Result,
+                        child_thread_id,
+                        /*source_call_id*/ None,
+                    ),
+                );
+                crate::agent_communication::emit_agent_communication_created(
+                    &communication,
+                    parent_thread_id,
                 );
                 let _ = control
                     .send_inter_agent_communication(parent_thread_id, communication)

--- a/codex-rs/core/src/agent/control.rs
+++ b/codex-rs/core/src/agent/control.rs
@@ -4,6 +4,8 @@ use crate::agent::registry::AgentRegistry;
 use crate::agent::role::DEFAULT_ROLE_NAME;
 use crate::agent::role::resolve_role_config;
 use crate::agent::status::is_final;
+use crate::agent_communication::AgentCommunicationContext;
+use crate::agent_communication::AgentCommunicationKind;
 use crate::codex_thread::ThreadConfigSnapshot;
 use crate::config::Config;
 use crate::config::RolloutBudgetConfig;
@@ -24,7 +26,6 @@ use codex_protocol::error::Result as CodexResult;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::MessagePhase;
 use codex_protocol::models::ResponseItem;
-use codex_protocol::protocol::AgentCommunicationKind;
 use codex_protocol::protocol::InitialHistory;
 use codex_protocol::protocol::InterAgentCommunication;
 use codex_protocol::protocol::MultiAgentVersion;
@@ -68,6 +69,7 @@ pub(crate) struct SpawnAgentOptions {
     pub(crate) fork_mode: Option<SpawnAgentForkMode>,
     pub(crate) parent_thread_id: Option<ThreadId>,
     pub(crate) environments: Option<Vec<TurnEnvironmentSelection>>,
+    pub(crate) agent_communication_context: Option<AgentCommunicationContext>,
 }
 
 #[derive(Clone, Debug)]
@@ -75,6 +77,11 @@ pub(crate) struct LiveAgent {
     pub(crate) thread_id: ThreadId,
     pub(crate) metadata: AgentMetadata,
     pub(crate) status: AgentStatus,
+}
+
+enum SubmissionId<'a> {
+    Generated,
+    Provided(&'a str),
 }
 
 #[derive(Clone, Debug, Serialize, PartialEq, Eq)]
@@ -145,8 +152,13 @@ impl AgentControl {
         let state = self.upgrade()?;
         self.ensure_execution_capacity_for_op(agent_id, &initial_operation)
             .await?;
-        self.send_input_after_capacity_check(agent_id, &state, initial_operation)
-            .await
+        self.send_input_after_capacity_check(
+            agent_id,
+            &state,
+            initial_operation,
+            SubmissionId::Generated,
+        )
+        .await
     }
 
     async fn send_input_after_capacity_check(
@@ -154,6 +166,7 @@ impl AgentControl {
         agent_id: ThreadId,
         state: &Arc<ThreadManagerState>,
         initial_operation: Op,
+        submission_id: SubmissionId<'_>,
     ) -> CodexResult<String> {
         let last_task_message = match &initial_operation {
             Op::InterAgentCommunication { communication } => {
@@ -161,12 +174,16 @@ impl AgentControl {
             }
             _ => non_empty_task_message(render_input_preview(&initial_operation)),
         };
+        let send_result = match submission_id {
+            SubmissionId::Generated => state.send_op(agent_id, initial_operation).await,
+            SubmissionId::Provided(id) => {
+                state
+                    .send_op_with_id(agent_id, id.to_string(), initial_operation)
+                    .await
+            }
+        };
         let result = self
-            .handle_thread_request_result(
-                agent_id,
-                state,
-                state.send_op(agent_id, initial_operation).await,
-            )
+            .handle_thread_request_result(agent_id, state, send_result)
             .await;
         if result.is_ok() {
             match last_task_message {
@@ -183,23 +200,23 @@ impl AgentControl {
         &self,
         agent_id: ThreadId,
         communication: InterAgentCommunication,
+        context: AgentCommunicationContext,
     ) -> CodexResult<String> {
-        let last_task_message = last_task_message_from_communication(&communication);
+        crate::agent_communication::emit_agent_communication_created(
+            &context,
+            &communication,
+            agent_id,
+        );
         let state = self.upgrade()?;
         let op = Op::InterAgentCommunication { communication };
         self.ensure_execution_capacity_for_op(agent_id, &op).await?;
-        let result = self
-            .handle_thread_request_result(agent_id, &state, state.send_op(agent_id, op).await)
-            .await;
-        if result.is_ok() {
-            match last_task_message {
-                Some(last_task_message) => self
-                    .state
-                    .update_last_task_message(agent_id, last_task_message),
-                None => self.state.clear_last_task_message(agent_id),
-            }
-        }
-        result
+        self.send_input_after_capacity_check(
+            agent_id,
+            &state,
+            op,
+            SubmissionId::Provided(context.id()),
+        )
+        .await
     }
 
     /// Interrupt the current task for an existing agent thread.
@@ -474,26 +491,23 @@ impl AgentControl {
                 ) else {
                     return;
                 };
-                let mut communication = InterAgentCommunication::new(
+                let communication = InterAgentCommunication::new(
                     child_agent_path,
                     parent_agent_path,
                     Vec::new(),
                     message,
                     /*trigger_turn*/ false,
                 );
-                communication.agent_communication_metadata = Some(
-                    crate::agent_communication::new_agent_communication_metadata(
-                        AgentCommunicationKind::Result,
-                        child_thread_id,
-                        /*source_call_id*/ None,
-                    ),
-                );
-                crate::agent_communication::emit_agent_communication_created(
-                    &communication,
-                    parent_thread_id,
+                let communication_context = AgentCommunicationContext::without_source_call(
+                    AgentCommunicationKind::Result,
+                    child_thread_id,
                 );
                 let _ = control
-                    .send_inter_agent_communication(parent_thread_id, communication)
+                    .send_inter_agent_communication(
+                        parent_thread_id,
+                        communication,
+                        communication_context,
+                    )
                     .await;
                 return;
             }

--- a/codex-rs/core/src/agent/control/spawn.rs
+++ b/codex-rs/core/src/agent/control/spawn.rs
@@ -356,17 +356,26 @@ impl AgentControl {
         )
         .await;
 
-        if multi_agent_version == MultiAgentVersion::V2
-            && let Op::InterAgentCommunication { communication } = &initial_operation
-        {
+        if let (Some(context), Op::InterAgentCommunication { communication }) = (
+            options.agent_communication_context.as_ref(),
+            &initial_operation,
+        ) {
             crate::agent_communication::emit_agent_communication_created(
+                context,
                 communication,
                 new_thread.thread_id,
             );
         }
-
-        self.send_input_after_capacity_check(new_thread.thread_id, &state, initial_operation)
-            .await?;
+        self.send_input_after_capacity_check(
+            new_thread.thread_id,
+            &state,
+            initial_operation,
+            match options.agent_communication_context.as_ref() {
+                Some(context) => SubmissionId::Provided(context.id()),
+                None => SubmissionId::Generated,
+            },
+        )
+        .await?;
         if multi_agent_version != MultiAgentVersion::V2 {
             let child_reference = agent_metadata
                 .agent_path

--- a/codex-rs/core/src/agent/control/spawn.rs
+++ b/codex-rs/core/src/agent/control/spawn.rs
@@ -356,6 +356,15 @@ impl AgentControl {
         )
         .await;
 
+        if multi_agent_version == MultiAgentVersion::V2
+            && let Op::InterAgentCommunication { communication } = &initial_operation
+        {
+            crate::agent_communication::emit_agent_communication_created(
+                communication,
+                new_thread.thread_id,
+            );
+        }
+
         self.send_input_after_capacity_check(new_thread.thread_id, &state, initial_operation)
             .await?;
         if multi_agent_version != MultiAgentVersion::V2 {

--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -3,6 +3,7 @@ use crate::CodexThread;
 use crate::StateDbHandle;
 use crate::ThreadManager;
 use crate::agent::agent_status_from_event;
+use crate::agent_communication::AgentCommunicationKind;
 use crate::config::AgentRoleConfig;
 use crate::config::Config;
 use crate::config::ConfigBuilder;
@@ -23,7 +24,6 @@ use codex_protocol::config_types::ModeKind;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::MessagePhase;
 use codex_protocol::models::ResponseItem;
-use codex_protocol::protocol::AgentCommunicationKind;
 use codex_protocol::protocol::CompactedItem;
 use codex_protocol::protocol::ErrorEvent;
 use codex_protocol::protocol::EventMsg;
@@ -459,29 +459,22 @@ async fn failed_communication_send_emits_created_without_enqueued() {
     let harness = AgentControlHarness::new().await;
     let sender_thread_id = ThreadId::new();
     let receiver_thread_id = ThreadId::new();
-    let metadata = codex_protocol::protocol::AgentCommunicationMetadata {
-        id: uuid::Uuid::new_v4().to_string(),
-        kind: codex_protocol::protocol::AgentCommunicationKind::Message,
+    let context = crate::agent_communication::AgentCommunicationContext::from_tool_call(
+        AgentCommunicationKind::Message,
         sender_thread_id,
-        source_call_id: Some("call-1".to_string()),
-    };
-    let id = metadata.id.clone();
-    let mut communication = InterAgentCommunication::new(
+        "call-1",
+    );
+    let id = context.id().to_string();
+    let communication = InterAgentCommunication::new(
         AgentPath::root(),
         AgentPath::try_from("/root/missing").expect("agent path"),
         Vec::new(),
         "mail".to_string(),
         /*trigger_turn*/ false,
     );
-    communication.agent_communication_metadata = Some(metadata);
-    crate::agent_communication::emit_agent_communication_created(
-        &communication,
-        receiver_thread_id,
-    );
-
     let err = harness
         .control
-        .send_inter_agent_communication(receiver_thread_id, communication)
+        .send_inter_agent_communication(receiver_thread_id, communication, context)
         .await
         .expect_err("send should fail for missing receiver");
     assert_matches!(err, CodexErr::ThreadNotFound(id) if id == receiver_thread_id);
@@ -594,12 +587,17 @@ async fn send_inter_agent_communication_without_turn_queues_message_without_trig
         /*trigger_turn*/ false,
     );
 
+    let context = crate::agent_communication::AgentCommunicationContext::without_source_call(
+        AgentCommunicationKind::Message,
+        ThreadId::new(),
+    );
+    let communication_id = context.id().to_string();
     let submission_id = harness
         .control
-        .send_inter_agent_communication(thread_id, communication.clone())
+        .send_inter_agent_communication(thread_id, communication.clone(), context)
         .await
         .expect("send_inter_agent_communication should succeed");
-    assert!(!submission_id.is_empty());
+    assert_eq!(submission_id, communication_id);
 
     let expected = (
         thread_id,
@@ -721,7 +719,14 @@ async fn ensure_v2_agent_loaded_reloads_registered_unloaded_agent() {
     );
     harness
         .control
-        .send_inter_agent_communication(spawned_agent.thread_id, communication.clone())
+        .send_inter_agent_communication(
+            spawned_agent.thread_id,
+            communication.clone(),
+            crate::agent_communication::AgentCommunicationContext::without_source_call(
+                AgentCommunicationKind::Message,
+                ThreadId::new(),
+            ),
+        )
         .await
         .expect("send_inter_agent_communication should succeed after reload");
     let expected = (
@@ -868,7 +873,14 @@ async fn encrypted_inter_agent_communication_clears_existing_last_task_message()
     );
     harness
         .control
-        .send_inter_agent_communication(spawned_agent.thread_id, communication)
+        .send_inter_agent_communication(
+            spawned_agent.thread_id,
+            communication,
+            crate::agent_communication::AgentCommunicationContext::without_source_call(
+                AgentCommunicationKind::Followup,
+                ThreadId::new(),
+            ),
+        )
         .await
         .expect("send_inter_agent_communication should succeed");
 
@@ -2191,24 +2203,10 @@ async fn multi_agent_v2_completion_queues_message_for_direct_parent() {
                 if thread_id != worker_thread_id {
                     continue;
                 }
-                let Op::InterAgentCommunication { mut communication } = op else {
+                let Op::InterAgentCommunication { communication } = op else {
                     continue;
                 };
-                let metadata = communication.agent_communication_metadata.take();
                 if communication == expected {
-                    let metadata = metadata.expect("completion communication metadata");
-                    assert_eq!(
-                        (
-                            metadata.kind,
-                            metadata.sender_thread_id,
-                            metadata.source_call_id,
-                        ),
-                        (
-                            AgentCommunicationKind::Result,
-                            tester_thread_id,
-                            /*source_call_id*/ None,
-                        )
-                    );
                     return;
                 }
             }

--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -23,6 +23,7 @@ use codex_protocol::config_types::ModeKind;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::MessagePhase;
 use codex_protocol::models::ResponseItem;
+use codex_protocol::protocol::AgentCommunicationKind;
 use codex_protocol::protocol::CompactedItem;
 use codex_protocol::protocol::ErrorEvent;
 use codex_protocol::protocol::EventMsg;
@@ -429,6 +430,70 @@ async fn send_input_errors_when_thread_missing() {
         .await
         .expect_err("send_input should fail for missing thread");
     assert_matches!(err, CodexErr::ThreadNotFound(id) if id == thread_id);
+}
+
+#[tokio::test]
+async fn failed_communication_send_emits_created_without_enqueued() {
+    use tracing_subscriber::filter::LevelFilter;
+    use tracing_subscriber::filter::Targets;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_test::internal::MockWriter;
+
+    let output: &'static std::sync::Mutex<Vec<u8>> =
+        Box::leak(Box::new(std::sync::Mutex::new(Vec::new())));
+    let subscriber = tracing_subscriber::registry()
+        .with(
+            Targets::new()
+                .with_default(LevelFilter::OFF)
+                .with_target("codex_core::agent_communication", LevelFilter::TRACE),
+        )
+        .with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_current_span(false)
+                .with_span_list(false)
+                .with_writer(MockWriter::new(output)),
+        );
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let harness = AgentControlHarness::new().await;
+    let sender_thread_id = ThreadId::new();
+    let receiver_thread_id = ThreadId::new();
+    let metadata = codex_protocol::protocol::AgentCommunicationMetadata {
+        id: uuid::Uuid::new_v4().to_string(),
+        kind: codex_protocol::protocol::AgentCommunicationKind::Message,
+        sender_thread_id,
+        source_call_id: Some("call-1".to_string()),
+    };
+    let id = metadata.id.clone();
+    let mut communication = InterAgentCommunication::new(
+        AgentPath::root(),
+        AgentPath::try_from("/root/missing").expect("agent path"),
+        Vec::new(),
+        "mail".to_string(),
+        /*trigger_turn*/ false,
+    );
+    communication.agent_communication_metadata = Some(metadata);
+    crate::agent_communication::emit_agent_communication_created(
+        &communication,
+        receiver_thread_id,
+    );
+
+    let err = harness
+        .control
+        .send_inter_agent_communication(receiver_thread_id, communication)
+        .await
+        .expect_err("send should fail for missing receiver");
+    assert_matches!(err, CodexErr::ThreadNotFound(id) if id == receiver_thread_id);
+
+    let events = String::from_utf8(output.lock().expect("buffer lock").clone())
+        .expect("JSON logs should be UTF-8")
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("valid JSON log event"))
+        .collect::<Vec<_>>();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["fields"]["communication_id"], id);
+    assert_eq!(events[0]["fields"]["state"], "created");
 }
 
 #[tokio::test]
@@ -2112,28 +2177,40 @@ async fn multi_agent_v2_completion_queues_message_for_direct_parent() {
         &AgentStatus::Completed(Some("done".to_string())),
     )
     .expect("completed status should render");
-    let expected = (
-        worker_thread_id,
-        Op::InterAgentCommunication {
-            communication: InterAgentCommunication::new(
-                tester_path.clone(),
-                worker_path.clone(),
-                Vec::new(),
-                expected_message.clone(),
-                /*trigger_turn*/ false,
-            ),
-        },
+    let expected = InterAgentCommunication::new(
+        tester_path.clone(),
+        worker_path.clone(),
+        Vec::new(),
+        expected_message.clone(),
+        /*trigger_turn*/ false,
     );
 
     timeout(Duration::from_secs(5), async {
         loop {
-            let captured = harness
-                .manager
-                .captured_ops()
-                .into_iter()
-                .find(|entry| *entry == expected);
-            if captured == Some(expected.clone()) {
-                break;
+            for (thread_id, op) in harness.manager.captured_ops() {
+                if thread_id != worker_thread_id {
+                    continue;
+                }
+                let Op::InterAgentCommunication { mut communication } = op else {
+                    continue;
+                };
+                let metadata = communication.agent_communication_metadata.take();
+                if communication == expected {
+                    let metadata = metadata.expect("completion communication metadata");
+                    assert_eq!(
+                        (
+                            metadata.kind,
+                            metadata.sender_thread_id,
+                            metadata.source_call_id,
+                        ),
+                        (
+                            AgentCommunicationKind::Result,
+                            tester_thread_id,
+                            /*source_call_id*/ None,
+                        )
+                    );
+                    return;
+                }
             }
             sleep(Duration::from_millis(10)).await;
         }

--- a/codex-rs/core/src/agent_communication.rs
+++ b/codex-rs/core/src/agent_communication.rs
@@ -1,65 +1,94 @@
 use codex_protocol::ThreadId;
-use codex_protocol::protocol::AgentCommunicationKind;
-use codex_protocol::protocol::AgentCommunicationMetadata;
-use codex_protocol::protocol::AgentCommunicationState;
 use codex_protocol::protocol::InterAgentCommunication;
 use uuid::Uuid;
 
-pub(crate) fn new_agent_communication_metadata(
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AgentCommunicationKind {
+    InitialTask,
+    Message,
+    Followup,
+    Result,
+}
+
+impl AgentCommunicationKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::InitialTask => "initialTask",
+            Self::Message => "message",
+            Self::Followup => "followup",
+            Self::Result => "result",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AgentCommunicationContext {
+    id: String,
     kind: AgentCommunicationKind,
     sender_thread_id: ThreadId,
-    source_call_id: Option<&str>,
-) -> AgentCommunicationMetadata {
-    AgentCommunicationMetadata {
-        id: Uuid::new_v4().to_string(),
-        kind,
-        sender_thread_id,
-        source_call_id: source_call_id.map(str::to_owned),
+    source_call_id: Option<String>,
+}
+
+impl AgentCommunicationContext {
+    pub(crate) fn from_tool_call(
+        kind: AgentCommunicationKind,
+        sender_thread_id: ThreadId,
+        source_call_id: &str,
+    ) -> Self {
+        Self::new(kind, sender_thread_id, Some(source_call_id.to_string()))
+    }
+
+    pub(crate) fn without_source_call(
+        kind: AgentCommunicationKind,
+        sender_thread_id: ThreadId,
+    ) -> Self {
+        Self::new(kind, sender_thread_id, None)
+    }
+
+    fn new(
+        kind: AgentCommunicationKind,
+        sender_thread_id: ThreadId,
+        source_call_id: Option<String>,
+    ) -> Self {
+        Self {
+            id: Uuid::now_v7().to_string(),
+            kind,
+            sender_thread_id,
+            source_call_id,
+        }
+    }
+
+    pub(crate) fn id(&self) -> &str {
+        &self.id
     }
 }
 
 pub(crate) fn emit_agent_communication_created(
+    context: &AgentCommunicationContext,
     communication: &InterAgentCommunication,
     receiver_thread_id: ThreadId,
-) {
-    let Some(metadata) = communication.agent_communication_metadata.as_ref() else {
-        return;
-    };
-    emit_agent_communication_event(
-        metadata,
-        AgentCommunicationState::Created,
-        receiver_thread_id,
-        communication_content(communication),
-    );
-}
-
-fn emit_agent_communication_event(
-    metadata: &AgentCommunicationMetadata,
-    state: AgentCommunicationState,
-    receiver_thread_id: ThreadId,
-    content: &str,
 ) {
     tracing::trace!(
         {
             event.name = "codex.agent_communication",
-            communication_id = %metadata.id,
-            kind = metadata.kind.as_str(),
-            state = state.as_str(),
-            sender_thread_id = %metadata.sender_thread_id,
+            communication_id = %context.id,
+            kind = context.kind.as_str(),
+            state = "created",
+            sender_thread_id = %context.sender_thread_id,
             receiver_thread_id = %receiver_thread_id,
-            content,
-            source_call_id = metadata.source_call_id.as_deref(),
+            content = communication_content(communication),
+            source_call_id = context.source_call_id.as_deref(),
         },
         "agent communication updated"
     );
 }
 
-pub(crate) fn emit_agent_communication_enqueued(metadata: AgentCommunicationMetadata) {
+pub(crate) fn emit_agent_communication_enqueued(id: &str) {
     tracing::trace!(
         {
             event.name = "codex.agent_communication",
-            communication_id = %metadata.id,
-            state = AgentCommunicationState::Enqueued.as_str(),
+            communication_id = id,
+            state = "enqueued",
         },
         "agent communication updated"
     );

--- a/codex-rs/core/src/agent_communication.rs
+++ b/codex-rs/core/src/agent_communication.rs
@@ -1,0 +1,81 @@
+use codex_protocol::ThreadId;
+use codex_protocol::protocol::AgentCommunicationKind;
+use codex_protocol::protocol::AgentCommunicationMetadata;
+use codex_protocol::protocol::AgentCommunicationState;
+use codex_protocol::protocol::InterAgentCommunication;
+use uuid::Uuid;
+
+pub(crate) fn new_agent_communication_metadata(
+    kind: AgentCommunicationKind,
+    sender_thread_id: ThreadId,
+    source_call_id: Option<&str>,
+) -> AgentCommunicationMetadata {
+    AgentCommunicationMetadata {
+        id: Uuid::new_v4().to_string(),
+        kind,
+        sender_thread_id,
+        source_call_id: source_call_id.map(str::to_owned),
+    }
+}
+
+pub(crate) fn emit_agent_communication_created(
+    communication: &InterAgentCommunication,
+    receiver_thread_id: ThreadId,
+) {
+    let Some(metadata) = communication.agent_communication_metadata.as_ref() else {
+        return;
+    };
+    emit_agent_communication_event(
+        metadata,
+        AgentCommunicationState::Created,
+        receiver_thread_id,
+        communication_content(communication),
+    );
+}
+
+fn emit_agent_communication_event(
+    metadata: &AgentCommunicationMetadata,
+    state: AgentCommunicationState,
+    receiver_thread_id: ThreadId,
+    content: &str,
+) {
+    tracing::trace!(
+        {
+            event.name = "codex.agent_communication",
+            communication_id = %metadata.id,
+            kind = metadata.kind.as_str(),
+            state = state.as_str(),
+            sender_thread_id = %metadata.sender_thread_id,
+            receiver_thread_id = %receiver_thread_id,
+            content,
+            source_call_id = metadata.source_call_id.as_deref(),
+        },
+        "agent communication updated"
+    );
+}
+
+pub(crate) fn emit_agent_communication_enqueued(metadata: AgentCommunicationMetadata) {
+    tracing::trace!(
+        {
+            event.name = "codex.agent_communication",
+            communication_id = %metadata.id,
+            state = AgentCommunicationState::Enqueued.as_str(),
+        },
+        "agent communication updated"
+    );
+}
+
+pub(crate) fn communication_content(communication: &InterAgentCommunication) -> &str {
+    if communication.content.is_empty() {
+        communication
+            .encrypted_content
+            .as_deref()
+            .unwrap_or_default()
+    } else {
+        &communication.content
+    }
+}
+
+#[cfg(test)]
+#[path = "agent_communication_tests.rs"]
+mod tests;

--- a/codex-rs/core/src/agent_communication_tests.rs
+++ b/codex-rs/core/src/agent_communication_tests.rs
@@ -1,0 +1,121 @@
+use super::*;
+use codex_protocol::AgentPath;
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+use serde_json::json;
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::filter::Targets;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_test::internal::MockWriter;
+
+#[test]
+fn emits_structured_lifecycle_events_at_trace() {
+    let output: &'static std::sync::Mutex<Vec<u8>> =
+        Box::leak(Box::new(std::sync::Mutex::new(Vec::new())));
+    let filter = Targets::new()
+        .with_default(LevelFilter::WARN)
+        .with_target("codex_core::agent_communication", LevelFilter::TRACE);
+    let subscriber = tracing_subscriber::registry().with(filter).with(
+        tracing_subscriber::fmt::layer()
+            .json()
+            .with_current_span(false)
+            .with_span_list(false)
+            .with_writer(MockWriter::new(output)),
+    );
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let sender_thread_id = ThreadId::new();
+    let receiver_thread_id = ThreadId::new();
+    let mut communication = InterAgentCommunication::new(
+        AgentPath::root(),
+        AgentPath::root(),
+        Vec::new(),
+        "hello".to_string(),
+        /*trigger_turn*/ false,
+    );
+    let metadata = new_agent_communication_metadata(
+        AgentCommunicationKind::Message,
+        sender_thread_id,
+        Some("call-1"),
+    );
+    communication.agent_communication_metadata = Some(metadata.clone());
+    emit_agent_communication_created(&communication, receiver_thread_id);
+    emit_agent_communication_enqueued(metadata.clone());
+
+    let result_metadata = new_agent_communication_metadata(
+        AgentCommunicationKind::Result,
+        receiver_thread_id,
+        /*source_call_id*/ None,
+    );
+    communication.agent_communication_metadata = Some(result_metadata.clone());
+    emit_agent_communication_created(&communication, sender_thread_id);
+
+    let events = String::from_utf8(output.lock().expect("buffer lock").clone())
+        .expect("JSON logs should be UTF-8")
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("valid JSON log event"))
+        .collect::<Vec<_>>();
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0]["level"], "TRACE");
+    assert_eq!(events[0]["target"], "codex_core::agent_communication");
+    assert_eq!(
+        events[0]["fields"],
+        json!({
+            "message": "agent communication updated",
+            "event.name": "codex.agent_communication",
+            "communication_id": metadata.id,
+            "kind": "message",
+            "state": "created",
+            "sender_thread_id": sender_thread_id.to_string(),
+            "receiver_thread_id": receiver_thread_id.to_string(),
+            "content": "hello",
+            "source_call_id": "call-1",
+        })
+    );
+    assert_eq!(events[1]["level"], "TRACE");
+    assert_eq!(events[1]["target"], "codex_core::agent_communication");
+    assert_eq!(
+        events[1]["fields"],
+        json!({
+            "message": "agent communication updated",
+            "event.name": "codex.agent_communication",
+            "communication_id": metadata.id,
+            "state": "enqueued",
+        })
+    );
+    assert_eq!(
+        events[2]["fields"],
+        json!({
+            "message": "agent communication updated",
+            "event.name": "codex.agent_communication",
+            "communication_id": result_metadata.id,
+            "kind": "result",
+            "state": "created",
+            "sender_thread_id": receiver_thread_id.to_string(),
+            "receiver_thread_id": sender_thread_id.to_string(),
+            "content": "hello",
+        })
+    );
+}
+
+#[test]
+fn content_prefers_plaintext_and_falls_back_to_encrypted_content() {
+    let mut plaintext = InterAgentCommunication::new(
+        AgentPath::root(),
+        AgentPath::root(),
+        Vec::new(),
+        "plain".to_string(),
+        /*trigger_turn*/ false,
+    );
+    plaintext.encrypted_content = Some("encrypted".to_string());
+    let encrypted = InterAgentCommunication::new_encrypted(
+        AgentPath::root(),
+        AgentPath::root(),
+        Vec::new(),
+        "encrypted".to_string(),
+        /*trigger_turn*/ false,
+    );
+
+    let contents = [&plaintext, &encrypted].map(communication_content);
+    assert_eq!(contents, ["plain", "encrypted"]);
+}

--- a/codex-rs/core/src/agent_communication_tests.rs
+++ b/codex-rs/core/src/agent_communication_tests.rs
@@ -26,29 +26,26 @@ fn emits_structured_lifecycle_events_at_trace() {
 
     let sender_thread_id = ThreadId::new();
     let receiver_thread_id = ThreadId::new();
-    let mut communication = InterAgentCommunication::new(
+    let communication = InterAgentCommunication::new(
         AgentPath::root(),
         AgentPath::root(),
         Vec::new(),
         "hello".to_string(),
         /*trigger_turn*/ false,
     );
-    let metadata = new_agent_communication_metadata(
+    let context = AgentCommunicationContext::from_tool_call(
         AgentCommunicationKind::Message,
         sender_thread_id,
-        Some("call-1"),
+        "call-1",
     );
-    communication.agent_communication_metadata = Some(metadata.clone());
-    emit_agent_communication_created(&communication, receiver_thread_id);
-    emit_agent_communication_enqueued(metadata.clone());
+    emit_agent_communication_created(&context, &communication, receiver_thread_id);
+    emit_agent_communication_enqueued(context.id());
 
-    let result_metadata = new_agent_communication_metadata(
+    let result_context = AgentCommunicationContext::without_source_call(
         AgentCommunicationKind::Result,
         receiver_thread_id,
-        /*source_call_id*/ None,
     );
-    communication.agent_communication_metadata = Some(result_metadata.clone());
-    emit_agent_communication_created(&communication, sender_thread_id);
+    emit_agent_communication_created(&result_context, &communication, sender_thread_id);
 
     let events = String::from_utf8(output.lock().expect("buffer lock").clone())
         .expect("JSON logs should be UTF-8")
@@ -63,7 +60,7 @@ fn emits_structured_lifecycle_events_at_trace() {
         json!({
             "message": "agent communication updated",
             "event.name": "codex.agent_communication",
-            "communication_id": metadata.id,
+            "communication_id": context.id(),
             "kind": "message",
             "state": "created",
             "sender_thread_id": sender_thread_id.to_string(),
@@ -79,7 +76,7 @@ fn emits_structured_lifecycle_events_at_trace() {
         json!({
             "message": "agent communication updated",
             "event.name": "codex.agent_communication",
-            "communication_id": metadata.id,
+            "communication_id": context.id(),
             "state": "enqueued",
         })
     );
@@ -88,7 +85,7 @@ fn emits_structured_lifecycle_events_at_trace() {
         json!({
             "message": "agent communication updated",
             "event.name": "codex.agent_communication",
-            "communication_id": result_metadata.id,
+            "communication_id": result_context.id(),
             "kind": "result",
             "state": "created",
             "sender_thread_id": receiver_thread_id.to_string(),
@@ -100,14 +97,16 @@ fn emits_structured_lifecycle_events_at_trace() {
 
 #[test]
 fn content_prefers_plaintext_and_falls_back_to_encrypted_content() {
-    let mut plaintext = InterAgentCommunication::new(
-        AgentPath::root(),
-        AgentPath::root(),
-        Vec::new(),
-        "plain".to_string(),
-        /*trigger_turn*/ false,
-    );
-    plaintext.encrypted_content = Some("encrypted".to_string());
+    let plaintext = InterAgentCommunication {
+        encrypted_content: Some("encrypted".to_string()),
+        ..InterAgentCommunication::new(
+            AgentPath::root(),
+            AgentPath::root(),
+            Vec::new(),
+            "plain".to_string(),
+            /*trigger_turn*/ false,
+        )
+    };
     let encrypted = InterAgentCommunication::new_encrypted(
         AgentPath::root(),
         AgentPath::root(),

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -31,6 +31,7 @@ pub use codex_thread::TryStartTurnIfIdleError;
 pub use codex_thread::TryStartTurnIfIdleRejectionReason;
 pub use session::turn_context::TurnContext;
 mod agent;
+mod agent_communication;
 mod attestation;
 mod codex_delegate;
 mod command_canonicalization;

--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -279,16 +279,13 @@ pub(super) async fn user_input_or_turn_inner(
 pub async fn inter_agent_communication(
     sess: &Arc<Session>,
     sub_id: String,
-    mut communication: InterAgentCommunication,
+    communication: InterAgentCommunication,
 ) {
     let trigger_turn = communication.trigger_turn;
-    let communication_metadata = communication.agent_communication_metadata.take();
     sess.input_queue
         .enqueue_mailbox_communication(communication)
         .await;
-    if let Some(metadata) = communication_metadata {
-        crate::agent_communication::emit_agent_communication_enqueued(metadata);
-    }
+    crate::agent_communication::emit_agent_communication_enqueued(&sub_id);
     if trigger_turn {
         sess.maybe_start_turn_for_pending_work_with_sub_id(sub_id)
             .await;

--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -279,12 +279,16 @@ pub(super) async fn user_input_or_turn_inner(
 pub async fn inter_agent_communication(
     sess: &Arc<Session>,
     sub_id: String,
-    communication: InterAgentCommunication,
+    mut communication: InterAgentCommunication,
 ) {
     let trigger_turn = communication.trigger_turn;
+    let communication_metadata = communication.agent_communication_metadata.take();
     sess.input_queue
         .enqueue_mailbox_communication(communication)
         .await;
+    if let Some(metadata) = communication_metadata {
+        crate::agent_communication::emit_agent_communication_enqueued(metadata);
+    }
     if trigger_turn {
         sess.maybe_start_turn_for_pending_work_with_sub_id(sub_id)
             .await;

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -111,6 +111,7 @@ use codex_protocol::openai_models::ModelPreset;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_protocol::protocol::AdditionalContextEntry;
+use codex_protocol::protocol::AgentCommunicationKind;
 use codex_protocol::protocol::FileChange;
 use codex_protocol::protocol::HasLegacyEvent;
 use codex_protocol::protocol::InterAgentCommunication;
@@ -1860,12 +1861,23 @@ impl Session {
             .rollout_thread_trace
             .is_enabled()
             .then(|| message.clone());
-        let communication = InterAgentCommunication::new(
+        let mut communication = InterAgentCommunication::new(
             child_agent_path.clone(),
             parent_agent_path,
             Vec::new(),
             message,
             /*trigger_turn*/ false,
+        );
+        communication.agent_communication_metadata = Some(
+            crate::agent_communication::new_agent_communication_metadata(
+                AgentCommunicationKind::Result,
+                self.thread_id,
+                /*source_call_id*/ None,
+            ),
+        );
+        crate::agent_communication::emit_agent_communication_created(
+            &communication,
+            parent_thread_id,
         );
         if let Err(err) = self
             .services

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -14,6 +14,7 @@ use crate::agent::AgentControl;
 use crate::agent::AgentStatus;
 use crate::agent::agent_status_from_event;
 use crate::agent::status::is_final;
+use crate::agent_communication::AgentCommunicationKind;
 use crate::attestation::AttestationProvider;
 use crate::build_available_skills;
 use crate::compact;
@@ -111,7 +112,6 @@ use codex_protocol::openai_models::ModelPreset;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_protocol::protocol::AdditionalContextEntry;
-use codex_protocol::protocol::AgentCommunicationKind;
 use codex_protocol::protocol::FileChange;
 use codex_protocol::protocol::HasLegacyEvent;
 use codex_protocol::protocol::InterAgentCommunication;
@@ -893,7 +893,7 @@ impl Codex {
 ///
 /// Some use cases take advantage of the fact that these are UUID7 which
 /// encodes a timestamp, so think carefully before changing this.
-fn new_submission_id() -> String {
+pub(crate) fn new_submission_id() -> String {
     Uuid::now_v7().to_string()
 }
 
@@ -1861,28 +1861,22 @@ impl Session {
             .rollout_thread_trace
             .is_enabled()
             .then(|| message.clone());
-        let mut communication = InterAgentCommunication::new(
+        let communication = InterAgentCommunication::new(
             child_agent_path.clone(),
             parent_agent_path,
             Vec::new(),
             message,
             /*trigger_turn*/ false,
         );
-        communication.agent_communication_metadata = Some(
-            crate::agent_communication::new_agent_communication_metadata(
+        let communication_context =
+            crate::agent_communication::AgentCommunicationContext::without_source_call(
                 AgentCommunicationKind::Result,
                 self.thread_id,
-                /*source_call_id*/ None,
-            ),
-        );
-        crate::agent_communication::emit_agent_communication_created(
-            &communication,
-            parent_thread_id,
-        );
+            );
         if let Err(err) = self
             .services
             .agent_control
-            .send_inter_agent_communication(parent_thread_id, communication)
+            .send_inter_agent_communication(parent_thread_id, communication, communication_context)
             .await
         {
             debug!("failed to notify parent thread {parent_thread_id}: {err}");

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -9806,29 +9806,15 @@ async fn mailbox_enqueue_emits_enqueued_communication_with_same_id() {
     let _guard = tracing::subscriber::set_default(subscriber);
 
     let (session, _) = make_session_and_context().await;
-    let sender_thread_id = ThreadId::new();
     let id = Uuid::new_v4().to_string();
-    let mut communication = InterAgentCommunication::new(
+    let communication = InterAgentCommunication::new(
         AgentPath::root(),
         AgentPath::root(),
         Vec::new(),
         "mail".to_string(),
         /*trigger_turn*/ false,
     );
-    communication.agent_communication_metadata =
-        Some(codex_protocol::protocol::AgentCommunicationMetadata {
-            id: id.clone(),
-            kind: codex_protocol::protocol::AgentCommunicationKind::Message,
-            sender_thread_id,
-            source_call_id: Some("call-1".to_string()),
-        });
-
-    super::handlers::inter_agent_communication(
-        &Arc::new(session),
-        "turn-1".to_string(),
-        communication,
-    )
-    .await;
+    super::handlers::inter_agent_communication(&Arc::new(session), id.clone(), communication).await;
 
     let events = String::from_utf8(output.lock().expect("buffer lock").clone())
         .expect("JSON logs should be UTF-8")

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -9782,6 +9782,72 @@ async fn task_finish_emits_thread_idle_lifecycle_after_active_turn_clears() {
 }
 
 #[tokio::test]
+async fn mailbox_enqueue_emits_enqueued_communication_with_same_id() {
+    use tracing_subscriber::filter::LevelFilter;
+    use tracing_subscriber::filter::Targets;
+    use tracing_subscriber::layer::SubscriberExt;
+    use tracing_test::internal::MockWriter;
+
+    let output: &'static std::sync::Mutex<Vec<u8>> =
+        Box::leak(Box::new(std::sync::Mutex::new(Vec::new())));
+    let subscriber = tracing_subscriber::registry()
+        .with(
+            Targets::new()
+                .with_default(LevelFilter::OFF)
+                .with_target("codex_core::agent_communication", LevelFilter::TRACE),
+        )
+        .with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_current_span(false)
+                .with_span_list(false)
+                .with_writer(MockWriter::new(output)),
+        );
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let (session, _) = make_session_and_context().await;
+    let sender_thread_id = ThreadId::new();
+    let id = Uuid::new_v4().to_string();
+    let mut communication = InterAgentCommunication::new(
+        AgentPath::root(),
+        AgentPath::root(),
+        Vec::new(),
+        "mail".to_string(),
+        /*trigger_turn*/ false,
+    );
+    communication.agent_communication_metadata =
+        Some(codex_protocol::protocol::AgentCommunicationMetadata {
+            id: id.clone(),
+            kind: codex_protocol::protocol::AgentCommunicationKind::Message,
+            sender_thread_id,
+            source_call_id: Some("call-1".to_string()),
+        });
+
+    super::handlers::inter_agent_communication(
+        &Arc::new(session),
+        "turn-1".to_string(),
+        communication,
+    )
+    .await;
+
+    let events = String::from_utf8(output.lock().expect("buffer lock").clone())
+        .expect("JSON logs should be UTF-8")
+        .lines()
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).expect("valid JSON log event"))
+        .collect::<Vec<_>>();
+    assert_eq!(events.len(), 1);
+    assert_eq!(
+        events[0]["fields"],
+        serde_json::json!({
+            "message": "agent communication updated",
+            "event.name": "codex.agent_communication",
+            "communication_id": id,
+            "state": "enqueued",
+        })
+    );
+}
+
+#[tokio::test]
 async fn thread_idle_lifecycle_waits_for_trigger_turn_mailbox_work() {
     struct ThreadIdleRecorder {
         calls: Arc<std::sync::atomic::AtomicUsize>,

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -13,6 +13,7 @@ use crate::session::Codex;
 use crate::session::CodexSpawnArgs;
 use crate::session::CodexSpawnOk;
 use crate::session::INITIAL_SUBMIT_ID;
+use crate::session::new_submission_id;
 use crate::session::resolve_multi_agent_version;
 use crate::tasks::InterruptedTurnHistoryMarker;
 use crate::tasks::interrupted_turn_history_marker;
@@ -56,6 +57,7 @@ use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::SessionConfiguredEvent;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SubAgentSource;
+use codex_protocol::protocol::Submission;
 use codex_protocol::protocol::ThreadHistoryMode;
 use codex_protocol::protocol::ThreadSource;
 use codex_protocol::protocol::TurnAbortReason;
@@ -1146,13 +1148,31 @@ impl ThreadManagerState {
 
     /// Send an operation to a thread by ID.
     pub(crate) async fn send_op(&self, thread_id: ThreadId, op: Op) -> CodexResult<String> {
+        self.send_op_with_id(thread_id, new_submission_id(), op)
+            .await
+    }
+
+    pub(crate) async fn send_op_with_id(
+        &self,
+        thread_id: ThreadId,
+        id: String,
+        op: Op,
+    ) -> CodexResult<String> {
         let thread = self.get_thread(thread_id).await?;
         if let Some(ops_log) = &self.ops_log
             && let Ok(mut log) = ops_log.lock()
         {
             log.push((thread_id, op.clone()));
         }
-        thread.submit(op).await
+        thread
+            .submit_with_id(Submission {
+                id: id.clone(),
+                op,
+                client_user_message_id: None,
+                trace: None,
+            })
+            .await?;
+        Ok(id)
     }
 
     /// Remove a thread from the manager by ID, returning it when present.

--- a/codex-rs/core/src/tools/handlers/multi_agents/spawn.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents/spawn.rs
@@ -132,6 +132,7 @@ async fn handle_spawn_agent(
             fork_mode: args.fork_context.then_some(SpawnAgentForkMode::FullHistory),
             parent_thread_id: Some(session.thread_id),
             environments: Some(turn.environments.to_selections()),
+            agent_communication_context: None,
         },
     ))
     .await

--- a/codex-rs/core/src/tools/handlers/multi_agents_v2/message_tool.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_v2/message_tool.rs
@@ -4,9 +4,9 @@
 //! resulting `InterAgentCommunication` should wake the target immediately.
 
 use super::*;
+use crate::agent_communication::AgentCommunicationKind;
 use crate::tools::context::FunctionToolOutput;
 use crate::turn_timing::now_unix_timestamp_ms;
-use codex_protocol::protocol::AgentCommunicationKind;
 use codex_protocol::protocol::InterAgentCommunication;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -93,23 +93,18 @@ pub(crate) async fn handle_message_string_tool(
         .session_source
         .get_agent_path()
         .unwrap_or_else(AgentPath::root);
-    let mut communication =
+    let communication =
         communication_from_tool_message(author, receiver_agent_path.clone(), message);
     let communication_kind = match mode {
         MessageDeliveryMode::QueueOnly => AgentCommunicationKind::Message,
         MessageDeliveryMode::TriggerTurn => AgentCommunicationKind::Followup,
     };
-    communication.agent_communication_metadata = Some(
-        crate::agent_communication::new_agent_communication_metadata(
+    let communication_context =
+        crate::agent_communication::AgentCommunicationContext::from_tool_call(
             communication_kind,
             session.thread_id,
-            Some(call_id.as_str()),
-        ),
-    );
-    crate::agent_communication::emit_agent_communication_created(
-        &communication,
-        receiver_thread_id,
-    );
+            call_id.as_str(),
+        );
 
     let resume_config = build_agent_resume_config(turn.as_ref())?;
     session
@@ -121,7 +116,11 @@ pub(crate) async fn handle_message_string_tool(
     let result = session
         .services
         .agent_control
-        .send_inter_agent_communication(receiver_thread_id, mode.apply(communication))
+        .send_inter_agent_communication(
+            receiver_thread_id,
+            mode.apply(communication),
+            communication_context,
+        )
         .await
         .map_err(|err| collab_agent_error(receiver_thread_id, err));
     result?;

--- a/codex-rs/core/src/tools/handlers/multi_agents_v2/message_tool.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_v2/message_tool.rs
@@ -6,6 +6,7 @@
 use super::*;
 use crate::tools::context::FunctionToolOutput;
 use crate::turn_timing::now_unix_timestamp_ms;
+use codex_protocol::protocol::AgentCommunicationKind;
 use codex_protocol::protocol::InterAgentCommunication;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -88,6 +89,28 @@ pub(crate) async fn handle_message_string_tool(
     let receiver_agent_path = receiver_agent.agent_path.clone().ok_or_else(|| {
         FunctionCallError::RespondToModel("target agent is missing an agent_path".to_string())
     })?;
+    let author = turn
+        .session_source
+        .get_agent_path()
+        .unwrap_or_else(AgentPath::root);
+    let mut communication =
+        communication_from_tool_message(author, receiver_agent_path.clone(), message);
+    let communication_kind = match mode {
+        MessageDeliveryMode::QueueOnly => AgentCommunicationKind::Message,
+        MessageDeliveryMode::TriggerTurn => AgentCommunicationKind::Followup,
+    };
+    communication.agent_communication_metadata = Some(
+        crate::agent_communication::new_agent_communication_metadata(
+            communication_kind,
+            session.thread_id,
+            Some(call_id.as_str()),
+        ),
+    );
+    crate::agent_communication::emit_agent_communication_created(
+        &communication,
+        receiver_thread_id,
+    );
+
     let resume_config = build_agent_resume_config(turn.as_ref())?;
     session
         .services
@@ -95,12 +118,6 @@ pub(crate) async fn handle_message_string_tool(
         .ensure_v2_agent_loaded(resume_config, receiver_thread_id)
         .await
         .map_err(|err| collab_agent_error(receiver_thread_id, err))?;
-    let author = turn
-        .session_source
-        .get_agent_path()
-        .unwrap_or_else(AgentPath::root);
-    let communication =
-        communication_from_tool_message(author, receiver_agent_path.clone(), message);
     let result = session
         .services
         .agent_control

--- a/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs
@@ -8,6 +8,7 @@ use crate::tools::handlers::multi_agents_spec::SpawnAgentToolOptions;
 use crate::tools::handlers::multi_agents_spec::create_spawn_agent_tool_v2;
 use crate::turn_timing::now_unix_timestamp_ms;
 use codex_protocol::AgentPath;
+use codex_protocol::protocol::AgentCommunicationKind;
 use codex_protocol::protocol::Op;
 use codex_tools::ToolSpec;
 
@@ -117,8 +118,15 @@ async fn handle_spawn_agent(
                         .session_source
                         .get_agent_path()
                         .unwrap_or_else(AgentPath::root);
-                    let communication =
+                    let mut communication =
                         communication_from_tool_message(author, new_agent_path.clone(), message);
+                    communication.agent_communication_metadata = Some(
+                        crate::agent_communication::new_agent_communication_metadata(
+                            AgentCommunicationKind::InitialTask,
+                            session.thread_id,
+                            Some(call_id.as_str()),
+                        ),
+                    );
                     Op::InterAgentCommunication { communication }
                 }
                 initial_operation => initial_operation,

--- a/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs
@@ -4,11 +4,11 @@ use crate::agent::control::SpawnAgentOptions;
 use crate::agent::next_thread_spawn_depth;
 use crate::agent::role::DEFAULT_ROLE_NAME;
 use crate::agent::role::apply_role_to_config;
+use crate::agent_communication::AgentCommunicationKind;
 use crate::tools::handlers::multi_agents_spec::SpawnAgentToolOptions;
 use crate::tools::handlers::multi_agents_spec::create_spawn_agent_tool_v2;
 use crate::turn_timing::now_unix_timestamp_ms;
 use codex_protocol::AgentPath;
-use codex_protocol::protocol::AgentCommunicationKind;
 use codex_protocol::protocol::Op;
 use codex_tools::ToolSpec;
 
@@ -105,41 +105,39 @@ async fn handle_spawn_agent(
             "spawned agent is missing a canonical task name".to_string(),
         )
     })?;
-    let spawned_agent = Box::pin(
-        session.services.agent_control.spawn_agent_with_metadata(
-            config,
-            match initial_operation {
-                Op::UserInput { items, .. }
-                    if items
-                        .iter()
-                        .all(|item| matches!(item, UserInput::Text { .. })) =>
-                {
-                    let author = turn
-                        .session_source
-                        .get_agent_path()
-                        .unwrap_or_else(AgentPath::root);
-                    let mut communication =
-                        communication_from_tool_message(author, new_agent_path.clone(), message);
-                    communication.agent_communication_metadata = Some(
-                        crate::agent_communication::new_agent_communication_metadata(
-                            AgentCommunicationKind::InitialTask,
-                            session.thread_id,
-                            Some(call_id.as_str()),
-                        ),
-                    );
-                    Op::InterAgentCommunication { communication }
-                }
-                initial_operation => initial_operation,
-            },
-            Some(spawn_source),
-            SpawnAgentOptions {
-                fork_parent_spawn_call_id: fork_mode.as_ref().map(|_| call_id.clone()),
-                fork_mode,
-                parent_thread_id: Some(session.thread_id),
-                environments: Some(turn.environments.to_selections()),
-            },
-        ),
-    )
+    let (initial_operation, agent_communication_context) = match initial_operation {
+        Op::UserInput { items, .. }
+            if items
+                .iter()
+                .all(|item| matches!(item, UserInput::Text { .. })) =>
+        {
+            let author = turn
+                .session_source
+                .get_agent_path()
+                .unwrap_or_else(AgentPath::root);
+            let communication =
+                communication_from_tool_message(author, new_agent_path.clone(), message);
+            let context = crate::agent_communication::AgentCommunicationContext::from_tool_call(
+                AgentCommunicationKind::InitialTask,
+                session.thread_id,
+                call_id.as_str(),
+            );
+            (Op::InterAgentCommunication { communication }, Some(context))
+        }
+        initial_operation => (initial_operation, None),
+    };
+    let spawned_agent = Box::pin(session.services.agent_control.spawn_agent_with_metadata(
+        config,
+        initial_operation,
+        Some(spawn_source),
+        SpawnAgentOptions {
+            fork_parent_spawn_call_id: fork_mode.as_ref().map(|_| call_id.clone()),
+            fork_mode,
+            parent_thread_id: Some(session.thread_id),
+            environments: Some(turn.environments.to_selections()),
+            agent_communication_context,
+        },
+    ))
     .await
     .map_err(collab_spawn_error)?;
     let new_thread_id = spawned_agent.thread_id;

--- a/codex-rs/feedback/src/lib.rs
+++ b/codex-rs/feedback/src/lib.rs
@@ -18,6 +18,7 @@ use tracing::Event;
 use tracing::Level;
 use tracing::field::Visit;
 use tracing_subscriber::Layer;
+use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::filter::Targets;
 use tracing_subscriber::fmt::writer::MakeWriter;
 use tracing_subscriber::registry::LookupSpan;
@@ -204,7 +205,11 @@ impl CodexFeedback {
             .with_target(false)
             // Capture everything, regardless of the caller's `RUST_LOG`, so feedback includes the
             // full trace when the user uploads a report.
-            .with_filter(Targets::new().with_default(Level::TRACE))
+            .with_filter(
+                Targets::new()
+                    .with_default(Level::TRACE)
+                    .with_target("codex_core::agent_communication", LevelFilter::OFF),
+            )
     }
 
     /// Returns a [`tracing_subscriber`] layer that collects structured metadata for feedback.
@@ -721,6 +726,24 @@ mod tests {
         let snap = fb.snapshot(/*session_id*/ None);
         pretty_assertions::assert_eq!(snap.tags.get("model").map(String::as_str), Some("gpt-5"));
         pretty_assertions::assert_eq!(snap.tags.get("cached").map(String::as_str), Some("true"));
+    }
+
+    #[test]
+    fn logger_layer_excludes_agent_communication_content() {
+        let fb = CodexFeedback::new();
+        let _guard = tracing_subscriber::registry()
+            .with(fb.logger_layer())
+            .set_default();
+
+        tracing::info!(target: "codex_core", "retained-log");
+        tracing::trace!(target: "codex_core::agent_communication", content = "secret", "dropped-log");
+
+        let logs = std::str::from_utf8(fb.snapshot(/*session_id*/ None).as_bytes())
+            .expect("feedback logs should be UTF-8")
+            .to_string();
+        assert!(logs.contains("retained-log"));
+        assert!(!logs.contains("secret"));
+        assert!(!logs.contains("dropped-log"));
     }
 
     #[test]

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -737,11 +737,6 @@ pub struct InterAgentCommunication {
     #[ts(optional)]
     pub internal_chat_message_metadata_passthrough: Option<InternalChatMessageMetadataPassthrough>,
     pub trigger_turn: bool,
-    /// Runtime-only metadata used to emit communication lifecycle records.
-    #[serde(skip)]
-    #[schemars(skip)]
-    #[ts(skip)]
-    pub agent_communication_metadata: Option<AgentCommunicationMetadata>,
 }
 
 impl InterAgentCommunication {
@@ -761,7 +756,6 @@ impl InterAgentCommunication {
             encrypted_content: None,
             internal_chat_message_metadata_passthrough: None,
             trigger_turn,
-            agent_communication_metadata: None,
         }
     }
 
@@ -781,7 +775,6 @@ impl InterAgentCommunication {
             encrypted_content: Some(encrypted_content),
             internal_chat_message_metadata_passthrough: None,
             trigger_turn,
-            agent_communication_metadata: None,
         }
     }
 
@@ -4279,48 +4272,6 @@ pub struct SubAgentActivityEvent {
     pub kind: SubAgentActivityKind,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AgentCommunicationKind {
-    InitialTask,
-    Message,
-    Followup,
-    Result,
-}
-
-impl AgentCommunicationKind {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::InitialTask => "initialTask",
-            Self::Message => "message",
-            Self::Followup => "followup",
-            Self::Result => "result",
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AgentCommunicationState {
-    Created,
-    Enqueued,
-}
-
-impl AgentCommunicationState {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Created => "created",
-            Self::Enqueued => "enqueued",
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AgentCommunicationMetadata {
-    pub id: String,
-    pub kind: AgentCommunicationKind,
-    pub sender_thread_id: ThreadId,
-    pub source_call_id: Option<String>,
-}
-
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, JsonSchema, TS)]
 pub struct CollabWaitingBeginEvent {
     #[serde(default)]
@@ -4569,7 +4520,6 @@ mod tests {
             encrypted_content: None,
             internal_chat_message_metadata_passthrough: None,
             trigger_turn: true,
-            agent_communication_metadata: None,
         };
         communication.set_turn_id_if_missing("turn-1");
         let mut serialized_communication = communication.clone();

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -737,6 +737,11 @@ pub struct InterAgentCommunication {
     #[ts(optional)]
     pub internal_chat_message_metadata_passthrough: Option<InternalChatMessageMetadataPassthrough>,
     pub trigger_turn: bool,
+    /// Runtime-only metadata used to emit communication lifecycle records.
+    #[serde(skip)]
+    #[schemars(skip)]
+    #[ts(skip)]
+    pub agent_communication_metadata: Option<AgentCommunicationMetadata>,
 }
 
 impl InterAgentCommunication {
@@ -756,6 +761,7 @@ impl InterAgentCommunication {
             encrypted_content: None,
             internal_chat_message_metadata_passthrough: None,
             trigger_turn,
+            agent_communication_metadata: None,
         }
     }
 
@@ -775,6 +781,7 @@ impl InterAgentCommunication {
             encrypted_content: Some(encrypted_content),
             internal_chat_message_metadata_passthrough: None,
             trigger_turn,
+            agent_communication_metadata: None,
         }
     }
 
@@ -4272,6 +4279,48 @@ pub struct SubAgentActivityEvent {
     pub kind: SubAgentActivityKind,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentCommunicationKind {
+    InitialTask,
+    Message,
+    Followup,
+    Result,
+}
+
+impl AgentCommunicationKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::InitialTask => "initialTask",
+            Self::Message => "message",
+            Self::Followup => "followup",
+            Self::Result => "result",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentCommunicationState {
+    Created,
+    Enqueued,
+}
+
+impl AgentCommunicationState {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Created => "created",
+            Self::Enqueued => "enqueued",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentCommunicationMetadata {
+    pub id: String,
+    pub kind: AgentCommunicationKind,
+    pub sender_thread_id: ThreadId,
+    pub source_call_id: Option<String>,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, JsonSchema, TS)]
 pub struct CollabWaitingBeginEvent {
     #[serde(default)]
@@ -4520,6 +4569,7 @@ mod tests {
             encrypted_content: None,
             internal_chat_message_metadata_passthrough: None,
             trigger_turn: true,
+            agent_communication_metadata: None,
         };
         communication.set_turn_id_if_missing("turn-1");
         let mut serialized_communication = communication.clone();

--- a/codex-rs/state/src/log_db.rs
+++ b/codex-rs/state/src/log_db.rs
@@ -54,6 +54,7 @@ pub fn default_filter() -> Targets {
     Targets::new()
         .with_default(LevelFilter::TRACE)
         .with_target("log", LevelFilter::OFF)
+        .with_target("codex_core::agent_communication", LevelFilter::OFF)
         .with_target("codex_otel.log_only", LevelFilter::OFF)
         .with_target("codex_otel.trace_safe", LevelFilter::OFF)
 }

--- a/codex-rs/state/src/log_db_filter_tests.rs
+++ b/codex-rs/state/src/log_db_filter_tests.rs
@@ -1,5 +1,4 @@
 use pretty_assertions::assert_eq;
-use tracing_subscriber::filter::Targets;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use uuid::Uuid;
@@ -16,17 +15,14 @@ async fn sqlite_sink_drops_low_level_opentelemetry_sdk_logs() {
     let layer = start(runtime.clone());
 
     let guard = tracing_subscriber::registry()
-        .with(
-            layer
-                .clone()
-                .with_filter(Targets::new().with_default(tracing::Level::TRACE)),
-        )
+        .with(layer.clone().with_filter(default_filter()))
         .set_default();
 
     tracing::trace!(target: "opentelemetry_sdk", "dropped-trace");
     tracing::debug!(target: "opentelemetry_sdk", "dropped-debug");
     tracing::info!(target: "opentelemetry_sdk", "retained-info");
     tracing::trace!(target: "codex_state", "retained-trace");
+    tracing::trace!(target: "codex_core::agent_communication", content = "secret", "dropped-agent-communication");
 
     layer.flush().await;
     drop(guard);


### PR DESCRIPTION
Currently there is no unified way to observe agent communication lifecycle events. This adds structured logging for communication creation and successful mailbox enqueue.

The records are emitted at `TRACE` under the `codex_core::agent_communication` module target. You can opt in with:

```bash
RUST_LOG=warn,codex_core::agent_communication=trace
```

Created event:

```json
{
  "timestamp": "2026-06-29T03:27:51.433693Z",
  "level": "TRACE",
  "fields": {
    "message": "agent communication updated",
    "event.name": "codex.agent_communication",
    "communication_id": "44e6762e-e19e-478d-ab94-c5e0be15209b",
    "kind": "result",
    "state": "created",
    "sender_thread_id": "019f116b-4219-7210-b88e-7615ba34bcef",
    "receiver_thread_id": "019f116b-2ddb-7c41-a9f4-e234bb5e5fc7",
    "content": "Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/toy_worker\nPayload:\nCHILD_OK"
  },
  "target": "codex_core::agent_communication"
}
```

Enqueued event:

```json
{
  "timestamp": "2026-06-29T03:27:51.434038Z",
  "level": "TRACE",
  "fields": {
    "message": "agent communication updated",
    "event.name": "codex.agent_communication",
    "communication_id": "44e6762e-e19e-478d-ab94-c5e0be15209b",
    "state": "enqueued"
  },
  "target": "codex_core::agent_communication"
}
```
