### PR TITLE
Preserve line endings when applying patches

### DIFF
--- a/codex-rs/apply-patch/src/invocation.rs
+++ b/codex-rs/apply-patch/src/invocation.rs
@@ -13,12 +13,13 @@ use crate::ApplyPatchArgs;
 use crate::ApplyPatchError;
 use crate::ApplyPatchFileChange;
 use crate::ApplyPatchFileUpdate;
+use crate::ApplyPatchFileUpdateMode;
 use crate::IoError;
 use crate::MaybeApplyPatchVerified;
 use crate::parser::Hunk;
 use crate::parser::ParseError;
 use crate::parser::parse_patch;
-use crate::unified_diff_from_chunks;
+use crate::unified_diff_from_chunks_with_mode;
 use codex_utils_path_uri::PathConvention;
 use codex_utils_path_uri::PathUri;
 use std::str::Utf8Error;
@@ -144,6 +145,25 @@ pub async fn maybe_parse_apply_patch_verified(
     fs: &dyn ExecutorFileSystem,
     sandbox: Option<&codex_exec_server::FileSystemSandboxContext>,
 ) -> MaybeApplyPatchVerified {
+    maybe_parse_apply_patch_verified_with_mode(
+        argv,
+        cwd,
+        ApplyPatchFileUpdateMode::default(),
+        fs,
+        sandbox,
+    )
+    .await
+}
+
+/// Parses and verifies an `apply_patch` invocation using the selected
+/// file-update mode.
+pub async fn maybe_parse_apply_patch_verified_with_mode(
+    argv: &[String],
+    cwd: &PathUri,
+    update_file_mode: ApplyPatchFileUpdateMode,
+    fs: &dyn ExecutorFileSystem,
+    sandbox: Option<&codex_exec_server::FileSystemSandboxContext>,
+) -> MaybeApplyPatchVerified {
     // Detect a raw patch body passed directly as the command or as the body of a shell
     // script. In these cases, report an explicit error rather than applying the patch.
     if let [body] = argv
@@ -158,7 +178,9 @@ pub async fn maybe_parse_apply_patch_verified(
     }
 
     match maybe_parse_apply_patch(argv, cwd) {
-        MaybeApplyPatch::Body(args) => verify_apply_patch_args(args, cwd, fs, sandbox).await,
+        MaybeApplyPatch::Body(args) => {
+            verify_apply_patch_args_with_mode(args, cwd, update_file_mode, fs, sandbox).await
+        }
         MaybeApplyPatch::ShellParseError(e) => MaybeApplyPatchVerified::ShellParseError(e),
         MaybeApplyPatch::PatchParseError(e) => MaybeApplyPatchVerified::CorrectnessError(e.into()),
         MaybeApplyPatch::NotApplyPatch => MaybeApplyPatchVerified::NotApplyPatch,
@@ -171,7 +193,19 @@ pub async fn verify_apply_patch_args(
     fs: &dyn ExecutorFileSystem,
     sandbox: Option<&codex_exec_server::FileSystemSandboxContext>,
 ) -> MaybeApplyPatchVerified {
-    match try_verify_apply_patch_args(args, cwd, fs, sandbox).await {
+    verify_apply_patch_args_with_mode(args, cwd, ApplyPatchFileUpdateMode::default(), fs, sandbox)
+        .await
+}
+
+/// Verifies parsed patch arguments using the selected file-update mode.
+pub async fn verify_apply_patch_args_with_mode(
+    args: ApplyPatchArgs,
+    cwd: &PathUri,
+    update_file_mode: ApplyPatchFileUpdateMode,
+    fs: &dyn ExecutorFileSystem,
+    sandbox: Option<&codex_exec_server::FileSystemSandboxContext>,
+) -> MaybeApplyPatchVerified {
+    match try_verify_apply_patch_args(args, cwd, update_file_mode, fs, sandbox).await {
         Ok(action) => MaybeApplyPatchVerified::Body(action),
         Err(err) => MaybeApplyPatchVerified::CorrectnessError(err),
     }
@@ -180,6 +214,7 @@ pub async fn verify_apply_patch_args(
 async fn try_verify_apply_patch_args(
     args: ApplyPatchArgs,
     cwd: &PathUri,
+    update_file_mode: ApplyPatchFileUpdateMode,
     fs: &dyn ExecutorFileSystem,
     sandbox: Option<&codex_exec_server::FileSystemSandboxContext>,
 ) -> Result<ApplyPatchAction, ApplyPatchError> {
@@ -217,7 +252,14 @@ async fn try_verify_apply_patch_args(
                     unified_diff,
                     content: contents,
                     ..
-                } = unified_diff_from_chunks(&path, &chunks, fs, sandbox).await?;
+                } = unified_diff_from_chunks_with_mode(
+                    &path,
+                    &chunks,
+                    update_file_mode,
+                    fs,
+                    sandbox,
+                )
+                .await?;
                 changes.insert(
                     path,
                     ApplyPatchFileChange::Update {
@@ -233,6 +275,7 @@ async fn try_verify_apply_patch_args(
     }
     Ok(ApplyPatchAction {
         changes,
+        update_file_mode,
         patch,
         cwd: effective_cwd,
     })
@@ -856,6 +899,7 @@ PATCH"#,
                         new_content: "updated session directory content\n".to_string(),
                     },
                 )]),
+                update_file_mode: ApplyPatchFileUpdateMode::default(),
                 patch: argv[1].clone(),
                 cwd: PathUri::from_host_native_path(session_dir.path())
                     .expect("absolute test path"),

--- a/codex-rs/apply-patch/src/lib.rs
+++ b/codex-rs/apply-patch/src/lib.rs
@@ -3,6 +3,7 @@ mod parser;
 mod seek_sequence;
 mod standalone_executable;
 mod streaming_parser;
+mod text_file;
 
 use std::collections::HashMap;
 use std::io;
@@ -23,6 +24,8 @@ pub use parser::UpdateFileChunk;
 pub use parser::parse_patch;
 use similar::TextDiff;
 pub use streaming_parser::StreamingPatchParser;
+use text_file::Replacement;
+use text_file::SourceFile;
 use thiserror::Error;
 
 pub use invocation::maybe_parse_apply_patch_verified;
@@ -688,22 +691,13 @@ async fn derive_new_contents_from_chunks(
         })
     })?;
 
-    let mut original_lines: Vec<String> = original_contents.split('\n').map(String::from).collect();
-
-    // Drop the trailing empty element that results from the final newline so
-    // that line counts match the behaviour of standard `diff`.
-    if original_lines.last().is_some_and(String::is_empty) {
-        original_lines.pop();
-    }
+    let mut source_file = SourceFile::parse(&original_contents);
+    let original_lines = source_file.line_texts();
 
     let path_text = path.inferred_native_path_string();
     let replacements = compute_replacements(&original_lines, &path_text, chunks)?;
