### PR TITLE
[codex] telemetry: narrow structured tool call timing

### DIFF
--- a/codex-rs/app-server/tests/suite/logging.rs
+++ b/codex-rs/app-server/tests/suite/logging.rs
@@ -47,7 +47,7 @@ fn standalone_app_server_emits_json_info_events() -> Result<()> {
 }
 
 #[tokio::test]
-async fn app_server_emits_structured_tool_timing_events() -> Result<()> {
+async fn app_server_emits_structured_tool_call_timing_event() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = create_mock_responses_server_sequence(vec![
@@ -70,12 +70,7 @@ async fn app_server_emits_structured_tool_timing_events() -> Result<()> {
         codex_home.path(),
         &[
             ("LOG_FORMAT", Some("json")),
-            (
-                "RUST_LOG",
-                Some(
-                    "warn,codex_core::tools::parallel=info,codex_core::turn_timing=info,codex_otel.log_only=info",
-                ),
-            ),
+            ("RUST_LOG", Some("warn,codex_core::tools::parallel=info")),
         ],
     )
     .await?;
@@ -149,57 +144,6 @@ async fn app_server_emits_structured_tool_timing_events() -> Result<()> {
         (0.0..=1.0).contains(&truncation_delta),
         "dispatch and handler durations must account for total duration within integer truncation: {tool_call}"
     );
-
-    let tool_result = app_server
-        .wait_for_json_log_event("codex.tool_result")
-        .await?;
-    assert_eq!(tool_result["level"], "INFO");
-    assert_eq!(tool_result["target"], "codex_otel.log_only");
-    assert!(tool_result["fields"]["trace_id"].is_string());
-    assert_eq!(tool_result["fields"]["conversation.id"], thread.id);
-    assert_eq!(tool_result["fields"]["turn_id"], turn.id);
-    assert_eq!(tool_result["fields"]["tool_name"], "exec_command");
-    assert_eq!(tool_result["fields"]["call_id"], "exec-call-1");
-    assert_eq!(tool_result["fields"]["tool_source"], "direct");
-    assert!(
-        matches!(
-            tool_result["fields"]["success"].as_str(),
-            Some("true" | "false")
-        ),
-        "success must be a boolean string: {tool_result}"
-    );
-    assert!(
-        tool_result["fields"]["duration_ms"]
-            .as_str()
-            .is_some_and(|duration_ms| duration_ms.parse::<u128>().is_ok()),
-        "duration_ms must retain its pre-existing integer-string schema: {tool_result}"
-    );
-
-    let inferences = app_server
-        .wait_for_json_log_events("codex.inference", /*count*/ 2)
-        .await?;
-    assert_eq!(
-        inferences
-            .iter()
-            .map(|event| event["fields"]["inference_index"].as_u64())
-            .collect::<Vec<_>>(),
-        vec![Some(1), Some(2)]
-    );
-    for inference in inferences {
-        assert_eq!(inference["level"], "INFO");
-        assert_eq!(inference["target"], "codex_core::turn_timing");
-        assert_eq!(inference["fields"]["message"], "inference completed");
-        assert!(inference["fields"]["trace_id"].is_string());
-        assert_eq!(inference["fields"]["conversation.id"], thread.id);
-        assert_eq!(inference["fields"]["turn_id"], turn.id);
-        assert_eq!(inference["fields"]["model"], "mock-model");
-        assert_eq!(
-            inference["fields"]["provider_name"],
-            "Mock provider for test"
-        );
-        assert_eq!(inference["fields"]["result"], "success");
-        assert_nonnegative_duration_fields(&inference, &["duration_ms"]);
-    }
 
     Ok(())
 }

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -65,7 +65,6 @@ use crate::tools::router::extension_tool_executors;
 use crate::tools::spec_plan::search_tool_enabled;
 use crate::tools::spec_plan::tool_suggest_enabled;
 use crate::turn_diff_tracker::TurnDiffTracker;
-use crate::turn_timing::InferenceTimingResult;
 use crate::turn_timing::record_turn_ttft_metric;
 use crate::util::error_or_panic;
 use codex_analytics::AppInvocation;
@@ -1904,19 +1903,13 @@ async fn try_run_sampling_request(
         auth_mode = sess.services.auth_manager.auth_mode(),
         features = sess.features.enabled_features(),
     );
-    let provider_info = turn_context.provider.info();
     let inference_trace = sess.services.rollout_thread_trace.inference_trace_context(
         turn_context.sub_id.as_str(),
         turn_context.model_info.slug.as_str(),
-        provider_info.name.as_str(),
+        turn_context.provider.info().name.as_str(),
     );
-    let sampling_timing_guard = turn_context.turn_timing_state.begin_sampling(
-        &sess.thread_id,
-        &turn_context.sub_id,
-        &turn_context.model_info.slug,
-        &provider_info.name,
-    );
-    let stream_result = client_session
+    let sampling_timing_guard = turn_context.turn_timing_state.begin_sampling();
+    let mut stream = client_session
         .stream(
             prompt,
             &turn_context.model_info,
@@ -1929,18 +1922,7 @@ async fn try_run_sampling_request(
         )
         .instrument(trace_span!("stream_request"))
         .or_cancel(&cancellation_token)
-        .await;
-    let mut stream = match stream_result {
-        Ok(Ok(stream)) => stream,
-        Ok(Err(err)) => {
-            sampling_timing_guard.finish_inference(InferenceTimingResult::Error);
-            return Err(err);
-        }
-        Err(codex_async_utils::CancelErr::Cancelled) => {
-            sampling_timing_guard.finish_inference(InferenceTimingResult::Cancelled);
-            return Err(CodexErr::TurnAborted);
-        }
-    };
+        .await??;
     let mut in_flight: FuturesOrdered<BoxFuture<'static, CodexResult<ResponseInputItem>>> =
         FuturesOrdered::new();
     let mut needs_follow_up = false;
@@ -2364,11 +2346,7 @@ async fn try_run_sampling_request(
             }
         }
     };
-    sampling_timing_guard.finish_inference(match &outcome {
-        Ok(_) => InferenceTimingResult::Success,
-        Err(CodexErr::TurnAborted) => InferenceTimingResult::Cancelled,
-        Err(_) => InferenceTimingResult::Error,
-    });
+    drop(sampling_timing_guard);
 
     flush_assistant_text_segments_all(
         &sess,

--- a/codex-rs/core/src/tools/parallel.rs
+++ b/codex-rs/core/src/tools/parallel.rs
@@ -283,6 +283,13 @@ impl ToolCallTimingGuard {
 impl Drop for ToolCallTimingGuard {
     fn drop(&mut self) {
         let completed_at = Instant::now();
+        // Snapshot once so a concurrently-starting dispatch cannot make one
+        // event internally inconsistent.
+        let execution_started_at = self
+            .execution_started_at
+            .get()
+            .copied()
+            .filter(|execution_started_at| *execution_started_at <= completed_at);
         info!(
             event.name = "codex.tool_call",
             trace_id = %codex_otel::current_span_trace_id().unwrap_or_default(),
@@ -293,18 +300,18 @@ impl Drop for ToolCallTimingGuard {
             tool_source = "direct",
             code_mode_cell_id = "",
             code_mode_runtime_tool_call_id = "",
-            execution_started = self.execution_started_at.get().is_some(),
-            dispatch_duration_ms = self.execution_started_at.get().map_or_else(
+            execution_started = execution_started_at.is_some(),
+            dispatch_duration_ms = execution_started_at.map_or_else(
                 || u64::try_from(completed_at.duration_since(self.started_at).as_millis()).unwrap_or(u64::MAX),
                 |execution_started_at| {
                     u64::try_from(execution_started_at.duration_since(self.started_at).as_millis())
                         .unwrap_or(u64::MAX)
                 },
             ),
-            handler_duration_ms = self.execution_started_at.get().map_or(
+            handler_duration_ms = execution_started_at.map_or(
                 0,
                 |execution_started_at| {
-                    u64::try_from(completed_at.duration_since(*execution_started_at).as_millis())
+                    u64::try_from(completed_at.duration_since(execution_started_at).as_millis())
                         .unwrap_or(u64::MAX)
                 },
             ),

--- a/codex-rs/core/src/tools/parallel.rs
+++ b/codex-rs/core/src/tools/parallel.rs
@@ -36,7 +36,6 @@ struct ToolCallTimingGuard {
     turn_id: String,
     call_id: String,
     tool_name: codex_tools::ToolName,
-    source: ToolCallSource,
 }
 
 #[derive(Clone)]
@@ -266,7 +265,7 @@ impl ToolCallTimingGuard {
         call: &ToolCall,
         source: &ToolCallSource,
     ) -> Option<Self> {
-        if !tracing::enabled!(tracing::Level::INFO) {
+        if !matches!(source, ToolCallSource::Direct) || !tracing::enabled!(tracing::Level::INFO) {
             return None;
         }
 
@@ -277,7 +276,6 @@ impl ToolCallTimingGuard {
             turn_id: turn_id.to_string(),
             call_id: call.call_id.clone(),
             tool_name: call.tool_name.clone(),
-            source: source.clone(),
         })
     }
 }
@@ -292,18 +290,9 @@ impl Drop for ToolCallTimingGuard {
             turn_id = %self.turn_id,
             tool_name = %self.tool_name,
             call_id = %self.call_id,
-            tool_source = match &self.source {
-                ToolCallSource::Direct => "direct",
-                ToolCallSource::CodeMode { .. } => "code_mode",
-            },
-            code_mode_cell_id = match &self.source {
-                ToolCallSource::Direct => "",
-                ToolCallSource::CodeMode { cell_id, .. } => cell_id.as_str(),
-            },
-            code_mode_runtime_tool_call_id = match &self.source {
-                ToolCallSource::Direct => "",
-                ToolCallSource::CodeMode { runtime_tool_call_id, .. } => runtime_tool_call_id.as_str(),
-            },
+            tool_source = "direct",
+            code_mode_cell_id = "",
+            code_mode_runtime_tool_call_id = "",
             execution_started = self.execution_started_at.get().is_some(),
             dispatch_duration_ms = self.execution_started_at.get().map_or_else(
                 || u64::try_from(completed_at.duration_since(self.started_at).as_millis()).unwrap_or(u64::MAX),
@@ -344,6 +333,43 @@ mod tests {
     use pretty_assertions::assert_eq;
     use tokio::sync::Notify;
     use tokio::sync::oneshot;
+
+    #[test]
+    fn tool_call_timing_guard_ignores_code_mode_source() {
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::INFO)
+            .finish();
+        tracing::subscriber::with_default(subscriber, || {
+            let call = ToolCall {
+                tool_name: codex_tools::ToolName::plain("test_tool"),
+                call_id: "call-1".to_string(),
+                payload: ToolPayload::Function {
+                    arguments: "{}".to_string(),
+                },
+            };
+            let direct_guard = ToolCallTimingGuard::capture(
+                Instant::now(),
+                &"conversation-id",
+                "turn-id",
+                &call,
+                &ToolCallSource::Direct,
+            );
+            assert!(direct_guard.is_some());
+            drop(direct_guard);
+
+            let code_mode_guard = ToolCallTimingGuard::capture(
+                Instant::now(),
+                &"conversation-id",
+                "turn-id",
+                &call,
+                &ToolCallSource::CodeMode {
+                    cell_id: "cell-1".to_string(),
+                    runtime_tool_call_id: "runtime-call-1".to_string(),
+                },
+            );
+            assert!(code_mode_guard.is_none());
+        });
+    }
 
     struct ImmediateHandler {
         tool_name: codex_tools::ToolName,

--- a/codex-rs/core/src/tools/registry.rs
+++ b/codex-rs/core/src/tools/registry.rs
@@ -14,7 +14,6 @@ use crate::sandbox_tags::permission_profile_policy_tag;
 use crate::sandbox_tags::permission_profile_sandbox_tag;
 use crate::session::turn_context::TurnContext;
 use crate::tools::context::FunctionToolOutput;
-use crate::tools::context::ToolCallSource;
 use crate::tools::context::ToolInvocation;
 use crate::tools::context::ToolOutput;
 use crate::tools::context::ToolPayload;
@@ -445,8 +444,6 @@ impl ToolRegistry {
             None => {
                 let message = unsupported_tool_call_message(&invocation.payload, &tool_name);
                 let log_payload = invocation.payload.log_payload();
-                let extra_trace_fields =
-                    tool_result_trace_fields(&invocation.turn.sub_id, &invocation.source, "", "");
                 otel.tool_result_with_tags(
                     tool_name_flat.as_ref(),
                     &call_id_owned,
@@ -455,7 +452,7 @@ impl ToolRegistry {
                     /*success*/ false,
                     &message,
                     &base_tool_result_tags,
-                    &extra_trace_fields,
+                    /*extra_trace_fields*/ &[],
                 );
                 let err = FunctionCallError::RespondToModel(message);
                 dispatch_trace.record_failed(&err);
@@ -466,25 +463,18 @@ impl ToolRegistry {
         let telemetry_tags = tool.telemetry_tags(&invocation).await;
         let mut tool_result_tags =
             Vec::with_capacity(base_tool_result_tags.len() + telemetry_tags.len());
-        let mut mcp_server = "";
-        let mut mcp_server_origin = "";
+        let mut extra_trace_fields = Vec::new();
         tool_result_tags.extend_from_slice(&base_tool_result_tags);
         for (key, value) in &telemetry_tags {
-            match *key {
-                "mcp_server" => mcp_server = value.as_str(),
-                "mcp_server_origin" => mcp_server_origin = value.as_str(),
-                _ => tool_result_tags.push((*key, value.as_str())),
+            if matches!(*key, "mcp_server" | "mcp_server_origin") {
+                extra_trace_fields.push((*key, value.as_str()));
+            } else {
+                tool_result_tags.push((*key, value.as_str()));
             }
         }
         if !tool.matches_kind(&invocation.payload) {
             let message = format!("tool {tool_name} invoked with incompatible payload");
             let log_payload = invocation.payload.log_payload();
-            let extra_trace_fields = tool_result_trace_fields(
-                &invocation.turn.sub_id,
-                &invocation.source,
-                mcp_server,
-                mcp_server_origin,
-            );
             otel.tool_result_with_tags(
                 tool_name_flat.as_ref(),
                 &call_id_owned,
@@ -551,12 +541,6 @@ impl ToolRegistry {
         let response_cell = tokio::sync::Mutex::new(None);
         let invocation_for_tool = invocation.clone();
         let log_payload = invocation.payload.log_payload();
-        let extra_trace_fields = tool_result_trace_fields(
-            &invocation.turn.sub_id,
-            &invocation.source,
-            mcp_server,
-            mcp_server_origin,
-        );
 
         let result = otel
             .log_tool_result_with_tags(
@@ -684,32 +668,6 @@ impl ToolRegistry {
             }
         }
     }
-}
-
-fn tool_result_trace_fields<'a>(
-    turn_id: &'a str,
-    source: &'a ToolCallSource,
-    mcp_server: &'a str,
-    mcp_server_origin: &'a str,
-) -> [(&'static str, &'a str); 6] {
-    let (tool_source, code_mode_cell_id, code_mode_runtime_tool_call_id) = match source {
-        ToolCallSource::Direct => ("direct", "", ""),
-        ToolCallSource::CodeMode {
-            cell_id,
-            runtime_tool_call_id,
-        } => ("code_mode", cell_id.as_str(), runtime_tool_call_id.as_str()),
-    };
-    [
-        ("turn_id", turn_id),
-        ("tool_source", tool_source),
-        ("code_mode_cell_id", code_mode_cell_id),
-        (
-            "code_mode_runtime_tool_call_id",
-            code_mode_runtime_tool_call_id,
-        ),
-        ("mcp_server", mcp_server),
-        ("mcp_server_origin", mcp_server_origin),
-    ]
 }
 
 async fn notify_tool_finish_if_unclaimed(

--- a/codex-rs/core/src/turn_timing.rs
+++ b/codex-rs/core/src/turn_timing.rs
@@ -10,7 +10,6 @@ use codex_otel::TURN_TTFM_DURATION_METRIC;
 use codex_protocol::items::TurnItem;
 use codex_protocol::models::ResponseItem;
 use tokio::sync::Mutex;
-use tracing::info;
 
 use crate::ResponseEvent;
 use crate::session::turn_context::TurnContext;
@@ -81,25 +80,6 @@ pub(crate) struct TurnProfileTimingGuard {
     timing: Arc<TurnTimingState>,
     phase: TurnProfilePhase,
     active: bool,
-    inference_log_context: Option<InferenceLogContext>,
-}
-
-#[derive(Clone, Copy)]
-pub(crate) enum InferenceTimingResult {
-    Success,
-    Cancelled,
-    Error,
-}
-
-struct InferenceLogContext {
-    started_at: Instant,
-    conversation_id: String,
-    turn_id: String,
-    model: String,
-    provider_name: String,
-    trace_id: String,
-    inference_index: u32,
-    result: InferenceTimingResult,
 }
 
 impl TurnTimingState {
@@ -138,35 +118,12 @@ impl TurnTimingState {
         self.profile_state().complete(Instant::now())
     }
 
-    pub(crate) fn begin_sampling(
-        self: &Arc<Self>,
-        conversation_id: &impl std::fmt::Display,
-        turn_id: &str,
-        model: &str,
-        provider_name: &str,
-    ) -> TurnProfileTimingGuard {
-        let started_at = Instant::now();
-        let inference_index = self.profile_state().begin_sampling(started_at);
-        let active = inference_index.is_some();
-        let inference_log_context = if tracing::enabled!(tracing::Level::INFO) {
-            inference_index.map(|inference_index| InferenceLogContext {
-                started_at,
-                conversation_id: conversation_id.to_string(),
-                turn_id: turn_id.to_string(),
-                model: model.to_string(),
-                provider_name: provider_name.to_string(),
-                trace_id: codex_otel::current_span_trace_id().unwrap_or_default(),
-                inference_index,
-                result: InferenceTimingResult::Error,
-            })
-        } else {
-            None
-        };
+    pub(crate) fn begin_sampling(self: &Arc<Self>) -> TurnProfileTimingGuard {
+        let active = self.profile_state().begin_sampling(Instant::now());
         TurnProfileTimingGuard {
             timing: Arc::clone(self),
             phase: TurnProfilePhase::Sampling,
             active,
-            inference_log_context,
         }
     }
 
@@ -180,7 +137,6 @@ impl TurnTimingState {
             timing: Arc::clone(self),
             phase: TurnProfilePhase::ToolBlocking,
             active,
-            inference_log_context: None,
         }
     }
 
@@ -210,39 +166,12 @@ impl TurnTimingState {
     }
 }
 
-impl TurnProfileTimingGuard {
-    pub(crate) fn finish_inference(mut self, result: InferenceTimingResult) {
-        if let Some(log_context) = &mut self.inference_log_context {
-            log_context.result = result;
-        }
-    }
-}
-
 impl Drop for TurnProfileTimingGuard {
     fn drop(&mut self) {
         if self.active {
             self.timing
                 .profile_state()
                 .end_phase(Instant::now(), self.phase);
-        }
-        if let Some(log_context) = &self.inference_log_context {
-            info!(
-                event.name = "codex.inference",
-                trace_id = %log_context.trace_id,
-                conversation.id = %log_context.conversation_id,
-                turn_id = %log_context.turn_id,
-                model = %log_context.model,
-                provider_name = %log_context.provider_name,
-                inference_index = log_context.inference_index,
-                result = match log_context.result {
-                    InferenceTimingResult::Success => "success",
-                    InferenceTimingResult::Cancelled => "cancelled",
-                    InferenceTimingResult::Error => "error",
-                },
-                duration_ms = u64::try_from(log_context.started_at.elapsed().as_millis())
-                    .unwrap_or(u64::MAX),
-                "inference completed"
-            );
         }
     }
 }
@@ -271,12 +200,12 @@ impl TurnProfileState {
         };
     }
 
-    fn begin_sampling(&mut self, now: Instant) -> Option<u32> {
+    fn begin_sampling(&mut self, now: Instant) -> bool {
         if self.completed_profile.is_some()
             || self.started_at.is_none()
             || self.active_phase.is_some()
         {
-            return None;
+            return false;
         }
         self.advance(now);
         if self.seen_sampling {
@@ -285,7 +214,7 @@ impl TurnProfileState {
         self.seen_sampling = true;
         self.active_phase = Some(TurnProfilePhase::Sampling);
         self.sampling_request_count = self.sampling_request_count.saturating_add(1);
-        Some(self.sampling_request_count)
+        true
     }
 
     fn record_sampling_retry(&mut self) {

--- a/codex-rs/otel/src/events/session_telemetry.rs
+++ b/codex-rs/otel/src/events/session_telemetry.rs
@@ -1062,14 +1062,7 @@ impl SessionTelemetry {
         log_event!(
             self,
             event.name = "codex.tool_result",
-            trace_id = %crate::current_span_trace_id().unwrap_or_default(),
-            turn_id = "",
             tool_name = %tool_name,
-            call_id = "",
-            tool_source = "",
-            code_mode_cell_id = "",
-            code_mode_runtime_tool_call_id = "",
-            arguments = "",
             duration_ms = %Duration::ZERO.as_millis(),
             success = %false,
             output = %error,
@@ -1079,13 +1072,7 @@ impl SessionTelemetry {
         trace_event!(
             self,
             event.name = "codex.tool_result",
-            trace_id = %crate::current_span_trace_id().unwrap_or_default(),
-            turn_id = "",
             tool_name = %tool_name,
-            call_id = "",
-            tool_source = "",
-            code_mode_cell_id = "",
-            code_mode_runtime_tool_call_id = "",
             duration_ms = %Duration::ZERO.as_millis(),
             success = %false,
             output_length = error.len() as i64,
@@ -1114,40 +1101,33 @@ impl SessionTelemetry {
         tags.extend_from_slice(extra_tags);
         self.counter(TOOL_CALL_COUNT_METRIC, /*inc*/ 1, &tags);
         self.record_duration(TOOL_CALL_DURATION_METRIC, duration, &tags);
+        let mcp_server = trace_field_value(extra_trace_fields, "mcp_server").unwrap_or("");
+        let mcp_server_origin =
+            trace_field_value(extra_trace_fields, "mcp_server_origin").unwrap_or("");
         log_event!(
             self,
             event.name = "codex.tool_result",
-            trace_id = %crate::current_span_trace_id().unwrap_or_default(),
-            turn_id = %trace_field_value(extra_trace_fields, "turn_id").unwrap_or(""),
             tool_name = %tool_name,
             call_id = %call_id,
-            tool_source = %trace_field_value(extra_trace_fields, "tool_source").unwrap_or(""),
-            code_mode_cell_id = %trace_field_value(extra_trace_fields, "code_mode_cell_id").unwrap_or(""),
-            code_mode_runtime_tool_call_id = %trace_field_value(extra_trace_fields, "code_mode_runtime_tool_call_id").unwrap_or(""),
             arguments = %arguments,
             duration_ms = %duration.as_millis(),
             success = %success_str,
             output = %output,
-            mcp_server = %trace_field_value(extra_trace_fields, "mcp_server").unwrap_or(""),
-            mcp_server_origin = %trace_field_value(extra_trace_fields, "mcp_server_origin").unwrap_or(""),
+            mcp_server = %mcp_server,
+            mcp_server_origin = %mcp_server_origin,
         );
         trace_event!(
             self,
             event.name = "codex.tool_result",
-            trace_id = %crate::current_span_trace_id().unwrap_or_default(),
-            turn_id = %trace_field_value(extra_trace_fields, "turn_id").unwrap_or(""),
             tool_name = %tool_name,
             call_id = %call_id,
-            tool_source = %trace_field_value(extra_trace_fields, "tool_source").unwrap_or(""),
-            code_mode_cell_id = %trace_field_value(extra_trace_fields, "code_mode_cell_id").unwrap_or(""),
-            code_mode_runtime_tool_call_id = %trace_field_value(extra_trace_fields, "code_mode_runtime_tool_call_id").unwrap_or(""),
             duration_ms = %duration.as_millis(),
             success = %success_str,
             arguments_length = arguments.len() as i64,
             output_length = output.len() as i64,
             output_line_count = output.lines().count() as i64,
-            tool_origin = if trace_field_value(extra_trace_fields, "mcp_server").unwrap_or("").is_empty() { "builtin" } else { "mcp" },
-            mcp_tool = !trace_field_value(extra_trace_fields, "mcp_server").unwrap_or("").is_empty(),
+            tool_origin = if mcp_server.is_empty() { "builtin" } else { "mcp" },
+            mcp_tool = !mcp_server.is_empty(),
         );
     }
 

--- a/codex-rs/otel/tests/suite/otel_export_routing_policy.rs
+++ b/codex-rs/otel/tests/suite/otel_export_routing_policy.rs
@@ -255,10 +255,6 @@ fn otel_export_routing_policy_routes_tool_result_log_and_trace_events() {
             &[
                 ("mcp_server", "internal-mcp"),
                 ("mcp_server_origin", "stdio"),
-                ("turn_id", "turn-1"),
-                ("tool_source", "code_mode"),
-                ("code_mode_cell_id", "cell-1"),
-                ("code_mode_runtime_tool_call_id", "runtime-call-1"),
             ],
         );
     });
@@ -290,29 +286,6 @@ fn otel_export_routing_policy_routes_tool_result_log_and_trace_events() {
         tool_log_attrs.get("mcp_server_origin").map(String::as_str),
         Some("stdio")
     );
-    assert_eq!(
-        tool_log_attrs.get("turn_id").map(String::as_str),
-        Some("turn-1")
-    );
-    assert_eq!(
-        tool_log_attrs.get("tool_source").map(String::as_str),
-        Some("code_mode")
-    );
-    assert_eq!(
-        tool_log_attrs.get("code_mode_cell_id").map(String::as_str),
-        Some("cell-1")
-    );
-    assert_eq!(
-        tool_log_attrs
-            .get("code_mode_runtime_tool_call_id")
-            .map(String::as_str),
-        Some("runtime-call-1")
-    );
-    assert_eq!(
-        tool_log_attrs.get("duration_ms").map(String::as_str),
-        Some("42")
-    );
-    assert!(tool_log_attrs.contains_key("trace_id"));
 
     let spans = span_exporter.get_finished_spans().expect("span export");
     assert_eq!(spans.len(), 1);


### PR DESCRIPTION
## Summary

- restore the existing `codex.tool_result` behavior and remove the added `codex.inference` event
- emit `codex.tool_call` timing events only for direct tool calls
- snapshot the execution-start marker once when emitting `codex.tool_call` so a concurrent dispatch start cannot produce internally inconsistent timing fields

## Why

This keeps the stacked change focused on direct tool-call timing without expanding result or inference telemetry. The timing-marker fix addresses repeated reads of the marker during event emission, which could otherwise observe different states if dispatch begins concurrently.

## Validation

- `just fmt`
- `git diff --check HEAD~3..HEAD`
- `just test -p codex-core tool_call_timing_guard_ignores_code_mode_source`
- `just test -p codex-app-server app_server_emits_structured_tool_call_timing_event`
- `just test -p codex-otel otel_export_routing_policy_routes_tool_result_log_and_trace_events`

I also attempted `just test -p codex-core -p codex-otel -p codex-app-server`; that broader run was not completed after multiple app-server tests timed out.
