### PR TITLE
telemetry(model): correlate WebSocket stage timing

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -150,6 +150,8 @@ pub const X_RESPONSESAPI_INCLUDE_TIMING_METRICS_HEADER: &str =
     "x-responsesapi-include-timing-metrics";
 const X_CODEX_WS_STREAM_REQUEST_START_MS_CLIENT_METADATA_KEY: &str =
     "x-codex-ws-stream-request-start-ms";
+const X_CODEX_WS_STREAM_REQUEST_ORDINAL_CLIENT_METADATA_KEY: &str =
+    "x-codex-ws-stream-request-ordinal";
 const WS_REQUEST_HEADER_RESPONSES_LITE_CLIENT_METADATA_KEY: &str =
     "ws_request_header_x_openai_internal_codex_responses_lite";
 const RESPONSES_WEBSOCKETS_V2_BETA_HEADER_VALUE: &str = "responses_websockets=2026-02-06";
@@ -298,6 +300,7 @@ struct WebsocketSession {
     last_response_rx: Option<oneshot::Receiver<LastResponse>>,
     last_response_from_untraced_warmup: bool,
     connection_reused: StdMutex<bool>,
+    next_request_ordinal: u64,
 }
 
 // This is intentionally not a `PartialEq` implementation: request equality includes `input` and
