### PR TITLE
[codex] fix status line full access label

### DIFF
--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_surface_previews_no_sandbox_with_approval.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_surface_previews_no_sandbox_with_approval.snap
@@ -1,0 +1,5 @@
+---
+source: tui/src/chatwidget/tests/status_surface_previews.rs
+expression: "status_preview_line(&mut chat,\n&[StatusLineItem::Permissions, StatusLineItem::ApprovalMode],)"
+---
+No Sandbox · Ask for approval

--- a/codex-rs/tui/src/chatwidget/status_surfaces.rs
+++ b/codex-rs/tui/src/chatwidget/status_surfaces.rs
@@ -1115,7 +1115,12 @@ fn permissions_display(config: &Config) -> String {
         return "Workspace".to_string();
     }
     if permission_profile == PermissionProfile::Disabled {
-        return "Full Access".to_string();
+        let approval_policy = AskForApproval::from(config.permissions.approval_policy.value());
+        return if approval_policy == AskForApproval::Never {
+            "Full Access".to_string()
+        } else {
+            "No Sandbox".to_string()
+        };
     }
 
     "Custom permissions".to_string()

--- a/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_and_layout.rs
@@ -195,6 +195,36 @@ async fn raw_output_status_line_value_only_shows_when_enabled() {
 }
 
 #[tokio::test]
+async fn status_line_permissions_distinguish_no_sandbox_from_full_access() {
+    let (mut chat, _rx, _ops) = make_chatwidget_manual(/*model_override*/ None).await;
+    chat.config
+        .permissions
+        .set_permission_profile(PermissionProfile::Disabled)
+        .expect("set permission profile");
+    chat.config
+        .permissions
+        .approval_policy
+        .set(AskForApproval::OnRequest.to_core())
+        .expect("set approval policy");
+
+    assert_eq!(
+        chat.status_line_value_for_item(crate::bottom_pane::StatusLineItem::Permissions),
+        Some("No Sandbox".to_string())
+    );
+
+    chat.config
+        .permissions
+        .approval_policy
+        .set(AskForApproval::Never.to_core())
+        .expect("set approval policy");
+
+    assert_eq!(
+        chat.status_line_value_for_item(crate::bottom_pane::StatusLineItem::Permissions),
+        Some("Full Access".to_string())
+    );
+}
+
+#[tokio::test]
 async fn status_line_branch_changes_render_no_changes() {
     let (mut chat, _rx, _ops) = make_chatwidget_manual(/*model_override*/ None).await;
     chat.status_line_git_summary = Some(StatusLineGitSummary {

--- a/codex-rs/tui/src/chatwidget/tests/status_surface_previews.rs
+++ b/codex-rs/tui/src/chatwidget/tests/status_surface_previews.rs
@@ -150,6 +150,28 @@ async fn status_surface_preview_lines_hardcoded_only_snapshot() {
 }
 
 #[tokio::test]
+async fn status_surface_preview_no_sandbox_with_approval_snapshot() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
+    chat.config
+        .permissions
+        .set_permission_profile(PermissionProfile::Disabled)
+        .expect("set permission profile");
+    chat.config
+        .permissions
+        .approval_policy
+        .set(AskForApproval::OnRequest.to_core())
+        .expect("set approval policy");
+
+    assert_chatwidget_snapshot!(
+        "status_surface_previews_no_sandbox_with_approval",
+        status_preview_line(
+            &mut chat,
+            &[StatusLineItem::Permissions, StatusLineItem::ApprovalMode],
+        )
+    );
+}
+
+#[tokio::test]
 async fn thread_title_falls_back_to_thread_id_when_unnamed() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(/*model_override*/ None).await;
     let thread_id = ThreadId::new();


### PR DESCRIPTION
## Summary
- Show `No Sandbox` in the TUI status line when sandboxing is disabled but command approvals are still enabled.
- Reserve `Full Access` for disabled sandboxing with `AskForApproval::Never`.
- Add focused behavior and snapshot regression coverage.

## Why
The compact status line derived its permissions label only from `PermissionProfile::Disabled`, so `sandbox_mode = "danger-full-access"` with an approval policy such as `OnRequest` was misleadingly shown as `Full Access` even though commands still required approval.

## User impact
Users can now distinguish an unsandboxed session that still asks for approval from a truly unrestricted full-access session.

Closes #30379

## Testing
- `just fmt`
- `CARGO_TARGET_DIR=/tmp/codex-target just test -p codex-tui status_line_permissions_distinguish_no_sandbox_from_full_access`
- `CARGO_TARGET_DIR=/tmp/codex-target just test -p codex-tui status_surface_preview_no_sandbox_with_approval_snapshot`
- `CARGO_TARGET_DIR=/tmp/codex-target just test -p codex-tui` (2950 passed; two unrelated existing Guardian feature-flag tests fail independently: `app::tests::update_feature_flags_disabling_guardian_clears_manual_review_policy_without_history` and `app::tests::update_feature_flags_disabling_guardian_clears_review_policy_and_restores_default`, both with `Err(Empty)`.)