### PR TITLE
perf: trace and reduce remote first-turn latency

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2833,6 +2833,7 @@ dependencies = [
  "codex-config",
  "codex-context-fragments",
  "codex-exec-server",
+ "codex-file-system",
  "codex-login",
  "codex-model-provider",
  "codex-otel",
@@ -4047,6 +4048,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/codex-rs/app-server/src/request_processors/thread_goal_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_goal_processor.rs
@@ -141,7 +141,7 @@ impl ThreadGoalRequestProcessor {
                 // Live goal-first threads can be listed before any user turn is written.
                 // Use the live path so JSONL and SQLite preview metadata stay in sync.
                 thread
-                    .append_rollout_items(&[outcome.thread_goal_updated_item()])
+                    .append_rollout_items_and_flush_metadata(&[outcome.thread_goal_updated_item()])
                     .await
             }
             Err(_) => Ok(()),

--- a/codex-rs/core-skills/Cargo.toml
+++ b/codex-rs/core-skills/Cargo.toml
@@ -18,6 +18,7 @@ codex-analytics = { workspace = true }
 codex-config = { workspace = true }
 codex-context-fragments = { workspace = true }
 codex-exec-server = { workspace = true }
+codex-file-system = { workspace = true }
 codex-login = { workspace = true }
 codex-model-provider = { workspace = true }
 codex-otel = { workspace = true }

--- a/codex-rs/core-skills/src/loader.rs
+++ b/codex-rs/core-skills/src/loader.rs
@@ -20,6 +20,8 @@ use codex_config::merge_toml_values;
 use codex_config::project_root_markers_from_config;
 use codex_exec_server::ExecutorFileSystem;
 use codex_exec_server::LOCAL_FS;
+use codex_file_system::FindUpErrorPolicy;
+use codex_file_system::find_nearest_native_ancestor_with_markers;
 use codex_protocol::protocol::Product;
 use codex_protocol::protocol::SkillScope;
 use codex_utils_absolute_path::AbsolutePathBuf;
@@ -238,6 +240,7 @@ pub(crate) async fn skill_roots(
     fs: Option<Arc<dyn ExecutorFileSystem>>,
     config_layer_stack: &ConfigLayerStack,
     cwd: &AbsolutePathBuf,
+    project_root: Option<(&AbsolutePathBuf, &AbsolutePathBuf)>,
     plugin_skill_roots: Vec<PluginSkillRoot>,
     extra_skill_roots: Vec<AbsolutePathBuf>,
 ) -> Vec<SkillRoot> {
@@ -247,6 +250,7 @@ pub(crate) async fn skill_roots(
         fs,
         config_layer_stack,
         cwd,
+        project_root,
         home_dir.as_ref(),
         plugin_skill_roots,
         extra_skill_roots,
@@ -258,6 +262,7 @@ async fn skill_roots_with_home_dir(
     fs: Option<Arc<dyn ExecutorFileSystem>>,
     config_layer_stack: &ConfigLayerStack,
     cwd: &AbsolutePathBuf,
+    project_root: Option<(&AbsolutePathBuf, &AbsolutePathBuf)>,
     home_dir: Option<&AbsolutePathBuf>,
     plugin_skill_roots: Vec<PluginSkillRoot>,
     extra_skill_roots: Vec<AbsolutePathBuf>,
@@ -279,7 +284,7 @@ async fn skill_roots_with_home_dir(
         plugin_namespace: None,
         plugin_root: None,
     }));
-    roots.extend(repo_agents_skill_roots(fs, config_layer_stack, cwd).await);
+    roots.extend(repo_agents_skill_roots(fs, config_layer_stack, cwd, project_root).await);
     dedupe_skill_roots_by_path(&mut roots);
     roots
 }
@@ -374,12 +379,20 @@ async fn repo_agents_skill_roots(
     fs: Option<Arc<dyn ExecutorFileSystem>>,
     config_layer_stack: &ConfigLayerStack,
     cwd: &AbsolutePathBuf,
+    project_root: Option<(&AbsolutePathBuf, &AbsolutePathBuf)>,
 ) -> Vec<SkillRoot> {
     let Some(fs) = fs else {
         return Vec::new();
     };
-    let project_root_markers = project_root_markers_from_stack(config_layer_stack);
-    let project_root = find_project_root(fs.as_ref(), cwd, &project_root_markers).await;
+    let project_root = match project_root.filter(|(discovery_cwd, root)| {
+        *discovery_cwd == cwd && cwd.as_path().starts_with(root.as_path())
+    }) {
+        Some((_, project_root)) => project_root.clone(),
+        None => {
+            let project_root_markers = project_root_markers_from_stack(config_layer_stack);
+            find_project_root(fs.as_ref(), cwd, &project_root_markers).await
+        }
+    };
     let dirs = dirs_between_project_root_and_cwd(cwd, &project_root);
     let mut roots = Vec::new();
     for dir in dirs {
@@ -438,24 +451,17 @@ async fn find_project_root(
         return cwd.clone();
     }
 
-    for ancestor in cwd.ancestors() {
-        for marker in project_root_markers {
-            let marker_path = ancestor.join(marker);
-            let marker_path_uri = PathUri::from_abs_path(&marker_path);
-            match fs.get_metadata(&marker_path_uri, /*sandbox*/ None).await {
-                Ok(_) => return ancestor,
-                Err(err) if err.kind() == io::ErrorKind::NotFound => {}
-                Err(err) => {
-                    tracing::warn!(
-                        "failed to stat project root marker {}: {err:#}",
-                        marker_path.display()
-                    );
-                }
-            }
-        }
-    }
-
-    cwd.clone()
+    find_nearest_native_ancestor_with_markers(
+        fs,
+        cwd,
+        project_root_markers.to_vec(),
+        FindUpErrorPolicy::Ignore,
+        /*sandbox*/ None,
+    )
+    .await
+    .ok()
+    .flatten()
+    .unwrap_or_else(|| cwd.clone())
 }
 
 fn dirs_between_project_root_and_cwd(
@@ -1280,6 +1286,7 @@ pub(crate) async fn skill_roots_from_layer_stack(
         Some(fs),
         config_layer_stack,
         cwd,
+        /*project_root*/ None,
         home_dir,
         Vec::new(),
         Vec::new(),

--- a/codex-rs/core-skills/src/loader_tests.rs
+++ b/codex-rs/core-skills/src/loader_tests.rs
@@ -4,18 +4,29 @@ use codex_config::ConfigLayerEntry;
 use codex_config::ConfigLayerStack;
 use codex_config::ConfigRequirements;
 use codex_config::ConfigRequirementsToml;
+use codex_exec_server::CopyOptions;
+use codex_exec_server::CreateDirectoryOptions;
+use codex_exec_server::ExecutorFileSystem;
+use codex_exec_server::ExecutorFileSystemFuture;
+use codex_exec_server::FileMetadata;
+use codex_exec_server::FileSystemReadStream;
+use codex_exec_server::FileSystemSandboxContext;
 use codex_exec_server::LOCAL_FS;
+use codex_exec_server::ReadDirectoryEntry;
+use codex_exec_server::RemoveOptions;
 use codex_protocol::protocol::Product;
 use codex_protocol::protocol::SkillScope;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_absolute_path::test_support::PathBufExt;
 use codex_utils_absolute_path::test_support::PathExt;
+use codex_utils_path_uri::PathUri;
 use dunce::canonicalize as canonicalize_path;
 use pretty_assertions::assert_eq;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::Mutex;
 use tempfile::TempDir;
 use toml::Value as TomlValue;
 
@@ -24,6 +35,108 @@ const REPO_ROOT_CONFIG_DIR_NAME: &str = ".codex";
 struct TestConfig {
     cwd: AbsolutePathBuf,
     config_layer_stack: ConfigLayerStack,
+}
+
+struct MetadataRecordingFileSystem {
+    metadata_paths: Mutex<Vec<PathUri>>,
+}
+
+impl MetadataRecordingFileSystem {
+    fn new() -> Self {
+        Self {
+            metadata_paths: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn metadata_paths(&self) -> Vec<PathUri> {
+        self.metadata_paths
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+}
+
+impl ExecutorFileSystem for MetadataRecordingFileSystem {
+    fn canonicalize<'a>(
+        &'a self,
+        path: &'a PathUri,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, PathUri> {
+        LOCAL_FS.canonicalize(path, sandbox)
+    }
+
+    fn read_file<'a>(
+        &'a self,
+        path: &'a PathUri,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, Vec<u8>> {
+        LOCAL_FS.read_file(path, sandbox)
+    }
+
+    fn read_file_stream<'a>(
+        &'a self,
+        path: &'a PathUri,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, FileSystemReadStream> {
+        LOCAL_FS.read_file_stream(path, sandbox)
+    }
+
+    fn write_file<'a>(
+        &'a self,
+        path: &'a PathUri,
+        contents: Vec<u8>,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, ()> {
+        LOCAL_FS.write_file(path, contents, sandbox)
+    }
+
+    fn create_directory<'a>(
+        &'a self,
+        path: &'a PathUri,
+        options: CreateDirectoryOptions,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, ()> {
+        LOCAL_FS.create_directory(path, options, sandbox)
+    }
+
+    fn get_metadata<'a>(
+        &'a self,
+        path: &'a PathUri,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, FileMetadata> {
+        self.metadata_paths
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(path.clone());
+        LOCAL_FS.get_metadata(path, sandbox)
+    }
+
+    fn read_directory<'a>(
+        &'a self,
+        path: &'a PathUri,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, Vec<ReadDirectoryEntry>> {
+        LOCAL_FS.read_directory(path, sandbox)
+    }
+
+    fn remove<'a>(
+        &'a self,
+        path: &'a PathUri,
+        options: RemoveOptions,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, ()> {
+        LOCAL_FS.remove(path, options, sandbox)
+    }
+
+    fn copy<'a>(
+        &'a self,
+        source_path: &'a PathUri,
+        destination_path: &'a PathUri,
+        options: CopyOptions,
+        sandbox: Option<&'a FileSystemSandboxContext>,
+    ) -> ExecutorFileSystemFuture<'a, ()> {
+        LOCAL_FS.copy(source_path, destination_path, options, sandbox)
+    }
 }
 
 async fn make_config(codex_home: &TempDir) -> TestConfig {
@@ -143,6 +256,94 @@ fn normalized(path: &Path) -> AbsolutePathBuf {
     canonicalize_path(path)
         .unwrap_or_else(|_| path.to_path_buf())
         .abs()
+}
+
+#[tokio::test]
+async fn repo_skill_roots_use_one_shot_hint_then_observe_new_nearest_marker() {
+    let codex_home = tempfile::tempdir().expect("codex home");
+    let repo = codex_home.path().join("repo");
+    let cwd = repo.join("packages/app");
+    let repo_skills = repo.join(".agents/skills");
+    fs::create_dir_all(&cwd).expect("create cwd");
+    fs::create_dir_all(&repo_skills).expect("create repo skills");
+    mark_as_git_repo(&repo);
+    let config = make_config_for_cwd(&codex_home, cwd).await;
+    let repo = repo.abs();
+
+    let supplied_root_fs = Arc::new(MetadataRecordingFileSystem::new());
+    let roots = super::repo_agents_skill_roots(
+        Some(supplied_root_fs.clone()),
+        &config.config_layer_stack,
+        &config.cwd,
+        Some((&config.cwd, &repo)),
+    )
+    .await;
+    assert!(roots.iter().any(|root| root.path == repo_skills.abs()));
+    assert!(
+        supplied_root_fs
+            .metadata_paths()
+            .iter()
+            .all(|path| path.basename().as_deref() != Some(".git")),
+        "a supplied root must avoid marker probes"
+    );
+
+    let nested_root = codex_home.path().join("repo/packages");
+    let nested_skills = nested_root.join(".agents/skills");
+    fs::create_dir_all(&nested_skills).expect("create nested repo skills");
+    mark_as_git_repo(&nested_root);
+
+    let fallback_fs = Arc::new(MetadataRecordingFileSystem::new());
+    let roots = super::repo_agents_skill_roots(
+        Some(fallback_fs.clone()),
+        &config.config_layer_stack,
+        &config.cwd,
+        /*project_root*/ None,
+    )
+    .await;
+    assert!(roots.iter().any(|root| root.path == nested_skills.abs()));
+    assert!(roots.iter().all(|root| root.path != repo_skills.abs()));
+    assert!(
+        fallback_fs
+            .metadata_paths()
+            .iter()
+            .any(|path| path == &PathUri::from_abs_path(&nested_root.join(".git").abs())),
+        "the post-startup fallback must observe a newly-created nearer marker"
+    );
+}
+
+#[tokio::test]
+async fn repo_skill_roots_ignore_hint_discovered_for_different_cwd() {
+    let codex_home = tempfile::tempdir().expect("codex home");
+    let repo = codex_home.path().join("repo");
+    let nested_root = repo.join("packages");
+    let cwd = nested_root.join("app");
+    let repo_skills = repo.join(".agents/skills");
+    let nested_skills = nested_root.join(".agents/skills");
+    fs::create_dir_all(&cwd).expect("create cwd");
+    fs::create_dir_all(&repo_skills).expect("create repo skills");
+    fs::create_dir_all(&nested_skills).expect("create nested repo skills");
+    mark_as_git_repo(&repo);
+    mark_as_git_repo(&nested_root);
+    let config = make_config_for_cwd(&codex_home, cwd).await;
+    let repo = repo.abs();
+
+    let fs = Arc::new(MetadataRecordingFileSystem::new());
+    let roots = super::repo_agents_skill_roots(
+        Some(fs.clone()),
+        &config.config_layer_stack,
+        &config.cwd,
+        Some((&repo, &repo)),
+    )
+    .await;
+
+    assert!(roots.iter().any(|root| root.path == nested_skills.abs()));
+    assert!(roots.iter().all(|root| root.path != repo_skills.abs()));
+    assert!(
+        fs.metadata_paths()
+            .iter()
+            .any(|path| path == &PathUri::from_abs_path(&nested_root.join(".git").abs())),
+        "a hint from a different cwd must be ignored so a nearer marker can be found"
+    );
 }
 
 #[tokio::test]
@@ -2147,6 +2348,7 @@ async fn skill_roots_include_admin_with_lowest_priority() {
         Some(Arc::clone(&LOCAL_FS)),
         &cfg.config_layer_stack,
         &cfg.cwd,
+        /*project_root*/ None,
         Vec::new(),
         Vec::new(),
     )

--- a/codex-rs/core-skills/src/service.rs
+++ b/codex-rs/core-skills/src/service.rs
@@ -33,7 +33,14 @@ pub struct SkillsLoadInput {
     pub effective_skill_roots: Vec<PluginSkillRoot>,
     pub config_layer_stack: ConfigLayerStack,
     pub bundled_skills_enabled: bool,
+    project_root: Option<ProjectRootHint>,
     plugin_skill_snapshots: Option<PluginSkillSnapshots>,
+}
+
+#[derive(Debug, Clone)]
+struct ProjectRootHint {
+    discovery_cwd: AbsolutePathBuf,
+    project_root: AbsolutePathBuf,
 }
 
 impl SkillsLoadInput {
@@ -48,8 +55,23 @@ impl SkillsLoadInput {
             effective_skill_roots,
             config_layer_stack,
             bundled_skills_enabled,
+            project_root: None,
             plugin_skill_snapshots: None,
         }
+    }
+
+    /// Reuses a project root discovered immediately before this load from the same config and cwd.
+    /// Callers must not retain this hint across turns because filesystem markers can change.
+    pub fn with_project_root(
+        mut self,
+        discovery_cwd: AbsolutePathBuf,
+        project_root: AbsolutePathBuf,
+    ) -> Self {
+        self.project_root = Some(ProjectRootHint {
+            discovery_cwd,
+            project_root,
+        });
+        self
     }
 
     /// Attaches plugin skill snapshots parsed during plugin loading, when available.
@@ -156,6 +178,10 @@ impl SkillsService {
             fs,
             &input.config_layer_stack,
             &input.cwd,
+            input
+                .project_root
+                .as_ref()
+                .map(|hint| (&hint.discovery_cwd, &hint.project_root)),
             input.effective_skill_roots.clone(),
             self.extra_roots(),
         )
@@ -184,6 +210,10 @@ impl SkillsService {
             fs.clone(),
             &input.config_layer_stack,
             &input.cwd,
+            input
+                .project_root
+                .as_ref()
+                .map(|hint| (&hint.discovery_cwd, &hint.project_root)),
             input.effective_skill_roots.clone(),
             self.extra_roots(),
         )

--- a/codex-rs/core/src/agents_md.rs
+++ b/codex-rs/core/src/agents_md.rs
@@ -29,6 +29,7 @@ use codex_file_system::FindUpErrorPolicy;
 use codex_file_system::find_nearest_ancestor_with_markers;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_path_uri::PathUri;
+use std::collections::HashMap;
 use std::io;
 use toml::Value as TomlValue;
 use tracing::error;
@@ -44,15 +45,57 @@ const AGENTS_MD_SEPARATOR: &str = "\n\n--- project-doc ---\n\n";
 
 /// Loads project AGENTS.md content and combines it with host-provided user
 /// instructions.
+#[cfg(test)]
 pub(crate) async fn load_project_instructions(
     config: &Config,
     user_instructions: Option<UserInstructions>,
     environments: &TurnEnvironmentSnapshot,
 ) -> Option<LoadedAgentsMd> {
+    load_project_instructions_with_roots(config, user_instructions, environments)
+        .await
+        .loaded
+}
+
+fn effective_project_root_markers(config: &Config) -> Vec<String> {
+    let mut merged = TomlValue::Table(toml::map::Map::new());
+    for layer in config.config_layer_stack.get_layers(
+        ConfigLayerStackOrdering::LowestPrecedenceFirst,
+        /*include_disabled*/ false,
+    ) {
+        if matches!(layer.name, ConfigLayerSource::Project { .. }) {
+            continue;
+        }
+        merge_toml_values(&mut merged, &layer.config);
+    }
+    match project_root_markers_from_config(&merged) {
+        Ok(Some(markers)) => markers,
+        Ok(None) => default_project_root_markers(),
+        Err(err) => {
+            tracing::warn!("invalid project_root_markers: {err}");
+            default_project_root_markers()
+        }
+    }
+}
+
+pub(crate) struct ProjectInstructionsLoadOutcome {
+    pub(crate) loaded: Option<LoadedAgentsMd>,
+    pub(crate) project_roots: HashMap<String, PathUri>,
+}
+
+/// Loads project instructions and retains the project roots found along the way.
+///
+/// Skills discovery uses the same project-root markers. Keeping this result avoids repeating the
+/// remote marker walk immediately after AGENTS.md discovery during session startup.
+pub(crate) async fn load_project_instructions_with_roots(
+    config: &Config,
+    user_instructions: Option<UserInstructions>,
+    environments: &TurnEnvironmentSnapshot,
+) -> ProjectInstructionsLoadOutcome {
     let mut loaded = LoadedAgentsMd::from_user_instructions(user_instructions);
+    let mut project_roots = HashMap::new();
     for turn_environment in &environments.turn_environments {
         let filesystem = turn_environment.environment.get_filesystem();
-        match read_agents_md(
+        match read_agents_md_with_root(
             config,
             filesystem.as_ref(),
             &turn_environment.environment_id,
@@ -60,8 +103,14 @@ pub(crate) async fn load_project_instructions(
         )
         .await
         {
-            Ok(Some(docs)) => loaded.entries.extend(docs.entries),
-            Ok(None) => {}
+            Ok(outcome) => {
+                if let Some(project_root) = outcome.project_root {
+                    project_roots.insert(turn_environment.environment_id.clone(), project_root);
+                }
+                if let Some(docs) = outcome.loaded {
+                    loaded.entries.extend(docs.entries);
+                }
+            }
             Err(e) => {
                 error!(
                     environment_id = turn_environment.environment_id,
@@ -71,7 +120,15 @@ pub(crate) async fn load_project_instructions(
         }
     }
 
-    (!loaded.is_empty()).then_some(loaded)
+    ProjectInstructionsLoadOutcome {
+        loaded: (!loaded.is_empty()).then_some(loaded),
+        project_roots,
+    }
+}
+
+struct ReadAgentsMdOutcome {
+    loaded: Option<LoadedAgentsMd>,
+    project_root: Option<PathUri>,
 }
 
 /// Attempt to locate and load AGENTS.md documentation.
@@ -80,27 +137,27 @@ pub(crate) async fn load_project_instructions(
 /// discovered doc. If no documentation file is found the function returns
 /// `Ok(None)`. Unexpected I/O failures bubble up as `Err` so callers can
 /// decide how to handle them.
-async fn read_agents_md(
+async fn read_agents_md_with_root(
     config: &Config,
     fs: &dyn ExecutorFileSystem,
     environment_id: &str,
     cwd: &PathUri,
-) -> io::Result<Option<LoadedAgentsMd>> {
+) -> io::Result<ReadAgentsMdOutcome> {
     let max_total = config.project_doc_max_bytes;
 
     if max_total == 0 {
-        return Ok(None);
+        return Ok(ReadAgentsMdOutcome {
+            loaded: None,
+            project_root: None,
+        });
     }
 
-    let paths = agents_md_paths(config, cwd, fs).await?;
-    if paths.is_empty() {
-        return Ok(None);
-    }
+    let discovery = discover_agents_md_paths(config, cwd, fs).await?;
 
     let mut remaining: u64 = max_total as u64;
     let mut loaded = LoadedAgentsMd::default();
 
-    for p in paths {
+    for p in discovery.paths {
         if remaining == 0 {
             break;
         }
@@ -137,40 +194,48 @@ async fn read_agents_md(
         }
     }
 
-    if loaded.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(loaded))
-    }
+    Ok(ReadAgentsMdOutcome {
+        loaded: (!loaded.is_empty()).then_some(loaded),
+        project_root: Some(discovery.project_root),
+    })
+}
+
+#[cfg(test)]
+async fn read_agents_md(
+    config: &Config,
+    fs: &dyn ExecutorFileSystem,
+    environment_id: &str,
+    cwd: &PathUri,
+) -> io::Result<Option<LoadedAgentsMd>> {
+    Ok(read_agents_md_with_root(config, fs, environment_id, cwd)
+        .await?
+        .loaded)
+}
+
+struct AgentsMdPathDiscovery {
+    paths: Vec<PathUri>,
+    project_root: PathUri,
 }
 
 /// Discovers AGENTS.md files from the project root to the current working
 /// directory, inclusive. Symlinks are allowed.
+#[cfg(test)]
 async fn agents_md_paths(
     config: &Config,
     cwd: &PathUri,
     fs: &dyn ExecutorFileSystem,
 ) -> io::Result<Vec<PathUri>> {
+    Ok(discover_agents_md_paths(config, cwd, fs).await?.paths)
+}
+
+async fn discover_agents_md_paths(
+    config: &Config,
+    cwd: &PathUri,
+    fs: &dyn ExecutorFileSystem,
+) -> io::Result<AgentsMdPathDiscovery> {
     let dir = cwd.clone();
 
-    let mut merged = TomlValue::Table(toml::map::Map::new());
-    for layer in config.config_layer_stack.get_layers(
-        ConfigLayerStackOrdering::LowestPrecedenceFirst,
-        /*include_disabled*/ false,
-    ) {
-        if matches!(layer.name, ConfigLayerSource::Project { .. }) {
-            continue;
-        }
-        merge_toml_values(&mut merged, &layer.config);
-    }
-    let project_root_markers = match project_root_markers_from_config(&merged) {
-        Ok(Some(markers)) => markers,
-        Ok(None) => default_project_root_markers(),
-        Err(err) => {
-            tracing::warn!("invalid project_root_markers: {err}");
-            default_project_root_markers()
-        }
-    };
+    let project_root_markers = effective_project_root_markers(config);
     let project_root = find_nearest_ancestor_with_markers(
         fs,
         &dir,
@@ -179,12 +244,13 @@ async fn agents_md_paths(
         /*sandbox*/ None,
     )
     .await?;
-    let search_dirs = if let Some(root) = project_root {
+    let project_root = project_root.unwrap_or_else(|| dir.clone());
+    let search_dirs = {
         let mut dirs = Vec::new();
         let mut cursor = dir.clone();
         loop {
             dirs.push(cursor.clone());
-            if cursor == root {
+            if cursor == project_root {
                 break;
             }
             let Some(parent) = cursor.parent() else {
@@ -194,8 +260,6 @@ async fn agents_md_paths(
         }
         dirs.reverse();
         dirs
-    } else {
-        vec![dir]
     };
 
     let mut found = Vec::new();
@@ -216,7 +280,10 @@ async fn agents_md_paths(
             }
         }
     }
-    Ok(found)
+    Ok(AgentsMdPathDiscovery {
+        paths: found,
+        project_root,
+    })
 }
 
 fn candidate_filenames(config: &Config) -> Vec<&str> {

--- a/codex-rs/core/src/agents_md_manager.rs
+++ b/codex-rs/core/src/agents_md_manager.rs
@@ -1,9 +1,10 @@
 use crate::agents_md::LoadedAgentsMd;
-use crate::agents_md::load_project_instructions;
+use crate::agents_md::load_project_instructions_with_roots;
 use crate::config::Config;
 use crate::environment_selection::TurnEnvironmentSnapshot;
 use codex_extension_api::UserInstructions;
 use codex_protocol::protocol::TurnEnvironmentSelection;
+use codex_utils_path_uri::PathUri;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -28,19 +29,29 @@ impl AgentsMdManager {
         }
     }
 
-    pub(crate) async fn refresh(&self, config: &Config, environments: &TurnEnvironmentSnapshot) {
+    pub(crate) async fn refresh(
+        &self,
+        config: &Config,
+        environments: &TurnEnvironmentSnapshot,
+    ) -> Option<PathUri> {
         let selections = environments.to_selections();
         if self.cache.lock().await.selections.as_ref() == Some(&selections) {
-            return;
+            return None;
         }
 
-        let loaded =
-            load_project_instructions(config, self.user_instructions.clone(), environments)
-                .await
-                .map(Arc::new);
+        let mut outcome = load_project_instructions_with_roots(
+            config,
+            self.user_instructions.clone(),
+            environments,
+        )
+        .await;
+        let primary_project_root = environments
+            .primary()
+            .and_then(|primary| outcome.project_roots.remove(&primary.environment_id));
         let mut cache = self.cache.lock().await;
         cache.selections = Some(selections);
-        cache.loaded = loaded;
+        cache.loaded = outcome.loaded.map(Arc::new);
+        primary_project_root
     }
 
     pub(crate) async fn get_loaded(&self) -> Option<Arc<LoadedAgentsMd>> {

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -146,6 +146,8 @@ pub const X_RESPONSESAPI_INCLUDE_TIMING_METRICS_HEADER: &str =
     "x-responsesapi-include-timing-metrics";
 const X_CODEX_WS_STREAM_REQUEST_START_MS_CLIENT_METADATA_KEY: &str =
     "x-codex-ws-stream-request-start-ms";
+const X_CODEX_WS_STREAM_REQUEST_ORDINAL_CLIENT_METADATA_KEY: &str =
+    "x-codex-ws-stream-request-ordinal";
 const WS_REQUEST_HEADER_RESPONSES_LITE_CLIENT_METADATA_KEY: &str =
     "ws_request_header_x_openai_internal_codex_responses_lite";
 const RESPONSES_WEBSOCKETS_V2_BETA_HEADER_VALUE: &str = "responses_websockets=2026-02-06";
@@ -292,6 +294,7 @@ struct WebsocketSession {
     last_response_rx: Option<oneshot::Receiver<LastResponse>>,
     last_response_from_untraced_warmup: bool,
     connection_reused: StdMutex<bool>,
+    next_request_ordinal: u64,
 }
 
 // This is intentionally not a `PartialEq` implementation: request equality includes `input` and
@@ -349,6 +352,12 @@ fn responses_request_properties_match(
 }
 
 impl WebsocketSession {
+    fn take_next_request_ordinal(&mut self) -> u64 {
+        let ordinal = self.next_request_ordinal;
+        self.next_request_ordinal = self.next_request_ordinal.saturating_add(1);
+        ordinal
+    }
+
     fn set_connection_reused(&self, connection_reused: bool) {
         *self
             .connection_reused
@@ -1083,6 +1092,7 @@ impl ModelClientSession {
         self.websocket_session.last_request = None;
         self.websocket_session.last_response_rx = None;
         self.websocket_session.last_response_from_untraced_warmup = false;
+        self.websocket_session.next_request_ordinal = 0;
         self.websocket_session
             .set_connection_reused(/*connection_reused*/ false);
     }
@@ -1284,6 +1294,7 @@ impl ModelClientSession {
             self.websocket_session.last_request = None;
             self.websocket_session.last_response_rx = None;
             self.websocket_session.last_response_from_untraced_warmup = false;
+            self.websocket_session.next_request_ordinal = 0;
             let new_conn = match self
                 .client
                 .connect_websocket(
@@ -1578,7 +1589,8 @@ impl ModelClientSession {
             } else {
                 inference_trace.start_attempt()
             };
-            stamp_ws_stream_request_start_ms(&mut ws_request);
+            let request_ordinal = self.websocket_session.take_next_request_ordinal();
+            stamp_ws_stream_request_metadata(&mut ws_request, request_ordinal);
             let ResponsesWsRequest::ResponseCreate(ws_payload) = &mut ws_request;
             let store = ws_payload.store;
             self.client
@@ -1797,19 +1809,22 @@ impl ModelClientSession {
     }
 }
 
-/// Stamp a ResponsesWsRequest with the current time.
+/// Stamp a ResponsesWsRequest with request-scoped correlation metadata.
 ///
 /// Meant to be called just before sending the request over the socket, to capture realistic
-/// transport timing.
-fn stamp_ws_stream_request_start_ms(request: &mut ResponsesWsRequest) {
+/// transport timing. The ordinal is scoped to the physical WebSocket connection and increments
+/// for every `response.create`, including `generate=false` warmups.
+fn stamp_ws_stream_request_metadata(request: &mut ResponsesWsRequest, request_ordinal: u64) {
     let ResponsesWsRequest::ResponseCreate(payload) = request;
-    payload
-        .client_metadata
-        .get_or_insert_with(HashMap::new)
-        .insert(
-            X_CODEX_WS_STREAM_REQUEST_START_MS_CLIENT_METADATA_KEY.to_string(),
-            crate::turn_timing::now_unix_timestamp_ms().to_string(),
-        );
+    let client_metadata = payload.client_metadata.get_or_insert_with(HashMap::new);
+    client_metadata.insert(
+        X_CODEX_WS_STREAM_REQUEST_START_MS_CLIENT_METADATA_KEY.to_string(),
+        crate::turn_timing::now_unix_timestamp_ms().to_string(),
+    );
+    client_metadata.insert(
+        X_CODEX_WS_STREAM_REQUEST_ORDINAL_CLIENT_METADATA_KEY.to_string(),
+        request_ordinal.to_string(),
+    );
 }
 
 /// Builds the extra headers attached to Responses API requests.

--- a/codex-rs/core/src/codex_thread.rs
+++ b/codex-rs/core/src/codex_thread.rs
@@ -565,6 +565,26 @@ impl CodexThread {
         live_thread.append_items(items).await
     }
 
+    /// Appends rollout items and waits until their derived thread metadata is queryable.
+    ///
+    /// Most turn-path appends intentionally project metadata in the background. Callers that
+    /// respond before a first turn exists, such as thread goals, need this stronger visibility
+    /// contract so an immediate thread read/list observes the new preview.
+    pub async fn append_rollout_items_and_flush_metadata(
+        &self,
+        items: &[RolloutItem],
+    ) -> ThreadStoreResult<()> {
+        let live_thread = self
+            .codex
+            .session
+            .live_thread_for_persistence("append rollout items and flush metadata")
+            .map_err(|err| ThreadStoreError::Internal {
+                message: err.to_string(),
+            })?;
+        live_thread.append_items(items).await?;
+        live_thread.flush().await
+    }
+
     pub fn state_db(&self) -> Option<StateDbHandle> {
         self.codex.state_db()
     }

--- a/codex-rs/core/src/environment_selection.rs
+++ b/codex-rs/core/src/environment_selection.rs
@@ -14,6 +14,7 @@ use codex_utils_path_uri::PathUri;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use futures::future::Shared;
+use tracing::Instrument;
 
 use crate::session::turn_context::TurnEnvironment;
 use crate::shell::Shell;
@@ -132,7 +133,12 @@ impl ThreadEnvironments {
                 self.shell_snapshot.clone(),
             )
             .remote_handle();
-            drop(tokio::spawn(resolution_task));
+            drop(tokio::spawn(resolution_task.instrument(
+                tracing::info_span!(
+                    "thread_environment.resolve",
+                    environment_id = %selected_environment.environment_id,
+                ),
+            )));
             let resolution = resolution.boxed().shared();
             next.push(SelectedTurnEnvironment {
                 selection: selected_environment.clone(),

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -168,6 +168,7 @@ use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use toml::Value as TomlValue;
 use tracing::Instrument;
+use tracing::Span;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
@@ -979,6 +980,33 @@ fn push_prompt_fragment(
     }
 }
 
+#[derive(Clone, Copy)]
+enum EventDeliveryTrace {
+    None,
+    ExecEnd,
+}
+
+impl EventDeliveryTrace {
+    fn for_event(event: &Event) -> Self {
+        if matches!(&event.msg, EventMsg::ExecCommandEnd(_)) {
+            Self::ExecEnd
+        } else {
+            Self::None
+        }
+    }
+
+    fn span(self, make_span: impl FnOnce() -> Span) -> Span {
+        match self {
+            Self::ExecEnd => make_span(),
+            Self::None => Span::none(),
+        }
+    }
+
+    fn in_scope<T>(self, make_span: impl FnOnce() -> Span, f: impl FnOnce() -> T) -> T {
+        self.span(make_span).in_scope(f)
+    }
+}
+
 impl Session {
     pub(crate) async fn app_server_client_metadata(&self) -> AppServerClientMetadata {
         let state = self.state.lock().await;
@@ -1741,6 +1769,12 @@ impl Session {
     /// Persist the event to rollout and send it to clients.
     pub(crate) async fn send_event(&self, turn_context: &TurnContext, msg: EventMsg) {
         let legacy_source = msg.clone();
+        let trace_exec_end = matches!(&legacy_source, EventMsg::ExecCommandEnd(_));
+        let event_trace = if trace_exec_end {
+            EventDeliveryTrace::ExecEnd
+        } else {
+            EventDeliveryTrace::None
+        };
         if let EventMsg::Error(error) = &legacy_source
             && error
                 .codex_error_info
@@ -1759,25 +1793,70 @@ impl Session {
         self.services
             .rollout_thread_trace
             .record_tool_call_event(turn_context.sub_id.clone(), &legacy_source);
-        let event = Event {
-            id: turn_context.sub_id.clone(),
-            msg,
-        };
-        self.send_event_raw(event).await;
+        async {
+            let event = event_trace.in_scope(
+                || info_span!("session.exec_end.primary.construct_event"),
+                || Event {
+                    id: turn_context.sub_id.clone(),
+                    msg,
+                },
+            );
+            self.send_event_raw_with_trace(event, event_trace).await;
+        }
+        .instrument(if trace_exec_end {
+            info_span!("session.exec_end.primary")
+        } else {
+            Span::none()
+        })
+        .await;
         self.maybe_notify_parent_of_terminal_turn(turn_context, &legacy_source)
+            .instrument(if trace_exec_end {
+                info_span!("session.exec_end.notify_parent")
+            } else {
+                Span::none()
+            })
             .await;
         self.maybe_mirror_event_text_to_realtime(&legacy_source)
+            .instrument(if trace_exec_end {
+                info_span!("session.exec_end.mirror_realtime")
+            } else {
+                Span::none()
+            })
             .await;
         self.maybe_clear_realtime_handoff_for_event(&legacy_source)
+            .instrument(if trace_exec_end {
+                info_span!("session.exec_end.clear_realtime_handoff")
+            } else {
+                Span::none()
+            })
             .await;
 
         let show_raw_agent_reasoning = self.show_raw_agent_reasoning();
         for legacy in legacy_source.as_legacy_events(show_raw_agent_reasoning) {
-            let legacy_event = Event {
-                id: turn_context.sub_id.clone(),
-                msg: legacy,
+            let trace_legacy_exec_end =
+                trace_exec_end || matches!(&legacy, EventMsg::ExecCommandEnd(_));
+            let legacy_event_trace = if trace_legacy_exec_end {
+                EventDeliveryTrace::ExecEnd
+            } else {
+                EventDeliveryTrace::None
             };
-            self.send_event_raw(legacy_event).await;
+            async {
+                let legacy_event = legacy_event_trace.in_scope(
+                    || info_span!("session.exec_end.legacy.construct_event"),
+                    || Event {
+                        id: turn_context.sub_id.clone(),
+                        msg: legacy,
+                    },
+                );
+                self.send_event_raw_with_trace(legacy_event, legacy_event_trace)
+                    .await;
+            }
+            .instrument(if trace_legacy_exec_end {
+                info_span!("session.exec_end.legacy")
+            } else {
+                Span::none()
+            })
+            .await;
         }
     }
 
@@ -1914,21 +1993,53 @@ impl Session {
     }
 
     pub(crate) async fn send_event_raw(&self, event: Event) {
+        let event_trace = EventDeliveryTrace::for_event(&event);
+        self.send_event_raw_with_trace(event, event_trace).await;
+    }
+
+    async fn send_event_raw_with_trace(&self, event: Event, event_trace: EventDeliveryTrace) {
         // Persist the event into rollout storage (the store filters as needed).
-        let rollout_items = vec![RolloutItem::EventMsg(event.msg.clone())];
-        self.persist_rollout_items(&rollout_items).await;
-        self.services
-            .rollout_thread_trace
-            .record_protocol_event(&event.msg);
-        self.deliver_event_raw(event).await;
+        let rollout_items = event_trace.in_scope(
+            || info_span!("session.exec_end.construct_rollout_items"),
+            || vec![RolloutItem::EventMsg(event.msg.clone())],
+        );
+        self.persist_rollout_items(&rollout_items)
+            .instrument(event_trace.span(|| info_span!("session.exec_end.rollout_append")))
+            .await;
+        event_trace.in_scope(
+            || info_span!("session.exec_end.record_protocol_event"),
+            || {
+                self.services
+                    .rollout_thread_trace
+                    .record_protocol_event(&event.msg);
+            },
+        );
+        self.deliver_event_raw_with_trace(event, event_trace)
+            .instrument(event_trace.span(|| info_span!("session.exec_end.downstream_delivery")))
+            .await;
     }
 
     async fn deliver_event_raw(&self, event: Event) {
+        let event_trace = EventDeliveryTrace::for_event(&event);
+        self.deliver_event_raw_with_trace(event, event_trace).await;
+    }
+
+    async fn deliver_event_raw_with_trace(&self, event: Event, event_trace: EventDeliveryTrace) {
         // Record the last known agent status.
-        if let Some(status) = agent_status_from_event(&event.msg) {
-            self.agent_status.send_replace(status);
-        }
-        if let Err(e) = self.tx_event.send(event).await {
+        event_trace.in_scope(
+            || info_span!("session.exec_end.broadcast_agent_status"),
+            || {
+                if let Some(status) = agent_status_from_event(&event.msg) {
+                    self.agent_status.send_replace(status);
+                }
+            },
+        );
+        if let Err(e) = self
+            .tx_event
+            .send(event)
+            .instrument(event_trace.span(|| info_span!("session.exec_end.client_delivery_barrier")))
+            .await
+        {
             debug!("dropping event because channel is closed: {e}");
         }
     }
@@ -2846,7 +2957,8 @@ impl Session {
             turn_context.environments.clone()
         };
         if deferred_executor_enabled {
-            self.services
+            let _ = self
+                .services
                 .agents_md_manager
                 .refresh(&turn_context.config, &environments)
                 .await;

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -444,14 +444,21 @@ async fn warm_plugins_and_skills_for_session_init(
     plugins_manager: Arc<PluginsManager>,
     skills_service: Arc<SkillsService>,
     turn_environments: &TurnEnvironmentSnapshot,
+    project_root: Option<(AbsolutePathBuf, AbsolutePathBuf)>,
 ) -> Vec<SkillError> {
     let fs = turn_environments.primary_filesystem();
     let plugins_input = config.plugins_config_input();
     let plugin_outcome = plugins_manager.plugins_for_config(&plugins_input).await;
     let effective_skill_roots = plugin_outcome.effective_plugin_skill_roots();
     let plugin_skill_snapshots = plugins_manager.plugin_skill_snapshots_for_config(&plugins_input);
-    let skills_input = skills_load_input_from_config(config.as_ref(), effective_skill_roots)
-        .with_plugin_skill_snapshots(plugin_skill_snapshots);
+    let skills_input = skills_load_input_from_config(config.as_ref(), effective_skill_roots);
+    let skills_input = match project_root {
+        Some((discovery_cwd, project_root)) => {
+            skills_input.with_project_root(discovery_cwd, project_root)
+        }
+        None => skills_input,
+    }
+    .with_plugin_skill_snapshots(plugin_skill_snapshots);
     skills_service
         .snapshot_for_config(&skills_input, fs)
         .await
@@ -717,48 +724,63 @@ impl Session {
             (auth, mcp_config, mcp_servers, auth_statuses, tool_plugin_provenance),
         ) = tokio::join!(thread_persistence_fut, state_db_fut, auth_and_mcp_fut);
 
-        let mut live_thread_init =
+        let mut live_thread_init = {
+            let _span = info_span!(
+                "session_init.post_parallel_setup",
+                otel.name = "session_init.post_parallel_setup",
+            )
+            .entered();
             LiveThreadInitGuard::new(thread_persistence_result.map_err(|e| {
                 error!("failed to initialize thread persistence: {e:#}");
                 e
-            })?);
+            })?)
+        };
         let session_result: anyhow::Result<Arc<Self>> = async {
-            let rollout_path = if let Some(live_thread) = live_thread_init.as_ref() {
-                live_thread.local_rollout_path().await?
-            } else {
-                None
-            };
-            let trace_agent_path = session_configuration
-                .session_source
-                .get_agent_path()
-                .unwrap_or_else(codex_protocol::AgentPath::root);
-            let trace_task_name =
-                (!trace_agent_path.is_root()).then(|| trace_agent_path.name().to_string());
-            let trace_metadata = ThreadStartedTraceMetadata {
-                thread_id: thread_id.to_string(),
-                agent_path: trace_agent_path.to_string(),
-                task_name: trace_task_name,
-                nickname: session_configuration.session_source.get_nickname(),
-                agent_role: session_configuration.session_source.get_agent_role(),
-                session_source: session_configuration.session_source.clone(),
-                cwd: session_configuration.cwd().to_path_buf(),
-                rollout_path: rollout_path.clone(),
-                model: session_configuration.collaboration_mode.model().to_string(),
-                provider_name: config.model_provider_id.clone(),
-                approval_policy: session_configuration.approval_policy.value().to_string(),
-                sandbox_policy: format!("{:?}", session_configuration.sandbox_policy()),
-            };
-            let rollout_thread_trace = if matches!(
-                session_configuration.session_source,
-                SessionSource::SubAgent(SubAgentSource::ThreadSpawn { .. })
-            ) {
-                // Spawned child threads are part of their root rollout tree. If the
-                // parent had no trace bundle, do not create an orphan child bundle
-                // that looks like an independent rollout.
-                parent_rollout_thread_trace.start_child_thread_trace_or_disabled(trace_metadata)
-            } else {
-                ThreadTraceContext::start_root_or_disabled(trace_metadata)
-            };
+            let (rollout_path, rollout_thread_trace) = async {
+                let rollout_path = if let Some(live_thread) = live_thread_init.as_ref() {
+                    live_thread.local_rollout_path().await?
+                } else {
+                    None
+                };
+                let trace_agent_path = session_configuration
+                    .session_source
+                    .get_agent_path()
+                    .unwrap_or_else(codex_protocol::AgentPath::root);
+                let trace_task_name =
+                    (!trace_agent_path.is_root()).then(|| trace_agent_path.name().to_string());
+                let trace_metadata = ThreadStartedTraceMetadata {
+                    thread_id: thread_id.to_string(),
+                    agent_path: trace_agent_path.to_string(),
+                    task_name: trace_task_name,
+                    nickname: session_configuration.session_source.get_nickname(),
+                    agent_role: session_configuration.session_source.get_agent_role(),
+                    session_source: session_configuration.session_source.clone(),
+                    cwd: session_configuration.cwd().to_path_buf(),
+                    rollout_path: rollout_path.clone(),
+                    model: session_configuration.collaboration_mode.model().to_string(),
+                    provider_name: config.model_provider_id.clone(),
+                    approval_policy: session_configuration.approval_policy.value().to_string(),
+                    sandbox_policy: format!("{:?}", session_configuration.sandbox_policy()),
+                };
+                let rollout_thread_trace = if matches!(
+                    session_configuration.session_source,
+                    SessionSource::SubAgent(SubAgentSource::ThreadSpawn { .. })
+                ) {
+                    // Spawned child threads are part of their root rollout tree. If the
+                    // parent had no trace bundle, do not create an orphan child bundle
+                    // that looks like an independent rollout.
+                    parent_rollout_thread_trace
+                        .start_child_thread_trace_or_disabled(trace_metadata)
+                } else {
+                    ThreadTraceContext::start_root_or_disabled(trace_metadata)
+                };
+                Ok::<_, anyhow::Error>((rollout_path, rollout_thread_trace))
+            }
+            .instrument(info_span!(
+                "session_init.rollout_trace_setup",
+                otel.name = "session_init.rollout_trace_setup",
+            ))
+            .await?;
 
             let mut post_session_configured_events = Vec::<Event>::new();
 
@@ -792,6 +814,11 @@ impl Session {
             ) {
                 post_session_configured_events.push(event);
             }
+            let telemetry_creation_span = info_span!(
+                "session_init.telemetry_creation",
+                otel.name = "session_init.telemetry_creation",
+            )
+            .entered();
             let auth = auth.as_ref();
             let auth_mode = auth.map(CodexAuth::auth_mode).map(TelemetryAuthMode::from);
             let account_id = auth.and_then(CodexAuth::get_account_id);
@@ -831,35 +858,56 @@ impl Session {
                 slug: Some(session_model),
             };
             config.features.emit_metrics(&session_telemetry);
-            session_telemetry.counter(
-                THREAD_STARTED_METRIC,
-                /*inc*/ 1,
-                &[(
-                    "is_git",
-                    if get_git_repo_root(session_configuration.cwd()).is_some() {
-                        "true"
-                    } else {
-                        "false"
-                    },
-                )],
-            );
+            drop(telemetry_creation_span);
+            let is_git = {
+                let _span = info_span!(
+                    "session_init.git_repo_probe",
+                    otel.name = "session_init.git_repo_probe",
+                )
+                .entered();
+                get_git_repo_root(session_configuration.cwd()).is_some()
+            };
+            {
+                let _span = info_span!(
+                    "session_init.thread_started_telemetry",
+                    otel.name = "session_init.thread_started_telemetry",
+                )
+                .entered();
+                session_telemetry.counter(
+                    THREAD_STARTED_METRIC,
+                    /*inc*/ 1,
+                    &[("is_git", if is_git { "true" } else { "false" })],
+                );
+            }
 
-            session_telemetry.conversation_starts(
-                config.model_provider.name.as_str(),
-                session_configuration.collaboration_mode.reasoning_effort(),
-                config
-                    .model_reasoning_summary
-                    .unwrap_or(ReasoningSummaryConfig::Auto),
-                config.model_context_window,
-                config.model_auto_compact_token_limit,
-                config.permissions.approval_policy.value(),
-                config
-                    .permissions
-                    .legacy_sandbox_policy(session_configuration.cwd().as_path()),
-                mcp_servers.keys().map(String::as_str).collect(),
-            );
+            {
+                let _span = info_span!(
+                    "session_init.conversation_start_telemetry",
+                    otel.name = "session_init.conversation_start_telemetry",
+                )
+                .entered();
+                session_telemetry.conversation_starts(
+                    config.model_provider.name.as_str(),
+                    session_configuration.collaboration_mode.reasoning_effort(),
+                    config
+                        .model_reasoning_summary
+                        .unwrap_or(ReasoningSummaryConfig::Auto),
+                    config.model_context_window,
+                    config.model_auto_compact_token_limit,
+                    config.permissions.approval_policy.value(),
+                    config
+                        .permissions
+                        .legacy_sandbox_policy(session_configuration.cwd().as_path()),
+                    mcp_servers.keys().map(String::as_str).collect(),
+                );
+            }
 
             let use_zsh_fork_shell = config.features.enabled(Feature::ShellZshFork);
+            let default_shell_resolution_span = info_span!(
+                "session_init.default_shell_resolution",
+                otel.name = "session_init.default_shell_resolution",
+            )
+            .entered();
             let default_shell = if let Some(user_shell_override) =
                 session_configuration.user_shell_override.clone()
             {
@@ -880,6 +928,12 @@ impl Session {
             } else {
                 shell::default_user_shell()
             };
+            drop(default_shell_resolution_span);
+            let turn_environment_creation_span = info_span!(
+                "session_init.turn_environment_creation",
+                otel.name = "session_init.turn_environment_creation",
+            )
+            .entered();
             let shell_snapshot = if config.features.enabled(Feature::ShellSnapshot) {
                 ShellSnapshot::new(
                     config.codex_home.clone(),
@@ -897,17 +951,41 @@ impl Session {
                 inherited_environments.unwrap_or_default(),
                 config.features.enabled(Feature::DeferredExecutor),
             ));
-            turn_environments.update_selections(session_configuration.environment_selections());
-            let resolved_environments = turn_environments.snapshot().await;
-            let agents_md_manager = Arc::new(AgentsMdManager::new(user_instructions));
-            agents_md_manager
-                .refresh(config.as_ref(), &resolved_environments)
+            drop(turn_environment_creation_span);
+            {
+                let _span = info_span!(
+                    "session_init.turn_environment_update",
+                    otel.name = "session_init.turn_environment_update",
+                )
+                .entered();
+                turn_environments.update_selections(session_configuration.environment_selections());
+            }
+            let resolved_environments = turn_environments
+                .snapshot()
+                .instrument(info_span!(
+                    "session_init.turn_environment_snapshot",
+                    otel.name = "session_init.turn_environment_snapshot",
+                ))
                 .await;
+            let agents_md_manager = Arc::new(AgentsMdManager::new(user_instructions));
+            let project_root = agents_md_manager
+                .refresh(config.as_ref(), &resolved_environments)
+                .instrument(info_span!(
+                    "session_init.agents_md_refresh",
+                    otel.name = "session_init.agents_md_refresh",
+                ))
+                .await
+                .and_then(|root| root.to_abs_path().ok());
+            let project_root = resolved_environments
+                .primary()
+                .and_then(|environment| environment.cwd().to_abs_path().ok())
+                .zip(project_root);
             let plugin_skill_errors = warm_plugins_and_skills_for_session_init(
                 Arc::clone(&config),
                 Arc::clone(&plugins_manager),
                 Arc::clone(&skills_service),
                 &resolved_environments,
+                project_root,
             )
             .instrument(info_span!(
                 "session_init.plugin_skill_warmup",

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -167,10 +167,9 @@ pub(crate) async fn run_turn(
     // run_turn owns the step used to seed context and make the first sampling request.
     let first_step_context = sess.capture_step_context(Arc::clone(&turn_context)).await;
     // Keep the exact model-visible state used by this turn and its inline compactions.
-    let (mut world_state, display_roots) = tokio::join!(
-        sess.record_context_updates_and_set_reference_context_item(first_step_context.as_ref()),
-        turn_diff_display_roots(turn_context.as_ref()),
-    );
+    let mut world_state = sess
+        .record_context_updates_and_set_reference_context_item(first_step_context.as_ref())
+        .await;
 
     let Some((injection_items, explicitly_enabled_connectors)) = build_skills_and_plugins(
         &sess,
@@ -210,9 +209,7 @@ pub(crate) async fn run_turn(
     let mut stop_hook_active = false;
     // Although from the perspective of codex.rs, TurnDiffTracker has the lifecycle of a Task which contains
     // many turns, from the perspective of the user, it is a single turn.
-    let turn_diff_tracker = Arc::new(tokio::sync::Mutex::new(
-        TurnDiffTracker::with_environment_display_roots(display_roots),
-    ));
+    let turn_diff_tracker = Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new()));
 
     // `ModelClientSession` is turn-scoped and caches WebSocket + sticky routing state, so we reuse
     // one instance across retries within this turn.
@@ -459,7 +456,7 @@ pub(crate) async fn run_turn(
 }
 
 #[instrument(level = "trace", skip_all)]
-async fn turn_diff_display_roots(turn_context: &TurnContext) -> Vec<(String, PathBuf)> {
+pub(crate) async fn turn_diff_display_roots(turn_context: &TurnContext) -> Vec<(String, PathBuf)> {
     let mut display_roots = Vec::new();
     for turn_environment in &turn_context.environments.turn_environments {
         // TODO(anp): Migrate git-root discovery and diff display roots to PathUri so foreign

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -612,13 +612,13 @@ impl Session {
                 Ok(update) => update,
                 Err(err) => {
                     let message = err.to_string();
-                    self.send_event_raw(Event {
+                    Box::pin(self.send_event_raw(Event {
                         id: sub_id.clone(),
                         msg: EventMsg::Error(ErrorEvent {
                             message: message.clone(),
                             codex_error_info: Some(CodexErrorInfo::BadRequest),
                         }),
-                    })
+                    }))
                     .await;
                     return Err(CodexErr::InvalidRequest(message));
                 }

--- a/codex-rs/core/src/tools/events.rs
+++ b/codex-rs/core/src/tools/events.rs
@@ -1,5 +1,6 @@
 use crate::function_tool::FunctionCallError;
 use crate::session::session::Session;
+use crate::session::turn::turn_diff_display_roots;
 use crate::session::turn_context::TurnContext;
 use crate::tools::context::SharedTurnDiffTracker;
 use crate::tools::sandboxing::ToolError;
@@ -25,6 +26,7 @@ use codex_utils_path_uri::PathUri;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
+use tracing::instrument;
 
 use super::format_exec_output_str;
 
@@ -83,7 +85,9 @@ fn tracker_update_for_known_delta<'a>(
     environment_id: Option<&str>,
     delta: &'a AppliedPatchDelta,
 ) -> TurnDiffTrackerUpdate<'a> {
-    if delta.is_exact() && delta.is_empty() {
+    if !delta.is_exact() {
+        TurnDiffTrackerUpdate::Invalidate
+    } else if delta.is_empty() {
         TurnDiffTrackerUpdate::None
     } else {
         TurnDiffTrackerUpdate::Track {
@@ -93,6 +97,7 @@ fn tracker_update_for_known_delta<'a>(
     }
 }
 
+#[instrument(name = "tool_event.exec_begin", level = "info", skip_all)]
 pub(crate) async fn emit_exec_command_begin(
     ctx: ToolEventCtx<'_>,
     command: &[String],
@@ -537,6 +542,7 @@ async fn emit_exec_stage(
     }
 }
 
+#[instrument(name = "tool_event.exec_end", level = "info", skip_all)]
 async fn emit_exec_end(
     ctx: ToolEventCtx<'_>,
     exec_input: ExecCommandInput<'_>,
@@ -590,6 +596,19 @@ async fn emit_patch_end(
         .await;
 
     if let Some(tracker) = ctx.turn_diff_tracker {
+        if matches!(&tracker_update, TurnDiffTrackerUpdate::Track { .. }) {
+            let should_discover_display_roots = {
+                let guard = tracker.lock().await;
+                guard.needs_display_roots()
+            };
+            if should_discover_display_roots {
+                let display_roots = turn_diff_display_roots(ctx.turn).await;
+                let mut guard = tracker.lock().await;
+                if guard.needs_display_roots() {
+                    guard.set_environment_display_roots(display_roots);
+                }
+            }
+        }
         let (should_emit_turn_diff, unified_diff) = {
             let mut guard = tracker.lock().await;
             let had_unified_diff = guard.has_unified_diff();

--- a/codex-rs/core/src/tools/handlers/unified_exec/exec_command.rs
+++ b/codex-rs/core/src/tools/handlers/unified_exec/exec_command.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
+use tracing::Instrument;
+use tracing::instrument;
 
 use crate::function_tool::FunctionCallError;
 use crate::maybe_emit_implicit_skill_invocation;
@@ -103,6 +105,12 @@ impl ToolExecutor<ToolInvocation> for ExecCommandHandler {
 }
 
 impl ExecCommandHandler {
+    #[instrument(
+        name = "unified_exec.handle_call",
+        level = "info",
+        skip_all,
+        fields(call_id = %invocation.call_id)
+    )]
     async fn handle_call(
         &self,
         invocation: ToolInvocation,
@@ -128,11 +136,16 @@ impl ExecCommandHandler {
 
         let manager: &UnifiedExecProcessManager = &session.services.unified_exec_manager;
         let context = UnifiedExecContext::new(session.clone(), turn.clone(), call_id.clone());
-        let environment_args: ExecCommandEnvironmentArgs = parse_arguments(&arguments)?;
-        let Some(turn_environment) = resolve_tool_environment(
-            &step_context.environments,
-            environment_args.environment_id.as_deref(),
-        )?
+        let environment_args: ExecCommandEnvironmentArgs =
+            tracing::info_span!("unified_exec.handle_call.parse_environment_args")
+                .in_scope(|| parse_arguments(&arguments))?;
+        let Some(turn_environment) =
+            tracing::info_span!("unified_exec.handle_call.resolve_environment").in_scope(|| {
+                resolve_tool_environment(
+                    &step_context.environments,
+                    environment_args.environment_id.as_deref(),
+                )
+            })?
         else {
             return Err(FunctionCallError::RespondToModel(
                 "unified exec is unavailable in this session".to_string(),
@@ -177,18 +190,21 @@ impl ExecCommandHandler {
                 )));
             }
         };
-        let mut args: ExecCommandArgs = match native_cwd.as_ref() {
-            Some(native_cwd) => {
-                // The base path only resolves paths nested in the permissions config types.
-                parse_arguments_with_base_path(&arguments, native_cwd)?
-            }
-            None => {
-                // Parsing without a base only skips relative-path resolution inside the
-                // permissions config. That is safe only for a truly unsandboxed attempt;
-                // sandboxed attempts fall through and return the conversion error below.
-                parse_arguments(&arguments)?
-            }
-        };
+        let mut args: ExecCommandArgs =
+            tracing::info_span!("unified_exec.handle_call.parse_exec_args").in_scope(|| {
+                match native_cwd.as_ref() {
+                    Some(native_cwd) => {
+                        // The base path only resolves paths nested in the permissions config types.
+                        parse_arguments_with_base_path(&arguments, native_cwd)
+                    }
+                    None => {
+                        // Parsing without a base only skips relative-path resolution inside the
+                        // permissions config. That is safe only for a truly unsandboxed attempt;
+                        // sandboxed attempts fall through and return the conversion error below.
+                        parse_arguments(&arguments)
+                    }
+                }
+            })?;
         let hook_command = args.cmd.clone();
         // TODO(anp) wire PathUri through implicit skills instead of skipping on foreign paths
         if let Some(native_cwd) = native_cwd.as_ref() {
@@ -198,6 +214,9 @@ impl ExecCommandHandler {
                 &hook_command,
                 native_cwd,
             )
+            .instrument(tracing::info_span!(
+                "unified_exec.handle_call.implicit_skill_detection"
+            ))
             .await;
         }
         let shell_mode =
@@ -228,14 +247,22 @@ impl ExecCommandHandler {
                 )));
             }
         }
-        let process_id = manager.allocate_process_id().await;
-        let resolved_command = get_command(
-            &args,
-            shell,
-            &shell_mode,
-            turn.config.permissions.allow_login_shell,
-        )
-        .map_err(FunctionCallError::RespondToModel)?;
+        let process_id = manager
+            .allocate_process_id()
+            .instrument(tracing::info_span!(
+                "unified_exec.handle_call.allocate_process_id"
+            ))
+            .await;
+        let resolved_command = tracing::info_span!("unified_exec.handle_call.resolve_command")
+            .in_scope(|| {
+                get_command(
+                    &args,
+                    shell,
+                    &shell_mode,
+                    turn.config.permissions.allow_login_shell,
+                )
+            })
+            .map_err(FunctionCallError::RespondToModel)?;
         let command = resolved_command.command;
         let shell_type = resolved_command.shell_type;
         let command_for_display = codex_shell_command::parse_command::shlex_join(&command);
@@ -263,6 +290,9 @@ impl ExecCommandHandler {
             sandbox_permissions,
             additional_permissions,
         )
+        .instrument(tracing::info_span!(
+            "unified_exec.handle_call.apply_granted_permissions"
+        ))
         .await;
         let additional_permissions_allowed = exec_permission_approvals_enabled
             || (session.features().enabled(Feature::RequestPermissionsTool)
@@ -322,6 +352,9 @@ impl ExecCommandHandler {
             &context.call_id,
             "exec_command",
         )
+        .instrument(tracing::info_span!(
+            "unified_exec.handle_call.intercept_apply_patch"
+        ))
         .await?
         {
             manager.release_process_id(process_id).await;

--- a/codex-rs/core/src/tools/orchestrator.rs
+++ b/codex-rs/core/src/tools/orchestrator.rs
@@ -41,6 +41,7 @@ use codex_sandboxing::SandboxManager;
 use codex_sandboxing::SandboxType;
 use codex_utils_path_uri::PathUri;
 use std::time::Instant;
+use tracing::Instrument;
 
 pub(crate) struct ToolOrchestrator {
     sandbox: SandboxManager,
@@ -58,6 +59,16 @@ impl ToolOrchestrator {
         }
     }
 
+    #[tracing::instrument(
+        name = "tool_orchestrator.run_attempt",
+        level = "info",
+        skip_all,
+        fields(
+            sandbox = ?attempt.sandbox,
+            sandbox_requested = attempt.sandbox_requested,
+            managed_network_active,
+        )
+    )]
     async fn run_attempt<Rq, Out, T>(
         tool: &mut T,
         req: &Rq,
@@ -74,6 +85,9 @@ impl ToolOrchestrator {
             managed_network_active,
             tool.network_approval_spec(req, tool_ctx),
         )
+        .instrument(tracing::info_span!(
+            "tool_orchestrator.begin_network_approval"
+        ))
         .await;
 
         let attempt_tool_ctx = ToolCtx {
@@ -101,6 +115,7 @@ impl ToolOrchestrator {
         };
         let run_result = tool
             .run(req, &attempt_with_network_approval, &attempt_tool_ctx)
+            .instrument(tracing::info_span!("tool_orchestrator.runtime_run"))
             .await;
 
         let Some(network_approval) = network_approval else {
@@ -110,7 +125,11 @@ impl ToolOrchestrator {
         match network_approval.mode() {
             NetworkApprovalMode::Immediate => {
                 let finalize_result =
-                    finish_immediate_network_approval(&tool_ctx.session, network_approval).await;
+                    finish_immediate_network_approval(&tool_ctx.session, network_approval)
+                        .instrument(tracing::info_span!(
+                            "tool_orchestrator.finish_immediate_network_approval"
+                        ))
+                        .await;
                 if let Err(err) = finalize_result {
                     return (Err(err), None);
                 }
@@ -120,7 +139,11 @@ impl ToolOrchestrator {
                 let deferred = network_approval.into_deferred();
                 if run_result.is_err() {
                     let finalize_result =
-                        finish_deferred_network_approval(&tool_ctx.session, deferred).await;
+                        finish_deferred_network_approval(&tool_ctx.session, deferred)
+                            .instrument(tracing::info_span!(
+                                "tool_orchestrator.finish_deferred_network_approval"
+                            ))
+                            .await;
                     if let Err(err) = finalize_result {
                         return (Err(err), None);
                     }
@@ -145,7 +168,13 @@ impl ToolOrchestrator {
         let otel = turn_ctx.session_telemetry.clone();
         let otel_tn = flat_tool_name(&tool_ctx.tool_name).into_owned();
         let otel_ci = &tool_ctx.call_id;
-        let strict_auto_review = tool_ctx.session.strict_auto_review_enabled_for_turn().await;
+        let strict_auto_review = tool_ctx
+            .session
+            .strict_auto_review_enabled_for_turn()
+            .instrument(tracing::info_span!(
+                "tool_orchestrator.resolve_auto_review_mode"
+            ))
+            .await;
         let use_guardian = routes_approval_to_guardian(turn_ctx) || strict_auto_review;
 
         // 1) Approval
@@ -510,6 +539,12 @@ impl ToolOrchestrator {
     // PermissionRequest hooks take top precedence for answering approval
     // prompts. If no matching hook returns a decision, fall back to the
     // normal guardian or user approval path.
+    #[tracing::instrument(
+        name = "tool_orchestrator.request_approval",
+        level = "info",
+        skip_all,
+        fields(evaluate_permission_request_hooks)
+    )]
     async fn request_approval<Rq, Out, T>(
         tool: &mut T,
         req: &Rq,

--- a/codex-rs/core/src/tools/parallel.rs
+++ b/codex-rs/core/src/tools/parallel.rs
@@ -113,26 +113,42 @@ impl ToolCallRuntime {
         let abort_dispatch_span = dispatch_span.clone();
 
         let mut handle: AbortOnDropHandle<Result<AnyToolResult, FunctionCallError>> =
-            AbortOnDropHandle::new(tokio::spawn(async move {
-                let _guard = if supports_parallel {
-                    Either::Left(lock.read().await)
-                } else {
-                    Either::Right(lock.write().await)
-                };
+            AbortOnDropHandle::new(tokio::spawn(
+                async move {
+                    let _guard = if supports_parallel {
+                        Either::Left(
+                            lock.read()
+                                .instrument(tracing::info_span!(
+                                    "tool_dispatch.parallel_execution_lock",
+                                    mode = "shared",
+                                ))
+                                .await,
+                        )
+                    } else {
+                        Either::Right(
+                            lock.write()
+                                .instrument(tracing::info_span!(
+                                    "tool_dispatch.parallel_execution_lock",
+                                    mode = "exclusive",
+                                ))
+                                .await,
+                        )
+                    };
 
-                router
-                    .dispatch_tool_call_with_terminal_outcome(
-                        session,
-                        step_context,
-                        invocation_cancellation_token,
-                        tracker,
-                        dispatch_call,
-                        source,
-                        dispatch_terminal_outcome_reached,
-                    )
-                    .instrument(dispatch_span.clone())
-                    .await
-            }));
+                    router
+                        .dispatch_tool_call_with_terminal_outcome(
+                            session,
+                            step_context,
+                            invocation_cancellation_token,
+                            tracker,
+                            dispatch_call,
+                            source,
+                            dispatch_terminal_outcome_reached,
+                        )
+                        .await
+                }
+                .instrument(dispatch_span),
+            ));
 
         async move {
             tokio::select! {

--- a/codex-rs/core/src/tools/registry.rs
+++ b/codex-rs/core/src/tools/registry.rs
@@ -34,6 +34,7 @@ use codex_tools::ToolSearchInfo;
 use codex_tools::ToolSpec;
 use futures::future::BoxFuture;
 use serde_json::Value;
+use tracing::Instrument;
 use tracing::instrument;
 
 pub(crate) type ToolTelemetryTags = Vec<(&'static str, String)>;
@@ -431,9 +432,18 @@ impl ToolRegistry {
         ];
 
         {
-            let mut active = invocation.session.active_turn.lock().await;
+            let mut active = invocation
+                .session
+                .active_turn
+                .lock()
+                .instrument(tracing::info_span!("tool_dispatch.active_turn_lock"))
+                .await;
             if let Some(active_turn) = active.as_mut() {
-                let mut turn_state = active_turn.turn_state.lock().await;
+                let mut turn_state = active_turn
+                    .turn_state
+                    .lock()
+                    .instrument(tracing::info_span!("tool_dispatch.turn_state_lock"))
+                    .await;
                 turn_state.tool_calls = turn_state.tool_calls.saturating_add(1);
             }
         }
@@ -460,7 +470,10 @@ impl ToolRegistry {
             }
         };
 
-        let telemetry_tags = tool.telemetry_tags(&invocation).await;
+        let telemetry_tags = tool
+            .telemetry_tags(&invocation)
+            .instrument(tracing::info_span!("tool_dispatch.telemetry_tags"))
+            .await;
         let mut tool_result_tags =
             Vec::with_capacity(base_tool_result_tags.len() + telemetry_tags.len());
         let mut extra_trace_fields = Vec::new();
@@ -490,7 +503,9 @@ impl ToolRegistry {
             return Err(err);
         }
 
-        notify_tool_start(&invocation).await;
+        notify_tool_start(&invocation)
+            .instrument(tracing::info_span!("tool_dispatch.notify_tool_start"))
+            .await;
 
         if let Some(pre_tool_use_payload) = tool.pre_tool_use_payload(&invocation) {
             match run_pre_tool_use_hooks(
@@ -500,6 +515,7 @@ impl ToolRegistry {
                 &pre_tool_use_payload.tool_name,
                 &pre_tool_use_payload.tool_input,
             )
+            .instrument(tracing::info_span!("tool_dispatch.pre_tool_use_hooks"))
             .await
             {
                 PreToolUseHookResult::Blocked(message) => {
@@ -683,6 +699,7 @@ async fn notify_tool_finish_if_unclaimed(
     true
 }
 
+#[instrument(name = "tool_dispatch.invoke_handler", level = "info", skip_all)]
 async fn handle_any_tool(
     tool: &dyn CoreToolRuntime,
     invocation: ToolInvocation,

--- a/codex-rs/core/src/turn_diff_tracker.rs
+++ b/codex-rs/core/src/turn_diff_tracker.rs
@@ -49,6 +49,7 @@ struct DiffCacheKey {
 /// mutations, without rereading the workspace filesystem.
 pub struct TurnDiffTracker {
     valid: bool,
+    display_roots_initialized: bool,
     display_roots_by_environment: HashMap<String, PathBuf>,
     baseline_by_path: HashMap<TrackedPath, TrackedContent>,
     current_by_path: HashMap<TrackedPath, TrackedContent>,
@@ -64,6 +65,7 @@ impl Default for TurnDiffTracker {
     fn default() -> Self {
         Self {
             valid: true,
+            display_roots_initialized: false,
             display_roots_by_environment: HashMap::new(),
             baseline_by_path: HashMap::new(),
             current_by_path: HashMap::new(),
@@ -82,12 +84,25 @@ impl TurnDiffTracker {
         Self::default()
     }
 
+    #[cfg(test)]
     pub fn with_environment_display_roots(
         display_roots: impl IntoIterator<Item = (String, PathBuf)>,
     ) -> Self {
         let mut tracker = Self::new();
-        tracker.display_roots_by_environment = display_roots.into_iter().collect();
+        tracker.set_environment_display_roots(display_roots);
         tracker
+    }
+
+    pub(crate) fn needs_display_roots(&self) -> bool {
+        self.valid && !self.display_roots_initialized
+    }
+
+    pub(crate) fn set_environment_display_roots(
+        &mut self,
+        display_roots: impl IntoIterator<Item = (String, PathBuf)>,
+    ) {
+        self.display_roots_by_environment = display_roots.into_iter().collect();
+        self.display_roots_initialized = true;
     }
 
     pub fn track_delta(&mut self, environment_id: &str, delta: &AppliedPatchDelta) {

--- a/codex-rs/core/src/turn_diff_tracker_tests.rs
+++ b/codex-rs/core/src/turn_diff_tracker_tests.rs
@@ -50,6 +50,22 @@ fn tracker_with_root(root: &Path) -> TurnDiffTracker {
     TurnDiffTracker::with_environment_display_roots([("".to_string(), root.to_path_buf())])
 }
 
+#[test]
+fn display_roots_are_initialized_only_when_supplied() {
+    let dir = tempdir().expect("tempdir");
+    let mut tracker = TurnDiffTracker::new();
+
+    assert!(tracker.needs_display_roots());
+
+    tracker.set_environment_display_roots([("local".to_string(), dir.path().to_path_buf())]);
+
+    assert!(!tracker.needs_display_roots());
+
+    let mut invalid_tracker = TurnDiffTracker::new();
+    invalid_tracker.invalidate();
+    assert!(!invalid_tracker.needs_display_roots());
+}
+
 #[tokio::test]
 async fn accumulates_add_then_update_as_single_add() {
     let dir = tempdir().expect("tempdir");

--- a/codex-rs/core/src/unified_exec/async_watcher.rs
+++ b/codex-rs/core/src/unified_exec/async_watcher.rs
@@ -5,6 +5,7 @@ use tokio::sync::Mutex;
 use tokio::time::Duration;
 use tokio::time::Instant;
 use tokio::time::Sleep;
+use tracing::instrument;
 
 use super::UnifiedExecContext;
 use super::process::UnifiedExecProcess;
@@ -192,6 +193,7 @@ async fn process_chunk(
 /// as the primary source of aggregated_output and falling back to the provided
 /// text when the transcript is empty.
 #[allow(clippy::too_many_arguments)]
+#[instrument(name = "unified_exec.emit_end", level = "info", skip_all)]
 pub(crate) async fn emit_exec_end_for_unified_exec(
     session_ref: Arc<Session>,
     turn_ref: Arc<TurnContext>,
@@ -317,6 +319,11 @@ fn split_valid_utf8_prefix_with_max(buffer: &mut Vec<u8>, max_bytes: usize) -> O
     Some(byte)
 }
 
+#[instrument(
+    name = "unified_exec.resolve_aggregated_output",
+    level = "info",
+    skip_all
+)]
 async fn resolve_aggregated_output(
     transcript: &Arc<Mutex<HeadTailBuffer>>,
     fallback: String,

--- a/codex-rs/core/src/unified_exec/process.rs
+++ b/codex-rs/core/src/unified_exec/process.rs
@@ -10,7 +10,11 @@ use tokio::sync::oneshot::error::TryRecvError;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio::time::Duration;
+use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
+use tracing::field;
+use tracing::instrument;
 
 use crate::exec::is_likely_sandbox_denied;
 use codex_exec_server::ExecProcess;
@@ -266,17 +270,33 @@ impl UnifiedExecProcess {
         self.state_rx.borrow().failure_message.clone()
     }
 
+    #[instrument(
+        name = "unified_exec.check_for_sandbox_denial",
+        level = "info",
+        skip_all
+    )]
     pub(super) async fn check_for_sandbox_denial(&self) -> Result<(), UnifiedExecError> {
-        let _ =
-            tokio::time::timeout(Duration::from_millis(20), self.output_notify.notified()).await;
+        let _ = tokio::time::timeout(Duration::from_millis(20), self.output_notify.notified())
+            .instrument(tracing::info_span!(
+                "unified_exec.check_for_sandbox_denial.wait_for_output"
+            ))
+            .await;
 
-        let collected_chunks = self.snapshot_output().await;
+        let collected_chunks = self
+            .snapshot_output()
+            .instrument(tracing::info_span!(
+                "unified_exec.check_for_sandbox_denial.snapshot_output"
+            ))
+            .await;
         let mut aggregated: Vec<u8> = Vec::new();
         for chunk in collected_chunks {
             aggregated.extend_from_slice(&chunk);
         }
         let aggregated_text = String::from_utf8_lossy(&aggregated).to_string();
         self.check_for_sandbox_denial_with_text(&aggregated_text)
+            .instrument(tracing::info_span!(
+                "unified_exec.check_for_sandbox_denial.classify"
+            ))
             .await?;
 
         Ok(())
@@ -374,8 +394,29 @@ impl UnifiedExecProcess {
         Ok(managed)
     }
 
+    #[instrument(
+        name = "unified_exec.attach_exec_server_process",
+        level = "info",
+        skip_all
+    )]
     pub(super) async fn from_exec_server_started(
         started: StartedExecProcess,
+    ) -> Result<Self, UnifiedExecError> {
+        Self::from_exec_server_started_with_output_task(
+            started,
+            Self::spawn_exec_server_output_task,
+        )
+        .await
+    }
+
+    pub(super) async fn from_exec_server_started_with_output_task(
+        started: StartedExecProcess,
+        spawn_output_task: impl FnOnce(
+            StartedExecProcess,
+            OutputHandles,
+            broadcast::Sender<Vec<u8>>,
+            watch::Sender<ProcessState>,
+        ) -> JoinHandle<()>,
     ) -> Result<Self, UnifiedExecError> {
         let process_handle = ProcessHandle::ExecServer(Arc::clone(&started.process));
         let mut managed = Self::new(
@@ -384,15 +425,24 @@ impl UnifiedExecProcess {
             /*spawn_lifecycle*/ None,
         );
         let output_handles = managed.output_handles();
-        managed.output_task = Some(Self::spawn_exec_server_output_task(
+        managed.output_task = Some(spawn_output_task(
             started,
             output_handles,
             managed.output_tx.clone(),
             managed.state_tx.clone(),
         ));
 
+        // Keep the initial sandbox-denial handshake inside ToolOrchestrator's attempt. A denial
+        // discovered only by exec_command's later output collection is too late for the
+        // orchestrator to perform its approval/escalation retry. This remains event-driven and
+        // returns as soon as the exec-server reports a terminal launch state.
         let mut state_rx = managed.state_rx.clone();
-        if tokio::time::timeout(EARLY_EXIT_GRACE_PERIOD, async {
+        let terminal_handshake_span = tracing::info_span!(
+            "unified_exec.initial_terminal_handshake",
+            timeout_ms = EARLY_EXIT_GRACE_PERIOD.as_millis(),
+            completion_reason = field::Empty,
+        );
+        let terminal_handshake = tokio::time::timeout(EARLY_EXIT_GRACE_PERIOD, async {
             loop {
                 let state = state_rx.borrow().clone();
                 if state.has_exited || state.failure_message.is_some() {
@@ -403,9 +453,17 @@ impl UnifiedExecProcess {
                 }
             }
         })
-        .await
-        .is_ok()
-        {
+        .instrument(terminal_handshake_span.clone())
+        .await;
+        terminal_handshake_span.record(
+            "completion_reason",
+            if terminal_handshake.is_ok() {
+                "terminal_state"
+            } else {
+                "timeout"
+            },
+        );
+        if terminal_handshake.is_ok() {
             managed.check_for_sandbox_denial().await?;
         }
 
@@ -426,153 +484,249 @@ impl UnifiedExecProcess {
             cancellation_token,
         } = output_handles;
         let process = started.process;
+        let process_id = process.process_id().to_string();
         let mut events = process.subscribe_events();
-        tokio::spawn(async move {
-            let mut last_seq: u64 = 0;
-            loop {
-                let event = match events.recv().await {
-                    Ok(event) => Some(event),
-                    Err(broadcast::error::RecvError::Lagged(_)) => None,
-                    Err(broadcast::error::RecvError::Closed) => {
-                        let state = state_tx.borrow().clone();
-                        let _ = state_tx.send_replace(
-                            state.failed("exec-server process event stream closed".to_string()),
-                        );
-                        output_closed.store(true, Ordering::Release);
-                        output_closed_notify.notify_waiters();
-                        cancellation_token.cancel();
-                        break;
-                    }
-                };
-                let event_seq = event.as_ref().and_then(|event| match event {
-                    ExecProcessEvent::Output(chunk) => Some(chunk.seq),
-                    ExecProcessEvent::Exited { seq, .. } | ExecProcessEvent::Closed { seq } => {
-                        Some(*seq)
-                    }
-                    ExecProcessEvent::Failed(_) => None,
-                });
-                let missing_sandbox_denial = matches!(
-                    event.as_ref(),
-                    Some(ExecProcessEvent::Exited {
-                        sandbox_denied: None,
-                        ..
-                    })
-                );
-                if event.is_none()
-                    || event_seq.is_some_and(|seq| seq > last_seq.saturating_add(1))
-                    || missing_sandbox_denial
-                {
-                    let response = match process
-                        .read(
-                            Some(last_seq),
-                            /*max_bytes*/ None,
-                            /*wait_ms*/ Some(0),
-                        )
-                        .await
-                    {
-                        Ok(response) => response,
-                        Err(err) => {
+        let lifecycle_started_at = Instant::now();
+        let lifecycle_span = tracing::info_span!(
+            "exec_server.remote.process_lifecycle",
+            process_id = %process_id,
+            attach_to_first_output_ms = field::Empty,
+            first_output_seq = field::Empty,
+            first_output_bytes = field::Empty,
+            attach_to_exit_ms = field::Empty,
+            exit_code = field::Empty,
+            attach_to_closed_ms = field::Empty,
+            recovery_reads = 0_u64,
+            completion_reason = field::Empty,
+        );
+        tokio::spawn(
+            async move {
+                let mut last_seq: u64 = 0;
+                let mut first_output_observed = false;
+                let mut exit_observed = false;
+                let mut recovery_reads: u64 = 0;
+                loop {
+                    let event = match events.recv().await {
+                        Ok(event) => Some(event),
+                        Err(broadcast::error::RecvError::Lagged(_)) => None,
+                        Err(broadcast::error::RecvError::Closed) => {
+                            tracing::Span::current()
+                                .record("completion_reason", "event_stream_closed");
                             let state = state_tx.borrow().clone();
-                            let _ = state_tx.send_replace(state.failed(err.to_string()));
+                            let _ = state_tx.send_replace(
+                                state.failed("exec-server process event stream closed".to_string()),
+                            );
                             output_closed.store(true, Ordering::Release);
                             output_closed_notify.notify_waiters();
                             cancellation_token.cancel();
                             break;
                         }
                     };
-                    let ExecReadResponse {
-                        chunks,
-                        next_seq,
-                        exited,
-                        exit_code,
-                        closed,
-                        failure,
-                        sandbox_denied,
-                    } = response;
-                    for chunk in chunks.into_iter().filter(|chunk| chunk.seq > last_seq) {
-                        let bytes = chunk.chunk.into_inner();
-                        let mut guard = output_buffer.lock().await;
-                        guard.push_chunk(bytes.clone());
-                        drop(guard);
-                        let _ = output_tx.send(bytes);
-                        output_notify.notify_waiters();
-                    }
-                    last_seq = last_seq.max(next_seq.saturating_sub(1));
-                    if let Some(message) = failure {
-                        let state = state_tx.borrow().clone();
-                        let _ = state_tx.send_replace(state.failed(message));
-                        output_closed.store(true, Ordering::Release);
-                        output_closed_notify.notify_waiters();
-                        cancellation_token.cancel();
-                        break;
-                    }
-                    if sandbox_denied || exited {
-                        let mut state = state_tx.borrow().clone();
-                        state.sandbox_denied |= sandbox_denied;
-                        let _ = state_tx.send_replace(if exited {
-                            state.exited(exit_code)
-                        } else {
-                            state
-                        });
-                    }
-                    if closed {
-                        output_closed.store(true, Ordering::Release);
-                        output_closed_notify.notify_waiters();
-                        cancellation_token.cancel();
-                        break;
-                    }
-                    continue;
-                }
 
-                let Some(event) = event else {
-                    continue;
-                };
-                match event {
-                    ExecProcessEvent::Output(chunk) => {
-                        if chunk.seq <= last_seq {
-                            continue;
+                    let event_seq = event.as_ref().and_then(|event| match event {
+                        ExecProcessEvent::Output(chunk) => Some(chunk.seq),
+                        ExecProcessEvent::Exited { seq, .. } | ExecProcessEvent::Closed { seq } => {
+                            Some(*seq)
                         }
-                        last_seq = chunk.seq;
-                        let bytes = chunk.chunk.into_inner();
-                        let mut guard = output_buffer.lock().await;
-                        guard.push_chunk(bytes.clone());
-                        drop(guard);
-                        let _ = output_tx.send(bytes);
-                        output_notify.notify_waiters();
-                    }
-                    ExecProcessEvent::Exited {
-                        seq,
-                        exit_code,
-                        sandbox_denied,
-                    } => {
-                        if seq <= last_seq {
-                            continue;
+                        ExecProcessEvent::Failed(_) => None,
+                    });
+                    let missing_sandbox_denial = matches!(
+                        event.as_ref(),
+                        Some(ExecProcessEvent::Exited {
+                            sandbox_denied: None,
+                            ..
+                        })
+                    );
+                    if event.is_none()
+                        || event_seq.is_some_and(|seq| seq > last_seq.saturating_add(1))
+                        || missing_sandbox_denial
+                    {
+                        let recovery_reason = if event.is_none() {
+                            "lagged"
+                        } else if missing_sandbox_denial {
+                            "missing_sandbox_denial"
+                        } else {
+                            "sequence_gap"
+                        };
+                        recovery_reads += 1;
+                        tracing::Span::current().record("recovery_reads", recovery_reads);
+                        let response = match process
+                            .read(
+                                Some(last_seq),
+                                /*max_bytes*/ None,
+                                /*wait_ms*/ Some(0),
+                            )
+                            .instrument(tracing::info_span!(
+                                "exec_server.remote.recovery_read",
+                                process_id = %process_id,
+                                reason = recovery_reason,
+                                after_seq = last_seq,
+                                observed_event_seq = ?event_seq,
+                            ))
+                            .await
+                        {
+                            Ok(response) => response,
+                            Err(err) => {
+                                tracing::Span::current()
+                                    .record("completion_reason", "recovery_read_failed");
+                                let state = state_tx.borrow().clone();
+                                let _ = state_tx.send_replace(state.failed(err.to_string()));
+                                output_closed.store(true, Ordering::Release);
+                                output_closed_notify.notify_waiters();
+                                cancellation_token.cancel();
+                                break;
+                            }
+                        };
+                        let ExecReadResponse {
+                            chunks,
+                            next_seq,
+                            exited,
+                            exit_code,
+                            closed,
+                            failure,
+                            sandbox_denied,
+                        } = response;
+                        for chunk in chunks.into_iter().filter(|chunk| chunk.seq > last_seq) {
+                            let seq = chunk.seq;
+                            let bytes = chunk.chunk.into_inner();
+                            if !first_output_observed {
+                                first_output_observed = true;
+                                let span = tracing::Span::current();
+                                span.record(
+                                    "attach_to_first_output_ms",
+                                    lifecycle_started_at.elapsed().as_secs_f64() * 1_000.0,
+                                );
+                                span.record("first_output_seq", seq);
+                                span.record("first_output_bytes", bytes.len());
+                            }
+                            let mut guard = output_buffer.lock().await;
+                            guard.push_chunk(bytes.clone());
+                            drop(guard);
+                            let _ = output_tx.send(bytes);
+                            output_notify.notify_waiters();
                         }
-                        last_seq = seq;
-                        let mut state = state_tx.borrow().clone();
-                        state.sandbox_denied |= sandbox_denied.unwrap_or(false);
-                        let _ = state_tx.send_replace(state.exited(Some(exit_code)));
-                    }
-                    ExecProcessEvent::Closed { seq } => {
-                        if seq <= last_seq {
-                            continue;
+                        last_seq = last_seq.max(next_seq.saturating_sub(1));
+                        if let Some(message) = failure {
+                            tracing::Span::current().record("completion_reason", "process_failed");
+                            let state = state_tx.borrow().clone();
+                            let _ = state_tx.send_replace(state.failed(message));
+                            output_closed.store(true, Ordering::Release);
+                            output_closed_notify.notify_waiters();
+                            cancellation_token.cancel();
+                            break;
                         }
-                        output_closed.store(true, Ordering::Release);
-                        output_closed_notify.notify_waiters();
-                        cancellation_token.cancel();
-                        break;
+                        if sandbox_denied || exited {
+                            if exited && !exit_observed {
+                                exit_observed = true;
+                                let span = tracing::Span::current();
+                                span.record(
+                                    "attach_to_exit_ms",
+                                    lifecycle_started_at.elapsed().as_secs_f64() * 1_000.0,
+                                );
+                                if let Some(exit_code) = exit_code {
+                                    span.record("exit_code", exit_code);
+                                }
+                            }
+                            let mut state = state_tx.borrow().clone();
+                            state.sandbox_denied |= sandbox_denied;
+                            let _ = state_tx.send_replace(if exited {
+                                state.exited(exit_code)
+                            } else {
+                                state
+                            });
+                        }
+                        if closed {
+                            let span = tracing::Span::current();
+                            span.record(
+                                "attach_to_closed_ms",
+                                lifecycle_started_at.elapsed().as_secs_f64() * 1_000.0,
+                            );
+                            span.record("completion_reason", "closed_after_recovery");
+                            output_closed.store(true, Ordering::Release);
+                            output_closed_notify.notify_waiters();
+                            cancellation_token.cancel();
+                            break;
+                        }
+                        continue;
                     }
-                    ExecProcessEvent::Failed(message) => {
-                        let state = state_tx.borrow().clone();
-                        let _ = state_tx.send_replace(state.failed(message));
-                        output_closed.store(true, Ordering::Release);
-                        output_closed_notify.notify_waiters();
-                        cancellation_token.cancel();
-                        break;
+
+                    let Some(event) = event else {
+                        continue;
+                    };
+                    match event {
+                        ExecProcessEvent::Output(chunk) => {
+                            if chunk.seq <= last_seq {
+                                continue;
+                            }
+                            last_seq = chunk.seq;
+                            let bytes = chunk.chunk.into_inner();
+                            if !first_output_observed {
+                                first_output_observed = true;
+                                let span = tracing::Span::current();
+                                span.record(
+                                    "attach_to_first_output_ms",
+                                    lifecycle_started_at.elapsed().as_secs_f64() * 1_000.0,
+                                );
+                                span.record("first_output_seq", last_seq);
+                                span.record("first_output_bytes", bytes.len());
+                            }
+                            let mut guard = output_buffer.lock().await;
+                            guard.push_chunk(bytes.clone());
+                            drop(guard);
+                            let _ = output_tx.send(bytes);
+                            output_notify.notify_waiters();
+                        }
+                        ExecProcessEvent::Exited {
+                            seq,
+                            exit_code,
+                            sandbox_denied,
+                        } => {
+                            if seq <= last_seq {
+                                continue;
+                            }
+                            last_seq = seq;
+                            if !exit_observed {
+                                exit_observed = true;
+                                let span = tracing::Span::current();
+                                span.record(
+                                    "attach_to_exit_ms",
+                                    lifecycle_started_at.elapsed().as_secs_f64() * 1_000.0,
+                                );
+                                span.record("exit_code", exit_code);
+                            }
+                            let mut state = state_tx.borrow().clone();
+                            state.sandbox_denied |= sandbox_denied.unwrap_or(false);
+                            let _ = state_tx.send_replace(state.exited(Some(exit_code)));
+                        }
+                        ExecProcessEvent::Closed { seq } => {
+                            if seq <= last_seq {
+                                continue;
+                            }
+                            let span = tracing::Span::current();
+                            span.record(
+                                "attach_to_closed_ms",
+                                lifecycle_started_at.elapsed().as_secs_f64() * 1_000.0,
+                            );
+                            span.record("completion_reason", "closed");
+                            output_closed.store(true, Ordering::Release);
+                            output_closed_notify.notify_waiters();
+                            cancellation_token.cancel();
+                            break;
+                        }
+                        ExecProcessEvent::Failed(message) => {
+                            tracing::Span::current().record("completion_reason", "process_failed");
+                            let state = state_tx.borrow().clone();
+                            let _ = state_tx.send_replace(state.failed(message));
+                            output_closed.store(true, Ordering::Release);
+                            output_closed_notify.notify_waiters();
+                            cancellation_token.cancel();
+                            break;
+                        }
                     }
                 }
             }
-        })
+            .instrument(lifecycle_span),
+        )
     }
 
     fn spawn_local_output_task(

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -10,6 +10,10 @@ use tokio::sync::watch;
 use tokio::time::Duration;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
+use tracing::Span;
+use tracing::field;
+use tracing::instrument;
 use uuid::Uuid;
 
 use crate::codex_thread::BackgroundTerminalInfo;
@@ -253,6 +257,9 @@ async fn finish_deferred_network_approval_for_session(
         return Ok(());
     };
     finish_deferred_network_approval(session.as_ref(), deferred)
+        .instrument(tracing::info_span!(
+            "unified_exec.post_exit.finalize_network_registration"
+        ))
         .await
         .map_err(network_approval_error_message)
 }
@@ -277,20 +284,36 @@ async fn network_denial_message_for_session(
     }
 }
 
+#[instrument(
+    name = "unified_exec.post_exit.wait_for_late_network_denial",
+    level = "info",
+    skip_all,
+    fields(has_deferred = network_cancelled.is_some(), denial_observed = field::Empty)
+)]
 async fn wait_for_late_network_denial(network_cancelled: Option<CancellationToken>) -> bool {
     let Some(network_cancelled) = network_cancelled else {
+        Span::current().record("denial_observed", false);
         return false;
     };
     if network_cancelled.is_cancelled() {
+        Span::current().record("denial_observed", true);
         return true;
     }
 
-    tokio::select! {
+    let denial_observed = tokio::select! {
         _ = network_cancelled.cancelled() => true,
         _ = tokio::time::sleep(LATE_NETWORK_DENIAL_GRACE_PERIOD) => false,
-    }
+    };
+    Span::current().record("denial_observed", denial_observed);
+    denial_observed
 }
 
+#[instrument(
+    name = "unified_exec.post_exit.finish_network_approval",
+    level = "info",
+    skip_all,
+    fields(has_deferred = deferred.is_some())
+)]
 async fn finish_deferred_network_approval_after_process_exit_for_session(
     session: Option<&Arc<crate::session::session::Session>>,
     deferred: Option<DeferredNetworkApproval>,
@@ -405,11 +428,29 @@ impl UnifiedExecProcessManager {
         }
     }
 
+    #[instrument(
+        name = "unified_exec.exec_command",
+        level = "info",
+        skip_all,
+        fields(
+            process_id = request.process_id,
+            environment_id = %request.turn_environment.environment_id,
+            remote = request.turn_environment.environment.is_remote(),
+            tty = request.tty,
+            output_collected_ms = field::Empty,
+            network_approval_complete_ms = field::Empty,
+            end_event_complete_ms = field::Empty,
+            process_released_ms = field::Empty,
+            sandbox_check_complete_ms = field::Empty,
+            response_ready_ms = field::Empty,
+        )
+    )]
     pub(crate) async fn exec_command(
         &self,
         request: ExecCommandRequest,
         context: &UnifiedExecContext,
     ) -> Result<ExecCommandToolOutput, UnifiedExecError> {
+        let exec_command_started_at = Instant::now();
         let cwd = request.cwd.clone();
         let process = self
             .open_session_with_sandbox(&request, cwd.clone(), context)
@@ -501,6 +542,10 @@ impl UnifiedExecProcessManager {
             deadline,
         )
         .await;
+        Span::current().record(
+            "output_collected_ms",
+            exec_command_started_at.elapsed().as_secs_f64() * 1_000.0,
+        );
         let wall_time = Instant::now().saturating_duration_since(start);
 
         let text = String::from_utf8_lossy(&collected).to_string();
@@ -585,6 +630,10 @@ impl UnifiedExecProcessManager {
                 deferred_network_approval.take(),
             )
             .await;
+            Span::current().record(
+                "network_approval_complete_ms",
+                exec_command_started_at.elapsed().as_secs_f64() * 1_000.0,
+            );
             if let Err(message) = finish_result {
                 emit_failed_initial_exec_end_if_unstored(
                     process_started_alive,
@@ -615,25 +664,54 @@ impl UnifiedExecProcessManager {
                 wall_time,
             )
             .await;
+            Span::current().record(
+                "end_event_complete_ms",
+                exec_command_started_at.elapsed().as_secs_f64() * 1_000.0,
+            );
 
-            self.release_process_id(request.process_id).await;
-            process.check_for_sandbox_denial_with_text(&text).await?;
+            self.release_process_id(request.process_id)
+                .instrument(tracing::info_span!(
+                    "unified_exec.post_exit.release_process_id",
+                    process_id = request.process_id,
+                ))
+                .await;
+            Span::current().record(
+                "process_released_ms",
+                exec_command_started_at.elapsed().as_secs_f64() * 1_000.0,
+            );
+            process
+                .check_for_sandbox_denial_with_text(&text)
+                .instrument(tracing::info_span!(
+                    "unified_exec.post_exit.check_sandbox_denial",
+                    process_id = request.process_id,
+                ))
+                .await?;
+            Span::current().record(
+                "sandbox_check_complete_ms",
+                exec_command_started_at.elapsed().as_secs_f64() * 1_000.0,
+            );
             (None, exit_code)
         };
 
-        let original_token_count = approx_token_count(&text);
-        let response = ExecCommandToolOutput {
-            event_call_id: context.call_id.clone(),
-            chunk_id,
-            wall_time,
-            raw_output: collected,
-            truncation_policy: context.turn.model_info.truncation_policy.into(),
-            max_output_tokens: request.max_output_tokens,
-            process_id: response_process_id,
-            exit_code,
-            original_token_count: Some(original_token_count),
-            hook_command: Some(request.hook_command.clone()),
-        };
+        let response = tracing::info_span!("unified_exec.build_tool_response").in_scope(|| {
+            let original_token_count = approx_token_count(&text);
+            ExecCommandToolOutput {
+                event_call_id: context.call_id.clone(),
+                chunk_id,
+                wall_time,
+                raw_output: collected,
+                truncation_policy: context.turn.model_info.truncation_policy.into(),
+                max_output_tokens: request.max_output_tokens,
+                process_id: response_process_id,
+                exit_code,
+                original_token_count: Some(original_token_count),
+                hook_command: Some(request.hook_command.clone()),
+            }
+        });
+        Span::current().record(
+            "response_ready_ms",
+            exec_command_started_at.elapsed().as_secs_f64() * 1_000.0,
+        );
 
         Ok(response)
     }
@@ -952,6 +1030,12 @@ impl UnifiedExecProcessManager {
         })
     }
 
+    #[instrument(
+        name = "unified_exec.open_prepared_session",
+        level = "info",
+        skip_all,
+        fields(process_id, remote = environment.is_remote(), tty)
+    )]
     pub(crate) async fn open_session_with_prepared_exec_env(
         &self,
         process_id: i32,
@@ -1055,9 +1139,15 @@ impl UnifiedExecProcessManager {
                 ));
             }
 
+            let params = tracing::info_span!("unified_exec.prepare_exec_server_request")
+                .in_scope(|| exec_server_params_for_request(process_id, request, tty));
             let started = environment
                 .get_exec_backend()
-                .start(exec_server_params_for_request(process_id, request, tty))
+                .start(params)
+                .instrument(tracing::info_span!(
+                    "unified_exec.remote_backend_start",
+                    process_id,
+                ))
                 .await
                 .map_err(|err| UnifiedExecError::create_process(err.to_string()))?;
             spawn_lifecycle.after_spawn();
@@ -1104,16 +1194,30 @@ impl UnifiedExecProcessManager {
         UnifiedExecProcess::from_spawned(spawned, request.sandbox, spawn_lifecycle).await
     }
 
+    #[instrument(
+        name = "unified_exec.open_session",
+        level = "info",
+        skip_all,
+        fields(
+            process_id = request.process_id,
+            environment_id = %request.turn_environment.environment_id,
+            remote = request.turn_environment.environment.is_remote(),
+            tty = request.tty,
+        )
+    )]
     pub(super) async fn open_session_with_sandbox(
         &self,
         request: &ExecCommandRequest,
         cwd: PathUri,
         context: &UnifiedExecContext,
     ) -> Result<(UnifiedExecProcess, Option<DeferredNetworkApproval>), UnifiedExecError> {
-        let local_policy_env = create_env(
-            &context.turn.config.permissions.shell_environment_policy,
-            /*thread_id*/ None,
-        );
+        let local_policy_env = tracing::info_span!("unified_exec.prepare_shell_environment")
+            .in_scope(|| {
+                create_env(
+                    &context.turn.config.permissions.shell_environment_policy,
+                    /*thread_id*/ None,
+                )
+            });
         let mut env = local_policy_env.clone();
         env.insert(
             CODEX_THREAD_ID_ENV_VAR.to_string(),
@@ -1146,6 +1250,9 @@ impl UnifiedExecProcessManager {
                 },
                 prefix_rule: request.prefix_rule.clone(),
             })
+            .instrument(tracing::info_span!(
+                "unified_exec.resolve_exec_approval_requirement"
+            ))
             .await;
         let req = UnifiedExecToolRequest {
             command: request.command.clone(),
@@ -1187,6 +1294,7 @@ impl UnifiedExecProcessManager {
                 &context.turn,
                 context.turn.approval_policy.value(),
             )
+            .instrument(tracing::info_span!("unified_exec.run_tool_orchestrator"))
             .await
             .map(|result| (result.output, result.deferred_network_approval))
             .map_err(|err| match err {
@@ -1204,6 +1312,16 @@ impl UnifiedExecProcessManager {
             })
     }
 
+    #[instrument(
+        name = "unified_exec.collect_output_until_deadline",
+        level = "info",
+        skip_all,
+        fields(
+            completion_reason = field::Empty,
+            exit_signal_received = field::Empty,
+            collected_bytes = field::Empty,
+        )
+    )]
     pub(super) async fn collect_output_until_deadline(
         output_buffer: &OutputBuffer,
         output_notify: &Arc<Notify>,
@@ -1218,7 +1336,7 @@ impl UnifiedExecProcessManager {
         let mut collected: Vec<u8> = Vec::with_capacity(4096);
         let mut exit_signal_received = cancellation_token.is_cancelled();
         let mut post_exit_deadline: Option<Instant> = None;
-        loop {
+        let completion_reason = loop {
             Self::extend_deadlines_while_paused(
                 &mut pause_state,
                 &mut deadline,
@@ -1239,11 +1357,11 @@ impl UnifiedExecProcessManager {
                 exit_signal_received |= cancellation_token.is_cancelled();
                 if exit_signal_received && output_closed.load(std::sync::atomic::Ordering::Acquire)
                 {
-                    break;
+                    break "output_closed";
                 }
                 let remaining = deadline.saturating_duration_since(Instant::now());
                 if remaining == Duration::ZERO {
-                    break;
+                    break "yield_deadline";
                 }
 
                 if exit_signal_received {
@@ -1252,7 +1370,7 @@ impl UnifiedExecProcessManager {
                         .get_or_insert_with(|| now + remaining.min(POST_EXIT_CLOSE_WAIT_CAP));
                     let close_wait_remaining = close_wait_deadline.saturating_duration_since(now);
                     if close_wait_remaining == Duration::ZERO {
-                        break;
+                        break "post_exit_close_wait_cap";
                     }
                     let notified = wait_for_output.unwrap_or_else(|| output_notify.notified());
                     let closed = output_closed_notify.notified();
@@ -1261,7 +1379,9 @@ impl UnifiedExecProcessManager {
                     tokio::select! {
                         _ = &mut notified => {}
                         _ = &mut closed => {}
-                        _ = tokio::time::sleep(close_wait_remaining) => break,
+                        _ = tokio::time::sleep(close_wait_remaining) => {
+                            break "post_exit_close_wait_cap";
+                        },
                         _ = Self::wait_for_pause_change(pause_state.as_ref()) => {}
                     }
                     continue;
@@ -1274,7 +1394,7 @@ impl UnifiedExecProcessManager {
                 tokio::select! {
                     _ = &mut notified => {}
                     _ = &mut exit_notified => exit_signal_received = true,
-                    _ = tokio::time::sleep(remaining) => break,
+                    _ = tokio::time::sleep(remaining) => break "yield_deadline",
                     _ = Self::wait_for_pause_change(pause_state.as_ref()) => {}
                 }
                 continue;
@@ -1286,9 +1406,14 @@ impl UnifiedExecProcessManager {
 
             exit_signal_received |= cancellation_token.is_cancelled();
             if Instant::now() >= deadline {
-                break;
+                break "yield_deadline_after_output";
             }
-        }
+        };
+
+        let span = Span::current();
+        span.record("completion_reason", completion_reason);
+        span.record("exit_signal_received", exit_signal_received);
+        span.record("collected_bytes", collected.len());
 
         collected
     }

--- a/codex-rs/core/src/unified_exec/process_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_tests.rs
@@ -172,3 +172,34 @@ async fn remote_terminate_confirmed_updates_state_on_success_only() {
 
     assert!(process.has_exited());
 }
+
+#[tokio::test]
+async fn remote_process_attach_surfaces_early_sandbox_denial() {
+    let (wake_tx, _wake_rx) = watch::channel(0);
+    let started = StartedExecProcess {
+        process: Arc::new(MockExecProcess {
+            process_id: "test-process".to_string().into(),
+            write_response: WriteResponse {
+                status: WriteStatus::Accepted,
+            },
+            read_responses: Mutex::new(VecDeque::new()),
+            terminate_error: None,
+            wake_tx,
+        }),
+    };
+
+    let error = UnifiedExecProcess::from_exec_server_started_with_output_task(
+        started,
+        |_started, _output_handles, _output_tx, state_tx| {
+            tokio::spawn(async move {
+                let mut state = state_tx.borrow().clone();
+                state.sandbox_denied = true;
+                let _ = state_tx.send_replace(state.exited(Some(1)));
+            })
+        },
+    )
+    .await
+    .expect_err("early remote sandbox denial should fail the orchestrated launch attempt");
+
+    assert!(matches!(error, UnifiedExecError::SandboxDenied { .. }));
+}

--- a/codex-rs/core/tests/suite/client_websockets.rs
+++ b/codex-rs/core/tests/suite/client_websockets.rs
@@ -72,6 +72,8 @@ const TEST_INSTALLATION_ID: &str = "11111111-1111-4111-8111-111111111111";
 const TEST_WINDOW_ID: &str = "test-thread:0";
 const X_CODEX_WS_STREAM_REQUEST_START_MS_CLIENT_METADATA_KEY: &str =
     "x-codex-ws-stream-request-start-ms";
+const X_CODEX_WS_STREAM_REQUEST_ORDINAL_CLIENT_METADATA_KEY: &str =
+    "x-codex-ws-stream-request-ordinal";
 
 fn assert_request_trace_matches(body: &serde_json::Value, expected_trace: &W3cTraceContext) {
     let client_metadata = body["client_metadata"]
@@ -204,6 +206,10 @@ async fn responses_websocket_streams_request() {
         .parse::<i64>()
         .expect("websocket stream request start timestamp should be an integer");
     assert!(stream_request_start_ms > 0);
+    assert_eq!(
+        body["client_metadata"][X_CODEX_WS_STREAM_REQUEST_ORDINAL_CLIENT_METADATA_KEY].as_str(),
+        Some("0")
+    );
 
     server.shutdown().await;
 }
@@ -288,6 +294,16 @@ async fn responses_websocket_reuses_connection_with_per_turn_trace_payloads() {
         .body_json();
     assert_request_trace_matches(&first_request, &first_trace);
     assert_request_trace_matches(&second_request, &second_trace);
+    assert_eq!(
+        first_request["client_metadata"][X_CODEX_WS_STREAM_REQUEST_ORDINAL_CLIENT_METADATA_KEY]
+            .as_str(),
+        Some("0")
+    );
+    assert_eq!(
+        second_request["client_metadata"][X_CODEX_WS_STREAM_REQUEST_ORDINAL_CLIENT_METADATA_KEY]
+            .as_str(),
+        Some("1")
+    );
 
     let first_traceparent = first_request["client_metadata"]
         [WS_REQUEST_HEADER_TRACEPARENT_CLIENT_METADATA_KEY]
@@ -423,6 +439,10 @@ async fn responses_websocket_request_prewarm_reuses_connection() {
     assert_eq!(warmup["type"].as_str(), Some("response.create"));
     assert_eq!(warmup["generate"].as_bool(), Some(false));
     assert_eq!(warmup["tools"], serde_json::json!([]));
+    assert_eq!(
+        warmup["client_metadata"][X_CODEX_WS_STREAM_REQUEST_ORDINAL_CLIENT_METADATA_KEY].as_str(),
+        Some("0")
+    );
     let warmup_turn_metadata: serde_json::Value = serde_json::from_str(
         warmup["client_metadata"]["x-codex-turn-metadata"]
             .as_str()
@@ -436,6 +456,11 @@ async fn responses_websocket_request_prewarm_reuses_connection() {
     assert_eq!(follow_up["type"].as_str(), Some("response.create"));
     assert_eq!(follow_up["previous_response_id"].as_str(), Some("warm-1"));
     assert_eq!(follow_up["input"], serde_json::json!([]));
+    assert_eq!(
+        follow_up["client_metadata"][X_CODEX_WS_STREAM_REQUEST_ORDINAL_CLIENT_METADATA_KEY]
+            .as_str(),
+        Some("1")
+    );
 
     server.shutdown().await;
 }

--- a/codex-rs/exec-server/src/client.rs
+++ b/codex-rs/exec-server/src/client.rs
@@ -7,9 +7,11 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
+use std::time::Instant;
 
 use arc_swap::ArcSwap;
 use codex_exec_server_protocol::JSONRPCNotification;
+use codex_protocol::protocol::W3cTraceContext;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use serde_json::Value;
@@ -21,7 +23,9 @@ use tokio_util::task::AbortOnDropHandle;
 
 use tokio::time::timeout;
 use tracing::Instrument;
+use tracing::Span;
 use tracing::debug;
+use tracing::field;
 
 use crate::ProcessId;
 use crate::client_api::ExecServerClientConnectOptions;
@@ -162,6 +166,7 @@ pub(crate) struct SessionState {
     ordered_events: StdMutex<OrderedSessionEvents>,
     recoverable: AtomicBool,
     next_write_id: AtomicU64,
+    trace_context: Option<W3cTraceContext>,
 }
 
 #[derive(Default)]
@@ -265,11 +270,17 @@ impl LazyRemoteExecServerClient {
             return None;
         }
         let client = self.clone();
-        Some(AbortOnDropHandle::new(tokio::spawn(async move {
-            if let Err(error) = client.wait_until_ready().await {
-                debug!(%error, "exec-server environment startup failed");
+        Some(AbortOnDropHandle::new(tokio::spawn(
+            async move {
+                if let Err(error) = client.wait_until_ready().await {
+                    debug!(%error, "exec-server environment startup failed");
+                }
             }
-        })))
+            .instrument(tracing::info_span!(
+                "exec_server.environment.start_connecting",
+                trigger = "registration",
+            )),
+        )))
     }
 
     pub(crate) fn startup_finished(&self) -> bool {
@@ -280,26 +291,42 @@ impl LazyRemoteExecServerClient {
         self.initial_client().await.map(drop)
     }
 
+    #[tracing::instrument(
+        name = "exec_server.remote_client.get",
+        level = "info",
+        skip_all,
+        fields(path = field::Empty)
+    )]
     pub(crate) async fn get(&self) -> Result<ExecServerClient, ExecServerError> {
         if let Some(client) = self.connected_client() {
+            Span::current().record("path", "cached_connected");
             return Ok(client);
         }
 
         let Some(cached_client) = self.cached_client() else {
+            Span::current().record("path", "initial_connect");
             let client = self.initial_client().await?;
             if !client.is_disconnected() || !self.can_reconnect() {
                 return Ok(client);
             }
+            Span::current().record("path", "initial_then_reconnect");
             return self.reconnect().await;
         };
 
         if !self.can_reconnect() {
+            Span::current().record("path", "cached_disconnected_nonrecoverable");
             return Ok(cached_client);
         }
 
+        Span::current().record("path", "reconnect");
         self.reconnect().await
     }
 
+    #[tracing::instrument(
+        name = "exec_server.remote_client.initial_client",
+        level = "info",
+        skip_all
+    )]
     async fn initial_client(&self) -> Result<ExecServerClient, ExecServerError> {
         // The first caller starts the work; every other caller waits for that same result.
         let result = self
@@ -321,6 +348,7 @@ impl LazyRemoteExecServerClient {
         }
     }
 
+    #[tracing::instrument(name = "exec_server.remote_client.reconnect", level = "info", skip_all)]
     async fn reconnect(&self) -> Result<ExecServerClient, ExecServerError> {
         // Callers handling the same outage share one reconnect attempt.
         let attempt = {
@@ -382,6 +410,11 @@ impl LazyRemoteExecServerClient {
     }
 }
 
+#[tracing::instrument(
+    name = "exec_server.remote_client.connect_once",
+    level = "info",
+    skip_all
+)]
 async fn connect_once(transport_params: ExecServerTransportParams) -> ConnectionResult {
     ExecServerClient::connect_for_transport(transport_params)
         .await
@@ -645,31 +678,75 @@ impl ExecServerClient {
         self.call(FS_COPY_METHOD, &params).await
     }
 
+    #[tracing::instrument(
+        name = "exec_server.client.start_process",
+        level = "info",
+        skip_all,
+        fields(
+            process_id = %params.process_id,
+            tty = params.tty,
+            connection_ready_ms = field::Empty,
+            session_registered_ms = field::Empty,
+            task_spawned_ms = field::Empty,
+            task_first_polled_ms = field::Empty,
+            response_received_ms = field::Empty,
+        )
+    )]
     pub(crate) async fn start_process(
         &self,
         params: ExecParams,
     ) -> Result<Session, ExecServerError> {
+        let start_process_started_at = Instant::now();
         loop {
-            let rpc_client = self.inner.rpc_client().await?;
+            let rpc_client = self
+                .inner
+                .rpc_client()
+                .instrument(tracing::info_span!("exec_server.client.rpc_client_ready"))
+                .await?;
+            Span::current().record(
+                "connection_ready_ms",
+                start_process_started_at.elapsed().as_secs_f64() * 1_000.0,
+            );
             if !self.inner.begin_process_start(&rpc_client) {
                 continue;
             }
 
             let process_id = params.process_id.clone();
             let state = Arc::new(SessionState::new(/*recoverable*/ false));
-            if let Err(error) = self.inner.insert_session(&process_id, Arc::clone(&state)) {
+            let insert_result = tracing::info_span!("exec_server.client.register_process_session")
+                .in_scope(|| self.inner.insert_session(&process_id, Arc::clone(&state)));
+            if let Err(error) = insert_result {
                 self.inner.finish_process_start();
                 return Err(error);
             }
+            Span::current().record(
+                "session_registered_ms",
+                start_process_started_at.elapsed().as_secs_f64() * 1_000.0,
+            );
             let active_start = ActiveProcessStart {
                 inner: Arc::clone(&self.inner),
             };
             let client = self.clone();
             let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+            let start_process_span = Span::current();
+            let process_start_task_started_at = start_process_started_at;
             let process_start_task = async move {
+                start_process_span.record(
+                    "task_first_polled_ms",
+                    process_start_task_started_at.elapsed().as_secs_f64() * 1_000.0,
+                );
+                tracing::info_span!(
+                    "exec_server.client.process_start_task_first_poll",
+                    process_id = %process_id,
+                )
+                .in_scope(|| {});
                 let _active_start = active_start;
                 match client
                     .call_rpc::<_, ExecResponse>(&rpc_client, EXEC_METHOD, &params)
+                    .instrument(tracing::info_span!(
+                        "exec_server.client.process_start_rpc",
+                        process_id = %process_id,
+                    ))
                     .await
                 {
                     Ok(_) => {
@@ -699,9 +776,23 @@ impl ExecServerClient {
                 }
             };
             tokio::spawn(process_start_task.in_current_span());
-            return result_rx.await.map_err(|_| {
-                ExecServerError::Protocol("process start task stopped unexpectedly".to_string())
-            })?;
+            Span::current().record(
+                "task_spawned_ms",
+                start_process_started_at.elapsed().as_secs_f64() * 1_000.0,
+            );
+            let result = result_rx
+                .instrument(tracing::info_span!(
+                    "exec_server.client.await_process_start_result"
+                ))
+                .await
+                .map_err(|_| {
+                    ExecServerError::Protocol("process start task stopped unexpectedly".to_string())
+                })?;
+            Span::current().record(
+                "response_received_ms",
+                start_process_started_at.elapsed().as_secs_f64() * 1_000.0,
+            );
+            return result;
         }
     }
 
@@ -846,6 +937,7 @@ impl SessionState {
             ordered_events: StdMutex::new(OrderedSessionEvents::default()),
             recoverable: AtomicBool::new(recoverable),
             next_write_id: AtomicU64::new(1),
+            trace_context: codex_otel::current_span_w3c_trace_context(),
         }
     }
 
@@ -967,6 +1059,19 @@ impl Session {
         self.state.subscribe_events()
     }
 
+    #[tracing::instrument(
+        name = "exec_server.remote.read",
+        level = "info",
+        skip_all,
+        fields(
+            process_id = %self.process_id,
+            after_seq,
+            wait_ms,
+            chunks = tracing::field::Empty,
+            exited = tracing::field::Empty,
+            closed = tracing::field::Empty,
+        )
+    )]
     pub(crate) async fn read(
         &self,
         after_seq: Option<u64>,
@@ -988,7 +1093,13 @@ impl Session {
                 })
                 .await
             {
-                Ok(response) => return Ok(response),
+                Ok(response) => {
+                    let span = Span::current();
+                    span.record("chunks", response.chunks.len());
+                    span.record("exited", response.exited);
+                    span.record("closed", response.closed);
+                    return Ok(response);
+                }
                 Err(error)
                     if is_transport_closed_error(&error) && !self.client.inner.is_failed() =>
                 {
@@ -1157,6 +1268,7 @@ async fn handle_server_notification(
                         chunk: params.chunk,
                     }));
                 if published_closed {
+                    record_closed_published(&session, &params.process_id);
                     inner.remove_session_if(&params.process_id, &session);
                 }
             }
@@ -1172,6 +1284,7 @@ async fn handle_server_notification(
                     sandbox_denied: params.sandbox_denied,
                 });
                 if published_closed {
+                    record_closed_published(&session, &params.process_id);
                     inner.remove_session_if(&params.process_id, &session);
                 }
             }
@@ -1180,6 +1293,18 @@ async fn handle_server_notification(
             let params: ExecClosedNotification =
                 serde_json::from_value(notification.params.unwrap_or(Value::Null))?;
             if let Some(session) = inner.get_session(&params.process_id) {
+                let received_span = tracing::info_span!(
+                    "exec_server.client.closed_notification_received",
+                    process_id = %params.process_id,
+                    seq = params.seq,
+                );
+                if let Some(trace_context) = session.trace_context.as_ref() {
+                    let _ = codex_otel::set_parent_from_w3c_trace_context(
+                        &received_span,
+                        trace_context,
+                    );
+                }
+                received_span.in_scope(|| {});
                 session.note_change(params.seq);
                 // Closed is terminal, but it can arrive before tail output or
                 // exited. Keep routing this process until the ordered publisher
@@ -1187,6 +1312,7 @@ async fn handle_server_notification(
                 let published_closed =
                     session.publish_ordered_event(ExecProcessEvent::Closed { seq: params.seq });
                 if published_closed {
+                    record_closed_published(&session, &params.process_id);
                     inner.remove_session_if(&params.process_id, &session);
                 }
             }
@@ -1201,6 +1327,17 @@ async fn handle_server_notification(
         }
     }
     Ok(())
+}
+
+fn record_closed_published(session: &SessionState, process_id: &ProcessId) {
+    let published_span = tracing::info_span!(
+        "exec_server.client.closed_notification_published",
+        process_id = %process_id,
+    );
+    if let Some(trace_context) = session.trace_context.as_ref() {
+        let _ = codex_otel::set_parent_from_w3c_trace_context(&published_span, trace_context);
+    }
+    published_span.in_scope(|| {});
 }
 
 #[cfg(test)]
@@ -1394,7 +1531,15 @@ mod tests {
 
         assert_eq!(session.process_id(), &process_id);
         let trace = server.await.expect("server task").expect("trace context");
-        assert_eq!(trace, expected_trace);
+        let traceparent = trace.traceparent.expect("request traceparent");
+        let expected_traceparent = expected_trace.traceparent.expect("parent span traceparent");
+        let trace_id = traceparent.split('-').nth(1).expect("request trace id");
+        let expected_trace_id = expected_traceparent
+            .split('-')
+            .nth(1)
+            .expect("parent span trace id");
+        assert_eq!(trace_id, expected_trace_id);
+        assert_ne!(traceparent, expected_traceparent);
     }
 
     async fn accept_websocket(listener: &TcpListener) -> WebSocketStream<TcpStream> {

--- a/codex-rs/exec-server/src/client_recovery.rs
+++ b/codex-rs/exec-server/src/client_recovery.rs
@@ -9,6 +9,7 @@ use tokio::sync::mpsc;
 use tokio::time::Instant;
 use tokio::time::sleep;
 use tokio::time::timeout_at;
+use tracing::Instrument;
 
 use super::ConnectionStatus;
 use super::ExecServerClient;
@@ -502,8 +503,43 @@ impl ExecServerClient {
                     return;
                 };
                 match event {
-                    RpcClientEvent::Notification(notification) => {
-                        if let Err(error) = handle_server_notification(&inner, notification).await {
+                    RpcClientEvent::Notification {
+                        notification,
+                        queued_at,
+                        trace,
+                    } => {
+                        let process_id = notification
+                            .params
+                            .as_ref()
+                            .and_then(|params| params.get("processId"))
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or("");
+                        let seq = notification
+                            .params
+                            .as_ref()
+                            .and_then(|params| params.get("seq"))
+                            .and_then(serde_json::Value::as_u64);
+                        let span = tracing::info_span!(
+                            "exec_server.client.notification_event_dequeued",
+                            method = notification.method,
+                            process_id,
+                            seq,
+                            queue_wait_ms = queued_at.elapsed().as_secs_f64() * 1_000.0,
+                        );
+                        if let Some(trace) = trace.as_ref() {
+                            let _ = codex_otel::set_parent_from_w3c_trace_context(&span, trace);
+                        } else if !process_id.is_empty()
+                            && let Some(session) =
+                                inner.get_session(&crate::ProcessId::from(process_id))
+                            && let Some(session_trace) = session.trace_context.as_ref()
+                        {
+                            let _ =
+                                codex_otel::set_parent_from_w3c_trace_context(&span, session_trace);
+                        }
+                        if let Err(error) = handle_server_notification(&inner, notification)
+                            .instrument(span)
+                            .await
+                        {
                             rpc_client.close_transport().await;
                             inner.request_recovery(
                                 rpc_client,

--- a/codex-rs/exec-server/src/connection.rs
+++ b/codex-rs/exec-server/src/connection.rs
@@ -4,10 +4,12 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
+use std::time::Instant;
 
 use axum::extract::ws::Message as AxumWebSocketMessage;
 use axum::extract::ws::WebSocket as AxumWebSocket;
 use codex_exec_server_protocol::JSONRPCMessage;
+use codex_protocol::protocol::W3cTraceContext;
 use futures::Sink;
 use futures::SinkExt;
 use futures::Stream;
@@ -38,8 +40,17 @@ pub(crate) const WEBSOCKET_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(30
 #[derive(Debug)]
 pub(crate) enum JsonRpcConnectionEvent {
     Message(JSONRPCMessage),
-    MalformedMessage { reason: String },
-    Disconnected { reason: Option<String> },
+    TracedMessage {
+        message: JSONRPCMessage,
+        trace: Option<W3cTraceContext>,
+        queued_at: Instant,
+    },
+    MalformedMessage {
+        reason: String,
+    },
+    Disconnected {
+        reason: Option<String>,
+    },
 }
 
 #[derive(Clone)]

--- a/codex-rs/exec-server/src/environment.rs
+++ b/codex-rs/exec-server/src/environment.rs
@@ -27,6 +27,7 @@ use crate::remote::NoiseRendezvousEnvironmentConfig;
 use crate::remote_file_system::RemoteFileSystem;
 use crate::remote_process::RemoteProcess;
 use tokio_util::task::AbortOnDropHandle;
+use tracing::Instrument;
 
 pub const CODEX_EXEC_SERVER_URL_ENV_VAR: &str = "CODEX_EXEC_SERVER_URL";
 pub const CODEX_EXEC_SERVER_NOISE_REGISTRY_URL_ENV_VAR: &str =
@@ -585,11 +586,17 @@ impl Environment {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         if startup_task.is_none() {
             let environment = Arc::clone(environment);
-            *startup_task = Some(AbortOnDropHandle::new(tokio::spawn(async move {
-                if let Err(error) = environment.wait_until_ready().await {
-                    tracing::debug!(%error, "exec-server environment startup failed");
+            *startup_task = Some(AbortOnDropHandle::new(tokio::spawn(
+                async move {
+                    if let Err(error) = environment.wait_until_ready().await {
+                        tracing::debug!(%error, "exec-server environment startup failed");
+                    }
                 }
-            })));
+                .instrument(tracing::info_span!(
+                    "exec_server.environment.start_connecting",
+                    trigger = "first_use",
+                )),
+            )));
         }
     }
 

--- a/codex-rs/exec-server/src/local_process.rs
+++ b/codex-rs/exec-server/src/local_process.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
+use std::time::Instant;
 
 use codex_exec_server_protocol::JSONRPCErrorError;
 use codex_protocol::config_types::EnvironmentVariablePattern;
@@ -22,6 +23,7 @@ use tokio::sync::Mutex;
 use tokio::sync::Notify;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
+use tracing::Instrument;
 
 use crate::ExecBackend;
 use crate::ExecBackendFuture;
@@ -55,7 +57,7 @@ use crate::protocol::WriteParams;
 use crate::protocol::WriteResponse;
 use crate::protocol::WriteStatus;
 use crate::rpc::RpcNotificationSender;
-use crate::rpc::RpcServerOutboundMessage;
+use crate::rpc::RpcServerOutboundEnvelope;
 use crate::rpc::internal_error;
 use crate::rpc::invalid_params;
 use crate::rpc::invalid_request;
@@ -87,6 +89,7 @@ struct RunningProcess {
     output: VecDeque<RetainedOutputChunk>,
     retained_bytes: usize,
     next_seq: u64,
+    first_output_observed: bool,
     exit_code: Option<i32>,
     wake_tx: watch::Sender<u64>,
     events: ExecProcessEventLog,
@@ -132,6 +135,55 @@ impl AcceptedStdinWriteIds {
 
 struct ProcessStart;
 
+#[derive(Clone, Copy)]
+enum OutputReader {
+    Stdout,
+    Stderr,
+}
+
+impl OutputReader {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Stdout => "stdout",
+            Self::Stderr => "stderr",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum OutputReaderCompletion {
+    Eof,
+    ProcessMissing,
+    ProcessNotRunning,
+}
+
+impl OutputReaderCompletion {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Eof => "eof",
+            Self::ProcessMissing => "process_missing",
+            Self::ProcessNotRunning => "process_not_running",
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum CloseTrigger {
+    ExitObserved,
+    StdoutReaderFinished,
+    StderrReaderFinished,
+}
+
+impl CloseTrigger {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::ExitObserved => "exit_observed",
+            Self::StdoutReaderFinished => "stdout_reader_finished",
+            Self::StderrReaderFinished => "stderr_reader_finished",
+        }
+    }
+}
+
 enum ProcessEntry {
     Starting(Arc<ProcessStart>),
     Running(Box<RunningProcess>),
@@ -169,7 +221,7 @@ impl LocalProcess {
 
     fn with_discarded_notifications(runtime_paths: Option<ExecServerRuntimePaths>) -> Self {
         let (outgoing_tx, mut outgoing_rx) =
-            mpsc::channel::<RpcServerOutboundMessage>(NOTIFICATION_CHANNEL_CAPACITY);
+            mpsc::channel::<RpcServerOutboundEnvelope>(NOTIFICATION_CHANNEL_CAPACITY);
         tokio::spawn(async move { while outgoing_rx.recv().await.is_some() {} });
         Self::with_runtime_paths(
             RpcNotificationSender::new(outgoing_tx),
@@ -229,13 +281,21 @@ impl LocalProcess {
         *notification_sender = notifications;
     }
 
+    #[tracing::instrument(
+        name = "exec_server.local.start_process",
+        level = "info",
+        skip_all,
+        fields(process_id = %params.process_id, tty = params.tty)
+    )]
     async fn start_process(
         &self,
         params: ExecParams,
     ) -> Result<(ExecResponse, watch::Sender<u64>, ExecProcessEventLog), JSONRPCErrorError> {
         let process_id = params.process_id.clone();
-        let prepared =
-            prepare_exec_request(&params, child_env(&params), self.runtime_paths.as_ref())?;
+        let prepared = {
+            let _span = tracing::info_span!("exec_server.local.prepare_request").entered();
+            prepare_exec_request(&params, child_env(&params), self.runtime_paths.as_ref())?
+        };
         let (program, args) = prepared
             .command
             .split_first()
@@ -255,35 +315,39 @@ impl LocalProcess {
             );
         }
 
-        let spawned_result = if params.tty {
-            codex_utils_pty::spawn_pty_process(
-                program,
-                args,
-                prepared.cwd.as_path(),
-                &prepared.env,
-                &prepared.arg0,
-                TerminalSize::default(),
-            )
-            .await
-        } else if params.pipe_stdin {
-            codex_utils_pty::spawn_pipe_process(
-                program,
-                args,
-                prepared.cwd.as_path(),
-                &prepared.env,
-                &prepared.arg0,
-            )
-            .await
-        } else {
-            codex_utils_pty::spawn_pipe_process_no_stdin(
-                program,
-                args,
-                prepared.cwd.as_path(),
-                &prepared.env,
-                &prepared.arg0,
-            )
-            .await
-        };
+        let spawned_result = async {
+            if params.tty {
+                codex_utils_pty::spawn_pty_process(
+                    program,
+                    args,
+                    prepared.cwd.as_path(),
+                    &prepared.env,
+                    &prepared.arg0,
+                    TerminalSize::default(),
+                )
+                .await
+            } else if params.pipe_stdin {
+                codex_utils_pty::spawn_pipe_process(
+                    program,
+                    args,
+                    prepared.cwd.as_path(),
+                    &prepared.env,
+                    &prepared.arg0,
+                )
+                .await
+            } else {
+                codex_utils_pty::spawn_pipe_process_no_stdin(
+                    program,
+                    args,
+                    prepared.cwd.as_path(),
+                    &prepared.env,
+                    &prepared.arg0,
+                )
+                .await
+            }
+        }
+        .instrument(tracing::info_span!("exec_server.local.spawn_process"))
+        .await;
         let spawned = match spawned_result {
             Ok(spawned) => spawned,
             Err(err) => {
@@ -328,6 +392,7 @@ impl LocalProcess {
                     output: VecDeque::new(),
                     retained_bytes: 0,
                     next_seq: 1,
+                    first_output_observed: false,
                     exit_code: None,
                     wake_tx: wake_tx.clone(),
                     events: events.clone(),
@@ -341,34 +406,59 @@ impl LocalProcess {
                 })),
             );
         }
-        tokio::spawn(stream_output(
-            process_id.clone(),
-            if params.tty {
-                ExecOutputStream::Pty
-            } else {
-                ExecOutputStream::Stdout
-            },
-            spawned.stdout_rx,
-            Arc::clone(&self.inner),
-            Arc::clone(&output_notify),
-        ));
-        tokio::spawn(stream_output(
-            process_id.clone(),
-            if params.tty {
-                ExecOutputStream::Pty
-            } else {
-                ExecOutputStream::Stderr
-            },
-            spawned.stderr_rx,
-            Arc::clone(&self.inner),
-            Arc::clone(&output_notify),
-        ));
-        tokio::spawn(watch_exit(
-            process_id.clone(),
-            spawned.exit_rx,
-            Arc::clone(&self.inner),
-            output_notify,
-        ));
+        let stdout_lifecycle_span = tracing::info_span!(
+            "exec_server.local.output_lifecycle",
+            process_id = %process_id,
+            reader = OutputReader::Stdout.as_str(),
+        );
+        tokio::spawn(
+            stream_output(
+                process_id.clone(),
+                OutputReader::Stdout,
+                if params.tty {
+                    ExecOutputStream::Pty
+                } else {
+                    ExecOutputStream::Stdout
+                },
+                spawned.stdout_rx,
+                Arc::clone(&self.inner),
+                Arc::clone(&output_notify),
+            )
+            .instrument(stdout_lifecycle_span),
+        );
+        let stderr_lifecycle_span = tracing::info_span!(
+            "exec_server.local.output_lifecycle",
+            process_id = %process_id,
+            reader = OutputReader::Stderr.as_str(),
+        );
+        tokio::spawn(
+            stream_output(
+                process_id.clone(),
+                OutputReader::Stderr,
+                if params.tty {
+                    ExecOutputStream::Pty
+                } else {
+                    ExecOutputStream::Stderr
+                },
+                spawned.stderr_rx,
+                Arc::clone(&self.inner),
+                Arc::clone(&output_notify),
+            )
+            .instrument(stderr_lifecycle_span),
+        );
+        let exit_lifecycle_span = tracing::info_span!(
+            "exec_server.local.exit_lifecycle",
+            process_id = %process_id,
+        );
+        tokio::spawn(
+            watch_exit(
+                process_id.clone(),
+                spawned.exit_rx,
+                Arc::clone(&self.inner),
+                output_notify,
+            )
+            .instrument(exit_lifecycle_span),
+        );
 
         Ok((ExecResponse { process_id }, wake_tx, events))
     }
@@ -758,23 +848,61 @@ fn map_handler_error(error: JSONRPCErrorError) -> ExecServerError {
     }
 }
 
+#[tracing::instrument(
+    name = "exec_server.local.output_reader",
+    level = "info",
+    skip_all,
+    fields(
+        reader = reader.as_str(),
+        completion_reason = tracing::field::Empty,
+        chunks = tracing::field::Empty,
+        bytes = tracing::field::Empty,
+        receiver_wait_ms = tracing::field::Empty,
+        process_lock_wait_ms = tracing::field::Empty,
+        processing_ms = tracing::field::Empty,
+        notification_lookup_ms = tracing::field::Empty,
+        notification_wait_ms = tracing::field::Empty,
+    )
+)]
 async fn stream_output(
     process_id: ProcessId,
+    reader: OutputReader,
     stream: ExecOutputStream,
     mut receiver: tokio::sync::mpsc::Receiver<Vec<u8>>,
     inner: Arc<Inner>,
     output_notify: Arc<Notify>,
 ) {
-    while let Some(chunk) = receiver.recv().await {
-        let _chunk_len = chunk.len();
+    let mut chunks = 0_u64;
+    let mut bytes = 0_u64;
+    let mut receiver_wait = Duration::ZERO;
+    let mut process_lock_wait = Duration::ZERO;
+    let mut processing = Duration::ZERO;
+    let mut notification_lookup = Duration::ZERO;
+    let mut notification_wait = Duration::ZERO;
+    let completion_reason = loop {
+        let receiver_wait_started = Instant::now();
+        let chunk = receiver.recv().await;
+        receiver_wait += receiver_wait_started.elapsed();
+        let Some(chunk) = chunk else {
+            break OutputReaderCompletion::Eof;
+        };
+
+        chunks += 1;
+        bytes = bytes.saturating_add(chunk.len() as u64);
+        let chunk_len = chunk.len();
         let notification = {
+            let process_lock_wait_started = Instant::now();
             let mut processes = inner.processes.lock().await;
+            process_lock_wait += process_lock_wait_started.elapsed();
             let Some(entry) = processes.get_mut(&process_id) else {
-                break;
+                break OutputReaderCompletion::ProcessMissing;
             };
             let ProcessEntry::Running(process) = entry else {
-                break;
+                break OutputReaderCompletion::ProcessNotRunning;
             };
+            let processing_started = Instant::now();
+            let is_first_output = !process.first_output_observed;
+            process.first_output_observed = true;
             let seq = process.next_seq;
             process.next_seq += 1;
             process.retained_bytes += chunk.len();
@@ -798,33 +926,99 @@ async fn stream_output(
             process
                 .events
                 .publish(ExecProcessEvent::Output(output.clone()));
-            ExecOutputDeltaNotification {
+            if is_first_output {
+                tracing::info_span!("exec_server.local.first_output", seq, bytes = chunk_len,)
+                    .in_scope(|| {});
+                tracing::info!(
+                    event = "exec_server.local.first_output",
+                    seq,
+                    bytes = chunk_len,
+                );
+            }
+            let notification = ExecOutputDeltaNotification {
                 process_id: process_id.clone(),
                 seq,
                 stream,
                 chunk: output.chunk,
-            }
+            };
+            processing += processing_started.elapsed();
+            notification
         };
         output_notify.notify_waiters();
-        if let Some(notifications) = notification_sender(&inner) {
+        let notification_lookup_started = Instant::now();
+        let notifications = notification_sender(&inner);
+        notification_lookup += notification_lookup_started.elapsed();
+        if let Some(notifications) = notifications {
+            let notification_wait_started = Instant::now();
             let _ = notifications
                 .notify(crate::protocol::EXEC_OUTPUT_DELTA_METHOD, &notification)
                 .await;
+            notification_wait += notification_wait_started.elapsed();
         }
-    }
+    };
 
-    finish_output_stream(process_id, inner).await;
+    let current_span = tracing::Span::current();
+    current_span.record("completion_reason", completion_reason.as_str());
+    current_span.record("chunks", chunks);
+    current_span.record("bytes", bytes);
+    current_span.record("receiver_wait_ms", duration_ms(receiver_wait));
+    current_span.record("process_lock_wait_ms", duration_ms(process_lock_wait));
+    current_span.record("processing_ms", duration_ms(processing));
+    current_span.record("notification_lookup_ms", duration_ms(notification_lookup));
+    current_span.record("notification_wait_ms", duration_ms(notification_wait));
+    tracing::info_span!(
+        "exec_server.local.output_source_complete",
+        reason = completion_reason.as_str(),
+        chunks,
+        bytes,
+    )
+    .in_scope(|| {});
+
+    finish_output_stream(process_id, inner, reader).await;
+    tracing::info_span!("exec_server.local.output_reader_complete").in_scope(|| {});
 }
 
+#[tracing::instrument(
+    name = "exec_server.local.exit_watcher",
+    level = "info",
+    skip_all,
+    fields(
+        receiver_result = tracing::field::Empty,
+        exit_code = tracing::field::Empty,
+        metrics_lock_wait_ms = tracing::field::Empty,
+        sandbox_sync_wait_ms = tracing::field::Empty,
+        state_lock_wait_ms = tracing::field::Empty,
+        state_update_ms = tracing::field::Empty,
+        notification_lookup_ms = tracing::field::Empty,
+        notification_wait_ms = tracing::field::Empty,
+    )
+)]
 async fn watch_exit(
     process_id: ProcessId,
     exit_rx: tokio::sync::oneshot::Receiver<i32>,
     inner: Arc<Inner>,
     output_notify: Arc<Notify>,
 ) {
-    let exit_code = exit_rx.await.unwrap_or(-1);
+    let (exit_code, receiver_result) = match exit_rx.await {
+        Ok(exit_code) => (exit_code, "exit_code"),
+        Err(_) => (-1, "sender_dropped"),
+    };
+    let current_span = tracing::Span::current();
+    current_span.record("receiver_result", receiver_result);
+    current_span.record("exit_code", exit_code);
+    tracing::info_span!(
+        "exec_server.local.exit_receiver_complete",
+        receiver_result,
+        exit_code,
+    )
+    .in_scope(|| {});
+    let metrics_lock_wait_started = Instant::now();
     let sandboxed = {
         let mut processes = inner.processes.lock().await;
+        current_span.record(
+            "metrics_lock_wait_ms",
+            duration_ms(metrics_lock_wait_started.elapsed()),
+        );
         match processes.get_mut(&process_id) {
             Some(ProcessEntry::Running(process)) => {
                 let sandboxed = process.sandbox != SandboxType::None;
@@ -842,11 +1036,22 @@ async fn watch_exit(
             Some(ProcessEntry::Starting(_)) | None => false,
         }
     };
+    let sandbox_sync_wait_started = Instant::now();
     if sandboxed {
         let _ = tokio::time::timeout(Duration::from_millis(20), output_notify.notified()).await;
     }
+    current_span.record(
+        "sandbox_sync_wait_ms",
+        duration_ms(sandbox_sync_wait_started.elapsed()),
+    );
+    let state_lock_wait_started = Instant::now();
     let notification = {
         let mut processes = inner.processes.lock().await;
+        current_span.record(
+            "state_lock_wait_ms",
+            duration_ms(state_lock_wait_started.elapsed()),
+        );
+        let state_update_started = Instant::now();
         if let Some(ProcessEntry::Running(process)) = processes.get_mut(&process_id) {
             let seq = process.next_seq;
             process.next_seq += 1;
@@ -881,69 +1086,183 @@ async fn watch_exit(
                 exit_code,
                 sandbox_denied: Some(process.sandbox_denied),
             });
-            Some(ExecExitedNotification {
+            let notification = Some(ExecExitedNotification {
                 process_id: process_id.clone(),
                 seq,
                 exit_code,
                 sandbox_denied: Some(process.sandbox_denied),
-            })
+            });
+            current_span.record(
+                "state_update_ms",
+                duration_ms(state_update_started.elapsed()),
+            );
+            notification
         } else {
+            current_span.record(
+                "state_update_ms",
+                duration_ms(state_update_started.elapsed()),
+            );
             None
         }
     };
     output_notify.notify_waiters();
+    if let Some(notification) = notification.as_ref() {
+        tracing::info_span!(
+            "exec_server.local.exited",
+            seq = notification.seq,
+            exit_code = notification.exit_code,
+        )
+        .in_scope(|| {});
+        tracing::info!(
+            event = "exec_server.local.exited",
+            seq = notification.seq,
+            exit_code = notification.exit_code,
+        );
+    }
+    let notification_lookup_started = Instant::now();
+    let notifications = notification_sender(&inner);
+    current_span.record(
+        "notification_lookup_ms",
+        duration_ms(notification_lookup_started.elapsed()),
+    );
     if let Some(notification) = notification
-        && let Some(notifications) = notification_sender(&inner)
+        && let Some(notifications) = notifications
     {
+        let notification_wait_started = Instant::now();
         let _ = notifications
             .notify(crate::protocol::EXEC_EXITED_METHOD, &notification)
             .await;
+        current_span.record(
+            "notification_wait_ms",
+            duration_ms(notification_wait_started.elapsed()),
+        );
     }
 
-    maybe_emit_closed(process_id, Arc::clone(&inner)).await;
+    maybe_emit_closed(process_id, Arc::clone(&inner), CloseTrigger::ExitObserved).await;
+    tracing::info_span!("exec_server.local.exit_watcher_complete").in_scope(|| {});
 }
 
-async fn finish_output_stream(process_id: ProcessId, inner: Arc<Inner>) {
+#[tracing::instrument(
+    name = "exec_server.local.finish_output_reader",
+    level = "info",
+    skip_all,
+    fields(
+        reader = reader.as_str(),
+        outcome = tracing::field::Empty,
+        open_streams_before = tracing::field::Empty,
+        process_lock_wait_ms = tracing::field::Empty,
+    )
+)]
+async fn finish_output_stream(process_id: ProcessId, inner: Arc<Inner>, reader: OutputReader) {
+    let current_span = tracing::Span::current();
+    let process_lock_wait_started = Instant::now();
     {
         let mut processes = inner.processes.lock().await;
-        let Some(ProcessEntry::Running(process)) = processes.get_mut(&process_id) else {
+        current_span.record(
+            "process_lock_wait_ms",
+            duration_ms(process_lock_wait_started.elapsed()),
+        );
+        let Some(entry) = processes.get_mut(&process_id) else {
+            current_span.record("outcome", "process_missing");
+            return;
+        };
+        let ProcessEntry::Running(process) = entry else {
+            current_span.record("outcome", "process_not_running");
             return;
         };
 
+        current_span.record("open_streams_before", process.open_streams as u64);
         if process.open_streams > 0 {
             process.open_streams -= 1;
         }
+        current_span.record("outcome", "marked_finished");
     }
 
-    maybe_emit_closed(process_id, inner).await;
+    let trigger = match reader {
+        OutputReader::Stdout => CloseTrigger::StdoutReaderFinished,
+        OutputReader::Stderr => CloseTrigger::StderrReaderFinished,
+    };
+    maybe_emit_closed(process_id, inner, trigger).await;
 }
 
-async fn maybe_emit_closed(process_id: ProcessId, inner: Arc<Inner>) {
+#[tracing::instrument(
+    name = "exec_server.local.close_check",
+    level = "info",
+    skip_all,
+    fields(
+        trigger = trigger.as_str(),
+        outcome = tracing::field::Empty,
+        open_streams = tracing::field::Empty,
+        exit_observed = tracing::field::Empty,
+        process_lock_wait_ms = tracing::field::Empty,
+        state_update_ms = tracing::field::Empty,
+        notification_lookup_ms = tracing::field::Empty,
+        notification_result = tracing::field::Empty,
+        notification_wait_ms = tracing::field::Empty,
+    )
+)]
+async fn maybe_emit_closed(process_id: ProcessId, inner: Arc<Inner>, trigger: CloseTrigger) {
+    let current_span = tracing::Span::current();
+    let process_lock_wait_started = Instant::now();
     let (notification, output_notify) = {
         let mut processes = inner.processes.lock().await;
-        let Some(ProcessEntry::Running(process)) = processes.get_mut(&process_id) else {
+        current_span.record(
+            "process_lock_wait_ms",
+            duration_ms(process_lock_wait_started.elapsed()),
+        );
+        let state_update_started = Instant::now();
+        let Some(entry) = processes.get_mut(&process_id) else {
+            current_span.record("outcome", "process_missing");
+            return;
+        };
+        let ProcessEntry::Running(process) = entry else {
+            current_span.record("outcome", "process_not_running");
             return;
         };
 
-        if process.closed || process.open_streams != 0 || process.exit_code.is_none() {
+        current_span.record("open_streams", process.open_streams as u64);
+        current_span.record("exit_observed", process.exit_code.is_some());
+
+        if process.closed {
+            current_span.record("outcome", "already_closed");
+            return;
+        }
+        if process.open_streams != 0 && process.exit_code.is_none() {
+            current_span.record("outcome", "waiting_for_exit_and_streams");
+            return;
+        }
+        if process.open_streams != 0 {
+            current_span.record("outcome", "waiting_for_streams");
+            return;
+        }
+        if process.exit_code.is_none() {
+            current_span.record("outcome", "waiting_for_exit");
             return;
         }
 
+        current_span.record("outcome", "emitted");
         process.closed = true;
         let seq = process.next_seq;
         process.next_seq += 1;
         let _ = process.wake_tx.send(seq);
         process.events.publish(ExecProcessEvent::Closed { seq });
-        (
+        let result = (
             ExecClosedNotification {
                 process_id: process_id.clone(),
                 seq,
             },
             Arc::clone(&process.output_notify),
-        )
+        );
+        current_span.record(
+            "state_update_ms",
+            duration_ms(state_update_started.elapsed()),
+        );
+        result
     };
 
     output_notify.notify_waiters();
+    tracing::info_span!("exec_server.local.closed", seq = notification.seq,).in_scope(|| {});
+    tracing::info!(event = "exec_server.local.closed", seq = notification.seq,);
     let cleanup_process_id = process_id.clone();
     let cleanup_inner = Arc::clone(&inner);
     tokio::spawn(async move {
@@ -959,11 +1278,32 @@ async fn maybe_emit_closed(process_id: ProcessId, inner: Arc<Inner>) {
         }
     });
 
-    if let Some(notifications) = notification_sender(&inner) {
-        let _ = notifications
+    let notification_lookup_started = Instant::now();
+    let notifications = notification_sender(&inner);
+    current_span.record(
+        "notification_lookup_ms",
+        duration_ms(notification_lookup_started.elapsed()),
+    );
+    if let Some(notifications) = notifications {
+        let notification_wait_started = Instant::now();
+        let result = notifications
             .notify(EXEC_CLOSED_METHOD, &notification)
             .await;
+        current_span.record(
+            "notification_wait_ms",
+            duration_ms(notification_wait_started.elapsed()),
+        );
+        current_span.record(
+            "notification_result",
+            if result.is_ok() { "sent" } else { "failed" },
+        );
+    } else {
+        current_span.record("notification_result", "sender_missing");
     }
+}
+
+fn duration_ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
 }
 
 fn notification_sender(inner: &Inner) -> Option<RpcNotificationSender> {
@@ -984,9 +1324,12 @@ mod tests {
     use opentelemetry_sdk::metrics::InMemoryMetricExporter;
     use opentelemetry_sdk::metrics::data::AggregatedMetrics;
     use opentelemetry_sdk::metrics::data::MetricData;
+    use opentelemetry_sdk::trace::InMemorySpanExporter;
+    use opentelemetry_sdk::trace::SdkTracerProvider;
     use pretty_assertions::assert_eq;
     use tokio::sync::oneshot;
     use tokio::time::timeout;
+    use tracing_subscriber::prelude::*;
 
     fn test_exec_params(env: HashMap<String, String>) -> ExecParams {
         ExecParams {
@@ -1260,6 +1603,112 @@ mod tests {
         backend.shutdown().await;
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn process_lifecycle_trace_separates_output_readers_and_exit_watcher() {
+        use opentelemetry::trace::TracerProvider as _;
+
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_simple_exporter(exporter.clone())
+            .build();
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("exec-server-test")));
+        let _guard = tracing::subscriber::set_default(subscriber);
+        tracing::callsite::rebuild_interest_cache();
+
+        let backend = LocalProcess::default();
+        let parent = tracing::info_span!("test.process_lifecycle_parent", process_id = "test");
+        let mut process = spawn_test_process(&backend, "trace-process")
+            .instrument(parent)
+            .await;
+        process.exit(/*exit_code*/ 0);
+        drop(process.stdout_tx);
+        drop(process.stderr_tx);
+        timeout(
+            Duration::from_secs(1),
+            read_process_until_closed(&backend, &process.process_id),
+        )
+        .await
+        .expect("process should close");
+        tokio::task::yield_now().await;
+        backend.shutdown().await;
+
+        provider.force_flush().expect("flush traces");
+        let spans = exporter.get_finished_spans().expect("span export");
+        let parent = spans
+            .iter()
+            .find(|span| span.name == "test.process_lifecycle_parent")
+            .expect("lifecycle parent span");
+        let lifecycle_parent_spans = spans
+            .iter()
+            .filter(|span| {
+                matches!(
+                    span.name.as_ref(),
+                    "exec_server.local.output_lifecycle" | "exec_server.local.exit_lifecycle"
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(lifecycle_parent_spans.len(), 3, "spans: {spans:?}");
+        for span in &lifecycle_parent_spans {
+            assert_eq!(span.parent_span_id, parent.span_context.span_id());
+        }
+
+        let lifecycle_spans = spans
+            .iter()
+            .filter(|span| {
+                matches!(
+                    span.name.as_ref(),
+                    "exec_server.local.output_reader" | "exec_server.local.exit_watcher"
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(lifecycle_spans.len(), 3, "spans: {spans:?}");
+        for span in &lifecycle_spans {
+            assert!(
+                lifecycle_parent_spans
+                    .iter()
+                    .any(|parent| { span.parent_span_id == parent.span_context.span_id() }),
+                "lifecycle work span is not parented by its process-owned wrapper: {span:?}"
+            );
+            assert!(
+                span.attributes
+                    .iter()
+                    .all(|attribute| attribute.key.as_str() != "process_id"),
+                "nested lifecycle span repeated process id: {span:?}"
+            );
+        }
+
+        let readers = lifecycle_spans
+            .iter()
+            .filter(|span| span.name == "exec_server.local.output_reader")
+            .map(|span| {
+                span.attributes
+                    .iter()
+                    .find(|attribute| attribute.key.as_str() == "reader")
+                    .map(|attribute| attribute.value.clone())
+                    .expect("output reader kind")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(readers.len(), 2);
+        assert!(readers.contains(&opentelemetry::Value::String("stdout".into())));
+        assert!(readers.contains(&opentelemetry::Value::String("stderr".into())));
+
+        assert_eq!(
+            spans
+                .iter()
+                .filter(|span| span.name == "exec_server.local.output_source_complete")
+                .count(),
+            2,
+        );
+        assert!(spans.iter().any(|span| {
+            span.name == "exec_server.local.close_check"
+                && span.attributes.iter().any(|attribute| {
+                    attribute.key.as_str() == "outcome"
+                        && attribute.value == opentelemetry::Value::String("emitted".into())
+                })
+        }));
+    }
+
     struct TestProcess {
         process_id: ProcessId,
         stdout_tx: mpsc::Sender<Vec<u8>>,
@@ -1300,6 +1749,7 @@ mod tests {
                 output: VecDeque::new(),
                 retained_bytes: 0,
                 next_seq: 1,
+                first_output_observed: false,
                 exit_code: None,
                 wake_tx: wake_tx.clone(),
                 events: events.clone(),
@@ -1315,26 +1765,51 @@ mod tests {
         assert!(previous.is_none());
         drop(processes);
 
-        tokio::spawn(stream_output(
-            process_id.clone(),
-            ExecOutputStream::Stdout,
-            stdout_rx,
-            Arc::clone(&backend.inner),
-            Arc::clone(&output_notify),
-        ));
-        tokio::spawn(stream_output(
-            process_id.clone(),
-            ExecOutputStream::Stderr,
-            stderr_rx,
-            Arc::clone(&backend.inner),
-            Arc::clone(&output_notify),
-        ));
-        tokio::spawn(watch_exit(
-            process_id.clone(),
-            exit_rx,
-            Arc::clone(&backend.inner),
-            output_notify,
-        ));
+        let stdout_lifecycle_span = tracing::info_span!(
+            "exec_server.local.output_lifecycle",
+            process_id = %process_id,
+            reader = OutputReader::Stdout.as_str(),
+        );
+        tokio::spawn(
+            stream_output(
+                process_id.clone(),
+                OutputReader::Stdout,
+                ExecOutputStream::Stdout,
+                stdout_rx,
+                Arc::clone(&backend.inner),
+                Arc::clone(&output_notify),
+            )
+            .instrument(stdout_lifecycle_span),
+        );
+        let stderr_lifecycle_span = tracing::info_span!(
+            "exec_server.local.output_lifecycle",
+            process_id = %process_id,
+            reader = OutputReader::Stderr.as_str(),
+        );
+        tokio::spawn(
+            stream_output(
+                process_id.clone(),
+                OutputReader::Stderr,
+                ExecOutputStream::Stderr,
+                stderr_rx,
+                Arc::clone(&backend.inner),
+                Arc::clone(&output_notify),
+            )
+            .instrument(stderr_lifecycle_span),
+        );
+        let exit_lifecycle_span = tracing::info_span!(
+            "exec_server.local.exit_lifecycle",
+            process_id = %process_id,
+        );
+        tokio::spawn(
+            watch_exit(
+                process_id.clone(),
+                exit_rx,
+                Arc::clone(&backend.inner),
+                output_notify,
+            )
+            .instrument(exit_lifecycle_span),
+        );
 
         TestProcess {
             process_id,

--- a/codex-rs/exec-server/src/noise_relay/executor_stream.rs
+++ b/codex-rs/exec-server/src/noise_relay/executor_stream.rs
@@ -6,9 +6,16 @@
 
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::time::Duration;
+use std::time::Instant;
 
+use codex_exec_server_protocol::JSONRPCMessage;
+use codex_protocol::protocol::W3cTraceContext;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
+use tracing::Instrument;
+use tracing::Span;
+use tracing::field;
 use tracing::warn;
 
 use crate::ExecServerError;
@@ -23,6 +30,7 @@ use crate::noise_relay::message_framing::NOISE_RECORD_PLAINTEXT_LEN;
 use crate::noise_relay::message_framing::frame_jsonrpc_message;
 use crate::noise_relay::ordered_ciphertext::OrderedCiphertextFrames;
 use crate::noise_relay::take_next_sequence;
+use crate::noise_relay::trace_context::NoiseTraceContext;
 use crate::relay::encode_relay_message_frame;
 use crate::relay_proto::RelayData;
 use crate::relay_proto::RelayMessageFrame;
@@ -39,6 +47,35 @@ pub(crate) struct ClosedNoiseVirtualStream {
     pub(crate) instance_id: u64,
 }
 
+/// One frame queued for the executor's shared physical rendezvous websocket.
+///
+/// Data frames carry the current trace context across the channel so the
+/// physical websocket send remains attributable to the originating RPC or
+/// process notification. Relay control frames intentionally carry no context.
+pub(crate) struct NoisePhysicalFrame {
+    pub(crate) encoded: Vec<u8>,
+    pub(crate) queued_at: Instant,
+    pub(crate) trace: Option<Arc<W3cTraceContext>>,
+}
+
+impl NoisePhysicalFrame {
+    pub(crate) fn data(encoded: Vec<u8>, trace: Option<Arc<W3cTraceContext>>) -> Self {
+        Self {
+            encoded,
+            queued_at: Instant::now(),
+            trace,
+        }
+    }
+
+    pub(crate) fn control(encoded: Vec<u8>) -> Self {
+        Self {
+            encoded,
+            queued_at: Instant::now(),
+            trace: None,
+        }
+    }
+}
+
 /// One authenticated JSON-RPC stream carried by the executor's physical relay.
 ///
 /// Inbound delivery is intentionally nonblocking. An overloaded or abandoned
@@ -50,7 +87,17 @@ pub(crate) struct NoiseVirtualStream {
     transport: Arc<Mutex<NoiseTransport>>,
     inbound_ciphertexts: OrderedCiphertextFrames,
     inbound_decoder: JsonRpcMessageDecoder,
+    trace_context: Arc<Mutex<NoiseTraceContext>>,
     pub(crate) instance_id: u64,
+}
+
+struct ExecutorInboundTimings {
+    websocket_ingress_to_decode: Duration,
+    relay_dispatch: Duration,
+    reorder: Duration,
+    decrypt: Duration,
+    decode: Duration,
+    trace_context: Duration,
 }
 
 impl NoiseVirtualStream {
@@ -63,8 +110,19 @@ impl NoiseVirtualStream {
 
     /// Reorder and decrypt one inbound record, then queue complete JSON-RPC messages.
     /// This must stay nonblocking because all virtual streams share the read loop.
-    pub(crate) fn receive_data(&mut self, data: RelayData) -> Result<(), ExecServerError> {
-        for ciphertext in self.inbound_ciphertexts.push(data.seq, data.payload)? {
+    pub(crate) fn receive_data(
+        &mut self,
+        data: RelayData,
+        physical_received_at: Instant,
+    ) -> Result<(), ExecServerError> {
+        let relay_seq = data.seq;
+        let ciphertext_bytes = data.payload.len();
+        let relay_dispatch_elapsed = physical_received_at.elapsed();
+        let reorder_started_at = Instant::now();
+        let ciphertexts = self.inbound_ciphertexts.push(data.seq, data.payload)?;
+        let reorder_elapsed = reorder_started_at.elapsed();
+        for ciphertext in ciphertexts {
+            let decrypt_started_at = Instant::now();
             let plaintext = {
                 let mut transport = self
                     .transport
@@ -74,18 +132,111 @@ impl NoiseVirtualStream {
                     ExecServerError::Protocol(format!("Noise relay decryption failed: {error}"))
                 })?
             };
-            for message in self.inbound_decoder.push(&plaintext)? {
-                self.incoming_tx
-                    .try_send(JsonRpcConnectionEvent::Message(message))
-                    .map_err(|_| {
-                        ExecServerError::Protocol(
-                            "Noise virtual stream inbound queue is full or closed".to_string(),
-                        )
-                    })?;
+            let decrypt_elapsed = decrypt_started_at.elapsed();
+            let decode_started_at = Instant::now();
+            let messages = self.inbound_decoder.push(&plaintext)?;
+            let decode_elapsed = decode_started_at.elapsed();
+            for message in messages {
+                let trace_context_started_at = Instant::now();
+                self.trace_context
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .observe_request(&message);
+                let trace_context_elapsed = trace_context_started_at.elapsed();
+                let decoded_span = decoded_message_span(
+                    &message,
+                    relay_seq,
+                    ciphertext_bytes,
+                    ExecutorInboundTimings {
+                        websocket_ingress_to_decode: physical_received_at.elapsed(),
+                        relay_dispatch: relay_dispatch_elapsed,
+                        reorder: reorder_elapsed,
+                        decrypt: decrypt_elapsed,
+                        decode: decode_elapsed,
+                        trace_context: trace_context_elapsed,
+                    },
+                );
+                let enqueued_span = enqueued_message_span(&message, relay_seq);
+                let enqueue_started_at = Instant::now();
+                let enqueue_result = decoded_span.in_scope(|| {
+                    self.incoming_tx
+                        .try_send(JsonRpcConnectionEvent::Message(message))
+                        .map_err(|_| {
+                            ExecServerError::Protocol(
+                                "Noise virtual stream inbound queue is full or closed".to_string(),
+                            )
+                        })
+                });
+                enqueued_span.record(
+                    "enqueue_ms",
+                    enqueue_started_at.elapsed().as_secs_f64() * 1_000.0,
+                );
+                enqueue_result?;
+                enqueued_span.in_scope(|| {});
             }
         }
         Ok(())
     }
+}
+
+fn decoded_message_span(
+    message: &JSONRPCMessage,
+    relay_seq: u32,
+    ciphertext_bytes: usize,
+    timings: ExecutorInboundTimings,
+) -> Span {
+    let (message_kind, method, trace) = match message {
+        JSONRPCMessage::Request(request) => {
+            ("request", request.method.as_str(), request.trace.as_ref())
+        }
+        JSONRPCMessage::Notification(notification) => {
+            ("notification", notification.method.as_str(), None)
+        }
+        JSONRPCMessage::Response(_) => ("response", "", None),
+        JSONRPCMessage::Error(_) => ("error", "", None),
+    };
+    let span = tracing::info_span!(
+        "exec_server.noise.executor_message_decoded",
+        message_kind,
+        method,
+        relay_seq,
+        ciphertext_bytes,
+        executor_websocket_ingress_to_decode_ms =
+            timings.websocket_ingress_to_decode.as_secs_f64() * 1_000.0,
+        relay_dispatch_ms = timings.relay_dispatch.as_secs_f64() * 1_000.0,
+        reorder_ms = timings.reorder.as_secs_f64() * 1_000.0,
+        decrypt_ms = timings.decrypt.as_secs_f64() * 1_000.0,
+        decode_ms = timings.decode.as_secs_f64() * 1_000.0,
+        trace_context_ms = timings.trace_context.as_secs_f64() * 1_000.0,
+    );
+    if let Some(trace) = trace {
+        let _ = codex_otel::set_parent_from_w3c_trace_context(&span, trace);
+    }
+    span
+}
+
+fn enqueued_message_span(message: &JSONRPCMessage, relay_seq: u32) -> Span {
+    let (message_kind, method, trace) = match message {
+        JSONRPCMessage::Request(request) => {
+            ("request", request.method.as_str(), request.trace.as_ref())
+        }
+        JSONRPCMessage::Notification(notification) => {
+            ("notification", notification.method.as_str(), None)
+        }
+        JSONRPCMessage::Response(_) => ("response", "", None),
+        JSONRPCMessage::Error(_) => ("error", "", None),
+    };
+    let span = tracing::info_span!(
+        "exec_server.noise.executor_message_enqueued",
+        message_kind,
+        method,
+        relay_seq,
+        enqueue_ms = field::Empty,
+    );
+    if let Some(trace) = trace {
+        let _ = codex_otel::set_parent_from_w3c_trace_context(&span, trace);
+    }
+    span
 }
 
 /// Start JSON-RPC processing for a completed handshake.
@@ -96,7 +247,7 @@ pub(crate) fn spawn_noise_virtual_stream(
     stream_id: String,
     instance_id: u64,
     processor: ConnectionProcessor,
-    physical_outgoing_tx: mpsc::Sender<Vec<u8>>,
+    physical_outgoing_tx: mpsc::Sender<NoisePhysicalFrame>,
     closed_stream_tx: mpsc::Sender<ClosedNoiseVirtualStream>,
     transport: NoiseTransport,
 ) -> NoiseVirtualStream {
@@ -105,49 +256,27 @@ pub(crate) fn spawn_noise_virtual_stream(
     let (disconnected_tx, disconnected_rx) = watch::channel(false);
     let transport = Arc::new(Mutex::new(transport));
     let writer_transport = Arc::clone(&transport);
+    let trace_context = Arc::new(Mutex::new(NoiseTraceContext::default()));
+    let writer_trace_context = Arc::clone(&trace_context);
     let processor_stream_id = stream_id.clone();
     let processor_closed_stream_tx = closed_stream_tx.clone();
     let writer_stream_id = stream_id;
     let writer_task = tokio::spawn(async move {
         let mut next_seq = 0u32;
         'writer: while let Some(message) = json_outgoing_rx.recv().await {
-            // Each chunk becomes one Noise record and consumes one nonce.
-            let framed = match frame_jsonrpc_message(&message) {
-                Ok(framed) => framed,
-                Err(error) => {
-                    warn!("failed to frame Noise virtual stream JSON-RPC payload: {error}");
-                    break;
-                }
-            };
-            for plaintext_record in framed.chunks(NOISE_RECORD_PLAINTEXT_LEN) {
-                let seq = match take_next_sequence(&mut next_seq) {
-                    Ok(seq) => seq,
-                    Err(error) => {
-                        warn!("Noise virtual stream sequence exhausted: {error}");
-                        break 'writer;
-                    }
-                };
-                let ciphertext = {
-                    let mut transport = writer_transport
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner);
-                    transport.encrypt(plaintext_record)
-                };
-                let ciphertext = match ciphertext {
-                    Ok(ciphertext) => ciphertext,
-                    Err(error) => {
-                        warn!("failed to encrypt Noise virtual stream payload: {error}");
-                        break 'writer;
-                    }
-                };
-                let frame = RelayMessageFrame::data(writer_stream_id.clone(), seq, ciphertext);
-                if physical_outgoing_tx
-                    .send(encode_relay_message_frame(&frame))
-                    .await
-                    .is_err()
-                {
-                    break 'writer;
-                }
+            let outbound_span = outbound_message_span(&message, &writer_trace_context);
+            if let Err(error) = send_outbound_message(
+                &physical_outgoing_tx,
+                &writer_transport,
+                &writer_stream_id,
+                &mut next_seq,
+                &message,
+            )
+            .instrument(outbound_span)
+            .await
+            {
+                warn!("failed to send Noise virtual stream JSON-RPC payload: {error}");
+                break 'writer;
             }
         }
 
@@ -158,7 +287,9 @@ pub(crate) fn spawn_noise_virtual_stream(
         };
         let reset =
             RelayMessageFrame::reset(writer_stream_id, NOISE_RELAY_RESET_REASON.to_string());
-        let _ = physical_outgoing_tx.try_send(encode_relay_message_frame(&reset));
+        let _ = physical_outgoing_tx.try_send(NoisePhysicalFrame::control(
+            encode_relay_message_frame(&reset),
+        ));
         let _ = closed_stream_tx.send(closed_stream).await;
     });
 
@@ -187,8 +318,101 @@ pub(crate) fn spawn_noise_virtual_stream(
         transport,
         inbound_ciphertexts: OrderedCiphertextFrames::default(),
         inbound_decoder: JsonRpcMessageDecoder::default(),
+        trace_context,
         instance_id,
     }
+}
+
+fn outbound_message_span(
+    message: &JSONRPCMessage,
+    trace_context: &Mutex<NoiseTraceContext>,
+) -> Span {
+    let (message_kind, method) = match message {
+        JSONRPCMessage::Request(request) => ("request", request.method.as_str()),
+        JSONRPCMessage::Notification(notification) => {
+            ("notification", notification.method.as_str())
+        }
+        JSONRPCMessage::Response(_) => ("response", ""),
+        JSONRPCMessage::Error(_) => ("error", ""),
+    };
+    let trace = trace_context
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .return_trace(message);
+    let span = tracing::info_span!(
+        "exec_server.noise.executor_outbound",
+        message_kind,
+        method,
+        framed_bytes = field::Empty,
+        records = field::Empty,
+        frame_complete_ms = field::Empty,
+        encrypt_complete_ms = field::Empty,
+        physical_queue_complete_ms = field::Empty,
+    );
+    if let Some(trace) = trace.as_ref() {
+        let _ = codex_otel::set_parent_from_w3c_trace_context(&span, trace);
+    }
+    span
+}
+
+async fn send_outbound_message(
+    physical_outgoing_tx: &mpsc::Sender<NoisePhysicalFrame>,
+    transport: &Mutex<NoiseTransport>,
+    stream_id: &str,
+    next_seq: &mut u32,
+    message: &JSONRPCMessage,
+) -> Result<(), ExecServerError> {
+    let started_at = Instant::now();
+    let framed = tracing::info_span!("exec_server.noise.executor_frame_message")
+        .in_scope(|| frame_jsonrpc_message(message))?;
+    let record_count = framed.len().div_ceil(NOISE_RECORD_PLAINTEXT_LEN);
+    let span = Span::current();
+    span.record("framed_bytes", framed.len());
+    span.record("records", record_count);
+    span.record(
+        "frame_complete_ms",
+        started_at.elapsed().as_secs_f64() * 1_000.0,
+    );
+    // Extracting W3C context allocates its string carrier. Do that once for the
+    // logical JSON-RPC message, then share it across all physical Noise records.
+    let trace = codex_otel::current_span_w3c_trace_context().map(Arc::new);
+
+    for (record_index, plaintext_record) in framed.chunks(NOISE_RECORD_PLAINTEXT_LEN).enumerate() {
+        let seq = take_next_sequence(next_seq)?;
+        let ciphertext =
+            tracing::info_span!("exec_server.noise.executor_encrypt_record", record_index,)
+                .in_scope(|| {
+                    transport
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .encrypt(plaintext_record)
+                })
+                .map_err(|error| {
+                    ExecServerError::Protocol(format!(
+                        "failed to encrypt Noise virtual stream payload: {error}"
+                    ))
+                })?;
+        span.record(
+            "encrypt_complete_ms",
+            started_at.elapsed().as_secs_f64() * 1_000.0,
+        );
+        let frame = RelayMessageFrame::data(stream_id.to_string(), seq, ciphertext);
+        let encoded = encode_relay_message_frame(&frame);
+        let permit = physical_outgoing_tx
+            .reserve()
+            .instrument(tracing::info_span!(
+                "exec_server.noise.executor_physical_queue",
+                record_index,
+            ))
+            .await
+            .map_err(|_| ExecServerError::Closed)?;
+        permit.send(NoisePhysicalFrame::data(encoded, trace.clone()));
+        span.record(
+            "physical_queue_complete_ms",
+            started_at.elapsed().as_secs_f64() * 1_000.0,
+        );
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/codex-rs/exec-server/src/noise_relay/executor_stream_tests.rs
+++ b/codex-rs/exec-server/src/noise_relay/executor_stream_tests.rs
@@ -1,22 +1,85 @@
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
 use codex_exec_server_protocol::JSONRPCMessage;
 use codex_exec_server_protocol::JSONRPCResponse;
 use codex_exec_server_protocol::RequestId;
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_sdk::trace::SdkTracerProvider;
 use tokio::sync::mpsc;
 use tokio::time::timeout;
+use tracing::Instrument;
+use tracing::instrument::WithSubscriber;
+use tracing_subscriber::prelude::*;
 
 use super::ClosedNoiseVirtualStream;
+use super::send_outbound_message;
 use super::spawn_noise_virtual_stream;
 use crate::ExecServerRuntimePaths;
 use crate::connection::CHANNEL_CAPACITY;
 use crate::noise_channel::InitiatorHandshake;
 use crate::noise_channel::NoiseChannelIdentity;
 use crate::noise_channel::PendingResponderHandshake;
+use crate::noise_relay::message_framing::NOISE_RECORD_PLAINTEXT_LEN;
 use crate::noise_relay::message_framing::frame_jsonrpc_message;
 use crate::relay_proto::RelayData;
 use crate::server::ConnectionProcessor;
+
+#[tokio::test(flavor = "current_thread")]
+async fn outbound_records_share_one_message_trace_context() -> Result<()> {
+    let executor_identity = NoiseChannelIdentity::generate()?;
+    let harness_identity = NoiseChannelIdentity::generate()?;
+    let (initiator, request) = InitiatorHandshake::start(
+        &harness_identity,
+        &executor_identity.public_key(),
+        b"test-prologue",
+        b"authorization",
+    )?;
+    let pending =
+        PendingResponderHandshake::read_request(&executor_identity, b"test-prologue", &request)?;
+    let (executor_transport, response) = pending.complete()?;
+    let _harness_transport = initiator.finish(&response)?;
+    let executor_transport = std::sync::Mutex::new(executor_transport);
+    let (physical_outgoing_tx, mut physical_outgoing_rx) = mpsc::channel(CHANNEL_CAPACITY);
+    let message = JSONRPCMessage::Response(JSONRPCResponse {
+        id: RequestId::Integer(1),
+        result: serde_json::Value::String("x".repeat(NOISE_RECORD_PLAINTEXT_LEN * 2)),
+    });
+
+    let provider = SdkTracerProvider::builder().build();
+    let subscriber = tracing_subscriber::registry()
+        .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("exec-server-test")));
+    let mut next_seq = 0;
+    async {
+        tracing::callsite::rebuild_interest_cache();
+        send_outbound_message(
+            &physical_outgoing_tx,
+            &executor_transport,
+            "stream-1",
+            &mut next_seq,
+            &message,
+        )
+        .instrument(tracing::info_span!("outbound-message"))
+        .await
+    }
+    .with_subscriber(subscriber)
+    .await?;
+
+    let mut frames = Vec::new();
+    while let Ok(frame) = physical_outgoing_rx.try_recv() {
+        frames.push(frame);
+    }
+    assert!(frames.len() > 1, "expected multiple physical records");
+    let first_trace = frames[0].trace.as_ref().expect("first record trace");
+    assert!(frames.iter().skip(1).all(|frame| {
+        Arc::ptr_eq(
+            first_trace,
+            frame.trace.as_ref().expect("subsequent record trace"),
+        )
+    }));
+    Ok(())
+}
 
 #[tokio::test]
 async fn processor_exit_reports_closed_virtual_stream() -> Result<()> {
@@ -52,12 +115,15 @@ async fn processor_exit_reports_closed_virtual_stream() -> Result<()> {
         result: serde_json::Value::Null,
     });
     let ciphertext = harness_transport.encrypt(&frame_jsonrpc_message(&message)?)?;
-    stream.receive_data(RelayData {
-        seq: 0,
-        segment_index: 0,
-        segment_count: 1,
-        payload: ciphertext,
-    })?;
+    stream.receive_data(
+        RelayData {
+            seq: 0,
+            segment_index: 0,
+            segment_count: 1,
+            payload: ciphertext,
+        },
+        std::time::Instant::now(),
+    )?;
 
     assert!(matches!(
         timeout(Duration::from_secs(1), closed_stream_rx.recv()).await?,

--- a/codex-rs/exec-server/src/noise_relay/harness.rs
+++ b/codex-rs/exec-server/src/noise_relay/harness.rs
@@ -6,6 +6,9 @@
 //! normal `JsonRpcConnection`. Outbound JSON-RPC is framed and split into Noise
 //! records; inbound records are reordered before decryption and reassembly.
 
+use std::time::Instant;
+
+use codex_exec_server_protocol::JSONRPCMessage;
 use futures::Sink;
 use futures::SinkExt;
 use futures::Stream;
@@ -14,7 +17,9 @@ use tokio::sync::mpsc;
 use tokio::sync::watch;
 use tokio_tungstenite::tungstenite::Message;
 use tracing::Instrument;
+use tracing::Span;
 use tracing::debug;
+use tracing::field;
 use tracing::info;
 use tracing::warn;
 use uuid::Uuid;
@@ -34,6 +39,7 @@ use crate::noise_relay::message_framing::NOISE_RECORD_PLAINTEXT_LEN;
 use crate::noise_relay::message_framing::frame_jsonrpc_message;
 use crate::noise_relay::ordered_ciphertext::OrderedCiphertextFrames;
 use crate::noise_relay::take_next_sequence;
+use crate::noise_relay::trace_context::NoiseTraceContext;
 use crate::relay::RelayFrameBodyKind;
 use crate::relay::decode_relay_message_frame;
 use crate::relay::encode_relay_message_frame;
@@ -266,42 +272,28 @@ where
         let mut next_outbound_seq = 0u32;
         let mut inbound_ciphertexts = OrderedCiphertextFrames::default();
         let mut inbound_decoder = JsonRpcMessageDecoder::default();
+        let mut trace_context = NoiseTraceContext::default();
         'relay: loop {
             tokio::select! {
                 maybe_message = outgoing_rx.recv() => {
                     let Some(message) = maybe_message else {
                         break;
                     };
-                    let framed = match frame_jsonrpc_message(&message) {
-                        Ok(framed) => framed,
-                        Err(error) => {
-                            warn!("failed to frame JSON-RPC payload for Noise relay: {error}");
-                            break;
-                        }
-                    };
-                    for plaintext_record in framed.chunks(NOISE_RECORD_PLAINTEXT_LEN) {
-                        let seq = match take_next_sequence(&mut next_outbound_seq) {
-                            Ok(seq) => seq,
-                            Err(error) => {
-                                warn!("Noise relay sequence exhausted: {error}");
-                                break 'relay;
-                            }
-                        };
-                        let ciphertext = match transport.encrypt(plaintext_record) {
-                            Ok(ciphertext) => ciphertext,
-                            Err(error) => {
-                                warn!("failed to encrypt JSON-RPC payload for Noise relay: {error}");
-                                break 'relay;
-                            }
-                        };
-                        let frame = RelayMessageFrame::data(stream_id.clone(), seq, ciphertext);
-                        if let Err(error) = websocket
-                            .send(Message::Binary(encode_relay_message_frame(&frame).into()))
-                            .await
-                        {
-                            warn!("failed to write Noise relay websocket: {error}");
-                            break 'relay;
-                        }
+                    trace_context.observe_request(&message);
+                    record_outbound_message_dequeued(&message);
+                    let outbound_span = outbound_message_span(&message);
+                    if let Err(error) = send_outbound_message(
+                        &mut websocket,
+                        &mut transport,
+                        &stream_id,
+                        &mut next_outbound_seq,
+                        &message,
+                    )
+                    .instrument(outbound_span)
+                    .await
+                    {
+                        warn!("failed to send JSON-RPC payload over Noise relay: {error}");
+                        break 'relay;
                     }
                 }
                 incoming_message = websocket.next() => {
@@ -310,6 +302,7 @@ where
                     };
                     match incoming_message {
                         Ok(Message::Binary(payload)) => {
+                            let frame_received_at = Instant::now();
                             let frame = match decode_relay_message_frame(payload.as_ref()) {
                                 Ok(frame) => frame,
                                 Err(error) => {
@@ -335,6 +328,8 @@ where
                                         &mut inbound_decoder,
                                         data,
                                         &incoming_tx,
+                                        &mut trace_context,
+                                        frame_received_at,
                                     )
                                     .await
                                     {
@@ -398,6 +393,107 @@ where
     }
 }
 
+fn record_outbound_message_dequeued(message: &JSONRPCMessage) {
+    let (message_kind, method, trace) = match message {
+        JSONRPCMessage::Request(request) => {
+            ("request", request.method.as_str(), request.trace.as_ref())
+        }
+        JSONRPCMessage::Notification(notification) => {
+            ("notification", notification.method.as_str(), None)
+        }
+        JSONRPCMessage::Response(_) => ("response", "", None),
+        JSONRPCMessage::Error(_) => ("error", "", None),
+    };
+    let span = tracing::info_span!(
+        "exec_server.noise.harness_outbound_dequeued",
+        message_kind,
+        method,
+    );
+    if let Some(trace) = trace {
+        let _ = codex_otel::set_parent_from_w3c_trace_context(&span, trace);
+    }
+    span.in_scope(|| {});
+}
+
+fn outbound_message_span(message: &JSONRPCMessage) -> Span {
+    let (message_kind, method, trace) = match message {
+        JSONRPCMessage::Request(request) => {
+            ("request", request.method.as_str(), request.trace.as_ref())
+        }
+        JSONRPCMessage::Notification(notification) => {
+            ("notification", notification.method.as_str(), None)
+        }
+        JSONRPCMessage::Response(_) => ("response", "", None),
+        JSONRPCMessage::Error(_) => ("error", "", None),
+    };
+    let span = tracing::info_span!(
+        "exec_server.noise.harness_outbound",
+        message_kind,
+        method,
+        framed_bytes = field::Empty,
+        records = field::Empty,
+        frame_complete_ms = field::Empty,
+        encrypt_complete_ms = field::Empty,
+        send_complete_ms = field::Empty,
+    );
+    if let Some(trace) = trace {
+        let _ = codex_otel::set_parent_from_w3c_trace_context(&span, trace);
+    }
+    span
+}
+
+async fn send_outbound_message<T, E>(
+    websocket: &mut T,
+    transport: &mut NoiseTransport,
+    stream_id: &str,
+    next_outbound_seq: &mut u32,
+    message: &JSONRPCMessage,
+) -> Result<(), ExecServerError>
+where
+    T: Sink<Message, Error = E> + Unpin,
+    E: std::fmt::Display,
+{
+    let started_at = Instant::now();
+    let framed = tracing::info_span!("exec_server.noise.frame_request")
+        .in_scope(|| frame_jsonrpc_message(message))?;
+    let record_count = framed.len().div_ceil(NOISE_RECORD_PLAINTEXT_LEN);
+    let span = Span::current();
+    span.record("framed_bytes", framed.len());
+    span.record("records", record_count);
+    span.record(
+        "frame_complete_ms",
+        started_at.elapsed().as_secs_f64() * 1_000.0,
+    );
+
+    for plaintext_record in framed.chunks(NOISE_RECORD_PLAINTEXT_LEN) {
+        let seq = take_next_sequence(next_outbound_seq)?;
+        let ciphertext = tracing::info_span!("exec_server.noise.encrypt_record")
+            .in_scope(|| transport.encrypt(plaintext_record))
+            .map_err(|error| {
+                ExecServerError::Protocol(format!(
+                    "failed to encrypt JSON-RPC payload for Noise relay: {error}"
+                ))
+            })?;
+        span.record(
+            "encrypt_complete_ms",
+            started_at.elapsed().as_secs_f64() * 1_000.0,
+        );
+        let frame = RelayMessageFrame::data(stream_id.to_string(), seq, ciphertext);
+        websocket
+            .send(Message::Binary(encode_relay_message_frame(&frame).into()))
+            .instrument(tracing::info_span!("exec_server.noise.websocket_send", seq,))
+            .await
+            .map_err(|error| {
+                ExecServerError::Protocol(format!("failed to write Noise relay websocket: {error}"))
+            })?;
+    }
+    span.record(
+        "send_complete_ms",
+        started_at.elapsed().as_secs_f64() * 1_000.0,
+    );
+    Ok(())
+}
+
 /// Order and decrypt one relay frame, then emit any complete JSON-RPC messages.
 /// Relay records and JSON-RPC messages do not share boundaries, so reassembly
 /// happens after decryption.
@@ -407,25 +503,109 @@ async fn receive_data(
     decoder: &mut JsonRpcMessageDecoder,
     data: RelayData,
     incoming_tx: &mpsc::Sender<JsonRpcConnectionEvent>,
+    trace_context: &mut NoiseTraceContext,
+    frame_received_at: Instant,
 ) -> Result<(), ExecServerError> {
+    let frame_decode_elapsed = frame_received_at.elapsed();
+    let ciphertext_bytes = data.payload.len();
     // Ordering must happen before decryption because Noise transport nonces are
     // implicit. A future or duplicate ciphertext passed directly to Clatter
     // would desynchronize the channel.
-    for ciphertext in inbound_ciphertexts.push(data.seq, data.payload)? {
+    let reorder_started_at = Instant::now();
+    let ciphertexts = inbound_ciphertexts.push(data.seq, data.payload)?;
+    let reorder_elapsed = reorder_started_at.elapsed();
+    for ciphertext in ciphertexts {
+        let decrypt_started_at = Instant::now();
         let plaintext = transport.decrypt(&ciphertext).map_err(|error| {
             ExecServerError::Protocol(format!("Noise relay decryption failed: {error}"))
         })?;
+        let decrypt_elapsed = decrypt_started_at.elapsed();
 
         // The authenticated byte stream can carry partial or multiple JSON-RPC
         // messages; emit only complete, successfully parsed messages.
-        for message in decoder.push(&plaintext)? {
-            incoming_tx
-                .send(JsonRpcConnectionEvent::Message(message))
-                .await
-                .map_err(|_| ExecServerError::Closed)?;
+        let decode_started_at = Instant::now();
+        let messages = decoder.push(&plaintext)?;
+        let decode_elapsed = decode_started_at.elapsed();
+        for message in messages {
+            let trace = trace_context.return_trace(&message);
+            let inbound_span = inbound_message_span(
+                &message,
+                trace.as_ref(),
+                ciphertext_bytes,
+                frame_decode_elapsed,
+                reorder_elapsed,
+                decrypt_elapsed,
+                decode_elapsed,
+            );
+            let delivery_started_at = Instant::now();
+            let send_result = async {
+                match incoming_tx
+                    .reserve()
+                    .instrument(tracing::info_span!(
+                        "exec_server.noise.harness_inbound_delivery"
+                    ))
+                    .await
+                {
+                    Ok(permit) => {
+                        permit.send(JsonRpcConnectionEvent::TracedMessage {
+                            message,
+                            trace,
+                            queued_at: Instant::now(),
+                        });
+                        Ok(())
+                    }
+                    Err(err) => Err(err),
+                }
+            }
+            .instrument(inbound_span.clone())
+            .await;
+            inbound_span.record(
+                "delivery_ms",
+                delivery_started_at.elapsed().as_secs_f64() * 1_000.0,
+            );
+            inbound_span.record(
+                "receive_complete_ms",
+                frame_received_at.elapsed().as_secs_f64() * 1_000.0,
+            );
+            send_result.map_err(|_| ExecServerError::Closed)?;
         }
     }
     Ok(())
+}
+
+fn inbound_message_span(
+    message: &JSONRPCMessage,
+    trace: Option<&codex_protocol::protocol::W3cTraceContext>,
+    ciphertext_bytes: usize,
+    frame_decode_elapsed: std::time::Duration,
+    reorder_elapsed: std::time::Duration,
+    decrypt_elapsed: std::time::Duration,
+    decode_elapsed: std::time::Duration,
+) -> Span {
+    let (message_kind, method) = match message {
+        JSONRPCMessage::Request(request) => ("request", request.method.as_str()),
+        JSONRPCMessage::Notification(notification) => {
+            ("notification", notification.method.as_str())
+        }
+        JSONRPCMessage::Response(_) => ("response", ""),
+        JSONRPCMessage::Error(_) => ("error", ""),
+    };
+    let span = tracing::info_span!(
+        "exec_server.noise.harness_inbound",
+        message_kind,
+        method,
+        ciphertext_bytes,
+        frame_decode_ms = frame_decode_elapsed.as_secs_f64() * 1_000.0,
+        reorder_ms = reorder_elapsed.as_secs_f64() * 1_000.0,
+        decrypt_ms = decrypt_elapsed.as_secs_f64() * 1_000.0,
+        decode_ms = decode_elapsed.as_secs_f64() * 1_000.0,
+        delivery_ms = field::Empty,
+        receive_complete_ms = field::Empty,
+    );
+    if let Some(trace) = trace {
+        let _ = codex_otel::set_parent_from_w3c_trace_context(&span, trace);
+    }
+    span
 }
 
 async fn send_malformed(incoming_tx: &mpsc::Sender<JsonRpcConnectionEvent>, reason: String) {

--- a/codex-rs/exec-server/src/noise_relay/mod.rs
+++ b/codex-rs/exec-server/src/noise_relay/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod executor_stream;
 mod harness;
 mod message_framing;
 mod ordered_ciphertext;
+mod trace_context;
 
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
 

--- a/codex-rs/exec-server/src/noise_relay/trace_context.rs
+++ b/codex-rs/exec-server/src/noise_relay/trace_context.rs
@@ -1,0 +1,63 @@
+use std::collections::HashMap;
+
+use codex_exec_server_protocol::EXEC_CLOSED_METHOD;
+use codex_exec_server_protocol::JSONRPCMessage;
+use codex_exec_server_protocol::RequestId;
+use codex_protocol::protocol::W3cTraceContext;
+
+/// Correlates return traffic with the trace carried by its originating request.
+///
+/// Responses do not repeat the request's W3C carrier, and process notifications
+/// are correlated by `processId`. Keeping this state per virtual stream avoids
+/// adding telemetry-only fields to the JSON-RPC wire protocol.
+#[derive(Default)]
+pub(super) struct NoiseTraceContext {
+    requests: HashMap<RequestId, W3cTraceContext>,
+    processes: HashMap<String, W3cTraceContext>,
+}
+
+impl NoiseTraceContext {
+    pub(super) fn observe_request(&mut self, message: &JSONRPCMessage) {
+        let JSONRPCMessage::Request(request) = message else {
+            return;
+        };
+        let Some(trace) = request.trace.as_ref() else {
+            return;
+        };
+        self.requests.insert(request.id.clone(), trace.clone());
+        if let Some(process_id) = message_process_id(message) {
+            self.processes
+                .entry(process_id.to_string())
+                .or_insert_with(|| trace.clone());
+        }
+    }
+
+    pub(super) fn return_trace(&mut self, message: &JSONRPCMessage) -> Option<W3cTraceContext> {
+        match message {
+            JSONRPCMessage::Response(response) => self.requests.remove(&response.id),
+            JSONRPCMessage::Error(error) => self.requests.remove(&error.id),
+            JSONRPCMessage::Notification(notification) => {
+                let process_id = message_process_id(message)?;
+                let trace = self.processes.get(process_id).cloned();
+                if notification.method == EXEC_CLOSED_METHOD {
+                    self.processes.remove(process_id);
+                }
+                trace
+            }
+            JSONRPCMessage::Request(request) => request.trace.clone(),
+        }
+    }
+}
+
+fn message_process_id(message: &JSONRPCMessage) -> Option<&str> {
+    let params = match message {
+        JSONRPCMessage::Request(request) => request.params.as_ref(),
+        JSONRPCMessage::Notification(notification) => notification.params.as_ref(),
+        JSONRPCMessage::Response(_) | JSONRPCMessage::Error(_) => None,
+    }?;
+    params.get("processId")?.as_str()
+}
+
+#[cfg(test)]
+#[path = "trace_context_tests.rs"]
+mod tests;

--- a/codex-rs/exec-server/src/noise_relay/trace_context_tests.rs
+++ b/codex-rs/exec-server/src/noise_relay/trace_context_tests.rs
@@ -1,0 +1,48 @@
+use codex_exec_server_protocol::EXEC_CLOSED_METHOD;
+use codex_exec_server_protocol::EXEC_METHOD;
+use codex_exec_server_protocol::JSONRPCMessage;
+use codex_exec_server_protocol::JSONRPCNotification;
+use codex_exec_server_protocol::JSONRPCRequest;
+use codex_exec_server_protocol::JSONRPCResponse;
+use codex_exec_server_protocol::RequestId;
+use codex_protocol::protocol::W3cTraceContext;
+use pretty_assertions::assert_eq;
+
+use super::NoiseTraceContext;
+
+fn trace_context() -> W3cTraceContext {
+    W3cTraceContext {
+        traceparent: Some("00-00000000000000000000000000000001-0000000000000002-01".to_string()),
+        tracestate: None,
+    }
+}
+
+fn process_start_request(trace: W3cTraceContext) -> JSONRPCMessage {
+    JSONRPCMessage::Request(JSONRPCRequest {
+        id: RequestId::Integer(7),
+        method: EXEC_METHOD.to_string(),
+        params: Some(serde_json::json!({"processId": "process-1"})),
+        trace: Some(trace),
+    })
+}
+
+#[test]
+fn correlates_response_and_terminal_notification_with_request_trace() {
+    let trace = trace_context();
+    let mut context = NoiseTraceContext::default();
+    context.observe_request(&process_start_request(trace.clone()));
+
+    let response = JSONRPCMessage::Response(JSONRPCResponse {
+        id: RequestId::Integer(7),
+        result: serde_json::Value::Null,
+    });
+    assert_eq!(context.return_trace(&response), Some(trace.clone()));
+    assert_eq!(context.return_trace(&response), None);
+
+    let closed = JSONRPCMessage::Notification(JSONRPCNotification {
+        method: EXEC_CLOSED_METHOD.to_string(),
+        params: Some(serde_json::json!({"processId": "process-1", "seq": 1})),
+    });
+    assert_eq!(context.return_trace(&closed), Some(trace));
+    assert_eq!(context.return_trace(&closed), None);
+}

--- a/codex-rs/exec-server/src/relay.rs
+++ b/codex-rs/exec-server/src/relay.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::time::Duration;
+use std::time::Instant;
 
 use codex_exec_server_protocol::JSONRPCMessage;
 use futures::Sink;
@@ -15,6 +16,7 @@ use tokio::task::JoinSet;
 use tokio::time::timeout;
 use tokio_tungstenite::WebSocketStream;
 use tokio_tungstenite::tungstenite::Message;
+use tracing::Instrument;
 use tracing::debug;
 use tracing::info;
 use tracing::warn;
@@ -32,6 +34,7 @@ use crate::noise_channel::PendingResponderHandshake;
 use crate::noise_channel::noise_channel_prologue;
 use crate::noise_relay::NOISE_RELAY_RESET_REASON;
 use crate::noise_relay::executor_stream::ClosedNoiseVirtualStream;
+use crate::noise_relay::executor_stream::NoisePhysicalFrame;
 use crate::noise_relay::executor_stream::NoiseVirtualStream;
 use crate::noise_relay::executor_stream::spawn_noise_virtual_stream;
 use crate::relay_proto::RelayData;
@@ -458,7 +461,7 @@ pub(crate) async fn run_multiplexed_environment<S, V>(
     );
     let (mut websocket_sink, mut websocket_stream) = stream.split();
     let (physical_outgoing_tx, mut physical_outgoing_rx) =
-        mpsc::channel::<Vec<u8>>(CHANNEL_CAPACITY);
+        mpsc::channel::<NoisePhysicalFrame>(CHANNEL_CAPACITY);
     let (closed_stream_tx, mut closed_stream_rx) =
         mpsc::channel::<ClosedNoiseVirtualStream>(MAX_ACTIVE_NOISE_RELAY_STREAMS);
     // Use a separate writer so this loop never waits on the channel it drains.
@@ -469,16 +472,29 @@ pub(crate) async fn run_multiplexed_environment<S, V>(
         );
         keepalive.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
         loop {
-            let message = tokio::select! {
-                encoded = physical_outgoing_rx.recv() => {
-                    let Some(encoded) = encoded else {
+            let (message, queued_frame) = tokio::select! {
+                frame = physical_outgoing_rx.recv() => {
+                    let Some(frame) = frame else {
                         break;
                     };
-                    Message::Binary(encoded.into())
+                    let bytes = frame.encoded.len();
+                    let message = Message::Binary(frame.encoded.into());
+                    (message, Some((frame.queued_at, frame.trace, bytes)))
                 }
-                _ = keepalive.tick() => Message::Ping(Vec::new().into()),
+                _ = keepalive.tick() => (Message::Ping(Vec::new().into()), None),
             };
-            if let Err(error) = websocket_sink.send(message).await {
+            let send_result = if let Some((queued_at, Some(trace), bytes)) = queued_frame {
+                let span = tracing::info_span!(
+                    "exec_server.noise.executor_physical_send",
+                    bytes,
+                    queue_wait_ms = queued_at.elapsed().as_secs_f64() * 1_000.0,
+                );
+                let _ = codex_otel::set_parent_from_w3c_trace_context(&span, trace.as_ref());
+                websocket_sink.send(message).instrument(span).await
+            } else {
+                websocket_sink.send(message).await
+            };
+            if let Err(error) = send_result {
                 warn!("Noise multiplexed environment websocket write failed: {error}");
                 break;
             }
@@ -492,7 +508,7 @@ pub(crate) async fn run_multiplexed_environment<S, V>(
 
     loop {
         // Registry calls run separately so a slow check does not block the relay.
-        let frame = tokio::select! {
+        let (frame, physical_received_at) = tokio::select! {
             writer_result = &mut physical_writer_task => {
                 if let Err(error) = writer_result {
                     warn!("Noise multiplexed environment websocket writer failed: {error}");
@@ -574,7 +590,9 @@ pub(crate) async fn run_multiplexed_environment<S, V>(
                         // Do not leave a half-open stream if the handshake reply
                         // cannot be queued immediately.
                         if physical_outgoing_tx
-                            .try_send(encode_relay_message_frame(&response))
+                            .try_send(NoisePhysicalFrame::control(encode_relay_message_frame(
+                                &response,
+                            )))
                             .is_err()
                         {
                             break;
@@ -614,11 +632,14 @@ pub(crate) async fn run_multiplexed_environment<S, V>(
                 continue;
             }
             incoming_message = websocket_stream.next() => match incoming_message {
-                Some(Ok(Message::Binary(payload))) => match decode_relay_message_frame(payload.as_ref()) {
-                    Ok(frame) => frame,
-                    Err(error) => {
-                        warn!("dropping malformed Noise relay frame from harness: {error}");
-                        continue;
+                Some(Ok(Message::Binary(payload))) => {
+                    let physical_received_at = Instant::now();
+                    match decode_relay_message_frame(payload.as_ref()) {
+                        Ok(frame) => (frame, physical_received_at),
+                        Err(error) => {
+                            warn!("dropping malformed Noise relay frame from harness: {error}");
+                            continue;
+                        }
                     }
                 },
                 Some(Ok(Message::Close(_))) | None => break,
@@ -775,7 +796,7 @@ pub(crate) async fn run_multiplexed_environment<S, V>(
                         continue;
                     }
                 };
-                if let Err(error) = stream.receive_data(data) {
+                if let Err(error) = stream.receive_data(data, physical_received_at) {
                     warn!("failed to process Noise relay payload: {error}");
                     streams.remove(&stream_id);
                     send_reset(&physical_outgoing_tx, stream_id);
@@ -828,9 +849,11 @@ struct HarnessKeyValidationResult {
 
 /// Queue a best-effort reset without blocking the shared websocket loop.
 /// Reset reasons are relay control data and are not treated as trusted text.
-fn send_reset(physical_outgoing_tx: &mpsc::Sender<Vec<u8>>, stream_id: String) {
+fn send_reset(physical_outgoing_tx: &mpsc::Sender<NoisePhysicalFrame>, stream_id: String) {
     let reset = RelayMessageFrame::reset(stream_id, NOISE_RELAY_RESET_REASON.to_string());
-    let _ = physical_outgoing_tx.try_send(encode_relay_message_frame(&reset));
+    let _ = physical_outgoing_tx.try_send(NoisePhysicalFrame::control(encode_relay_message_frame(
+        &reset,
+    )));
 }
 
 #[cfg(test)]

--- a/codex-rs/exec-server/src/remote.rs
+++ b/codex-rs/exec-server/src/remote.rs
@@ -15,6 +15,8 @@ use tokio_tungstenite::MaybeTlsStream;
 use tokio_tungstenite::WebSocketStream;
 use tokio_tungstenite::connect_async_with_config;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tracing::Instrument;
+use tracing::Span;
 use tracing::debug;
 use tracing::info;
 use tracing::warn;
@@ -94,6 +96,8 @@ impl EnvironmentRegistryClient {
             otel.kind = "client",
             otel.name = "codex.exec_server.remote.register",
             result = tracing::field::Empty,
+            send_ms = tracing::field::Empty,
+            response_parse_ms = tracing::field::Empty,
         )
     )]
     async fn register_environment(
@@ -117,6 +121,7 @@ impl EnvironmentRegistryClient {
         environment_id: &str,
         executor_public_key: &NoiseChannelPublicKey,
     ) -> Result<EnvironmentRegistryRegistrationResponse, ExecServerError> {
+        let send_started_at = Instant::now();
         let response = self
             .http
             .post(endpoint_url(
@@ -130,9 +135,22 @@ impl EnvironmentRegistryClient {
                 executor_public_key: executor_public_key.clone(),
             })
             .send()
+            .instrument(tracing::info_span!(
+                "codex.exec_server.remote.register.send"
+            ))
             .await?;
-        let response: EnvironmentRegistryRegistrationResponse =
-            self.parse_json_response(response).await?;
+        Span::current().record("send_ms", duration_ms(send_started_at.elapsed()));
+        let response_parse_started_at = Instant::now();
+        let response: EnvironmentRegistryRegistrationResponse = self
+            .parse_json_response(response)
+            .instrument(tracing::info_span!(
+                "codex.exec_server.remote.register.parse_response"
+            ))
+            .await?;
+        Span::current().record(
+            "response_parse_ms",
+            duration_ms(response_parse_started_at.elapsed()),
+        );
         if response.environment_id != environment_id {
             return Err(ExecServerError::Protocol(
                 "environment registry returned a different environment id".to_string(),
@@ -543,6 +561,9 @@ pub async fn run_remote_environment(
         otel.kind = "client",
         otel.name = "codex.exec_server.remote.rendezvous.connect",
         result = tracing::field::Empty,
+        endpoint_host = tracing::field::Empty,
+        request_build_ms = tracing::field::Empty,
+        websocket_connect_ms = tracing::field::Empty,
     )
 )]
 async fn connect_rendezvous(
@@ -553,24 +574,46 @@ async fn connect_rendezvous(
     tokio_tungstenite::tungstenite::Error,
 > {
     let started_at = Instant::now();
+    if let Ok(parsed) = url.parse::<http::Uri>()
+        && let Some(host) = parsed.host()
+    {
+        Span::current().record("endpoint_host", host);
+    }
     let result = async {
+        let request_build_started_at = Instant::now();
         let mut request = url.into_client_request()?;
         request
             .headers_mut()
             .extend(current_trace_context_headers());
-        connect_async_with_config(
+        Span::current().record(
+            "request_build_ms",
+            duration_ms(request_build_started_at.elapsed()),
+        );
+        let websocket_connect_started_at = Instant::now();
+        let result = connect_async_with_config(
             request,
             Some(noise_relay_websocket_config()),
             /*disable_nagle*/ false,
         )
-        .await
-        .map(|(websocket, _)| websocket)
+        .instrument(tracing::info_span!(
+            "codex.exec_server.remote.rendezvous.websocket_connect"
+        ))
+        .await;
+        Span::current().record(
+            "websocket_connect_ms",
+            duration_ms(websocket_connect_started_at.elapsed()),
+        );
+        result.map(|(websocket, _)| websocket)
     }
     .await;
     let result_name = if result.is_ok() { "success" } else { "error" };
     tracing::Span::current().record("result", result_name);
     telemetry.remote_rendezvous_completed(result_name, started_at.elapsed());
     result
+}
+
+fn duration_ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000.0
 }
 
 fn normalize_environment_id(environment_id: String) -> Result<String, ExecServerError> {

--- a/codex-rs/exec-server/src/remote_process.rs
+++ b/codex-rs/exec-server/src/remote_process.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use tokio::sync::watch;
+use tracing::Instrument;
 use tracing::trace;
 
 use crate::ExecBackend;
@@ -31,11 +32,21 @@ impl RemoteProcess {
         Self { client }
     }
 
+    #[tracing::instrument(
+        name = "exec_server.remote.start",
+        level = "info",
+        skip_all,
+        fields(process_id = %params.process_id, tty = params.tty)
+    )]
     async fn start(
         &self,
         params: ExecParams,
     ) -> Result<StartedExecProcess, crate::ExecServerError> {
-        let client = self.client.get().await?;
+        let client = self
+            .client
+            .get()
+            .instrument(tracing::info_span!("exec_server.remote.client_ready"))
+            .await?;
         let session = client.start_process(params).await?;
 
         Ok(StartedExecProcess {

--- a/codex-rs/exec-server/src/rpc.rs
+++ b/codex-rs/exec-server/src/rpc.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI64;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
+use std::time::Instant;
 
 use codex_exec_server_protocol::JSONRPCError;
 use codex_exec_server_protocol::JSONRPCErrorError;
@@ -14,6 +15,7 @@ use codex_exec_server_protocol::JSONRPCNotification;
 use codex_exec_server_protocol::JSONRPCRequest;
 use codex_exec_server_protocol::JSONRPCResponse;
 use codex_exec_server_protocol::RequestId;
+use codex_protocol::protocol::W3cTraceContext;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
@@ -23,6 +25,9 @@ use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio::time::timeout;
+use tracing::Instrument;
+use tracing::Span;
+use tracing::field;
 
 use crate::connection::JsonRpcConnection;
 use crate::connection::JsonRpcConnectionEvent;
@@ -42,7 +47,11 @@ pub(crate) enum RpcCallError {
     TimedOut { method: String, timeout: Duration },
 }
 
-type PendingRequest = oneshot::Sender<Result<Value, RpcCallError>>;
+struct PendingRequest {
+    response_tx: oneshot::Sender<Result<Value, RpcCallError>>,
+    method: String,
+    trace: Option<W3cTraceContext>,
+}
 type BoxFuture<T> = Pin<Box<dyn Future<Output = T> + Send + 'static>>;
 type RequestRoute<S> = Box<
     dyn Fn(Arc<S>, JSONRPCRequest) -> BoxFuture<Option<RpcServerOutboundMessage>> + Send + Sync,
@@ -55,10 +64,29 @@ enum RpcCallTimeout {
     After(Duration),
 }
 
+fn rpc_call_span(method: &str) -> Span {
+    tracing::info_span!(
+        "exec_server.rpc.call",
+        method,
+        request_id = field::Empty,
+        pending_registered_ms = field::Empty,
+        request_serialized_ms = field::Empty,
+        request_enqueued_ms = field::Empty,
+        response_received_ms = field::Empty,
+        response_decoded_ms = field::Empty,
+    )
+}
+
 #[derive(Debug)]
 pub(crate) enum RpcClientEvent {
-    Notification(JSONRPCNotification),
-    Disconnected { reason: Option<String> },
+    Notification {
+        notification: JSONRPCNotification,
+        queued_at: Instant,
+        trace: Option<W3cTraceContext>,
+    },
+    Disconnected {
+        reason: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -74,13 +102,40 @@ pub(crate) enum RpcServerOutboundMessage {
     Notification(JSONRPCNotification),
 }
 
+/// Carries executor-local timing and trace state across the server outbound queue.
+///
+/// The metadata is deliberately not serialized onto the JSON-RPC wire. Noise
+/// transport correlation uses the originating request ID or process ID instead.
+pub(crate) struct RpcServerOutboundEnvelope {
+    pub(crate) message: RpcServerOutboundMessage,
+    pub(crate) queued_at: Instant,
+    pub(crate) trace: Option<W3cTraceContext>,
+}
+
+impl RpcServerOutboundEnvelope {
+    pub(crate) fn from_current_span(message: RpcServerOutboundMessage) -> Self {
+        Self::with_trace(message, codex_otel::current_span_w3c_trace_context())
+    }
+
+    pub(crate) fn with_trace(
+        message: RpcServerOutboundMessage,
+        trace: Option<W3cTraceContext>,
+    ) -> Self {
+        Self {
+            message,
+            queued_at: Instant::now(),
+            trace,
+        }
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct RpcNotificationSender {
-    outgoing_tx: mpsc::Sender<RpcServerOutboundMessage>,
+    outgoing_tx: mpsc::Sender<RpcServerOutboundEnvelope>,
 }
 
 impl RpcNotificationSender {
-    pub(crate) fn new(outgoing_tx: mpsc::Sender<RpcServerOutboundMessage>) -> Self {
+    pub(crate) fn new(outgoing_tx: mpsc::Sender<RpcServerOutboundEnvelope>) -> Self {
         Self { outgoing_tx }
     }
 
@@ -89,10 +144,19 @@ impl RpcNotificationSender {
         request_id: RequestId,
         result: Value,
     ) -> Result<(), JSONRPCErrorError> {
-        self.outgoing_tx
-            .send(RpcServerOutboundMessage::Response { request_id, result })
+        let permit = self
+            .outgoing_tx
+            .reserve()
+            .instrument(tracing::info_span!(
+                "exec_server.rpc_server.outbound_queue_enqueue",
+                message_kind = "response",
+            ))
             .await
-            .map_err(|_| internal_error("RPC connection closed while sending response".into()))
+            .map_err(|_| internal_error("RPC connection closed while sending response".into()))?;
+        permit.send(RpcServerOutboundEnvelope::from_current_span(
+            RpcServerOutboundMessage::Response { request_id, result },
+        ));
+        Ok(())
     }
 
     pub(crate) async fn notify<P: Serialize>(
@@ -100,16 +164,28 @@ impl RpcNotificationSender {
         method: &str,
         params: &P,
     ) -> Result<(), JSONRPCErrorError> {
-        let params = serde_json::to_value(params).map_err(|err| internal_error(err.to_string()))?;
-        self.outgoing_tx
-            .send(RpcServerOutboundMessage::Notification(
-                JSONRPCNotification {
-                    method: method.to_string(),
-                    params: Some(params),
-                },
+        let params = tracing::info_span!("exec_server.rpc_server.notification_serialize", method,)
+            .in_scope(|| serde_json::to_value(params))
+            .map_err(|err| internal_error(err.to_string()))?;
+        let permit = self
+            .outgoing_tx
+            .reserve()
+            .instrument(tracing::info_span!(
+                "exec_server.rpc_server.outbound_queue_enqueue",
+                message_kind = "notification",
+                method,
             ))
             .await
-            .map_err(|_| internal_error("RPC connection closed while sending notification".into()))
+            .map_err(|_| {
+                internal_error("RPC connection closed while sending notification".into())
+            })?;
+        permit.send(RpcServerOutboundEnvelope::from_current_span(
+            RpcServerOutboundMessage::Notification(JSONRPCNotification {
+                method: method.to_string(),
+                params: Some(params),
+            }),
+        ));
+        Ok(())
     }
 }
 
@@ -269,8 +345,30 @@ impl RpcClient {
                 };
                 match event {
                     JsonRpcConnectionEvent::Message(message) => {
+                        let reader_span = rpc_reader_message_span(&message, None, None);
                         if let Err(err) =
-                            handle_server_message(&pending_for_reader, &event_tx, message).await
+                            handle_server_message(&pending_for_reader, &event_tx, message, None)
+                                .instrument(reader_span)
+                                .await
+                        {
+                            let _ = err;
+                            break None;
+                        }
+                    }
+                    JsonRpcConnectionEvent::TracedMessage {
+                        message,
+                        trace,
+                        queued_at,
+                    } => {
+                        let reader_span = rpc_reader_message_span(
+                            &message,
+                            trace.as_ref(),
+                            Some(queued_at.elapsed()),
+                        );
+                        if let Err(err) =
+                            handle_server_message(&pending_for_reader, &event_tx, message, trace)
+                                .instrument(reader_span)
+                                .await
                         {
                             let _ = err;
                             break None;
@@ -347,7 +445,9 @@ impl RpcClient {
         P: Serialize,
         T: DeserializeOwned,
     {
-        self.call_inner(method, params, RpcCallTimeout::None).await
+        self.call_inner(method, params, RpcCallTimeout::None)
+            .instrument(rpc_call_span(method))
+            .await
     }
 
     pub(crate) async fn call_with_timeout<P, T>(
@@ -361,6 +461,7 @@ impl RpcClient {
         T: DeserializeOwned,
     {
         self.call_inner(method, params, RpcCallTimeout::After(call_timeout))
+            .instrument(rpc_call_span(method))
             .await
     }
 
@@ -374,40 +475,71 @@ impl RpcClient {
         P: Serialize,
         T: DeserializeOwned,
     {
-        let request_id = RequestId::Integer(self.next_request_id.fetch_add(1, Ordering::SeqCst));
+        let call_started_at = Instant::now();
+        let request_number = self.next_request_id.fetch_add(1, Ordering::SeqCst);
+        Span::current().record("request_id", request_number);
+        let request_id = RequestId::Integer(request_number);
         let (response_tx, response_rx) = oneshot::channel();
+        let trace = codex_otel::current_span_w3c_trace_context();
         {
-            let mut pending = self.pending.lock().await;
+            let mut pending = self
+                .pending
+                .lock()
+                .instrument(tracing::info_span!("exec_server.rpc.pending_registration"))
+                .await;
             // Registering the pending request and checking disconnect must be
             // atomic with the reader's drain_pending path. Otherwise a call
             // can sneak in after the drain and wait forever.
             if self.closed.load(Ordering::Acquire) || *self.disconnected_rx.borrow() {
                 return Err(RpcCallError::Closed);
             }
-            pending.insert(request_id.clone(), response_tx);
+            pending.insert(
+                request_id.clone(),
+                PendingRequest {
+                    response_tx,
+                    method: method.to_string(),
+                    trace: trace.clone(),
+                },
+            );
         }
+        Span::current().record(
+            "pending_registered_ms",
+            call_started_at.elapsed().as_secs_f64() * 1_000.0,
+        );
 
-        let params = match serde_json::to_value(params) {
+        let params = match tracing::info_span!("exec_server.rpc.serialize_params")
+            .in_scope(|| serde_json::to_value(params))
+        {
             Ok(params) => params,
             Err(err) => {
                 self.pending.lock().await.remove(&request_id);
                 return Err(RpcCallError::Json(err));
             }
         };
+        Span::current().record(
+            "request_serialized_ms",
+            call_started_at.elapsed().as_secs_f64() * 1_000.0,
+        );
+        let message = JSONRPCMessage::Request(JSONRPCRequest {
+            id: request_id.clone(),
+            method: method.to_string(),
+            params: Some(params),
+            trace,
+        });
         if self
             .write_tx
-            .send(JSONRPCMessage::Request(JSONRPCRequest {
-                id: request_id.clone(),
-                method: method.to_string(),
-                params: Some(params),
-                trace: codex_otel::current_span_w3c_trace_context(),
-            }))
+            .send(message)
+            .instrument(tracing::info_span!("exec_server.rpc.enqueue_request"))
             .await
             .is_err()
         {
             self.pending.lock().await.remove(&request_id);
             return Err(RpcCallError::Closed);
         }
+        Span::current().record(
+            "request_enqueued_ms",
+            call_started_at.elapsed().as_secs_f64() * 1_000.0,
+        );
 
         // Do not race in-flight requests directly against the transport-close
         // watch value. The connection reader receives JSON-RPC messages and
@@ -415,9 +547,12 @@ impl RpcClient {
         // still-pending requests. Awaiting this receiver preserves that order:
         // responses already read before EOF still win, and truly pending calls
         // are failed once the reader observes the disconnect.
+        let response_wait =
+            response_rx.instrument(tracing::info_span!("exec_server.rpc.await_response"));
         let response = match call_timeout {
-            RpcCallTimeout::None => response_rx.await,
-            RpcCallTimeout::After(call_timeout) => match timeout(call_timeout, response_rx).await {
+            RpcCallTimeout::None => response_wait.await,
+            RpcCallTimeout::After(call_timeout) => match timeout(call_timeout, response_wait).await
+            {
                 Ok(response) => response,
                 Err(_) => {
                     self.pending.lock().await.remove(&request_id);
@@ -428,12 +563,23 @@ impl RpcClient {
                 }
             },
         };
+        Span::current().record(
+            "response_received_ms",
+            call_started_at.elapsed().as_secs_f64() * 1_000.0,
+        );
         let result: Result<Value, RpcCallError> = response.map_err(|_| RpcCallError::Closed)?;
         let response = match result {
             Ok(response) => response,
             Err(error) => return Err(error),
         };
-        serde_json::from_value(response).map_err(RpcCallError::Json)
+        let decoded = tracing::info_span!("exec_server.rpc.deserialize_response")
+            .in_scope(|| serde_json::from_value(response))
+            .map_err(RpcCallError::Json);
+        Span::current().record(
+            "response_decoded_ms",
+            call_started_at.elapsed().as_secs_f64() * 1_000.0,
+        );
+        decoded
     }
 
     #[cfg(test)]
@@ -557,22 +703,31 @@ async fn handle_server_message(
     pending: &Mutex<HashMap<RequestId, PendingRequest>>,
     event_tx: &mpsc::Sender<RpcClientEvent>,
     message: JSONRPCMessage,
+    trace: Option<W3cTraceContext>,
 ) -> Result<(), String> {
     match message {
         JSONRPCMessage::Response(JSONRPCResponse { id, result }) => {
-            if let Some(pending) = pending.lock().await.remove(&id) {
-                let _ = pending.send(Ok(result));
-            }
+            dispatch_response(pending, id, Ok(result), "response", trace).await;
         }
         JSONRPCMessage::Error(JSONRPCError { id, error }) => {
-            if let Some(pending) = pending.lock().await.remove(&id) {
-                let _ = pending.send(Err(RpcCallError::Server(error)));
-            }
+            dispatch_response(
+                pending,
+                id,
+                Err(RpcCallError::Server(error)),
+                "error",
+                trace,
+            )
+            .await;
         }
         JSONRPCMessage::Notification(notification) => {
-            let _ = event_tx
-                .send(RpcClientEvent::Notification(notification))
-                .await;
+            let span = notification_dispatch_span(&notification);
+            if let Ok(permit) = event_tx.reserve().instrument(span).await {
+                permit.send(RpcClientEvent::Notification {
+                    notification,
+                    queued_at: Instant::now(),
+                    trace,
+                });
+            }
         }
         JSONRPCMessage::Request(request) => {
             return Err(format!(
@@ -585,6 +740,115 @@ async fn handle_server_message(
     Ok(())
 }
 
+async fn dispatch_response(
+    pending: &Mutex<HashMap<RequestId, PendingRequest>>,
+    id: RequestId,
+    result: Result<Value, RpcCallError>,
+    message_kind: &'static str,
+    received_trace: Option<W3cTraceContext>,
+) {
+    let lookup_started_at = Instant::now();
+    let pending = pending
+        .lock()
+        .instrument(tracing::info_span!(
+            "exec_server.rpc.response_pending_lookup",
+            request_id = %id,
+        ))
+        .await
+        .remove(&id);
+    let Some(pending) = pending else {
+        return;
+    };
+    let span = tracing::info_span!(
+        "exec_server.rpc.response_dispatch",
+        message_kind,
+        method = pending.method,
+        request_id = %id,
+        pending_lookup_ms = lookup_started_at.elapsed().as_secs_f64() * 1_000.0,
+    );
+    if let Some(trace) = received_trace.as_ref().or(pending.trace.as_ref()) {
+        let _ = codex_otel::set_parent_from_w3c_trace_context(&span, trace);
+    }
+    span.in_scope(|| {
+        let _ = pending.response_tx.send(result);
+    });
+}
+
+fn rpc_reader_message_span(
+    message: &JSONRPCMessage,
+    trace: Option<&W3cTraceContext>,
+    queue_wait: Option<std::time::Duration>,
+) -> Span {
+    let (message_kind, method, request_id, process_id, seq) = message_trace_fields(message);
+    let span = tracing::info_span!(
+        "exec_server.rpc.reader_message_dequeued",
+        message_kind,
+        method,
+        request_id,
+        process_id,
+        seq,
+        queue_wait_ms = queue_wait.map(|wait| wait.as_secs_f64() * 1_000.0),
+    );
+    if let Some(trace) = trace {
+        let _ = codex_otel::set_parent_from_w3c_trace_context(&span, trace);
+    }
+    span
+}
+
+fn notification_dispatch_span(notification: &JSONRPCNotification) -> Span {
+    let process_id = notification
+        .params
+        .as_ref()
+        .and_then(|params| params.get("processId"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let seq = notification
+        .params
+        .as_ref()
+        .and_then(|params| params.get("seq"))
+        .and_then(Value::as_u64);
+    tracing::info_span!(
+        "exec_server.rpc.notification_event_enqueue",
+        method = notification.method,
+        process_id,
+        seq,
+    )
+}
+
+fn message_trace_fields(message: &JSONRPCMessage) -> (&str, &str, String, &str, Option<u64>) {
+    let (message_kind, method, request_id, payload) = match message {
+        JSONRPCMessage::Request(request) => (
+            "request",
+            request.method.as_str(),
+            request.id.to_string(),
+            request.params.as_ref(),
+        ),
+        JSONRPCMessage::Notification(notification) => (
+            "notification",
+            notification.method.as_str(),
+            String::new(),
+            notification.params.as_ref(),
+        ),
+        JSONRPCMessage::Response(response) => (
+            "response",
+            "",
+            response.id.to_string(),
+            Some(&response.result),
+        ),
+        JSONRPCMessage::Error(error) => {
+            ("error", "", error.id.to_string(), error.error.data.as_ref())
+        }
+    };
+    let process_id = payload
+        .and_then(|payload| payload.get("processId"))
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let seq = payload
+        .and_then(|payload| payload.get("seq"))
+        .and_then(Value::as_u64);
+    (message_kind, method, request_id, process_id, seq)
+}
+
 async fn drain_pending(pending: &Mutex<HashMap<RequestId, PendingRequest>>) {
     let pending = {
         let mut pending = pending.lock().await;
@@ -594,7 +858,7 @@ async fn drain_pending(pending: &Mutex<HashMap<RequestId, PendingRequest>>) {
             .collect::<Vec<_>>()
     };
     for pending in pending {
-        let _ = pending.send(Err(RpcCallError::Closed));
+        let _ = pending.response_tx.send(Err(RpcCallError::Closed));
     }
 }
 
@@ -803,6 +1067,14 @@ mod tests {
             .expect("RPC response");
         assert_eq!(response, serde_json::json!({}));
         let trace = server.await.expect("server task").expect("trace context");
-        assert_eq!(trace, expected_trace);
+        let traceparent = trace.traceparent.expect("request traceparent");
+        let expected_traceparent = expected_trace.traceparent.expect("parent span traceparent");
+        let trace_id = traceparent.split('-').nth(1).expect("request trace id");
+        let expected_trace_id = expected_traceparent
+            .split('-')
+            .nth(1)
+            .expect("parent span trace id");
+        assert_eq!(trace_id, expected_trace_id);
+        assert_ne!(traceparent, expected_traceparent);
     }
 }

--- a/codex-rs/exec-server/src/server/processor.rs
+++ b/codex-rs/exec-server/src/server/processor.rs
@@ -11,6 +11,7 @@ use crate::connection::CHANNEL_CAPACITY;
 use crate::connection::JsonRpcConnection;
 use crate::connection::JsonRpcConnectionEvent;
 use crate::rpc::RpcNotificationSender;
+use crate::rpc::RpcServerOutboundEnvelope;
 use crate::rpc::RpcServerOutboundMessage;
 use crate::rpc::encode_server_message;
 use crate::rpc::invalid_request;
@@ -82,7 +83,7 @@ async fn run_connection(
         transport: _transport,
     } = connection;
     let (outgoing_tx, mut outgoing_rx) =
-        mpsc::channel::<RpcServerOutboundMessage>(CHANNEL_CAPACITY);
+        mpsc::channel::<RpcServerOutboundEnvelope>(CHANNEL_CAPACITY);
     let notifications = RpcNotificationSender::new(outgoing_tx.clone());
     let handler = Arc::new(ExecServerHandler::new(
         session_registry,
@@ -91,15 +92,26 @@ async fn run_connection(
     ));
 
     let outbound_task = tokio::spawn(async move {
-        while let Some(message) = outgoing_rx.recv().await {
-            let json_message = match encode_server_message(message) {
+        while let Some(envelope) = outgoing_rx.recv().await {
+            let outbound_span = server_outbound_span(&envelope);
+            let json_message = match outbound_span.in_scope(|| {
+                tracing::info_span!("exec_server.rpc_server.build_jsonrpc_envelope")
+                    .in_scope(|| encode_server_message(envelope.message))
+            }) {
                 Ok(json_message) => json_message,
                 Err(err) => {
                     warn!("failed to serialize exec-server outbound message: {err}");
                     break;
                 }
             };
-            if json_outgoing_tx.send(json_message).await.is_err() {
+            let transport_enqueue_span = outbound_span
+                .in_scope(|| tracing::info_span!("exec_server.rpc_server.transport_queue_enqueue"));
+            if json_outgoing_tx
+                .send(json_message)
+                .instrument(transport_enqueue_span)
+                .await
+                .is_err()
+            {
                 break;
             }
         }
@@ -114,19 +126,27 @@ async fn run_connection(
         match event {
             JsonRpcConnectionEvent::MalformedMessage { reason } => {
                 warn!("ignoring malformed exec-server message: {reason}");
-                if outgoing_tx
-                    .send(RpcServerOutboundMessage::Error {
+                let permit = outgoing_tx
+                    .reserve()
+                    .instrument(tracing::info_span!(
+                        "exec_server.rpc_server.outbound_queue_enqueue",
+                        message_kind = "error",
+                    ))
+                    .await;
+                let Ok(permit) = permit else {
+                    break;
+                };
+                permit.send(RpcServerOutboundEnvelope::from_current_span(
+                    RpcServerOutboundMessage::Error {
                         request_id: codex_exec_server_protocol::RequestId::Integer(-1),
                         error: invalid_request(reason),
-                    })
-                    .await
-                    .is_err()
-                {
-                    break;
-                }
+                    },
+                ));
             }
-            JsonRpcConnectionEvent::Message(message) => match message {
+            JsonRpcConnectionEvent::Message(message)
+            | JsonRpcConnectionEvent::TracedMessage { message, .. } => match message {
                 codex_exec_server_protocol::JSONRPCMessage::Request(request) => {
+                    record_request_dequeued(&request);
                     let request_started_at = Instant::now();
                     if let Some((method, route)) = router.request_route(request.method.as_str()) {
                         let request_span = request_span(method, &request);
@@ -144,16 +164,29 @@ async fn run_connection(
                             }
                         };
                         let result = request_result(&message);
-                        if let Some(message) = message
-                            && outgoing_tx.send(message).await.is_err()
-                        {
-                            request_span.record("result", "disconnected");
-                            telemetry.request_completed(
-                                method,
-                                "disconnected",
-                                request_started_at.elapsed(),
-                            );
-                            break;
+                        let request_trace = codex_otel::span_w3c_trace_context(&request_span);
+                        if let Some(message) = message {
+                            let enqueue_span = request_span.in_scope(|| {
+                                tracing::info_span!(
+                                    "exec_server.rpc_server.outbound_queue_enqueue",
+                                    message_kind = "response",
+                                    method,
+                                )
+                            });
+                            let permit = outgoing_tx.reserve().instrument(enqueue_span).await;
+                            let Ok(permit) = permit else {
+                                request_span.record("result", "disconnected");
+                                telemetry.request_completed(
+                                    method,
+                                    "disconnected",
+                                    request_started_at.elapsed(),
+                                );
+                                break;
+                            };
+                            permit.send(RpcServerOutboundEnvelope::with_trace(
+                                message,
+                                request_trace,
+                            ));
                         }
                         request_span.record("result", result);
                         telemetry.request_completed(method, result, request_started_at.elapsed());
@@ -161,17 +194,18 @@ async fn run_connection(
                     } else {
                         let method = "unknown";
                         let request_span = request_span(method, &request);
-                        if outgoing_tx
-                            .send(RpcServerOutboundMessage::Error {
-                                request_id: request.id,
-                                error: method_not_found(format!(
-                                    "exec-server stub does not implement `{}` yet",
-                                    request.method
-                                )),
-                            })
-                            .await
-                            .is_err()
-                        {
+                        let request_trace = codex_otel::span_w3c_trace_context(&request_span);
+                        let permit = outgoing_tx
+                            .reserve()
+                            .instrument(request_span.in_scope(|| {
+                                tracing::info_span!(
+                                    "exec_server.rpc_server.outbound_queue_enqueue",
+                                    message_kind = "error",
+                                    method,
+                                )
+                            }))
+                            .await;
+                        let Ok(permit) = permit else {
                             request_span.record("result", "disconnected");
                             telemetry.request_completed(
                                 method,
@@ -179,7 +213,17 @@ async fn run_connection(
                                 request_started_at.elapsed(),
                             );
                             break;
-                        }
+                        };
+                        permit.send(RpcServerOutboundEnvelope::with_trace(
+                            RpcServerOutboundMessage::Error {
+                                request_id: request.id,
+                                error: method_not_found(format!(
+                                    "exec-server stub does not implement `{}` yet",
+                                    request.method
+                                )),
+                            },
+                            request_trace,
+                        ));
                         request_span.record("result", "error");
                         telemetry.request_completed(method, "error", request_started_at.elapsed());
                     }
@@ -239,6 +283,61 @@ async fn run_connection(
         let _ = task.await;
     }
     let _ = outbound_task.await;
+}
+
+fn server_outbound_span(envelope: &RpcServerOutboundEnvelope) -> tracing::Span {
+    let (message_kind, method, request_id, process_id, seq) = match &envelope.message {
+        RpcServerOutboundMessage::Response { request_id, .. } => {
+            ("response", "", request_id.to_string(), "", None)
+        }
+        RpcServerOutboundMessage::Error { request_id, .. } => {
+            ("error", "", request_id.to_string(), "", None)
+        }
+        RpcServerOutboundMessage::Notification(notification) => {
+            let process_id = notification
+                .params
+                .as_ref()
+                .and_then(|params| params.get("processId"))
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("");
+            let seq = notification
+                .params
+                .as_ref()
+                .and_then(|params| params.get("seq"))
+                .and_then(serde_json::Value::as_u64);
+            (
+                "notification",
+                notification.method.as_str(),
+                String::new(),
+                process_id,
+                seq,
+            )
+        }
+    };
+    let span = tracing::info_span!(
+        "exec_server.rpc_server.outbound_queue_dequeued",
+        message_kind,
+        method,
+        request_id,
+        process_id,
+        seq,
+        queue_wait_ms = envelope.queued_at.elapsed().as_secs_f64() * 1_000.0,
+    );
+    if let Some(trace) = envelope.trace.as_ref() {
+        let _ = codex_otel::set_parent_from_w3c_trace_context(&span, trace);
+    }
+    span
+}
+
+fn record_request_dequeued(request: &codex_exec_server_protocol::JSONRPCRequest) {
+    let method = request.method.as_str();
+    let span = tracing::info_span!("exec_server.processor.request_dequeued", method,);
+    if let Some(trace) = &request.trace
+        && !codex_otel::set_parent_from_w3c_trace_context(&span, trace)
+    {
+        warn!(method, "ignoring invalid inbound exec-server trace carrier");
+    }
+    span.in_scope(|| {});
 }
 
 fn request_span(
@@ -302,6 +401,7 @@ mod tests {
     use tracing_subscriber::filter::filter_fn;
     use tracing_subscriber::prelude::*;
 
+    use super::record_request_dequeued;
     use super::request_span;
     use super::run_connection;
     use crate::ExecServerRuntimePaths;
@@ -351,6 +451,7 @@ mod tests {
                 params: None,
                 trace: Some(trace),
             };
+            record_request_dequeued(&request);
             let request_span = request_span("unknown", &request);
             request_span.in_scope(|| {});
             drop(request_span);
@@ -372,6 +473,12 @@ mod tests {
         );
         assert_eq!(request_span.span_context.trace_id(), trace_id);
         assert_eq!(request_span.parent_span_id, parent_span_id);
+        let dequeued_span = spans
+            .iter()
+            .find(|span| span.name.as_ref() == "exec_server.processor.request_dequeued")
+            .expect("request dequeued span");
+        assert_eq!(dequeued_span.span_context.trace_id(), trace_id);
+        assert_eq!(dequeued_span.parent_span_id, parent_span_id);
     }
 
     #[tokio::test]

--- a/codex-rs/otel/src/events/session_telemetry.rs
+++ b/codex-rs/otel/src/events/session_telemetry.rs
@@ -66,6 +66,13 @@ const RESPONSES_API_ENGINE_IAPI_TTFT_FIELD: &str = "engine_iapi_ttft_total_ms";
 const RESPONSES_API_ENGINE_SERVICE_TTFT_FIELD: &str = "engine_service_ttft_total_ms";
 const RESPONSES_API_ENGINE_IAPI_TBT_FIELD: &str = "engine_iapi_tbt_across_engine_calls_ms";
 const RESPONSES_API_ENGINE_SERVICE_TBT_FIELD: &str = "engine_service_tbt_across_engine_calls_ms";
+const RESPONSES_API_ROUTING_TIMING_SEMANTICS_V1: &str = concat!(
+    "nested_non_additive:engine_iapi_ttft_includes_engine_routing_and_engine_batcher_ttft;",
+    "engine_routing_includes_pipereplica_lb_routing;",
+    "engine_queue_is_iapi_ttft_minus_batcher_ttft_and_overlaps_engine_routing;",
+    "cross_cluster_network_overhead_is_outside_engine_iapi_ttft",
+);
+const ROUTING_TIMING_SEMANTICS_V1_ROLE: &str = "nested_non_additive_v1";
 
 fn trace_field_value<'a>(fields: &'a [(&str, &str)], key: &str) -> Option<&'a str> {
     fields
@@ -1133,53 +1140,154 @@ impl SessionTelemetry {
 
     fn record_responses_websocket_timing_metrics(&self, value: &serde_json::Value) {
         let timing_metrics = value.get(RESPONSES_WEBSOCKET_TIMING_METRICS_FIELD);
+        let timing_value = |key| timing_metrics.and_then(|value| value.get(key));
+        let timing_f64 = |key| non_negative_f64_from_value(timing_value(key));
 
-        let overhead_value =
-            timing_metrics.and_then(|value| value.get(RESPONSES_API_OVERHEAD_FIELD));
-        if let Some(duration) = duration_from_ms_value(overhead_value) {
-            self.record_duration(RESPONSES_API_OVERHEAD_DURATION_METRIC, duration, &[]);
-        }
+        let request_ordinal = non_negative_i64_from_value(value.get("request_ordinal"));
+        let pre_inference_ms = timing_f64("pre_inference_ms");
+        let client_tool_pause_total_ms = timing_f64("client_tool_pause_total_ms");
+        let total_turn_time_s = timing_f64("total_turn_time_s");
+        let xapi_validation_time_s = timing_f64("xapi_validation_time_s");
+        let num_engine_calls = non_negative_i64_from_value(timing_value("num_engine_calls"));
+        let latest_inference_lb_routing_ms = timing_f64("latest_inference_lb_routing_ms");
+        let latest_inference_engine_routing_ms = timing_f64("latest_inference_engine_routing_ms");
+        let latest_cross_cluster_network_overhead_ms =
+            timing_f64("latest_cross_cluster_network_overhead_ms");
+        // This event is intentionally restricted to numeric measurements and a normalized,
+        // bounded semantics role. Opaque response/request/engine/pipereplica identifiers and
+        // free-form route diagnostics are neither useful dimensions nor safe span attributes.
+        let inference_routing_timing_semantics =
+            routing_timing_semantics_role(timing_value("inference_routing_timing_semantics"));
+        let engine_queue_max_ms = timing_f64("engine_queue_max_ms");
+        let first_sampled_message_ttft_ms = timing_f64("first_sampled_message_ttft_ms");
+        let engine_iapi_ttft_total_ms = timing_f64(RESPONSES_API_ENGINE_IAPI_TTFT_FIELD);
+        let engine_service_ttft_total_ms = timing_f64(RESPONSES_API_ENGINE_SERVICE_TTFT_FIELD);
+        let engine_iapi_sampling_total_ms = timing_f64("engine_iapi_sampling_total_ms");
+        let engine_service_sampling_total_ms = timing_f64("engine_service_sampling_total_ms");
+        let engine_iapi_tbt_across_engine_calls_ms =
+            timing_f64(RESPONSES_API_ENGINE_IAPI_TBT_FIELD);
+        let engine_service_tbt_across_engine_calls_ms =
+            timing_f64(RESPONSES_API_ENGINE_SERVICE_TBT_FIELD);
+        let taas_request_to_provider_start_total_ms =
+            timing_f64("taas_request_to_provider_start_total_ms");
+        let taas_provider_start_to_first_token_total_ms =
+            timing_f64("taas_provider_start_to_first_token_total_ms");
+        let responsesapi_duration_excl_client_tools_ms =
+            timing_f64("responsesapi_duration_excl_client_tools_ms");
+        let responses_duration_excl_engine_wait_and_sampling_ms =
+            timing_f64("responses_duration_excl_engine_wait_and_sampling_ms");
+        let responses_duration_excl_engine_wait_and_sampling_iapi_ms =
+            timing_f64("responses_duration_excl_engine_wait_and_sampling_iapi_ms");
+        let responses_duration_excl_engine_and_client_tool_time_ms =
+            timing_f64(RESPONSES_API_OVERHEAD_FIELD);
+        let engine_service_total_ms = timing_f64(RESPONSES_API_INFERENCE_FIELD);
+        let prompt_full_render_total_ms = timing_f64("prompt_full_render_total_ms");
+        let prompt_shadow_render_total_ms = timing_f64("prompt_shadow_render_total_ms");
 
-        let inference_value =
-            timing_metrics.and_then(|value| value.get(RESPONSES_API_INFERENCE_FIELD));
-        if let Some(duration) = duration_from_ms_value(inference_value) {
-            self.record_duration(RESPONSES_API_INFERENCE_TIME_DURATION_METRIC, duration, &[]);
-        }
+        log_event!(
+            self,
+            event.name = "codex.responses_websocket_timing",
+            model.request_ordinal = request_ordinal,
+            responsesapi.pre_inference_ms = pre_inference_ms,
+            responsesapi.client_tool_pause_total_ms = client_tool_pause_total_ms,
+            responsesapi.total_turn_time_s = total_turn_time_s,
+            responsesapi.xapi_validation_time_s = xapi_validation_time_s,
+            responsesapi.duration_excl_client_tools_ms = responsesapi_duration_excl_client_tools_ms,
+            responsesapi.duration_excl_engine_wait_and_sampling_ms =
+                responses_duration_excl_engine_wait_and_sampling_ms,
+            responsesapi.duration_excl_engine_wait_and_sampling_iapi_ms =
+                responses_duration_excl_engine_wait_and_sampling_iapi_ms,
+            responsesapi.duration_excl_engine_and_client_tool_time_ms =
+                responses_duration_excl_engine_and_client_tool_time_ms,
+            responsesapi.engine_service_total_ms = engine_service_total_ms,
+            responsesapi.prompt_full_render_total_ms = prompt_full_render_total_ms,
+            responsesapi.prompt_shadow_render_total_ms = prompt_shadow_render_total_ms,
+            inference.num_engine_calls = num_engine_calls,
+            inference.latest_lb_routing_ms = latest_inference_lb_routing_ms,
+            inference.latest_engine_routing_ms = latest_inference_engine_routing_ms,
+            inference.latest_cross_cluster_network_overhead_ms =
+                latest_cross_cluster_network_overhead_ms,
+            inference.routing_timing_semantics = inference_routing_timing_semantics,
+            inference.engine_queue_max_ms = engine_queue_max_ms,
+            inference.first_sampled_message_ttft_ms = first_sampled_message_ttft_ms,
+            inference.engine_iapi_ttft_total_ms = engine_iapi_ttft_total_ms,
+            inference.engine_service_ttft_total_ms = engine_service_ttft_total_ms,
+            inference.engine_iapi_sampling_total_ms = engine_iapi_sampling_total_ms,
+            inference.engine_service_sampling_total_ms = engine_service_sampling_total_ms,
+            inference.engine_iapi_tbt_across_engine_calls_ms =
+                engine_iapi_tbt_across_engine_calls_ms,
+            inference.engine_service_tbt_across_engine_calls_ms =
+                engine_service_tbt_across_engine_calls_ms,
+            inference.taas_request_to_provider_start_total_ms =
+                taas_request_to_provider_start_total_ms,
+            inference.taas_provider_start_to_first_token_total_ms =
+                taas_provider_start_to_first_token_total_ms,
+        );
 
-        let engine_iapi_ttft_value =
-            timing_metrics.and_then(|value| value.get(RESPONSES_API_ENGINE_IAPI_TTFT_FIELD));
-        if let Some(duration) = duration_from_ms_value(engine_iapi_ttft_value) {
-            self.record_duration(
+        // CCA exports traces but not general OTEL logs. Use a real child span so this breakdown is
+        // queryable in trace backends that do not retain span events.
+        let timing_span = tracing::info_span!(
+            "codex.responses_websocket_timing",
+            model = %self.metadata.model,
+            model.request_ordinal = request_ordinal,
+            responsesapi.pre_inference_ms = pre_inference_ms,
+            responsesapi.client_tool_pause_total_ms = client_tool_pause_total_ms,
+            responsesapi.total_turn_time_s = total_turn_time_s,
+            responsesapi.xapi_validation_time_s = xapi_validation_time_s,
+            responsesapi.duration_excl_client_tools_ms = responsesapi_duration_excl_client_tools_ms,
+            responsesapi.duration_excl_engine_wait_and_sampling_ms = responses_duration_excl_engine_wait_and_sampling_ms,
+            responsesapi.duration_excl_engine_wait_and_sampling_iapi_ms = responses_duration_excl_engine_wait_and_sampling_iapi_ms,
+            responsesapi.duration_excl_engine_and_client_tool_time_ms = responses_duration_excl_engine_and_client_tool_time_ms,
+            responsesapi.engine_service_total_ms = engine_service_total_ms,
+            responsesapi.prompt_full_render_total_ms = prompt_full_render_total_ms,
+            responsesapi.prompt_shadow_render_total_ms = prompt_shadow_render_total_ms,
+            inference.num_engine_calls = num_engine_calls,
+            inference.latest_lb_routing_ms = latest_inference_lb_routing_ms,
+            inference.latest_engine_routing_ms = latest_inference_engine_routing_ms,
+            inference.latest_cross_cluster_network_overhead_ms = latest_cross_cluster_network_overhead_ms,
+            inference.routing_timing_semantics = inference_routing_timing_semantics,
+            inference.engine_queue_max_ms = engine_queue_max_ms,
+            inference.first_sampled_message_ttft_ms = first_sampled_message_ttft_ms,
+            inference.engine_iapi_ttft_total_ms = engine_iapi_ttft_total_ms,
+            inference.engine_service_ttft_total_ms = engine_service_ttft_total_ms,
+            inference.engine_iapi_sampling_total_ms = engine_iapi_sampling_total_ms,
+            inference.engine_service_sampling_total_ms = engine_service_sampling_total_ms,
+            inference.engine_iapi_tbt_across_engine_calls_ms = engine_iapi_tbt_across_engine_calls_ms,
+            inference.engine_service_tbt_across_engine_calls_ms = engine_service_tbt_across_engine_calls_ms,
+            inference.taas_request_to_provider_start_total_ms = taas_request_to_provider_start_total_ms,
+            inference.taas_provider_start_to_first_token_total_ms = taas_provider_start_to_first_token_total_ms,
+        );
+        timing_span.in_scope(|| {});
+
+        for (value, metric) in [
+            (
+                responses_duration_excl_engine_and_client_tool_time_ms,
+                RESPONSES_API_OVERHEAD_DURATION_METRIC,
+            ),
+            (
+                engine_service_total_ms,
+                RESPONSES_API_INFERENCE_TIME_DURATION_METRIC,
+            ),
+            (
+                engine_iapi_ttft_total_ms,
                 RESPONSES_API_ENGINE_IAPI_TTFT_DURATION_METRIC,
-                duration,
-                &[],
-            );
-        }
-
-        let engine_service_ttft_value =
-            timing_metrics.and_then(|value| value.get(RESPONSES_API_ENGINE_SERVICE_TTFT_FIELD));
-        if let Some(duration) = duration_from_ms_value(engine_service_ttft_value) {
-            self.record_duration(
+            ),
+            (
+                engine_service_ttft_total_ms,
                 RESPONSES_API_ENGINE_SERVICE_TTFT_DURATION_METRIC,
-                duration,
-                &[],
-            );
-        }
-
-        let engine_iapi_tbt_value =
-            timing_metrics.and_then(|value| value.get(RESPONSES_API_ENGINE_IAPI_TBT_FIELD));
-        if let Some(duration) = duration_from_ms_value(engine_iapi_tbt_value) {
-            self.record_duration(RESPONSES_API_ENGINE_IAPI_TBT_DURATION_METRIC, duration, &[]);
-        }
-
-        let engine_service_tbt_value =
-            timing_metrics.and_then(|value| value.get(RESPONSES_API_ENGINE_SERVICE_TBT_FIELD));
-        if let Some(duration) = duration_from_ms_value(engine_service_tbt_value) {
-            self.record_duration(
+            ),
+            (
+                engine_iapi_tbt_across_engine_calls_ms,
+                RESPONSES_API_ENGINE_IAPI_TBT_DURATION_METRIC,
+            ),
+            (
+                engine_service_tbt_across_engine_calls_ms,
                 RESPONSES_API_ENGINE_SERVICE_TBT_DURATION_METRIC,
-                duration,
-                &[],
-            );
+            ),
+        ] {
+            if let Some(duration) = duration_from_ms(value) {
+                self.record_duration(metric, duration, &[]);
+            }
         }
     }
 
@@ -1230,15 +1338,42 @@ impl SessionTelemetry {
     }
 }
 
-fn duration_from_ms_value(value: Option<&serde_json::Value>) -> Option<Duration> {
+fn duration_from_ms(ms: Option<f64>) -> Option<Duration> {
+    let ms = ms?;
+    let clamped = ms.min(u64::MAX as f64);
+    Some(Duration::from_millis(clamped.round() as u64))
+}
+
+fn non_negative_f64_from_value(value: Option<&serde_json::Value>) -> Option<f64> {
     let value = value?;
-    let ms = value
+    let value = value
         .as_f64()
         .or_else(|| value.as_i64().map(|v| v as f64))
         .or_else(|| value.as_u64().map(|v| v as f64))?;
-    if !ms.is_finite() || ms < 0.0 {
+    if !value.is_finite() || value < 0.0 {
         return None;
     }
-    let clamped = ms.min(u64::MAX as f64);
-    Some(Duration::from_millis(clamped.round() as u64))
+    Some(value)
+}
+
+fn non_negative_i64_from_value(value: Option<&serde_json::Value>) -> Option<i64> {
+    let value = value?;
+    value
+        .as_i64()
+        .filter(|value| *value >= 0)
+        .or_else(|| value.as_u64().and_then(|value| i64::try_from(value).ok()))
+        .or_else(|| {
+            value
+                .as_str()?
+                .parse::<i64>()
+                .ok()
+                .filter(|value| *value >= 0)
+        })
+}
+
+fn routing_timing_semantics_role(value: Option<&serde_json::Value>) -> Option<&'static str> {
+    match value.and_then(serde_json::Value::as_str) {
+        Some(RESPONSES_API_ROUTING_TIMING_SEMANTICS_V1) => Some(ROUTING_TIMING_SEMANTICS_V1_ROLE),
+        _ => None,
+    }
 }

--- a/codex-rs/otel/tests/suite/otel_export_routing_policy.rs
+++ b/codex-rs/otel/tests/suite/otel_export_routing_policy.rs
@@ -15,6 +15,7 @@ use pretty_assertions::assert_eq;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use tokio_tungstenite::tungstenite::Message;
 use tracing_subscriber::Layer;
 use tracing_subscriber::filter::filter_fn;
 use tracing_subscriber::layer::SubscriberExt;
@@ -912,4 +913,194 @@ fn otel_export_routing_policy_routes_websocket_request_transport_observability()
         request_trace_attrs.get("auth.task_id").map(String::as_str),
         Some("task-run-ws-request")
     );
+}
+
+#[test]
+fn otel_export_routing_policy_routes_correlated_websocket_timing_breakdown() {
+    let log_exporter = InMemoryLogExporter::default();
+    let logger_provider = SdkLoggerProvider::builder()
+        .with_simple_exporter(log_exporter.clone())
+        .build();
+    let span_exporter = InMemorySpanExporter::default();
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_simple_exporter(span_exporter.clone())
+        .build();
+    let tracer = tracer_provider.tracer("sink-split-test");
+
+    let subscriber = tracing_subscriber::registry()
+        .with(
+            opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::new(
+                &logger_provider,
+            )
+            .with_filter(filter_fn(OtelProvider::log_export_filter)),
+        )
+        .with(
+            tracing_opentelemetry::layer()
+                .with_tracer(tracer)
+                .with_filter(filter_fn(OtelProvider::trace_export_filter)),
+        );
+
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::callsite::rebuild_interest_cache();
+        let manager = SessionTelemetry::new(
+            ThreadId::new(),
+            "gpt-5.1",
+            "gpt-5.1",
+            Some("account-id".to_string()),
+            Some("engineer@example.com".to_string()),
+            Some(TelemetryAuthMode::Chatgpt),
+            "codex_exec".to_string(),
+            /*log_user_prompts*/ true,
+            "tty".to_string(),
+            SessionSource::Cli,
+        );
+        let root_span = tracing::info_span!("root");
+        let _root_guard = root_span.enter();
+        let response: std::result::Result<
+            Option<std::result::Result<Message, tokio_tungstenite::tungstenite::Error>>,
+            codex_api::ApiError,
+        > = Ok(Some(Ok(Message::Text(
+            r#"{
+                "type":"responsesapi.websocket_timing",
+                "request_ordinal":2,
+                "timing_metrics":{
+                    "response_id":"resp-correlated",
+                    "pre_inference_ms":120.5,
+                    "engine_queue_max_ms":87.25,
+                    "engine_iapi_ttft_total_ms":310,
+                    "engine_service_ttft_total_ms":340,
+                    "taas_request_to_provider_start_total_ms":41.5,
+                    "taas_provider_start_to_first_token_total_ms":201.75,
+                    "engine_ids":"engine-a,engine-b",
+                    "latest_engine_id":"engine-b",
+                    "latest_inference_request_id":"req-route",
+                    "latest_engine_provider":"provider-a",
+                    "latest_engine_cluster":"cluster-a",
+                    "latest_engine_region":"westus",
+                    "latest_engine_geography":"us",
+                    "latest_pipereplica_id":"pipe-7",
+                    "latest_pipereplica_snapshot_id":"snapshot-8",
+                    "latest_pipereplica_image_tag":"image-9",
+                    "latest_load_balancer_image_tag":"lb-image-10",
+                    "latest_inference_lb_routing_ms":2.5,
+                    "latest_inference_engine_routing_ms":8.5,
+                    "latest_cross_cluster_network_overhead_ms":11.5,
+                    "inference_routing_timing_semantics":"nested_non_additive:engine_iapi_ttft_includes_engine_routing_and_engine_batcher_ttft;engine_routing_includes_pipereplica_lb_routing;engine_queue_is_iapi_ttft_minus_batcher_ttft_and_overlaps_engine_routing;cross_cluster_network_overhead_is_outside_engine_iapi_ttft",
+                    "inference_route_diagnostics":[{"engine_call_id":"call-1","engine_provider":"provider-a"}],
+                    "num_engine_calls":2,
+                    "responses_duration_excl_engine_and_client_tool_time_ms":98.5
+                }
+            }"#
+            .into(),
+        ))));
+        manager.record_websocket_event(&response, std::time::Duration::from_millis(3));
+    });
+
+    logger_provider.force_flush().expect("flush logs");
+    tracer_provider.force_flush().expect("flush traces");
+
+    let logs = log_exporter.get_emitted_logs().expect("log export");
+    let timing_log = find_log_by_event_name(&logs, "codex.responses_websocket_timing");
+    let timing_log_attrs = log_attributes(&timing_log.record);
+    assert_eq!(
+        timing_log_attrs
+            .get("model.request_ordinal")
+            .map(String::as_str),
+        Some("2")
+    );
+    assert_eq!(
+        timing_log_attrs
+            .get("inference.engine_queue_max_ms")
+            .map(String::as_str),
+        Some("87.25")
+    );
+    assert_eq!(
+        timing_log_attrs
+            .get("inference.routing_timing_semantics")
+            .map(String::as_str),
+        Some("nested_non_additive_v1")
+    );
+    for forbidden_attribute in [
+        "model.response_id",
+        "inference.engine_ids",
+        "inference.latest_request_id",
+        "inference.latest_engine_id",
+        "inference.latest_engine_provider",
+        "inference.latest_engine_cluster",
+        "inference.latest_engine_region",
+        "inference.latest_engine_geography",
+        "inference.latest_pipereplica_id",
+        "inference.latest_pipereplica_snapshot_id",
+        "inference.latest_pipereplica_image_tag",
+        "inference.latest_load_balancer_image_tag",
+        "inference.route_diagnostics_json",
+    ] {
+        assert!(
+            !timing_log_attrs.contains_key(forbidden_attribute),
+            "log exported forbidden high-cardinality attribute {forbidden_attribute}"
+        );
+    }
+
+    let spans = span_exporter.get_finished_spans().expect("span export");
+    let timing_span = spans
+        .iter()
+        .find(|span| span.name == "codex.responses_websocket_timing")
+        .expect("timing child span should exist");
+    let timing_trace_attrs = timing_span
+        .attributes
+        .iter()
+        .map(|KeyValue { key, value, .. }| (key.as_str().to_string(), value.to_string()))
+        .collect::<BTreeMap<_, _>>();
+    assert_eq!(
+        timing_trace_attrs
+            .get("model.request_ordinal")
+            .map(String::as_str),
+        Some("2")
+    );
+    assert_eq!(
+        timing_trace_attrs
+            .get("inference.taas_request_to_provider_start_total_ms")
+            .map(String::as_str),
+        Some("41.5")
+    );
+    assert_eq!(
+        timing_trace_attrs
+            .get("responsesapi.duration_excl_engine_and_client_tool_time_ms")
+            .map(String::as_str),
+        Some("98.5")
+    );
+    assert_eq!(
+        timing_trace_attrs
+            .get("inference.latest_engine_routing_ms")
+            .map(String::as_str),
+        Some("8.5")
+    );
+    assert_eq!(
+        timing_trace_attrs
+            .get("inference.routing_timing_semantics")
+            .map(String::as_str),
+        Some("nested_non_additive_v1")
+    );
+    for forbidden_attribute in [
+        "conversation.id",
+        "slug",
+        "model.response_id",
+        "inference.engine_ids",
+        "inference.latest_request_id",
+        "inference.latest_engine_id",
+        "inference.latest_engine_provider",
+        "inference.latest_engine_cluster",
+        "inference.latest_engine_region",
+        "inference.latest_engine_geography",
+        "inference.latest_pipereplica_id",
+        "inference.latest_pipereplica_snapshot_id",
+        "inference.latest_pipereplica_image_tag",
+        "inference.latest_load_balancer_image_tag",
+        "inference.route_diagnostics_json",
+    ] {
+        assert!(
+            !timing_trace_attrs.contains_key(forbidden_attribute),
+            "span exported forbidden high-cardinality attribute {forbidden_attribute}"
+        );
+    }
 }

--- a/codex-rs/rollout/src/recorder.rs
+++ b/codex-rs/rollout/src/recorder.rs
@@ -25,6 +25,8 @@ use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
+use tracing::Instrument;
+use tracing::Span;
 use tracing::error;
 use tracing::info;
 use tracing::trace;
@@ -104,16 +106,26 @@ pub enum RolloutRecorderParams {
 }
 
 enum RolloutCmd {
-    AddItems(Vec<RolloutItem>),
+    AddItems {
+        items: Vec<RolloutItem>,
+        span: Span,
+        queue_wait_span: Span,
+    },
     Persist {
         ack: oneshot::Sender<std::io::Result<()>>,
+        span: Span,
+        queue_wait_span: Span,
     },
     /// Ensure all prior writes are processed; respond when flushed.
     Flush {
         ack: oneshot::Sender<std::io::Result<()>>,
+        span: Span,
+        queue_wait_span: Span,
     },
     Shutdown {
         ack: oneshot::Sender<std::io::Result<()>>,
+        span: Span,
+        queue_wait_span: Span,
     },
 }
 
@@ -878,14 +890,34 @@ impl RolloutRecorder {
         if items.is_empty() {
             return Ok(());
         }
-        self.tx
-            .send(RolloutCmd::AddItems(items.to_vec()))
+        let command_span = tracing::info_span!(
+            "rollout_recorder.command.add_items",
+            item_count = items.len(),
+        );
+        let enqueue_span = tracing::info_span!(
+            parent: &command_span,
+            "rollout_recorder.command.enqueue_wait"
+        );
+        let permit = self
+            .tx
+            .reserve()
+            .instrument(enqueue_span)
             .await
             .map_err(|e| {
                 self.writer_task.terminal_failure().unwrap_or_else(|| {
                     IoError::other(format!("failed to queue rollout items: {e}"))
                 })
-            })
+            })?;
+        let queue_wait_span = tracing::info_span!(
+            parent: &command_span,
+            "rollout_recorder.command.queue_wait"
+        );
+        permit.send(RolloutCmd::AddItems {
+            items: items.to_vec(),
+            span: command_span,
+            queue_wait_span,
+        });
+        Ok(())
     }
 
     /// Materialize the rollout file and persist all buffered items.
@@ -894,15 +926,36 @@ impl RolloutRecorder {
     /// and a later `persist()` or `flush()` can retry opening and writing the rollout file.
     pub async fn persist(&self) -> std::io::Result<()> {
         let (tx, rx) = oneshot::channel();
-        self.tx
-            .send(RolloutCmd::Persist { ack: tx })
+        let command_span = tracing::info_span!("rollout_recorder.command.persist");
+        let enqueue_span = tracing::info_span!(
+            parent: &command_span,
+            "rollout_recorder.command.enqueue_wait"
+        );
+        let permit = self
+            .tx
+            .reserve()
+            .instrument(enqueue_span)
             .await
             .map_err(|e| {
                 self.writer_task.terminal_failure().unwrap_or_else(|| {
                     IoError::other(format!("failed to queue rollout persist: {e}"))
                 })
             })?;
-        rx.await.map_err(|e| {
+        let queue_wait_span = tracing::info_span!(
+            parent: &command_span,
+            "rollout_recorder.command.queue_wait"
+        );
+        permit.send(RolloutCmd::Persist {
+            ack: tx,
+            span: command_span.clone(),
+            queue_wait_span,
+        });
+        rx.instrument(tracing::info_span!(
+            parent: &command_span,
+            "rollout_recorder.command.response_wait"
+        ))
+        .await
+        .map_err(|e| {
             self.writer_task.terminal_failure().unwrap_or_else(|| {
                 IoError::other(format!("failed waiting for rollout persist: {e}"))
             })
@@ -915,15 +968,36 @@ impl RolloutRecorder {
     /// retrying. This returns an error only when that retry also fails or the writer task is gone.
     pub async fn flush(&self) -> std::io::Result<()> {
         let (tx, rx) = oneshot::channel();
-        self.tx
-            .send(RolloutCmd::Flush { ack: tx })
+        let command_span = tracing::info_span!("rollout_recorder.command.flush");
+        let enqueue_span = tracing::info_span!(
+            parent: &command_span,
+            "rollout_recorder.command.enqueue_wait"
+        );
+        let permit = self
+            .tx
+            .reserve()
+            .instrument(enqueue_span)
             .await
             .map_err(|e| {
                 self.writer_task.terminal_failure().unwrap_or_else(|| {
                     IoError::other(format!("failed to queue rollout flush: {e}"))
                 })
             })?;
-        rx.await.map_err(|e| {
+        let queue_wait_span = tracing::info_span!(
+            parent: &command_span,
+            "rollout_recorder.command.queue_wait"
+        );
+        permit.send(RolloutCmd::Flush {
+            ack: tx,
+            span: command_span.clone(),
+            queue_wait_span,
+        });
+        rx.instrument(tracing::info_span!(
+            parent: &command_span,
+            "rollout_recorder.command.response_wait"
+        ))
+        .await
+        .map_err(|e| {
             self.writer_task
                 .terminal_failure()
                 .unwrap_or_else(|| IoError::other(format!("failed waiting for rollout flush: {e}")))
@@ -1017,12 +1091,13 @@ impl RolloutRecorder {
     /// If draining fails, the writer stays alive so callers can continue retrying flush/shutdown.
     pub async fn shutdown(&self) -> std::io::Result<()> {
         let (tx_done, rx_done) = oneshot::channel();
-        match self.tx.send(RolloutCmd::Shutdown { ack: tx_done }).await {
-            Ok(_) => rx_done.await.map_err(|e| {
-                self.writer_task.terminal_failure().unwrap_or_else(|| {
-                    IoError::other(format!("failed waiting for rollout shutdown: {e}"))
-                })
-            })??,
+        let command_span = tracing::info_span!("rollout_recorder.command.shutdown");
+        let enqueue_span = tracing::info_span!(
+            parent: &command_span,
+            "rollout_recorder.command.enqueue_wait"
+        );
+        let permit = match self.tx.reserve().instrument(enqueue_span).await {
+            Ok(permit) => permit,
             Err(e) => {
                 if let Some(err) = self.writer_task.terminal_failure() {
                     warn!(
@@ -1036,6 +1111,26 @@ impl RolloutRecorder {
                 )));
             }
         };
+        let queue_wait_span = tracing::info_span!(
+            parent: &command_span,
+            "rollout_recorder.command.queue_wait"
+        );
+        permit.send(RolloutCmd::Shutdown {
+            ack: tx_done,
+            span: command_span.clone(),
+            queue_wait_span,
+        });
+        rx_done
+            .instrument(tracing::info_span!(
+                parent: &command_span,
+                "rollout_recorder.command.response_wait"
+            ))
+            .await
+            .map_err(|e| {
+                self.writer_task.terminal_failure().unwrap_or_else(|| {
+                    IoError::other(format!("failed waiting for rollout shutdown: {e}"))
+                })
+            })??;
         Ok(())
     }
 }
@@ -1580,19 +1675,37 @@ impl RolloutWriterState {
         self.pending_items.extend(items);
     }
 
+    #[tracing::instrument(
+        level = "info",
+        name = "rollout_recorder.writer.add_items.auto_flush",
+        skip_all,
+        fields(pending_item_count = self.pending_items.len())
+    )]
     async fn flush_if_materialized(&mut self) {
         if self.is_deferred() {
             return;
         }
-        if let Err(err) = self.flush().await {
+        if let Err(err) = self.write_pending_with_recovery("auto_flush").await {
             self.enter_recovery_mode(&err);
         }
     }
 
+    #[tracing::instrument(
+        level = "info",
+        name = "rollout_recorder.writer.persist_command",
+        skip_all,
+        fields(pending_item_count = self.pending_items.len())
+    )]
     async fn persist(&mut self) -> std::io::Result<()> {
         self.write_pending_with_recovery("persist").await
     }
 
+    #[tracing::instrument(
+        level = "info",
+        name = "rollout_recorder.writer.flush_command",
+        skip_all,
+        fields(pending_item_count = self.pending_items.len())
+    )]
     async fn flush(&mut self) -> std::io::Result<()> {
         if self.is_deferred() && self.pending_items.is_empty() {
             return Ok(());
@@ -1607,6 +1720,12 @@ impl RolloutWriterState {
         self.write_pending_with_recovery("shutdown").await
     }
 
+    #[tracing::instrument(
+        level = "info",
+        name = "rollout_recorder.writer.write_pending_with_recovery",
+        skip_all,
+        fields(operation, pending_item_count = self.pending_items.len())
+    )]
     async fn write_pending_with_recovery(&mut self, operation: &str) -> std::io::Result<()> {
         match self.write_pending_once().await {
             Ok(()) => {
@@ -1653,6 +1772,7 @@ impl RolloutWriterState {
         self.writer = None;
     }
 
+    #[tracing::instrument(level = "info", name = "rollout_recorder.writer.ensure_open", skip_all)]
     async fn ensure_writer_open(&mut self) -> std::io::Result<()> {
         if self.writer.is_some() {
             return Ok(());
@@ -1671,6 +1791,12 @@ impl RolloutWriterState {
         Ok(())
     }
 
+    #[tracing::instrument(
+        level = "info",
+        name = "rollout_recorder.writer.write_session_meta",
+        skip_all,
+        fields(has_session_meta = self.meta.is_some())
+    )]
     async fn write_session_meta_if_needed(&mut self) -> std::io::Result<()> {
         let Some(session_meta) = self.meta.as_ref().cloned() else {
             return Ok(());
@@ -1680,18 +1806,36 @@ impl RolloutWriterState {
         Ok(())
     }
 
+    #[tracing::instrument(
+        level = "info",
+        name = "rollout_recorder.writer.write_pending",
+        skip_all,
+        fields(
+            pending_item_count = self.pending_items.len(),
+            has_session_meta = self.meta.is_some(),
+        )
+    )]
     async fn write_pending_once(&mut self) -> std::io::Result<()> {
+        // The command queue is ordered, so a clean writer has already flushed every prior write.
+        // In particular, an explicit Flush immediately following AddItems does not need to issue a
+        // second identical file flush after AddItems' auto-flush completed successfully.
+        if self.meta.is_none() && self.pending_items.is_empty() {
+            return Ok(());
+        }
         self.ensure_writer_open().await?;
         self.write_session_meta_if_needed().await?;
 
         self.write_pending_items_once().await?;
 
-        if let Some(writer) = self.writer.as_mut() {
-            writer.file.flush().await?;
-        }
         Ok(())
     }
 
+    #[tracing::instrument(
+        level = "info",
+        name = "rollout_recorder.writer.serialize_and_write_items",
+        skip_all,
+        fields(item_count = self.pending_items.len())
+    )]
     async fn write_pending_items_once(&mut self) -> std::io::Result<()> {
         let Some(writer) = self.writer.as_mut() else {
             return Err(IoError::other("rollout writer is not open"));
@@ -1728,25 +1872,67 @@ async fn rollout_writer(
     // Process rollout commands
     while let Some(cmd) = rx.recv().await {
         match cmd {
-            RolloutCmd::AddItems(items) => {
-                state.add_items(items);
-                state.flush_if_materialized().await;
+            RolloutCmd::AddItems {
+                items,
+                span,
+                queue_wait_span,
+            } => {
+                drop(queue_wait_span);
+                async {
+                    state.add_items(items);
+                    state.flush_if_materialized().await;
+                }
+                .instrument(span)
+                .await;
             }
-            RolloutCmd::Persist { ack } => {
-                let _ = ack.send(state.persist().await);
+            RolloutCmd::Persist {
+                ack,
+                span,
+                queue_wait_span,
+            } => {
+                drop(queue_wait_span);
+                async {
+                    let _ = ack.send(state.persist().await);
+                }
+                .instrument(span)
+                .await;
             }
-            RolloutCmd::Flush { ack } => {
-                let _ = ack.send(state.flush().await);
+            RolloutCmd::Flush {
+                ack,
+                span,
+                queue_wait_span,
+            } => {
+                drop(queue_wait_span);
+                async {
+                    let _ = ack.send(state.flush().await);
+                }
+                .instrument(span)
+                .await;
             }
-            RolloutCmd::Shutdown { ack } => match state.shutdown().await {
-                Ok(()) => {
-                    let _ = ack.send(Ok(()));
+            RolloutCmd::Shutdown {
+                ack,
+                span,
+                queue_wait_span,
+            } => {
+                drop(queue_wait_span);
+                let should_break = async {
+                    match state.shutdown().await {
+                        Ok(()) => {
+                            let _ = ack.send(Ok(()));
+                            true
+                        }
+                        Err(err) => {
+                            let _ = ack.send(Err(err));
+                            false
+                        }
+                    }
+                }
+                .instrument(span)
+                .await;
+                if should_break {
                     break;
                 }
-                Err(err) => {
-                    let _ = ack.send(Err(err));
-                }
-            },
+            }
         }
     }
 
@@ -1758,12 +1944,19 @@ async fn write_session_meta(
     session_meta: SessionMeta,
     cwd: &Path,
 ) -> std::io::Result<()> {
-    let git_info = if get_git_repo_root(cwd).is_some() {
-        collect_git_info(cwd).await.map(|info| ProtocolGitInfo {
-            commit_hash: info.commit_hash,
-            branch: info.branch,
-            repository_url: info.repository_url,
-        })
+    let is_git_repo = tracing::info_span!("rollout_recorder.writer.git_root_discovery")
+        .in_scope(|| get_git_repo_root(cwd).is_some());
+    let git_info = if is_git_repo {
+        collect_git_info(cwd)
+            .instrument(tracing::info_span!(
+                "rollout_recorder.writer.collect_git_info"
+            ))
+            .await
+            .map(|info| ProtocolGitInfo {
+                commit_hash: info.commit_hash,
+                branch: info.branch,
+                repository_url: info.repository_url,
+            })
     } else {
         None
     };
@@ -1824,10 +2017,20 @@ impl JsonlWriter {
         self.write_line(&line).await
     }
     async fn write_line(&mut self, item: &impl serde::Serialize) -> std::io::Result<()> {
-        let mut json = serde_json::to_string(item)?;
+        let mut json = tracing::info_span!("rollout_recorder.writer.serialize")
+            .in_scope(|| serde_json::to_string(item))?;
         json.push('\n');
-        self.file.write_all(json.as_bytes()).await?;
-        self.file.flush().await?;
+        self.file
+            .write_all(json.as_bytes())
+            .instrument(tracing::info_span!(
+                "rollout_recorder.writer.write",
+                byte_count = json.len(),
+            ))
+            .await?;
+        self.file
+            .flush()
+            .instrument(tracing::info_span!("rollout_recorder.writer.file_flush"))
+            .await?;
         Ok(())
     }
 }

--- a/codex-rs/rollout/src/recorder_tests.rs
+++ b/codex-rs/rollout/src/recorder_tests.rs
@@ -508,6 +508,27 @@ async fn recorder_materializes_on_flush_with_pending_items() -> std::io::Result<
 }
 
 #[tokio::test]
+async fn clean_writer_flush_skips_redundant_file_io() -> std::io::Result<()> {
+    let home = TempDir::new().expect("temp dir");
+    let rollout_path = home.path().join("missing/rollout.jsonl");
+    let mut state = RolloutWriterState::new(
+        /*file*/ None,
+        /*deferred_log_file_info*/ None,
+        /*meta*/ None,
+        home.path().to_path_buf(),
+        rollout_path.clone(),
+    );
+
+    state.flush().await?;
+
+    assert!(
+        !rollout_path.exists(),
+        "a clean writer should acknowledge the ordered flush barrier without reopening the file"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn persist_reports_filesystem_error_and_retries_buffered_items() -> std::io::Result<()> {
     let home = TempDir::new().expect("temp dir");
     let config = test_config(home.path());

--- a/codex-rs/thread-store/Cargo.toml
+++ b/codex-rs/thread-store/Cargo.toml
@@ -31,4 +31,5 @@ tracing = { workspace = true }
 pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tracing-subscriber = { workspace = true }
 uuid = { workspace = true }

--- a/codex-rs/thread-store/src/error.rs
+++ b/codex-rs/thread-store/src/error.rs
@@ -16,7 +16,7 @@ pub(crate) fn reject_paginated_history_mode(
 }
 
 /// Error type shared by thread-store implementations.
-#[derive(Debug, thiserror::Error)]
+#[derive(Clone, Debug, thiserror::Error)]
 pub enum ThreadStoreError {
     /// The requested thread does not exist in this store.
     #[error("thread {thread_id} not found")]

--- a/codex-rs/thread-store/src/live_thread.rs
+++ b/codex-rs/thread-store/src/live_thread.rs
@@ -1,13 +1,17 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Instant;
 
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::ThreadMemoryMode;
+use codex_protocol::protocol::W3cTraceContext;
 use codex_rollout::RolloutPersistenceTelemetry;
 use codex_rollout::measure_and_filter_rollout_items;
 use codex_rollout::persisted_rollout_items;
 use tokio::sync::Mutex;
+use tokio::sync::oneshot;
+use tracing::Instrument;
 use tracing::warn;
 
 use crate::AppendThreadItemsParams;
@@ -20,8 +24,10 @@ use crate::StoredThread;
 use crate::StoredThreadHistory;
 use crate::ThreadMetadataPatch;
 use crate::ThreadStore;
+use crate::ThreadStoreError;
 use crate::ThreadStoreResult;
 use crate::UpdateThreadMetadataParams;
+use crate::thread_metadata_sync::PendingThreadMetadataPatch;
 use crate::thread_metadata_sync::ThreadMetadataSync;
 
 /// Handle for an active thread's persistence lifecycle.
@@ -33,8 +39,52 @@ use crate::thread_metadata_sync::ThreadMetadataSync;
 pub struct LiveThread {
     thread_id: ThreadId,
     thread_store: Arc<dyn ThreadStore>,
-    metadata_sync: Arc<Mutex<ThreadMetadataSync>>,
+    metadata_worker: Arc<MetadataUpdateWorker>,
     persistence_telemetry: RolloutPersistenceTelemetry,
+}
+
+struct MetadataUpdateWorker {
+    thread_id: ThreadId,
+    thread_store: Arc<dyn ThreadStore>,
+    state: Mutex<MetadataUpdateWorkerState>,
+}
+
+struct MetadataUpdateWorkerState {
+    metadata_sync: ThreadMetadataSync,
+    applied_generation: u64,
+    running: bool,
+    in_flight_generation: Option<u64>,
+    queued_update: Option<QueuedMetadataUpdate>,
+    barriers: Vec<MetadataBarrier>,
+    discarding: bool,
+    idle_waiters: Vec<oneshot::Sender<()>>,
+}
+
+struct QueuedMetadataUpdate {
+    update: PendingThreadMetadataPatch,
+    enqueued_at: Instant,
+    trace_context: Option<W3cTraceContext>,
+}
+
+impl QueuedMetadataUpdate {
+    fn new(update: PendingThreadMetadataPatch) -> Self {
+        Self {
+            update,
+            enqueued_at: Instant::now(),
+            trace_context: codex_otel::current_span_w3c_trace_context(),
+        }
+    }
+}
+
+struct MetadataBarrier {
+    target_generation: u64,
+    sender: oneshot::Sender<ThreadStoreResult<()>>,
+}
+
+#[derive(Clone, Copy)]
+enum MetadataBarrierKind {
+    All,
+    ExistingHistory,
 }
 
 /// Owns a live thread while session initialization is still fallible.
@@ -94,12 +144,7 @@ impl LiveThread {
         let thread_id = params.thread_id;
         let metadata_sync = ThreadMetadataSync::for_create(&params).await;
         thread_store.create_thread(params).await?;
-        Ok(Self {
-            thread_id,
-            thread_store,
-            metadata_sync: Arc::new(Mutex::new(metadata_sync)),
-            persistence_telemetry: RolloutPersistenceTelemetry::new(thread_id),
-        })
+        Ok(Self::new(thread_id, thread_store, metadata_sync))
     }
 
     pub async fn resume(
@@ -130,12 +175,34 @@ impl LiveThread {
                 }
             }
         }
-        Ok(Self {
+        Ok(Self::new(thread_id, thread_store, metadata_sync))
+    }
+
+    fn new(
+        thread_id: ThreadId,
+        thread_store: Arc<dyn ThreadStore>,
+        metadata_sync: ThreadMetadataSync,
+    ) -> Self {
+        let metadata_worker = Arc::new(MetadataUpdateWorker {
+            thread_id,
+            thread_store: Arc::clone(&thread_store),
+            state: Mutex::new(MetadataUpdateWorkerState {
+                metadata_sync,
+                applied_generation: 0,
+                running: false,
+                in_flight_generation: None,
+                queued_update: None,
+                barriers: Vec::new(),
+                discarding: false,
+                idle_waiters: Vec::new(),
+            }),
+        });
+        Self {
             thread_id,
             thread_store,
-            metadata_sync: Arc::new(Mutex::new(metadata_sync)),
+            metadata_worker,
             persistence_telemetry: RolloutPersistenceTelemetry::new(thread_id),
-        })
+        }
     }
 
     #[tracing::instrument(
@@ -148,17 +215,27 @@ impl LiveThread {
         if items.is_empty() {
             return Ok(());
         }
-        let (canonical_items, measurement) = if self.persistence_telemetry.is_enabled() {
-            let (canonical_items, measurement) = measure_and_filter_rollout_items(items);
-            (canonical_items, Some(measurement))
-        } else {
-            (persisted_rollout_items(items), None)
-        };
+        let (canonical_items, measurement) = tracing::info_span!(
+            "thread_store.live_append.filter_items",
+            item_count = items.len(),
+        )
+        .in_scope(|| {
+            if self.persistence_telemetry.is_enabled() {
+                let (canonical_items, measurement) = measure_and_filter_rollout_items(items);
+                (canonical_items, Some(measurement))
+            } else {
+                (persisted_rollout_items(items), None)
+            }
+        });
         self.thread_store
             .append_items(AppendThreadItemsParams {
                 thread_id: self.thread_id,
                 items: items.to_vec(),
             })
+            .instrument(tracing::info_span!(
+                "thread_store.live_append.store_append",
+                item_count = items.len(),
+            ))
             .await?;
         if let Some(measurement) = measurement.as_ref() {
             self.persistence_telemetry.record_batch(items, measurement);
@@ -166,45 +243,37 @@ impl LiveThread {
         if canonical_items.is_empty() {
             return Ok(());
         }
-        let update = self
-            .metadata_sync
-            .lock()
-            .await
-            .observe_appended_items(canonical_items.as_slice());
-        if let Some(update) = update {
-            self.thread_store
-                .update_thread_metadata(UpdateThreadMetadataParams {
-                    thread_id: self.thread_id,
-                    patch: update.patch.clone(),
-                    include_archived: true,
-                })
-                .await?;
-            self.metadata_sync
-                .lock()
-                .await
-                .mark_pending_update_applied(&update);
-        }
+        self.metadata_worker
+            .observe_appended_items(canonical_items.as_slice())
+            .instrument(tracing::info_span!(
+                "thread_store.live_append.observe_metadata",
+                item_count = canonical_items.len(),
+            ))
+            .await;
         Ok(())
     }
 
     pub async fn persist(&self) -> ThreadStoreResult<()> {
         self.thread_store.persist_thread(self.thread_id).await?;
-        self.flush_pending_metadata_update().await
+        self.metadata_worker.barrier(MetadataBarrierKind::All).await
     }
 
     pub async fn flush(&self) -> ThreadStoreResult<()> {
         self.thread_store.flush_thread(self.thread_id).await?;
-        self.flush_pending_metadata_update_for_existing_history()
+        self.metadata_worker
+            .barrier(MetadataBarrierKind::ExistingHistory)
             .await
     }
 
     pub async fn shutdown(&self) -> ThreadStoreResult<()> {
-        self.flush_pending_metadata_update_for_existing_history()
+        self.metadata_worker
+            .barrier(MetadataBarrierKind::ExistingHistory)
             .await?;
         self.thread_store.shutdown_thread(self.thread_id).await
     }
 
     pub async fn discard(&self) -> ThreadStoreResult<()> {
+        self.metadata_worker.discard_pending_and_wait().await?;
         self.thread_store.discard_thread(self.thread_id).await
     }
 
@@ -239,7 +308,9 @@ impl LiveThread {
         mode: ThreadMemoryMode,
         include_archived: bool,
     ) -> ThreadStoreResult<()> {
-        self.flush_pending_metadata_update().await?;
+        self.metadata_worker
+            .barrier(MetadataBarrierKind::All)
+            .await?;
         self.thread_store
             .update_thread_metadata(UpdateThreadMetadataParams {
                 thread_id: self.thread_id,
@@ -258,7 +329,9 @@ impl LiveThread {
         patch: ThreadMetadataPatch,
         include_archived: bool,
     ) -> ThreadStoreResult<StoredThread> {
-        self.flush_pending_metadata_update().await?;
+        self.metadata_worker
+            .barrier(MetadataBarrierKind::All)
+            .await?;
         self.thread_store
             .update_thread_metadata(UpdateThreadMetadataParams {
                 thread_id: self.thread_id,
@@ -284,39 +357,246 @@ impl LiveThread {
             .await
             .map(Some)
     }
+}
 
-    async fn flush_pending_metadata_update(&self) -> ThreadStoreResult<()> {
-        let update = self.metadata_sync.lock().await.take_pending_update();
-        self.apply_pending_metadata_update(update).await
-    }
-
-    async fn flush_pending_metadata_update_for_existing_history(&self) -> ThreadStoreResult<()> {
-        let update = self
-            .metadata_sync
-            .lock()
-            .await
-            .take_pending_update_for_existing_history();
-        self.apply_pending_metadata_update(update).await
-    }
-
-    async fn apply_pending_metadata_update(
-        &self,
-        update: Option<crate::thread_metadata_sync::PendingThreadMetadataPatch>,
-    ) -> ThreadStoreResult<()> {
-        let Some(update) = update else {
-            return Ok(());
+impl MetadataUpdateWorker {
+    async fn observe_appended_items(self: &Arc<Self>, items: &[RolloutItem]) {
+        let should_spawn = {
+            let mut state = self.state.lock().await;
+            if state.discarding {
+                return;
+            }
+            let update = state.metadata_sync.observe_appended_items(items);
+            if let Some(update) = update {
+                state.queued_update = Some(QueuedMetadataUpdate::new(update));
+            }
+            Self::start_if_needed(&mut state)
         };
-        self.thread_store
-            .update_thread_metadata(UpdateThreadMetadataParams {
-                thread_id: self.thread_id,
-                patch: update.patch.clone(),
-                include_archived: true,
+        if should_spawn {
+            self.spawn();
+        }
+    }
+
+    async fn barrier(self: &Arc<Self>, kind: MetadataBarrierKind) -> ThreadStoreResult<()> {
+        let (receiver, should_spawn) = {
+            let mut state = self.state.lock().await;
+            if state.discarding {
+                return Err(ThreadStoreError::InvalidRequest {
+                    message: "thread metadata update worker is being discarded".to_string(),
+                });
+            }
+            let update = match kind {
+                MetadataBarrierKind::All => state.metadata_sync.take_pending_update(),
+                MetadataBarrierKind::ExistingHistory => state
+                    .metadata_sync
+                    .take_pending_update_for_existing_history(),
+            };
+            let Some(update) = update else {
+                return Ok(());
+            };
+            let target_generation = update.generation();
+            if target_generation <= state.applied_generation {
+                return Ok(());
+            }
+            let generation_is_covered = state.in_flight_generation == Some(target_generation)
+                || state
+                    .queued_update
+                    .as_ref()
+                    .is_some_and(|queued| queued.update.generation() >= target_generation);
+            if !generation_is_covered {
+                state.queued_update = Some(QueuedMetadataUpdate::new(update));
+            }
+            let (sender, receiver) = oneshot::channel();
+            state.barriers.push(MetadataBarrier {
+                target_generation,
+                sender,
+            });
+            let should_spawn = Self::start_if_needed(&mut state);
+            (receiver, should_spawn)
+        };
+        if should_spawn {
+            self.spawn();
+        }
+        receiver.await.unwrap_or_else(|err| {
+            Err(ThreadStoreError::Internal {
+                message: format!("thread metadata update worker stopped before barrier: {err}"),
             })
-            .await?;
-        self.metadata_sync
-            .lock()
-            .await
-            .mark_pending_update_applied(&update);
+        })
+    }
+
+    async fn discard_pending_and_wait(&self) -> ThreadStoreResult<()> {
+        let (receiver, barriers) = {
+            let mut state = self.state.lock().await;
+            state.discarding = true;
+            state.queued_update = None;
+            let barriers = std::mem::take(&mut state.barriers);
+            let receiver = if state.running {
+                let (sender, receiver) = oneshot::channel();
+                state.idle_waiters.push(sender);
+                Some(receiver)
+            } else {
+                None
+            };
+            (receiver, barriers)
+        };
+        for barrier in barriers {
+            let _ = barrier.sender.send(Err(ThreadStoreError::InvalidRequest {
+                message: "thread metadata update worker was discarded".to_string(),
+            }));
+        }
+        if let Some(receiver) = receiver {
+            receiver.await.map_err(|err| ThreadStoreError::Internal {
+                message: format!("thread metadata update worker stopped before discard: {err}"),
+            })?;
+        }
         Ok(())
     }
+
+    fn start_if_needed(state: &mut MetadataUpdateWorkerState) -> bool {
+        if state.discarding || state.running || state.queued_update.is_none() {
+            return false;
+        }
+        state.running = true;
+        true
+    }
+
+    fn spawn(self: &Arc<Self>) {
+        tokio::spawn(
+            Arc::clone(self)
+                .run()
+                .instrument(tracing::info_span!("thread_store.metadata_update_worker")),
+        );
+    }
+
+    async fn run(self: Arc<Self>) {
+        loop {
+            let queued = {
+                let mut state = self.state.lock().await;
+                let Some(queued) = state.queued_update.take() else {
+                    state.running = false;
+                    let barriers = std::mem::take(&mut state.barriers);
+                    let idle_waiters = std::mem::take(&mut state.idle_waiters);
+                    let applied_generation = state.applied_generation;
+                    drop(state);
+                    for barrier in barriers {
+                        let result = if barrier.target_generation <= applied_generation {
+                            Ok(())
+                        } else {
+                            Err(ThreadStoreError::Internal {
+                                message:
+                                    "metadata worker became idle before its barrier generation"
+                                        .to_string(),
+                            })
+                        };
+                        let _ = barrier.sender.send(result);
+                    }
+                    for waiter in idle_waiters {
+                        let _ = waiter.send(());
+                    }
+                    return;
+                };
+                state.in_flight_generation = Some(queued.update.generation());
+                queued
+            };
+
+            let generation = queued.update.generation();
+            let apply_span = tracing::info_span!(
+                "thread_store.metadata_update.apply",
+                generation,
+                queue_age_ms = queued.enqueued_at.elapsed().as_secs_f64() * 1_000.0,
+            );
+            if let Some(trace_context) = queued.trace_context.as_ref() {
+                let _ = codex_otel::set_parent_from_w3c_trace_context(&apply_span, trace_context);
+            }
+            let result = async {
+                self.thread_store
+                    .update_thread_metadata(UpdateThreadMetadataParams {
+                        thread_id: self.thread_id,
+                        patch: queued.update.patch.clone(),
+                        include_archived: true,
+                    })
+                    .instrument(tracing::info_span!(
+                        "thread_store.metadata_update.update_thread_metadata"
+                    ))
+                    .await
+            }
+            .instrument(apply_span)
+            .await;
+            match result {
+                Ok(_) => {
+                    let mut state = self.state.lock().await;
+                    state
+                        .metadata_sync
+                        .mark_pending_update_applied(&queued.update);
+                    state.applied_generation =
+                        state.applied_generation.max(queued.update.generation());
+                    state.in_flight_generation = None;
+                    let applied_generation = state.applied_generation;
+                    let mut pending_barriers = Vec::new();
+                    let mut satisfied_barriers = Vec::new();
+                    for barrier in std::mem::take(&mut state.barriers) {
+                        if barrier.target_generation <= applied_generation {
+                            satisfied_barriers.push(barrier);
+                        } else {
+                            pending_barriers.push(barrier);
+                        }
+                    }
+                    state.barriers = pending_barriers;
+                    drop(state);
+                    for barrier in satisfied_barriers {
+                        let _ = barrier.sender.send(Ok(()));
+                    }
+                }
+                Err(err) => {
+                    warn!(
+                        thread_id = %self.thread_id,
+                        error = %err,
+                        "failed to asynchronously update thread metadata"
+                    );
+                    let (failed_barriers, idle_waiters, should_retry) = {
+                        let mut state = self.state.lock().await;
+                        state.in_flight_generation = None;
+                        let retry_generation = if state.discarding {
+                            None
+                        } else {
+                            state
+                                .queued_update
+                                .as_ref()
+                                .map(|queued| queued.update.generation())
+                        };
+                        let should_retry = retry_generation.is_some();
+                        let (pending_barriers, failed_barriers) =
+                            std::mem::take(&mut state.barriers)
+                                .into_iter()
+                                .partition(|barrier| {
+                                    retry_generation.is_some_and(|generation| {
+                                        barrier.target_generation <= generation
+                                    })
+                                });
+                        state.barriers = pending_barriers;
+                        state.running = should_retry;
+                        let idle_waiters = if should_retry {
+                            Vec::new()
+                        } else {
+                            std::mem::take(&mut state.idle_waiters)
+                        };
+                        (failed_barriers, idle_waiters, should_retry)
+                    };
+                    for barrier in failed_barriers {
+                        let _ = barrier.sender.send(Err(err.clone()));
+                    }
+                    for waiter in idle_waiters {
+                        let _ = waiter.send(());
+                    }
+                    if !should_retry {
+                        return;
+                    }
+                }
+            }
+        }
+    }
 }
+
+#[cfg(test)]
+#[path = "live_thread_tests.rs"]
+mod tests;

--- a/codex-rs/thread-store/src/live_thread_tests.rs
+++ b/codex-rs/thread-store/src/live_thread_tests.rs
@@ -1,0 +1,567 @@
+use std::any::Any;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::time::Duration;
+
+use codex_protocol::ThreadId;
+use codex_protocol::models::BaseInstructions;
+use codex_protocol::protocol::EventMsg;
+use codex_protocol::protocol::RolloutItem;
+use codex_protocol::protocol::SessionSource;
+use codex_protocol::protocol::ThreadHistoryMode;
+use codex_protocol::protocol::ThreadMemoryMode;
+use codex_protocol::protocol::UserMessageEvent;
+use pretty_assertions::assert_eq;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::time::timeout;
+use tracing::Subscriber;
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::util::SubscriberInitExt;
+use uuid::Uuid;
+
+use super::LiveThread;
+use crate::AppendThreadItemsParams;
+use crate::ArchiveThreadParams;
+use crate::CreateThreadParams;
+use crate::DeleteThreadParams;
+use crate::InMemoryThreadStore;
+use crate::ItemPage;
+use crate::ListItemsParams;
+use crate::ListThreadsParams;
+use crate::ListTurnsParams;
+use crate::LoadThreadHistoryParams;
+use crate::ReadThreadByRolloutPathParams;
+use crate::ReadThreadParams;
+use crate::ResumeThreadParams;
+use crate::SearchThreadsParams;
+use crate::StoredThread;
+use crate::StoredThreadHistory;
+use crate::ThreadPage;
+use crate::ThreadPersistenceMetadata;
+use crate::ThreadSearchPage;
+use crate::ThreadStore;
+use crate::ThreadStoreError;
+use crate::ThreadStoreFuture;
+use crate::ThreadStoreResult;
+use crate::TurnPage;
+use crate::UpdateThreadMetadataParams;
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(1);
+
+struct MetadataUpdateAttempt {
+    params: UpdateThreadMetadataParams,
+    completion: oneshot::Sender<ThreadStoreResult<()>>,
+}
+
+struct ControlledThreadStore {
+    inner: InMemoryThreadStore,
+    update_sender: mpsc::UnboundedSender<MetadataUpdateAttempt>,
+}
+
+impl ControlledThreadStore {
+    fn new() -> (Arc<Self>, mpsc::UnboundedReceiver<MetadataUpdateAttempt>) {
+        let (update_sender, update_receiver) = mpsc::unbounded_channel();
+        (
+            Arc::new(Self {
+                inner: InMemoryThreadStore::default(),
+                update_sender,
+            }),
+            update_receiver,
+        )
+    }
+}
+
+impl ThreadStore for ControlledThreadStore {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn create_thread(&self, params: CreateThreadParams) -> ThreadStoreFuture<'_, ()> {
+        ThreadStore::create_thread(&self.inner, params)
+    }
+
+    fn resume_thread(&self, params: ResumeThreadParams) -> ThreadStoreFuture<'_, ()> {
+        ThreadStore::resume_thread(&self.inner, params)
+    }
+
+    fn append_items(&self, params: AppendThreadItemsParams) -> ThreadStoreFuture<'_, ()> {
+        ThreadStore::append_items(&self.inner, params)
+    }
+
+    fn persist_thread(&self, thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
+        ThreadStore::persist_thread(&self.inner, thread_id)
+    }
+
+    fn flush_thread(&self, thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
+        ThreadStore::flush_thread(&self.inner, thread_id)
+    }
+
+    fn shutdown_thread(&self, thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
+        ThreadStore::shutdown_thread(&self.inner, thread_id)
+    }
+
+    fn discard_thread(&self, thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
+        ThreadStore::discard_thread(&self.inner, thread_id)
+    }
+
+    fn load_history(
+        &self,
+        params: LoadThreadHistoryParams,
+    ) -> ThreadStoreFuture<'_, StoredThreadHistory> {
+        ThreadStore::load_history(&self.inner, params)
+    }
+
+    fn read_thread(&self, params: ReadThreadParams) -> ThreadStoreFuture<'_, StoredThread> {
+        ThreadStore::read_thread(&self.inner, params)
+    }
+
+    fn read_thread_by_rollout_path(
+        &self,
+        params: ReadThreadByRolloutPathParams,
+    ) -> ThreadStoreFuture<'_, StoredThread> {
+        ThreadStore::read_thread_by_rollout_path(&self.inner, params)
+    }
+
+    fn list_threads(&self, params: ListThreadsParams) -> ThreadStoreFuture<'_, ThreadPage> {
+        ThreadStore::list_threads(&self.inner, params)
+    }
+
+    fn search_threads(
+        &self,
+        params: SearchThreadsParams,
+    ) -> ThreadStoreFuture<'_, ThreadSearchPage> {
+        ThreadStore::search_threads(&self.inner, params)
+    }
+
+    fn list_turns(&self, params: ListTurnsParams) -> ThreadStoreFuture<'_, TurnPage> {
+        ThreadStore::list_turns(&self.inner, params)
+    }
+
+    fn list_items(&self, params: ListItemsParams) -> ThreadStoreFuture<'_, ItemPage> {
+        ThreadStore::list_items(&self.inner, params)
+    }
+
+    fn update_thread_metadata(
+        &self,
+        params: UpdateThreadMetadataParams,
+    ) -> ThreadStoreFuture<'_, StoredThread> {
+        Box::pin(async move {
+            let (completion, result) = oneshot::channel();
+            self.update_sender
+                .send(MetadataUpdateAttempt {
+                    params: params.clone(),
+                    completion,
+                })
+                .map_err(|_| ThreadStoreError::Internal {
+                    message: "metadata update test receiver dropped".to_string(),
+                })?;
+            result.await.map_err(|err| ThreadStoreError::Internal {
+                message: format!("metadata update test completion dropped: {err}"),
+            })??;
+            ThreadStore::update_thread_metadata(&self.inner, params).await
+        })
+    }
+
+    fn archive_thread(&self, params: ArchiveThreadParams) -> ThreadStoreFuture<'_, ()> {
+        ThreadStore::archive_thread(&self.inner, params)
+    }
+
+    fn unarchive_thread(&self, params: ArchiveThreadParams) -> ThreadStoreFuture<'_, StoredThread> {
+        ThreadStore::unarchive_thread(&self.inner, params)
+    }
+
+    fn delete_thread(&self, params: DeleteThreadParams) -> ThreadStoreFuture<'_, ()> {
+        ThreadStore::delete_thread(&self.inner, params)
+    }
+}
+
+#[tokio::test]
+async fn append_returns_after_history_acceptance_while_metadata_is_blocked() {
+    let (store, mut updates) = ControlledThreadStore::new();
+    let live_thread = create_live_thread(Arc::clone(&store)).await;
+
+    timeout(
+        TEST_TIMEOUT,
+        live_thread.append_items(&[user_message("first message")]),
+    )
+    .await
+    .expect("append should not wait for metadata persistence")
+    .expect("append should succeed");
+    let attempt = next_update(&mut updates).await;
+
+    assert_eq!(store.inner.calls().await.append_items, 1);
+    assert_eq!(store.inner.calls().await.update_thread_metadata, 0);
+    assert_eq!(
+        attempt.params.patch.preview.as_deref(),
+        Some("first message")
+    );
+
+    attempt
+        .completion
+        .send(Ok(()))
+        .expect("metadata worker should still be waiting");
+    live_thread
+        .flush()
+        .await
+        .expect("flush should drain metadata");
+    assert_eq!(store.inner.calls().await.update_thread_metadata, 1);
+}
+
+#[tokio::test]
+async fn appends_coalesce_while_metadata_update_is_in_flight() {
+    let (store, mut updates) = ControlledThreadStore::new();
+    let live_thread = create_live_thread(Arc::clone(&store)).await;
+
+    live_thread
+        .append_items(&[user_message("first message")])
+        .await
+        .expect("first append should succeed");
+    let first_attempt = next_update(&mut updates).await;
+    live_thread
+        .append_items(&[user_message("second message")])
+        .await
+        .expect("second append should succeed");
+    live_thread
+        .append_items(&[user_message("third message")])
+        .await
+        .expect("third append should succeed");
+
+    first_attempt
+        .completion
+        .send(Ok(()))
+        .expect("metadata worker should still be waiting");
+    let second_attempt = next_update(&mut updates).await;
+    let mut flush = tokio::spawn({
+        let live_thread = live_thread.clone();
+        async move { live_thread.flush().await }
+    });
+    assert!(
+        timeout(Duration::from_millis(20), &mut flush)
+            .await
+            .is_err(),
+        "flush should wait for the in-flight coalesced update"
+    );
+    live_thread
+        .append_items(&[user_message("accepted after flush barrier")])
+        .await
+        .expect("later append should succeed");
+    second_attempt
+        .completion
+        .send(Ok(()))
+        .expect("metadata worker should still be waiting");
+    timeout(TEST_TIMEOUT, flush)
+        .await
+        .expect("flush should not wait for metadata accepted after its barrier")
+        .expect("flush task should not panic")
+        .expect("flush should succeed");
+    let third_attempt = next_update(&mut updates).await;
+    third_attempt
+        .completion
+        .send(Ok(()))
+        .expect("metadata worker should still be waiting");
+    live_thread
+        .flush()
+        .await
+        .expect("final flush should drain later metadata");
+
+    let calls = store.inner.calls().await;
+    assert_eq!(calls.append_items, 4);
+    assert_eq!(calls.update_thread_metadata, 3);
+}
+
+#[tokio::test]
+async fn queued_generation_keeps_its_barrier_when_in_flight_update_fails() {
+    let (store, mut updates) = ControlledThreadStore::new();
+    let live_thread = create_live_thread(Arc::clone(&store)).await;
+
+    live_thread
+        .append_items(&[user_message("first message")])
+        .await
+        .expect("first append should succeed");
+    let first_attempt = next_update(&mut updates).await;
+    live_thread
+        .append_items(&[user_message("second message")])
+        .await
+        .expect("second append should succeed");
+    let mut flush = tokio::spawn({
+        let live_thread = live_thread.clone();
+        async move { live_thread.flush().await }
+    });
+    assert!(
+        timeout(Duration::from_millis(20), &mut flush)
+            .await
+            .is_err(),
+        "flush should wait for the queued generation"
+    );
+
+    first_attempt
+        .completion
+        .send(Err(test_error("superseded generation failed")))
+        .expect("metadata worker should still be waiting");
+    let retry_attempt = next_update(&mut updates).await;
+    assert!(
+        timeout(Duration::from_millis(20), &mut flush)
+            .await
+            .is_err(),
+        "a failure covered by the queued generation must not fail its barrier"
+    );
+    retry_attempt
+        .completion
+        .send(Ok(()))
+        .expect("metadata worker should still be waiting");
+    timeout(TEST_TIMEOUT, flush)
+        .await
+        .expect("flush should finish after the queued generation is applied")
+        .expect("flush task should not panic")
+        .expect("flush should succeed");
+    assert_eq!(store.inner.calls().await.update_thread_metadata, 1);
+}
+
+#[derive(Clone)]
+struct WorkerSpanParentLayer {
+    parent_name: Arc<StdMutex<Option<String>>>,
+}
+
+impl<S> Layer<S> for WorkerSpanParentLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(
+        &self,
+        _attrs: &tracing::span::Attributes<'_>,
+        id: &tracing::span::Id,
+        ctx: Context<'_, S>,
+    ) {
+        let Some(span) = ctx.span(id) else {
+            return;
+        };
+        if span.metadata().name() != "thread_store.metadata_update_worker" {
+            return;
+        }
+        *self.parent_name.lock().expect("parent name lock") = span
+            .parent()
+            .map(|parent| parent.metadata().name().to_string());
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn metadata_worker_span_preserves_append_trace() {
+    let (store, mut updates) = ControlledThreadStore::new();
+    let live_thread = create_live_thread(Arc::clone(&store)).await;
+    let parent_name = Arc::new(StdMutex::new(None));
+    let _guard = tracing_subscriber::registry()
+        .with(WorkerSpanParentLayer {
+            parent_name: Arc::clone(&parent_name),
+        })
+        .set_default();
+    tracing::callsite::rebuild_interest_cache();
+
+    live_thread
+        .append_items(&[user_message("trace me")])
+        .await
+        .expect("append should succeed");
+    next_update(&mut updates)
+        .await
+        .completion
+        .send(Ok(()))
+        .expect("metadata worker should still be waiting");
+    live_thread
+        .flush()
+        .await
+        .expect("flush should drain metadata");
+
+    assert_eq!(
+        parent_name.lock().expect("parent name lock").as_deref(),
+        Some("thread_store.live_append.observe_metadata")
+    );
+}
+
+#[tokio::test]
+async fn failed_async_update_is_retried_and_reported_by_barriers() {
+    let (store, mut updates) = ControlledThreadStore::new();
+    let live_thread = create_live_thread(Arc::clone(&store)).await;
+
+    live_thread
+        .append_items(&[user_message("retry me")])
+        .await
+        .expect("append should succeed independently of metadata");
+    next_update(&mut updates)
+        .await
+        .completion
+        .send(Err(test_error("background failure")))
+        .expect("metadata worker should still be waiting");
+    wait_until_worker_stops(&live_thread).await;
+
+    let retrying_flush = tokio::spawn({
+        let live_thread = live_thread.clone();
+        async move { live_thread.flush().await }
+    });
+    next_update(&mut updates)
+        .await
+        .completion
+        .send(Err(ThreadStoreError::Conflict {
+            message: "barrier failure".to_string(),
+        }))
+        .expect("metadata worker should still be waiting");
+    let error = retrying_flush
+        .await
+        .expect("flush task should not panic")
+        .expect_err("barrier should report the repeated failure");
+    assert!(matches!(
+        error,
+        ThreadStoreError::Conflict { message } if message == "barrier failure"
+    ));
+    wait_until_worker_stops(&live_thread).await;
+
+    let successful_flush = tokio::spawn({
+        let live_thread = live_thread.clone();
+        async move { live_thread.flush().await }
+    });
+    next_update(&mut updates)
+        .await
+        .completion
+        .send(Ok(()))
+        .expect("metadata worker should still be waiting");
+    successful_flush
+        .await
+        .expect("flush task should not panic")
+        .expect("later barrier should retry pending metadata successfully");
+    assert_eq!(store.inner.calls().await.update_thread_metadata, 1);
+}
+
+#[tokio::test]
+async fn shutdown_waits_for_queued_metadata_before_closing_store() {
+    let (store, mut updates) = ControlledThreadStore::new();
+    let live_thread = create_live_thread(Arc::clone(&store)).await;
+
+    live_thread
+        .append_items(&[user_message("finish before shutdown")])
+        .await
+        .expect("append should succeed");
+    let attempt = next_update(&mut updates).await;
+    let mut shutdown = tokio::spawn({
+        let live_thread = live_thread.clone();
+        async move { live_thread.shutdown().await }
+    });
+    assert!(
+        timeout(Duration::from_millis(20), &mut shutdown)
+            .await
+            .is_err(),
+        "shutdown should wait for the in-flight metadata update"
+    );
+    assert_eq!(store.inner.calls().await.shutdown_thread, 0);
+
+    attempt
+        .completion
+        .send(Ok(()))
+        .expect("metadata worker should still be waiting");
+    shutdown
+        .await
+        .expect("shutdown task should not panic")
+        .expect("shutdown should succeed");
+    assert_eq!(store.inner.calls().await.shutdown_thread, 1);
+}
+
+#[tokio::test]
+async fn discard_waits_for_in_flight_metadata_before_discarding_store() {
+    let (store, mut updates) = ControlledThreadStore::new();
+    let live_thread = create_live_thread(Arc::clone(&store)).await;
+
+    live_thread
+        .append_items(&[user_message("discard me")])
+        .await
+        .expect("append should succeed");
+    let attempt = next_update(&mut updates).await;
+    let mut discard = tokio::spawn({
+        let live_thread = live_thread.clone();
+        async move { live_thread.discard().await }
+    });
+    assert!(
+        timeout(Duration::from_millis(20), &mut discard)
+            .await
+            .is_err(),
+        "discard should wait for the in-flight metadata update"
+    );
+    assert_eq!(store.inner.calls().await.discard_thread, 0);
+
+    attempt
+        .completion
+        .send(Ok(()))
+        .expect("metadata worker should still be waiting");
+    discard
+        .await
+        .expect("discard task should not panic")
+        .expect("discard should succeed");
+    assert_eq!(store.inner.calls().await.discard_thread, 1);
+}
+
+async fn create_live_thread(store: Arc<ControlledThreadStore>) -> LiveThread {
+    let thread_id = ThreadId::new();
+    let thread_store: Arc<dyn ThreadStore> = store;
+    LiveThread::create(thread_store, create_params(thread_id))
+        .await
+        .expect("live thread should be created")
+}
+
+fn create_params(thread_id: ThreadId) -> CreateThreadParams {
+    CreateThreadParams {
+        session_id: thread_id.into(),
+        thread_id,
+        extra_config: None,
+        forked_from_id: None,
+        parent_thread_id: None,
+        source: SessionSource::Exec,
+        thread_source: None,
+        originator: "test_originator".to_string(),
+        base_instructions: BaseInstructions::default(),
+        dynamic_tools: Vec::new(),
+        selected_capability_roots: Vec::new(),
+        multi_agent_version: None,
+        history_mode: ThreadHistoryMode::Legacy,
+        initial_window_id: Uuid::now_v7().to_string(),
+        metadata: ThreadPersistenceMetadata {
+            cwd: None,
+            model_provider: "test-provider".to_string(),
+            memory_mode: ThreadMemoryMode::Enabled,
+        },
+    }
+}
+
+fn user_message(message: &str) -> RolloutItem {
+    RolloutItem::EventMsg(EventMsg::UserMessage(UserMessageEvent {
+        message: message.to_string(),
+        ..Default::default()
+    }))
+}
+
+async fn next_update(
+    updates: &mut mpsc::UnboundedReceiver<MetadataUpdateAttempt>,
+) -> MetadataUpdateAttempt {
+    timeout(TEST_TIMEOUT, updates.recv())
+        .await
+        .expect("metadata update should start")
+        .expect("metadata update channel should remain open")
+}
+
+async fn wait_until_worker_stops(live_thread: &LiveThread) {
+    timeout(TEST_TIMEOUT, async {
+        loop {
+            if !live_thread.metadata_worker.state.lock().await.running {
+                return;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("metadata worker should stop");
+}
+
+fn test_error(message: &str) -> ThreadStoreError {
+    ThreadStoreError::Internal {
+        message: message.to_string(),
+    }
+}

--- a/codex-rs/thread-store/src/local/live_writer.rs
+++ b/codex-rs/thread-store/src/local/live_writer.rs
@@ -6,6 +6,7 @@ use codex_rollout::RolloutConfig;
 use codex_rollout::RolloutRecorder;
 use codex_rollout::RolloutRecorderParams;
 use codex_rollout::persisted_rollout_items;
+use tracing::Instrument;
 use tracing::warn;
 
 use super::LocalThreadStore;
@@ -115,18 +116,35 @@ pub(super) async fn append_items(
     store: &LocalThreadStore,
     params: AppendThreadItemsParams,
 ) -> ThreadStoreResult<()> {
-    let canonical_items = persisted_rollout_items(params.items.as_slice());
+    let canonical_items = tracing::info_span!(
+        "thread_store.append_items.canonicalize",
+        item_count = params.items.len(),
+    )
+    .in_scope(|| persisted_rollout_items(params.items.as_slice()));
     if canonical_items.is_empty() {
         return Ok(());
     }
-    let recorder = store.live_recorder(params.thread_id).await?;
+    let recorder = store
+        .live_recorder(params.thread_id)
+        .instrument(tracing::info_span!(
+            "thread_store.append_items.get_recorder"
+        ))
+        .await?;
     recorder
         .record_canonical_items(canonical_items.as_slice())
+        .instrument(tracing::info_span!(
+            "thread_store.append_items.record_canonical_items",
+            item_count = canonical_items.len(),
+        ))
         .await
         .map_err(thread_store_io_error)?;
     // LiveThread applies metadata immediately after append_items returns. Wait for the local
     // writer so SQLite never gets ahead of JSONL for accepted live appends.
-    recorder.flush().await.map_err(thread_store_io_error)
+    recorder
+        .flush()
+        .instrument(tracing::info_span!("thread_store.append_items.flush"))
+        .await
+        .map_err(thread_store_io_error)
 }
 
 pub(super) async fn persist_thread(

--- a/codex-rs/thread-store/src/local/mod.rs
+++ b/codex-rs/thread-store/src/local/mod.rs
@@ -713,6 +713,10 @@ mod tests {
             .append_items(&[user_message_item("new live append")])
             .await
             .expect("append after resume");
+        live_thread
+            .flush()
+            .await
+            .expect("flush append-derived metadata");
 
         let metadata = runtime
             .get_thread(thread_id)
@@ -767,6 +771,10 @@ mod tests {
             .append_items(&[user_message_item("new external append")])
             .await
             .expect("append after external resume");
+        live_thread
+            .flush()
+            .await
+            .expect("flush append-derived metadata");
 
         let metadata = runtime
             .get_thread(thread_id)

--- a/codex-rs/thread-store/src/thread_metadata_sync.rs
+++ b/codex-rs/thread-store/src/thread_metadata_sync.rs
@@ -50,6 +50,12 @@ pub(crate) struct PendingThreadMetadataPatch {
     generation: u64,
 }
 
+impl PendingThreadMetadataPatch {
+    pub(crate) fn generation(&self) -> u64 {
+        self.generation
+    }
+}
+
 impl ThreadMetadataSync {
     pub(crate) async fn for_create(params: &CreateThreadParams) -> Self {
         let created_at = Utc::now();


### PR DESCRIPTION
## Summary

This change makes remote first-turn and command latency attributable end to end, and removes several avoidable waits found while profiling that path.

- propagate W3C trace context across Core, exec-server RPC, and the encrypted Noise relay
- add stage-level spans for tool dispatch, RPC queues, relay framing, local process lifecycle, terminal delivery, and thread metadata work
- consume pushed terminal events directly instead of polling when the transport supports them
- keep thread metadata persistence off the synchronous event-delivery path while preserving explicit flush barriers
- make turn-diff repository discovery lazy
- reuse the AGENTS project root once during adjacent startup skill discovery, with a pipelined fallback for later independent loads
- preserve client/server timing correlation for Responses WebSocket requests

## Why

The previous telemetry exposed large envelopes such as `exec_command` and `session_init`, but could not distinguish queue residence, transport transit, child-process work, terminal notification delivery, or persistence. Profiling also showed that skill discovery repeated the same remote ancestor-marker walk that AGENTS discovery had just completed.

The one-shot root handoff removes that duplicate startup walk without caching filesystem topology across turns. Later loads rediscover the nearest marker, so creating or removing a closer repository boundary remains observable.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p codex-core`
- `cargo test -p codex-core-skills repo_skill_roots_use_one_shot_hint_then_observe_new_nearest_marker -- --nocapture`
- `cargo test -p codex-exec-server process_lifecycle_trace_separates_output_readers_and_exit_watcher -- --nocapture`
- `cargo test -p codex-exec-server --test exec_process`
- `cargo test -p codex-thread-store`
- `just bazel-lock-check`

The new trace boundaries were also exercised with a real remote command flow. Local process handling remained small; the added spans separated it from the dominant transport legs and exposed the repeated startup metadata RPCs.

This is an internally requested performance and observability enhancement; there is no public issue.
