### PR TITLE
[4/5] [codex] consume managed layers with v2 cache

### DIFF
--- a/codex-rs/cloud-config/src/backend.rs
+++ b/codex-rs/cloud-config/src/backend.rs
@@ -1,5 +1,6 @@
 use codex_backend_client::Client as BackendClient;
 use codex_backend_client::ConfigBundleResponse;
+use codex_backend_client::DeliveredManagedLayers;
 use codex_backend_client::DeliveredTomlFragment;
 use codex_config::CloudConfigBundle;
 use codex_config::CloudConfigFragment;
@@ -33,12 +34,15 @@ pub(crate) enum BundleRequestError {
         status_code: Option<u16>,
         message: String,
     },
+    InvalidBundle {
+        message: String,
+    },
 }
 
 /// Retrieves one cloud config bundle from the backend.
 ///
-/// Implementations should return the backend-selected bundle exactly as delivered and leave
-/// validation, caching, and config/requirements parsing decisions to the service layer.
+/// Implementations translate the backend response into the managed-only domain model. TOML
+/// parsing, semantic validation, and caching remain service-layer responsibilities.
 pub(crate) trait BundleClient: Send + Sync {
     fn get_bundle(
         &self,
@@ -85,40 +89,75 @@ impl BundleClient for BackendBundleClient {
                 }
             })?;
 
-        Ok(bundle_from_response(response))
+        bundle_from_response(response)
     }
 }
 
-pub(crate) fn bundle_from_response(response: ConfigBundleResponse) -> CloudConfigBundle {
-    let config_toml = response
-        .config_toml
-        .flatten()
-        .map(|config_toml| *config_toml)
-        .and_then(|config_toml| config_toml.enterprise_managed.flatten())
-        .unwrap_or_default()
-        .into_iter()
-        .map(config_fragment_from_delivered)
-        .collect();
-    let requirements_toml = response
-        .requirements_toml
-        .flatten()
-        .map(|requirements_toml| *requirements_toml)
-        .and_then(|requirements_toml| requirements_toml.enterprise_managed.flatten())
-        .unwrap_or_default()
-        .into_iter()
-        .map(requirements_fragment_from_delivered)
-        .collect();
+pub(crate) fn bundle_from_response(
+    response: ConfigBundleResponse,
+) -> Result<CloudConfigBundle, BundleRequestError> {
+    let config_toml = match response.config_toml.flatten() {
+        Some(config_toml) => {
+            let (baseline, system_overlay) = managed_fragments_from_delivered(
+                config_toml.managed_layers,
+                config_fragment_from_delivered,
+                "config_toml",
+            )?;
+            CloudConfigTomlBundle {
+                enterprise_managed: Vec::new(),
+                managed_layers: CloudConfigTomlManagedLayers {
+                    baseline,
+                    system_overlay,
+                },
+            }
+        }
+        None => CloudConfigTomlBundle::default(),
+    };
+    let requirements_toml = match response.requirements_toml.flatten() {
+        Some(requirements_toml) => {
+            let (baseline, system_overlay) = managed_fragments_from_delivered(
+                requirements_toml.managed_layers,
+                requirements_fragment_from_delivered,
+                "requirements_toml",
+            )?;
+            CloudRequirementsTomlBundle {
+                enterprise_managed: Vec::new(),
+                managed_layers: CloudRequirementsTomlManagedLayers {
+                    baseline,
+                    system_overlay,
+                },
+            }
+        }
+        None => CloudRequirementsTomlBundle::default(),
+    };
 
-    CloudConfigBundle {
-        config_toml: CloudConfigTomlBundle {
-            enterprise_managed: config_toml,
-            managed_layers: CloudConfigTomlManagedLayers::default(),
-        },
-        requirements_toml: CloudRequirementsTomlBundle {
-            enterprise_managed: requirements_toml,
-            managed_layers: CloudRequirementsTomlManagedLayers::default(),
-        },
-    }
+    Ok(CloudConfigBundle {
+        config_toml,
+        requirements_toml,
+    })
+}
+
+fn managed_fragments_from_delivered<T>(
+    managed_layers: Option<Option<Box<DeliveredManagedLayers>>>,
+    convert: fn(DeliveredTomlFragment) -> T,
+    document_name: &str,
+) -> Result<(Vec<T>, Vec<T>), BundleRequestError> {
+    let managed_layers = managed_layers
+        .flatten()
+        .map(|managed_layers| *managed_layers)
+        .ok_or_else(|| BundleRequestError::InvalidBundle {
+            message: format!(
+                "cloud config bundle {document_name} is present but managed_layers is missing or null"
+            ),
+        })?;
+    let DeliveredManagedLayers {
+        baseline,
+        system_overlay,
+    } = managed_layers;
+    Ok((
+        baseline.into_iter().map(convert).collect(),
+        system_overlay.into_iter().map(convert).collect(),
+    ))
 }
 
 fn config_fragment_from_delivered(fragment: DeliveredTomlFragment) -> CloudConfigFragment {

--- a/codex-rs/cloud-config/src/cache.rs
+++ b/codex-rs/cloud-config/src/cache.rs
@@ -20,7 +20,8 @@ use std::time::Duration;
 use thiserror::Error;
 use tokio::fs;
 
-const CLOUD_CONFIG_BUNDLE_CACHE_VERSION: u32 = 1;
+// Cache v2 signs the complete managed-only payload. V1 entries are cache misses.
+const CLOUD_CONFIG_BUNDLE_CACHE_VERSION: u32 = 2;
 pub(super) const CLOUD_CONFIG_BUNDLE_CACHE_FILENAME: &str = "cloud-config-bundle-cache.json";
 const CLOUD_CONFIG_BUNDLE_CACHE_TTL: Duration = Duration::from_secs(60 * 60);
 const CLOUD_CONFIG_BUNDLE_CACHE_WRITE_HMAC_KEY: &[u8] =
@@ -87,7 +88,6 @@ impl CloudConfigBundleCache {
                 cache_file.signed_payload.version,
             ));
         }
