### PR TITLE
[codex] mention alternative installer options after rate limits

### DIFF
--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -217,7 +217,7 @@ function Resolve-Release {
     try {
         $releaseMetadata = Invoke-RestMethod -Uri $metadataUri
     } catch {
-        throw "Could not fetch GitHub release metadata for Codex $requestedRelease. GitHub API may be unavailable or rate limited. $($_.Exception.Message)"
+        throw "Could not fetch GitHub release metadata for Codex $requestedRelease. GitHub API may be unavailable or rate limited. $($_.Exception.Message) Consider other installation options https://developers.openai.com/codex/cli"
     }
 
     if ($normalizedVersion -eq "latest") {

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -152,7 +152,7 @@ resolve_release() {
   fi
 
   if ! release_json="$(download_text "$metadata_url")"; then
-    echo "Could not fetch GitHub release metadata for Codex $requested_release. GitHub API may be unavailable or rate limited." >&2
+    echo "Could not fetch GitHub release metadata for Codex $requested_release. GitHub API may be unavailable or rate limited. Consider other installation options https://developers.openai.com/codex/cli" >&2
     exit 1
   fi
 

--- a/scripts/install/test_install_sh.py
+++ b/scripts/install/test_install_sh.py
@@ -29,6 +29,11 @@ class InstallShTest(unittest.TestCase):
             f"Could not fetch GitHub release metadata for Codex {VERSION}",
             result.stderr,
         )
+        self.assertIn(
+            "Consider other installation options "
+            "https://developers.openai.com/codex/cli",
+            result.stderr,
+        )
         self.assertNotIn("Could not find Codex package", result.stderr)
 
     def test_exact_release_fetches_metadata_once(self) -> None:


### PR DESCRIPTION
## Summary

- point standalone installer GitHub rate-limit failures to the Codex CLI installation options
- keep the shell and PowerShell diagnostics aligned
- cover the new guidance in the mocked shell installer regression test

## Why

#31056 made GitHub release metadata failures explicit when the shared unauthenticated API rate limit is exhausted. The diagnostic now gives affected users an actionable next step:

`Consider other installation options https://developers.openai.com/codex/cli`

## User impact

Users blocked by GitHub API availability or rate limits can immediately find supported alternative installation methods instead of being left without a recovery path.

## Testing

- `python3 -m unittest discover -s scripts/install -p 'test_*.py' -v`
- `sh -n scripts/install/install.sh`
- `git diff --check`
