### PR TITLE
[codex] sanitize exec config summary values

### DIFF
--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -421,13 +421,21 @@ fn sanitize_config_summary_value(value: &str) -> String {
     value
         .chars()
         .map(|ch| {
-            if ch.is_control()
+            if ch.is_control() // C0/C1 controls, including newlines and escape.
                 || matches!(
                     ch,
-                    '\u{061C}'
-                        | '\u{200E}'..='\u{200F}'
-                        | '\u{202A}'..='\u{202E}'
-                        | '\u{2066}'..='\u{2069}'
+                    '\u{061C}' // Arabic letter mark.
+                        | '\u{200E}' // Left-to-right mark.
+                        | '\u{200F}' // Right-to-left mark.
+                        | '\u{202A}' // Left-to-right embedding.
+                        | '\u{202B}' // Right-to-left embedding.
+                        | '\u{202C}' // Pop directional formatting.
+                        | '\u{202D}' // Left-to-right override.
+                        | '\u{202E}' // Right-to-left override.
+                        | '\u{2066}' // Left-to-right isolate.
+                        | '\u{2067}' // Right-to-left isolate.
+                        | '\u{2068}' // First strong isolate.
+                        | '\u{2069}' // Pop directional isolate.
                 )
             {
                 '�'

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -417,7 +417,6 @@ impl EventProcessor for EventProcessorWithHumanOutput {
     }
 }
 
-/// Converts a config-summary value into printable single-line terminal text.
 fn sanitize_config_summary_value(value: &str) -> String {
     let mut sanitized = String::new();
     let mut pending_space = false;
@@ -443,7 +442,6 @@ fn sanitize_config_summary_value(value: &str) -> String {
     sanitized
 }
 
-/// Returns whether `ch` should be dropped from config-summary output.
 fn is_disallowed_config_summary_char(ch: char) -> bool {
     if ch.is_control() {
         return true;

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -418,50 +418,24 @@ impl EventProcessor for EventProcessorWithHumanOutput {
 }
 
 fn sanitize_config_summary_value(value: &str) -> String {
-    let mut sanitized = String::new();
-    let mut pending_space = false;
-
-    for ch in value.chars() {
-        if ch.is_whitespace() {
-            pending_space = !sanitized.is_empty();
-            continue;
-        }
-
-        if is_disallowed_config_summary_char(ch) {
-            continue;
-        }
-
-        if pending_space {
-            sanitized.push(' ');
-            pending_space = false;
-        }
-
-        sanitized.push(ch);
-    }
-
-    sanitized
-}
-
-fn is_disallowed_config_summary_char(ch: char) -> bool {
-    if ch.is_control() {
-        return true;
-    }
-
-    matches!(
-        ch,
-        '\u{00AD}'
-            | '\u{034F}'
-            | '\u{061C}'
-            | '\u{180E}'
-            | '\u{200B}'..='\u{200F}'
-            | '\u{202A}'..='\u{202E}'
-            | '\u{2060}'..='\u{206F}'
-            | '\u{FE00}'..='\u{FE0F}'
-            | '\u{FEFF}'
-            | '\u{FFF9}'..='\u{FFFB}'
-            | '\u{1BCA0}'..='\u{1BCA3}'
-            | '\u{E0100}'..='\u{E01EF}'
-    )
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_control()
+                || matches!(
+                    ch,
+                    '\u{061C}'
+                        | '\u{200E}'..='\u{200F}'
+                        | '\u{202A}'..='\u{202E}'
+                        | '\u{2066}'..='\u{2069}'
+                )
+            {
+                '�'
+            } else {
+                ch
+            }
+        })
+        .collect()
 }
 
 fn config_summary_entries(

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -217,6 +217,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
         const VERSION: &str = env!("CARGO_PKG_VERSION");
         eprintln!("OpenAI Codex v{VERSION}\n--------");
         for (key, value) in config_summary_entries(config, session_configured_event) {
+            let value = sanitize_config_summary_value(&value);
             eprintln!("{} {}", format!("{key}:").style(self.bold), value);
         }
         eprintln!("--------");
@@ -414,6 +415,14 @@ impl EventProcessor for EventProcessorWithHumanOutput {
             );
         }
     }
+}
+
+/// Converts a config-summary value into printable single-line terminal text.
+fn sanitize_config_summary_value(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| if ch.is_control() { '�' } else { ch })
+        .collect()
 }
 
 fn config_summary_entries(

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -419,10 +419,51 @@ impl EventProcessor for EventProcessorWithHumanOutput {
 
 /// Converts a config-summary value into printable single-line terminal text.
 fn sanitize_config_summary_value(value: &str) -> String {
-    value
-        .chars()
-        .map(|ch| if ch.is_control() { '�' } else { ch })
-        .collect()
+    let mut sanitized = String::new();
+    let mut pending_space = false;
+
+    for ch in value.chars() {
+        if ch.is_whitespace() {
+            pending_space = !sanitized.is_empty();
+            continue;
+        }
+
+        if is_disallowed_config_summary_char(ch) {
+            continue;
+        }
+
+        if pending_space {
+            sanitized.push(' ');
+            pending_space = false;
+        }
+
+        sanitized.push(ch);
+    }
+
+    sanitized
+}
+
+/// Returns whether `ch` should be dropped from config-summary output.
+fn is_disallowed_config_summary_char(ch: char) -> bool {
+    if ch.is_control() {
+        return true;
+    }
+
+    matches!(
+        ch,
+        '\u{00AD}'
+            | '\u{034F}'
+            | '\u{061C}'
+            | '\u{180E}'
+            | '\u{200B}'..='\u{200F}'
+            | '\u{202A}'..='\u{202E}'
+            | '\u{2060}'..='\u{206F}'
+            | '\u{FE00}'..='\u{FE0F}'
+            | '\u{FEFF}'
+            | '\u{FFF9}'..='\u{FFFB}'
+            | '\u{1BCA0}'..='\u{1BCA3}'
+            | '\u{E0100}'..='\u{E01EF}'
+    )
 }
 
 fn config_summary_entries(

--- a/codex-rs/exec/src/event_processor_with_human_output_tests.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output_tests.rs
@@ -178,8 +178,10 @@ fn summarizes_managed_read_only_permission_profile() {
 #[test]
 fn config_summary_values_are_single_line_terminal_text() {
     assert_eq!(
-        sanitize_config_summary_value("repo\nmodel: other\r\x1b[2J\u{0007}"),
-        "repo�model: other��[2J�"
+        sanitize_config_summary_value(
+            "  repo\t|\nWorking\x1b\u{0007}\u{009D}\u{009C} | \u{202E}T\u{2066}ext  "
+        ),
+        "repo | Working | Text"
     );
 }
 

--- a/codex-rs/exec/src/event_processor_with_human_output_tests.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output_tests.rs
@@ -178,10 +178,8 @@ fn summarizes_managed_read_only_permission_profile() {
 #[test]
 fn config_summary_values_are_single_line_terminal_text() {
     assert_eq!(
-        sanitize_config_summary_value(
-            "  repo\t|\nWorking\x1b\u{0007}\u{009D}\u{009C} | \u{202E}T\u{2066}ext  "
-        ),
-        "repo | Working | Text"
+        sanitize_config_summary_value("repo\nmodel: other\r\x1b[2J\u{0007}\u{202E}rtl\u{2066}"),
+        "repo�model: other��[2J��rtl�"
     );
 }
 

--- a/codex-rs/exec/src/event_processor_with_human_output_tests.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output_tests.rs
@@ -23,6 +23,7 @@ use super::EventProcessorWithHumanOutput;
 use super::config_summary_entries;
 use super::final_message_from_turn_items;
 use super::reasoning_text;
+use super::sanitize_config_summary_value;
 use super::should_print_final_message_to_stdout;
 use super::should_print_final_message_to_tty;
 use crate::event_processor::EventProcessor;
@@ -171,6 +172,14 @@ fn summarizes_managed_read_only_permission_profile() {
     assert_eq!(
         summarize_permission_profile(&profile, &cwd, std::slice::from_ref(&cwd)),
         "read-only"
+    );
+}
+
+#[test]
+fn config_summary_values_are_single_line_terminal_text() {
+    assert_eq!(
+        sanitize_config_summary_value("repo\nmodel: other\r\x1b[2J\u{0007}"),
+        "repo�model: other��[2J�"
     );
 }
 


### PR DESCRIPTION
## Summary
- sanitize repo-controlled values before rendering them in the exec config summary
- add focused coverage for control-character normalization

## Testing
- `just test -p codex-exec`