-
         let (Some(cached_chatgpt_user_id), Some(cached_account_id)) = (
             cache_file.signed_payload.chatgpt_user_id.as_deref(),
             cache_file.signed_payload.account_id.as_deref(),

--- a/codex-rs/cloud-config/src/cache_tests.rs
+++ b/codex-rs/cloud-config/src/cache_tests.rs
@@ -13,20 +13,26 @@ use tempfile::tempdir;
 fn test_bundle() -> CloudConfigBundle {
     CloudConfigBundle {
         config_toml: CloudConfigTomlBundle {
-            enterprise_managed: vec![CloudConfigFragment {
-                id: "cfg_1".to_string(),
-                name: "Base config".to_string(),
-                contents: "model = \"gpt-5\"".to_string(),
-            }],
-            managed_layers: CloudConfigTomlManagedLayers::default(),
+            enterprise_managed: Vec::new(),
+            managed_layers: CloudConfigTomlManagedLayers {
+                baseline: vec![CloudConfigFragment {
+                    id: "cfg_1".to_string(),
+                    name: "Base config".to_string(),
+                    contents: "model = \"gpt-5\"".to_string(),
+                }],
+                system_overlay: Vec::new(),
+            },
         },
         requirements_toml: CloudRequirementsTomlBundle {
-            enterprise_managed: vec![CloudRequirementsFragment {
-                id: "req_1".to_string(),
-                name: "Base requirements".to_string(),
-                contents: "allowed_approval_policies = [\"never\"]".to_string(),
-            }],
-            managed_layers: CloudRequirementsTomlManagedLayers::default(),
+            enterprise_managed: Vec::new(),
+            managed_layers: CloudRequirementsTomlManagedLayers {
+                baseline: Vec::new(),
+                system_overlay: vec![CloudRequirementsFragment {
+                    id: "req_1".to_string(),
+                    name: "Base requirements".to_string(),
+                    contents: "allowed_approval_policies = [\"never\"]".to_string(),
+                }],
+            },
         },
     }
 }
@@ -83,6 +89,8 @@ async fn save_writes_signed_payload_and_loads_for_matching_identity() {
     let cache_file: CloudConfigBundleCacheFile =
         serde_json::from_slice(&std::fs::read(cache.path()).expect("read cache"))
             .expect("parse cache");
+    let cache_json = serde_json::to_string(&cache_file).expect("serialize cache as JSON");
+    assert!(!cache_json.contains("enterprise_managed"));
     assert!(
         cache_file.signed_payload.expires_at
             <= cache_file.signed_payload.cached_at + ChronoDuration::minutes(60)
@@ -141,22 +149,34 @@ async fn load_reports_missing_and_malformed_cache_files() {
 }
 
 #[tokio::test]
-async fn load_rejects_tampered_payload() {
-    let codex_home = tempdir().expect("tempdir");
-    let cache = create_test_cache(codex_home.path());
-    let mut cache_file = signed_cache_file(valid_signed_payload());
-    cache_file
+async fn load_rejects_tampering_in_either_managed_bucket() {
+    let mut baseline = signed_cache_file(valid_signed_payload());
+    baseline
+        .signed_payload
+        .bundle
+        .config_toml
+        .managed_layers
+        .baseline[0]
+        .contents = "model = \"tampered\"".to_string();
+    let mut system_overlay = signed_cache_file(valid_signed_payload());
+    system_overlay
         .signed_payload
         .bundle
         .requirements_toml
-        .enterprise_managed[0]
+        .managed_layers
+        .system_overlay[0]
         .contents = "allowed_approval_policies = [\"on-request\"]".to_string();
-    write_cache_file(&cache, &cache_file);
 
-    assert_eq!(
-        cache.load(Some("user-12345"), Some("account-12345")).await,
-        Err(CacheLoadStatus::CacheSignatureInvalid)
-    );
+    for cache_file in [baseline, system_overlay] {
+        let codex_home = tempdir().expect("tempdir");
+        let cache = create_test_cache(codex_home.path());
+        write_cache_file(&cache, &cache_file);
+
+        assert_eq!(
+            cache.load(Some("user-12345"), Some("account-12345")).await,
+            Err(CacheLoadStatus::CacheSignatureInvalid)
+        );
+    }
 }
 
 #[tokio::test]
@@ -196,15 +216,15 @@ async fn load_rejects_expired_cache() {
 }
 
 #[tokio::test]
-async fn load_rejects_unsupported_cache_version() {
+async fn load_rejects_v1_cache() {
     let codex_home = tempdir().expect("tempdir");
     let cache = create_test_cache(codex_home.path());
     let mut signed_payload = valid_signed_payload();
-    signed_payload.version = 2;
+    signed_payload.version = 1;
     write_cache_file(&cache, &signed_cache_file(signed_payload));
 
     assert_eq!(
         cache.load(Some("user-12345"), Some("account-12345")).await,
-        Err(CacheLoadStatus::CacheVersionUnsupported(2))
+        Err(CacheLoadStatus::CacheVersionUnsupported(1))
     );
 }

--- a/codex-rs/cloud-config/src/metrics.rs
+++ b/codex-rs/cloud-config/src/metrics.rs
@@ -63,11 +63,13 @@ pub(crate) fn bundle_shape_tag(bundle: Option<&CloudConfigBundle>) -> String {
     };
 
     let mut sources = Vec::new();
-    if !bundle.config_toml.enterprise_managed.is_empty() {
-        sources.push("enterprise_config");
+    let config_layers = &bundle.config_toml.managed_layers;
+    if !config_layers.baseline.is_empty() || !config_layers.system_overlay.is_empty() {
+        sources.push("cloud_managed_config");
     }
-    if !bundle.requirements_toml.enterprise_managed.is_empty() {
-        sources.push("enterprise_requirements");
+    let requirements_layers = &bundle.requirements_toml.managed_layers;
+    if !requirements_layers.baseline.is_empty() || !requirements_layers.system_overlay.is_empty() {
+        sources.push("cloud_managed_requirements");
     }
 
     if sources.is_empty() {

--- a/codex-rs/cloud-config/src/service.rs
+++ b/codex-rs/cloud-config/src/service.rs
@@ -150,8 +150,13 @@ where
             Some(bundle) => {
                 tracing::info!(
                     elapsed_ms = started_at.elapsed().as_millis(),
-                    config_fragments = bundle.config_toml.enterprise_managed.len(),
-                    requirements_fragments = bundle.requirements_toml.enterprise_managed.len(),
+                    config_baseline_fragments = bundle.config_toml.managed_layers.baseline.len(),
+                    config_system_overlay_fragments =
+                        bundle.config_toml.managed_layers.system_overlay.len(),
+                    requirements_baseline_fragments =
+                        bundle.requirements_toml.managed_layers.baseline.len(),
+                    requirements_system_overlay_fragments =
+                        bundle.requirements_toml.managed_layers.system_overlay.len(),
                     "Cloud config bundle load completed"
                 );
                 emit_load_metric("startup", "success", Some(bundle));
@@ -272,6 +277,24 @@ where
                             continue;
                         }
                     }
+                }
+                Err(BundleRequestError::InvalidBundle { message }) => {
+                    emit_fetch_attempt_metric(
+                        trigger, attempt, "success", /*status_code*/ None,
+                    );
+                    emit_fetch_final_metric(
+                        trigger,
+                        "error",
+                        "invalid_bundle",
+                        attempt,
+                        /*status_code*/ None,
+                        /*bundle*/ None,
+                    );
+                    return Err(CloudConfigBundleLoadError::new(
+                        CloudConfigBundleLoadErrorCode::InvalidBundle,
+                        /*status_code*/ None,
+                        message,
+                    ));
                 }
             }
 

--- a/codex-rs/cloud-config/src/service_tests.rs
+++ b/codex-rs/cloud-config/src/service_tests.rs
@@ -5,10 +5,13 @@ use crate::backend::RetryableFailureKind;
 use crate::backend::bundle_from_response;
 use crate::cache::CLOUD_CONFIG_BUNDLE_CACHE_FILENAME;
 use crate::cache::CloudConfigBundleCache;
+use crate::cache::sign_cache_payload;
+use crate::cache::verify_cache_signature;
 use crate::metrics::bundle_shape_tag;
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use codex_backend_client::ConfigBundleResponse;
+use codex_backend_client::DeliveredManagedLayers;
 use codex_backend_client::DeliveredTomlFragment;
 use codex_config::AbsolutePathBuf;
 use codex_config::CloudConfigFragment;
@@ -37,6 +40,60 @@ fn write_auth_json(codex_home: &Path, value: serde_json::Value) -> std::io::Resu
 
 fn create_test_cache(codex_home: &Path) -> CloudConfigBundleCache {
     CloudConfigBundleCache::new(AbsolutePathBuf::resolve_path_against_base(codex_home, "/"))
+}
+
+fn write_legacy_v1_cache(cache: &CloudConfigBundleCache) {
+    #[derive(serde::Serialize)]
+    struct LegacyTomlBundle<T> {
+        enterprise_managed: Vec<T>,
+    }
+    #[derive(serde::Serialize)]
+    struct LegacyBundle {
+        config_toml: LegacyTomlBundle<CloudConfigFragment>,
+        requirements_toml: LegacyTomlBundle<CloudRequirementsFragment>,
+    }
+    #[derive(serde::Serialize)]
+    struct LegacySignedPayload {
+        version: u32,
+        cached_at: chrono::DateTime<chrono::Utc>,
+        expires_at: chrono::DateTime<chrono::Utc>,
+        chatgpt_user_id: Option<String>,
+        account_id: Option<String>,
+        bundle: LegacyBundle,
+    }
+
+    let cached_at = chrono::Utc::now();
+    let signed_payload = LegacySignedPayload {
+        version: 1,
+        cached_at,
+        expires_at: cached_at + chrono::Duration::minutes(30),
+        chatgpt_user_id: Some("user-12345".to_string()),
+        account_id: Some("account-12345".to_string()),
+        bundle: LegacyBundle {
+            config_toml: LegacyTomlBundle {
+                enterprise_managed: vec![config_fragment("cfg_legacy", "model = \"legacy\"")],
+            },
+            requirements_toml: LegacyTomlBundle {
+                enterprise_managed: vec![requirements_fragment(
+                    "req_legacy",
+                    "allowed_approval_policies = [\"never\"]",
+                )],
+            },
+        },
+    };
+    let payload_bytes = serde_json::to_vec(&signed_payload).expect("serialize legacy payload");
+    let signature = sign_cache_payload(&payload_bytes).expect("sign legacy payload");
+    assert!(verify_cache_signature(&payload_bytes, &signature));
+    std::fs::write(
+        cache.path(),
+        serde_json::to_vec_pretty(&json!({
+            "signed_payload": serde_json::to_value(signed_payload)
+                .expect("serialize legacy signed payload"),
+            "signature": signature,
+        }))
+        .expect("serialize legacy cache"),
+    )
+    .expect("write legacy cache");
 }
 
 async fn auth_manager_with_api_key() -> Arc<AuthManager> {
@@ -198,43 +255,122 @@ fn chatgpt_auth_json_with_mode(
 fn test_bundle() -> CloudConfigBundle {
     CloudConfigBundle {
         config_toml: CloudConfigTomlBundle {
-            enterprise_managed: vec![test_config_fragment()],
-            managed_layers: CloudConfigTomlManagedLayers::default(),
+            enterprise_managed: Vec::new(),
+            managed_layers: CloudConfigTomlManagedLayers {
+                baseline: vec![test_config_fragment()],
+                system_overlay: Vec::new(),
+            },
         },
         requirements_toml: CloudRequirementsTomlBundle {
-            enterprise_managed: vec![test_requirements_fragment()],
-            managed_layers: CloudRequirementsTomlManagedLayers::default(),
+            enterprise_managed: Vec::new(),
+            managed_layers: CloudRequirementsTomlManagedLayers {
+                baseline: Vec::new(),
+                system_overlay: vec![test_requirements_fragment()],
+            },
         },
     }
 }
 
 fn test_config_fragment() -> CloudConfigFragment {
-    CloudConfigFragment {
-        id: "cfg_1".to_string(),
-        name: "Base config".to_string(),
-        contents: "model = \"gpt-5\"".to_string(),
-    }
+    config_fragment("cfg_1", "model = \"gpt-5\"")
 }
 
 fn test_requirements_fragment() -> CloudRequirementsFragment {
+    requirements_fragment("req_1", "allowed_approval_policies = [\"never\"]")
+}
+
+fn delivered_fragment(id: &str, contents: &str) -> DeliveredTomlFragment {
+    DeliveredTomlFragment::new(id.to_string(), id.to_string(), contents.to_string())
+}
+
+fn config_fragment(id: &str, contents: &str) -> CloudConfigFragment {
+    CloudConfigFragment {
+        id: id.to_string(),
+        name: id.to_string(),
+        contents: contents.to_string(),
+    }
+}
+
+fn requirements_fragment(id: &str, contents: &str) -> CloudRequirementsFragment {
     CloudRequirementsFragment {
-        id: "req_1".to_string(),
-        name: "Base requirements".to_string(),
-        contents: "allowed_approval_policies = [\"never\"]".to_string(),
+        id: id.to_string(),
+        name: id.to_string(),
+        contents: contents.to_string(),
+    }
+}
+
+fn delivered_managed_layers(
+    baseline: Vec<DeliveredTomlFragment>,
+    system_overlay: Vec<DeliveredTomlFragment>,
+) -> Option<Option<Box<DeliveredManagedLayers>>> {
+    Some(Some(Box::new(DeliveredManagedLayers::new(
+        baseline,
+        system_overlay,
+    ))))
+}
+
+fn replacement_requirements_bundle() -> CloudConfigBundle {
+    CloudConfigBundle {
+        config_toml: CloudConfigTomlBundle::default(),
+        requirements_toml: CloudRequirementsTomlBundle {
+            managed_layers: CloudRequirementsTomlManagedLayers {
+                baseline: Vec::new(),
+                system_overlay: vec![CloudRequirementsFragment {
+                    id: "req_2".to_string(),
+                    name: "Replacement requirements".to_string(),
+                    contents: "allowed_approval_policies = [\"on-request\"]".to_string(),
+                }],
+            },
+            ..Default::default()
+        },
     }
 }
 
 fn invalid_config_bundle() -> CloudConfigBundle {
     CloudConfigBundle {
         config_toml: CloudConfigTomlBundle {
-            enterprise_managed: vec![CloudConfigFragment {
-                id: "cfg_invalid".to_string(),
-                name: "Invalid config".to_string(),
-                contents: "model = [".to_string(),
-            }],
+            managed_layers: CloudConfigTomlManagedLayers {
+                baseline: vec![CloudConfigFragment {
+                    id: "cfg_invalid".to_string(),
+                    name: "Invalid config".to_string(),
+                    contents: "model = [".to_string(),
+                }],
+                system_overlay: Vec::new(),
+            },
             ..Default::default()
         },
         requirements_toml: CloudRequirementsTomlBundle::default(),
+    }
+}
+
+fn conflicting_managed_requirements_bundle() -> CloudConfigBundle {
+    CloudConfigBundle {
+        config_toml: CloudConfigTomlBundle::default(),
+        requirements_toml: CloudRequirementsTomlBundle {
+            managed_layers: CloudRequirementsTomlManagedLayers {
+                baseline: vec![CloudRequirementsFragment {
+                    id: "req_baseline".to_string(),
+                    name: "Baseline requirements".to_string(),
+                    contents: r#"
+[hooks]
+managed_dir = "/managed/baseline"
+windows_managed_dir = 'C:\managed\baseline'
+"#
+                    .to_string(),
+                }],
+                system_overlay: vec![CloudRequirementsFragment {
+                    id: "req_overlay".to_string(),
+                    name: "System overlay requirements".to_string(),
+                    contents: r#"
+[hooks]
+managed_dir = "/managed/overlay"
+windows_managed_dir = 'C:\managed\overlay'
+"#
+                    .to_string(),
+                }],
+            },
+            ..Default::default()
+        },
     }
 }
 
@@ -335,7 +471,7 @@ impl BundleClient for UnauthorizedBundleClient {
 }
 
 #[test]
-fn bundle_shape_tag_describes_sorted_enterprise_sources() {
+fn bundle_shape_tag_describes_managed_documents() {
     assert_eq!(bundle_shape_tag(/*bundle*/ None), "none");
     assert_eq!(
         bundle_shape_tag(Some(&CloudConfigBundle::default())),
@@ -344,35 +480,21 @@ fn bundle_shape_tag_describes_sorted_enterprise_sources() {
     assert_eq!(
         bundle_shape_tag(Some(&CloudConfigBundle {
             config_toml: CloudConfigTomlBundle {
-                enterprise_managed: vec![test_config_fragment()],
-                ..Default::default()
-            },
-            requirements_toml: CloudRequirementsTomlBundle::default(),
-        })),
-        "enterprise_config"
-    );
-    assert_eq!(
-        bundle_shape_tag(Some(&CloudConfigBundle {
-            config_toml: CloudConfigTomlBundle::default(),
-            requirements_toml: CloudRequirementsTomlBundle {
-                enterprise_managed: vec![test_requirements_fragment()],
-                ..Default::default()
-            },
-        })),
-        "enterprise_requirements"
-    );
-    assert_eq!(
-        bundle_shape_tag(Some(&CloudConfigBundle {
-            config_toml: CloudConfigTomlBundle {
-                enterprise_managed: vec![test_config_fragment()],
+                managed_layers: CloudConfigTomlManagedLayers {
+                    baseline: vec![test_config_fragment()],
+                    system_overlay: vec![test_config_fragment()],
+                },
                 ..Default::default()
             },
             requirements_toml: CloudRequirementsTomlBundle {
-                enterprise_managed: vec![test_requirements_fragment()],
+                managed_layers: CloudRequirementsTomlManagedLayers {
+                    baseline: vec![test_requirements_fragment()],
+                    system_overlay: vec![test_requirements_fragment()],
+                },
                 ..Default::default()
             },
         })),
-        "enterprise_config,enterprise_requirements"
+        "cloud_managed_config,cloud_managed_requirements"
     );
 }
 
@@ -485,8 +607,47 @@ async fn get_bundle_skips_team_like_usage_based_plan() {
 
 #[tokio::test]
 async fn get_bundle_rejects_invalid_remote_bundle_before_cache_write() {
+    for bundle in [
+        invalid_config_bundle(),
+        conflicting_managed_requirements_bundle(),
+    ] {
+        let codex_home = tempdir().expect("tempdir");
+        let fetcher = Arc::new(StaticBundleClient::new(bundle));
+        let service = CloudConfigBundleService::new(
+            auth_manager_with_plan("business").await,
+            fetcher.clone(),
+            codex_home.path().to_path_buf(),
+            CLOUD_CONFIG_BUNDLE_TIMEOUT,
+        );
+
+        let err = service
+            .load_startup_bundle()
+            .await
+            .expect_err("invalid remote bundle should fail closed");
+
+        assert_eq!(err.code(), CloudConfigBundleLoadErrorCode::InvalidBundle);
+        assert!(err.to_string().contains("invalid cloud config bundle"));
+        assert_eq!(fetcher.request_count.load(Ordering::SeqCst), 1);
+        assert!(
+            !codex_home
+                .path()
+                .join(CLOUD_CONFIG_BUNDLE_CACHE_FILENAME)
+                .exists()
+        );
+    }
+}
+
+#[tokio::test]
+async fn get_bundle_does_not_retry_or_cache_invalid_transport_bundle() {
     let codex_home = tempdir().expect("tempdir");
-    let fetcher = Arc::new(StaticBundleClient::new(invalid_config_bundle()));
+    let fetcher = Arc::new(SequenceBundleClient::new(vec![
+        Err(BundleRequestError::InvalidBundle {
+            message:
+                "cloud config bundle config_toml is present but managed_layers is missing or null"
+                    .to_string(),
+        }),
+        Ok(test_bundle()),
+    ]));
     let service = CloudConfigBundleService::new(
         auth_manager_with_plan("business").await,
         fetcher.clone(),
@@ -497,10 +658,13 @@ async fn get_bundle_rejects_invalid_remote_bundle_before_cache_write() {
     let err = service
         .load_startup_bundle()
         .await
-        .expect_err("invalid remote bundle should fail closed");
+        .expect_err("invalid transport bundle should fail closed");
 
     assert_eq!(err.code(), CloudConfigBundleLoadErrorCode::InvalidBundle);
-    assert!(err.to_string().contains("invalid cloud config bundle"));
+    assert!(
+        err.to_string()
+            .contains("managed_layers is missing or null")
+    );
     assert_eq!(fetcher.request_count.load(Ordering::SeqCst), 1);
     assert!(
         !codex_home
@@ -592,6 +756,51 @@ async fn get_bundle_uses_cache_when_valid() {
 }
 
 #[tokio::test]
+async fn get_bundle_treats_legacy_v1_cache_as_miss_and_rewrites_v2() {
+    let codex_home = tempdir().expect("tempdir");
+    let cache = create_test_cache(codex_home.path());
+    write_legacy_v1_cache(&cache);
+    let replacement_bundle = test_bundle();
+    let fetcher = Arc::new(StaticBundleClient::new(replacement_bundle.clone()));
+    let service = CloudConfigBundleService::new(
+        auth_manager_with_plan("business").await,
+        fetcher.clone(),
+        codex_home.path().to_path_buf(),
+        CLOUD_CONFIG_BUNDLE_TIMEOUT,
+    );
+
+    assert_eq!(
+        service.load_startup_bundle().await,
+        Ok(Some(replacement_bundle.clone()))
+    );
+    assert_eq!(fetcher.request_count.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        cache
+            .load(Some("user-12345"), Some("account-12345"))
+            .await
+            .expect("load rewritten cache")
+            .bundle,
+        replacement_bundle
+    );
+    let cache_json: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(cache.path()).expect("read rewritten cache"))
+            .expect("parse rewritten cache");
+    assert_eq!(cache_json["signed_payload"]["version"], 2);
+    let bundle_json = &cache_json["signed_payload"]["bundle"];
+    assert!(bundle_json["config_toml"]["managed_layers"].is_object());
+    assert!(
+        bundle_json["config_toml"]
+            .get("enterprise_managed")
+            .is_none()
+    );
+    assert!(
+        bundle_json["requirements_toml"]
+            .get("enterprise_managed")
+            .is_none()
+    );
+}
+
+#[tokio::test]
 async fn get_bundle_ignores_cache_for_different_auth_identity() {
     let codex_home = tempdir().expect("tempdir");
     let prime_service = CloudConfigBundleService::new(
@@ -603,17 +812,7 @@ async fn get_bundle_ignores_cache_for_different_auth_identity() {
     );
     let _ = prime_service.load_startup_bundle().await;
 
-    let replacement_bundle = CloudConfigBundle {
-        config_toml: CloudConfigTomlBundle::default(),
-        requirements_toml: CloudRequirementsTomlBundle {
-            enterprise_managed: vec![CloudRequirementsFragment {
-                id: "req_2".to_string(),
-                name: "Replacement requirements".to_string(),
-                contents: "allowed_approval_policies = [\"on-request\"]".to_string(),
-            }],
-            ..Default::default()
-        },
-    };
+    let replacement_bundle = replacement_requirements_bundle();
     let fetcher = Arc::new(SequenceBundleClient::new(vec![Ok(
         replacement_bundle.clone()
     )]));
@@ -933,17 +1132,7 @@ async fn get_bundle_does_not_use_cache_when_auth_identity_is_incomplete() {
     );
     let _ = prime_service.load_startup_bundle().await;
 
-    let replacement_bundle = CloudConfigBundle {
-        config_toml: CloudConfigTomlBundle::default(),
-        requirements_toml: CloudRequirementsTomlBundle {
-            enterprise_managed: vec![CloudRequirementsFragment {
-                id: "req_2".to_string(),
-                name: "Replacement requirements".to_string(),
-                contents: "allowed_approval_policies = [\"on-request\"]".to_string(),
-            }],
-            ..Default::default()
-        },
-    };
+    let replacement_bundle = replacement_requirements_bundle();
     let fetcher = Arc::new(SequenceBundleClient::new(vec![Ok(
         replacement_bundle.clone()
     )]));
@@ -999,17 +1188,7 @@ async fn get_bundle_stops_after_max_retries() {
 
 #[tokio::test]
 async fn refresh_from_remote_updates_cached_bundle() {
-    let replacement_bundle = CloudConfigBundle {
-        config_toml: CloudConfigTomlBundle::default(),
-        requirements_toml: CloudRequirementsTomlBundle {
-            enterprise_managed: vec![CloudRequirementsFragment {
-                id: "req_2".to_string(),
-                name: "Replacement requirements".to_string(),
-                contents: "allowed_approval_policies = [\"on-request\"]".to_string(),
-            }],
-            ..Default::default()
-        },
-    };
+    let replacement_bundle = replacement_requirements_bundle();
     let codex_home = tempdir().expect("tempdir");
     let fetcher = Arc::new(SequenceBundleClient::new(vec![
         Ok(test_bundle()),
@@ -1034,69 +1213,135 @@ async fn refresh_from_remote_updates_cached_bundle() {
 }
 
 #[test]
-fn bundle_response_conversion_preserves_fragment_order() {
+fn bundle_response_conversion_uses_only_managed_layers_and_preserves_order() {
+    let legacy_config = delivered_fragment("legacy", "model = [");
+    let baseline_config = delivered_fragment("baseline", "model = \"baseline\"");
+    let high_config = delivered_fragment("high", "model = \"high\"");
+    let low_config = delivered_fragment("low", "model = \"low\"");
+    let overlay_requirements =
+        delivered_fragment("overlay", "allowed_approval_policies = [\"never\"]");
     let response = ConfigBundleResponse {
         config_toml: Some(Some(Box::new(codex_backend_client::DeliveredConfigToml {
-            enterprise_managed: Some(Some(vec![
-                DeliveredTomlFragment::new(
-                    "cfg_high".to_string(),
-                    "High config".to_string(),
-                    "model = \"high\"".to_string(),
-                ),
-                DeliveredTomlFragment::new(
-                    "cfg_low".to_string(),
-                    "Low config".to_string(),
-                    "model = \"low\"".to_string(),
-                ),
-            ])),
-            managed_layers: None,
+            enterprise_managed: Some(Some(vec![legacy_config])),
+            managed_layers: delivered_managed_layers(
+                vec![baseline_config],
+                vec![high_config, low_config],
+            ),
         }))),
         requirements_toml: Some(Some(Box::new(
             codex_backend_client::DeliveredRequirementsToml {
-                enterprise_managed: Some(Some(vec![DeliveredTomlFragment::new(
-                    "req_high".to_string(),
-                    "High requirements".to_string(),
-                    "allowed_approval_policies = [\"never\"]".to_string(),
+                enterprise_managed: Some(Some(vec![delivered_fragment(
+                    "legacy",
+                    "allowed_approval_policies = [",
                 )])),
-                managed_layers: None,
+                managed_layers: delivered_managed_layers(Vec::new(), vec![overlay_requirements]),
             },
         ))),
     };
 
     assert_eq!(
         bundle_from_response(response),
-        CloudConfigBundle {
+        Ok(CloudConfigBundle {
             config_toml: CloudConfigTomlBundle {
-                enterprise_managed: vec![
-                    CloudConfigFragment {
-                        id: "cfg_high".to_string(),
-                        name: "High config".to_string(),
-                        contents: "model = \"high\"".to_string(),
-                    },
-                    CloudConfigFragment {
-                        id: "cfg_low".to_string(),
-                        name: "Low config".to_string(),
-                        contents: "model = \"low\"".to_string(),
-                    },
-                ],
+                managed_layers: CloudConfigTomlManagedLayers {
+                    baseline: vec![config_fragment("baseline", "model = \"baseline\"")],
+                    system_overlay: vec![
+                        config_fragment("high", "model = \"high\""),
+                        config_fragment("low", "model = \"low\""),
+                    ],
+                },
                 ..Default::default()
             },
             requirements_toml: CloudRequirementsTomlBundle {
-                enterprise_managed: vec![CloudRequirementsFragment {
-                    id: "req_high".to_string(),
-                    name: "High requirements".to_string(),
-                    contents: "allowed_approval_policies = [\"never\"]".to_string(),
-                }],
+                managed_layers: CloudRequirementsTomlManagedLayers {
+                    baseline: Vec::new(),
+                    system_overlay: vec![requirements_fragment(
+                        "overlay",
+                        "allowed_approval_policies = [\"never\"]",
+                    )],
+                },
                 ..Default::default()
             },
-        }
+        })
     );
 }
 
 #[test]
-fn bundle_response_conversion_treats_missing_sections_as_empty() {
+fn bundle_response_conversion_treats_missing_or_null_sections_as_empty() {
     assert_eq!(
         bundle_from_response(ConfigBundleResponse::new()),
-        CloudConfigBundle::default()
+        Ok(CloudConfigBundle::default())
     );
+    assert_eq!(
+        bundle_from_response(ConfigBundleResponse {
+            config_toml: Some(None),
+            requirements_toml: Some(None),
+        }),
+        Ok(CloudConfigBundle::default())
+    );
+}
+
+#[test]
+fn bundle_response_conversion_accepts_explicitly_empty_managed_layers() {
+    assert_eq!(
+        bundle_from_response(ConfigBundleResponse {
+            config_toml: Some(Some(Box::new(codex_backend_client::DeliveredConfigToml {
+                enterprise_managed: Some(Some(vec![delivered_fragment("legacy", "model = [")])),
+                managed_layers: delivered_managed_layers(Vec::new(), Vec::new()),
+            }))),
+            requirements_toml: Some(Some(Box::new(
+                codex_backend_client::DeliveredRequirementsToml {
+                    enterprise_managed: None,
+                    managed_layers: delivered_managed_layers(Vec::new(), Vec::new()),
+                },
+            ))),
+        }),
+        Ok(CloudConfigBundle::default())
+    );
+}
+
+#[test]
+fn bundle_response_conversion_rejects_present_section_without_managed_layers() {
+    for managed_layers in [None, Some(None)] {
+        assert_eq!(
+            bundle_from_response(ConfigBundleResponse {
+                config_toml: Some(Some(Box::new(codex_backend_client::DeliveredConfigToml {
+                    enterprise_managed: Some(Some(vec![delivered_fragment(
+                        "legacy",
+                        "model = \"ignored\"",
+                    )])),
+                    managed_layers,
+                }))),
+                requirements_toml: Some(None),
+            }),
+            Err(BundleRequestError::InvalidBundle {
+                message: concat!(
+                    "cloud config bundle config_toml is present but managed_layers ",
+                    "is missing or null"
+                )
+                .to_string(),
+            })
+        );
+    }
+
+    for managed_layers in [None, Some(None)] {
+        assert_eq!(
+            bundle_from_response(ConfigBundleResponse {
+                config_toml: Some(None),
+                requirements_toml: Some(Some(Box::new(
+                    codex_backend_client::DeliveredRequirementsToml {
+                        enterprise_managed: Some(Some(Vec::new())),
+                        managed_layers,
+                    },
+                ))),
+            }),
+            Err(BundleRequestError::InvalidBundle {
+                message: concat!(
+                    "cloud config bundle requirements_toml is present but managed_layers ",
+                    "is missing or null"
+                )
+                .to_string(),
+            })
+        );
+    }
 }

--- a/codex-rs/cloud-config/src/validation.rs
+++ b/codex-rs/cloud-config/src/validation.rs
@@ -21,12 +21,13 @@ pub(crate) fn validate_bundle(
         baseline_config: _,
         system_overlay_config: _,
         enterprise_managed_config: _,
-        baseline_requirements: _,
-        system_overlay_requirements: _,
-        enterprise_managed_requirements,
+        mut baseline_requirements,
+        system_overlay_requirements,
+        enterprise_managed_requirements: _,
     } = bundle_layers;
 
-    compose_requirements(enterprise_managed_requirements).map_err(|err| {
+    baseline_requirements.extend(system_overlay_requirements);
+    compose_requirements(baseline_requirements).map_err(|err| {
         CloudConfigBundleLoadError::new(
             CloudConfigBundleLoadErrorCode::InvalidBundle,
             /*status_code*/ None,

--- a/codex-rs/config/src/cloud_config_bundle.rs
+++ b/codex-rs/config/src/cloud_config_bundle.rs
@@ -56,6 +56,7 @@ impl CloudConfigBundle {
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CloudConfigTomlBundle {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub enterprise_managed: Vec<CloudConfigFragment>,
     #[serde(
         default,
@@ -78,6 +79,7 @@ impl CloudConfigTomlManagedLayers {
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CloudRequirementsTomlBundle {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub enterprise_managed: Vec<CloudRequirementsFragment>,
     #[serde(
         default,

--- a/codex-rs/config/src/test_support.rs
+++ b/codex-rs/config/src/test_support.rs
@@ -18,6 +18,10 @@ impl CloudConfigBundleFixture {
         Self::default().add_enterprise_requirement(contents)
     }
 
+    pub fn system_overlay_requirement(contents: impl Into<String>) -> Self {
+        Self::default().add_managed_requirement(CloudManagedLayer::SystemOverlay, contents)
+    }
+
     pub fn enterprise_config(contents: impl Into<String>) -> Self {
         Self::default().add_enterprise_config(contents)
     }
@@ -26,6 +30,12 @@ impl CloudConfigBundleFixture {
         contents: impl Into<String>,
     ) -> CloudConfigBundleLoader {
         Self::enterprise_requirement(contents).into_loader()
+    }
+
+    pub fn loader_with_system_overlay_requirement(
+        contents: impl Into<String>,
+    ) -> CloudConfigBundleLoader {
+        Self::system_overlay_requirement(contents).into_loader()
     }
 
     pub fn loader_with_enterprise_config(contents: impl Into<String>) -> CloudConfigBundleLoader {

--- a/codex-rs/core/tests/common/lib.rs
+++ b/codex-rs/core/tests/common/lib.rs
@@ -218,7 +218,7 @@ pub async fn load_default_config_for_test_with_cloud_config_bundle(
 }
 
 pub fn managed_network_requirements_loader() -> CloudConfigBundleLoader {
-    CloudConfigBundleFixture::loader_with_enterprise_requirement(
+    CloudConfigBundleFixture::loader_with_system_overlay_requirement(
         r#"
 [experimental_network]
 enabled = true


### PR DESCRIPTION
## Why

The backend now publishes the authoritative configuration in `managed_layers`. Continuing to consume or cache `enterprise_managed` would lose baseline/system-overlay semantics and let old and new clients interpret the same cache version differently.

## What changed

- consume only `managed_layers`; conflicting or invalid legacy TOML is never parsed as config
- treat absent/null outer documents as empty, but reject a present document whose `managed_layers` is absent/null
- stop retries and avoid cache writes for that invalid bundle shape
- validate baseline and system-overlay requirements as one composed stack before caching
- bump the existing signed cache to v2 without migration or an alternate envelope
- treat v1 as a miss, fetch once, and rewrite a managed-only v2 payload
- retain the existing workspace-plan eligibility rules
- exercise the running-agent policy path with system-overlay requirements through the existing `test_codex` integration scenarios

The inner `baseline` and `system_overlay` arrays remain required, matching the current generated backend schema.

## Stack

4 of 5: #31285 → #31286 → #31287 → this PR → #31315.

This stack supersedes #28965 and #28979.

## Validation

- `just test -p codex-cloud-config` (34 passed)
- genuine signed enterprise-shaped v1 → miss → one fetch → managed-only v2 rewrite
- managed-shaped version 1 rejection, v2 cache hit, and both-tier tamper rejection
- missing/null document-shape and combined cross-tier requirements conflict coverage
- representative system-overlay `test_codex` policy integration coverage
- `just fix -p codex-config -p codex-cloud-config`
- two independent reviews found no remaining actionable issues
