### PR TITLE
Fix inherited availability metadata for Bedrock models

### DIFF
--- a/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
+++ b/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
@@ -61,6 +61,8 @@ fn gpt_5_bedrock_model(openai_slug: &str, bedrock_slug: &str, priority: i32) -> 
     model.priority = priority;
     model.context_window = Some(GPT_5_BEDROCK_CONTEXT_WINDOW);
     model.max_context_window = Some(GPT_5_BEDROCK_CONTEXT_WINDOW);
+    model.availability_nux = None;
+    model.upgrade = None;
     model
 }
 
@@ -124,6 +126,15 @@ mod tests {
                     Some(GPT_5_BEDROCK_CONTEXT_WINDOW)
                 )
             );
+        }
+    }
+
+    #[test]
+    fn gpt_5_bedrock_models_do_not_include_availability_nux_or_upgrade() {
+        let catalog = static_model_catalog();
+
+        for model in catalog.models {
+            assert_eq!((model.availability_nux, model.upgrade), (None, None));
         }
     }
 


### PR DESCRIPTION
## Why

Amazon Bedrock's static catalog derives its GPT model definitions from bundled OpenAI model metadata. The GPT-5.6 variants introduced in #30285 clone GPT-5.5, which carries an `availability_nux`; because app-server forwards that metadata through `model/list`, clients can show GPT-5.5 launch copy for a GPT-5.6 Bedrock model.

`upgrade` is also model-catalog availability metadata and should not be inherited by provider-specific Bedrock models.

## What changed

- Clear `availability_nux` and `upgrade` when constructing static Bedrock GPT models.
- Add a regression test asserting that every static Bedrock model omits both fields.

## Testing

- `just test -p codex-model-provider`
