### PR TITLE
[core] Drop parent MCP lifecycle events from forked agent history

### DIFF
--- a/codex-rs/core/src/agent/control/spawn.rs
+++ b/codex-rs/core/src/agent/control/spawn.rs
@@ -1,6 +1,7 @@
 use super::residency::is_v2_resident_session_source;
 use super::*;
 use codex_extension_api::ExtensionDataInit;
+use codex_protocol::protocol::EventMsg;
 
 const AGENT_NAMES: &str = include_str!("../agent_names.txt");
 
@@ -70,6 +71,9 @@ fn keep_forked_rollout_item(item: &RolloutItem, preserve_reference_context_item:
         ) => false,
         RolloutItem::InterAgentCommunication(_)
         | RolloutItem::InterAgentCommunicationMetadata { .. } => false,
+        // MCP lifecycle events are parent-only UI state, and tool results can be arbitrarily
+        // large. Drop both halves so legacy rollouts cannot leave an unmatched in-progress call.
+        RolloutItem::EventMsg(EventMsg::McpToolCallBegin(_) | EventMsg::McpToolCallEnd(_)) => false,
         // Full-history forks preserve the cached prompt prefix and can keep diffing
         // from the parent's durable baseline. Truncated forks drop part of that prompt,
         // so they must rebuild context on their first child turn.
@@ -764,5 +768,66 @@ impl AgentControl {
         .await;
 
         Ok((resumed_thread.thread_id, multi_agent_version))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codex_protocol::protocol::McpInvocation;
+    use codex_protocol::protocol::McpToolCallBeginEvent;
+    use codex_protocol::protocol::McpToolCallEndEvent;
+    use std::time::Duration;
+
+    fn test_mcp_invocation() -> McpInvocation {
+        McpInvocation {
+            server: "parent-server".to_string(),
+            tool: "parent-tool".to_string(),
+            arguments: Some(serde_json::json!({"input": "parent-only"})),
+        }
+    }
+
+    fn test_mcp_tool_call_begin_event() -> McpToolCallBeginEvent {
+        McpToolCallBeginEvent {
+            call_id: "parent-mcp-call".to_string(),
+            invocation: test_mcp_invocation(),
+            connector_id: None,
+            mcp_app_resource_uri: None,
+            link_id: None,
+            app_name: None,
+            template_id: None,
+            action_name: None,
+            plugin_id: None,
+        }
+    }
+
+    fn test_mcp_tool_call_end_event() -> McpToolCallEndEvent {
+        McpToolCallEndEvent {
+            call_id: "parent-mcp-call".to_string(),
+            invocation: test_mcp_invocation(),
+            connector_id: None,
+            mcp_app_resource_uri: None,
+            link_id: None,
+            app_name: None,
+            template_id: None,
+            action_name: None,
+            plugin_id: None,
+            duration: Duration::from_millis(1),
+            result: Err("parent-only result".to_string()),
+        }
+    }
+
+    #[test]
+    fn forked_rollout_item_filter_drops_mcp_tool_call_lifecycle() {
+        let items = [
+            RolloutItem::EventMsg(EventMsg::McpToolCallBegin(test_mcp_tool_call_begin_event())),
+            RolloutItem::EventMsg(EventMsg::McpToolCallEnd(test_mcp_tool_call_end_event())),
+        ];
+
+        for item in &items {
+            assert!(!keep_forked_rollout_item(
+                item, /*preserve_reference_context_item*/ true,
+            ));
+        }
     }
 }

--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -30,6 +30,8 @@ use codex_protocol::protocol::ErrorEvent;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::InitialHistory;
 use codex_protocol::protocol::InterAgentCommunication;
+use codex_protocol::protocol::McpInvocation;
+use codex_protocol::protocol::McpToolCallEndEvent;
 use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SubAgentSource;
@@ -104,6 +106,39 @@ fn spawn_agent_call(call_id: &str) -> ResponseItem {
         call_id: call_id.to_string(),
         internal_chat_message_metadata_passthrough: None,
     }
