### PR TITLE
[codex] Avoid warning for unset Windows sandbox mode

### DIFF
--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -9541,6 +9541,37 @@ async fn explicit_sandbox_mode_falls_back_when_disallowed_by_requirements() -> s
 }
 
 #[tokio::test]
+async fn unset_windows_sandbox_mode_uses_requirements_default_without_warning()
+-> std::io::Result<()> {
+    let codex_home = TempDir::new()?;
+
+    let config = ConfigBuilder::without_managed_config_for_tests()
+        .codex_home(codex_home.path().to_path_buf())
+        .fallback_cwd(Some(codex_home.path().to_path_buf()))
+        .cloud_config_bundle(
+            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+                r#"[windows]
+allowed_sandbox_implementations = ["elevated"]
+"#,
+            ),
+        )
+        .build()
+        .await?;
+
+    assert_eq!(
+        config.permissions.windows_sandbox_mode,
+        Some(codex_config::types::WindowsSandboxModeToml::Elevated)
+    );
+    assert!(
+        config.startup_warnings.iter().all(|warning| !warning
+            .contains("Configured value for `windows.sandbox` is disallowed by requirements")),
+        "{:?}",
+        config.startup_warnings
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn windows_sandbox_mode_falls_back_when_disallowed_by_requirements() -> std::io::Result<()> {
     let codex_home = TempDir::new()?;
     std::fs::write(

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -3070,12 +3070,14 @@ impl Config {
                 WindowsSandboxLevel::Disabled => None,
             }
         });
-        apply_requirement_constrained_value(
-            "windows.sandbox",
-            selected_windows_sandbox_mode,
-            &mut constrained_windows_sandbox_mode,
-            &mut startup_warnings,
-        )?;
+        if let Some(selected_windows_sandbox_mode) = selected_windows_sandbox_mode {
+            apply_requirement_constrained_value(
+                "windows.sandbox",
+                Some(selected_windows_sandbox_mode),
+                &mut constrained_windows_sandbox_mode,
+                &mut startup_warnings,
+            )?;
+        }
         let effective_windows_sandbox_mode = *constrained_windows_sandbox_mode.get();
         let windows_sandbox_mode = if constrained_windows_sandbox_mode.source.is_some() {
             effective_windows_sandbox_mode


### PR DESCRIPTION
## Summary

- treat an unset Windows sandbox mode as the absence of a value to constrain
- keep the managed requirement's preferred implementation as the effective default
- preserve warnings and fallback behavior for explicit or feature-selected conflicts
- add regression coverage for an elevated-only requirement with no selected mode

## Root cause

Core config resolution passed `None` through the generic requirements fallback path. The Windows sandbox constraint correctly rejects `None`, but in this case it represented an unset value rather than a conflicting selection. That produced a misleading startup warning even though the constraint already held the correct managed default.

## Impact

Managed Windows sandbox requirements now select their default silently when no implementation was chosen. Explicit conflicts are still rejected with the existing warning, and the effective Windows mode remains available as portable intent for remote execution.

Fixes #31250

## Testing

- `just test -p codex-core windows_sandbox_mode -- --nocapture`
- `just fix -p codex-core`
- structured autoreview: clean, no accepted/actionable findings
- `just test -p codex-core`: 2,893 passed; 10 unrelated ambient-environment failures remained (`/tmp` is a Git repo in this environment and inherited environment/fixture state affects the other failures)
