### PR TITLE
[codex] Enable tool search for fallback models

### DIFF
--- a/codex-rs/models-manager/src/model_info.rs
+++ b/codex-rs/models-manager/src/model_info.rs
@@ -100,7 +100,7 @@ pub fn model_info_from_slug(slug: &str) -> ModelInfo {
         experimental_supported_tools: Vec::new(),
         input_modalities: default_input_modalities(),
         used_fallback_model_metadata: true, // this is the fallback model metadata
-        supports_search_tool: false,
+        supports_search_tool: true,
         use_responses_lite: false,
         auto_review_model_override: None,
         tool_mode: None,


### PR DESCRIPTION
## Summary

- enable `tool_search` capability in synthesized fallback model metadata
- keep unknown or newly introduced model slugs aligned with the bundled catalog, where all current models support tool search

## Why

When a requested model is absent from the available model catalog, Codex synthesizes fallback metadata. That fallback currently disables `supports_search_tool`, so stale catalogs can cause newly introduced models to lose deferred MCP, plugin, extension, and collaboration tool discovery even though the current model baseline supports it.

This changes the fallback to opt into tool search. Existing provider capability gating and the requirement for deferred searchable tools still apply, and this does not enable hosted web search.

## Validation

- `just fmt`
- `just test -p codex-models-manager` (37 passed)