### PR TITLE
[codex] Update safety notice wording

### DIFF
--- a/codex-rs/tui/src/history_cell/notices.rs
+++ b/codex-rs/tui/src/history_cell/notices.rs
@@ -96,7 +96,7 @@ const SAFETY_ACCESS_BLOCK_LEARN_MORE_URL: &str = "https://help.openai.com/en/art
 
 pub(crate) fn new_safety_access_block_event() -> SafetyAccessBlockCell {
     SafetyAccessBlockCell {
-        body: "We take extra caution with requests involving biological research and applications that could pose safety risks. Eligible researchers can apply for Trusted Access. If you’re a researcher at an approved organization, you may be able to apply for Trusted Access.",
+        body: "We take extra caution with requests involving biological research and applications that could pose safety risks. Eligible researchers can apply for Trusted Access.",
         trusted_access_url: "https://www.openai.com/form/trusted-access-for-biology-research/",
     }
 }

--- a/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__safety_access_block_event_snapshot.snap
+++ b/codex-rs/tui/src/history_cell/snapshots/codex_tui__history_cell__tests__safety_access_block_event_snapshot.snap
@@ -5,8 +5,7 @@ expression: rendered
 ⓘ This content can't be shown
   We take extra caution with requests involving biological research and
   applications that could pose safety risks. Eligible researchers can apply
-  for Trusted Access. If you’re a researcher at an approved organization, you
-  may be able to apply for Trusted Access.
+  for Trusted Access.
   Trusted Access: https://www.openai.com/form/trusted-access-for-biology-
   research/
   Learn more: https://help.openai.com/en/articles/20001326


### PR DESCRIPTION
## Summary

The TUI biosafety block still included obsolete copy telling approved researchers they may be able to apply for Trusted Access.

Remove that sentence and update the UI snapshot to match the approved wording.