### PR TITLE
Clarify guardian reviewer permission instructions

### DIFF
--- a/codex-rs/core/src/context_manager/updates.rs
+++ b/codex-rs/core/src/context_manager/updates.rs
@@ -34,23 +34,25 @@ fn build_permissions_update_item(
         return None;
     }
 
-    Some(
-        PermissionsInstructions::from_permission_profile(
-            &next.permission_profile,
-            next.approval_policy.value(),
-            next.config.approvals_reviewer,
-            exec_policy,
-            #[allow(deprecated)]
-            &next.cwd,
-            next.config
-                .features
-                .enabled(Feature::ExecPermissionApprovals),
-            next.config
-                .features
-                .enabled(Feature::RequestPermissionsTool),
-        )
-        .render(),
-    )
+    let mut permissions_instructions = PermissionsInstructions::from_permission_profile(
+        &next.permission_profile,
+        next.approval_policy.value(),
+        next.config.approvals_reviewer,
+        exec_policy,
+        #[allow(deprecated)]
+        &next.cwd,
+        next.config
+            .features
+            .enabled(Feature::ExecPermissionApprovals),
+        next.config
+            .features
+            .enabled(Feature::RequestPermissionsTool),
+    );
+    if crate::guardian::is_guardian_reviewer_source(&next.session_source) {
+        permissions_instructions = permissions_instructions.for_guardian_reviewer();
+    }
+
+    Some(permissions_instructions.render())
 }
 
 fn build_collaboration_mode_update_item(

--- a/codex-rs/core/src/guardian/tests.rs
+++ b/codex-rs/core/src/guardian/tests.rs
@@ -1743,7 +1743,18 @@ async fn guardian_review_request_layout_matches_model_visible_request_snapshot()
     ));
     let request = request_log.single_request();
     let request_body = request.body_json();
+    let guardian_developer_text = request.message_input_texts("developer").join("\n");
     let guardian_user_text = request.message_input_texts("user").join("\n");
