### PR TITLE
fix(login): improve device auth contrast on dark terminals

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -3313,6 +3313,7 @@ dependencies = [
  "codex-terminal-detection",
  "codex-utils-template",
  "core_test_support",
+ "insta",
  "jsonwebtoken",
  "keyring",
  "once_cell",

--- a/codex-rs/login/BUILD.bazel
+++ b/codex-rs/login/BUILD.bazel
@@ -8,4 +8,7 @@ codex_rust_crate(
         "src/assets/success_legacy.html",
     ],
     crate_name = "codex_login",
+    test_data_extra = [
+        "src/snapshots/codex_login__device_code_auth__tests__device_code_prompt_uses_terminal_relative_styles.snap",
+    ],
 )

--- a/codex-rs/login/Cargo.toml
+++ b/codex-rs/login/Cargo.toml
@@ -45,6 +45,7 @@ webbrowser = { workspace = true }
 anyhow = { workspace = true }
 core_test_support = { workspace = true }
 jsonwebtoken = { workspace = true }
+insta = { workspace = true }
 keyring = { workspace = true }
 pretty_assertions = { workspace = true }
 regex-lite = { workspace = true }

--- a/codex-rs/login/src/device_code_auth.rs
+++ b/codex-rs/login/src/device_code_auth.rs
@@ -12,7 +12,7 @@ use crate::server::ServerOptions;
 use std::io;
 
 const ANSI_BLUE: &str = "\x1b[94m";
-const ANSI_GRAY: &str = "\x1b[90m";
+const ANSI_DIM: &str = "\x1b[2m";
 const ANSI_RESET: &str = "\x1b[0m";
 
 #[derive(Debug, Clone)]
@@ -145,16 +145,26 @@ async fn poll_for_token(
     }
 }
 
-fn print_device_code_prompt(verification_url: &str, code: &str) {
-    let version = env!("CARGO_PKG_VERSION");
-    println!(
-        "\nWelcome to Codex [v{ANSI_GRAY}{version}{ANSI_RESET}]\n{ANSI_GRAY}OpenAI's command-line coding agent{ANSI_RESET}\n\
+fn format_device_code_prompt(version: &str, verification_url: &str, code: &str) -> String {
+    format!(
+        "\nWelcome to Codex [v{ANSI_DIM}{version}{ANSI_RESET}]\n{ANSI_DIM}OpenAI's command-line coding agent{ANSI_RESET}\n\
 \nFollow these steps to sign in with ChatGPT using device code authorization:\n\
 \n1. Open this link in your browser and sign in to your account\n   {ANSI_BLUE}{verification_url}{ANSI_RESET}\n\
-\n2. Enter this one-time code {ANSI_GRAY}(expires in 15 minutes){ANSI_RESET}\n   {ANSI_BLUE}{code}{ANSI_RESET}\n\
-\n{ANSI_GRAY}Device codes are a common phishing target. Never share this code.{ANSI_RESET}\n",
+\n2. Enter this one-time code {ANSI_DIM}(expires in 15 minutes){ANSI_RESET}\n   {ANSI_BLUE}{code}{ANSI_RESET}\n\
+\nDevice codes are a common phishing target. Never share this code.\n",
+    )
+}
+
+fn print_device_code_prompt(verification_url: &str, code: &str) {
+    println!(
+        "{}",
+        format_device_code_prompt(env!("CARGO_PKG_VERSION"), verification_url, code)
     );
 }
+
+#[cfg(test)]
+#[path = "device_code_auth_tests.rs"]
+mod tests;
 
 pub async fn request_device_code(opts: &ServerOptions) -> std::io::Result<DeviceCode> {
     let base_url = opts.issuer.trim_end_matches('/');

--- a/codex-rs/login/src/device_code_auth_tests.rs
+++ b/codex-rs/login/src/device_code_auth_tests.rs
@@ -1,0 +1,9 @@
+use super::format_device_code_prompt;
+
+#[test]
+fn device_code_prompt_uses_terminal_relative_styles() {
+    let prompt =
+        format_device_code_prompt("1.2.3", "https://auth.openai.com/codex/device", "ABCD-EFGH");
+
+    insta::assert_snapshot!(prompt.escape_default().to_string());
+}

--- a/codex-rs/login/src/snapshots/codex_login__device_code_auth__tests__device_code_prompt_uses_terminal_relative_styles.snap
+++ b/codex-rs/login/src/snapshots/codex_login__device_code_auth__tests__device_code_prompt_uses_terminal_relative_styles.snap
@@ -1,0 +1,5 @@
+---
+source: login/src/device_code_auth_tests.rs
+expression: prompt.escape_default().to_string()
+---
+\nWelcome to Codex [v\u{1b}[2m1.2.3\u{1b}[0m]\n\u{1b}[2mOpenAI\'s command-line coding agent\u{1b}[0m\n\nFollow these steps to sign in with ChatGPT using device code authorization:\n\n1. Open this link in your browser and sign in to your account\n   \u{1b}[94mhttps://auth.openai.com/codex/device\u{1b}[0m\n\n2. Enter this one-time code \u{1b}[2m(expires in 15 minutes)\u{1b}[0m\n   \u{1b}[94mABCD-EFGH\u{1b}[0m\n\nDevice codes are a common phishing target. Never share this code.\n


### PR DESCRIPTION
## Summary

- replace the device-auth prompt's fixed bright-black ANSI color with dimming of the terminal's default foreground
- render the phishing warning at full default-foreground contrast
- add a snapshot covering the prompt's emitted style sequences

## Why

SGR 90 selects a terminal palette's bright-black slot; it is not a theme-aware gray. Some dark terminal themes map that slot close to the background, making the version, tagline, expiry, and phishing warning nearly unreadable.

Using SGR 2 preserves the intended secondary-text hierarchy relative to the terminal's own foreground, while the security warning remains fully legible.

## Validation

- `just fmt`
- `just test -p codex-login` (150 passed)
- `just fix -p codex-login`
