### PR TITLE
[codex] Backport websocket trace fix to release/0.142

### DIFF
--- a/codex-rs/codex-api/src/endpoint/responses_websocket.rs
+++ b/codex-rs/codex-api/src/endpoint/responses_websocket.rs
@@ -43,7 +43,6 @@ use tracing::debug;
 use tracing::error;
 use tracing::info;
 use tracing::instrument;
-use tracing::trace;
 use tungstenite::extensions::ExtensionsConfig;
 use tungstenite::extensions::compression::deflate::DeflateConfig;
 use tungstenite::protocol::WebSocketConfig;
@@ -782,8 +781,6 @@ async fn send_websocket_request(
     telemetry: Option<&Arc<dyn WebsocketTelemetry>>,
     connection_reused: bool,
 ) -> Result<(), ApiError> {
-    trace!("websocket request: {request_text}");
-
     let request_start = Instant::now();
     let result = tokio::time::timeout(
         idle_timeout,


### PR DESCRIPTION
## Summary

Backports #30757 to `release/0.142`.

Removes the trace-level log that emitted the full Responses WebSocket request text.

## Why

The full request payload was still being logged by this trace statement and was not covered by the existing request-log filtering.

## Impact

Prevents full WebSocket request contents from being written to traces on the 0.142 release branch. This does not change request behavior or the app-server API.

## Testing

- `just fmt`
- `just test -p codex-api` (130 passed)

Cherry-picked from `db887d03e1f907467e33271572dffb73bceecd6b` with `-x`.