### PR TITLE
fix: release thread writer after failed shutdown

### DIFF
--- a/codex-rs/app-server/src/request_processors/external_agent_session_import.rs
+++ b/codex-rs/app-server/src/request_processors/external_agent_session_import.rs
@@ -26,6 +26,7 @@ use codex_thread_store::ThreadStore;
 use codex_thread_store::UpdateThreadMetadataParams;
 use futures::StreamExt;
 use tokio::sync::Semaphore;
+use tracing::warn;
 
 use crate::config::external_agent_config::ExternalAgentConfigImportItemResult;
 use crate::config::external_agent_config::record_import_error;
@@ -41,6 +42,59 @@ pub(super) struct ExternalAgentSessionImporter {
     thread_store: Arc<dyn ThreadStore>,
     config_manager: ConfigManager,
     arg0_paths: Arg0DispatchPaths,
+}
+
+/// Owns an imported thread writer while the post-create pipeline is still fallible.
+///
+/// Starting terminal cleanup disarms the drop fallback before awaiting so cancellation cannot
+/// launch a later discard against a replacement writer.
+struct ImportedThreadCleanupGuard {
+    thread_store: Arc<dyn ThreadStore>,
+    thread_id: ThreadId,
+    terminal_cleanup_started: bool,
+}
+
+impl ImportedThreadCleanupGuard {
+    fn new(thread_store: Arc<dyn ThreadStore>, thread_id: ThreadId) -> Self {
+        Self {
+            thread_store,
+            thread_id,
+            terminal_cleanup_started: false,
+        }
+    }
+
+    async fn discard(&mut self) {
+        let cleanup = self.thread_store.discard_thread(self.thread_id);
+        self.terminal_cleanup_started = true;
+        if let Err(err) = cleanup.await {
+            warn!("failed to discard imported session after persistence error: {err}");
+        }
+    }
+
+    async fn shutdown(&mut self) -> Result<(), String> {
+        let cleanup = self.thread_store.shutdown_thread(self.thread_id);
+        self.terminal_cleanup_started = true;
+        if let Err(err) = cleanup.await {
+            let discard = self.thread_store.discard_thread(self.thread_id);
+            if let Err(discard_err) = discard.await {
+                return Err(format!(
+                    "failed to shutdown imported session: {err}; failed to discard imported session: {discard_err}"
+                ));
+            }
+            return Err(format!("failed to shutdown imported session: {err}"));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for ImportedThreadCleanupGuard {
+    fn drop(&mut self) {
+        if self.terminal_cleanup_started {
+            return;
+        }
+        self.terminal_cleanup_started = true;
+        drop(self.thread_store.discard_thread(self.thread_id));
+    }
 }
 
 impl ExternalAgentSessionImporter {
@@ -256,35 +310,39 @@ impl ExternalAgentSessionImporter {
             .create_thread(create_params)
             .await
             .map_err(|err| format!("failed to import session: {err}"))?;
-        if !rollout_items.is_empty()
-            && let Err(err) = self
-                .thread_store
-                .append_items(AppendThreadItemsParams {
+        let mut cleanup =
+            ImportedThreadCleanupGuard::new(Arc::clone(&self.thread_store), thread_id);
+        let persist_result: Result<(), String> = async {
+            if !rollout_items.is_empty() {
+                self.thread_store
+                    .append_items(AppendThreadItemsParams {
+                        thread_id,
+                        items: rollout_items,
+                    })
+                    .await
+                    .map_err(|err| format!("failed to import session: {err}"))?;
+            }
+
+            self.thread_store
+                .update_thread_metadata(UpdateThreadMetadataParams {
                     thread_id,
-                    items: rollout_items,
+                    patch: metadata,
+                    include_archived: false,
                 })
                 .await
-        {
-            let _ = self.thread_store.discard_thread(thread_id).await;
-            return Err(format!("failed to import session: {err}"));
+                .map_err(|err| format!("failed to update imported session: {err}"))?;
+            self.thread_store
+                .persist_thread(thread_id)
+                .await
+                .map_err(|err| format!("failed to persist imported session: {err}"))?;
+            Ok(())
         }
-
-        self.thread_store
-            .update_thread_metadata(UpdateThreadMetadataParams {
-                thread_id,
-                patch: metadata,
-                include_archived: false,
-            })
-            .await
-            .map_err(|err| format!("failed to update imported session: {err}"))?;
-        self.thread_store
-            .persist_thread(thread_id)
-            .await
-            .map_err(|err| format!("failed to persist imported session: {err}"))?;
-        self.thread_store
-            .shutdown_thread(thread_id)
-            .await
-            .map_err(|err| format!("failed to shutdown imported session: {err}"))?;
+        .await;
+        if let Err(err) = persist_result {
+            cleanup.discard().await;
+            return Err(err);
+        }
+        cleanup.shutdown().await?;
         Ok(thread_id)
     }
 }

--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -617,6 +617,47 @@ async fn emit_thread_stop_lifecycle(sess: &Session) {
     }
 }
 
+enum ThreadPersistenceShutdown {
+    Closed,
+    DiscardedAfterError,
+}
+
+async fn shutdown_thread_persistence(
+    sess: &Session,
+    failure_context: &str,
+) -> ThreadPersistenceShutdown {
+    let Some(live_thread) = sess.live_thread().cloned() else {
+        return ThreadPersistenceShutdown::Closed;
+    };
+    let failure_context = failure_context.to_owned();
+    // Terminal cleanup must outlive the submission loop. If the loop is canceled while a
+    // graceful shutdown is still waiting on I/O, the same task still reaches the discard
+    // fallback and releases the live-writer lease.
+    tokio::spawn(async move {
+        if let Err(err) = live_thread.shutdown().await {
+            warn!("{failure_context}: {err}");
+            // A terminal session has no remaining owner that can retry a buffered writer.
+            // Release the writer lease so a later resume can recover the durable prefix
+            // instead of failing forever with a duplicate live writer.
+            if let Err(discard_err) = live_thread.discard().await {
+                warn!(
+                    "thread persistence discard reported an error after terminal release: {discard_err}"
+                );
+            }
+            warn!(
+                "discarded thread persistence after shutdown error; buffered rollout items may be lost"
+            );
+            return ThreadPersistenceShutdown::DiscardedAfterError;
+        }
+        ThreadPersistenceShutdown::Closed
+    })
+    .await
+    .unwrap_or_else(|err| {
+        warn!("terminal thread persistence cleanup task failed: {err}");
+        ThreadPersistenceShutdown::DiscardedAfterError
+    })
+}
+
 pub async fn shutdown(sess: &Arc<Session>, sub_id: String) -> bool {
     shutdown_session_runtime(sess).await;
     info!("Shutting down Codex instance");
@@ -634,12 +675,10 @@ pub async fn shutdown(sess: &Arc<Session>, sub_id: String) -> bool {
 
     emit_thread_stop_lifecycle(sess.as_ref()).await;
 
-    // Gracefully flush and shutdown thread persistence on session end so tests
-    // that inspect durable state do not race with the background writer.
-    if let Some(live_thread) = sess.live_thread()
-        && let Err(e) = live_thread.shutdown().await
-    {
-        warn!("failed to shutdown thread persistence: {e}");
+    if matches!(
+        shutdown_thread_persistence(sess.as_ref(), "failed to shutdown thread persistence").await,
+        ThreadPersistenceShutdown::DiscardedAfterError
+    ) {
         let event = Event {
             id: sub_id.clone(),
             msg: EventMsg::Error(ErrorEvent {
@@ -851,11 +890,11 @@ pub(super) async fn submission_loop(
     if !shutdown_received {
         shutdown_session_runtime(&sess).await;
         emit_thread_stop_lifecycle(sess.as_ref()).await;
-        if let Some(live_thread) = sess.live_thread()
-            && let Err(err) = live_thread.shutdown().await
-        {
-            warn!("failed to shutdown thread persistence after submission channel closed: {err}");
-        }
+        let _ = shutdown_thread_persistence(
+            sess.as_ref(),
+            "failed to shutdown thread persistence after submission channel closed",
+        )
+        .await;
     }
     debug!("Agent loop exited");
 }

--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -630,9 +630,10 @@ async fn shutdown_thread_persistence(
         return ThreadPersistenceShutdown::Closed;
     };
     let failure_context = failure_context.to_owned();
-    // Terminal cleanup must outlive the submission loop. If the loop is canceled while a
-    // graceful shutdown is still waiting on I/O, the same task still reaches the discard
-    // fallback and releases the live-writer lease.
+    // Await a child task so ordinary shutdown still waits for cleanup before completion. If the
+    // submission loop is canceled while graceful shutdown is waiting on I/O, dropping the
+    // JoinHandle detaches the child; it still reaches the discard fallback and releases the
+    // live-writer lease.
     tokio::spawn(async move {
         if let Err(err) = live_thread.shutdown().await {
             warn!("{failure_context}: {err}");

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -6991,6 +6991,149 @@ async fn shutdown_complete_does_not_append_to_thread_store_after_shutdown() {
     );
 }
 
+async fn make_session_with_unflushable_thread_persistence() -> (
+    tempfile::TempDir,
+    Session,
+    Arc<codex_thread_store::LocalThreadStore>,
+    async_channel::Receiver<Event>,
+) {
+    let codex_home = tempfile::tempdir().expect("create codex home");
+    let (session, _turn_context, rx_event) = make_session_and_context_with_auth_config_home_and_rx(
+        CodexAuth::from_api_key("Test API Key"),
+        Vec::new(),
+        codex_home.path(),
+        |_config| {},
+    )
+    .await;
+    let mut session = Arc::into_inner(session).expect("test session should be uniquely owned");
+    let config = session.get_config().await;
+    let store = Arc::new(codex_thread_store::LocalThreadStore::new(
+        codex_thread_store::LocalThreadStoreConfig::from_config(config.as_ref()),
+        /*state_db*/ None,
+    ));
+    let thread_store: Arc<dyn codex_thread_store::ThreadStore> = store.clone();
+    let live_thread = LiveThread::create(
+        Arc::clone(&thread_store),
+        CreateThreadParams {
+            session_id: session.session_id(),
+            thread_id: session.thread_id,
+            extra_config: None,
+            forked_from_id: None,
+            parent_thread_id: None,
+            source: SessionSource::Exec,
+            thread_source: None,
+            originator: "test_originator".to_string(),
+            base_instructions: BaseInstructions::default(),
+            dynamic_tools: Vec::new(),
+            selected_capability_roots: Vec::new(),
+            multi_agent_version: None,
+            history_mode: Default::default(),
+            initial_window_id: Uuid::now_v7().to_string(),
+            metadata: ThreadPersistenceMetadata {
+                cwd: Some(config.cwd.to_path_buf()),
+                model_provider: config.model_provider_id.clone(),
+                memory_mode: if config.memories.generate_memories {
+                    ThreadMemoryMode::Enabled
+                } else {
+                    ThreadMemoryMode::Disabled
+                },
+            },
+        },
+    )
+    .await
+    .expect("create thread persistence");
+    let sessions_blocker_path = config.codex_home.join("sessions");
+    std::fs::File::create(&sessions_blocker_path).expect("block sessions directory");
+    live_thread
+        .append_items(&[RolloutItem::EventMsg(EventMsg::UserMessage(
+            UserMessageEvent {
+                client_id: None,
+                message: "buffered before failed shutdown".to_string(),
+                images: None,
+                local_images: Vec::new(),
+                text_elements: Vec::new(),
+                ..Default::default()
+            },
+        ))])
+        .await
+        .expect_err("blocked sessions directory should fail append");
+    session.services.thread_store = thread_store;
+    session.services.live_thread = Some(live_thread);
+    (codex_home, session, store, rx_event)
+}
+
+#[tokio::test]
+async fn shutdown_discards_unflushable_thread_persistence_before_completing() {
+    let (_codex_home, session, store, rx_event) =
+        make_session_with_unflushable_thread_persistence().await;
+    let thread_id = session.thread_id;
+    let config = session.get_config().await;
+    let session = Arc::new(session);
+    let (tx_sub, rx_sub) = async_channel::bounded(4);
+    let (_agent_status_tx, agent_status) = watch::channel(AgentStatus::PendingInit);
+    let session_for_loop = Arc::clone(&session);
+    let session_loop_handle = tokio::spawn(async move {
+        submission_loop(session_for_loop, config, rx_sub).await;
+    });
+    let codex = Codex {
+        tx_sub,
+        rx_event,
+        agent_status,
+        session,
+        session_loop_termination: session_loop_termination_from_handle(session_loop_handle),
+    };
+
+    codex
+        .submit(Op::Shutdown)
+        .await
+        .expect("submit terminal shutdown");
+
+    let mut saw_persistence_error = false;
+    loop {
+        let event = timeout(StdDuration::from_secs(2), codex.next_event())
+            .await
+            .expect("timeout waiting for shutdown event")
+            .expect("receive shutdown event");
+        match event.msg {
+            EventMsg::Error(_) => saw_persistence_error = true,
+            EventMsg::ShutdownComplete => break,
+            _ => {}
+        }
+    }
+    assert!(
+        saw_persistence_error,
+        "failed graceful shutdown should report its persistence error"
+    );
+    let err = store
+        .live_rollout_path(thread_id)
+        .await
+        .expect_err("terminal shutdown should release the live writer");
+    assert!(
+        matches!(err, codex_thread_store::ThreadStoreError::ThreadNotFound { thread_id: missing } if missing == thread_id)
+    );
+    codex.session_loop_termination.clone().await;
+}
+
+#[tokio::test]
+async fn submission_loop_channel_close_discards_unflushable_thread_persistence() {
+    let (_codex_home, session, store, _rx_event) =
+        make_session_with_unflushable_thread_persistence().await;
+    let thread_id = session.thread_id;
+    let config = session.get_config().await;
+    let (tx_sub, rx_sub) = async_channel::bounded(1);
+    drop(tx_sub);
+
+    submission_loop(Arc::new(session), config, rx_sub).await;
+
+    let err = store
+        .live_rollout_path(thread_id)
+        .await
+        .expect_err("channel close should release the live writer");
+    assert!(
+        matches!(err, codex_thread_store::ThreadStoreError::ThreadNotFound { thread_id: missing } if missing == thread_id)
+    );
+}
+
 #[tokio::test]
 async fn submission_loop_channel_close_runs_full_thread_teardown() {
     struct SessionStopMarker;

--- a/codex-rs/rollout/src/recorder.rs
+++ b/codex-rs/rollout/src/recorder.rs
@@ -115,6 +115,9 @@ enum RolloutCmd {
     Shutdown {
         ack: oneshot::Sender<std::io::Result<()>>,
     },
+    Discard {
+        ack: oneshot::Sender<()>,
+    },
 }
 
 /// Observable state for the background rollout writer task.
@@ -1038,6 +1041,23 @@ impl RolloutRecorder {
         };
         Ok(())
     }
+
+    /// Stop the writer without draining buffered items.
+    ///
+    /// This returns only after the writer has closed its command receiver, so stale recorder
+    /// clones cannot enqueue writes after the caller releases its live-writer lease.
+    pub async fn discard(&self) {
+        let (tx_done, rx_done) = oneshot::channel();
+        if self
+            .tx
+            .send(RolloutCmd::Discard { ack: tx_done })
+            .await
+            .is_err()
+        {
+            return;
+        }
+        let _ = rx_done.await;
+    }
 }
 
 pub(crate) fn reject_unknown_thread_history_mode(value: &Value) -> std::io::Result<()> {
@@ -1723,10 +1743,18 @@ async fn rollout_writer(
     cwd: PathBuf,
     rollout_path: PathBuf,
 ) -> std::io::Result<()> {
+    enum TerminalAck {
+        Shutdown(oneshot::Sender<std::io::Result<()>>),
+        Discard(oneshot::Sender<()>),
+    }
+
     let mut state = RolloutWriterState::new(file, deferred_log_file_info, meta, cwd, rollout_path);
 
     // Process rollout commands
-    while let Some(cmd) = rx.recv().await {
+    let terminal_ack = loop {
+        let Some(cmd) = rx.recv().await else {
+            break None;
+        };
         match cmd {
             RolloutCmd::AddItems(items) => {
                 state.add_items(items);
@@ -1740,14 +1768,28 @@ async fn rollout_writer(
             }
             RolloutCmd::Shutdown { ack } => match state.shutdown().await {
                 Ok(()) => {
-                    let _ = ack.send(Ok(()));
-                    break;
+                    break Some(TerminalAck::Shutdown(ack));
                 }
                 Err(err) => {
                     let _ = ack.send(Err(err));
                 }
             },
+            RolloutCmd::Discard { ack } => {
+                break Some(TerminalAck::Discard(ack));
+            }
         }
+    };
+
+    drop(state);
+    drop(rx);
+    match terminal_ack {
+        Some(TerminalAck::Shutdown(ack)) => {
+            let _ = ack.send(Ok(()));
+        }
+        Some(TerminalAck::Discard(ack)) => {
+            let _ = ack.send(());
+        }
+        None => {}
     }
 
     Ok(())

--- a/codex-rs/thread-store/src/in_memory.rs
+++ b/codex-rs/thread-store/src/in_memory.rs
@@ -53,12 +53,71 @@ mod tests {
     use super::*;
     use crate::ListItemsParams;
     use crate::ListTurnsParams;
+    use crate::LiveThread;
+    use crate::LiveThreadInitGuard;
     use crate::SortDirection;
     use crate::StoredTurnItemsView;
     use crate::ThreadPersistenceMetadata;
     use crate::ThreadSortKey;
     use codex_protocol::models::BaseInstructions;
     use codex_protocol::protocol::SessionSource;
+    use pretty_assertions::assert_eq;
+    use std::future::Future;
+    use std::task::Poll;
+
+    #[tokio::test]
+    async fn canceled_init_discard_starts_only_one_cleanup() {
+        let store = Arc::new(InMemoryThreadStore::default());
+        let thread_id = ThreadId::default();
+        let thread_store: Arc<dyn ThreadStore> = store.clone();
+        let live_thread = LiveThread::create(
+            thread_store,
+            create_thread_params(thread_id, ThreadHistoryMode::Legacy),
+        )
+        .await
+        .expect("create live thread");
+        let mut guard = LiveThreadInitGuard::new(Some(live_thread));
+        let state = Arc::clone(&store.state).lock_owned().await;
+        let (release_lock, lock_released) = std::sync::mpsc::channel();
+        let lock_holder = tokio::task::spawn_blocking(move || {
+            let _state = state;
+            lock_released.recv().expect("receive state lock release");
+        });
+        let mut discard = Box::pin(guard.discard());
+        std::future::poll_fn(|cx| {
+            assert!(matches!(discard.as_mut().poll(cx), Poll::Pending));
+            Poll::Ready(())
+        })
+        .await;
+        drop(discard);
+        drop(guard);
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+        release_lock.send(()).expect("release state lock");
+        lock_holder.await.expect("join state lock holder");
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if store.calls().await.discard_thread == 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("discard cleanup should complete");
+        for _ in 0..10 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            store.calls().await,
+            InMemoryThreadStoreCalls {
+                create_thread: 1,
+                discard_thread: 1,
+                ..Default::default()
+            }
+        );
+    }
 
     #[tokio::test]
     async fn default_turn_pagination_methods_return_unsupported() {

--- a/codex-rs/thread-store/src/in_memory.rs
+++ b/codex-rs/thread-store/src/in_memory.rs
@@ -33,6 +33,7 @@ use crate::ThreadMetadataPatch;
 use crate::ThreadPage;
 use crate::ThreadRelationFilter;
 use crate::ThreadStore;
+use crate::ThreadStoreCleanup;
 use crate::ThreadStoreError;
 use crate::ThreadStoreFuture;
 use crate::ThreadStoreResult;
@@ -385,7 +386,7 @@ pub struct InMemoryThreadStoreCalls {
 /// service.
 #[derive(Default)]
 pub struct InMemoryThreadStore {
-    state: tokio::sync::Mutex<InMemoryThreadStoreState>,
+    state: Arc<tokio::sync::Mutex<InMemoryThreadStoreState>>,
 }
 
 #[derive(Default)]
@@ -634,16 +635,18 @@ impl ThreadStore for InMemoryThreadStore {
         })
     }
 
-    fn shutdown_thread(&self, _thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
-        Box::pin(async move {
-            self.state.lock().await.calls.shutdown_thread += 1;
+    fn shutdown_thread(&self, thread_id: ThreadId) -> ThreadStoreCleanup {
+        let state = Arc::clone(&self.state);
+        ThreadStoreCleanup::spawn("shutdown", thread_id, async move {
+            state.lock().await.calls.shutdown_thread += 1;
             Ok(())
         })
     }
 
-    fn discard_thread(&self, _thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
-        Box::pin(async move {
-            self.state.lock().await.calls.discard_thread += 1;
+    fn discard_thread(&self, thread_id: ThreadId) -> ThreadStoreCleanup {
+        let state = Arc::clone(&self.state);
+        ThreadStoreCleanup::spawn("discard", thread_id, async move {
+            state.lock().await.calls.discard_thread += 1;
             Ok(())
         })
     }

--- a/codex-rs/thread-store/src/lib.rs
+++ b/codex-rs/thread-store/src/lib.rs
@@ -21,6 +21,7 @@ pub use live_thread::LiveThreadInitGuard;
 pub use local::LocalThreadStore;
 pub use local::LocalThreadStoreConfig;
 pub use store::ThreadStore;
+pub use store::ThreadStoreCleanup;
 pub use store::ThreadStoreFuture;
 pub use types::AppendThreadItemsParams;
 pub use types::ArchiveThreadParams;

--- a/codex-rs/thread-store/src/live_thread.rs
+++ b/codex-rs/thread-store/src/live_thread.rs
@@ -60,12 +60,16 @@ impl LiveThreadInitGuard {
     }
 
     pub async fn discard(&mut self) {
-        let Some(live_thread) = self.live_thread.take() else {
+        let Some(live_thread) = self.live_thread.as_ref().cloned() else {
             return;
         };
         if let Err(err) = live_thread.discard().await {
             warn!("failed to discard thread persistence for failed session init: {err}");
+            return;
         }
+        // Keep the guard armed until discard completes so cancellation still leaves Drop able to
+        // retry terminal cleanup.
+        self.live_thread = None;
     }
 }
 

--- a/codex-rs/thread-store/src/live_thread.rs
+++ b/codex-rs/thread-store/src/live_thread.rs
@@ -60,16 +60,12 @@ impl LiveThreadInitGuard {
     }
 
     pub async fn discard(&mut self) {
-        let Some(live_thread) = self.live_thread.as_ref().cloned() else {
+        let Some(live_thread) = self.live_thread.take() else {
             return;
         };
         if let Err(err) = live_thread.discard().await {
             warn!("failed to discard thread persistence for failed session init: {err}");
-            return;
         }
-        // Keep the guard armed until discard completes so cancellation still leaves Drop able to
-        // retry terminal cleanup.
-        self.live_thread = None;
     }
 }
 

--- a/codex-rs/thread-store/src/local/live_writer.rs
+++ b/codex-rs/thread-store/src/local/live_writer.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::ThreadMemoryMode;
@@ -160,30 +161,66 @@ pub(super) async fn shutdown_thread(
     thread_id: ThreadId,
 ) -> ThreadStoreResult<()> {
     let recorder = store.live_recorder(thread_id).await?;
-    let rollout_path = recorder.rollout_path().to_path_buf();
-    recorder.shutdown().await.map_err(thread_store_io_error)?;
-    sync_materialized_rollout_path(store, thread_id).await?;
-    if let Some(metrics) = codex_otel::global()
-        && let Ok(metadata) = tokio::fs::metadata(rollout_path).await
-    {
-        let size_bytes = i64::try_from(metadata.len()).unwrap_or(i64::MAX);
-        let _ = metrics.histogram(ROLLOUT_SIZE_BYTES_METRIC, size_bytes, &[]);
-    }
-    store.live_recorders.lock().await.remove(&thread_id);
-    Ok(())
+    let store = store.clone();
+    tokio::spawn(async move {
+        let rollout_path = recorder.rollout_path().to_path_buf();
+        recorder.shutdown().await.map_err(thread_store_io_error)?;
+        sync_materialized_rollout_path(&store, thread_id).await?;
+        if let Some(metrics) = codex_otel::global()
+            && let Ok(metadata) = tokio::fs::metadata(rollout_path).await
+        {
+            let size_bytes = i64::try_from(metadata.len()).unwrap_or(i64::MAX);
+            let _ = metrics.histogram(ROLLOUT_SIZE_BYTES_METRIC, size_bytes, &[]);
+        }
+        remove_live_recorder_if_current(&store, thread_id, &recorder).await;
+        Ok(())
+    })
+    .await
+    .map_err(|err| ThreadStoreError::Internal {
+        message: format!("shutdown cleanup task failed for thread {thread_id}: {err}"),
+    })?
 }
 
 pub(super) async fn discard_thread(
     store: &LocalThreadStore,
     thread_id: ThreadId,
 ) -> ThreadStoreResult<()> {
-    store
-        .live_recorders
-        .lock()
+    let recorder = match store.live_recorder(thread_id).await {
+        Ok(recorder) => recorder,
+        Err(ThreadStoreError::ThreadNotFound { .. }) => return Ok(()),
+        Err(err) => return Err(err),
+    };
+    spawn_discard_cleanup(store.clone(), thread_id, recorder)
         .await
-        .remove(&thread_id)
-        .map(|_| ())
-        .ok_or(ThreadStoreError::ThreadNotFound { thread_id })
+        .map_err(|err| ThreadStoreError::Internal {
+            message: format!("discard cleanup task failed for thread {thread_id}: {err}"),
+        })?;
+    Ok(())
+}
+
+pub(super) fn spawn_discard_cleanup(
+    store: LocalThreadStore,
+    thread_id: ThreadId,
+    recorder: Arc<RolloutRecorder>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        recorder.discard().await;
+        remove_live_recorder_if_current(&store, thread_id, &recorder).await;
+    })
+}
+
+async fn remove_live_recorder_if_current(
+    store: &LocalThreadStore,
+    thread_id: ThreadId,
+    recorder: &Arc<RolloutRecorder>,
+) {
+    let mut live_recorders = store.live_recorders.lock().await;
+    if live_recorders
+        .get(&thread_id)
+        .is_some_and(|entry| Arc::ptr_eq(&entry.recorder, recorder))
+    {
+        live_recorders.remove(&thread_id);
+    }
 }
 
 pub(super) async fn rollout_path(

--- a/codex-rs/thread-store/src/local/live_writer.rs
+++ b/codex-rs/thread-store/src/local/live_writer.rs
@@ -162,6 +162,9 @@ pub(super) async fn shutdown_thread(
 ) -> ThreadStoreResult<()> {
     let recorder = store.live_recorder(thread_id).await?;
     let store = store.clone();
+    // The writer can close before this future removes its live-recorder entry. Keep those steps
+    // in one detached task so canceling an arbitrary ThreadStore caller cannot strand a closed
+    // recorder that blocks a later resume.
     tokio::spawn(async move {
         let rollout_path = recorder.rollout_path().to_path_buf();
         recorder.shutdown().await.map_err(thread_store_io_error)?;
@@ -190,6 +193,8 @@ pub(super) async fn discard_thread(
         Err(ThreadStoreError::ThreadNotFound { .. }) => return Ok(()),
         Err(err) => return Err(err),
     };
+    // Discard closes stale recorder clones before removing the lease. Keep that sequence alive if
+    // an arbitrary ThreadStore caller is canceled between the two steps.
     spawn_discard_cleanup(store.clone(), thread_id, recorder)
         .await
         .map_err(|err| ThreadStoreError::Internal {

--- a/codex-rs/thread-store/src/local/live_writer.rs
+++ b/codex-rs/thread-store/src/local/live_writer.rs
@@ -15,6 +15,7 @@ use crate::AppendThreadItemsParams;
 use crate::CreateThreadParams;
 use crate::ReadThreadParams;
 use crate::ResumeThreadParams;
+use crate::ThreadStoreCleanup;
 use crate::ThreadStoreError;
 use crate::ThreadStoreResult;
 use crate::error::reject_paginated_history_mode;
@@ -156,62 +157,57 @@ pub(super) async fn flush_thread(
     sync_materialized_rollout_path(store, thread_id).await
 }
 
-pub(super) async fn shutdown_thread(
-    store: &LocalThreadStore,
-    thread_id: ThreadId,
-) -> ThreadStoreResult<()> {
-    let recorder = store.live_recorder(thread_id).await?;
-    let store = store.clone();
-    // The writer can close before this future removes its live-recorder entry. Keep those steps
-    // in one detached task so canceling an arbitrary ThreadStore caller cannot strand a closed
-    // recorder that blocks a later resume.
-    tokio::spawn(async move {
-        let rollout_path = recorder.rollout_path().to_path_buf();
-        recorder.shutdown().await.map_err(thread_store_io_error)?;
-        sync_materialized_rollout_path(&store, thread_id).await?;
-        if let Some(metrics) = codex_otel::global()
-            && let Ok(metadata) = tokio::fs::metadata(rollout_path).await
-        {
-            let size_bytes = i64::try_from(metadata.len()).unwrap_or(i64::MAX);
-            let _ = metrics.histogram(ROLLOUT_SIZE_BYTES_METRIC, size_bytes, &[]);
-        }
-        remove_live_recorder_if_current(&store, thread_id, &recorder).await;
-        Ok(())
+pub(super) fn shutdown_thread(store: LocalThreadStore, thread_id: ThreadId) -> ThreadStoreCleanup {
+    let generation_cutoff = store.live_recorder_generation_cutoff();
+    ThreadStoreCleanup::spawn("shutdown", thread_id, async move {
+        let recorder = store
+            .live_recorder_before_generation(thread_id, generation_cutoff)
+            .await?;
+        shutdown_cleanup(store, thread_id, recorder).await
     })
-    .await
-    .map_err(|err| ThreadStoreError::Internal {
-        message: format!("shutdown cleanup task failed for thread {thread_id}: {err}"),
-    })?
 }
 
-pub(super) async fn discard_thread(
-    store: &LocalThreadStore,
-    thread_id: ThreadId,
-) -> ThreadStoreResult<()> {
-    let recorder = match store.live_recorder(thread_id).await {
-        Ok(recorder) => recorder,
-        Err(ThreadStoreError::ThreadNotFound { .. }) => return Ok(()),
-        Err(err) => return Err(err),
-    };
-    // Discard closes stale recorder clones before removing the lease. Keep that sequence alive if
-    // an arbitrary ThreadStore caller is canceled between the two steps.
-    spawn_discard_cleanup(store.clone(), thread_id, recorder)
-        .await
-        .map_err(|err| ThreadStoreError::Internal {
-            message: format!("discard cleanup task failed for thread {thread_id}: {err}"),
-        })?;
-    Ok(())
+pub(super) fn discard_thread(store: LocalThreadStore, thread_id: ThreadId) -> ThreadStoreCleanup {
+    let generation_cutoff = store.live_recorder_generation_cutoff();
+    ThreadStoreCleanup::spawn("discard", thread_id, async move {
+        let recorder = match store
+            .live_recorder_before_generation(thread_id, generation_cutoff)
+            .await
+        {
+            Ok(recorder) => recorder,
+            Err(ThreadStoreError::ThreadNotFound { .. }) => return Ok(()),
+            Err(err) => return Err(err),
+        };
+        discard_cleanup(store, thread_id, recorder).await
+    })
 }
 
-pub(super) fn spawn_discard_cleanup(
+pub(super) async fn shutdown_cleanup(
     store: LocalThreadStore,
     thread_id: ThreadId,
     recorder: Arc<RolloutRecorder>,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        recorder.discard().await;
-        remove_live_recorder_if_current(&store, thread_id, &recorder).await;
-    })
+) -> ThreadStoreResult<()> {
+    let rollout_path = recorder.rollout_path().to_path_buf();
+    recorder.shutdown().await.map_err(thread_store_io_error)?;
+    sync_materialized_rollout_path(&store, thread_id).await?;
+    if let Some(metrics) = codex_otel::global()
+        && let Ok(metadata) = tokio::fs::metadata(rollout_path).await
+    {
+        let size_bytes = i64::try_from(metadata.len()).unwrap_or(i64::MAX);
+        let _ = metrics.histogram(ROLLOUT_SIZE_BYTES_METRIC, size_bytes, &[]);
+    }
+    remove_live_recorder_if_current(&store, thread_id, &recorder).await;
+    Ok(())
+}
+
+pub(super) async fn discard_cleanup(
+    store: LocalThreadStore,
+    thread_id: ThreadId,
+    recorder: Arc<RolloutRecorder>,
+) -> ThreadStoreResult<()> {
+    recorder.discard().await;
+    remove_live_recorder_if_current(&store, thread_id, &recorder).await;
+    Ok(())
 }
 
 async fn remove_live_recorder_if_current(

--- a/codex-rs/thread-store/src/local/mod.rs
+++ b/codex-rs/thread-store/src/local/mod.rs
@@ -63,7 +63,7 @@ pub struct LocalThreadStore {
 }
 
 struct LiveRecorderEntry {
-    recorder: RolloutRecorder,
+    recorder: Arc<RolloutRecorder>,
     // Local rollout files are materialized lazily, but metadata updates can arrive before the
     // canonical SessionMeta is durable. Retain the mode captured when live persistence was opened
     // so missing SQLite rows can still be seeded.
@@ -139,12 +139,12 @@ impl LocalThreadStore {
     pub(super) async fn live_recorder(
         &self,
         thread_id: ThreadId,
-    ) -> ThreadStoreResult<RolloutRecorder> {
+    ) -> ThreadStoreResult<Arc<RolloutRecorder>> {
         self.live_recorders
             .lock()
             .await
             .get(&thread_id)
-            .map(|entry| entry.recorder.clone())
+            .map(|entry| Arc::clone(&entry.recorder))
             .ok_or(ThreadStoreError::ThreadNotFound { thread_id })
     }
 
@@ -172,7 +172,7 @@ impl LocalThreadStore {
             }),
             Entry::Vacant(entry) => {
                 entry.insert(LiveRecorderEntry {
-                    recorder,
+                    recorder: Arc::new(recorder),
                     history_mode,
                 });
                 Ok(())
@@ -805,7 +805,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discard_thread_drops_unmaterialized_live_writer() {
+    async fn discard_thread_stops_cloned_recorder_and_drops_unmaterialized_live_writer() {
         let home = TempDir::new().expect("temp dir");
         let store = LocalThreadStore::new(test_config(home.path()), /*state_db*/ None);
         let thread_id = ThreadId::default();
@@ -818,11 +818,23 @@ mod tests {
             .live_rollout_path(thread_id)
             .await
             .expect("load rollout path");
+        let stale_recorder = store
+            .live_recorder(thread_id)
+            .await
+            .expect("clone live recorder");
         store
             .discard_thread(thread_id)
             .await
             .expect("discard live thread");
+        store
+            .discard_thread(thread_id)
+            .await
+            .expect("discard should be idempotent");
 
+        stale_recorder
+            .record_canonical_items(&[user_message_item("write through stale recorder")])
+            .await
+            .expect_err("discard should stop stale recorder clones");
         assert!(
             !tokio::fs::try_exists(rollout_path.as_path())
                 .await
@@ -838,6 +850,127 @@ mod tests {
         assert!(
             matches!(err, ThreadStoreError::ThreadNotFound { thread_id: missing } if missing == thread_id)
         );
+    }
+
+    #[tokio::test]
+    async fn discard_thread_preserves_durable_prefix_for_resume() {
+        let home = TempDir::new().expect("temp dir");
+        let config = test_config(home.path());
+        let thread_id = ThreadId::default();
+
+        let first_store = LocalThreadStore::new(config.clone(), /*state_db*/ None);
+        first_store
+            .create_thread(create_thread_params(thread_id))
+            .await
+            .expect("create initial thread");
+        first_store
+            .append_items(AppendThreadItemsParams {
+                thread_id,
+                items: vec![user_message_item("before discard")],
+            })
+            .await
+            .expect("append durable prefix");
+        first_store
+            .persist_thread(thread_id)
+            .await
+            .expect("persist durable prefix");
+        first_store
+            .flush_thread(thread_id)
+            .await
+            .expect("flush durable prefix");
+        let rollout_path = first_store
+            .live_rollout_path(thread_id)
+            .await
+            .expect("load rollout path");
+        first_store
+            .discard_thread(thread_id)
+            .await
+            .expect("discard live thread");
+
+        let resumed_store = LocalThreadStore::new(config, /*state_db*/ None);
+        resumed_store
+            .resume_thread(ResumeThreadParams {
+                thread_id,
+                rollout_path: None,
+                history: None,
+                include_archived: true,
+                metadata: thread_metadata(),
+            })
+            .await
+            .expect("resume live thread");
+        resumed_store
+            .append_items(AppendThreadItemsParams {
+                thread_id,
+                items: vec![user_message_item("after resume")],
+            })
+            .await
+            .expect("append resumed item");
+        resumed_store
+            .flush_thread(thread_id)
+            .await
+            .expect("flush resumed thread");
+
+        assert_rollout_contains_message(rollout_path.as_path(), "before discard").await;
+        assert_rollout_contains_message(rollout_path.as_path(), "after resume").await;
+    }
+
+    #[tokio::test]
+    async fn detached_discard_cleanup_removes_closed_writer_after_caller_cancels() {
+        let home = TempDir::new().expect("temp dir");
+        let store = LocalThreadStore::new(test_config(home.path()), /*state_db*/ None);
+        let thread_id = ThreadId::default();
+
+        store
+            .create_thread(create_thread_params(thread_id))
+            .await
+            .expect("create live thread");
+        let recorder = store
+            .live_recorder(thread_id)
+            .await
+            .expect("clone live recorder");
+        let stale_recorder = Arc::clone(&recorder);
+        let live_recorders = Arc::clone(&store.live_recorders).lock_owned().await;
+        let (release_lock, lock_released) = std::sync::mpsc::channel();
+        let lock_holder = tokio::task::spawn_blocking(move || {
+            let _live_recorders = live_recorders;
+            lock_released
+                .recv()
+                .expect("receive live recorder lock release");
+        });
+        let cleanup = live_writer::spawn_discard_cleanup(store.clone(), thread_id, recorder);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if stale_recorder
+                    .record_canonical_items(&[user_message_item("write through stale recorder")])
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("discard should close the stale recorder");
+        drop(cleanup);
+        release_lock.send(()).expect("release live recorder lock");
+        lock_holder.await.expect("join live recorder lock holder");
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if matches!(
+                    store.live_rollout_path(thread_id).await,
+                    Err(ThreadStoreError::ThreadNotFound { thread_id: missing })
+                        if missing == thread_id
+                ) {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("detached discard cleanup should release the live writer");
     }
 
     #[tokio::test]

--- a/codex-rs/thread-store/src/local/mod.rs
+++ b/codex-rs/thread-store/src/local/mod.rs
@@ -20,6 +20,8 @@ use std::collections::HashMap;
 use std::collections::hash_map::Entry;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 use tokio::sync::Mutex;
 
 use crate::AppendThreadItemsParams;
@@ -37,6 +39,7 @@ use crate::StoredThreadHistory;
 use crate::ThreadPage;
 use crate::ThreadSearchPage;
 use crate::ThreadStore;
+use crate::ThreadStoreCleanup;
 use crate::ThreadStoreError;
 use crate::ThreadStoreFuture;
 use crate::ThreadStoreResult;
@@ -59,11 +62,15 @@ use crate::UpdateThreadMetadataParams;
 pub struct LocalThreadStore {
     pub(super) config: LocalThreadStoreConfig,
     live_recorders: Arc<Mutex<HashMap<ThreadId, LiveRecorderEntry>>>,
+    next_live_recorder_generation: Arc<AtomicU64>,
     state_db: Option<StateDbHandle>,
 }
 
 struct LiveRecorderEntry {
     recorder: Arc<RolloutRecorder>,
+    // Detached terminal cleanup captures an exclusive cutoff before it spawns, so a delayed task
+    // cannot bind itself to a writer inserted after the cleanup request.
+    generation: u64,
     // Local rollout files are materialized lazily, but metadata updates can arrive before the
     // canonical SessionMeta is durable. Retain the mode captured when live persistence was opened
     // so missing SQLite rows can still be seeded.
@@ -106,6 +113,7 @@ impl LocalThreadStore {
         Self {
             config,
             live_recorders: Arc::new(Mutex::new(HashMap::new())),
+            next_live_recorder_generation: Arc::new(AtomicU64::new(0)),
             state_db,
         }
     }
@@ -148,6 +156,25 @@ impl LocalThreadStore {
             .ok_or(ThreadStoreError::ThreadNotFound { thread_id })
     }
 
+    /// Returns the exclusive generation bound for a terminal cleanup requested now.
+    pub(super) fn live_recorder_generation_cutoff(&self) -> u64 {
+        self.next_live_recorder_generation.load(Ordering::SeqCst)
+    }
+
+    pub(super) async fn live_recorder_before_generation(
+        &self,
+        thread_id: ThreadId,
+        generation_cutoff: u64,
+    ) -> ThreadStoreResult<Arc<RolloutRecorder>> {
+        self.live_recorders
+            .lock()
+            .await
+            .get(&thread_id)
+            .filter(|entry| entry.generation < generation_cutoff)
+            .map(|entry| Arc::clone(&entry.recorder))
+            .ok_or(ThreadStoreError::ThreadNotFound { thread_id })
+    }
+
     pub(super) async fn ensure_live_recorder_absent(
         &self,
         thread_id: ThreadId,
@@ -171,8 +198,12 @@ impl LocalThreadStore {
                 message: format!("thread {} already has a live local writer", entry.key()),
             }),
             Entry::Vacant(entry) => {
+                let generation = self
+                    .next_live_recorder_generation
+                    .fetch_add(1, Ordering::SeqCst);
                 entry.insert(LiveRecorderEntry {
                     recorder: Arc::new(recorder),
+                    generation,
                     history_mode,
                 });
                 Ok(())
@@ -262,12 +293,12 @@ impl ThreadStore for LocalThreadStore {
         Box::pin(async move { live_writer::flush_thread(self, thread_id).await })
     }
 
-    fn shutdown_thread(&self, thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
-        Box::pin(async move { live_writer::shutdown_thread(self, thread_id).await })
+    fn shutdown_thread(&self, thread_id: ThreadId) -> ThreadStoreCleanup {
+        live_writer::shutdown_thread(self.clone(), thread_id)
     }
 
-    fn discard_thread(&self, thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
-        Box::pin(async move { live_writer::discard_thread(self, thread_id).await })
+    fn discard_thread(&self, thread_id: ThreadId) -> ThreadStoreCleanup {
+        live_writer::discard_thread(self.clone(), thread_id)
     }
 
     fn load_history(
@@ -915,7 +946,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn detached_discard_cleanup_removes_closed_writer_after_caller_cancels() {
+    async fn discard_cleanup_handle_removes_closed_writer_after_caller_cancels() {
         let home = TempDir::new().expect("temp dir");
         let store = LocalThreadStore::new(test_config(home.path()), /*state_db*/ None);
         let thread_id = ThreadId::default();
@@ -937,7 +968,11 @@ mod tests {
                 .recv()
                 .expect("receive live recorder lock release");
         });
-        let cleanup = live_writer::spawn_discard_cleanup(store.clone(), thread_id, recorder);
+        let cleanup = ThreadStoreCleanup::spawn(
+            "discard",
+            thread_id,
+            live_writer::discard_cleanup(store.clone(), thread_id, recorder),
+        );
 
         tokio::time::timeout(std::time::Duration::from_secs(1), async {
             loop {
@@ -970,7 +1005,118 @@ mod tests {
             }
         })
         .await
-        .expect("detached discard cleanup should release the live writer");
+        .expect("discard cleanup handle should release the live writer");
+    }
+
+    #[tokio::test]
+    async fn shutdown_cleanup_handle_removes_closed_writer_after_caller_cancels() {
+        let home = TempDir::new().expect("temp dir");
+        let store = LocalThreadStore::new(test_config(home.path()), /*state_db*/ None);
+        let thread_id = ThreadId::default();
+
+        store
+            .create_thread(create_thread_params(thread_id))
+            .await
+            .expect("create live thread");
+        let recorder = store
+            .live_recorder(thread_id)
+            .await
+            .expect("clone live recorder");
+        let stale_recorder = Arc::clone(&recorder);
+        let live_recorders = Arc::clone(&store.live_recorders).lock_owned().await;
+        let (release_lock, lock_released) = std::sync::mpsc::channel();
+        let lock_holder = tokio::task::spawn_blocking(move || {
+            let _live_recorders = live_recorders;
+            lock_released
+                .recv()
+                .expect("receive live recorder lock release");
+        });
+        let cleanup = ThreadStoreCleanup::spawn(
+            "shutdown",
+            thread_id,
+            live_writer::shutdown_cleanup(store.clone(), thread_id, recorder),
+        );
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if stale_recorder
+                    .record_canonical_items(&[user_message_item("write through stale recorder")])
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("shutdown should close the stale recorder");
+        drop(cleanup);
+        release_lock.send(()).expect("release live recorder lock");
+        lock_holder.await.expect("join live recorder lock holder");
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if matches!(
+                    store.live_rollout_path(thread_id).await,
+                    Err(ThreadStoreError::ThreadNotFound { thread_id: missing })
+                        if missing == thread_id
+                ) {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("shutdown cleanup handle should release the live writer");
+    }
+
+    #[tokio::test]
+    async fn stale_cleanup_generation_does_not_discard_replacement_writer() {
+        let home = TempDir::new().expect("temp dir");
+        let store = LocalThreadStore::new(test_config(home.path()), /*state_db*/ None);
+        let thread_id = ThreadId::default();
+
+        store
+            .create_thread(create_thread_params(thread_id))
+            .await
+            .expect("create initial live thread");
+        let stale_generation_cutoff = store.live_recorder_generation_cutoff();
+        store
+            .discard_thread(thread_id)
+            .await
+            .expect("discard initial live thread");
+        store
+            .create_thread(create_thread_params(thread_id))
+            .await
+            .expect("create replacement live thread");
+
+        let delayed_store = store.clone();
+        ThreadStoreCleanup::spawn("discard", thread_id, async move {
+            let recorder = match delayed_store
+                .live_recorder_before_generation(thread_id, stale_generation_cutoff)
+                .await
+            {
+                Ok(recorder) => recorder,
+                Err(ThreadStoreError::ThreadNotFound { .. }) => return Ok(()),
+                Err(err) => return Err(err),
+            };
+            live_writer::discard_cleanup(delayed_store, thread_id, recorder).await
+        })
+        .await
+        .expect("stale cleanup should not touch the replacement writer");
+
+        store
+            .append_items(AppendThreadItemsParams {
+                thread_id,
+                items: vec![user_message_item("write through replacement writer")],
+            })
+            .await
+            .expect("replacement writer should remain live");
+        store
+            .discard_thread(thread_id)
+            .await
+            .expect("discard replacement live thread");
     }
 
     #[tokio::test]

--- a/codex-rs/thread-store/src/store.rs
+++ b/codex-rs/thread-store/src/store.rs
@@ -66,8 +66,10 @@ pub trait ThreadStore: Any + Send + Sync {
     /// Discards the live thread writer without forcing pending in-memory items to become durable.
     ///
     /// Core calls this when session initialization fails after a live writer has been created.
-    /// Implementations should release any live writer resources for the thread while preserving
-    /// already-durable thread data.
+    /// This is an idempotent terminal release: implementations must preserve already-durable
+    /// thread data, finish releasing the lease after cleanup starts even if the returned future
+    /// is canceled or reports a diagnostic error, and prevent previously obtained writer handles
+    /// from appending once it returns.
     fn discard_thread(&self, thread_id: ThreadId) -> ThreadStoreFuture<'_, ()>;
 
     /// Loads persisted history for resume, fork, rollback, and memory jobs.

--- a/codex-rs/thread-store/src/store.rs
+++ b/codex-rs/thread-store/src/store.rs
@@ -3,6 +3,9 @@ use codex_protocol::protocol::ThreadHistoryMode;
 use std::any::Any;
 use std::future::Future;
 use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
+use tokio::task::JoinHandle;
 
 use crate::AppendThreadItemsParams;
 use crate::ArchiveThreadParams;
@@ -28,6 +31,54 @@ use crate::UpdateThreadMetadataParams;
 
 /// Future returned by [`ThreadStore`] operations.
 pub type ThreadStoreFuture<'a, T> = Pin<Box<dyn Future<Output = ThreadStoreResult<T>> + Send + 'a>>;
+
+/// Handle for eagerly started terminal thread cleanup.
+///
+/// Awaiting the handle joins cleanup and reports its result. Dropping it detaches the underlying
+/// task instead of canceling cleanup, so terminal cleanup keeps running after its caller is
+/// canceled.
+#[must_use = "await this handle to observe terminal cleanup failures"]
+pub struct ThreadStoreCleanup {
+    operation: &'static str,
+    thread_id: ThreadId,
+    task: JoinHandle<ThreadStoreResult<()>>,
+}
+
+impl ThreadStoreCleanup {
+    /// Starts terminal cleanup immediately on the current Tokio runtime.
+    pub fn spawn(
+        operation: &'static str,
+        thread_id: ThreadId,
+        cleanup: impl Future<Output = ThreadStoreResult<()>> + Send + 'static,
+    ) -> Self {
+        Self {
+            operation,
+            thread_id,
+            task: tokio::spawn(cleanup),
+        }
+    }
+}
+
+impl Future for ThreadStoreCleanup {
+    type Output = ThreadStoreResult<()>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        match Pin::new(&mut this.task).poll(cx) {
+            Poll::Ready(Ok(result)) => Poll::Ready(result),
+            Poll::Ready(Err(err)) => {
+                let operation = this.operation;
+                let thread_id = &this.thread_id;
+                Poll::Ready(Err(ThreadStoreError::Internal {
+                    message: format!(
+                        "{operation} cleanup task failed for thread {thread_id}: {err}"
+                    ),
+                }))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
 
 /// Storage-neutral thread persistence boundary.
 pub trait ThreadStore: Any + Send + Sync {
@@ -60,17 +111,21 @@ pub trait ThreadStore: Any + Send + Sync {
     /// Flushes all queued items and returns once they are durable/readable.
     fn flush_thread(&self, thread_id: ThreadId) -> ThreadStoreFuture<'_, ()>;
 
-    /// Flushes pending items and closes the live thread writer.
-    fn shutdown_thread(&self, thread_id: ThreadId) -> ThreadStoreFuture<'_, ()>;
+    /// Starts terminal cleanup that flushes pending items and closes the live thread writer.
+    ///
+    /// This starts terminal cleanup before returning. Await the handle to observe completion; if
+    /// the caller is canceled, dropping the handle detaches the terminal task instead of
+    /// canceling it.
+    fn shutdown_thread(&self, thread_id: ThreadId) -> ThreadStoreCleanup;
 
     /// Discards the live thread writer without forcing pending in-memory items to become durable.
     ///
     /// Core calls this when session initialization fails after a live writer has been created.
     /// This is an idempotent terminal release: implementations must preserve already-durable
-    /// thread data, finish releasing the lease after cleanup starts even if the returned future
-    /// is canceled or reports a diagnostic error, and prevent previously obtained writer handles
-    /// from appending once it returns.
-    fn discard_thread(&self, thread_id: ThreadId) -> ThreadStoreFuture<'_, ()>;
+    /// thread data, keep releasing the lease after cleanup starts even if the returned handle is
+    /// dropped, and prevent previously obtained writer handles from appending after cleanup
+    /// completes.
+    fn discard_thread(&self, thread_id: ThreadId) -> ThreadStoreCleanup;
 
     /// Loads persisted history for resume, fork, rollback, and memory jobs.
     fn load_history(


### PR DESCRIPTION
## Why

A terminal session could report shutdown complete after rollout persistence failed to flush.
`RolloutRecorder::shutdown` intentionally kept the writer alive for retry, but the terminal session had no remaining owner to retry it.
The local store kept that live-writer lease registered, so a later resume could fail with a duplicate live local writer instead of recovering the durable rollout prefix.

Related: internal incident report; no public issue.

## What Changed

- Added an ordered recorder discard command that closes the writer receiver before acknowledging release, so stale recorder clones cannot append after the lease is dropped.
- Added an eager `ThreadStoreCleanup` handle for both shutdown and discard: awaiting joins cleanup, while dropping the handle detaches the task so terminal lease release survives caller cancellation.
- Bound detached local cleanup to the writer generation present when the handle is created, so a delayed stale cleanup cannot shut down or discard a replacement writer after resume.
- Made local discard idempotent and identity-checked while preserving already durable rollout data.
- Made explicit shutdown and submission-channel-close run terminal persistence cleanup in a detached task: try graceful shutdown, discard on failure, and wait for lease release before emitting `ShutdownComplete` or exiting.
- Added regressions for failed shutdown completion ordering, channel-close cleanup, stale clones, cancellation during shutdown/discard cleanup, stale cleanup generations, and durable-prefix resume.

## Verification

- Reproduced the failure path by blocking rollout materialization, then verified public `Op::Shutdown` reports the persistence error, emits `ShutdownComplete`, and has already released the live writer.
- Verified dropped cleanup handles finish releasing shutdown/discard leases and stale cleanup generations do not touch replacement writers.
- Verified discard preserves a durable prefix across resume and prevents stale recorder clones from appending.
