### PR TITLE
app-server: reuse loaded threads when resume config matches

### DIFF
--- a/codex-rs/app-server/src/request_processors/thread_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor.rs
@@ -3,6 +3,7 @@ use crate::error_code::method_not_found;
 use codex_app_server_protocol::SelectedCapabilityRoot;
 use codex_extension_api::ExtensionDataInit;
 use codex_protocol::config_types::MultiAgentMode;
+use codex_protocol::config_types::SERVICE_TIER_DEFAULT_REQUEST_VALUE;
 use codex_protocol::models::BUILT_IN_PERMISSION_PROFILE_DANGER_FULL_ACCESS;
 use codex_protocol::models::BUILT_IN_PERMISSION_PROFILE_WORKSPACE;
 use codex_protocol::protocol::ThreadHistoryMode;
@@ -21,6 +22,109 @@ struct ThreadListFilters {
     search_term: Option<String>,
     use_state_db_only: bool,
     relation_filter: Option<StoreThreadRelationFilter>,
+}
+
+fn resume_configs_semantically_equal(
+    desired: &Config,
+    loaded: &Config,
+    snapshot: &ThreadConfigSnapshot,
+) -> bool {
+    let desired_service_tier = desired
+        .service_tier
+        .as_deref()
+        .filter(|service_tier| *service_tier != SERVICE_TIER_DEFAULT_REQUEST_VALUE);
+    let loaded_service_tier = snapshot
+        .service_tier
+        .as_deref()
+        .filter(|service_tier| *service_tier != SERVICE_TIER_DEFAULT_REQUEST_VALUE);
+    let desired_permission_profile = desired
+        .permissions
+        .permission_profile()
+        .clone()
+        .materialize_project_roots_with_workspace_roots(&desired.workspace_roots);
+    if desired.model.as_deref() != Some(snapshot.model.as_str())
+        || desired.model_provider_id != snapshot.model_provider_id
+        || desired_service_tier != loaded_service_tier
+        || desired.cwd.as_path() != snapshot.cwd().as_path()
+        || desired.workspace_roots != snapshot.workspace_roots
+        || desired.model_reasoning_effort != snapshot.reasoning_effort
+        || desired.model_reasoning_summary != snapshot.reasoning_summary
+        || desired.personality != snapshot.personality
+        || desired.approvals_reviewer != snapshot.approvals_reviewer
+        || desired.permissions.approval_policy.value() != snapshot.approval_policy
+        || desired.permissions.active_permission_profile() != snapshot.active_permission_profile
+        || desired.permissions.profile_workspace_roots() != snapshot.profile_workspace_roots
+        || desired_permission_profile != snapshot.permission_profile
+        || desired.permissions.network != loaded.permissions.network
+        || desired.permissions.allow_login_shell != loaded.permissions.allow_login_shell
+        || desired.permissions.shell_environment_policy
+            != loaded.permissions.shell_environment_policy
+        || desired.permissions.windows_sandbox_mode != loaded.permissions.windows_sandbox_mode
+        || desired.permissions.windows_sandbox_private_desktop
+            != loaded.permissions.windows_sandbox_private_desktop
+    {
+        return false;
+    }
+
+    let mut desired = desired.clone();
+    let mut loaded = loaded.clone();
+    loaded.model = desired.model.clone();
+    loaded.model_provider_id = desired.model_provider_id.clone();
+    loaded.service_tier = desired.service_tier.clone();
+    loaded.cwd = desired.cwd.clone();
+    loaded.workspace_roots = desired.workspace_roots.clone();
+    loaded.workspace_roots_explicit = desired.workspace_roots_explicit;
+    loaded.model_reasoning_effort = desired.model_reasoning_effort.clone();
+    loaded.model_reasoning_summary = desired.model_reasoning_summary;
+    loaded.personality = desired.personality;
+    loaded.approvals_reviewer = desired.approvals_reviewer;
+    loaded.permissions = desired.permissions.clone();
+
+    const LIVE_SETTING_KEYS: &[&str] = &[
+        "approval_policy",
+        "approvals_reviewer",
+        "cwd",
+        "default_permissions",
+        "developer_instructions",
+        "instructions",
+        "model",
+        "model_provider",
+        "model_reasoning_effort",
+        "model_reasoning_summary",
+        "personality",
+        "sandbox_mode",
+        "sandbox_workspace_write",
+        "service_tier",
+        "workspace_roots",
+    ];
+    let normalize_layer_config = |config: &Config| {
+        let mut effective_config = config.config_layer_stack.effective_config();
+        if let Some(table) = effective_config.as_table_mut() {
+            for key in LIVE_SETTING_KEYS {
+                table.remove(*key);
+            }
+        }
+        effective_config
+    };
+    if normalize_layer_config(&desired) != normalize_layer_config(&loaded)
+        || desired.config_layer_stack.requirements() != loaded.config_layer_stack.requirements()
+        || desired.config_layer_stack.requirements_toml()
+            != loaded.config_layer_stack.requirements_toml()
+        || desired
+            .config_layer_stack
+            .ignore_user_and_project_exec_policy_rules()
+            != loaded
+                .config_layer_stack
+                .ignore_user_and_project_exec_policy_rules()
+    {
+        return false;
+    }
+
+    desired.config_layer_stack = ConfigLayerStack::default();
+    loaded.config_layer_stack = ConfigLayerStack::default();
+    desired.startup_warnings.clear();
+    loaded.startup_warnings.clear();
+    desired == loaded
 }
 
 fn collect_resume_override_mismatches(
@@ -128,10 +232,6 @@ fn collect_resume_override_mismatches(
         ));
     }
 
