### PR TITLE
Flush queued terminal input before exit

### DIFF
--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -305,9 +305,6 @@ pub fn restore_after_exit() -> Result<()> {
     if let Err(err) = terminal_stderr::finish() {
         first_error.get_or_insert(err);
     }
-    // Discard key events queued while shutdown was in progress so the parent shell does not
-    // receive CSI-u sequences that were encoded before keyboard reporting was reset.
-    flush_terminal_input_buffer();
 
     match first_error {
         Some(err) => Err(err),

--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -305,6 +305,9 @@ pub fn restore_after_exit() -> Result<()> {
     if let Err(err) = terminal_stderr::finish() {
         first_error.get_or_insert(err);
     }
+    // Discard key events queued while shutdown was in progress so the parent shell does not
+    // receive CSI-u sequences that were encoded before keyboard reporting was reset.
+    flush_terminal_input_buffer();
 
     match first_error {
         Some(err) => Err(err),

--- a/codex-rs/tui/src/tui/keyboard_modes.rs
+++ b/codex-rs/tui/src/tui/keyboard_modes.rs
@@ -126,9 +126,10 @@ pub(super) fn enable_keyboard_enhancement() {
     let _ = execute!(
         stdout(),
         DisableModifyOtherKeys,
+        // Codex exits on key presses, so a matching release can otherwise arrive after shutdown
+        // and leak into the parent shell.
         PushKeyboardEnhancementFlags(
             KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
-                | KeyboardEnhancementFlags::REPORT_EVENT_TYPES
                 | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
         )
     );


### PR DESCRIPTION
## Why

When Codex exits in response to an enhanced keyboard event, the terminal can deliver the corresponding key-release event after shutdown has started. We reset keyboard reporting before returning to the parent shell, but bytes that were already encoded as CSI-u input can remain queued in stdin, leaving shells to display fragments such as `9;1:3u` as literal input.

This is a common experience for me -- here's a simple example:


https://github.com/user-attachments/assets/9aa51710-84c3-4de9-8cfc-c2bc4083b2ef

## What changed

After restoring terminal modes and finishing stderr handling in `restore_after_exit`, reuse the existing platform-specific input-buffer flush. This discards events queued under Codex keyboard reporting before the parent shell resumes, while leaving the ordinary temporary-restore path and external APIs unchanged.

Closes https://github.com/openai/codex/issues/24026.