@@ -359,6 +362,12 @@ fn responses_request_properties_match(
 }
 
 impl WebsocketSession {
+    fn take_next_request_ordinal(&mut self) -> u64 {
+        let ordinal = self.next_request_ordinal;
+        self.next_request_ordinal = self.next_request_ordinal.saturating_add(1);
+        ordinal
+    }
+
     fn set_connection_reused(&self, connection_reused: bool) {
         *self
             .connection_reused
@@ -1121,6 +1130,7 @@ impl ModelClientSession {
         self.websocket_session.last_request = None;
         self.websocket_session.last_response_rx = None;
         self.websocket_session.last_response_from_untraced_warmup = false;
+        self.websocket_session.next_request_ordinal = 0;
         self.websocket_session
             .set_connection_reused(/*connection_reused*/ false);
     }
@@ -1328,6 +1338,7 @@ impl ModelClientSession {
             self.websocket_session.last_request = None;
             self.websocket_session.last_response_rx = None;
             self.websocket_session.last_response_from_untraced_warmup = false;
+            self.websocket_session.next_request_ordinal = 0;
             let new_conn = match self
                 .client
                 .connect_websocket(
@@ -1624,7 +1635,8 @@ impl ModelClientSession {
             } else {
                 inference_trace.start_attempt()
             };
-            stamp_ws_stream_request_start_ms(&mut ws_request);
+            let request_ordinal = self.websocket_session.take_next_request_ordinal();
+            stamp_ws_stream_request_metadata(&mut ws_request, request_ordinal);
             let ResponsesWsRequest::ResponseCreate(ws_payload) = &mut ws_request;
             let store = ws_payload.store;
             self.client
@@ -1843,19 +1855,22 @@ impl ModelClientSession {
     }
 }
 
-/// Stamp a ResponsesWsRequest with the current time.
+/// Stamp a ResponsesWsRequest with request-scoped correlation metadata.
 ///
 /// Meant to be called just before sending the request over the socket, to capture realistic
-/// transport timing.
-fn stamp_ws_stream_request_start_ms(request: &mut ResponsesWsRequest) {
+/// transport timing. The ordinal is scoped to the physical WebSocket connection and increments
+/// for every `response.create`, including `generate=false` warmups.
+fn stamp_ws_stream_request_metadata(request: &mut ResponsesWsRequest, request_ordinal: u64) {
     let ResponsesWsRequest::ResponseCreate(payload) = request;
-    payload
-        .client_metadata
-        .get_or_insert_with(HashMap::new)
-        .insert(
-            X_CODEX_WS_STREAM_REQUEST_START_MS_CLIENT_METADATA_KEY.to_string(),
-            crate::turn_timing::now_unix_timestamp_ms().to_string(),
-        );
+    let client_metadata = payload.client_metadata.get_or_insert_with(HashMap::new);
+    client_metadata.insert(
+        X_CODEX_WS_STREAM_REQUEST_START_MS_CLIENT_METADATA_KEY.to_string(),
+        crate::turn_timing::now_unix_timestamp_ms().to_string(),
+    );
+    client_metadata.insert(
+        X_CODEX_WS_STREAM_REQUEST_ORDINAL_CLIENT_METADATA_KEY.to_string(),
+        request_ordinal.to_string(),
+    );
 }
 
 /// Builds the extra headers attached to Responses API requests.

--- a/codex-rs/core/tests/suite/client_websockets.rs
+++ b/codex-rs/core/tests/suite/client_websockets.rs
@@ -72,6 +72,8 @@ const TEST_INSTALLATION_ID: &str = "11111111-1111-4111-8111-111111111111";
 const TEST_WINDOW_ID: &str = "test-thread:0";
 const X_CODEX_WS_STREAM_REQUEST_START_MS_CLIENT_METADATA_KEY: &str =
     "x-codex-ws-stream-request-start-ms";
+const X_CODEX_WS_STREAM_REQUEST_ORDINAL_CLIENT_METADATA_KEY: &str =
+    "x-codex-ws-stream-request-ordinal";
 
 fn assert_request_trace_matches(body: &serde_json::Value, expected_trace: &W3cTraceContext) {
     let client_metadata = body["client_metadata"]
@@ -204,6 +206,10 @@ async fn responses_websocket_streams_request() {
         .parse::<i64>()
         .expect("websocket stream request start timestamp should be an integer");
     assert!(stream_request_start_ms > 0);
+    assert_eq!(
+        body["client_metadata"][X_CODEX_WS_STREAM_REQUEST_ORDINAL_CLIENT_METADATA_KEY].as_str(),
+        Some("0")
+    );
 
     server.shutdown().await;
 }
@@ -288,6 +294,16 @@ async fn responses_websocket_reuses_connection_with_per_turn_trace_payloads() {
         .body_json();
     assert_request_trace_matches(&first_request, &first_trace);
     assert_request_trace_matches(&second_request, &second_trace);
+    assert_eq!(
+        first_request["client_metadata"][X_CODEX_WS_STREAM_REQUEST_ORDINAL_CLIENT_METADATA_KEY]
+            .as_str(),
+        Some("0")
+    );
+    assert_eq!(
+        second_request["client_metadata"][X_CODEX_WS_STREAM_REQUEST_ORDINAL_CLIENT_METADATA_KEY]
+            .as_str(),
+        Some("1")
+    );
 
     let first_traceparent = first_request["client_metadata"]
         [WS_REQUEST_HEADER_TRACEPARENT_CLIENT_METADATA_KEY]
@@ -433,6 +449,10 @@ async fn responses_websocket_request_prewarm_reuses_connection() {
         Some("sequential_cutoff")
     );
     assert_eq!(warmup["tools"], serde_json::json!([]));
+    assert_eq!(
+        warmup["client_metadata"][X_CODEX_WS_STREAM_REQUEST_ORDINAL_CLIENT_METADATA_KEY].as_str(),
+        Some("0")
+    );
     let warmup_turn_metadata: serde_json::Value = serde_json::from_str(
         warmup["client_metadata"]["x-codex-turn-metadata"]
             .as_str()
@@ -449,6 +469,11 @@ async fn responses_websocket_request_prewarm_reuses_connection() {
     assert_eq!(
         follow_up["stream_options"]["reasoning_summary_delivery"].as_str(),
         Some("sequential_cutoff")
+    );
+    assert_eq!(
+        follow_up["client_metadata"][X_CODEX_WS_STREAM_REQUEST_ORDINAL_CLIENT_METADATA_KEY]
+            .as_str(),
+        Some("1")
     );
 
     server.shutdown().await;

--- a/codex-rs/otel/src/events/session_telemetry.rs
+++ b/codex-rs/otel/src/events/session_telemetry.rs
@@ -66,6 +66,13 @@ const RESPONSES_API_ENGINE_IAPI_TTFT_FIELD: &str = "engine_iapi_ttft_total_ms";
 const RESPONSES_API_ENGINE_SERVICE_TTFT_FIELD: &str = "engine_service_ttft_total_ms";
 const RESPONSES_API_ENGINE_IAPI_TBT_FIELD: &str = "engine_iapi_tbt_across_engine_calls_ms";
 const RESPONSES_API_ENGINE_SERVICE_TBT_FIELD: &str = "engine_service_tbt_across_engine_calls_ms";
+const RESPONSES_API_ROUTING_TIMING_SEMANTICS_V1: &str = concat!(
+    "nested_non_additive:engine_iapi_ttft_includes_engine_routing_and_engine_batcher_ttft;",
+    "engine_routing_includes_pipereplica_lb_routing;",
+    "engine_queue_is_iapi_ttft_minus_batcher_ttft_and_overlaps_engine_routing;",
+    "cross_cluster_network_overhead_is_outside_engine_iapi_ttft",
+);
+const ROUTING_TIMING_SEMANTICS_V1_ROLE: &str = "nested_non_additive_v1";
 
 fn trace_field_value<'a>(fields: &'a [(&str, &str)], key: &str) -> Option<&'a str> {
     fields
@@ -1135,53 +1142,154 @@ impl SessionTelemetry {
 
     fn record_responses_websocket_timing_metrics(&self, value: &serde_json::Value) {
         let timing_metrics = value.get(RESPONSES_WEBSOCKET_TIMING_METRICS_FIELD);
+        let timing_value = |key| timing_metrics.and_then(|value| value.get(key));
+        let timing_f64 = |key| non_negative_f64_from_value(timing_value(key));
 
-        let overhead_value =
-            timing_metrics.and_then(|value| value.get(RESPONSES_API_OVERHEAD_FIELD));
-        if let Some(duration) = duration_from_ms_value(overhead_value) {
-            self.record_duration(RESPONSES_API_OVERHEAD_DURATION_METRIC, duration, &[]);
-        }
+        let request_ordinal = non_negative_i64_from_value(value.get("request_ordinal"));
+        let pre_inference_ms = timing_f64("pre_inference_ms");
+        let client_tool_pause_total_ms = timing_f64("client_tool_pause_total_ms");
+        let total_turn_time_s = timing_f64("total_turn_time_s");
+        let xapi_validation_time_s = timing_f64("xapi_validation_time_s");
+        let num_engine_calls = non_negative_i64_from_value(timing_value("num_engine_calls"));
+        let latest_inference_lb_routing_ms = timing_f64("latest_inference_lb_routing_ms");
+        let latest_inference_engine_routing_ms = timing_f64("latest_inference_engine_routing_ms");
+        let latest_cross_cluster_network_overhead_ms =
+            timing_f64("latest_cross_cluster_network_overhead_ms");
+        // This event is intentionally restricted to numeric measurements and a normalized,
+        // bounded semantics role. Opaque response/request/engine/pipereplica identifiers and
+        // free-form route diagnostics are neither useful dimensions nor safe span attributes.
+        let inference_routing_timing_semantics =
+            routing_timing_semantics_role(timing_value("inference_routing_timing_semantics"));
+        let engine_queue_max_ms = timing_f64("engine_queue_max_ms");
+        let first_sampled_message_ttft_ms = timing_f64("first_sampled_message_ttft_ms");
+        let engine_iapi_ttft_total_ms = timing_f64(RESPONSES_API_ENGINE_IAPI_TTFT_FIELD);
+        let engine_service_ttft_total_ms = timing_f64(RESPONSES_API_ENGINE_SERVICE_TTFT_FIELD);
+        let engine_iapi_sampling_total_ms = timing_f64("engine_iapi_sampling_total_ms");
+        let engine_service_sampling_total_ms = timing_f64("engine_service_sampling_total_ms");
+        let engine_iapi_tbt_across_engine_calls_ms =
+            timing_f64(RESPONSES_API_ENGINE_IAPI_TBT_FIELD);
+        let engine_service_tbt_across_engine_calls_ms =
+            timing_f64(RESPONSES_API_ENGINE_SERVICE_TBT_FIELD);
+        let taas_request_to_provider_start_total_ms =
+            timing_f64("taas_request_to_provider_start_total_ms");
+        let taas_provider_start_to_first_token_total_ms =
+            timing_f64("taas_provider_start_to_first_token_total_ms");
+        let responsesapi_duration_excl_client_tools_ms =
+            timing_f64("responsesapi_duration_excl_client_tools_ms");
+        let responses_duration_excl_engine_wait_and_sampling_ms =
+            timing_f64("responses_duration_excl_engine_wait_and_sampling_ms");
+        let responses_duration_excl_engine_wait_and_sampling_iapi_ms =
+            timing_f64("responses_duration_excl_engine_wait_and_sampling_iapi_ms");
+        let responses_duration_excl_engine_and_client_tool_time_ms =
+            timing_f64(RESPONSES_API_OVERHEAD_FIELD);
+        let engine_service_total_ms = timing_f64(RESPONSES_API_INFERENCE_FIELD);
+        let prompt_full_render_total_ms = timing_f64("prompt_full_render_total_ms");
+        let prompt_shadow_render_total_ms = timing_f64("prompt_shadow_render_total_ms");
 
-        let inference_value =
-            timing_metrics.and_then(|value| value.get(RESPONSES_API_INFERENCE_FIELD));
-        if let Some(duration) = duration_from_ms_value(inference_value) {
-            self.record_duration(RESPONSES_API_INFERENCE_TIME_DURATION_METRIC, duration, &[]);
-        }
+        log_event!(
+            self,
+            event.name = "codex.responses_websocket_timing",
+            model.request_ordinal = request_ordinal,
+            responsesapi.pre_inference_ms = pre_inference_ms,
+            responsesapi.client_tool_pause_total_ms = client_tool_pause_total_ms,
+            responsesapi.total_turn_time_s = total_turn_time_s,
+            responsesapi.xapi_validation_time_s = xapi_validation_time_s,
+            responsesapi.duration_excl_client_tools_ms = responsesapi_duration_excl_client_tools_ms,
+            responsesapi.duration_excl_engine_wait_and_sampling_ms =
+                responses_duration_excl_engine_wait_and_sampling_ms,
+            responsesapi.duration_excl_engine_wait_and_sampling_iapi_ms =
+                responses_duration_excl_engine_wait_and_sampling_iapi_ms,
+            responsesapi.duration_excl_engine_and_client_tool_time_ms =
+                responses_duration_excl_engine_and_client_tool_time_ms,
+            responsesapi.engine_service_total_ms = engine_service_total_ms,
+            responsesapi.prompt_full_render_total_ms = prompt_full_render_total_ms,
+            responsesapi.prompt_shadow_render_total_ms = prompt_shadow_render_total_ms,
+            inference.num_engine_calls = num_engine_calls,
+            inference.latest_lb_routing_ms = latest_inference_lb_routing_ms,
+            inference.latest_engine_routing_ms = latest_inference_engine_routing_ms,
+            inference.latest_cross_cluster_network_overhead_ms =
+                latest_cross_cluster_network_overhead_ms,
+            inference.routing_timing_semantics = inference_routing_timing_semantics,
+            inference.engine_queue_max_ms = engine_queue_max_ms,
+            inference.first_sampled_message_ttft_ms = first_sampled_message_ttft_ms,
+            inference.engine_iapi_ttft_total_ms = engine_iapi_ttft_total_ms,
+            inference.engine_service_ttft_total_ms = engine_service_ttft_total_ms,
+            inference.engine_iapi_sampling_total_ms = engine_iapi_sampling_total_ms,
+            inference.engine_service_sampling_total_ms = engine_service_sampling_total_ms,
+            inference.engine_iapi_tbt_across_engine_calls_ms =
+                engine_iapi_tbt_across_engine_calls_ms,
+            inference.engine_service_tbt_across_engine_calls_ms =
+                engine_service_tbt_across_engine_calls_ms,
+            inference.taas_request_to_provider_start_total_ms =
+                taas_request_to_provider_start_total_ms,
+            inference.taas_provider_start_to_first_token_total_ms =
+                taas_provider_start_to_first_token_total_ms,
+        );
 
-        let engine_iapi_ttft_value =
-            timing_metrics.and_then(|value| value.get(RESPONSES_API_ENGINE_IAPI_TTFT_FIELD));
-        if let Some(duration) = duration_from_ms_value(engine_iapi_ttft_value) {
-            self.record_duration(
+        // CCA exports traces but not general OTEL logs. Use a real child span so this breakdown is
+        // queryable in trace backends that do not retain span events.
+        let timing_span = tracing::info_span!(
+            "codex.responses_websocket_timing",
+            model = %self.metadata.model,
+            model.request_ordinal = request_ordinal,
+            responsesapi.pre_inference_ms = pre_inference_ms,
+            responsesapi.client_tool_pause_total_ms = client_tool_pause_total_ms,
+            responsesapi.total_turn_time_s = total_turn_time_s,
+            responsesapi.xapi_validation_time_s = xapi_validation_time_s,
+            responsesapi.duration_excl_client_tools_ms = responsesapi_duration_excl_client_tools_ms,
+            responsesapi.duration_excl_engine_wait_and_sampling_ms = responses_duration_excl_engine_wait_and_sampling_ms,
+            responsesapi.duration_excl_engine_wait_and_sampling_iapi_ms = responses_duration_excl_engine_wait_and_sampling_iapi_ms,
+            responsesapi.duration_excl_engine_and_client_tool_time_ms = responses_duration_excl_engine_and_client_tool_time_ms,
+            responsesapi.engine_service_total_ms = engine_service_total_ms,
+            responsesapi.prompt_full_render_total_ms = prompt_full_render_total_ms,
+            responsesapi.prompt_shadow_render_total_ms = prompt_shadow_render_total_ms,
+            inference.num_engine_calls = num_engine_calls,
+            inference.latest_lb_routing_ms = latest_inference_lb_routing_ms,
+            inference.latest_engine_routing_ms = latest_inference_engine_routing_ms,
+            inference.latest_cross_cluster_network_overhead_ms = latest_cross_cluster_network_overhead_ms,
+            inference.routing_timing_semantics = inference_routing_timing_semantics,
+            inference.engine_queue_max_ms = engine_queue_max_ms,
+            inference.first_sampled_message_ttft_ms = first_sampled_message_ttft_ms,
+            inference.engine_iapi_ttft_total_ms = engine_iapi_ttft_total_ms,
+            inference.engine_service_ttft_total_ms = engine_service_ttft_total_ms,
+            inference.engine_iapi_sampling_total_ms = engine_iapi_sampling_total_ms,
+            inference.engine_service_sampling_total_ms = engine_service_sampling_total_ms,
+            inference.engine_iapi_tbt_across_engine_calls_ms = engine_iapi_tbt_across_engine_calls_ms,
+            inference.engine_service_tbt_across_engine_calls_ms = engine_service_tbt_across_engine_calls_ms,
+            inference.taas_request_to_provider_start_total_ms = taas_request_to_provider_start_total_ms,
+            inference.taas_provider_start_to_first_token_total_ms = taas_provider_start_to_first_token_total_ms,
+        );
+        timing_span.in_scope(|| {});
+
+        for (value, metric) in [
+            (
+                responses_duration_excl_engine_and_client_tool_time_ms,
+                RESPONSES_API_OVERHEAD_DURATION_METRIC,
+            ),
+            (
+                engine_service_total_ms,
+                RESPONSES_API_INFERENCE_TIME_DURATION_METRIC,
+            ),
+            (
+                engine_iapi_ttft_total_ms,
                 RESPONSES_API_ENGINE_IAPI_TTFT_DURATION_METRIC,
-                duration,
-                &[],
-            );
-        }
-
-        let engine_service_ttft_value =
-            timing_metrics.and_then(|value| value.get(RESPONSES_API_ENGINE_SERVICE_TTFT_FIELD));
-        if let Some(duration) = duration_from_ms_value(engine_service_ttft_value) {
-            self.record_duration(
+            ),
+            (
+                engine_service_ttft_total_ms,
                 RESPONSES_API_ENGINE_SERVICE_TTFT_DURATION_METRIC,
-                duration,
-                &[],
-            );
-        }
-
-        let engine_iapi_tbt_value =
-            timing_metrics.and_then(|value| value.get(RESPONSES_API_ENGINE_IAPI_TBT_FIELD));
-        if let Some(duration) = duration_from_ms_value(engine_iapi_tbt_value) {
-            self.record_duration(RESPONSES_API_ENGINE_IAPI_TBT_DURATION_METRIC, duration, &[]);
-        }
-
-        let engine_service_tbt_value =
-            timing_metrics.and_then(|value| value.get(RESPONSES_API_ENGINE_SERVICE_TBT_FIELD));
-        if let Some(duration) = duration_from_ms_value(engine_service_tbt_value) {
-            self.record_duration(
+            ),
+            (
+                engine_iapi_tbt_across_engine_calls_ms,
+                RESPONSES_API_ENGINE_IAPI_TBT_DURATION_METRIC,
+            ),
+            (
+                engine_service_tbt_across_engine_calls_ms,
                 RESPONSES_API_ENGINE_SERVICE_TBT_DURATION_METRIC,
-                duration,
-                &[],
-            );
+            ),
+        ] {
+            if let Some(duration) = duration_from_ms(value) {
+                self.record_duration(metric, duration, &[]);
+            }
         }
     }
 
@@ -1233,15 +1341,42 @@ impl SessionTelemetry {
     }
 }
 
-fn duration_from_ms_value(value: Option<&serde_json::Value>) -> Option<Duration> {
+fn duration_from_ms(ms: Option<f64>) -> Option<Duration> {
+    let ms = ms?;
+    let clamped = ms.min(u64::MAX as f64);
+    Some(Duration::from_millis(clamped.round() as u64))
+}
+
+fn non_negative_f64_from_value(value: Option<&serde_json::Value>) -> Option<f64> {
     let value = value?;
-    let ms = value
+    let value = value
         .as_f64()
         .or_else(|| value.as_i64().map(|v| v as f64))
         .or_else(|| value.as_u64().map(|v| v as f64))?;
-    if !ms.is_finite() || ms < 0.0 {
+    if !value.is_finite() || value < 0.0 {
         return None;
     }
-    let clamped = ms.min(u64::MAX as f64);
-    Some(Duration::from_millis(clamped.round() as u64))
+    Some(value)
+}
+
+fn non_negative_i64_from_value(value: Option<&serde_json::Value>) -> Option<i64> {
+    let value = value?;
+    value
+        .as_i64()
+        .filter(|value| *value >= 0)
+        .or_else(|| value.as_u64().and_then(|value| i64::try_from(value).ok()))
+        .or_else(|| {
+            value
+                .as_str()?
+                .parse::<i64>()
+                .ok()
+                .filter(|value| *value >= 0)
+        })
+}
+
+fn routing_timing_semantics_role(value: Option<&serde_json::Value>) -> Option<&'static str> {
+    match value.and_then(serde_json::Value::as_str) {
+        Some(RESPONSES_API_ROUTING_TIMING_SEMANTICS_V1) => Some(ROUTING_TIMING_SEMANTICS_V1_ROLE),
+        _ => None,
+    }
 }

--- a/codex-rs/otel/tests/suite/otel_export_routing_policy.rs
+++ b/codex-rs/otel/tests/suite/otel_export_routing_policy.rs
@@ -15,6 +15,7 @@ use pretty_assertions::assert_eq;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::path::PathBuf;
+use tokio_tungstenite::tungstenite::Message;
 use tracing_subscriber::Layer;
 use tracing_subscriber::filter::filter_fn;
 use tracing_subscriber::layer::SubscriberExt;
@@ -912,4 +913,194 @@ fn otel_export_routing_policy_routes_websocket_request_transport_observability()
         request_trace_attrs.get("auth.task_id").map(String::as_str),
         Some("task-run-ws-request")
     );
+}
+
+#[test]
+fn otel_export_routing_policy_routes_correlated_websocket_timing_breakdown() {
+    let log_exporter = InMemoryLogExporter::default();
+    let logger_provider = SdkLoggerProvider::builder()
+        .with_simple_exporter(log_exporter.clone())
+        .build();
+    let span_exporter = InMemorySpanExporter::default();
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_simple_exporter(span_exporter.clone())
+        .build();
+    let tracer = tracer_provider.tracer("sink-split-test");
+
+    let subscriber = tracing_subscriber::registry()
+        .with(
+            opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge::new(
+                &logger_provider,
+            )
+            .with_filter(filter_fn(OtelProvider::log_export_filter)),
+        )
+        .with(
+            tracing_opentelemetry::layer()
+                .with_tracer(tracer)
+                .with_filter(filter_fn(OtelProvider::trace_export_filter)),
+        );
+
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::callsite::rebuild_interest_cache();
+        let manager = SessionTelemetry::new(
+            ThreadId::new(),
+            "gpt-5.1",
+            "gpt-5.1",
+            Some("account-id".to_string()),
+            Some("engineer@example.com".to_string()),
+            Some(TelemetryAuthMode::Chatgpt),
+            "codex_exec".to_string(),
+            /*log_user_prompts*/ true,
+            "tty".to_string(),
+            SessionSource::Cli,
+        );
+        let root_span = tracing::info_span!("root");
+        let _root_guard = root_span.enter();
+        let response: std::result::Result<
+            Option<std::result::Result<Message, tokio_tungstenite::tungstenite::Error>>,
+            codex_api::ApiError,
+        > = Ok(Some(Ok(Message::Text(
+            r#"{
+                "type":"responsesapi.websocket_timing",
+                "request_ordinal":2,
+                "timing_metrics":{
+                    "response_id":"resp-correlated",
+                    "pre_inference_ms":120.5,
+                    "engine_queue_max_ms":87.25,
+                    "engine_iapi_ttft_total_ms":310,
+                    "engine_service_ttft_total_ms":340,
+                    "taas_request_to_provider_start_total_ms":41.5,
+                    "taas_provider_start_to_first_token_total_ms":201.75,
+                    "engine_ids":"engine-a,engine-b",
+                    "latest_engine_id":"engine-b",
+                    "latest_inference_request_id":"req-route",
+                    "latest_engine_provider":"provider-a",
+                    "latest_engine_cluster":"cluster-a",
+                    "latest_engine_region":"westus",
+                    "latest_engine_geography":"us",
+                    "latest_pipereplica_id":"pipe-7",
+                    "latest_pipereplica_snapshot_id":"snapshot-8",
+                    "latest_pipereplica_image_tag":"image-9",
+                    "latest_load_balancer_image_tag":"lb-image-10",
+                    "latest_inference_lb_routing_ms":2.5,
+                    "latest_inference_engine_routing_ms":8.5,
+                    "latest_cross_cluster_network_overhead_ms":11.5,
+                    "inference_routing_timing_semantics":"nested_non_additive:engine_iapi_ttft_includes_engine_routing_and_engine_batcher_ttft;engine_routing_includes_pipereplica_lb_routing;engine_queue_is_iapi_ttft_minus_batcher_ttft_and_overlaps_engine_routing;cross_cluster_network_overhead_is_outside_engine_iapi_ttft",
+                    "inference_route_diagnostics":[{"engine_call_id":"call-1","engine_provider":"provider-a"}],
+                    "num_engine_calls":2,
+                    "responses_duration_excl_engine_and_client_tool_time_ms":98.5
+                }
+            }"#
+            .into(),
+        ))));
+        manager.record_websocket_event(&response, std::time::Duration::from_millis(3));
+    });
+
+    logger_provider.force_flush().expect("flush logs");
+    tracer_provider.force_flush().expect("flush traces");
+
+    let logs = log_exporter.get_emitted_logs().expect("log export");
+    let timing_log = find_log_by_event_name(&logs, "codex.responses_websocket_timing");
+    let timing_log_attrs = log_attributes(&timing_log.record);
+    assert_eq!(
+        timing_log_attrs
+            .get("model.request_ordinal")
+            .map(String::as_str),
+        Some("2")
+    );
+    assert_eq!(
+        timing_log_attrs
+            .get("inference.engine_queue_max_ms")
+            .map(String::as_str),
+        Some("87.25")
+    );
+    assert_eq!(
+        timing_log_attrs
+            .get("inference.routing_timing_semantics")
+            .map(String::as_str),
+        Some("nested_non_additive_v1")
+    );
+    for forbidden_attribute in [
+        "model.response_id",
+        "inference.engine_ids",
+        "inference.latest_request_id",
+        "inference.latest_engine_id",
+        "inference.latest_engine_provider",
+        "inference.latest_engine_cluster",
+        "inference.latest_engine_region",
+        "inference.latest_engine_geography",
+        "inference.latest_pipereplica_id",
+        "inference.latest_pipereplica_snapshot_id",
+        "inference.latest_pipereplica_image_tag",
+        "inference.latest_load_balancer_image_tag",
+        "inference.route_diagnostics_json",
+    ] {
+        assert!(
+            !timing_log_attrs.contains_key(forbidden_attribute),
+            "log exported forbidden high-cardinality attribute {forbidden_attribute}"
+        );
+    }
+
+    let spans = span_exporter.get_finished_spans().expect("span export");
+    let timing_span = spans
+        .iter()
+        .find(|span| span.name == "codex.responses_websocket_timing")
+        .expect("timing child span should exist");
+    let timing_trace_attrs = timing_span
+        .attributes
+        .iter()
+        .map(|KeyValue { key, value, .. }| (key.as_str().to_string(), value.to_string()))
+        .collect::<BTreeMap<_, _>>();
+    assert_eq!(
+        timing_trace_attrs
+            .get("model.request_ordinal")
+            .map(String::as_str),
+        Some("2")
+    );
+    assert_eq!(
+        timing_trace_attrs
+            .get("inference.taas_request_to_provider_start_total_ms")
+            .map(String::as_str),
+        Some("41.5")
+    );
+    assert_eq!(
+        timing_trace_attrs
+            .get("responsesapi.duration_excl_engine_and_client_tool_time_ms")
+            .map(String::as_str),
+        Some("98.5")
+    );
+    assert_eq!(
+        timing_trace_attrs
+            .get("inference.latest_engine_routing_ms")
+            .map(String::as_str),
+        Some("8.5")
+    );
+    assert_eq!(
+        timing_trace_attrs
+            .get("inference.routing_timing_semantics")
+            .map(String::as_str),
+        Some("nested_non_additive_v1")
+    );
+    for forbidden_attribute in [
+        "conversation.id",
+        "slug",
+        "model.response_id",
+        "inference.engine_ids",
+        "inference.latest_request_id",
+        "inference.latest_engine_id",
+        "inference.latest_engine_provider",
+        "inference.latest_engine_cluster",
+        "inference.latest_engine_region",
+        "inference.latest_engine_geography",
+        "inference.latest_pipereplica_id",
+        "inference.latest_pipereplica_snapshot_id",
+        "inference.latest_pipereplica_image_tag",
+        "inference.latest_load_balancer_image_tag",
+        "inference.route_diagnostics_json",
+    ] {
+        assert!(
+            !timing_trace_attrs.contains_key(forbidden_attribute),
+            "span exported forbidden high-cardinality attribute {forbidden_attribute}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Correlate each Responses WebSocket request with the server timing sideband that belongs to it.

- Stamp each logical WebSocket request with a client start timestamp and ordinal.
- Parse optional pre-inference, routing, queue, engine TTFT, and sampling fields.
- Route correlated timing through the existing OTel export policy.
- Keep all server timing fields optional for compatibility.

This is the model-timing slice split out of #30632.

## Validation

- `just test -p codex-core responses_websocket` passed 37 tests.
- `just test -p codex-otel otel_export_routing_policy_routes_correlated_websocket_timing_breakdown` passed.
- `just fmt` passed, with an unrelated justfile rewrite discarded.