-    if request.config.is_some() {
-        mismatch_details
-            .push("config overrides were provided and ignored while running".to_string());
-    }
     if request.base_instructions.is_some() {
         mismatch_details
             .push("baseInstructions override was provided and ignored while running".to_string());
@@ -376,6 +476,12 @@ enum RunningThreadResumeResult {
     /// The optional stored thread contains the history-bearing probe that cold
     /// resume can reuse instead of reading the rollout again.
     NotRunning(Option<Box<StoredThread>>),
+}
+
+enum IdleThreadShutdownResult {
+    Complete,
+    Busy,
+    Pending,
 }
 
 impl ThreadRequestProcessor {
@@ -792,7 +898,6 @@ impl ThreadRequestProcessor {
     }
 
     async fn finalize_thread_teardown(&self, thread_id: ThreadId) {
-        self.pending_thread_unloads.lock().await.remove(&thread_id);
         self.outgoing
             .cancel_requests_for_thread(thread_id, /*error*/ None)
             .await;
@@ -802,6 +907,49 @@ impl ThreadRequestProcessor {
         self.thread_watch_manager
             .remove_thread(&thread_id.to_string())
             .await;
+        self.pending_thread_unloads.lock().await.remove(&thread_id);
+    }
+
+    async fn shutdown_idle_thread_for_replacement(
+        &self,
+        thread_id: ThreadId,
+        thread: Arc<CodexThread>,
+    ) -> IdleThreadShutdownResult {
+        let processor = self.clone();
+        let shutdown = self.background_tasks.spawn(async move {
+            let complete = match thread.try_shutdown_if_idle().await {
+                Ok(false) => false,
+                Ok(true) | Err(_) => {
+                    thread.wait_until_terminated().await;
+                    true
+                }
+            };
+            if complete {
+                processor.thread_manager.remove_thread(&thread_id).await;
+                processor.finalize_thread_teardown(thread_id).await;
+            } else {
+                processor
+                    .pending_thread_unloads
+                    .lock()
+                    .await
+                    .remove(&thread_id);
+            }
+            complete
+        });
+        match tokio::time::timeout(Duration::from_secs(10), shutdown).await {
+            Ok(Ok(true)) => IdleThreadShutdownResult::Complete,
+            Ok(Ok(false)) => IdleThreadShutdownResult::Busy,
+            Ok(Err(error)) => {
+                warn!("thread {thread_id} replacement shutdown task failed: {error}");
+                IdleThreadShutdownResult::Pending
+            }
+            Err(_) => {
+                warn!(
+                    "thread {thread_id} replacement shutdown is still pending; teardown will continue in the background"
+                );
+                IdleThreadShutdownResult::Pending
+            }
+        }
     }
 
     async fn thread_unsubscribe_response_inner(
@@ -1497,10 +1645,11 @@ impl ThreadRequestProcessor {
         let count = thread
             .increment_out_of_band_elicitation_count()
             .await
-            .map_err(|err| {
-                internal_error(format!(
+            .map_err(|err| match err {
+                CodexErr::InvalidRequest(message) => invalid_request(message),
+                err => internal_error(format!(
                     "failed to increment out-of-band elicitation counter: {err}"
-                ))
+                )),
             })?;
         Ok(ThreadIncrementElicitationResponse {
             count,
@@ -2641,24 +2790,6 @@ impl ThreadRequestProcessor {
         app_server_client_version: Option<String>,
         supports_openai_form_elicitation: bool,
     ) -> Result<(), JSONRPCErrorError> {
-        if let Ok(thread_id) = ThreadId::from_string(&params.thread_id)
-            && self
-                .pending_thread_unloads
-                .lock()
-                .await
-                .contains(&thread_id)
-        {
-            self.outgoing
-                .send_error(
-                    request_id,
-                    invalid_request(format!(
-                        "thread {thread_id} is closing; retry thread/resume after the thread is closed"
-                    )),
-                )
-                .await;
-            return Ok(());
-        }
-
         if params.sandbox.is_some() && params.permissions.is_some() {
             self.outgoing
                 .send_error(
@@ -2678,6 +2809,23 @@ impl ThreadRequestProcessor {
                 return Ok(());
             }
         };
+        if let Ok(thread_id) = ThreadId::from_string(&params.thread_id)
+            && self
+                .pending_thread_unloads
+                .lock()
+                .await
+                .contains(&thread_id)
+        {
+            self.outgoing
+                .send_error(
+                    request_id,
+                    invalid_request(format!(
+                        "thread {thread_id} is closing; retry thread/resume after the thread is closed"
+                    )),
+                )
+                .await;
+            return Ok(());
+        }
         let stored_thread_from_running_probe = match self
             .resume_running_thread(
                 &request_id,
@@ -2695,29 +2843,10 @@ impl ThreadRequestProcessor {
             }
         };
 
-        let ThreadResumeParams {
-            thread_id,
-            history,
-            path,
-            model,
-            model_provider,
-            service_tier,
-            cwd,
-            runtime_workspace_roots,
-            approval_policy,
-            approvals_reviewer,
-            sandbox,
-            permissions,
-            config: mut request_overrides,
-            base_instructions,
-            developer_instructions,
-            personality,
-            exclude_turns,
-            initial_turns_page,
-        } = params;
-        let include_turns = !exclude_turns;
+        let include_turns = !params.exclude_turns;
+        let initial_turns_page = params.initial_turns_page.clone();
 
-        let resume_result = if let Some(history) = history {
+        let resume_result = if let Some(history) = params.history.as_ref() {
             self.resume_thread_from_history(history.as_slice())
                 .await
                 .map(|thread_history| (thread_history, None))
@@ -2726,7 +2855,7 @@ impl ThreadRequestProcessor {
                 .await
                 .map(|thread_history| (thread_history, Some(*stored_thread)))
         } else {
-            self.resume_thread_from_rollout(&thread_id, path.as_ref())
+            self.resume_thread_from_rollout(&params.thread_id, params.path.as_ref())
                 .await
                 .map(|(thread_history, stored_thread)| (thread_history, Some(stored_thread)))
         };
@@ -2738,38 +2867,17 @@ impl ThreadRequestProcessor {
             }
         };
 
-        let history_cwd = thread_history.session_cwd();
-        let runtime_workspace_roots = runtime_workspace_roots.map(resolve_runtime_workspace_roots);
-        let mut typesafe_overrides = self.build_thread_config_overrides(
-            model,
-            model_provider,
-            service_tier,
-            cwd,
-            runtime_workspace_roots,
-            approval_policy,
-            approvals_reviewer,
-            sandbox,
-            permissions,
-            base_instructions,
-            developer_instructions,
-            personality,
-        );
-        self.load_and_apply_persisted_resume_metadata(
-            &thread_history,
-            &mut request_overrides,
-            &mut typesafe_overrides,
-        )
-        .await;
-
         // Derive a Config using the same logic as new conversation, honoring overrides if provided.
+        let resumed_thread_id = match &thread_history {
+            InitialHistory::Resumed(resumed) => Some(resumed.conversation_id),
+            InitialHistory::New | InitialHistory::Cleared | InitialHistory::Forked(_) => None,
+        };
         let config = match self
-            .config_manager
-            .load_for_cwd(request_overrides, typesafe_overrides, history_cwd)
+            .load_resume_config(&params, resumed_thread_id, thread_history.session_cwd())
             .await
         {
             Ok(config) => config,
-            Err(err) => {
-                let error = config_load_error(&err);
+            Err(error) => {
                 self.outgoing.send_error(request_id, error).await;
                 return Ok(());
             }
@@ -2953,23 +3061,59 @@ impl ThreadRequestProcessor {
 
     async fn load_and_apply_persisted_resume_metadata(
         &self,
-        thread_history: &InitialHistory,
+        thread_id: Option<ThreadId>,
         request_overrides: &mut Option<HashMap<String, serde_json::Value>>,
         typesafe_overrides: &mut ConfigOverrides,
     ) -> Option<ThreadMetadata> {
-        let InitialHistory::Resumed(resumed_history) = thread_history else {
-            return None;
-        };
+        let thread_id = thread_id?;
         let state_db_ctx = self.state_db.clone()?;
-        let persisted_metadata = state_db_ctx
-            .get_thread(resumed_history.conversation_id)
-            .await
-            .ok()
-            .flatten()?;
+        let persisted_metadata = state_db_ctx.get_thread(thread_id).await.ok().flatten()?;
         merge_persisted_resume_metadata(request_overrides, typesafe_overrides, &persisted_metadata);
         Some(persisted_metadata)
     }
 
+    async fn load_resume_config(
+        &self,
+        params: &ThreadResumeParams,
+        thread_id: Option<ThreadId>,
+        history_cwd: Option<PathBuf>,
+    ) -> Result<Config, JSONRPCErrorError> {
+        let runtime_workspace_roots = params
+            .runtime_workspace_roots
+            .clone()
+            .map(resolve_runtime_workspace_roots);
+        let mut typesafe_overrides = self.build_thread_config_overrides(
+            params.model.clone(),
+            params.model_provider.clone(),
+            params.service_tier.clone(),
+            params.cwd.clone(),
+            runtime_workspace_roots,
+            params.approval_policy,
+            params.approvals_reviewer,
+            params.sandbox,
+            params.permissions.clone(),
+            params.base_instructions.clone(),
+            params.developer_instructions.clone(),
+            params.personality,
+        );
+        let mut request_overrides = params.config.clone();
+        self.load_and_apply_persisted_resume_metadata(
+            thread_id,
+            &mut request_overrides,
+            &mut typesafe_overrides,
+        )
+        .await;
+
+        self.config_manager
+            .load_for_cwd(request_overrides, typesafe_overrides, history_cwd)
+            .await
+            .map_err(|err| config_load_error(&err))
+    }
+
+    #[expect(
+        clippy::await_holding_invalid_type,
+        reason = "resume replacement must be serialized against listener subscription"
+    )]
     #[tracing::instrument(level = "trace", skip_all)]
     async fn resume_running_thread(
         &self,
@@ -3035,14 +3179,111 @@ impl ThreadRequestProcessor {
                     active_path.display()
                 )));
             }
-            let config_snapshot = existing_thread.config_snapshot().await;
-            let mismatch_details = collect_resume_override_mismatches(params, &config_snapshot);
+            let (mismatch_details, allow_cold_resume) = if params.config.is_some() {
+                let session_meta = source_thread.history.as_ref().and_then(|history| {
+                    history.items.iter().find_map(|item| match item {
+                        RolloutItem::SessionMeta(meta_line) => Some(&meta_line.meta),
+                        _ => None,
+                    })
+                });
+                let history_cwd = session_meta.map(|meta| meta.cwd.clone());
+                let persisted_base_instructions = session_meta
+                    .and_then(|meta| meta.base_instructions.as_ref())
+                    .map(|instructions| instructions.text.clone());
+                let desired_config = self
+                    .load_resume_config(params, Some(existing_thread_id), history_cwd)
+                    .await;
+                match desired_config {
+                    Ok(mut desired_config) => {
+                        let config_snapshot = existing_thread.config_snapshot().await;
+                        let mut loaded_config = (*existing_thread.config().await).clone();
+
+                        desired_config.base_instructions = desired_config
+                            .base_instructions
+                            .or_else(|| persisted_base_instructions.clone());
+                        loaded_config.base_instructions =
+                            persisted_base_instructions.or(loaded_config.base_instructions);
+
+                        desired_config.service_tier =
+                            if desired_config.features.enabled(Feature::FastMode) {
+                                match desired_config.service_tier.take() {
+                                    Some(service_tier) => {
+                                        let model = desired_config
+                                            .model
+                                            .as_deref()
+                                            .unwrap_or(config_snapshot.model.as_str());
+                                        let model_info = self
+                                            .thread_manager
+                                            .get_models_manager()
+                                            .get_model_info(
+                                                model,
+                                                &desired_config.to_models_manager_config(),
+                                            )
+                                            .await;
+                                        (service_tier == SERVICE_TIER_DEFAULT_REQUEST_VALUE
+                                            || model_info.supports_service_tier(&service_tier))
+                                        .then_some(service_tier)
+                                    }
+                                    None => None,
+                                }
+                            } else {
+                                None
+                            };
+                        loaded_config.service_tier = config_snapshot.service_tier.clone();
+
+                        if resume_configs_semantically_equal(
+                            &desired_config,
+                            &loaded_config,
+                            &config_snapshot,
+                        ) {
+                            (Vec::new(), true)
+                        } else {
+                            (
+                                vec![
+                                    "effective resume configuration differs from the loaded thread configuration"
+                                        .to_string(),
+                                ],
+                                true,
+                            )
+                        }
+                    }
+                    Err(error) => {
+                        let loaded_status = self
+                            .thread_watch_manager
+                            .loaded_status_for_thread(&existing_thread_id.to_string())
+                            .await;
+                        let is_running =
+                            matches!(existing_thread.agent_status().await, AgentStatus::Running);
+                        let has_subscribers = !self
+                            .thread_state_manager
+                            .subscribed_connection_ids(existing_thread_id)
+                            .await
+                            .is_empty();
+                        if matches!(loaded_status, ThreadStatus::Idle)
+                            && !is_running
+                            && !has_subscribers
+                        {
+                            return Err(error);
+                        }
+                        (
+                            vec![format!(
+                                "requested resume configuration is invalid: {}",
+                                error.message
+                            )],
+                            // Invalid input may be ignored to preserve rejoin, but
+                            // must never evict the valid cached thread.
+                            false,
+                        )
+                    }
+                }
+            } else {
+                let config_snapshot = existing_thread.config_snapshot().await;
+                (
+                    collect_resume_override_mismatches(params, &config_snapshot),
+                    true,
+                )
+            };
             if !mismatch_details.is_empty() {
-                let has_subscribers = !self
-                    .thread_state_manager
-                    .subscribed_connection_ids(existing_thread_id)
-                    .await
-                    .is_empty();
                 let loaded_status = self
                     .thread_watch_manager
                     .loaded_status_for_thread(&existing_thread_id.to_string())
@@ -3050,23 +3291,49 @@ impl ThreadRequestProcessor {
                 let is_running =
                     matches!(existing_thread.agent_status().await, AgentStatus::Running);
 
-                if !has_subscribers && matches!(loaded_status, ThreadStatus::Idle) && !is_running {
-                    // A loaded idle thread is only a cache entry. Shut it down
-                    // before removing it so cold resume cannot duplicate a
-                    // thread that timed out during shutdown.
-                    match wait_for_thread_shutdown(&existing_thread).await {
-                        ThreadShutdownResult::Complete => {
-                            self.thread_manager.remove_thread(&existing_thread_id).await;
-                            self.finalize_thread_teardown(existing_thread_id).await;
+                let should_cold_resume = if allow_cold_resume
+                    && matches!(loaded_status, ThreadStatus::Idle)
+                    && !is_running
+                {
+                    let mut pending_thread_unloads = self.pending_thread_unloads.lock().await;
+                    let has_subscribers = !self
+                        .thread_state_manager
+                        .subscribed_connection_ids(existing_thread_id)
+                        .await
+                        .is_empty();
+                    if has_subscribers {
+                        false
+                    } else if pending_thread_unloads.insert(existing_thread_id) {
+                        true
+                    } else {
+                        return Err(invalid_request(format!(
+                            "thread {existing_thread_id} is closing; retry thread/resume after the thread is closed"
+                        )));
+                    }
+                } else {
+                    false
+                };
+                if should_cold_resume {
+                    // A loaded idle thread is only a cache entry. Mark it as
+                    // closing before shutdown so a new subscriber cannot race
+                    // with replacement.
+                    match self
+                        .shutdown_idle_thread_for_replacement(
+                            existing_thread_id,
+                            Arc::clone(&existing_thread),
+                        )
+                        .await
+                    {
+                        IdleThreadShutdownResult::Complete => {
                             // Shutdown can flush newer rollout items, so reload the
                             // stored thread before starting the replacement session.
                             return Ok(RunningThreadResumeResult::NotRunning(None));
                         }
-                        ThreadShutdownResult::SubmitFailed => {
-                            warn!("failed to submit Shutdown to thread {existing_thread_id}");
-                        }
-                        ThreadShutdownResult::TimedOut => {
-                            warn!("thread {existing_thread_id} shutdown timed out");
+                        IdleThreadShutdownResult::Busy => {}
+                        IdleThreadShutdownResult::Pending => {
+                            return Err(invalid_request(format!(
+                                "thread {existing_thread_id} is closing; retry thread/resume after the thread is closed"
+                            )));
                         }
                     }
                 }
@@ -3079,6 +3346,7 @@ impl ThreadRequestProcessor {
                     mismatch_details.join("; ")
                 );
             }
+            let config_snapshot = existing_thread.config_snapshot().await;
             let redact_resume_payloads =
                 should_redact_thread_resume_payloads(app_server_client_name.as_deref());
             let history_items = source_thread

--- a/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor_tests.rs
@@ -732,7 +732,7 @@ mod thread_processor_behavior_tests {
     }
 
     #[test]
-    fn collect_resume_override_mismatches_includes_service_tier() {
+    fn collect_resume_override_mismatches_compares_effective_resume_settings() {
         let cwd = test_path_buf("/tmp").abs();
         let request = ThreadResumeParams {
             thread_id: "thread-1".to_string(),

--- a/codex-rs/app-server/src/request_processors/turn_processor.rs
+++ b/codex-rs/app-server/src/request_processors/turn_processor.rs
@@ -526,15 +526,19 @@ impl TurnRequestProcessor {
             additional_context,
             thread_settings,
         };
+        let trace_context = self.request_trace_context(&request_id).await;
         let turn_id = thread
             .submit_user_input_with_client_user_message_id(
                 turn_op,
-                self.request_trace_context(&request_id).await,
+                trace_context,
                 client_user_message_id,
             )
             .await
             .map_err(|err| {
-                let error = internal_error(format!("failed to start turn: {err}"));
+                let error = match err {
+                    CodexErr::InvalidRequest(message) => invalid_request(message),
+                    err => internal_error(format!("failed to start turn: {err}")),
+                };
                 self.track_error_response(&request_id, &error, /*error_type*/ None);
                 error
             })?;

--- a/codex-rs/app-server/tests/suite/v2/thread_resume.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_resume.rs
@@ -262,13 +262,15 @@ async fn thread_resume_with_empty_path_uses_running_thread_id() -> Result<()> {
 }
 
 #[tokio::test]
-async fn thread_resume_running_thread_uses_cached_instruction_sources() -> Result<()> {
+async fn thread_resume_reuses_idle_thread_when_full_config_matches() -> Result<()> {
     let server = create_mock_responses_server_repeating_assistant("Done").await;
     let codex_home = TempDir::new()?;
     create_config_toml(codex_home.path(), &server.uri())?;
     let workspace = TempDir::new()?;
     let project_agents = workspace.path().join("AGENTS.md");
     std::fs::write(&project_agents, "project instructions")?;
+    let config = std::collections::HashMap::from([("features.plugins".to_string(), json!(false))]);
+    let developer_instructions = "stable developer instructions".to_string();
 
     let mut mcp = TestAppServer::new(codex_home.path()).await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
@@ -276,6 +278,8 @@ async fn thread_resume_running_thread_uses_cached_instruction_sources() -> Resul
     let start_id = mcp
         .send_thread_start_request(ThreadStartParams {
             cwd: Some(workspace.path().display().to_string()),
+            config: Some(config.clone()),
+            developer_instructions: Some(developer_instructions.clone()),
             ..Default::default()
         })
         .await?;
@@ -315,11 +319,82 @@ async fn thread_resume_running_thread_uses_cached_instruction_sources() -> Resul
     )
     .await??;
 
+    let base_instructions = read_session_meta_line(
+        thread
+            .path
+            .as_deref()
+            .expect("materialized thread should have a rollout path"),
+    )
+    .await?
+    .meta
+    .base_instructions
+    .expect("materialized thread should persist base instructions")
+    .text;
+
+    let subscribed_invalid_resume_id = mcp
+        .send_thread_resume_request(ThreadResumeParams {
+            thread_id: thread.id.clone(),
+            cwd: Some(workspace.path().display().to_string()),
+            config: Some(std::collections::HashMap::from([(
+                "features.plugins".to_string(),
+                json!("invalid"),
+            )])),
+            base_instructions: Some(base_instructions.clone()),
+            developer_instructions: Some(developer_instructions.clone()),
+            ..Default::default()
+        })
+        .await?;
+    let subscribed_invalid_resume_resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(subscribed_invalid_resume_id)),
+    )
+    .await??;
+    let ThreadResumeResponse {
+        instruction_sources,
+        ..
+    } = to_response::<ThreadResumeResponse>(subscribed_invalid_resume_resp)?;
+    assert_eq!(instruction_sources, vec![project_agents_source.clone()]);
+
+    let unsubscribe_id = mcp
+        .send_thread_unsubscribe_request(ThreadUnsubscribeParams {
+            thread_id: thread.id.clone(),
+        })
+        .await?;
+    timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(unsubscribe_id)),
+    )
+    .await??;
+
     std::fs::remove_file(project_agents.as_path())?;
+
+    let invalid_resume_id = mcp
+        .send_thread_resume_request(ThreadResumeParams {
+            thread_id: thread.id.clone(),
+            cwd: Some(workspace.path().display().to_string()),
+            config: Some(std::collections::HashMap::from([(
+                "features.plugins".to_string(),
+                json!("invalid"),
+            )])),
+            base_instructions: Some(base_instructions.clone()),
+            developer_instructions: Some(developer_instructions.clone()),
+            ..Default::default()
+        })
+        .await?;
+    timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(invalid_resume_id)),
+    )
+    .await??;
 
     let resume_id = mcp
         .send_thread_resume_request(ThreadResumeParams {
-            thread_id: thread.id,
+            thread_id: thread.id.clone(),
+            cwd: Some(workspace.path().display().to_string()),
+            service_tier: Some(None),
+            config: Some(config.clone()),
+            base_instructions: Some(base_instructions.clone()),
+            developer_instructions: Some(developer_instructions.clone()),
             ..Default::default()
         })
         .await?;
@@ -334,6 +409,41 @@ async fn thread_resume_running_thread_uses_cached_instruction_sources() -> Resul
     } = to_response::<ThreadResumeResponse>(resume_resp)?;
 
     assert_eq!(instruction_sources, vec![project_agents_source]);
+
+    let unsubscribe_id = mcp
+        .send_thread_unsubscribe_request(ThreadUnsubscribeParams {
+            thread_id: thread.id.clone(),
+        })
+        .await?;
+    timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(unsubscribe_id)),
+    )
+    .await??;
+
+    let changed_resume_id = mcp
+        .send_thread_resume_request(ThreadResumeParams {
+            thread_id: thread.id,
+            cwd: Some(workspace.path().display().to_string()),
+            config: Some(std::collections::HashMap::from([(
+                "features.plugins".to_string(),
+                json!(true),
+            )])),
+            base_instructions: Some(base_instructions),
+            developer_instructions: Some(developer_instructions),
+            ..Default::default()
+        })
+        .await?;
+    let changed_resume_response: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(changed_resume_id)),
+    )
+    .await??;
+    let ThreadResumeResponse {
+        instruction_sources,
+        ..
+    } = to_response::<ThreadResumeResponse>(changed_resume_response)?;
+    assert!(instruction_sources.is_empty());
 
     Ok(())
 }
@@ -2969,6 +3079,10 @@ async fn thread_resume_rejoins_running_thread_even_with_override_mismatch() -> R
             thread_id: thread.id.clone(),
             model: Some("not-the-running-model".to_string()),
             cwd: Some("/tmp".to_string()),
+            config: Some(std::collections::HashMap::from([(
+                "features.plugins".to_string(),
+                json!(false),
+            )])),
             initial_turns_page: Some(ThreadResumeInitialTurnsPageParams {
                 limit: None,
                 sort_direction: None,

--- a/codex-rs/core/src/agent/control.rs
+++ b/codex-rs/core/src/agent/control.rs
@@ -42,6 +42,7 @@ use serde::Serialize;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::Weak;
 use tokio::sync::watch;
 use tracing::warn;
@@ -103,8 +104,65 @@ pub(crate) struct AgentControl {
     state: Arc<AgentRegistry>,
     v2_residency: Arc<V2Residency>,
     agent_execution_limiter: Arc<AgentExecutionLimiter>,
+    completion_watchers: Arc<CompletionWatcherTracker>,
     /// Session-scoped state shared by the root thread and every cloned sub-agent control handle.
     rollout_budget: Arc<RolloutBudget>,
+}
+
+#[derive(Default)]
+struct CompletionWatcherTracker {
+    state: Mutex<HashMap<ThreadId, CompletionWatcherState>>,
+}
+
+#[derive(Default)]
+struct CompletionWatcherState {
+    pending: usize,
+    generation: u64,
+}
+
+pub(crate) struct CompletionWatcherGuard {
+    tracker: Arc<CompletionWatcherTracker>,
+    parent_thread_id: ThreadId,
+}
+
+impl CompletionWatcherTracker {
+    fn register(self: &Arc<Self>, parent_thread_id: ThreadId) -> CompletionWatcherGuard {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let entry = state.entry(parent_thread_id).or_default();
+        entry.pending += 1;
+        entry.generation = entry.generation.wrapping_add(1);
+        CompletionWatcherGuard {
+            tracker: Arc::clone(self),
+            parent_thread_id,
+        }
+    }
+
+    fn snapshot(&self, parent_thread_id: ThreadId) -> (usize, u64) {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state
+            .get(&parent_thread_id)
+            .map(|entry| (entry.pending, entry.generation))
+            .unwrap_or_default()
+    }
+}
+
+impl Drop for CompletionWatcherGuard {
+    fn drop(&mut self) {
+        let mut state = self
+            .tracker
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(entry) = state.get_mut(&self.parent_thread_id) {
+            entry.pending = entry.pending.saturating_sub(1);
+        }
+    }
 }
 
 impl AgentControl {
@@ -135,6 +193,46 @@ impl AgentControl {
 
     pub(crate) fn rollout_budget(&self) -> &RolloutBudget {
         self.rollout_budget.as_ref()
+    }
+
+    pub(crate) fn completion_watcher_snapshot(&self, parent_thread_id: ThreadId) -> (usize, u64) {
+        self.completion_watchers.snapshot(parent_thread_id)
+    }
+
+    pub(crate) fn register_completion_watcher(
+        &self,
+        parent_thread_id: ThreadId,
+    ) -> CompletionWatcherGuard {
+        self.completion_watchers.register(parent_thread_id)
+    }
+
+    pub(crate) async fn has_nonfinal_thread_spawn_children(
+        &self,
+        parent_thread_id: ThreadId,
+    ) -> bool {
+        let Ok(state) = self.upgrade() else {
+            return false;
+        };
+        let Ok(children) = self.open_thread_spawn_children(parent_thread_id).await else {
+            return false;
+        };
+        for (child_thread_id, _) in children {
+            let Ok(child_thread) = state.get_thread(child_thread_id).await else {
+                continue;
+            };
+            if !is_final(&child_thread.agent_status().await)
+                || child_thread
+                    .codex
+                    .session
+                    .active_turn
+                    .lock()
+                    .await
+                    .is_some()
+            {
+                return true;
+            }
+        }
+        false
     }
 
     /// Send rich user input items to an existing agent thread.
@@ -468,8 +566,10 @@ impl AgentControl {
         else {
             return;
         };
+        let completion_watcher = self.register_completion_watcher(parent_thread_id);
         let control = self.clone();
         tokio::spawn(async move {
+            let _completion_watcher = completion_watcher;
             let status = match control.subscribe_status(child_thread_id).await {
                 Ok(mut status_rx) => {
                     let mut status = status_rx.borrow().clone();

--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -11,6 +11,7 @@ use crate::config::ConfigBuilder;
 use crate::context::ContextualUserFragment;
 use crate::context::SubagentNotification;
 use crate::init_state_db;
+use crate::state::ActiveTurn;
 use crate::thread_manager::StartThreadOptions;
 use assert_matches::assert_matches;
 use codex_extension_api::ExtensionDataInit;
@@ -2168,6 +2169,126 @@ async fn multi_agent_v2_completion_queues_message_for_direct_parent() {
             /*trigger_turn*/ false,
         )
     ));
+}
+
+#[tokio::test]
+#[expect(
+    clippy::await_holding_invalid_type,
+    reason = "the test intentionally blocks parent delivery while asserting the idle-shutdown gate"
+)]
+async fn multi_agent_v2_terminal_delivery_blocks_parent_idle_shutdown() {
+    let harness = AgentControlHarness::new().await;
+    let mut config = harness.config.clone();
+    let _ = config.features.enable(Feature::MultiAgentV2);
+    let root = harness
+        .manager
+        .start_thread(config.clone())
+        .await
+        .expect("root thread should start");
+    let root_thread_id = root.thread_id;
+    let root_thread = root.thread;
+    let root_control = root_thread.codex.session.services.agent_control.clone();
+    let child_path = AgentPath::root().join("worker_a").expect("child path");
+    let child_thread_id = root_control
+        .spawn_agent(
+            config,
+            text_input("hello worker"),
+            Some(SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
+                parent_thread_id: root_thread_id,
+                depth: 1,
+                agent_path: Some(child_path),
+                agent_nickname: None,
+                agent_role: Some("explorer".to_string()),
+            })),
+        )
+        .await
+        .expect("child spawn should succeed");
+    let child_thread = harness
+        .manager
+        .get_thread(child_thread_id)
+        .await
+        .expect("child thread should exist");
+    let child_session = Arc::clone(&child_thread.codex.session);
+    let child_submission_guard = timeout(
+        Duration::from_secs(5),
+        child_session.submission_send_lock.lock(),
+    )
+    .await
+    .expect("child input submission should dispatch");
+    drop(child_submission_guard);
+    child_session
+        .abort_all_tasks(TurnAbortReason::Interrupted)
+        .await;
+    assert!(child_session.active_turn.lock().await.is_none());
+
+    let error_turn = child_session.new_default_turn().await;
+    *child_session.active_turn.lock().await = Some(ActiveTurn::default());
+    child_session
+        .send_event(
+            error_turn.as_ref(),
+            EventMsg::Error(ErrorEvent {
+                message: "terminal turn error".to_string(),
+                codex_error_info: None,
+            }),
+        )
+        .await;
+    assert!(
+        root_thread
+            .codex
+            .session
+            .try_claim_idle_shutdown()
+            .await
+            .is_none(),
+        "an Error status must not hide an active child turn"
+    );
+    assert!(!root_thread.codex.session.submission_lifecycle.is_closing());
+    child_session.active_turn.lock().await.take();
+
+    let parent_send_guard = root_thread.codex.session.submission_send_lock.lock().await;
+    let child_turn = child_session.new_default_turn().await;
+    let terminal_delivery = tokio::spawn(async move {
+        child_session
+            .send_event(
+                child_turn.as_ref(),
+                EventMsg::TurnComplete(TurnCompleteEvent {
+                    turn_id: child_turn.sub_id.clone(),
+                    last_agent_message: Some("done".to_string()),
+                    completed_at: None,
+                    duration_ms: None,
+                    time_to_first_token_ms: None,
+                }),
+            )
+            .await;
+    });
+
+    timeout(Duration::from_secs(5), async {
+        loop {
+            let (pending, _) = root_control.completion_watcher_snapshot(root_thread_id);
+            if pending > 0 && is_final(&child_thread.agent_status().await) {
+                break;
+            }
+            sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("terminal status should publish while parent delivery is blocked");
+
+    assert!(
+        root_thread
+            .codex
+            .session
+            .try_claim_idle_shutdown()
+            .await
+            .is_none(),
+        "parent must remain reusable until child completion delivery finishes"
+    );
+    assert!(!root_thread.codex.session.submission_lifecycle.is_closing());
+
+    drop(parent_send_guard);
+    timeout(Duration::from_secs(5), terminal_delivery)
+        .await
+        .expect("terminal delivery should unblock")
+        .expect("terminal delivery task should succeed");
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -232,7 +232,6 @@ pub(crate) async fn run_codex_thread_one_shot(
 
     // Bridge events so we can observe completion and shut down automatically.
     let (tx_bridge, rx_bridge) = async_channel::bounded(SUBMISSION_CHANNEL_CAPACITY);
-    let ops_tx = io.tx_sub.clone();
     let agent_status = io.agent_status.clone();
     let session = Arc::clone(&io.session);
     let session_loop_termination = io.session_loop_termination.clone();
@@ -245,14 +244,7 @@ pub(crate) async fn run_codex_thread_one_shot(
             );
             let _ = tx_bridge.send(event).await;
             if should_shutdown {
-                let _ = ops_tx
-                    .send(Submission {
-                        id: "shutdown".to_string(),
-                        op: Op::Shutdown {},
-                        client_user_message_id: None,
-                        trace: None,
-                    })
-                    .await;
+                let _ = io_for_bridge.submit(Op::Shutdown {}).await;
                 child_cancel.cancel();
                 break;
             }

--- a/codex-rs/core/src/codex_thread.rs
+++ b/codex-rs/core/src/codex_thread.rs
@@ -211,6 +211,10 @@ impl CodexThread {
         self.codex.shutdown_and_wait().await
     }
 
+    pub async fn try_shutdown_if_idle(&self) -> CodexResult<bool> {
+        self.codex.try_shutdown_if_idle().await
+    }
+
     /// Wait until the underlying session loop has terminated.
     pub async fn wait_until_terminated(&self) {
         self.codex.session_loop_termination.clone().await;
@@ -452,6 +456,9 @@ impl CodexThread {
 
     /// Records a user-role session-prefix message without creating a new user turn boundary.
     pub(crate) async fn inject_user_message_without_turn(&self, message: String) {
+        let Some(_reservation) = self.codex.session.try_reserve_activity() else {
+            return;
+        };
         let item = ResponseItem::Message {
             id: None,
             role: "user".to_string(),
@@ -472,6 +479,11 @@ impl CodexThread {
                 "items must not be empty".to_string(),
             ));
         }
+        let Some(_reservation) = self.codex.session.try_reserve_activity() else {
+            return Err(CodexErr::InvalidRequest(
+                "thread is shutting down".to_string(),
+            ));
+        };
 
         let turn_context = self.codex.session.new_default_turn().await;
         if self.codex.session.reference_context_item().await.is_none() {
@@ -634,6 +646,11 @@ impl CodexThread {
         server: &str,
         uri: &str,
     ) -> anyhow::Result<serde_json::Value> {
+        let _reservation = self
+            .codex
+            .session
+            .try_reserve_activity()
+            .ok_or_else(|| anyhow::anyhow!("thread is shutting down"))?;
         let result = self
             .current_mcp_runtime()
             .await
@@ -651,6 +668,11 @@ impl CodexThread {
         arguments: Option<serde_json::Value>,
         meta: Option<serde_json::Value>,
     ) -> anyhow::Result<CallToolResult> {
+        let _reservation = self
+            .codex
+            .session
+            .try_reserve_activity()
+            .ok_or_else(|| anyhow::anyhow!("thread is shutting down"))?;
         self.current_mcp_runtime()
             .await
             .manager_arc()
@@ -663,6 +685,11 @@ impl CodexThread {
     }
 
     pub async fn increment_out_of_band_elicitation_count(&self) -> CodexResult<i64> {
+        let Some(_reservation) = self.codex.session.try_reserve_activity() else {
+            return Err(CodexErr::InvalidRequest(
+                "thread is shutting down".to_string(),
+            ));
+        };
         let mut elicitations = self.out_of_band_elicitations.lock().await;
         let incremented = elicitations.count.checked_add(1).ok_or_else(|| {
             CodexErr::Fatal("out-of-band elicitation count overflowed".to_string())
@@ -675,6 +702,11 @@ impl CodexThread {
     }
 
     pub async fn decrement_out_of_band_elicitation_count(&self) -> CodexResult<i64> {
+        let Some(_reservation) = self.codex.session.try_reserve_activity() else {
+            return Err(CodexErr::InvalidRequest(
+                "thread is shutting down".to_string(),
+            ));
+        };
         let mut elicitations = self.out_of_band_elicitations.lock().await;
         if elicitations.count == 0 {
             return Err(CodexErr::InvalidRequest(

--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -841,6 +841,7 @@ pub(super) async fn submission_loop(
         }
         .instrument(dispatch_span)
         .await;
+        sess.submission_lifecycle.finish_submission();
         if should_exit {
             shutdown_received = true;
             break;

--- a/codex-rs/core/src/session/inject.rs
+++ b/codex-rs/core/src/session/inject.rs
@@ -62,6 +62,12 @@ impl Session {
             ));
         }
 
+        let Some(reservation) = self.try_reserve_activity() else {
+            return Err(TryStartTurnIfIdleError::new(
+                TryStartTurnIfIdleRejectionReason::Busy,
+                input,
+            ));
+        };
         let turn_state = {
             let mut active_turn = self.active_turn.lock().await;
             if active_turn.is_some() {
@@ -73,6 +79,7 @@ impl Session {
             let active_turn = active_turn.get_or_insert_with(ActiveTurn::default);
             Arc::clone(&active_turn.turn_state)
         };
+        drop(reservation);
 
         if self.input_queue.has_trigger_turn_mailbox_items().await {
             self.clear_reserved_idle_turn(&turn_state).await;

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -767,15 +767,57 @@ impl Codex {
 
     /// Use sparingly: prefer `submit()` so Codex is responsible for generating
     /// unique IDs for each submission.
+    #[expect(
+        clippy::await_holding_invalid_type,
+        reason = "submission ordering must remain serialized while a bounded-channel send waits"
+    )]
     pub async fn submit_with_id(&self, mut sub: Submission) -> CodexResult<()> {
         if sub.trace.is_none() {
             sub.trace = current_span_w3c_trace_context();
         }
-        self.tx_sub
-            .send(sub)
-            .await
-            .map_err(|_| CodexErr::InternalAgentDied)?;
+        let is_shutdown = matches!(&sub.op, Op::Shutdown);
+        let _send_guard = self.session.submission_send_lock.lock().await;
+        let Some(reservation) = self.session.submission_lifecycle.try_reserve(is_shutdown) else {
+            if is_shutdown {
+                return Ok(());
+            }
+            return Err(CodexErr::InvalidRequest(
+                "thread is shutting down".to_string(),
+            ));
+        };
+        if self.tx_sub.send(sub).await.is_err() {
+            return Err(CodexErr::InternalAgentDied);
+        }
+        reservation.commit();
         Ok(())
+    }
+
+    /// Atomically submits shutdown only when no work is active, queued, or
+    /// being dispatched. Once claimed, new submissions and automatic idle work
+    /// are rejected so shutdown cannot race a newly starting turn.
+    #[expect(
+        clippy::await_holding_invalid_type,
+        reason = "the send lock serializes the idle claim with submission delivery"
+    )]
+    pub async fn try_shutdown_if_idle(&self) -> CodexResult<bool> {
+        let _send_guard = self.session.submission_send_lock.lock().await;
+        if self.session.submission_lifecycle.is_closing() {
+            return Ok(true);
+        }
+        let Some(reservation) = self.session.try_claim_idle_shutdown().await else {
+            return Ok(false);
+        };
+        let sub = Submission {
+            id: new_submission_id(),
+            op: Op::Shutdown,
+            client_user_message_id: None,
+            trace: current_span_w3c_trace_context(),
+        };
+        if self.tx_sub.send(sub).await.is_err() {
+            return Err(CodexErr::InternalAgentDied);
+        }
+        reservation.commit();
+        Ok(true)
     }
 
     /// Persist a thread-level memory mode update for the active session.
@@ -978,6 +1020,44 @@ fn push_prompt_fragment(
 }
 
 impl Session {
+    async fn has_idle_shutdown_blocker(&self) -> bool {
+        matches!(self.agent_status.borrow().clone(), AgentStatus::Running)
+            || self.conversation.running_state().await.is_some()
+            || *self.services.elicitations.subscribe().borrow()
+            || self.input_queue.has_pending_mailbox_items().await
+            || self.active_turn.lock().await.is_some()
+            || !self.list_background_terminals().await.is_empty()
+            || self
+                .services
+                .agent_control
+                .has_nonfinal_thread_spawn_children(self.thread_id)
+                .await
+    }
+
+    pub(crate) async fn try_claim_idle_shutdown(
+        &self,
+    ) -> Option<session::SubmissionReservation<'_>> {
+        let watcher_snapshot = self
+            .services
+            .agent_control
+            .completion_watcher_snapshot(self.thread_id);
+        if watcher_snapshot.0 > 0 || self.has_idle_shutdown_blocker().await {
+            return None;
+        }
+        let reservation = self.submission_lifecycle.try_reserve_idle_shutdown()?;
+        let watcher_recheck = self
+            .services
+            .agent_control
+            .completion_watcher_snapshot(self.thread_id);
+        if watcher_recheck.0 > 0
+            || watcher_recheck.1 != watcher_snapshot.1
+            || self.has_idle_shutdown_blocker().await
+        {
+            return None;
+        }
+        Some(reservation)
+    }
+
     pub(crate) async fn app_server_client_metadata(&self) -> AppServerClientMetadata {
         let state = self.state.lock().await;
         AppServerClientMetadata {
@@ -1194,6 +1274,9 @@ impl Session {
     }
 
     pub(crate) async fn route_realtime_text_input(self: &Arc<Self>, text: String) {
+        let Some(_reservation) = self.try_reserve_activity() else {
+            return;
+        };
         handlers::user_input_or_turn_inner(
             self,
             Uuid::now_v7().to_string(),
@@ -1757,9 +1840,27 @@ impl Session {
             id: turn_context.sub_id.clone(),
             msg,
         };
+        let parent_completion_guard = if turn_context.multi_agent_version == MultiAgentVersion::V2
+            && matches!(
+                legacy_source,
+                EventMsg::TurnComplete(_) | EventMsg::TurnAborted(_)
+            )
+            && let SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
+                parent_thread_id, ..
+            }) = &turn_context.session_source
+        {
+            Some(
+                self.services
+                    .agent_control
+                    .register_completion_watcher(*parent_thread_id),
+            )
+        } else {
+            None
+        };
         self.send_event_raw(event).await;
         self.maybe_notify_parent_of_terminal_turn(turn_context, &legacy_source)
             .await;
+        drop(parent_completion_guard);
         self.maybe_mirror_event_text_to_realtime(&legacy_source)
             .await;
         self.maybe_clear_realtime_handoff_for_event(&legacy_source)

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -20,11 +20,107 @@ use codex_protocol::protocol::ThreadHistoryMode;
 use codex_protocol::protocol::ThreadSource;
 use codex_protocol::protocol::TurnEnvironmentSelections;
 use std::sync::OnceLock;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use tokio::sync::Semaphore;
 
 /// Context for an initialized model agent
 ///
 /// A session has at most 1 running task at a time, and can be interrupted by user input.
+pub(crate) struct SubmissionLifecycle {
+    state: AtomicUsize,
+}
+
+const SUBMISSION_CLOSING: usize = 1 << (usize::BITS - 1);
+const SUBMISSION_COUNT_MASK: usize = SUBMISSION_CLOSING - 1;
+
+impl Default for SubmissionLifecycle {
+    fn default() -> Self {
+        Self {
+            state: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl SubmissionLifecycle {
+    pub(crate) fn is_closing(&self) -> bool {
+        self.state.load(Ordering::SeqCst) & SUBMISSION_CLOSING != 0
+    }
+
+    pub(crate) fn try_reserve(&self, close: bool) -> Option<SubmissionReservation<'_>> {
+        self.state
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |state| {
+                if state & SUBMISSION_CLOSING != 0 {
+                    return None;
+                }
+                let count = state & SUBMISSION_COUNT_MASK;
+                assert!(count < SUBMISSION_COUNT_MASK, "submission count overflow");
+                Some((state + 1) | if close { SUBMISSION_CLOSING } else { 0 })
+            })
+            .ok()?;
+        Some(SubmissionReservation {
+            lifecycle: self,
+            clear_closing_on_drop: close,
+            active: true,
+        })
+    }
+
+    pub(crate) fn try_reserve_idle_shutdown(&self) -> Option<SubmissionReservation<'_>> {
+        self.state
+            .compare_exchange(
+                0,
+                SUBMISSION_CLOSING | 1,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            )
+            .ok()
+            .map(|_| SubmissionReservation {
+                lifecycle: self,
+                clear_closing_on_drop: true,
+                active: true,
+            })
+    }
+
+    pub(crate) fn finish_submission(&self) {
+        self.release(/*clear_closing*/ false);
+    }
+
+    fn release(&self, clear_closing: bool) {
+        let _ = self
+            .state
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |state| {
+                if state & SUBMISSION_COUNT_MASK == 0 {
+                    return None;
+                }
+                let mut next = state - 1;
+                if clear_closing {
+                    next &= !SUBMISSION_CLOSING;
+                }
+                Some(next)
+            });
+    }
+}
+
+pub(crate) struct SubmissionReservation<'a> {
+    lifecycle: &'a SubmissionLifecycle,
+    clear_closing_on_drop: bool,
+    active: bool,
+}
+
+impl SubmissionReservation<'_> {
+    pub(crate) fn commit(mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for SubmissionReservation<'_> {
+    fn drop(&mut self) {
+        if self.active {
+            self.lifecycle.release(self.clear_closing_on_drop);
+        }
+    }
+}
+
 pub(crate) struct Session {
     pub(crate) thread_id: ThreadId,
     pub(crate) installation_id: String,
@@ -41,6 +137,8 @@ pub(crate) struct Session {
     pub(super) pending_mcp_server_refresh_config: Mutex<Option<McpServerRefreshConfig>>,
     pub(crate) conversation: Arc<RealtimeConversationManager>,
     pub(crate) active_turn: Mutex<Option<ActiveTurn>>,
+    pub(crate) submission_lifecycle: SubmissionLifecycle,
+    pub(crate) submission_send_lock: Mutex<()>,
     pub(crate) input_queue: InputQueue,
     pub(crate) guardian_review_session: GuardianReviewSessionManager,
     pub(crate) services: SessionServices,
@@ -463,6 +561,10 @@ impl Session {
     /// Returns the concrete identity for this thread.
     pub(crate) fn thread_id(&self) -> ThreadId {
         self.thread_id
+    }
+
+    pub(crate) fn try_reserve_activity(&self) -> Option<SubmissionReservation<'_>> {
+        self.submission_lifecycle.try_reserve(/*close*/ false)
     }
 
     /// Returns the identity shared by the root thread and all descendant threads.
@@ -1137,6 +1239,8 @@ impl Session {
                 pending_mcp_server_refresh_config: Mutex::new(None),
                 conversation: Arc::new(RealtimeConversationManager::new()),
                 active_turn: Mutex::new(None),
+                submission_lifecycle: SubmissionLifecycle::default(),
+                submission_send_lock: Mutex::new(()),
                 input_queue: InputQueue::new(),
                 guardian_review_session: GuardianReviewSessionManager::default(),
                 services,

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -1,3 +1,4 @@
+use super::session::SubmissionLifecycle;
 use super::turn_context::TurnEnvironment;
 use super::*;
 use crate::agents_md_manager::AgentsMdManager;
@@ -5518,6 +5519,8 @@ pub(crate) async fn make_session_and_context() -> (Session, TurnContext) {
         pending_mcp_server_refresh_config: Mutex::new(None),
         conversation: Arc::new(RealtimeConversationManager::new()),
         active_turn: Mutex::new(None),
+        submission_lifecycle: SubmissionLifecycle::default(),
+        submission_send_lock: Mutex::new(()),
         input_queue: super::input_queue::InputQueue::new(),
         guardian_review_session: crate::guardian::GuardianReviewSessionManager::default(),
         services,
@@ -6481,6 +6484,94 @@ async fn submit_with_id_captures_current_span_trace_context() {
 
     let submitted = rx_sub.recv().await.expect("submission");
     assert_eq!(submitted.trace, Some(expected_trace));
+}
+
+#[tokio::test]
+async fn cancelled_submission_and_idle_shutdown_release_lifecycle_reservations() {
+    let (session, _turn_context) = make_session_and_context().await;
+    let session = Arc::new(session);
+    let (tx_sub, rx_sub) = async_channel::bounded(1);
+    let (_tx_event, rx_event) = async_channel::unbounded();
+    let (_agent_status_tx, agent_status) = watch::channel(AgentStatus::PendingInit);
+
+    tx_sub
+        .send(Submission {
+            id: "filler".into(),
+            op: Op::Interrupt,
+            client_user_message_id: None,
+            trace: None,
+        })
+        .await
+        .expect("fill submission channel");
+
+    let codex = Arc::new(Codex {
+        tx_sub,
+        rx_event,
+        agent_status,
+        session: Arc::clone(&session),
+        session_loop_termination: completed_session_loop_termination(),
+    });
+
+    let blocked_submit = {
+        let codex = Arc::clone(&codex);
+        tokio::spawn(async move { codex.submit(Op::Interrupt).await })
+    };
+    tokio::time::timeout(StdDuration::from_secs(1), async {
+        while session.submission_send_lock.try_lock().is_ok() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("submission should hold the send lock while blocking");
+    blocked_submit.abort();
+    assert!(
+        blocked_submit
+            .await
+            .expect_err("blocked submission should be cancelled")
+            .is_cancelled()
+    );
+    let released_submission = session
+        .try_claim_idle_shutdown()
+        .await
+        .expect("cancelled submission should release its lifecycle reservation");
+    drop(released_submission);
+    assert!(!session.submission_lifecycle.is_closing());
+
+    let blocked_shutdown = {
+        let codex = Arc::clone(&codex);
+        tokio::spawn(async move { codex.try_shutdown_if_idle().await })
+    };
+    tokio::time::timeout(StdDuration::from_secs(1), async {
+        while !session.submission_lifecycle.is_closing() {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("idle shutdown should claim lifecycle state before blocking");
+    blocked_shutdown.abort();
+    assert!(
+        blocked_shutdown
+            .await
+            .expect_err("blocked idle shutdown should be cancelled")
+            .is_cancelled()
+    );
+    let released_shutdown = session
+        .try_claim_idle_shutdown()
+        .await
+        .expect("cancelled idle shutdown should release its lifecycle reservation");
+    drop(released_shutdown);
+    assert!(!session.submission_lifecycle.is_closing());
+
+    let filler = rx_sub.recv().await.expect("filler submission");
+    assert_eq!(filler.id, "filler");
+    assert!(
+        codex
+            .try_shutdown_if_idle()
+            .await
+            .expect("idle shutdown should submit after cancellation")
+    );
+    let shutdown = rx_sub.recv().await.expect("shutdown submission");
+    assert_eq!(shutdown.op, Op::Shutdown);
 }
 
 #[tokio::test]
@@ -7644,6 +7735,8 @@ where
         pending_mcp_server_refresh_config: Mutex::new(None),
         conversation: Arc::new(RealtimeConversationManager::new()),
         active_turn: Mutex::new(None),
+        submission_lifecycle: SubmissionLifecycle::default(),
+        submission_send_lock: Mutex::new(()),
         input_queue: super::input_queue::InputQueue::new(),
         guardian_review_session: crate::guardian::GuardianReviewSessionManager::default(),
         services,
@@ -9949,6 +10042,43 @@ async fn try_start_turn_if_idle_rejects_active_turn_without_injecting() {
     );
 
     sess.abort_all_tasks(TurnAbortReason::Interrupted).await;
+}
+
+#[tokio::test]
+async fn idle_shutdown_claim_waits_for_submissions_and_blocks_automatic_turns() {
+    let (sess, _tc, _rx) = make_session_and_context_with_rx().await;
+    let pending = sess
+        .try_reserve_activity()
+        .expect("open session should reserve a submission");
+    assert!(sess.try_claim_idle_shutdown().await.is_none());
+    drop(pending);
+
+    sess.input_queue
+        .enqueue_mailbox_communication(InterAgentCommunication::new(
+            AgentPath::root(),
+            AgentPath::root(),
+            Vec::new(),
+            "pending context".to_string(),
+            /*trigger_turn*/ false,
+        ))
+        .await;
+    assert!(sess.try_claim_idle_shutdown().await.is_none());
+    sess.input_queue.drain_mailbox_input_items().await;
+
+    let shutdown = sess
+        .try_claim_idle_shutdown()
+        .await
+        .expect("idle session should claim shutdown");
+    let item = user_message("synthetic idle input");
+    let err = sess
+        .try_start_turn_if_idle(vec![item.clone()])
+        .await
+        .expect_err("claimed shutdown should reject automatic idle work");
+
+    assert_eq!(TryStartTurnIfIdleRejectionReason::Busy, err.reason());
+    assert_eq!(vec![item], err.into_input());
+    assert!(sess.active_turn.lock().await.is_none());
+    drop(shutdown);
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -474,6 +474,9 @@ impl Session {
             return;
         }
 
+        let Some(reservation) = self.try_reserve_activity() else {
+            return;
+        };
         {
             let mut active_turn = self.active_turn.lock().await;
             if active_turn.is_some() {
@@ -481,6 +484,7 @@ impl Session {
             }
             *active_turn = Some(ActiveTurn::default());
         }
+        drop(reservation);
 
         let turn_context = self.new_default_turn_with_sub_id(sub_id).await;
         self.maybe_emit_model_warnings_for_turn(turn_context.as_ref())


### PR DESCRIPTION
## Status

Closed: this optimization is not being pursued in its current form.

## Why

The effective-config comparison is not linearizable with queued thread-settings updates, and it can reuse live collaboration-mode or environment state that a cold resume would reset. Making that guarantee sound requires an explicit core generation or barrier rather than an app-server-only semantic comparison.

Keeping the existing resume replacement behavior is safer than merging a partial fast path.

## Validation performed

- `just test -p codex-app-server thread_resume_reuses_loaded_thread_when_full_config_matches -- --nocapture`
- `just test -p codex-app-server thread_resume_rejoins_running_thread_even_with_override_mismatch`
- `just test -p codex-app-server thread_resume_surfaces_cloud_config_bundle_load_errors`
- `just fix -p codex-app-server`
- `just fmt`
- `git diff --check`
