### PR TITLE
[codex] Trace startup WebSocket prewarm

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -1663,6 +1663,16 @@ impl ModelClientSession {
         websocket_telemetry
     }
 
+    #[instrument(
+        name = "model_client.prewarm_websocket",
+        level = "trace",
+        skip_all,
+        fields(
+            model = %model_info.slug,
+            transport = "responses_websocket",
+            websocket.warmup = true
+        )
+    )]
     #[allow(clippy::too_many_arguments)]
     pub async fn prewarm_websocket(
         &mut self,

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -139,6 +139,7 @@ use tracing::warn;
 /// - If the model sends only an assistant message, we record it in the
 ///   conversation history and consider the turn complete.
 ///
+#[instrument(level = "trace", skip_all)]
 pub(crate) async fn run_turn(
     sess: Arc<Session>,
     turn_context: Arc<TurnContext>,

--- a/codex-rs/core/src/session_startup_prewarm.rs
+++ b/codex-rs/core/src/session_startup_prewarm.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::AbortOnDropHandle;
+use tracing::Instrument;
 use tracing::info;
 use tracing::instrument;
 use tracing::warn;
@@ -198,22 +199,26 @@ impl Session {
         let websocket_connect_timeout = self.provider().await.websocket_connect_timeout();
         let started_at = Instant::now();
         let startup_prewarm_session = Arc::clone(self);
-        let startup_prewarm = tokio::spawn(async move {
-            let result =
-                schedule_startup_prewarm_inner(startup_prewarm_session, base_instructions).await;
-            let status = if result.is_ok() { "ready" } else { "failed" };
-            session_telemetry.record_startup_phase(
-                "startup_prewarm_total",
-                started_at.elapsed(),
-                Some(status),
-            );
-            session_telemetry.record_duration(
-                STARTUP_PREWARM_DURATION_METRIC,
-                started_at.elapsed(),
-                &[("status", status)],
-            );
-            result
-        });
+        let startup_prewarm = tokio::spawn(
+            async move {
+                let result =
+                    schedule_startup_prewarm_inner(startup_prewarm_session, base_instructions)
+                        .await;
+                let status = if result.is_ok() { "ready" } else { "failed" };
+                session_telemetry.record_startup_phase(
+                    "startup_prewarm_total",
+                    started_at.elapsed(),
+                    Some(status),
+                );
+                session_telemetry.record_duration(
+                    STARTUP_PREWARM_DURATION_METRIC,
+                    started_at.elapsed(),
+                    &[("status", status)],
+                );
+                result
+            }
+            .in_current_span(),
+        );
         self.set_session_startup_prewarm(SessionStartupPrewarmHandle::new(
             startup_prewarm,
             started_at,
@@ -238,6 +243,7 @@ impl Session {
     }
 }
 
+#[instrument(name = "startup_prewarm.run", level = "trace", skip_all)]
 async fn schedule_startup_prewarm_inner(
     session: Arc<Session>,
     base_instructions: String,

--- a/codex-rs/core/src/tasks/regular.rs
+++ b/codex-rs/core/src/tasks/regular.rs
@@ -43,7 +43,6 @@ impl SessionTask for RegularTask {
     ) -> SessionTaskResult {
         let sess = session.clone_session();
         let turn_extension_data = session.turn_extension_data();
-        let run_turn_span = trace_span!("run_turn");
         // Regular turns emit `TurnStarted` inline so first-turn lifecycle does
         // not wait on startup prewarm resolution.
         let prewarmed_client_session = async {
@@ -79,7 +78,6 @@ impl SessionTask for RegularTask {
                 prewarmed_client_session.take(),
                 cancellation_token.child_token(),
             )
-            .instrument(run_turn_span.clone())
             .await?;
             if !sess.input_queue.has_pending_input(&sess.active_turn).await {
                 return Ok(last_agent_message);


### PR DESCRIPTION
## Summary

- preserve the active trace context across the spawned startup prewarm task
- add spans for the startup prewarm and WebSocket warmup work
- start the `run_turn` span when `run_turn` begins executing

## Why

Startup WebSocket prewarming runs in a separate Tokio task before the regular turn enters `run_turn`. The spawned future did not retain the current span, so prewarm latency appeared as an untraced gap and the warmup request could not derive downstream trace context from that work.

This change carries the current span into the spawned task and instruments the functions that own the async work. It does not add the warmup request body to span attributes; the existing request trace metadata can now be populated from the active span.

## Validation

- `just fmt`
- `cargo build --bin codex --bin test_stdio_server`
- `just test -p codex-core`: 2,901 passed, 7 failed, 16 skipped. The remaining failures are in apply-patch symlink handling and unified-exec timing/output assertions outside the touched paths; relevant startup-prewarm and WebSocket tests passed in the same run.

No issue; follow-up to a trace-quality investigation.