-    let new_lines = apply_replacements(original_lines, &replacements);
-    let mut new_lines = new_lines;
-    if !new_lines.last().is_some_and(String::is_empty) {
-        new_lines.push(String::new());
-    }
-    let new_contents = new_lines.join("\n");
+    source_file.apply_replacements(&replacements);
+    let new_contents = source_file.into_contents();
     Ok(AppliedPatch {
         original_contents,
         new_contents,
@@ -717,8 +711,8 @@ fn compute_replacements(
     original_lines: &[String],
     path: &str,
     chunks: &[UpdateFileChunk],
-) -> std::result::Result<Vec<(usize, usize, Vec<String>)>, ApplyPatchError> {
-    let mut replacements: Vec<(usize, usize, Vec<String>)> = Vec::new();
+) -> std::result::Result<Vec<Replacement>, ApplyPatchError> {
+    let mut replacements: Vec<Replacement> = Vec::new();
     let mut line_index: usize = 0;
 
     for chunk in chunks {
@@ -756,11 +750,11 @@ fn compute_replacements(
         // Attempt to locate the `old_lines` verbatim within the file.  In many
         // real‑world diffs the last element of `old_lines` is an *empty* string
         // representing the terminating newline of the region being replaced.
-        // This sentinel is not present in `original_lines` because we strip the
-        // trailing empty slice emitted by `split('\n')`.  If a direct search
-        // fails and the pattern ends with an empty string, retry without that
-        // final element so that modifications touching the end‑of‑file can be
-        // located reliably.
+        // This sentinel is not present in `original_lines` because `SourceFile`
+        // stores the terminator on the preceding line rather than as an extra
+        // trailing element. If a direct search fails and the pattern ends with
+        // an empty string, retry without that final element so modifications
+        // touching the end‑of‑file can be located reliably.
 
         let mut pattern: &[String] = &chunk.old_lines;
         let mut found =
@@ -785,7 +779,34 @@ fn compute_replacements(
         }
 
         if let Some(start_idx) = found {
-            replacements.push((start_idx, pattern.len(), new_slice.to_vec()));
+            // Context lines occur in both sides of a patch chunk. Keep those
+            // original lines in place so their exact contents and terminators
+            // survive, especially when the file has mixed line endings.
+            let mut old_start = 0;
+            let mut new_start = 0;
+            for &(old_context, new_context) in &chunk.context_line_indices {
+                // A trailing empty context line can be removed from `pattern`
+                // and `new_slice` above when it represents the final newline.
+                if old_context >= pattern.len() || new_context >= new_slice.len() {
+                    break;
+                }
+                if old_start != old_context || new_start != new_context {
+                    replacements.push((
+                        start_idx + old_start,
+                        old_context - old_start,
+                        new_slice[new_start..new_context].to_vec(),
+                    ));
+                }
+                old_start = old_context + 1;
+                new_start = new_context + 1;
+            }
+            if old_start != pattern.len() || new_start != new_slice.len() {
+                replacements.push((
+                    start_idx + old_start,
+                    pattern.len() - old_start,
+                    new_slice[new_start..].to_vec(),
+                ));
+            }
             line_index = start_idx + pattern.len();
         } else {
             return Err(ApplyPatchError::ComputeReplacements(format!(
@@ -799,34 +820,6 @@ fn compute_replacements(
     replacements.sort_by_key(|(index, _, _)| *index);
 
     Ok(replacements)
-}
-
-/// Apply the `(start_index, old_len, new_lines)` replacements to `original_lines`,
-/// returning the modified file contents as a vector of lines.
-fn apply_replacements(
-    mut lines: Vec<String>,
-    replacements: &[(usize, usize, Vec<String>)],
-) -> Vec<String> {
-    // We must apply replacements in descending order so that earlier replacements
-    // don't shift the positions of later ones.
-    for (start_idx, old_len, new_segment) in replacements.iter().rev() {
-        let start_idx = *start_idx;
-        let old_len = *old_len;
-
-        // Remove old lines.
-        for _ in 0..old_len {
-            if start_idx < lines.len() {
-                lines.remove(start_idx);
-            }
-        }
-
-        // Insert new lines.
-        for (offset, new_line) in new_segment.iter().enumerate() {
-            lines.insert(start_idx + offset, new_line.clone());
-        }
-    }
-
-    lines
 }
 
 /// Intended result of a file update for apply_patch.

--- a/codex-rs/apply-patch/src/lib.rs
+++ b/codex-rs/apply-patch/src/lib.rs
@@ -29,7 +29,9 @@ use text_file::SourceFile;
 use thiserror::Error;
 
 pub use invocation::maybe_parse_apply_patch_verified;
+pub use invocation::maybe_parse_apply_patch_verified_with_mode;
 pub use invocation::verify_apply_patch_args;
+pub use invocation::verify_apply_patch_args_with_mode;
 pub use standalone_executable::main;
 
 use crate::invocation::ExtractHeredocError;
@@ -42,6 +44,30 @@ use crate::invocation::ExtractHeredocError;
 /// process-invocation contract for the standalone `apply_patch` command
 /// surface.
 pub const CODEX_CORE_APPLY_PATCH_ARG1: &str = "--codex-run-as-apply-patch";
+
+/// Internal environment variable used to carry the selected update mode
+/// through the arg0-dispatched standalone executable.
+pub const CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR: &str =
+    "CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS";
+
+/// Controls how updates reconstruct the target file after matching a patch.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ApplyPatchFileUpdateMode {
+    /// Preserve the historical behavior of normalizing updated files to LF.
+    #[default]
+    NormalizeToLf,
+    /// Preserve existing line endings and use the file's preferred ending for new lines.
+    PreserveLineEndings,
+}
+
+/// Reads the update mode selected for an arg0-dispatched `apply_patch` process.
+#[doc(hidden)]
+pub fn apply_patch_file_update_mode_from_env() -> ApplyPatchFileUpdateMode {
+    match std::env::var(CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR).as_deref() {
+        Ok("1") => ApplyPatchFileUpdateMode::PreserveLineEndings,
+        _ => ApplyPatchFileUpdateMode::NormalizeToLf,
+    }
+}
 
 #[derive(Debug, Error, PartialEq)]
 pub enum ApplyPatchError {
@@ -141,6 +167,8 @@ pub enum MaybeApplyPatchVerified {
 pub struct ApplyPatchAction {
     changes: HashMap<PathUri, ApplyPatchFileChange>,
 
+    update_file_mode: ApplyPatchFileUpdateMode,
+
     /// The raw patch argument that can be used to apply the patch. i.e., if the
     /// original arg was parsed in "lenient" mode with a
     /// heredoc, this should be the value without the heredoc wrapper.
@@ -160,6 +188,11 @@ impl ApplyPatchAction {
         &self.changes
     }
 
+    /// Returns the update mode selected while the patch was verified.
+    pub fn update_file_mode(&self) -> ApplyPatchFileUpdateMode {
+        self.update_file_mode
+    }
+
     /// Should be used exclusively for testing. (Not worth the overhead of
     /// creating a feature flag for this.)
     pub fn new_add_for_test(path: &PathUri, content: String) -> Self {
@@ -176,6 +209,7 @@ impl ApplyPatchAction {
         #[expect(clippy::expect_used)]
         Self {
             changes,
+            update_file_mode: ApplyPatchFileUpdateMode::default(),
             cwd: path.parent().expect("path should have parent"),
             patch,
         }
@@ -284,6 +318,29 @@ pub async fn apply_patch(
     fs: &dyn ExecutorFileSystem,
     sandbox: Option<&FileSystemSandboxContext>,
 ) -> Result<AppliedPatchDelta, ApplyPatchFailure> {
+    apply_patch_with_mode(
+        patch,
+        ApplyPatchFileUpdateMode::default(),
+        cwd,
+        stdout,
+        stderr,
+        fs,
+        sandbox,
+    )
+    .await
+}
+
+/// Applies the patch using the selected file-update mode and prints the result
+/// to stdout/stderr.
+pub async fn apply_patch_with_mode(
+    patch: &str,
+    update_file_mode: ApplyPatchFileUpdateMode,
+    cwd: &PathUri,
+    stdout: &mut impl std::io::Write,
+    stderr: &mut impl std::io::Write,
+    fs: &dyn ExecutorFileSystem,
+    sandbox: Option<&FileSystemSandboxContext>,
+) -> Result<AppliedPatchDelta, ApplyPatchFailure> {
     let hunks = match parse_patch(patch) {
         Ok(source) => source.hunks,
         Err(e) => {
@@ -311,7 +368,7 @@ pub async fn apply_patch(
         }
     };
 
-    apply_hunks(&hunks, cwd, stdout, stderr, fs, sandbox).await
+    apply_hunks_with_mode(&hunks, update_file_mode, cwd, stdout, stderr, fs, sandbox).await
 }
 
 /// Applies hunks and continues to update stdout/stderr
@@ -323,8 +380,31 @@ pub async fn apply_hunks(
     fs: &dyn ExecutorFileSystem,
     sandbox: Option<&FileSystemSandboxContext>,
 ) -> Result<AppliedPatchDelta, ApplyPatchFailure> {
+    apply_hunks_with_mode(
+        hunks,
+        ApplyPatchFileUpdateMode::default(),
+        cwd,
+        stdout,
+        stderr,
+        fs,
+        sandbox,
+    )
+    .await
+}
+
+/// Applies hunks using the selected file-update mode and continues to update
+/// stdout/stderr.
+async fn apply_hunks_with_mode(
+    hunks: &[Hunk],
+    update_file_mode: ApplyPatchFileUpdateMode,
+    cwd: &PathUri,
+    stdout: &mut impl std::io::Write,
+    stderr: &mut impl std::io::Write,
+    fs: &dyn ExecutorFileSystem,
+    sandbox: Option<&FileSystemSandboxContext>,
+) -> Result<AppliedPatchDelta, ApplyPatchFailure> {
     let mut delta = AppliedPatchDelta::empty();
-    match apply_hunks_to_files(hunks, cwd, fs, sandbox, &mut delta).await {
+    match apply_hunks_to_files(hunks, update_file_mode, cwd, fs, sandbox, &mut delta).await {
         Ok(affected_paths) => {
             print_summary(&affected_paths, stdout).map_err(|error| {
                 ApplyPatchFailure::new(ApplyPatchError::from(error), delta.clone())
@@ -363,6 +443,7 @@ pub struct AffectedPaths {
 /// Returns an error if the patch could not be applied.
 async fn apply_hunks_to_files(
     hunks: &[Hunk],
+    update_file_mode: ApplyPatchFileUpdateMode,
     cwd: &PathUri,
     fs: &dyn ExecutorFileSystem,
     sandbox: Option<&FileSystemSandboxContext>,
@@ -472,7 +553,14 @@ async fn apply_hunks_to_files(
                 let AppliedPatch {
                     original_contents,
                     new_contents,
-                } = derive_new_contents_from_chunks(&path_uri, chunks, fs, sandbox).await?;
+                } = derive_new_contents_from_chunks(
+                    &path_uri,
+                    chunks,
+                    update_file_mode,
+                    fs,
+                    sandbox,
+                )
+                .await?;
                 if let Some(dest) = move_path {
                     let dest_uri = cwd.join(&dest.to_string_lossy())?;
                     let overwritten_move_content =
@@ -678,6 +766,7 @@ struct AppliedPatch {
 async fn derive_new_contents_from_chunks(
     path: &PathUri,
     chunks: &[UpdateFileChunk],
+    update_file_mode: ApplyPatchFileUpdateMode,
     fs: &dyn ExecutorFileSystem,
     sandbox: Option<&FileSystemSandboxContext>,
 ) -> std::result::Result<AppliedPatch, ApplyPatchError> {
@@ -691,13 +780,37 @@ async fn derive_new_contents_from_chunks(
         })
     })?;
 
-    let mut source_file = SourceFile::parse(&original_contents);
-    let original_lines = source_file.line_texts();
-
     let path_text = path.inferred_native_path_string();
-    let replacements = compute_replacements(&original_lines, &path_text, chunks)?;
-    source_file.apply_replacements(&replacements);
-    let new_contents = source_file.into_contents();
+    let new_contents = match update_file_mode {
+        ApplyPatchFileUpdateMode::NormalizeToLf => {
+            let mut original_lines = original_contents
+                .split('\n')
+                .map(String::from)
+                .collect::<Vec<_>>();
+
+            // Drop the trailing empty element that results from the final newline so
+            // that line counts match the behaviour of standard `diff`.
+            if original_lines.last().is_some_and(String::is_empty) {
+                original_lines.pop();
+            }
+
+            let replacements =
+                compute_replacements(&original_lines, &path_text, chunks, update_file_mode)?;
+            let mut new_lines = apply_replacements(original_lines, &replacements);
+            if !new_lines.last().is_some_and(String::is_empty) {
+                new_lines.push(String::new());
+            }
+            new_lines.join("\n")
+        }
+        ApplyPatchFileUpdateMode::PreserveLineEndings => {
+            let mut source_file = SourceFile::parse(&original_contents);
+            let original_lines = source_file.line_texts();
+            let replacements =
+                compute_replacements(&original_lines, &path_text, chunks, update_file_mode)?;
+            source_file.apply_replacements(&replacements);
+            source_file.into_contents()
+        }
+    };
     Ok(AppliedPatch {
         original_contents,
         new_contents,
@@ -711,6 +824,7 @@ fn compute_replacements(
     original_lines: &[String],
     path: &str,
     chunks: &[UpdateFileChunk],
+    update_file_mode: ApplyPatchFileUpdateMode,
 ) -> std::result::Result<Vec<Replacement>, ApplyPatchError> {
     let mut replacements: Vec<Replacement> = Vec::new();
     let mut line_index: usize = 0;
@@ -779,33 +893,40 @@ fn compute_replacements(
         }
 
         if let Some(start_idx) = found {
-            // Context lines occur in both sides of a patch chunk. Keep those
-            // original lines in place so their exact contents and terminators
-            // survive, especially when the file has mixed line endings.
-            let mut old_start = 0;
-            let mut new_start = 0;
-            for &(old_context, new_context) in &chunk.context_line_indices {
-                // A trailing empty context line can be removed from `pattern`
-                // and `new_slice` above when it represents the final newline.
-                if old_context >= pattern.len() || new_context >= new_slice.len() {
-                    break;
+            match update_file_mode {
+                ApplyPatchFileUpdateMode::NormalizeToLf => {
+                    replacements.push((start_idx, pattern.len(), new_slice.to_vec()));
                 }
-                if old_start != old_context || new_start != new_context {
-                    replacements.push((
-                        start_idx + old_start,
-                        old_context - old_start,
-                        new_slice[new_start..new_context].to_vec(),
-                    ));
+                ApplyPatchFileUpdateMode::PreserveLineEndings => {
+                    // Context lines occur in both sides of a patch chunk. Keep those
+                    // original lines in place so their exact contents and terminators
+                    // survive, especially when the file has mixed line endings.
+                    let mut old_start = 0;
+                    let mut new_start = 0;
+                    for &(old_context, new_context) in &chunk.context_line_indices {
+                        // A trailing empty context line can be removed from `pattern`
+                        // and `new_slice` above when it represents the final newline.
+                        if old_context >= pattern.len() || new_context >= new_slice.len() {
+                            break;
+                        }
+                        if old_start != old_context || new_start != new_context {
+                            replacements.push((
+                                start_idx + old_start,
+                                old_context - old_start,
+                                new_slice[new_start..new_context].to_vec(),
+                            ));
+                        }
+                        old_start = old_context + 1;
+                        new_start = new_context + 1;
+                    }
+                    if old_start != pattern.len() || new_start != new_slice.len() {
+                        replacements.push((
+                            start_idx + old_start,
+                            pattern.len() - old_start,
+                            new_slice[new_start..].to_vec(),
+                        ));
+                    }
                 }
-                old_start = old_context + 1;
-                new_start = new_context + 1;
-            }
-            if old_start != pattern.len() || new_start != new_slice.len() {
-                replacements.push((
-                    start_idx + old_start,
-                    pattern.len() - old_start,
-                    new_slice[new_start..].to_vec(),
-                ));
             }
             line_index = start_idx + pattern.len();
         } else {
@@ -822,6 +943,31 @@ fn compute_replacements(
     Ok(replacements)
 }
 
+/// Apply the `(start_index, old_len, new_lines)` replacements to `original_lines`,
+/// returning the modified file contents as a vector of lines.
+fn apply_replacements(mut lines: Vec<String>, replacements: &[Replacement]) -> Vec<String> {
+    // We must apply replacements in descending order so that earlier replacements
+    // don't shift the positions of later ones.
+    for (start_idx, old_len, new_segment) in replacements.iter().rev() {
+        let start_idx = *start_idx;
+        let old_len = *old_len;
+
+        // Remove old lines.
+        for _ in 0..old_len {
+            if start_idx < lines.len() {
+                lines.remove(start_idx);
+            }
+        }
+
+        // Insert new lines.
+        for (offset, new_line) in new_segment.iter().enumerate() {
+            lines.insert(start_idx + offset, new_line.clone());
+        }
+    }
+
+    lines
+}
+
 /// Intended result of a file update for apply_patch.
 #[derive(Debug, Eq, PartialEq)]
 pub struct ApplyPatchFileUpdate {
@@ -836,7 +982,32 @@ pub async fn unified_diff_from_chunks(
     fs: &dyn ExecutorFileSystem,
     sandbox: Option<&FileSystemSandboxContext>,
 ) -> std::result::Result<ApplyPatchFileUpdate, ApplyPatchError> {
-    unified_diff_from_chunks_with_context(path, chunks, /*context*/ 1, fs, sandbox).await
+    unified_diff_from_chunks_with_mode(
+        path,
+        chunks,
+        ApplyPatchFileUpdateMode::default(),
+        fs,
+        sandbox,
+    )
+    .await
+}
+
+pub(crate) async fn unified_diff_from_chunks_with_mode(
+    path: &PathUri,
+    chunks: &[UpdateFileChunk],
+    update_file_mode: ApplyPatchFileUpdateMode,
+    fs: &dyn ExecutorFileSystem,
+    sandbox: Option<&FileSystemSandboxContext>,
+) -> std::result::Result<ApplyPatchFileUpdate, ApplyPatchError> {
+    unified_diff_from_chunks_with_context_and_mode(
+        path,
+        chunks,
+        /*context*/ 1,
+        update_file_mode,
+        fs,
+        sandbox,
+    )
+    .await
 }
 
 pub async fn unified_diff_from_chunks_with_context(
@@ -846,10 +1017,29 @@ pub async fn unified_diff_from_chunks_with_context(
     fs: &dyn ExecutorFileSystem,
     sandbox: Option<&FileSystemSandboxContext>,
 ) -> std::result::Result<ApplyPatchFileUpdate, ApplyPatchError> {
+    unified_diff_from_chunks_with_context_and_mode(
+        path,
+        chunks,
+        context,
+        ApplyPatchFileUpdateMode::default(),
+        fs,
+        sandbox,
+    )
+    .await
+}
+
+async fn unified_diff_from_chunks_with_context_and_mode(
+    path: &PathUri,
+    chunks: &[UpdateFileChunk],
+    context: usize,
+    update_file_mode: ApplyPatchFileUpdateMode,
+    fs: &dyn ExecutorFileSystem,
+    sandbox: Option<&FileSystemSandboxContext>,
+) -> std::result::Result<ApplyPatchFileUpdate, ApplyPatchError> {
     let AppliedPatch {
         original_contents,
         new_contents,
-    } = derive_new_contents_from_chunks(path, chunks, fs, sandbox).await?;
+    } = derive_new_contents_from_chunks(path, chunks, update_file_mode, fs, sandbox).await?;
     let text_diff = TextDiff::from_lines(&original_contents, &new_contents);
     let unified_diff = text_diff.unified_diff().context_radius(context).to_string();
     Ok(ApplyPatchFileUpdate {

--- a/codex-rs/apply-patch/src/lib.rs
+++ b/codex-rs/apply-patch/src/lib.rs
@@ -838,6 +838,7 @@ fn compute_replacements(
                 std::slice::from_ref(ctx_line),
                 line_index,
                 /*eof*/ false,
+                update_file_mode,
             ) {
                 line_index = idx + 1;
             } else {
@@ -871,8 +872,13 @@ fn compute_replacements(
         // touching the end‑of‑file can be located reliably.
 
         let mut pattern: &[String] = &chunk.old_lines;
-        let mut found =
-            seek_sequence::seek_sequence(original_lines, pattern, line_index, chunk.is_end_of_file);
+        let mut found = seek_sequence::seek_sequence(
+            original_lines,
+            pattern,
+            line_index,
+            chunk.is_end_of_file,
+            update_file_mode,
+        );
 
         let mut new_slice: &[String] = &chunk.new_lines;
 
@@ -889,6 +895,7 @@ fn compute_replacements(
                 pattern,
                 line_index,
                 chunk.is_end_of_file,
+                update_file_mode,
             );
         }
 

--- a/codex-rs/apply-patch/src/lib.rs
+++ b/codex-rs/apply-patch/src/lib.rs
@@ -849,12 +849,18 @@ fn compute_replacements(
         }
 
         if chunk.old_lines.is_empty() {
-            // Pure addition (no old lines). We'll add them at the end or just
-            // before the final empty line if one exists.
-            let insertion_idx = if original_lines.last().is_some_and(String::is_empty) {
-                original_lines.len() - 1
-            } else {
-                original_lines.len()
+            // Preserve the legacy split representation's handling of a final
+            // empty line. `SourceFile` only exposes real source lines, so its
+            // insertion point is always after the final line.
+            let insertion_idx = match update_file_mode {
+                ApplyPatchFileUpdateMode::NormalizeToLf => {
+                    if original_lines.last().is_some_and(String::is_empty) {
+                        original_lines.len() - 1
+                    } else {
+                        original_lines.len()
+                    }
+                }
+                ApplyPatchFileUpdateMode::PreserveLineEndings => original_lines.len(),
             };
             replacements.push((insertion_idx, 0, chunk.new_lines.clone()));
             continue;

--- a/codex-rs/apply-patch/src/parser.rs
+++ b/codex-rs/apply-patch/src/parser.rs
@@ -111,7 +111,7 @@ impl Hunk {
 #[cfg(test)]
 use Hunk::*;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Clone)]
 pub struct UpdateFileChunk {
     /// A single line of context used to narrow down the position of the chunk
     /// (this is usually a class, method, or function definition.)
@@ -122,9 +122,22 @@ pub struct UpdateFileChunk {
     pub old_lines: Vec<String>,
     pub new_lines: Vec<String>,
 
+    /// Pairs of indices into `old_lines` and `new_lines` that identify lines
+    /// parsed as context rather than inferred to be equal by their contents.
+    pub(crate) context_line_indices: Vec<(usize, usize)>,
+
     /// If set to true, `old_lines` must occur at the end of the source file.
     /// (Tolerance around trailing newlines should be encouraged.)
     pub is_end_of_file: bool,
+}
+
+impl UpdateFileChunk {
+    pub(crate) fn push_context_line(&mut self, line: String) {
+        self.context_line_indices
+            .push((self.old_lines.len(), self.new_lines.len()));
+        self.old_lines.push(line.clone());
+        self.new_lines.push(line);
+    }
 }
 
 pub fn parse_patch(patch: &str) -> Result<ApplyPatchArgs, ParseError> {
@@ -345,6 +358,7 @@ fn test_parse_patch() {
                     change_context: Some("def f():".to_string()),
                     old_lines: vec!["    pass".to_string()],
                     new_lines: vec!["    return 123".to_string()],
+                    context_line_indices: vec![],
                     is_end_of_file: false
                 }]
             }
@@ -372,6 +386,7 @@ fn test_parse_patch() {
                     change_context: None,
                     old_lines: vec![],
                     new_lines: vec!["line".to_string()],
+                    context_line_indices: vec![],
                     is_end_of_file: false
                 }],
             },
@@ -402,6 +417,7 @@ fn test_parse_patch() {
                 change_context: None,
                 old_lines: vec!["import foo".to_string()],
                 new_lines: vec!["import foo".to_string(), "bar".to_string()],
+                context_line_indices: vec![(0, 0)],
                 is_end_of_file: false,
             }],
         }]
@@ -422,6 +438,7 @@ fn test_parse_patch_preserves_end_of_file_marker() {
                     change_context: None,
                     old_lines: Vec::new(),
                     new_lines: vec!["quux".to_string()],
+                    context_line_indices: vec![],
                     is_end_of_file: true,
                 }],
             }],
@@ -470,6 +487,7 @@ fn test_parse_patch_accepts_relative_and_absolute_hunk_paths() {
                     change_context: None,
                     old_lines: vec!["old".to_string()],
                     new_lines: vec!["new".to_string()],
+                    context_line_indices: vec![],
                     is_end_of_file: false
                 }]
             },
@@ -548,6 +566,7 @@ fn test_parse_patch_lenient() {
             change_context: None,
             old_lines: vec!["import foo".to_string()],
             new_lines: vec!["import foo".to_string(), "bar".to_string()],
+            context_line_indices: vec![(0, 0)],
             is_end_of_file: false,
         }],
     }];

--- a/codex-rs/apply-patch/src/parser.rs
+++ b/codex-rs/apply-patch/src/parser.rs
@@ -132,6 +132,8 @@ pub struct UpdateFileChunk {
 }
 
 impl UpdateFileChunk {
+    /// Adds a context line to both sides while recording its corresponding
+    /// indices so it remains distinguishable from identical changed lines.
     pub(crate) fn push_context_line(&mut self, line: String) {
         self.context_line_indices
             .push((self.old_lines.len(), self.new_lines.len()));

--- a/codex-rs/apply-patch/src/seek_sequence.rs
+++ b/codex-rs/apply-patch/src/seek_sequence.rs
@@ -27,7 +27,7 @@ pub(crate) fn seek_sequence(
         return None;
     }
     let search_start = if eof && lines.len() >= pattern.len() {
-        lines.len() - pattern.len()
+        (lines.len() - pattern.len()).max(start)
     } else {
         start
     };

--- a/codex-rs/apply-patch/src/seek_sequence.rs
+++ b/codex-rs/apply-patch/src/seek_sequence.rs
@@ -14,6 +14,7 @@ pub(crate) fn seek_sequence(
     pattern: &[String],
     start: usize,
     eof: bool,
+    update_file_mode: crate::ApplyPatchFileUpdateMode,
 ) -> Option<usize> {
     if pattern.is_empty() {
         return Some(start);
@@ -27,7 +28,11 @@ pub(crate) fn seek_sequence(
         return None;
     }
     let search_start = if eof && lines.len() >= pattern.len() {
-        (lines.len() - pattern.len()).max(start)
+        let eof_start = lines.len() - pattern.len();
+        match update_file_mode {
+            crate::ApplyPatchFileUpdateMode::NormalizeToLf => eof_start,
+            crate::ApplyPatchFileUpdateMode::PreserveLineEndings => eof_start.max(start),
+        }
     } else {
         start
     };
@@ -112,6 +117,7 @@ pub(crate) fn seek_sequence(
 #[cfg(test)]
 mod tests {
     use super::seek_sequence;
+    use crate::ApplyPatchFileUpdateMode;
     use std::string::ToString;
 
     fn to_vec(strings: &[&str]) -> Vec<String> {
@@ -123,7 +129,13 @@ mod tests {
         let lines = to_vec(&["foo", "bar", "baz"]);
         let pattern = to_vec(&["bar", "baz"]);
         assert_eq!(
-            seek_sequence(&lines, &pattern, /*start*/ 0, /*eof*/ false),
+            seek_sequence(
+                &lines,
+                &pattern,
+                /*start*/ 0,
+                /*eof*/ false,
+                ApplyPatchFileUpdateMode::NormalizeToLf,
+            ),
             Some(1)
         );
     }
@@ -134,7 +146,13 @@ mod tests {
         // Pattern omits trailing whitespace.
         let pattern = to_vec(&["foo", "bar"]);
         assert_eq!(
-            seek_sequence(&lines, &pattern, /*start*/ 0, /*eof*/ false),
+            seek_sequence(
+                &lines,
+                &pattern,
+                /*start*/ 0,
+                /*eof*/ false,
+                ApplyPatchFileUpdateMode::NormalizeToLf,
+            ),
             Some(0)
         );
     }
@@ -145,7 +163,13 @@ mod tests {
         // Pattern omits any additional whitespace.
         let pattern = to_vec(&["foo", "bar"]);
         assert_eq!(
-            seek_sequence(&lines, &pattern, /*start*/ 0, /*eof*/ false),
+            seek_sequence(
+                &lines,
+                &pattern,
+                /*start*/ 0,
+                /*eof*/ false,
+                ApplyPatchFileUpdateMode::NormalizeToLf,
+            ),
             Some(0)
         );
     }
@@ -156,7 +180,13 @@ mod tests {
         let pattern = to_vec(&["too", "many", "lines"]);
         // Should not panic – must return None when pattern cannot possibly fit.
         assert_eq!(
-            seek_sequence(&lines, &pattern, /*start*/ 0, /*eof*/ false),
+            seek_sequence(
+                &lines,
+                &pattern,
+                /*start*/ 0,
+                /*eof*/ false,
+                ApplyPatchFileUpdateMode::NormalizeToLf,
+            ),
             None
         );
     }

--- a/codex-rs/apply-patch/src/standalone_executable.rs
+++ b/codex-rs/apply-patch/src/standalone_executable.rs
@@ -67,8 +67,10 @@ pub fn run_main() -> i32 {
     };
     // TODO(anp): Discover the standalone executable cwd as PathUri directly.
     let cwd = codex_utils_path_uri::PathUri::from_abs_path(&cwd);
-    match runtime.block_on(crate::apply_patch(
+    let update_file_mode = crate::apply_patch_file_update_mode_from_env();
+    match runtime.block_on(crate::apply_patch_with_mode(
         &patch_arg,
+        update_file_mode,
         &cwd,
         &mut stdout,
         &mut stderr,

--- a/codex-rs/apply-patch/src/streaming_parser.rs
+++ b/codex-rs/apply-patch/src/streaming_parser.rs
@@ -274,12 +274,7 @@ impl StreamingPatchParser {
                     }
 
                     if update_line == EMPTY_CHANGE_CONTEXT_MARKER {
-                        chunks.push(UpdateFileChunk {
-                            change_context: None,
-                            old_lines: Vec::new(),
-                            new_lines: Vec::new(),
-                            is_end_of_file: false,
-                        });
+                        chunks.push(UpdateFileChunk::default());
                         self.state.mode = StreamingParserMode::UpdateFile { hunk_line_number };
                         return Ok(());
                     }
@@ -287,9 +282,7 @@ impl StreamingPatchParser {
                     if let Some(change_context) = update_line.strip_prefix(CHANGE_CONTEXT_MARKER) {
                         chunks.push(UpdateFileChunk {
                             change_context: Some(change_context.to_string()),
-                            old_lines: Vec::new(),
-                            new_lines: Vec::new(),
-                            is_end_of_file: false,
+                            ..UpdateFileChunk::default()
                         });
                         self.state.mode = StreamingParserMode::UpdateFile { hunk_line_number };
                         return Ok(());
@@ -313,16 +306,10 @@ impl StreamingPatchParser {
 
                     if line.is_empty() {
                         if chunks.is_empty() {
-                            chunks.push(UpdateFileChunk {
-                                change_context: None,
-                                old_lines: Vec::new(),
-                                new_lines: Vec::new(),
-                                is_end_of_file: false,
-                            });
+                            chunks.push(UpdateFileChunk::default());
                         }
                         if let Some(chunk) = chunks.last_mut() {
-                            chunk.old_lines.push(String::new());
-                            chunk.new_lines.push(String::new());
+                            chunk.push_context_line(String::new());
                         }
                         self.state.mode = StreamingParserMode::UpdateFile { hunk_line_number };
                         return Ok(());
@@ -330,16 +317,10 @@ impl StreamingPatchParser {
 
                     if let Some(line_to_add) = line.strip_prefix(' ') {
                         if chunks.is_empty() {
-                            chunks.push(UpdateFileChunk {
-                                change_context: None,
-                                old_lines: Vec::new(),
-                                new_lines: Vec::new(),
-                                is_end_of_file: false,
-                            });
+                            chunks.push(UpdateFileChunk::default());
                         }
                         if let Some(chunk) = chunks.last_mut() {
-                            chunk.old_lines.push(line_to_add.to_string());
-                            chunk.new_lines.push(line_to_add.to_string());
+                            chunk.push_context_line(line_to_add.to_string());
                         }
                         self.state.mode = StreamingParserMode::UpdateFile { hunk_line_number };
                         return Ok(());
@@ -347,12 +328,7 @@ impl StreamingPatchParser {
 
                     if let Some(line_to_add) = line.strip_prefix('+') {
                         if chunks.is_empty() {
-                            chunks.push(UpdateFileChunk {
-                                change_context: None,
-                                old_lines: Vec::new(),
-                                new_lines: Vec::new(),
-                                is_end_of_file: false,
-                            });
+                            chunks.push(UpdateFileChunk::default());
                         }
                         if let Some(chunk) = chunks.last_mut() {
                             chunk.new_lines.push(line_to_add.to_string());
@@ -363,12 +339,7 @@ impl StreamingPatchParser {
 
                     if let Some(line_to_remove) = line.strip_prefix('-') {
                         if chunks.is_empty() {
-                            chunks.push(UpdateFileChunk {
-                                change_context: None,
-                                old_lines: Vec::new(),
-                                new_lines: Vec::new(),
-                                is_end_of_file: false,
-                            });
+                            chunks.push(UpdateFileChunk::default());
                         }
                         if let Some(chunk) = chunks.last_mut() {
                             chunk.old_lines.push(line_to_remove.to_string());
@@ -445,6 +416,7 @@ mod tests {
                     change_context: None,
                     old_lines: vec!["old".to_string()],
                     new_lines: vec!["new".to_string()],
+                    context_line_indices: vec![],
                     is_end_of_file: false,
                 }],
             }])
@@ -635,12 +607,14 @@ mod tests {
                         change_context: None,
                         old_lines: vec!["old a".to_string(), "*** Update File: b.txt".to_string()],
                         new_lines: vec!["new a".to_string(), "*** Update File: b.txt".to_string()],
+                        context_line_indices: vec![(1, 1)],
                         is_end_of_file: false,
                     },
                     UpdateFileChunk {
                         change_context: None,
                         old_lines: vec!["old b".to_string()],
                         new_lines: vec!["new b".to_string()],
+                        context_line_indices: vec![],
                         is_end_of_file: false,
                     },
                 ],
@@ -680,6 +654,7 @@ mod tests {
                         String::new(),
                         "context after".to_string(),
                     ],
+                    context_line_indices: vec![(0, 0), (1, 1), (2, 2)],
                     is_end_of_file: false,
                 }],
             }])
@@ -700,6 +675,7 @@ mod tests {
                     change_context: None,
                     old_lines: Vec::new(),
                     new_lines: vec!["quux".to_string()],
+                    context_line_indices: vec![],
                     is_end_of_file: true,
                 }],
             }])
@@ -718,6 +694,7 @@ mod tests {
                     change_context: None,
                     old_lines: vec!["old".to_string()],
                     new_lines: vec!["new".to_string()],
+                    context_line_indices: vec![],
                     is_end_of_file: false,
                 }],
             }])
@@ -733,6 +710,7 @@ mod tests {
                     change_context: None,
                     old_lines: vec!["old\r".to_string()],
                     new_lines: vec!["new".to_string()],
+                    context_line_indices: vec![],
                     is_end_of_file: false,
                 }],
             }])
@@ -769,6 +747,7 @@ mod tests {
                     change_context: None,
                     old_lines: vec!["old".to_string()],
                     new_lines: vec!["new".to_string()],
+                    context_line_indices: vec![],
                     is_end_of_file: false,
                 }],
             }])
@@ -782,6 +761,7 @@ mod tests {
                     change_context: None,
                     old_lines: vec!["old".to_string()],
                     new_lines: vec!["new".to_string()],
+                    context_line_indices: vec![],
                     is_end_of_file: false,
                 }],
             }])

--- a/codex-rs/apply-patch/src/text_file.rs
+++ b/codex-rs/apply-patch/src/text_file.rs
@@ -1,0 +1,105 @@
+pub(super) type Replacement = (usize, usize, Vec<String>);
+
+#[derive(Clone, Copy)]
+enum LineEnding {
+    Lf,
+    CrLf,
+}
+
+impl LineEnding {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Lf => "\n",
+            Self::CrLf => "\r\n",
+        }
+    }
+}
+
+struct SourceLine {
+    text: String,
+    ending: Option<LineEnding>,
+}
+
+pub(super) struct SourceFile {
+    lines: Vec<SourceLine>,
+    preferred_ending: LineEnding,
+}
+
+impl SourceFile {
+    pub(super) fn parse(contents: &str) -> Self {
+        let mut lines = Vec::new();
+        let mut preferred_ending = None;
+        let mut line_start = 0;
+
+        for (newline, _) in contents.match_indices('\n') {
+            let line = &contents[line_start..newline];
+            let (text, ending) = if let Some(text) = line.strip_suffix('\r') {
+                (text, LineEnding::CrLf)
+            } else {
+                (line, LineEnding::Lf)
+            };
+            // Match rustfmt and Ruff's auto-detection behavior by using the
+            // first existing newline as the file's preferred style.
+            preferred_ending.get_or_insert(ending);
+            lines.push(SourceLine {
+                text: text.to_string(),
+                ending: Some(ending),
+            });
+            line_start = newline + 1;
+        }
+
+        if line_start < contents.len() {
+            lines.push(SourceLine {
+                text: contents[line_start..].to_string(),
+                ending: None,
+            });
+        }
+
+        Self {
+            lines,
+            preferred_ending: preferred_ending.unwrap_or(LineEnding::Lf),
+        }
+    }
+
+    pub(super) fn line_texts(&self) -> Vec<String> {
+        self.lines.iter().map(|line| line.text.clone()).collect()
+    }
+
+    pub(super) fn apply_replacements(&mut self, replacements: &[Replacement]) {
+        let mut source_lines = std::mem::take(&mut self.lines).into_iter();
+        let mut new_lines = Vec::new();
+        let mut source_index = 0;
+
+        for (start_idx, old_len, new_segment) in replacements {
+            debug_assert!(*start_idx >= source_index);
+            for line in source_lines.by_ref().take(*start_idx - source_index) {
+                new_lines.push(line);
+            }
+            for _ in source_lines.by_ref().take(*old_len) {}
+            new_lines.extend(new_segment.iter().map(|text| SourceLine {
+                text: text.clone(),
+                ending: Some(self.preferred_ending),
+            }));
+            source_index = start_idx + old_len;
+        }
+        new_lines.extend(source_lines);
+        self.lines = new_lines;
+
+        // Updates have historically added a trailing newline. This also gives
+        // an unterminated last line an ending if an insertion moved it inward.
+        for line in &mut self.lines {
+            line.ending.get_or_insert(self.preferred_ending);
+        }
+    }
+
+    pub(super) fn into_contents(self) -> String {
+        let mut contents = String::new();
+        for line in self.lines {
+            contents.push_str(&line.text);
+            if let Some(ending) = line.ending {
+                contents.push_str(ending.as_str());
+            }
+        }
+        contents
+    }
+}

--- a/codex-rs/apply-patch/src/text_file.rs
+++ b/codex-rs/apply-patch/src/text_file.rs
@@ -26,6 +26,10 @@ pub(super) struct SourceFile {
 }
 
 impl SourceFile {
+    /// Splits contents into logical lines while retaining each line ending.
+    ///
+    /// The first existing ending becomes the preferred style for inserted
+    /// lines; files without an ending default to LF.
     pub(super) fn parse(contents: &str) -> Self {
         let mut lines = Vec::new();
         let mut preferred_ending = None;
@@ -38,8 +42,6 @@ impl SourceFile {
             } else {
                 (line, LineEnding::Lf)
             };
-            // Match rustfmt and Ruff's auto-detection behavior by using the
-            // first existing newline as the file's preferred style.
             preferred_ending.get_or_insert(ending);
             lines.push(SourceLine {
                 text: text.to_string(),
@@ -65,6 +67,11 @@ impl SourceFile {
         self.lines.iter().map(|line| line.text.clone()).collect()
     }
 
+    /// Rebuilds the file from source-ordered, non-overlapping replacements.
+    ///
+    /// Unchanged lines retain their original endings, inserted lines use the
+    /// preferred ending, and every resulting line receives an ending to match
+    /// apply-patch's historical trailing-newline behavior.
     pub(super) fn apply_replacements(&mut self, replacements: &[Replacement]) {
         let mut source_lines = std::mem::take(&mut self.lines).into_iter();
         let mut new_lines = Vec::new();

--- a/codex-rs/apply-patch/src/text_file.rs
+++ b/codex-rs/apply-patch/src/text_file.rs
@@ -4,6 +4,7 @@ pub(super) type Replacement = (usize, usize, Vec<String>);
 enum LineEnding {
     Lf,
     CrLf,
+    Cr,
 }
 
 impl LineEnding {
@@ -11,6 +12,7 @@ impl LineEnding {
         match self {
             Self::Lf => "\n",
             Self::CrLf => "\r\n",
+            Self::Cr => "\r",
         }
     }
 }
@@ -34,20 +36,27 @@ impl SourceFile {
         let mut lines = Vec::new();
         let mut preferred_ending = None;
         let mut line_start = 0;
+        let mut cursor = 0;
 
-        for (newline, _) in contents.match_indices('\n') {
-            let line = &contents[line_start..newline];
-            let (text, ending) = if let Some(text) = line.strip_suffix('\r') {
-                (text, LineEnding::CrLf)
-            } else {
-                (line, LineEnding::Lf)
+        while cursor < contents.len() {
+            let (ending, ending_len) = match contents.as_bytes()[cursor] {
+                b'\r' if contents.as_bytes().get(cursor + 1) == Some(&b'\n') => {
+                    (LineEnding::CrLf, 2)
+                }
+                b'\r' => (LineEnding::Cr, 1),
+                b'\n' => (LineEnding::Lf, 1),
+                _ => {
+                    cursor += 1;
+                    continue;
+                }
             };
             preferred_ending.get_or_insert(ending);
             lines.push(SourceLine {
-                text: text.to_string(),
+                text: contents[line_start..cursor].to_string(),
                 ending: Some(ending),
             });
-            line_start = newline + 1;
+            cursor += ending_len;
+            line_start = cursor;
         }
 
         if line_start < contents.len() {

--- a/codex-rs/apply-patch/tests/fixtures/scenarios/.gitattributes
+++ b/codex-rs/apply-patch/tests/fixtures/scenarios/.gitattributes
@@ -1,1 +1,3 @@
 ** text eol=lf
+023_preserves_crlf_line_endings/input/*.txt -diff -text
+023_preserves_crlf_line_endings/expected/*.txt -diff -text

--- a/codex-rs/apply-patch/tests/fixtures/scenarios/023_preserves_crlf_line_endings/expected/lines.txt
+++ b/codex-rs/apply-patch/tests/fixtures/scenarios/023_preserves_crlf_line_endings/expected/lines.txt
@@ -1,0 +1,4 @@
+ONE
+two
+between
+three

--- a/codex-rs/apply-patch/tests/fixtures/scenarios/023_preserves_crlf_line_endings/input/lines.txt
+++ b/codex-rs/apply-patch/tests/fixtures/scenarios/023_preserves_crlf_line_endings/input/lines.txt
@@ -1,0 +1,3 @@
+one
+two
+three

--- a/codex-rs/apply-patch/tests/fixtures/scenarios/023_preserves_crlf_line_endings/patch.txt
+++ b/codex-rs/apply-patch/tests/fixtures/scenarios/023_preserves_crlf_line_endings/patch.txt
@@ -1,0 +1,9 @@
+*** Begin Patch
+*** Update File: lines.txt
+@@
+-one
++ONE
+ two
++between
+ three
+*** End Patch

--- a/codex-rs/apply-patch/tests/suite/scenarios.rs
+++ b/codex-rs/apply-patch/tests/suite/scenarios.rs
@@ -1,4 +1,6 @@
-use codex_utils_cargo_bin::repo_root;
+use anyhow::Context;
+use codex_apply_patch::CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR;
+use codex_utils_cargo_bin::find_resource;
 use pretty_assertions::assert_eq;
 use std::collections::BTreeMap;
 use std::fs;
@@ -9,17 +11,15 @@ use tempfile::tempdir;
 
 #[test]
 fn test_apply_patch_scenarios() -> anyhow::Result<()> {
-    let scenarios_dir = repo_root()?
-        .join("codex-rs")
-        .join("apply-patch")
-        .join("tests")
-        .join("fixtures")
-        .join("scenarios");
-    for scenario in fs::read_dir(scenarios_dir)? {
+    let scenarios_dir = find_resource!("tests/fixtures/scenarios")?;
+    for scenario in fs::read_dir(&scenarios_dir)
+        .with_context(|| format!("failed to read {}", scenarios_dir.display()))?
+    {
         let scenario = scenario?;
         let path = scenario.path();
         if path.is_dir() {
-            run_apply_patch_scenario(&path)?;
+            run_apply_patch_scenario(&path)
+                .with_context(|| format!("failed to run scenario {}", path.display()))?;
         }
     }
     Ok(())
@@ -37,15 +37,19 @@ fn run_apply_patch_scenario(dir: &Path) -> anyhow::Result<()> {
     }
 
     // Read the patch.txt file
-    let patch = fs::read_to_string(dir.join("patch.txt"))?;
+    let patch_path = dir.join("patch.txt");
+    let patch = fs::read_to_string(&patch_path)
+        .with_context(|| format!("failed to read {}", patch_path.display()))?;
 
     // Run apply_patch in the temporary directory. We intentionally do not assert
     // on the exit status here; the scenarios are specified purely in terms of
     // final filesystem state, which we compare below.
     Command::new(codex_utils_cargo_bin::cargo_bin("apply_patch")?)
         .arg(patch)
+        .env(CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR, "1")
         .current_dir(tmp.path())
-        .output()?;
+        .output()
+        .with_context(|| format!("failed to run scenario {}", dir.display()))?;
 
     // Assert that the final state matches the expected state exactly
     let expected_dir = dir.join("expected");

--- a/codex-rs/apply-patch/tests/suite/scenarios.rs
+++ b/codex-rs/apply-patch/tests/suite/scenarios.rs
@@ -11,8 +11,11 @@ use tempfile::tempdir;
 
 #[test]
 fn test_apply_patch_scenarios() -> anyhow::Result<()> {
-    let scenarios_dir = find_resource!("tests/fixtures/scenarios")?;
-    for scenario in fs::read_dir(&scenarios_dir)
+    let scenarios_marker = find_resource!("tests/fixtures/scenarios/.gitattributes")?;
+    let scenarios_dir = scenarios_marker
+        .parent()
+        .context("scenario marker should have a parent directory")?;
+    for scenario in fs::read_dir(scenarios_dir)
         .with_context(|| format!("failed to read {}", scenarios_dir.display()))?
     {
         let scenario = scenario?;

--- a/codex-rs/apply-patch/tests/suite/tool.rs
+++ b/codex-rs/apply-patch/tests/suite/tool.rs
@@ -65,6 +65,97 @@ fn test_apply_patch_cli_applies_multiple_chunks() -> anyhow::Result<()> {
 }
 
 #[test]
+fn test_apply_patch_cli_preserves_crlf_from_target_file() -> anyhow::Result<()> {
+    let tmp = tempdir()?;
+    let target_path = tmp.path().join("crlf.txt");
+    fs::write(&target_path, b"one\r\ntwo\r\nthree\r\n")?;
+
+    let patch = "*** Begin Patch\n*** Update File: crlf.txt\n@@\n-one\n+uno\n@@\n two\n+\n+between\n three\n*** End Patch";
+
+    run_apply_patch_in_dir(tmp.path(), patch)?
+        .success()
+        .stdout("Success. Updated the following files:\nM crlf.txt\n");
+
+    assert_eq!(
+        fs::read(target_path)?,
+        b"uno\r\ntwo\r\n\r\nbetween\r\nthree\r\n"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_apply_patch_cli_preserves_change_order_with_repeated_lines() -> anyhow::Result<()> {
+    let tmp = tempdir()?;
+    let target_path = tmp.path().join("repeated.txt");
+    fs::write(&target_path, "a\nb\n")?;
+
+    let patch =
+        "*** Begin Patch\n*** Update File: repeated.txt\n@@\n-a\n-b\n+b\n+b\n+a\n*** End Patch";
+
+    run_apply_patch_in_dir(tmp.path(), patch)?
+        .success()
+        .stdout("Success. Updated the following files:\nM repeated.txt\n");
+
+    assert_eq!(fs::read_to_string(target_path)?, "b\nb\na\n");
+
+    Ok(())
+}
+
+#[test]
+fn test_apply_patch_cli_preserves_repeated_context_line_ending() -> anyhow::Result<()> {
+    let tmp = tempdir()?;
+    let target_path = tmp.path().join("repeated_context.txt");
+    fs::write(&target_path, b"same\r\nsame\n")?;
+
+    let patch =
+        "*** Begin Patch\n*** Update File: repeated_context.txt\n@@\n-same\n same\n*** End Patch";
+
+    run_apply_patch_in_dir(tmp.path(), patch)?
+        .success()
+        .stdout("Success. Updated the following files:\nM repeated_context.txt\n");
+
+    assert_eq!(fs::read(target_path)?, b"same\n");
+
+    Ok(())
+}
+
+#[test]
+fn test_apply_patch_cli_preserves_untouched_mixed_line_endings() -> anyhow::Result<()> {
+    let tmp = tempdir()?;
+    let target_path = tmp.path().join("mixed.txt");
+    fs::write(&target_path, b"one\r\ntwo\nthree\r\nfour\n")?;
+
+    let patch = "*** Begin Patch\n*** Update File: mixed.txt\n@@\n one\n two\n-three\n+THREE\n four\n*** End Patch";
+
+    run_apply_patch_in_dir(tmp.path(), patch)?
+        .success()
+        .stdout("Success. Updated the following files:\nM mixed.txt\n");
+
+    assert_eq!(fs::read(target_path)?, b"one\r\ntwo\nTHREE\r\nfour\n");
+
+    Ok(())
+}
+
+#[test]
+fn test_apply_patch_cli_uses_crlf_for_new_trailing_newline() -> anyhow::Result<()> {
+    let tmp = tempdir()?;
+    let target_path = tmp.path().join("no_trailing_newline.txt");
+    fs::write(&target_path, b"one\r\ntwo")?;
+
+    let patch =
+        "*** Begin Patch\n*** Update File: no_trailing_newline.txt\n@@\n-one\n+ONE\n*** End Patch";
+
+    run_apply_patch_in_dir(tmp.path(), patch)?
+        .success()
+        .stdout("Success. Updated the following files:\nM no_trailing_newline.txt\n");
+
+    assert_eq!(fs::read(target_path)?, b"ONE\r\ntwo\r\n");
+
+    Ok(())
+}
+
+#[test]
 fn test_apply_patch_cli_moves_file_to_new_directory() -> anyhow::Result<()> {
     let tmp = tempdir()?;
     let original_path = tmp.path().join("old/name.txt");

--- a/codex-rs/apply-patch/tests/suite/tool.rs
+++ b/codex-rs/apply-patch/tests/suite/tool.rs
@@ -11,6 +11,26 @@ fn run_apply_patch_in_dir(dir: &Path, patch: &str) -> anyhow::Result<assert_cmd:
     Ok(cmd.arg(patch).assert())
 }
 
+fn assert_apply_patch_updates_file(
+    file_name: &str,
+    original: &[u8],
+    patch: &str,
+    expected: &[u8],
+) -> anyhow::Result<()> {
+    let tmp = tempdir()?;
+    let target_path = tmp.path().join(file_name);
+    fs::write(&target_path, original)?;
+
+    run_apply_patch_in_dir(tmp.path(), patch)?
+        .success()
+        .stdout(format!(
+            "Success. Updated the following files:\nM {file_name}\n"
+        ));
+
+    assert_eq!(fs::read(target_path)?, expected);
+    Ok(())
+}
+
 fn apply_patch_command(dir: &Path) -> anyhow::Result<Command> {
     let mut cmd = Command::new(codex_utils_cargo_bin::cargo_bin("apply_patch")?);
     cmd.current_dir(dir);
@@ -66,93 +86,55 @@ fn test_apply_patch_cli_applies_multiple_chunks() -> anyhow::Result<()> {
 
 #[test]
 fn test_apply_patch_cli_preserves_crlf_from_target_file() -> anyhow::Result<()> {
-    let tmp = tempdir()?;
-    let target_path = tmp.path().join("crlf.txt");
-    fs::write(&target_path, b"one\r\ntwo\r\nthree\r\n")?;
-
     let patch = "*** Begin Patch\n*** Update File: crlf.txt\n@@\n-one\n+uno\n@@\n two\n+\n+between\n three\n*** End Patch";
 
-    run_apply_patch_in_dir(tmp.path(), patch)?
-        .success()
-        .stdout("Success. Updated the following files:\nM crlf.txt\n");
-
-    assert_eq!(
-        fs::read(target_path)?,
-        b"uno\r\ntwo\r\n\r\nbetween\r\nthree\r\n"
-    );
-
-    Ok(())
+    assert_apply_patch_updates_file(
+        "crlf.txt",
+        b"one\r\ntwo\r\nthree\r\n",
+        patch,
+        b"uno\r\ntwo\r\n\r\nbetween\r\nthree\r\n",
+    )
 }
 
 #[test]
 fn test_apply_patch_cli_preserves_change_order_with_repeated_lines() -> anyhow::Result<()> {
-    let tmp = tempdir()?;
-    let target_path = tmp.path().join("repeated.txt");
-    fs::write(&target_path, "a\nb\n")?;
-
     let patch =
         "*** Begin Patch\n*** Update File: repeated.txt\n@@\n-a\n-b\n+b\n+b\n+a\n*** End Patch";
 
-    run_apply_patch_in_dir(tmp.path(), patch)?
-        .success()
-        .stdout("Success. Updated the following files:\nM repeated.txt\n");
-
-    assert_eq!(fs::read_to_string(target_path)?, "b\nb\na\n");
-
-    Ok(())
+    assert_apply_patch_updates_file("repeated.txt", b"a\nb\n", patch, b"b\nb\na\n")
 }
 
 #[test]
 fn test_apply_patch_cli_preserves_repeated_context_line_ending() -> anyhow::Result<()> {
-    let tmp = tempdir()?;
-    let target_path = tmp.path().join("repeated_context.txt");
-    fs::write(&target_path, b"same\r\nsame\n")?;
-
     let patch =
         "*** Begin Patch\n*** Update File: repeated_context.txt\n@@\n-same\n same\n*** End Patch";
 
-    run_apply_patch_in_dir(tmp.path(), patch)?
-        .success()
-        .stdout("Success. Updated the following files:\nM repeated_context.txt\n");
-
-    assert_eq!(fs::read(target_path)?, b"same\n");
-
-    Ok(())
+    assert_apply_patch_updates_file("repeated_context.txt", b"same\r\nsame\n", patch, b"same\n")
 }
 
 #[test]
 fn test_apply_patch_cli_preserves_untouched_mixed_line_endings() -> anyhow::Result<()> {
-    let tmp = tempdir()?;
-    let target_path = tmp.path().join("mixed.txt");
-    fs::write(&target_path, b"one\r\ntwo\nthree\r\nfour\n")?;
-
     let patch = "*** Begin Patch\n*** Update File: mixed.txt\n@@\n one\n two\n-three\n+THREE\n four\n*** End Patch";
 
-    run_apply_patch_in_dir(tmp.path(), patch)?
-        .success()
-        .stdout("Success. Updated the following files:\nM mixed.txt\n");
-
-    assert_eq!(fs::read(target_path)?, b"one\r\ntwo\nTHREE\r\nfour\n");
-
-    Ok(())
+    assert_apply_patch_updates_file(
+        "mixed.txt",
+        b"one\r\ntwo\nthree\r\nfour\n",
+        patch,
+        b"one\r\ntwo\nTHREE\r\nfour\n",
+    )
 }
 
 #[test]
 fn test_apply_patch_cli_uses_crlf_for_new_trailing_newline() -> anyhow::Result<()> {
-    let tmp = tempdir()?;
-    let target_path = tmp.path().join("no_trailing_newline.txt");
-    fs::write(&target_path, b"one\r\ntwo")?;
-
     let patch =
         "*** Begin Patch\n*** Update File: no_trailing_newline.txt\n@@\n-one\n+ONE\n*** End Patch";
 
-    run_apply_patch_in_dir(tmp.path(), patch)?
-        .success()
-        .stdout("Success. Updated the following files:\nM no_trailing_newline.txt\n");
-
-    assert_eq!(fs::read(target_path)?, b"ONE\r\ntwo\r\n");
-
-    Ok(())
+    assert_apply_patch_updates_file(
+        "no_trailing_newline.txt",
+        b"one\r\ntwo",
+        patch,
+        b"ONE\r\ntwo\r\n",
+    )
 }
 
 #[test]

--- a/codex-rs/apply-patch/tests/suite/tool.rs
+++ b/codex-rs/apply-patch/tests/suite/tool.rs
@@ -108,6 +108,26 @@ fn test_apply_patch_cli_rejects_overlapping_end_of_file_chunks() -> anyhow::Resu
 }
 
 #[test]
+fn test_apply_patch_cli_allows_overlapping_eof_chunks_in_legacy_mode() -> anyhow::Result<()> {
+    let tmp = tempdir()?;
+    let target_path = tmp.path().join("overlapping.txt");
+    fs::write(&target_path, "one\n")?;
+
+    let patch = "*** Begin Patch\n*** Update File: overlapping.txt\n@@\n-one\n+first\n@@\n-one\n+second\n*** End of File\n*** End Patch";
+
+    Command::new(codex_utils_cargo_bin::cargo_bin("apply_patch")?)
+        .env_remove(CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR)
+        .arg(patch)
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout("Success. Updated the following files:\nM overlapping.txt\n");
+
+    assert_eq!(fs::read_to_string(target_path)?, "first\n");
+    Ok(())
+}
+
+#[test]
 fn test_apply_patch_cli_preserves_crlf_from_target_file() -> anyhow::Result<()> {
     let patch = "*** Begin Patch\n*** Update File: crlf.txt\n@@\n-one\n+uno\n@@\n two\n+\n+between\n three\n*** End Patch";
 

--- a/codex-rs/apply-patch/tests/suite/tool.rs
+++ b/codex-rs/apply-patch/tests/suite/tool.rs
@@ -140,6 +140,18 @@ fn test_apply_patch_cli_preserves_crlf_from_target_file() -> anyhow::Result<()> 
 }
 
 #[test]
+fn test_apply_patch_cli_appends_after_trailing_blank_crlf_line() -> anyhow::Result<()> {
+    let patch = "*** Begin Patch\n*** Update File: trailing_blank.txt\n@@\n+new\n*** End Patch";
+
+    assert_apply_patch_updates_file(
+        "trailing_blank.txt",
+        b"a\r\n\r\n",
+        patch,
+        b"a\r\n\r\nnew\r\n",
+    )
+}
+
+#[test]
 fn test_apply_patch_cli_uses_legacy_line_handling_without_rollout_env() -> anyhow::Result<()> {
     let tmp = tempdir()?;
     let target_path = tmp.path().join("crlf.txt");

--- a/codex-rs/apply-patch/tests/suite/tool.rs
+++ b/codex-rs/apply-patch/tests/suite/tool.rs
@@ -85,6 +85,26 @@ fn test_apply_patch_cli_applies_multiple_chunks() -> anyhow::Result<()> {
 }
 
 #[test]
+fn test_apply_patch_cli_rejects_overlapping_end_of_file_chunks() -> anyhow::Result<()> {
+    let tmp = tempdir()?;
+    let target_path = tmp.path().join("overlapping.txt");
+    let expected_target_path = resolved_under(tmp.path(), "overlapping.txt")?;
+    fs::write(&target_path, "one\n")?;
+
+    let patch = "*** Begin Patch\n*** Update File: overlapping.txt\n@@\n-one\n+first\n@@\n-one\n+second\n*** End of File\n*** End Patch";
+
+    run_apply_patch_in_dir(tmp.path(), patch)?
+        .failure()
+        .stderr(format!(
+            "Failed to find expected lines in {}:\none\n",
+            expected_target_path.display()
+        ));
+
+    assert_eq!(fs::read_to_string(target_path)?, "one\n");
+    Ok(())
+}
+
+#[test]
 fn test_apply_patch_cli_preserves_crlf_from_target_file() -> anyhow::Result<()> {
     let patch = "*** Begin Patch\n*** Update File: crlf.txt\n@@\n-one\n+uno\n@@\n two\n+\n+between\n three\n*** End Patch";
 

--- a/codex-rs/apply-patch/tests/suite/tool.rs
+++ b/codex-rs/apply-patch/tests/suite/tool.rs
@@ -97,6 +97,18 @@ fn test_apply_patch_cli_preserves_crlf_from_target_file() -> anyhow::Result<()> 
 }
 
 #[test]
+fn test_apply_patch_cli_preserves_cr_from_target_file() -> anyhow::Result<()> {
+    let patch = "*** Begin Patch\n*** Update File: cr.txt\n@@\n-one\n+uno\n@@\n two\n+\n+between\n three\n*** End Patch";
+
+    assert_apply_patch_updates_file(
+        "cr.txt",
+        b"one\rtwo\rthree\r",
+        patch,
+        b"uno\rtwo\r\rbetween\rthree\r",
+    )
+}
+
+#[test]
 fn test_apply_patch_cli_preserves_change_order_with_repeated_lines() -> anyhow::Result<()> {
     let patch =
         "*** Begin Patch\n*** Update File: repeated.txt\n@@\n-a\n-b\n+b\n+b\n+a\n*** End Patch";
@@ -118,9 +130,9 @@ fn test_apply_patch_cli_preserves_untouched_mixed_line_endings() -> anyhow::Resu
 
     assert_apply_patch_updates_file(
         "mixed.txt",
-        b"one\r\ntwo\nthree\r\nfour\n",
+        b"one\r\ntwo\rthree\nfour\r\n",
         patch,
-        b"one\r\ntwo\nTHREE\r\nfour\n",
+        b"one\r\ntwo\rTHREE\r\nfour\r\n",
     )
 }
 

--- a/codex-rs/apply-patch/tests/suite/tool.rs
+++ b/codex-rs/apply-patch/tests/suite/tool.rs
@@ -1,4 +1,5 @@
 use assert_cmd::Command;
+use codex_apply_patch::CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR;
 use pretty_assertions::assert_eq;
 use std::fs;
 use std::path::Path;
@@ -7,6 +8,7 @@ use tempfile::tempdir;
 
 fn run_apply_patch_in_dir(dir: &Path, patch: &str) -> anyhow::Result<assert_cmd::assert::Assert> {
     let mut cmd = Command::new(codex_utils_cargo_bin::cargo_bin("apply_patch")?);
+    cmd.env(CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR, "1");
     cmd.current_dir(dir);
     Ok(cmd.arg(patch).assert())
 }
@@ -33,6 +35,7 @@ fn assert_apply_patch_updates_file(
 
 fn apply_patch_command(dir: &Path) -> anyhow::Result<Command> {
     let mut cmd = Command::new(codex_utils_cargo_bin::cargo_bin("apply_patch")?);
+    cmd.env(CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR, "1");
     cmd.current_dir(dir);
     Ok(cmd)
 }
@@ -114,6 +117,24 @@ fn test_apply_patch_cli_preserves_crlf_from_target_file() -> anyhow::Result<()> 
         patch,
         b"uno\r\ntwo\r\n\r\nbetween\r\nthree\r\n",
     )
+}
+
+#[test]
+fn test_apply_patch_cli_uses_legacy_line_handling_without_rollout_env() -> anyhow::Result<()> {
+    let tmp = tempdir()?;
+    let target_path = tmp.path().join("crlf.txt");
+    fs::write(&target_path, b"one\r\n")?;
+    let patch = "*** Begin Patch\n*** Update File: crlf.txt\n@@\n-one\n+uno\n*** End Patch";
+
+    Command::new(codex_utils_cargo_bin::cargo_bin("apply_patch")?)
+        .env_remove(CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR)
+        .arg(patch)
+        .current_dir(tmp.path())
+        .assert()
+        .success();
+
+    assert_eq!(fs::read(target_path)?, b"uno\n");
+    Ok(())
 }
 
 #[test]

--- a/codex-rs/arg0/src/lib.rs
+++ b/codex-rs/arg0/src/lib.rs
@@ -123,8 +123,10 @@ pub fn arg0_dispatch() -> Option<Arg0PathEntryGuard> {
                     Err(_) => std::process::exit(1),
                 };
                 let cwd = cwd.into();
-                match runtime.block_on(codex_apply_patch::apply_patch(
+                let update_file_mode = codex_apply_patch::apply_patch_file_update_mode_from_env();
+                match runtime.block_on(codex_apply_patch::apply_patch_with_mode(
                     &patch_arg,
+                    update_file_mode,
                     &cwd,
                     &mut stdout,
                     &mut stderr,

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -405,6 +405,9 @@
             "apply_patch_freeform": {
               "type": "boolean"
             },
+            "apply_patch_preserve_line_endings": {
+              "type": "boolean"
+            },
             "apply_patch_streaming_events": {
               "type": "boolean"
             },
@@ -4775,6 +4778,9 @@
       "description": "Centralized feature flags (new). Prefer this over individual toggles.",
       "properties": {
         "apply_patch_freeform": {
+          "type": "boolean"
+        },
+        "apply_patch_preserve_line_endings": {
           "type": "boolean"
         },
         "apply_patch_streaming_events": {

--- a/codex-rs/core/src/exec_env.rs
+++ b/codex-rs/core/src/exec_env.rs
@@ -1,3 +1,6 @@
+use codex_apply_patch::CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR;
+use codex_features::Feature;
+use codex_features::Features;
 use codex_protocol::ThreadId;
 #[cfg(test)]
 use codex_protocol::config_types::EnvironmentVariablePattern;
@@ -47,6 +50,18 @@ pub(crate) fn inject_permission_profile_env(
         env.insert(
             CODEX_PERMISSION_PROFILE_ENV_VAR.to_string(),
             active_permission_profile.id.clone(),
+        );
+    }
+}
+
+/// Carries the apply_patch line-ending rollout state into arg0-dispatched
+/// helper processes. The in-process apply_patch path reads the feature directly.
+pub(crate) fn inject_apply_patch_env(env: &mut HashMap<String, String>, features: &Features) {
+    env.retain(|key, _| !key.eq_ignore_ascii_case(CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR));
+    if features.enabled(Feature::ApplyPatchPreserveLineEndings) {
+        env.insert(
+            CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR.to_string(),
+            "1".to_string(),
         );
     }
 }

--- a/codex-rs/core/src/exec_env_tests.rs
+++ b/codex-rs/core/src/exec_env_tests.rs
@@ -41,6 +41,28 @@ fn inject_permission_profile_env_removes_stale_value_without_active_profile() {
     assert_eq!(env.get(CODEX_PERMISSION_PROFILE_ENV_VAR), None);
 }
 
+#[test]
+fn inject_apply_patch_env_follows_preserve_line_endings_feature() {
+    let mut env = HashMap::from([(
+        CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR.to_ascii_lowercase(),
+        "stale".to_string(),
+    )]);
+    let mut features = Features::with_defaults();
+
+    inject_apply_patch_env(&mut env, &features);
+    assert_eq!(env, HashMap::new());
+
+    features.enable(Feature::ApplyPatchPreserveLineEndings);
+    inject_apply_patch_env(&mut env, &features);
+    assert_eq!(
+        env,
+        HashMap::from([(
+            CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR.to_string(),
+            "1".to_string(),
+        )])
+    );
+}
+
 #[cfg(target_os = "windows")]
 #[test]
 fn inject_permission_profile_env_replaces_differently_cased_windows_key() {

--- a/codex-rs/core/src/tools/handlers/apply_patch.rs
+++ b/codex-rs/core/src/tools/handlers/apply_patch.rs
@@ -37,6 +37,7 @@ use crate::tools::runtimes::apply_patch::ApplyPatchRuntime;
 use crate::tools::sandboxing::ToolCtx;
 use codex_apply_patch::ApplyPatchAction;
 use codex_apply_patch::ApplyPatchFileChange;
+use codex_apply_patch::ApplyPatchFileUpdateMode;
 use codex_apply_patch::Hunk;
 use codex_apply_patch::StreamingPatchParser;
 use codex_exec_server::ExecutorFileSystem;
@@ -55,6 +56,19 @@ use codex_utils_absolute_path::AbsolutePathBuf;
 use codex_utils_path_uri::PathUri;
 
 const APPLY_PATCH_ARGUMENT_DIFF_BUFFER_INTERVAL: Duration = Duration::from_millis(500);
+
+fn apply_patch_file_update_mode(turn: &TurnContext) -> ApplyPatchFileUpdateMode {
+    if turn
+        .config
+        .features
+        .enabled(Feature::ApplyPatchPreserveLineEndings)
+    {
+        ApplyPatchFileUpdateMode::PreserveLineEndings
+    } else {
+        ApplyPatchFileUpdateMode::NormalizeToLf
+    }
+}
+
 /// Handles freeform `apply_patch` requests and routes verified patches to the
 /// selected environment filesystem.
 #[derive(Default)]
@@ -387,9 +401,10 @@ impl ApplyPatchHandler {
             /*additional_permissions*/ None,
             turn_environment.cwd(),
         );
-        match codex_apply_patch::verify_apply_patch_args(
+        match codex_apply_patch::verify_apply_patch_args_with_mode(
             args,
             turn_environment.cwd(),
+            apply_patch_file_update_mode(&turn),
             fs.as_ref(),
             Some(&sandbox),
         )
@@ -555,8 +570,14 @@ pub(crate) async fn intercept_apply_patch(
     tool_name: &str,
 ) -> Result<Option<FunctionToolOutput>, FunctionCallError> {
     let sandbox = turn.file_system_sandbox_context(/*additional_permissions*/ None, cwd);
-    match codex_apply_patch::maybe_parse_apply_patch_verified(command, cwd, fs, Some(&sandbox))
-        .await
+    match codex_apply_patch::maybe_parse_apply_patch_verified_with_mode(
+        command,
+        cwd,
+        apply_patch_file_update_mode(&turn),
+        fs,
+        Some(&sandbox),
+    )
+    .await
     {
         codex_apply_patch::MaybeApplyPatchVerified::Body(changes) => {
             let (approval_keys, effective_additional_permissions, file_system_sandbox_policy) =

--- a/codex-rs/core/src/tools/handlers/apply_patch_tests.rs
+++ b/codex-rs/core/src/tools/handlers/apply_patch_tests.rs
@@ -45,6 +45,24 @@ async fn invocation_for_payload(payload: ToolPayload) -> ToolInvocation {
 }
 
 #[tokio::test]
+async fn file_update_mode_follows_preserve_line_endings_feature() {
+    let (_, mut turn) = make_session_and_context().await;
+    assert_eq!(
+        apply_patch_file_update_mode(&turn),
+        codex_apply_patch::ApplyPatchFileUpdateMode::NormalizeToLf
+    );
+
+    Arc::make_mut(&mut turn.config)
+        .features
+        .enable(codex_features::Feature::ApplyPatchPreserveLineEndings)
+        .expect("feature should be enabled");
+    assert_eq!(
+        apply_patch_file_update_mode(&turn),
+        codex_apply_patch::ApplyPatchFileUpdateMode::PreserveLineEndings
+    );
+}
+
+#[tokio::test]
 async fn pre_tool_use_payload_uses_freeform_patch_input() {
     let patch = sample_patch();
     let payload = ToolPayload::Custom {

--- a/codex-rs/core/src/tools/handlers/shell/shell_command.rs
+++ b/codex-rs/core/src/tools/handlers/shell/shell_command.rs
@@ -6,6 +6,7 @@ use codex_utils_absolute_path::AbsolutePathBuf;
 use crate::exec::ExecCapturePolicy;
 use crate::exec::ExecParams;
 use crate::exec_env::create_env;
+use crate::exec_env::inject_apply_patch_env;
 use crate::exec_env::inject_permission_profile_env;
 use crate::function_tool::FunctionCallError;
 use crate::maybe_emit_implicit_skill_invocation;
@@ -104,6 +105,7 @@ impl ShellCommandHandler {
             &turn_context.config.permissions.shell_environment_policy,
             Some(session.thread_id),
         );
+        inject_apply_patch_env(&mut env, &turn_context.config.features);
         let active_permission_profile = turn_context.config.permissions.active_permission_profile();
         inject_permission_profile_env(&mut env, active_permission_profile.as_ref());
 

--- a/codex-rs/core/src/tools/runtimes/apply_patch.rs
+++ b/codex-rs/core/src/tools/runtimes/apply_patch.rs
@@ -240,8 +240,9 @@ impl ToolRuntime<ApplyPatchRequest, ApplyPatchRuntimeOutput> for ApplyPatchRunti
         let sandbox = Self::file_system_sandbox_context_for_attempt(req, attempt);
         let mut stdout = Vec::new();
         let mut stderr = Vec::new();
-        let result = codex_apply_patch::apply_patch(
+        let result = codex_apply_patch::apply_patch_with_mode(
             &req.action.patch,
+            req.action.update_file_mode(),
             &req.action.cwd,
             &mut stdout,
             &mut stderr,

--- a/codex-rs/core/src/tools/runtimes/mod.rs
+++ b/codex-rs/core/src/tools/runtimes/mod.rs
@@ -10,6 +10,7 @@ use crate::sandboxing::SandboxPermissions;
 use crate::shell::Shell;
 use crate::shell::ShellType;
 use crate::tools::sandboxing::ToolError;
+use codex_apply_patch::CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR;
 #[cfg(unix)]
 use codex_install_context::InstallContext;
 #[cfg(target_os = "macos")]
@@ -288,14 +289,23 @@ pub(crate) fn maybe_wrap_shell_lc_with_snapshot(
         .map(|arg| format!(" '{}'", shell_single_quote(arg)))
         .collect::<String>();
     let mut override_env = explicit_env_overrides.clone();
-    for key in [CODEX_THREAD_ID_ENV_VAR, CODEX_PERMISSION_PROFILE_ENV_VAR] {
+    for key in [
+        CODEX_THREAD_ID_ENV_VAR,
+        CODEX_PERMISSION_PROFILE_ENV_VAR,
+        CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR,
+    ] {
         if let Some(value) = env.get(key) {
             override_env.insert(key.to_string(), value.clone());
         }
     }
-    // Do not let a snapshot resurrect a stale profile when no named profile is active.
-    let (override_captures, override_exports) =
-        build_override_exports(&override_env, &[CODEX_PERMISSION_PROFILE_ENV_VAR]);
+    // Do not let a snapshot resurrect stale runtime state when it is inactive.
+    let (override_captures, override_exports) = build_override_exports(
+        &override_env,
+        &[
+            CODEX_PERMISSION_PROFILE_ENV_VAR,
+            CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR,
+        ],
+    );
     let (proxy_captures, proxy_exports) = build_proxy_env_exports();
     let runtime_path_prepend_exports =
         runtime_path_prepends.shell_exports_after_snapshot(explicit_env_overrides);

--- a/codex-rs/core/src/tools/runtimes/mod_tests.rs
+++ b/codex-rs/core/src/tools/runtimes/mod_tests.rs
@@ -608,6 +608,61 @@ fn maybe_wrap_shell_lc_with_snapshot_unsets_absent_permission_profile() {
 }
 
 #[test]
+fn maybe_wrap_shell_lc_with_snapshot_restores_apply_patch_rollout_state() {
+    let dir = tempdir().expect("create temp dir");
+    let snapshot_path = dir.path().join("snapshot.sh");
+    std::fs::write(
+        &snapshot_path,
+        "# Snapshot file\nexport CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS='stale'\n",
+    )
+    .expect("write snapshot");
+    let (session_shell, shell_snapshot) =
+        shell_with_snapshot(ShellType::Bash, "/bin/bash", snapshot_path.abs());
+    let command = vec![
+        "/bin/bash".to_string(),
+        "-lc".to_string(),
+        "printenv CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS".to_string(),
+    ];
+    let env = HashMap::from([(
+        CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR.to_string(),
+        "1".to_string(),
+    )]);
+    let rewritten = maybe_wrap_shell_lc_with_snapshot(
+        &command,
+        &session_shell,
+        Some(&shell_snapshot),
+        &HashMap::new(),
+        &env,
+        &RuntimePathPrepends::default(),
+    );
+    let output = Command::new(&rewritten[0])
+        .args(&rewritten[1..])
+        .env(CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR, "1")
+        .output()
+        .expect("run rewritten command");
+
+    assert!(output.status.success(), "command failed: {output:?}");
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "1\n");
+
+    let rewritten = maybe_wrap_shell_lc_with_snapshot(
+        &command,
+        &session_shell,
+        Some(&shell_snapshot),
+        &HashMap::new(),
+        &HashMap::new(),
+        &RuntimePathPrepends::default(),
+    );
+    let output = Command::new(&rewritten[0])
+        .args(&rewritten[1..])
+        .env_remove(CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR)
+        .output()
+        .expect("run rewritten command");
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(output.stdout, b"");
+}
+
+#[test]
 fn maybe_wrap_shell_lc_with_snapshot_restores_proxy_env_from_process_env() {
     let dir = tempdir().expect("create temp dir");
     let snapshot_path = dir.path().join("snapshot.sh");

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -16,6 +16,7 @@ use crate::codex_thread::BackgroundTerminalInfo;
 use crate::exec_env::CODEX_PERMISSION_PROFILE_ENV_VAR;
 use crate::exec_env::CODEX_THREAD_ID_ENV_VAR;
 use crate::exec_env::create_env;
+use crate::exec_env::inject_apply_patch_env;
 use crate::exec_env::inject_permission_profile_env;
 use crate::exec_policy::ExecApprovalRequest;
 use crate::sandboxing::ExecOptions;
@@ -1114,6 +1115,7 @@ impl UnifiedExecProcessManager {
             CODEX_THREAD_ID_ENV_VAR.to_string(),
             context.session.thread_id.to_string(),
         );
+        inject_apply_patch_env(&mut env, &context.turn.config.features);
         let active_permission_profile = context.turn.config.permissions.active_permission_profile();
         inject_permission_profile_env(&mut env, active_permission_profile.as_ref());
         let env = apply_unified_exec_env(env);

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -117,9 +117,19 @@ fn exec_env_policy_from_shell_policy(
         .iter()
         .map(std::string::ToString::to_string)
         .collect::<Vec<_>>();
-    exclude.push(CODEX_PERMISSION_PROFILE_ENV_VAR.to_string());
+    exclude.extend([
+        CODEX_PERMISSION_PROFILE_ENV_VAR.to_string(),
+        codex_apply_patch::CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR.to_string(),
+    ]);
     let mut r#set = policy.r#set.clone();
-    r#set.retain(|key, _| !key.eq_ignore_ascii_case(CODEX_PERMISSION_PROFILE_ENV_VAR));
+    r#set.retain(|key, _| {
+        ![
+            CODEX_PERMISSION_PROFILE_ENV_VAR,
+            codex_apply_patch::CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR,
+        ]
+        .iter()
+        .any(|runtime_key| key.eq_ignore_ascii_case(runtime_key))
+    });
     codex_exec_server::ExecEnvPolicy {
         inherit: policy.inherit.clone(),
         ignore_default_excludes: policy.ignore_default_excludes,
@@ -140,8 +150,11 @@ fn env_overlay_for_exec_server(
     request_env
         .iter()
         .filter(|(key, value)| {
-            key.as_str() == CODEX_PERMISSION_PROFILE_ENV_VAR
-                || local_policy_env.get(*key) != Some(*value)
+            matches!(
+                key.as_str(),
+                CODEX_PERMISSION_PROFILE_ENV_VAR
+                    | codex_apply_patch::CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR
+            ) || local_policy_env.get(*key) != Some(*value)
         })
         .map(|(key, value)| (key.clone(), value.clone()))
         .collect()

--- a/codex-rs/core/src/unified_exec/process_manager_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_manager_tests.rs
@@ -46,6 +46,10 @@ fn env_overlay_for_exec_server_keeps_runtime_changes_only() {
             CODEX_PERMISSION_PROFILE_ENV_VAR.to_string(),
             "current-profile".to_string(),
         ),
+        (
+            codex_apply_patch::CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR.to_string(),
+            "1".to_string(),
+        ),
     ]);
     let request_env = HashMap::from([
         ("HOME".to_string(), "/client-home".to_string()),
@@ -55,6 +59,10 @@ fn env_overlay_for_exec_server_keeps_runtime_changes_only() {
         (
             CODEX_PERMISSION_PROFILE_ENV_VAR.to_string(),
             "current-profile".to_string(),
+        ),
+        (
+            codex_apply_patch::CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR.to_string(),
+            "1".to_string(),
         ),
         (
             "CODEX_SANDBOX_NETWORK_DISABLED".to_string(),
@@ -72,6 +80,10 @@ fn env_overlay_for_exec_server_keeps_runtime_changes_only() {
                 "current-profile".to_string(),
             ),
             (
+                codex_apply_patch::CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR.to_string(),
+                "1".to_string(),
+            ),
+            (
                 "CODEX_SANDBOX_NETWORK_DISABLED".to_string(),
                 "1".to_string()
             ),
@@ -80,12 +92,16 @@ fn env_overlay_for_exec_server_keeps_runtime_changes_only() {
 }
 
 #[test]
-fn exec_env_policy_excludes_runtime_permission_profile() {
+fn exec_env_policy_excludes_runtime_apply_patch_and_permission_profile_vars() {
     let policy = ShellEnvironmentPolicy {
         r#set: HashMap::from([
             (
                 "codex_permission_profile".to_string(),
                 "stale-profile".to_string(),
+            ),
+            (
+                "codex_apply_patch_preserve_line_endings".to_string(),
+                "1".to_string(),
             ),
             ("KEEP".to_string(), "value".to_string()),
         ]),
@@ -97,7 +113,10 @@ fn exec_env_policy_excludes_runtime_permission_profile() {
         codex_exec_server::ExecEnvPolicy {
             inherit: policy.inherit,
             ignore_default_excludes: policy.ignore_default_excludes,
-            exclude: vec![CODEX_PERMISSION_PROFILE_ENV_VAR.to_string()],
+            exclude: vec![
+                CODEX_PERMISSION_PROFILE_ENV_VAR.to_string(),
+                codex_apply_patch::CODEX_APPLY_PATCH_PRESERVE_LINE_ENDINGS_ENV_VAR.to_string(),
+            ],
             r#set: HashMap::from([("KEEP".to_string(), "value".to_string())]),
             include_only: Vec::new(),
         }

--- a/codex-rs/core/tests/suite/apply_patch_cli.rs
+++ b/codex-rs/core/tests/suite/apply_patch_cli.rs
@@ -251,6 +251,54 @@ fn apply_patch_responses(
     ]
 }
 
+async fn assert_apply_patch_crlf_update(
+    configure: impl FnOnce(TestCodexBuilder) -> TestCodexBuilder,
+    expected: &str,
+) -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let harness = apply_patch_harness_with(configure).await?;
+    let call_id = "apply-patch-crlf-rollout";
+    let file_name = "crlf.txt";
+    harness.write_file(file_name, "before\r\n").await?;
+    let patch = format!(
+        "*** Begin Patch\n*** Update File: {file_name}\n@@\n-before\n+after\n*** End Patch\n"
+    );
+    mount_apply_patch(&harness, call_id, &patch, "apply_patch done").await;
+
+    harness
+        .test()
+        .submit_turn_with_permission_profile(
+            "update the CRLF file with apply_patch",
+            PermissionProfile::Disabled,
+        )
+        .await?;
+
+    assert_eq!(harness.read_file_text(file_name).await?, expected);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn apply_patch_normalizes_crlf_without_preserve_line_endings_feature() -> Result<()> {
+    assert_apply_patch_crlf_update(|builder| builder, "after\n").await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn apply_patch_preserves_crlf_with_preserve_line_endings_feature() -> Result<()> {
+    assert_apply_patch_crlf_update(
+        |builder| {
+            builder.with_config(|config| {
+                config
+                    .features
+                    .enable(Feature::ApplyPatchPreserveLineEndings)
+                    .expect("feature should be enabled");
+            })
+        },
+        "after\r\n",
+    )
+    .await
+}
+
 #[cfg(target_os = "linux")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn apply_patch_cli_uses_codex_self_exe_with_linux_sandbox_helper_alias() -> Result<()> {

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -112,6 +112,8 @@ pub enum Feature {
     TerminalVisualizationInstructions,
     /// Stream structured progress while apply_patch input is being generated.
     ApplyPatchStreamingEvents,
+    /// Preserve existing line endings when apply_patch updates files.
+    ApplyPatchPreserveLineEndings,
     /// Allow exec tools to request additional permissions while staying sandboxed.
     ExecPermissionApprovals,
     /// Expose the built-in request_permissions tool.
@@ -951,6 +953,12 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::ApplyPatchStreamingEvents,
         key: "apply_patch_streaming_events",
+        stage: Stage::UnderDevelopment,
+        default_enabled: false,
+    },
+    FeatureSpec {
+        id: Feature::ApplyPatchPreserveLineEndings,
+        key: "apply_patch_preserve_line_endings",
         stage: Stage::UnderDevelopment,
         default_enabled: false,
     },


### PR DESCRIPTION
## Summary

- add line-ending preservation behind the new `apply_patch_preserve_line_endings` feature flag, which is under development and disabled by default
- when enabled, preserve each untouched source line's existing LF, CRLF, or CR terminator and use the first detected source terminator for inserted and replaced lines, defaulting to LF when the file has none
- propagate the selected behavior consistently through in-process `apply_patch`, arg0-dispatched helpers, classic and unified shell execution, remote exec, and shell snapshots
- retain parsed context-line identity so repeated or fuzzily matched lines preserve the correct source occurrence
- rebuild updated files from sorted replacement ranges in one forward pass

## Rollout

This change is feature flagged for a controlled rollout. The feature is disabled by default, so an unset or false flag retains the existing behavior of normalizing updated files to LF. Enable preservation with:

```toml
[features]
apply_patch_preserve_line_endings = true
```

Codex resolves the feature state for in-process tool calls and carries it into helper processes as runtime-owned state. Remote environment policies and shell snapshots cannot inherit or resurrect a stale enabled value. End-to-end agent coverage verifies both the default normalization behavior and preservation when the feature is enabled through an actual tool call.

## Why

`apply_patch` currently splits source contents on `\n`, which leaves `\r` attached to existing CRLF lines, while replacement lines parsed from the patch contain no `\r`. Joining the result with `\n` therefore preserves CRLF on untouched lines but emits LF on changed lines, producing mixed-ending files.

The previous fix in [#7515](https://github.com/openai/codex/pull/7515) intentionally applied only to Windows. It stripped terminators with `str::lines`, classified the entire file as CRLF only when every newline was CRLF, and then regenerated the whole file with one separator. That fixed uniform CRLF files, but it coupled behavior to the host OS and normalized mixed-ending files instead of preserving untouched source. The change was reverted wholesale by [#7903](https://github.com/openai/codex/pull/7903), leaving the original split/join behavior in place.

## Design

This follows the line-ending design we use in Ruff. Ruff's [universal newline model](https://github.com/astral-sh/ruff/blob/675a38bc06f44477ce971d61f19ccbcc447e1d90/crates/ruff_source_file/src/newlines.rs#L56-L70) recognizes LF, CRLF, and CR and exposes the [actual terminator for each source line](https://github.com/astral-sh/ruff/blob/675a38bc06f44477ce971d61f19ccbcc447e1d90/crates/ruff_source_file/src/newlines.rs#L239-L263). Ruff's [`LineEnding::Auto`](https://github.com/astral-sh/ruff/blob/675a38bc06f44477ce971d61f19ccbcc447e1d90/crates/ruff_workspace/src/settings.rs#L214-L232) uses the first detected newline as the preferred style and defaults to LF.

`SourceFile` applies the same preferred-style rule for new text while remaining more conservative than a formatter: untouched lines retain their exact original terminators, including in mixed-ending files. The patch parser also records which old/new line pairs were context rather than trying to infer equality after parsing. Replacement ranges can then exclude those exact context lines, even when adjacent changed lines have identical text or matching required whitespace normalization.

Closes https://github.com/openai/codex/issues/4003.
