### PR TITLE
fix(core) Remove full text websocket trace

### DIFF
--- a/codex-rs/codex-api/src/endpoint/responses_websocket.rs
+++ b/codex-rs/codex-api/src/endpoint/responses_websocket.rs
@@ -43,7 +43,6 @@ use tracing::debug;
 use tracing::error;
 use tracing::info;
 use tracing::instrument;
-use tracing::trace;
 use tungstenite::extensions::ExtensionsConfig;
 use tungstenite::extensions::compression::deflate::DeflateConfig;
 use tungstenite::protocol::WebSocketConfig;

--- a/codex-rs/codex-api/src/endpoint/responses_websocket.rs
+++ b/codex-rs/codex-api/src/endpoint/responses_websocket.rs
@@ -782,8 +782,6 @@ async fn send_websocket_request(
     telemetry: Option<&Arc<dyn WebsocketTelemetry>>,
     connection_reused: bool,
 ) -> Result<(), ApiError> {
-    trace!("websocket request: {request_text}");
-
     let request_start = Instant::now();
     let result = tokio::time::timeout(
         idle_timeout,


### PR DESCRIPTION
## Summary
This is a follow-up to https://github.com/openai/codex/pull/29432 to remove one additional trace statement that is not being filtered by https://github.com/openai/codex/pull/29457.


## Testing
- [x] Unit tests pass

