### PR TITLE
[codex] Avoid logging websocket request payloads

### DIFF
--- a/codex-rs/codex-api/src/endpoint/responses_websocket.rs
+++ b/codex-rs/codex-api/src/endpoint/responses_websocket.rs
@@ -782,7 +782,7 @@ async fn send_websocket_request(
     telemetry: Option<&Arc<dyn WebsocketTelemetry>>,
     connection_reused: bool,
 ) -> Result<(), ApiError> {
-    trace!("websocket request: {request_text}");
+    trace!(request_len = request_text.len(), "websocket request");
 
     let request_start = Instant::now();
     let result = tokio::time::timeout(


### PR DESCRIPTION
## What

Replace the full Responses WebSocket request body in TRACE logs with its byte length.

## Why

Responses WebSocket requests include accumulated conversation context and can grow to multiple megabytes. Persisting each body in `logs_2.sqlite` creates avoidable database and WAL growth while providing little additional diagnostic value.

This keeps the useful request-size signal without storing the payload itself. It complements #29432, which removed full incoming WebSocket event logging.

Related to #29674.

## Validation

- `cargo test -p codex-api --lib --locked` — 115 passed
- `just fix -p codex-api`
- `just fmt`