+    assert!(
+        guardian_developer_text.contains(
+            "These are the permissions of this reviewer thread only. They are not the permissions of the Codex session being reviewed."
+        ),
+        "guardian request should distinguish reviewer permissions from the reviewed session"
+    );
+    assert!(
+        !guardian_developer_text.contains("Approval policy is currently never."),
+        "guardian request should omit the reviewer thread's approval policy reminder"
+    );
     assert!(
         guardian_user_text.contains(&format!("${GUARDIAN_SKILL_NAME}")),
         "guardian request should contain the untrusted skill mention from the parent transcript"

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -3177,32 +3177,32 @@ impl Session {
         {
             developer_sections.push(model_switch_message);
         }
+        let is_guardian_reviewer = crate::guardian::is_guardian_reviewer_source(&session_source);
         if turn_context.config.include_permissions_instructions {
-            developer_sections.push(
-                PermissionsInstructions::from_permission_profile(
-                    &turn_context.permission_profile,
-                    turn_context.approval_policy.value(),
-                    turn_context.config.approvals_reviewer,
-                    self.services.exec_policy.current().as_ref(),
-                    #[allow(deprecated)]
-                    &turn_context.cwd,
-                    turn_context
-                        .config
-                        .features
-                        .enabled(Feature::ExecPermissionApprovals),
-                    turn_context
-                        .config
-                        .features
-                        .enabled(Feature::RequestPermissionsTool),
-                )
-                .render(),
+            let mut permissions_instructions = PermissionsInstructions::from_permission_profile(
+                &turn_context.permission_profile,
+                turn_context.approval_policy.value(),
+                turn_context.config.approvals_reviewer,
+                self.services.exec_policy.current().as_ref(),
+                #[allow(deprecated)]
+                &turn_context.cwd,
+                turn_context
+                    .config
+                    .features
+                    .enabled(Feature::ExecPermissionApprovals),
+                turn_context
+                    .config
+                    .features
+                    .enabled(Feature::RequestPermissionsTool),
             );
+            if is_guardian_reviewer {
+                permissions_instructions = permissions_instructions.for_guardian_reviewer();
+            }
+            developer_sections.push(permissions_instructions.render());
         }
-        let separate_guardian_developer_message =
-            crate::guardian::is_guardian_reviewer_source(&session_source);
         // Keep the guardian policy prompt out of the aggregated developer bundle so it
         // stays isolated as its own top-level developer message for guardian subagents.
-        if !separate_guardian_developer_message
+        if !is_guardian_reviewer
             && let Some(developer_instructions) = turn_context.developer_instructions.as_deref()
             && !developer_instructions.is_empty()
         {
@@ -3441,7 +3441,7 @@ impl Session {
         }
         // Emit the guardian policy prompt as a separate developer item so the guardian
         // subagent sees a distinct, easy-to-audit instruction block.
-        if separate_guardian_developer_message
+        if is_guardian_reviewer
             && let Some(developer_instructions) = turn_context.developer_instructions.as_deref()
             && !developer_instructions.is_empty()
             && let Some(guardian_developer_message) =

--- a/codex-rs/prompts/src/permissions_instructions.rs
+++ b/codex-rs/prompts/src/permissions_instructions.rs
@@ -58,6 +58,8 @@ pub struct PermissionsInstructions {
     text: String,
 }
 
+const GUARDIAN_REVIEWER_SCOPE_TEXT: &str = "These are the permissions of this reviewer thread only. They are not the permissions of the Codex session being reviewed.";
+
 impl PermissionsInstructions {
     /// Builds permissions instructions from the effective permission profile and approval policy.
     pub fn from_permission_profile(
@@ -90,6 +92,21 @@ impl PermissionsInstructions {
 
     pub fn body(&self) -> String {
         self.text.clone()
+    }
+
+    /// Clarifies that these permissions belong to a guardian reviewer, not the reviewed session.
+    ///
+    /// Guardian reviewers always run with a non-requesting approval policy, so the ordinary
+    /// approval-policy reminder is omitted to avoid confusing it with the reviewed session's
+    /// permissions. If the reviewer attempts an escalation anyway, its fixed approval policy
+    /// rejects the request.
+    pub fn for_guardian_reviewer(mut self) -> Self {
+        let reviewer_permissions = self.text.replace(APPROVAL_POLICY_NEVER, "");
+        self.text = format!(
+            "{GUARDIAN_REVIEWER_SCOPE_TEXT}\n{}\n",
+            reviewer_permissions.trim()
+        );
+        self
     }
 
     #[cfg(test)]

--- a/codex-rs/prompts/src/permissions_instructions_tests.rs
+++ b/codex-rs/prompts/src/permissions_instructions_tests.rs
@@ -55,6 +55,28 @@ fn builds_permissions_with_network_access_override() {
 }
 
 #[test]
+fn guardian_reviewer_permissions_distinguish_the_reviewed_session() {
+    let instructions = PermissionsInstructions::from_permissions_with_network(
+        SandboxMode::ReadOnly,
+        NetworkAccess::Restricted,
+        PermissionsPromptConfig {
+            approval_policy: AskForApproval::Never,
+            approvals_reviewer: ApprovalsReviewer::User,
+            exec_policy: &Policy::empty(),
+            exec_permission_approvals_enabled: false,
+            request_permissions_tool_enabled: false,
+        },
+        /*writable_roots*/ None,
+    )
+    .for_guardian_reviewer();
+
+    assert_eq!(
+        instructions.body(),
+        "These are the permissions of this reviewer thread only. They are not the permissions of the Codex session being reviewed.\nFilesystem sandboxing defines which files can be read or written. `sandbox_mode` is `read-only`: The sandbox only permits reading files. Network access is restricted.\n"
+    );
+}
+
+#[test]
 fn builds_permissions_from_profile() {
     let cwd = PathBuf::from("/tmp");
     let writable_root =


### PR DESCRIPTION
## Why

Guardian review threads receive their own locked-down permissions context. The generic permissions wording made it easy to mistake the reviewer's read-only sandbox for the permissions of the Codex session being reviewed, which could confuse approval decisions.

## What changed

- Added guardian-specific wording that states the permissions belong only to the reviewer thread, not the reviewed Codex session.
- Omitted the reviewer thread's `approval_policy = never` reminder from that guardian-only block.
- Applied the wording to both initial guardian context and later permissions updates; non-guardian sessions are unchanged.
- Added focused prompt-rendering and guardian-request assertions.

## Test plan

- `just test -p codex-prompts`
- `just test -p codex-core guardian_review_request_layout_matches_model_visible_request_snapshot`