### PR TITLE
Warn when configured service tiers are unsupported

### DIFF
--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -631,11 +631,14 @@ impl Codex {
                 developer_instructions: None,
             },
         };
-        let service_tier = get_service_tier(
-            config.service_tier.clone(),
-            config.features.enabled(Feature::FastMode),
+        let fast_mode_enabled = config.features.enabled(Feature::FastMode);
+        let initial_service_tier_warning = unsupported_service_tier_warning(
+            config.service_tier.as_deref(),
+            fast_mode_enabled,
             &model_info,
         );
+        let service_tier =
+            get_service_tier(config.service_tier.clone(), fast_mode_enabled, &model_info);
         let session_configuration = SessionConfiguration {
             provider: config.model_provider.clone(),
             collaboration_mode,
@@ -708,6 +711,14 @@ impl Codex {
             error!("Failed to create session: {e:#}");
             map_session_init_error(&e, &config.codex_home)
         })?;
+        if let Some(message) = initial_service_tier_warning {
+            session
+                .send_event_raw(Event {
+                    id: INITIAL_SUBMIT_ID.to_owned(),
+                    msg: EventMsg::Warning(WarningEvent { message }),
+                })
+                .await;
+        }
         let thread_id = session.thread_id;
 
         // This task will run until Op::Shutdown is received.
@@ -908,6 +919,22 @@ fn get_service_tier(
         service_tier == SERVICE_TIER_DEFAULT_REQUEST_VALUE
             || model_info.supports_service_tier(service_tier)
     })