+}
+
+fn test_mcp_invocation() -> McpInvocation {
+    McpInvocation {
+        server: "parent-server".to_string(),
+        tool: "parent-tool".to_string(),
+        arguments: Some(serde_json::json!({"input": "parent-only"})),
+    }
+}
+
+fn test_mcp_tool_call_end_event() -> McpToolCallEndEvent {
+    McpToolCallEndEvent {
+        call_id: "parent-mcp-call".to_string(),
+        invocation: test_mcp_invocation(),
+        connector_id: None,
+        mcp_app_resource_uri: None,
+        link_id: None,
+        app_name: None,
+        template_id: None,
+        action_name: None,
+        plugin_id: None,
+        duration: Duration::from_millis(1),
+        result: Err("parent-only result".to_string()),
+    }
+}
+
+fn contains_mcp_tool_call_lifecycle_event(items: &[RolloutItem]) -> bool {
+    items.iter().any(|item| {
+        matches!(
+            item,
+            RolloutItem::EventMsg(EventMsg::McpToolCallBegin(_) | EventMsg::McpToolCallEnd(_))
+        )
+    })
 }
 
 struct AgentControlHarness {
@@ -987,9 +1022,10 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
     parent_thread
         .codex
         .session
-        .persist_rollout_items(&[RolloutItem::TurnContext(
-            parent_reference_context_item.clone(),
-        )])
+        .persist_rollout_items(&[
+            RolloutItem::TurnContext(parent_reference_context_item.clone()),
+            RolloutItem::EventMsg(EventMsg::McpToolCallEnd(test_mcp_tool_call_end_event())),
+        ])
         .await;
     parent_thread
         .codex
@@ -1002,6 +1038,21 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
         .flush_rollout()
         .await
         .expect("parent rollout should flush");
+    let persisted_parent = parent_thread
+        .read_thread(
+            /*include_archived*/ true, /*include_history*/ true,
+        )
+        .await
+        .expect("parent thread should be readable");
+    assert!(
+        contains_mcp_tool_call_lifecycle_event(
+            &persisted_parent
+                .history
+                .expect("parent history should be loaded")
+                .items,
+        ),
+        "parent rollout should persist the MCP tool result fixture"
+    );
     let child_thread_id = harness
         .control
         .spawn_agent_with_metadata(
@@ -1051,6 +1102,26 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
         history.raw_items(),
         &expected_history,
         "full-history forked child history should replace parent usage hints with the child subagent hint while filtering non-final assistant/tool chatter"
+    );
+    child_thread.ensure_rollout_materialized().await;
+    child_thread
+        .flush_rollout()
+        .await
+        .expect("child rollout should flush");
+    let persisted_child = child_thread
+        .read_thread(
+            /*include_archived*/ true, /*include_history*/ true,
+        )
+        .await
+        .expect("child thread should be readable");
+    assert!(
+        !contains_mcp_tool_call_lifecycle_event(
+            &persisted_child
+                .history
+                .expect("child history should be loaded")
+                .items,
+        ),
+        "full-history forked child rollout should not copy parent MCP tool lifecycle events"
     );
     assert_eq!(
         serde_json::to_value(child_thread.codex.session.reference_context_item().await)


### PR DESCRIPTION
## summary

- exclude inherited `McpToolCallBegin` and `McpToolCallEnd` events when constructing forked agent history
- preserve the complete MCP history in the parent rollout while keeping parent tool execution state out of the child
- drop both lifecycle halves so legacy histories cannot create an orphaned in-progress tool call

## why

#16709 stripped parent tool and reasoning items from forked history, but retained every `EventMsg`

MCP results are also persisted in `McpToolCallEnd` events and may contain large text, structured output, or embedded resources. Forks that retain those parent events serialize the same result payloads into each child rollout, multiplying disk writes, rollout size, and later read and parse work as agent fan-out grows

These events describe calls already executed by the parent and do not contribute to the child model context, so filtering them completes the existing fork sanitizer boundary without changing active MCP execution or parent history

## testing

- `just test -p codex-core forked_rollout_item_filter_drops_mcp_tool_call_lifecycle`
- `just test -p codex-core spawn_agent_can_fork_parent_thread_history_with_sanitized_items`
- `just fmt`