+}
+
+fn unsupported_service_tier_warning(
+    configured_service_tier: Option<&str>,
+    fast_mode_enabled: bool,
+    model_info: &ModelInfo,
+) -> Option<String> {
+    let service_tier = configured_service_tier.filter(|service_tier| {
+        fast_mode_enabled
+            && *service_tier != SERVICE_TIER_DEFAULT_REQUEST_VALUE
+            && !model_info.supports_service_tier(service_tier)
+    })?;
+    Some(format!(
+        "Configured service tier `{service_tier}` is not advertised as supported for model `{}` and will be omitted from requests.",
+        model_info.slug
+    ))
 }
 
 fn session_permission_profile_state_from_config(

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -585,6 +585,11 @@ impl Session {
                     let next_permission_profile = next.permission_profile();
                     let permission_profile_changed =
                         previous_permission_profile != next_permission_profile;
+                    // Repeated turns with unchanged settings should not repeat the warning.
+                    let service_tier_configuration_changed = next.service_tier
+                        != state.session_configuration.service_tier
+                        || next.collaboration_mode.model()
+                            != state.session_configuration.collaboration_mode.model();
                     let previous_config = notify_config_contributors.then(|| {
                         Self::build_effective_session_config(&state.session_configuration)
                     });
@@ -599,6 +604,7 @@ impl Session {
                     Ok((
                         next,
                         permission_profile_changed,
+                        service_tier_configuration_changed,
                         previous_config,
                         new_config,
                     ))
@@ -607,22 +613,27 @@ impl Session {
             }
         };
 
-        let (session_configuration, permission_profile_changed, previous_config, new_config) =
-            match update_result {
-                Ok(update) => update,
-                Err(err) => {
-                    let message = err.to_string();
-                    self.send_event_raw(Event {
-                        id: sub_id.clone(),
-                        msg: EventMsg::Error(ErrorEvent {
-                            message: message.clone(),
-                            codex_error_info: Some(CodexErrorInfo::BadRequest),
-                        }),
-                    })
-                    .await;
-                    return Err(CodexErr::InvalidRequest(message));
-                }
-            };
+        let (
+            session_configuration,
+            permission_profile_changed,
+            service_tier_configuration_changed,
+            previous_config,
+            new_config,
+        ) = match update_result {
+            Ok(update) => update,
+            Err(err) => {
+                let message = err.to_string();
+                self.send_event_raw(Event {
+                    id: sub_id.clone(),
+                    msg: EventMsg::Error(ErrorEvent {
+                        message: message.clone(),
+                        codex_error_info: Some(CodexErrorInfo::BadRequest),
+                    }),
+                })
+                .await;
+                return Err(CodexErr::InvalidRequest(message));
+            }
+        };
         self.emit_config_changed_contributors(previous_config.as_ref(), new_config.as_ref());
 
         if permission_profile_changed {
@@ -630,13 +641,28 @@ impl Session {
                 .await;
         }
 
-        Ok(self
+        let configured_service_tier = session_configuration.service_tier.clone();
+        let turn_context = self
             .new_turn_from_configuration(
                 sub_id,
                 session_configuration,
                 updates.final_output_json_schema,
             )
-            .await)
+            .await;
+        if service_tier_configuration_changed
+            && let Some(message) = unsupported_service_tier_warning(
+                configured_service_tier.as_deref(),
+                turn_context.config.features.enabled(Feature::FastMode),
+                &turn_context.model_info,
+            )
+        {
+            self.send_event(
+                turn_context.as_ref(),
+                EventMsg::Warning(WarningEvent { message }),
+            )
+            .await;
+        }
+        Ok(turn_context)
     }
 
     async fn new_turn_from_configuration(

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -585,11 +585,6 @@ impl Session {
                     let next_permission_profile = next.permission_profile();
                     let permission_profile_changed =
                         previous_permission_profile != next_permission_profile;
-                    // Repeated turns with unchanged settings should not repeat the warning.
-                    let service_tier_configuration_changed = next.service_tier
-                        != state.session_configuration.service_tier
-                        || next.collaboration_mode.model()
-                            != state.session_configuration.collaboration_mode.model();
                     let previous_config = notify_config_contributors.then(|| {
                         Self::build_effective_session_config(&state.session_configuration)
                     });
@@ -604,7 +599,6 @@ impl Session {
                     Ok((
                         next,
                         permission_profile_changed,
-                        service_tier_configuration_changed,
                         previous_config,
                         new_config,
                     ))
@@ -613,27 +607,22 @@ impl Session {
             }
         };
 
-        let (
-            session_configuration,
-            permission_profile_changed,
-            service_tier_configuration_changed,
-            previous_config,
-            new_config,
-        ) = match update_result {
-            Ok(update) => update,
-            Err(err) => {
-                let message = err.to_string();
-                self.send_event_raw(Event {
-                    id: sub_id.clone(),
-                    msg: EventMsg::Error(ErrorEvent {
-                        message: message.clone(),
-                        codex_error_info: Some(CodexErrorInfo::BadRequest),
-                    }),
-                })
-                .await;
-                return Err(CodexErr::InvalidRequest(message));
-            }
-        };
+        let (session_configuration, permission_profile_changed, previous_config, new_config) =
+            match update_result {
+                Ok(update) => update,
+                Err(err) => {
+                    let message = err.to_string();
+                    self.send_event_raw(Event {
+                        id: sub_id.clone(),
+                        msg: EventMsg::Error(ErrorEvent {
+                            message: message.clone(),
+                            codex_error_info: Some(CodexErrorInfo::BadRequest),
+                        }),
+                    })
+                    .await;
+                    return Err(CodexErr::InvalidRequest(message));
+                }
+            };
         self.emit_config_changed_contributors(previous_config.as_ref(), new_config.as_ref());
 
         if permission_profile_changed {
@@ -641,28 +630,13 @@ impl Session {
                 .await;
         }
 
-        let configured_service_tier = session_configuration.service_tier.clone();
-        let turn_context = self
+        Ok(self
             .new_turn_from_configuration(
                 sub_id,
                 session_configuration,
                 updates.final_output_json_schema,
             )
-            .await;
-        if service_tier_configuration_changed
-            && let Some(message) = unsupported_service_tier_warning(
-                configured_service_tier.as_deref(),
-                turn_context.config.features.enabled(Feature::FastMode),
-                &turn_context.model_info,
-            )
-        {
-            self.send_event(
-                turn_context.as_ref(),
-                EventMsg::Warning(WarningEvent { message }),
-            )
-            .await;
-        }
-        Ok(turn_context)
+            .await)
     }
 
     async fn new_turn_from_configuration(

--- a/codex-rs/core/tests/suite/model_switching.rs
+++ b/codex-rs/core/tests/suite/model_switching.rs
@@ -366,7 +366,11 @@ async fn unsupported_service_tier_is_omitted_from_http_turn() -> Result<()> {
         "no service tiers",
         default_input_modalities(),
     );
-    let resp_mock = mount_sse_once(&server, sse_completed("resp-1")).await;
+    let resp_mock = mount_sse_sequence(
+        &server,
+        vec![sse_completed("resp-1"), sse_completed("resp-2")],
+    )
+    .await;
 
     let mut builder = test_codex()
         .with_model(model_slug)
@@ -377,13 +381,92 @@ async fn unsupported_service_tier_is_omitted_from_http_turn() -> Result<()> {
         });
     let test = builder.build(&server).await?;
 
-    test.submit_turn_with_service_tier("fast turn", Some(ServiceTier::Fast.request_value()))
-        .await?;
+    let mut warning_count = 0;
+    for (prompt, service_tier) in [
+        (
+            "first turn",
+            Some(Some(ServiceTier::Fast.request_value().to_string())),
+        ),
+        ("second turn", None),
+    ] {
+        test.codex
+            .submit(Op::UserInput {
+                items: vec![UserInput::Text {
+                    text: prompt.to_string(),
+                    text_elements: Vec::new(),
+                }],
+                final_output_json_schema: None,
+                responsesapi_client_metadata: None,
+                additional_context: Default::default(),
+                thread_settings: codex_protocol::protocol::ThreadSettingsOverrides {
+                    service_tier,
+                    ..Default::default()
+                },
+            })
+            .await?;
 
-    let request = resp_mock.single_request();
-    let body = request.body_json();
-    assert_eq!(body.get("service_tier"), None);
+        loop {
+            match wait_for_event(&test.codex, |_| true).await {
+                EventMsg::Warning(warning)
+                    if warning.message.contains("will be omitted from requests") =>
+                {
+                    warning_count += 1;
+                }
+                EventMsg::TurnComplete(_) => break,
+                _ => {}
+            }
+        }
+    }
 
+    assert_eq!(warning_count, 1);
+    let requests = resp_mock.requests();
+    assert_eq!(requests.len(), 2);
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.body_json().get("service_tier").is_none())
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unsupported_configured_service_tier_warns_at_session_start() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let model_slug = "test-no-tier-model";
+    let model = test_model_info(
+        model_slug,
+        model_slug,
+        "no service tiers",
+        default_input_modalities(),
+    );
+    let mut builder = test_codex()
+        .with_model(model_slug)
+        .with_config(move |config| {
+            config.service_tier = Some(ServiceTier::Flex.request_value().to_string());
+            config.model_catalog = Some(ModelsResponse {
+                models: vec![model],
+            });
+        });
+    let test = builder.build(&server).await?;
+
+    let warning = wait_for_event(&test.codex, |event| {
+        matches!(
+            event,
+            EventMsg::Warning(warning)
+                if warning.message.contains("will be omitted from requests")
+        )
+    })
+    .await;
+    let EventMsg::Warning(warning) = warning else {
+        unreachable!("wait_for_event matched a warning")
+    };
+    assert_eq!(
+        warning.message,
+        "Configured service tier `flex` is not advertised as supported for model `test-no-tier-model` and will be omitted from requests."
+    );
     Ok(())
 }
 

--- a/codex-rs/core/tests/suite/model_switching.rs
+++ b/codex-rs/core/tests/suite/model_switching.rs
@@ -366,11 +366,7 @@ async fn unsupported_service_tier_is_omitted_from_http_turn() -> Result<()> {
         "no service tiers",
         default_input_modalities(),
     );
-    let resp_mock = mount_sse_sequence(
-        &server,
-        vec![sse_completed("resp-1"), sse_completed("resp-2")],
-    )
-    .await;
+    let resp_mock = mount_sse_once(&server, sse_completed("resp-1")).await;
 
     let mut builder = test_codex()
         .with_model(model_slug)
@@ -381,51 +377,12 @@ async fn unsupported_service_tier_is_omitted_from_http_turn() -> Result<()> {
         });
     let test = builder.build(&server).await?;
 
-    let mut warning_count = 0;
-    for (prompt, service_tier) in [
-        (
-            "first turn",
-            Some(Some(ServiceTier::Fast.request_value().to_string())),
-        ),
-        ("second turn", None),
-    ] {
-        test.codex
-            .submit(Op::UserInput {
-                items: vec![UserInput::Text {
-                    text: prompt.to_string(),
-                    text_elements: Vec::new(),
-                }],
-                final_output_json_schema: None,
-                responsesapi_client_metadata: None,
-                additional_context: Default::default(),
-                thread_settings: codex_protocol::protocol::ThreadSettingsOverrides {
-                    service_tier,
-                    ..Default::default()
-                },
-            })
-            .await?;
+    test.submit_turn_with_service_tier("fast turn", Some(ServiceTier::Fast.request_value()))
+        .await?;
 
-        loop {
-            match wait_for_event(&test.codex, |_| true).await {
-                EventMsg::Warning(warning)
-                    if warning.message.contains("will be omitted from requests") =>
-                {
-                    warning_count += 1;
-                }
-                EventMsg::TurnComplete(_) => break,
-                _ => {}
-            }
-        }
-    }
-
-    assert_eq!(warning_count, 1);
-    let requests = resp_mock.requests();
-    assert_eq!(requests.len(), 2);
-    assert!(
-        requests
-            .iter()
-            .all(|request| request.body_json().get("service_tier").is_none())
-    );
+    let request = resp_mock.single_request();
+    let body = request.body_json();
+    assert_eq!(body.get("service_tier"), None);
 
     Ok(())
 }


### PR DESCRIPTION
## Why

Codex currently omits a configured `service_tier` when the selected model's catalog entry does not advertise support for it. That fallback is silent, so users can unknowingly send requests at the default tier instead. This makes cases such as #26604 difficult to diagnose.

## What changed

- Emit the shared core `Warning` event during session startup when a configured service tier will be omitted because the initial model does not advertise support for it.
- Do not warn on later model or service-tier changes, which keeps warning emission stateless and avoids client-specific handling.
- Keep the existing request filtering behavior unchanged.

## Validation

- `just test -p codex-core unsupported_service_tier`
- `just test -p codex-core unsupported_configured_service_tier_warns_at_session_start`

### Manual validation

- Launched the real TUI with the bundled catalog, where `gpt-5.5` advertises the `priority` tier but not `flex`, and configured `service_tier = "flex"`.
- Confirmed the unsupported-tier warning appeared exactly once during startup.
- Submitted two turns through a local Responses API SSE stub; both received mock replies and neither emitted another warning.
- Inspected both captured `/v1/responses` request bodies and confirmed that neither contained a `service_tier` field.
- Repeated the two-turn TUI flow against the live Responses API; both turns completed and the warning was not repeated.
