### PR TITLE
[thread-store] let stores own derived metadata

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/remote_thread_store.rs
+++ b/codex-rs/app-server/tests/suite/v2/remote_thread_store.rs
@@ -32,6 +32,8 @@ use codex_app_server_protocol::ThreadDeleteParams;
 use codex_app_server_protocol::ThreadDeleteResponse;
 use codex_app_server_protocol::ThreadListParams;
 use codex_app_server_protocol::ThreadListResponse;
+use codex_app_server_protocol::ThreadReadParams;
+use codex_app_server_protocol::ThreadReadResponse;
 use codex_app_server_protocol::ThreadResumeParams;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
@@ -143,8 +145,27 @@ async fn thread_delete_with_non_local_thread_store_does_not_create_local_persist
     assert_eq!(data.len(), 1);
     assert_eq!(data[0].id, thread.id);
     assert_eq!(data[0].path, None);
+    assert_eq!(data[0].preview, "Hello");
+    assert_eq!(data[0].model_provider, "mock_provider");
 
-    delete_thread(&client, /*request_id*/ 4, thread.id.clone()).await?;
+    let response = client
+        .request(ClientRequest::ThreadRead {
+            request_id: RequestId::Integer(4),
+            params: ThreadReadParams {
+                thread_id: thread.id.clone(),
+                include_turns: false,
+            },
+        })
+        .await?
+        .expect("thread/read should succeed");
+    let ThreadReadResponse {
+        thread: read_thread,
+    } = serde_json::from_value(response).expect("thread/read response should parse");
+    assert_eq!(read_thread.preview, "Hello");
+    assert_eq!(read_thread.model_provider, "mock_provider");
+    assert_eq!(read_thread.path, None);
+
+    delete_thread(&client, /*request_id*/ 5, thread.id.clone()).await?;
     let unloaded_thread_id = ThreadId::from_string(&Uuid::new_v4().to_string())?;
     thread_store
         .create_thread(StoreCreateThreadParams {
@@ -171,7 +192,7 @@ async fn thread_delete_with_non_local_thread_store_does_not_create_local_persist
         .await?;
     delete_thread(
         &client,
-        /*request_id*/ 5,
+        /*request_id*/ 6,
         unloaded_thread_id.to_string(),
     )
     .await?;

--- a/codex-rs/app-server/tests/suite/v2/thread_read.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_read.rs
@@ -694,7 +694,7 @@ async fn thread_list_includes_store_thread_without_rollout_path() -> Result<()> 
     let thread = &data[0];
     assert_eq!(thread.id, thread_id.to_string());
     assert_eq!(thread.path, None);
-    assert_eq!(thread.preview, "");
+    assert_eq!(thread.preview, "history from store");
     assert_eq!(thread.name.as_deref(), Some("named pathless thread"));
 
     client.shutdown().await?;

--- a/codex-rs/thread-store/README.md
+++ b/codex-rs/thread-store/README.md
@@ -6,30 +6,27 @@ implementations may live outside this repository.
 
 ## Responsibilities
 
-- `ThreadStore::append_items` is the raw canonical history append API. It does
-  not infer metadata from item contents.
-- `ThreadStore::update_thread_metadata` is the only thread metadata write API.
-  It accepts a single literal metadata patch shape, regardless of whether the
-  caller is applying a user/API mutation or facts derived above the store from
-  appended history.
-- `LiveThread` is the preferred API for active session persistence. It owns a
-  per-thread metadata sync helper, applies the rollout persistence policy,
-  appends canonical history, and then sends metadata patches through
-  `ThreadStore::update_thread_metadata`.
+- `ThreadStore::append_items` is the raw history append API. Implementations
+  apply the rollout persistence policy and may derive implementation-owned
+  metadata from canonical items.
+- `ThreadStore::update_thread_metadata` applies literal metadata patches for
+  explicit user or API mutations.
+- `LiveThread` is the preferred API for active session persistence. It forwards
+  history and explicit metadata operations without deriving storage metadata.
 - `ThreadManager` routes metadata mutations for loaded and cold threads through
   one entrypoint. Loaded threads use their `LiveThread`; cold threads go
   directly to the store.
 - `LocalThreadStore` persists history through `codex-rollout` JSONL files and
-  persists queryable metadata through the SQLite state database when available.
-  Local explicit metadata mutations also maintain JSONL/name-index compatibility
-  so reading old or SQLite-less local storage keeps working.
+  derives the queryable metadata needed by its SQLite state database when
+  available. Local explicit metadata mutations also maintain JSONL/name-index
+  compatibility so reading old or SQLite-less local storage keeps working.
 - `RolloutRecorder` is the local JSONL writer. It writes already-canonical
-  items for `ThreadStore::append_items`; it no longer decides metadata updates
-  for live thread-store appends.
+  items for `ThreadStore::append_items`; the local store owns metadata updates
+  around that writer.
 - `core/session` creates or resumes `LiveThread` handles and does not need to
   know whether persistence is backed by local files or another store.
 
 ## Direction
 
-New metadata observation semantics should live above `ThreadStore`. Stores
-persist explicit metadata fields, but raw history appends remain history-only.
+Each store owns any metadata it derives from appended history. Callers use
+`update_thread_metadata` only for explicit metadata mutations.

--- a/codex-rs/thread-store/src/in_memory.rs
+++ b/codex-rs/thread-store/src/in_memory.rs
@@ -38,6 +38,8 @@ use crate::ThreadStoreFuture;
 use crate::ThreadStoreResult;
 use crate::UpdateThreadMetadataParams;
 use crate::error::reject_paginated_history_mode;
+use crate::thread_metadata_sync::PendingThreadMetadataPatch;
+use crate::thread_metadata_sync::ThreadMetadataSync;
 use crate::types::canonical_history_mode_from_rollout_items;
 
 static IN_MEMORY_THREAD_STORES: OnceLock<Mutex<HashMap<String, Arc<InMemoryThreadStore>>>> =
@@ -393,9 +395,45 @@ struct InMemoryThreadStoreState {
     calls: InMemoryThreadStoreCalls,
     created_threads: HashMap<ThreadId, CreateThreadParams>,
     histories: HashMap<ThreadId, Vec<RolloutItem>>,
+    metadata_syncs: HashMap<ThreadId, ThreadMetadataSync>,
     metadata_updates: HashMap<ThreadId, ThreadMetadataPatch>,
     names: HashMap<ThreadId, Option<String>>,
     rollout_paths: HashMap<PathBuf, ThreadId>,
+}
+
+impl InMemoryThreadStoreState {
+    fn apply_pending_metadata_update(
+        &mut self,
+        thread_id: ThreadId,
+        update: Option<PendingThreadMetadataPatch>,
+    ) {
+        let Some(update) = update else {
+            return;
+        };
+        self.metadata_updates
+            .entry(thread_id)
+            .or_default()
+            .merge(update.patch.clone());
+        if let Some(metadata_sync) = self.metadata_syncs.get_mut(&thread_id) {
+            metadata_sync.mark_pending_update_applied(&update);
+        }
+    }
+
+    fn flush_pending_metadata_update(&mut self, thread_id: ThreadId) {
+        let update = self
+            .metadata_syncs
+            .get(&thread_id)
+            .and_then(ThreadMetadataSync::take_pending_update);
+        self.apply_pending_metadata_update(thread_id, update);
+    }
+
+    fn flush_pending_metadata_update_for_existing_history(&mut self, thread_id: ThreadId) {
+        let update = self
+            .metadata_syncs
+            .get(&thread_id)
+            .and_then(ThreadMetadataSync::take_pending_update_for_existing_history);
+        self.apply_pending_metadata_update(thread_id, update);
+    }
 }
 
 impl InMemoryThreadStore {
@@ -421,6 +459,7 @@ impl InMemoryThreadStore {
 
     async fn create_thread(&self, params: CreateThreadParams) -> ThreadStoreResult<()> {
         reject_paginated_history_mode(params.history_mode)?;
+        let metadata_sync = ThreadMetadataSync::for_create(&params).await;
         let mut state = self.state.lock().await;
         state.calls.create_thread += 1;
         let session_meta = SessionMeta {
@@ -454,30 +493,36 @@ impl InMemoryThreadStore {
                 meta: session_meta,
                 git: None,
             }));
-        state.created_threads.insert(params.thread_id, params);
+        let thread_id = params.thread_id;
+        state.created_threads.insert(thread_id, params);
+        state.metadata_syncs.insert(thread_id, metadata_sync);
         Ok(())
     }
 
     async fn resume_thread(&self, params: ResumeThreadParams) -> ThreadStoreResult<()> {
+        let mut metadata_sync = ThreadMetadataSync::for_resume(&params);
         let mut state = self.state.lock().await;
         state.calls.resume_thread += 1;
+        let thread_id = params.thread_id;
         let history_mode = params
             .history
             .as_deref()
             .map(Vec::as_slice)
             .map(canonical_history_mode_from_rollout_items)
-            .unwrap_or_else(|| history_mode_from_state(&state, params.thread_id));
+            .unwrap_or_else(|| history_mode_from_state(&state, thread_id));
         reject_paginated_history_mode(history_mode)?;
         if let Some(history) = params.history {
             state
                 .histories
-                .insert(params.thread_id, Arc::unwrap_or_clone(history));
+                .insert(thread_id, Arc::unwrap_or_clone(history));
         } else {
-            state.histories.entry(params.thread_id).or_default();
+            let history = state.histories.entry(thread_id).or_default();
+            metadata_sync.record_resume_history(history);
         }
         if let Some(rollout_path) = params.rollout_path {
-            state.rollout_paths.insert(rollout_path, params.thread_id);
+            state.rollout_paths.insert(rollout_path, thread_id);
         }
+        state.metadata_syncs.insert(thread_id, metadata_sync);
         Ok(())
     }
 
@@ -488,11 +533,16 @@ impl InMemoryThreadStore {
         }
         let mut state = self.state.lock().await;
         state.calls.append_items += 1;
+        let update = state
+            .metadata_syncs
+            .get_mut(&params.thread_id)
+            .and_then(|metadata_sync| metadata_sync.observe_appended_items(&canonical_items));
         state
             .histories
             .entry(params.thread_id)
             .or_default()
             .extend(canonical_items);
+        state.apply_pending_metadata_update(params.thread_id, update);
         Ok(())
     }
 
@@ -572,6 +622,7 @@ impl InMemoryThreadStore {
     ) -> ThreadStoreResult<StoredThread> {
         let mut state = self.state.lock().await;
         state.calls.update_thread_metadata += 1;
+        state.flush_pending_metadata_update(params.thread_id);
         if let Some(name) = params.patch.name.clone() {
             state.names.insert(params.thread_id, name);
         }
@@ -588,6 +639,7 @@ impl InMemoryThreadStore {
         state.calls.delete_thread += 1;
         let existed = state.histories.remove(&params.thread_id).is_some();
         state.created_threads.remove(&params.thread_id);
+        state.metadata_syncs.remove(&params.thread_id);
         state.names.remove(&params.thread_id);
         state.metadata_updates.remove(&params.thread_id);
         state
@@ -620,30 +672,39 @@ impl ThreadStore for InMemoryThreadStore {
         Box::pin(InMemoryThreadStore::append_items(self, params))
     }
 
-    fn persist_thread(&self, _thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
+    fn persist_thread(&self, thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
         Box::pin(async move {
-            self.state.lock().await.calls.persist_thread += 1;
+            let mut state = self.state.lock().await;
+            state.calls.persist_thread += 1;
+            state.flush_pending_metadata_update(thread_id);
             Ok(())
         })
     }
 
-    fn flush_thread(&self, _thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
+    fn flush_thread(&self, thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
         Box::pin(async move {
-            self.state.lock().await.calls.flush_thread += 1;
+            let mut state = self.state.lock().await;
+            state.calls.flush_thread += 1;
+            state.flush_pending_metadata_update_for_existing_history(thread_id);
             Ok(())
         })
     }
 
-    fn shutdown_thread(&self, _thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
+    fn shutdown_thread(&self, thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
         Box::pin(async move {
-            self.state.lock().await.calls.shutdown_thread += 1;
+            let mut state = self.state.lock().await;
+            state.calls.shutdown_thread += 1;
+            state.flush_pending_metadata_update_for_existing_history(thread_id);
+            state.metadata_syncs.remove(&thread_id);
             Ok(())
         })
     }
 
-    fn discard_thread(&self, _thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
+    fn discard_thread(&self, thread_id: ThreadId) -> ThreadStoreFuture<'_, ()> {
         Box::pin(async move {
-            self.state.lock().await.calls.discard_thread += 1;
+            let mut state = self.state.lock().await;
+            state.calls.discard_thread += 1;
+            state.metadata_syncs.remove(&thread_id);
             Ok(())
         })
     }

--- a/codex-rs/thread-store/src/live_thread.rs
+++ b/codex-rs/thread-store/src/live_thread.rs
@@ -6,8 +6,6 @@ use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::ThreadMemoryMode;
 use codex_rollout::RolloutPersistenceTelemetry;
 use codex_rollout::measure_and_filter_rollout_items;
-use codex_rollout::persisted_rollout_items;
-use tokio::sync::Mutex;
 use tracing::warn;
 
 use crate::AppendThreadItemsParams;
@@ -22,7 +20,6 @@ use crate::ThreadMetadataPatch;
 use crate::ThreadStore;
 use crate::ThreadStoreResult;
 use crate::UpdateThreadMetadataParams;
-use crate::thread_metadata_sync::ThreadMetadataSync;
 
 /// Handle for an active thread's persistence lifecycle.
 ///
@@ -33,7 +30,6 @@ use crate::thread_metadata_sync::ThreadMetadataSync;
 pub struct LiveThread {
     thread_id: ThreadId,
     thread_store: Arc<dyn ThreadStore>,
-    metadata_sync: Arc<Mutex<ThreadMetadataSync>>,
     persistence_telemetry: RolloutPersistenceTelemetry,
 }
 
@@ -92,12 +88,10 @@ impl LiveThread {
         params: CreateThreadParams,
     ) -> ThreadStoreResult<Self> {
         let thread_id = params.thread_id;
-        let metadata_sync = ThreadMetadataSync::for_create(&params).await;
         thread_store.create_thread(params).await?;
         Ok(Self {
             thread_id,
             thread_store,
-            metadata_sync: Arc::new(Mutex::new(metadata_sync)),
             persistence_telemetry: RolloutPersistenceTelemetry::new(thread_id),
         })
     }
@@ -107,33 +101,10 @@ impl LiveThread {
         params: ResumeThreadParams,
     ) -> ThreadStoreResult<Self> {
         let thread_id = params.thread_id;
-        let should_load_history = params.history.is_none();
-        let include_archived = params.include_archived;
-        let mut metadata_sync = ThreadMetadataSync::for_resume(&params);
         thread_store.resume_thread(params).await?;
-        if should_load_history {
-            match thread_store
-                .load_history(LoadThreadHistoryParams {
-                    thread_id,
-                    include_archived,
-                })
-                .await
-            {
-                Ok(history) => metadata_sync.record_resume_history(&history.items),
-                Err(err) => {
-                    if let Err(discard_err) = thread_store.discard_thread(thread_id).await {
-                        warn!(
-                            "failed to discard thread persistence after resume history load failed: {discard_err}"
-                        );
-                    }
-                    return Err(err);
-                }
-            }
-        }
         Ok(Self {
             thread_id,
             thread_store,
-            metadata_sync: Arc::new(Mutex::new(metadata_sync)),
             persistence_telemetry: RolloutPersistenceTelemetry::new(thread_id),
         })
     }
@@ -148,11 +119,10 @@ impl LiveThread {
         if items.is_empty() {
             return Ok(());
         }
-        let (canonical_items, measurement) = if self.persistence_telemetry.is_enabled() {
-            let (canonical_items, measurement) = measure_and_filter_rollout_items(items);
-            (canonical_items, Some(measurement))
+        let measurement = if self.persistence_telemetry.is_enabled() {
+            Some(measure_and_filter_rollout_items(items).1)
         } else {
-            (persisted_rollout_items(items), None)
+            None
         };
         self.thread_store
             .append_items(AppendThreadItemsParams {
@@ -163,44 +133,18 @@ impl LiveThread {
         if let Some(measurement) = measurement.as_ref() {
             self.persistence_telemetry.record_batch(items, measurement);
         }
-        if canonical_items.is_empty() {
-            return Ok(());
-        }
-        let update = self
-            .metadata_sync
-            .lock()
-            .await
-            .observe_appended_items(canonical_items.as_slice());
-        if let Some(update) = update {
-            self.thread_store
-                .update_thread_metadata(UpdateThreadMetadataParams {
-                    thread_id: self.thread_id,
-                    patch: update.patch.clone(),
-                    include_archived: true,
-                })
-                .await?;
-            self.metadata_sync
-                .lock()
-                .await
-                .mark_pending_update_applied(&update);
-        }
         Ok(())
     }
 
     pub async fn persist(&self) -> ThreadStoreResult<()> {
-        self.thread_store.persist_thread(self.thread_id).await?;
-        self.flush_pending_metadata_update().await
+        self.thread_store.persist_thread(self.thread_id).await
     }
 
     pub async fn flush(&self) -> ThreadStoreResult<()> {
-        self.thread_store.flush_thread(self.thread_id).await?;
-        self.flush_pending_metadata_update_for_existing_history()
-            .await
+        self.thread_store.flush_thread(self.thread_id).await
     }
 
     pub async fn shutdown(&self) -> ThreadStoreResult<()> {
-        self.flush_pending_metadata_update_for_existing_history()
-            .await?;
         self.thread_store.shutdown_thread(self.thread_id).await
     }
 
@@ -239,7 +183,6 @@ impl LiveThread {
         mode: ThreadMemoryMode,
         include_archived: bool,
     ) -> ThreadStoreResult<()> {
-        self.flush_pending_metadata_update().await?;
         self.thread_store
             .update_thread_metadata(UpdateThreadMetadataParams {
                 thread_id: self.thread_id,
@@ -258,7 +201,6 @@ impl LiveThread {
         patch: ThreadMetadataPatch,
         include_archived: bool,
     ) -> ThreadStoreResult<StoredThread> {
-        self.flush_pending_metadata_update().await?;
         self.thread_store
             .update_thread_metadata(UpdateThreadMetadataParams {
                 thread_id: self.thread_id,
@@ -283,40 +225,5 @@ impl LiveThread {
             .live_rollout_path(self.thread_id)
             .await
             .map(Some)
-    }
-
-    async fn flush_pending_metadata_update(&self) -> ThreadStoreResult<()> {
-        let update = self.metadata_sync.lock().await.take_pending_update();
-        self.apply_pending_metadata_update(update).await
-    }
-
-    async fn flush_pending_metadata_update_for_existing_history(&self) -> ThreadStoreResult<()> {
-        let update = self
-            .metadata_sync
-            .lock()
-            .await
-            .take_pending_update_for_existing_history();
-        self.apply_pending_metadata_update(update).await
-    }
-
-    async fn apply_pending_metadata_update(
-        &self,
-        update: Option<crate::thread_metadata_sync::PendingThreadMetadataPatch>,
-    ) -> ThreadStoreResult<()> {
-        let Some(update) = update else {
-            return Ok(());
-        };
-        self.thread_store
-            .update_thread_metadata(UpdateThreadMetadataParams {
-                thread_id: self.thread_id,
-                patch: update.patch.clone(),
-                include_archived: true,
-            })
-            .await?;
-        self.metadata_sync
-            .lock()
-            .await
-            .mark_pending_update_applied(&update);
-        Ok(())
     }
 }

--- a/codex-rs/thread-store/src/local/live_writer.rs
+++ b/codex-rs/thread-store/src/local/live_writer.rs
@@ -12,11 +12,13 @@ use super::LocalThreadStore;
 use super::create_thread;
 use crate::AppendThreadItemsParams;
 use crate::CreateThreadParams;
+use crate::LoadThreadHistoryParams;
 use crate::ReadThreadParams;
 use crate::ResumeThreadParams;
 use crate::ThreadStoreError;
 use crate::ThreadStoreResult;
 use crate::error::reject_paginated_history_mode;
+use crate::thread_metadata_sync::ThreadMetadataSync;
 use crate::types::canonical_history_mode_from_rollout_items;
 
 const ROLLOUT_SIZE_BYTES_METRIC: &str = "codex.rollout.size_bytes";
@@ -27,10 +29,11 @@ pub(super) async fn create_thread(
 ) -> ThreadStoreResult<()> {
     let thread_id = params.thread_id;
     let history_mode = params.history_mode;
+    let metadata_sync = ThreadMetadataSync::for_create(&params).await;
     store.ensure_live_recorder_absent(thread_id).await?;
     let recorder = create_thread::create_thread(store, params).await?;
     store
-        .insert_live_recorder(thread_id, recorder, history_mode)
+        .insert_live_recorder(thread_id, recorder, history_mode, metadata_sync)
         .await
 }
 
@@ -38,6 +41,10 @@ pub(super) async fn resume_thread(
     store: &LocalThreadStore,
     params: ResumeThreadParams,
 ) -> ThreadStoreResult<()> {
+    let thread_id = params.thread_id;
+    let should_load_history = params.history.is_none();
+    let include_archived = params.include_archived;
+    let metadata_sync = ThreadMetadataSync::for_resume(&params);
     store.ensure_live_recorder_absent(params.thread_id).await?;
     let history_mode = if let Some(history) = params.history.as_deref() {
         canonical_history_mode_from_rollout_items(history)
@@ -102,8 +109,32 @@ pub(super) async fn resume_thread(
             message: format!("failed to resume local thread recorder: {err}"),
         })?;
     store
-        .insert_live_recorder(params.thread_id, recorder, history_mode)
-        .await
+        .insert_live_recorder(thread_id, recorder, history_mode, metadata_sync)
+        .await?;
+    if should_load_history {
+        match store
+            .load_history(LoadThreadHistoryParams {
+                thread_id,
+                include_archived,
+            })
+            .await
+        {
+            Ok(history) => {
+                store
+                    .record_resume_history(thread_id, &history.items)
+                    .await?
+            }
+            Err(err) => {
+                if let Err(discard_err) = discard_thread(store, thread_id).await {
+                    warn!(
+                        "failed to discard local thread persistence after resume history load failed: {discard_err}"
+                    );
+                }
+                return Err(err);
+            }
+        }
+    }
+    Ok(())
 }
 
 #[tracing::instrument(
@@ -124,9 +155,14 @@ pub(super) async fn append_items(
         .record_canonical_items(canonical_items.as_slice())
         .await
         .map_err(thread_store_io_error)?;
-    // LiveThread applies metadata immediately after append_items returns. Wait for the local
-    // writer so SQLite never gets ahead of JSONL for accepted live appends.
-    recorder.flush().await.map_err(thread_store_io_error)
+    // Wait for the local writer so SQLite never gets ahead of JSONL for accepted live appends.
+    recorder.flush().await.map_err(thread_store_io_error)?;
+    let update = store
+        .observe_appended_metadata(params.thread_id, canonical_items.as_slice())
+        .await?;
+    store
+        .apply_pending_metadata_update(params.thread_id, update)
+        .await
 }
 
 pub(super) async fn persist_thread(
@@ -139,7 +175,8 @@ pub(super) async fn persist_thread(
         .persist()
         .await
         .map_err(thread_store_io_error)?;
-    sync_materialized_rollout_path(store, thread_id).await
+    sync_materialized_rollout_path(store, thread_id).await?;
+    store.flush_pending_metadata_update(thread_id).await
 }
 
 pub(super) async fn flush_thread(
@@ -152,13 +189,19 @@ pub(super) async fn flush_thread(
         .flush()
         .await
         .map_err(thread_store_io_error)?;
-    sync_materialized_rollout_path(store, thread_id).await
+    sync_materialized_rollout_path(store, thread_id).await?;
+    store
+        .flush_pending_metadata_update_for_existing_history(thread_id)
+        .await
 }
 
 pub(super) async fn shutdown_thread(
     store: &LocalThreadStore,
     thread_id: ThreadId,
 ) -> ThreadStoreResult<()> {
+    store
+        .flush_pending_metadata_update_for_existing_history(thread_id)
+        .await?;
     let recorder = store.live_recorder(thread_id).await?;
     let rollout_path = recorder.rollout_path().to_path_buf();
     recorder.shutdown().await.map_err(thread_store_io_error)?;

--- a/codex-rs/thread-store/src/local/live_writer.rs
+++ b/codex-rs/thread-store/src/local/live_writer.rs
@@ -169,14 +169,21 @@ pub(super) async fn persist_thread(
     store: &LocalThreadStore,
     thread_id: ThreadId,
 ) -> ThreadStoreResult<()> {
+    persist_history(store, thread_id).await?;
+    store.flush_pending_metadata_update(thread_id).await
+}
+
+pub(super) async fn persist_history(
+    store: &LocalThreadStore,
+    thread_id: ThreadId,
+) -> ThreadStoreResult<()> {
     store
         .live_recorder(thread_id)
         .await?
         .persist()
         .await
         .map_err(thread_store_io_error)?;
-    sync_materialized_rollout_path(store, thread_id).await?;
-    store.flush_pending_metadata_update(thread_id).await
+    sync_materialized_rollout_path(store, thread_id).await
 }
 
 pub(super) async fn flush_thread(

--- a/codex-rs/thread-store/src/local/mod.rs
+++ b/codex-rs/thread-store/src/local/mod.rs
@@ -41,6 +41,8 @@ use crate::ThreadStoreError;
 use crate::ThreadStoreFuture;
 use crate::ThreadStoreResult;
 use crate::UpdateThreadMetadataParams;
+use crate::thread_metadata_sync::PendingThreadMetadataPatch;
+use crate::thread_metadata_sync::ThreadMetadataSync;
 
 /// Local filesystem/SQLite-backed implementation of [`ThreadStore`].
 ///
@@ -50,10 +52,9 @@ use crate::UpdateThreadMetadataParams;
 /// The SQLite state DB, when available, is the queryable metadata index used by
 /// list/read paths for fast lookup.
 ///
-/// Live appends still write canonical JSONL history, but append-derived
-/// metadata is observed above the store and applied through
-/// [`ThreadStore::update_thread_metadata`]. This implementation applies that
-/// patch literally to SQLite while keeping the JSONL/name-index compatibility
+/// Live appends write canonical JSONL history and derive the local metadata
+/// needed by the SQLite thread index. Explicit metadata patches remain literal
+/// updates. The implementation also keeps the JSONL/name-index compatibility
 /// behavior needed for SQLite-less reads, repair, and old local rollout files.
 #[derive(Clone)]
 pub struct LocalThreadStore {
@@ -64,6 +65,7 @@ pub struct LocalThreadStore {
 
 struct LiveRecorderEntry {
     recorder: RolloutRecorder,
+    metadata_sync: ThreadMetadataSync,
     // Local rollout files are materialized lazily, but metadata updates can arrive before the
     // canonical SessionMeta is durable. Retain the mode captured when live persistence was opened
     // so missing SQLite rows can still be seeded.
@@ -165,6 +167,7 @@ impl LocalThreadStore {
         thread_id: ThreadId,
         recorder: RolloutRecorder,
         history_mode: ThreadHistoryMode,
+        metadata_sync: ThreadMetadataSync,
     ) -> ThreadStoreResult<()> {
         match self.live_recorders.lock().await.entry(thread_id) {
             Entry::Occupied(entry) => Err(ThreadStoreError::InvalidRequest {
@@ -173,11 +176,90 @@ impl LocalThreadStore {
             Entry::Vacant(entry) => {
                 entry.insert(LiveRecorderEntry {
                     recorder,
+                    metadata_sync,
                     history_mode,
                 });
                 Ok(())
             }
         }
+    }
+
+    pub(super) async fn record_resume_history(
+        &self,
+        thread_id: ThreadId,
+        history: &[codex_protocol::protocol::RolloutItem],
+    ) -> ThreadStoreResult<()> {
+        let mut recorders = self.live_recorders.lock().await;
+        let entry = recorders
+            .get_mut(&thread_id)
+            .ok_or(ThreadStoreError::ThreadNotFound { thread_id })?;
+        entry.metadata_sync.record_resume_history(history);
+        Ok(())
+    }
+
+    pub(super) async fn observe_appended_metadata(
+        &self,
+        thread_id: ThreadId,
+        items: &[codex_protocol::protocol::RolloutItem],
+    ) -> ThreadStoreResult<Option<PendingThreadMetadataPatch>> {
+        let mut recorders = self.live_recorders.lock().await;
+        let entry = recorders
+            .get_mut(&thread_id)
+            .ok_or(ThreadStoreError::ThreadNotFound { thread_id })?;
+        Ok(entry.metadata_sync.observe_appended_items(items))
+    }
+
+    async fn apply_pending_metadata_update(
+        &self,
+        thread_id: ThreadId,
+        update: Option<PendingThreadMetadataPatch>,
+    ) -> ThreadStoreResult<()> {
+        let Some(update) = update else {
+            return Ok(());
+        };
+        update_thread_metadata::update_thread_metadata(
+            self,
+            UpdateThreadMetadataParams {
+                thread_id,
+                patch: update.patch.clone(),
+                include_archived: true,
+            },
+        )
+        .await?;
+        if let Some(entry) = self.live_recorders.lock().await.get_mut(&thread_id) {
+            entry.metadata_sync.mark_pending_update_applied(&update);
+        }
+        Ok(())
+    }
+
+    pub(super) async fn flush_pending_metadata_update(
+        &self,
+        thread_id: ThreadId,
+    ) -> ThreadStoreResult<()> {
+        let update = self
+            .live_recorders
+            .lock()
+            .await
+            .get(&thread_id)
+            .and_then(|entry| entry.metadata_sync.take_pending_update());
+        self.apply_pending_metadata_update(thread_id, update).await
+    }
+
+    pub(super) async fn flush_pending_metadata_update_for_existing_history(
+        &self,
+        thread_id: ThreadId,
+    ) -> ThreadStoreResult<()> {
+        let update = self
+            .live_recorders
+            .lock()
+            .await
+            .get(&thread_id)
+            .and_then(|entry| {
+                entry
+                    .metadata_sync
+                    .take_pending_update_for_existing_history()
+            });
+        self.apply_pending_metadata_update(thread_id, update).await
     }
 
     async fn load_history(
@@ -305,7 +387,10 @@ impl ThreadStore for LocalThreadStore {
         &self,
         params: UpdateThreadMetadataParams,
     ) -> ThreadStoreFuture<'_, StoredThread> {
-        Box::pin(async move { update_thread_metadata::update_thread_metadata(self, params).await })
+        Box::pin(async move {
+            self.flush_pending_metadata_update(params.thread_id).await?;
+            update_thread_metadata::update_thread_metadata(self, params).await
+        })
     }
 
     fn archive_thread(&self, params: ArchiveThreadParams) -> ThreadStoreFuture<'_, ()> {
@@ -399,9 +484,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn raw_append_items_does_not_update_sqlite_metadata() {
-        // This pins the ThreadStore contract: raw appends are history-only. Callers that need
-        // metadata updates must use LiveThread or call update_thread_metadata explicitly.
+    async fn local_store_derives_sqlite_metadata_from_appended_items() {
         let home = TempDir::new().expect("temp dir");
         let config = test_config(home.path());
         let runtime = codex_state::StateRuntime::init(
@@ -420,42 +503,11 @@ mod tests {
         store
             .append_items(AppendThreadItemsParams {
                 thread_id,
-                items: vec![user_message_item("raw append")],
+                items: vec![user_message_item("observed append")],
             })
             .await
-            .expect("append raw item");
+            .expect("append item");
         store.flush_thread(thread_id).await.expect("flush thread");
-
-        assert_eq!(
-            runtime
-                .get_thread(thread_id)
-                .await
-                .expect("sqlite metadata read"),
-            None
-        );
-    }
-
-    #[tokio::test]
-    async fn live_thread_observes_appended_items_into_sqlite_metadata() {
-        let home = TempDir::new().expect("temp dir");
-        let config = test_config(home.path());
-        let runtime = codex_state::StateRuntime::init(
-            config.sqlite_home.clone(),
-            config.default_model_provider_id.clone(),
-        )
-        .await
-        .expect("state db should initialize");
-        let store = Arc::new(LocalThreadStore::new(config, Some(runtime.clone())));
-        let thread_id = ThreadId::default();
-        let live_thread = LiveThread::create(store.clone(), create_thread_params(thread_id))
-            .await
-            .expect("create live thread");
-
-        live_thread
-            .append_items(&[user_message_item("observed append")])
-            .await
-            .expect("append observed item");
-        live_thread.flush().await.expect("flush thread");
 
         let metadata = runtime
             .get_thread(thread_id)

--- a/codex-rs/thread-store/src/local/update_thread_metadata.rs
+++ b/codex-rs/thread-store/src/local/update_thread_metadata.rs
@@ -83,7 +83,7 @@ pub(super) async fn update_thread_metadata(
     }
 
     if live_writer::rollout_path(store, thread_id).await.is_ok() {
-        live_writer::persist_thread(store, thread_id).await?;
+        live_writer::persist_history(store, thread_id).await?;
     }
     let mut resolved_rollout_path =
         resolve_rollout_path(store, thread_id, params.include_archived).await?;

--- a/codex-rs/thread-store/src/store.rs
+++ b/codex-rs/thread-store/src/store.rs
@@ -122,8 +122,9 @@ pub trait ThreadStore: Any + Send + Sync {
 
     /// Applies a literal metadata patch and returns the updated thread.
     ///
-    /// Implementations should apply the supplied fields directly. Policy such as deciding whether
-    /// an append-derived preview should be emitted belongs above the store.
+    /// Implementations should apply the supplied fields directly. Metadata derived from appended
+    /// history is implementation-owned and does not flow through this method from
+    /// [`crate::LiveThread`].
     fn update_thread_metadata(
         &self,
         params: UpdateThreadMetadataParams,

--- a/codex-rs/thread-store/src/thread_metadata_sync.rs
+++ b/codex-rs/thread-store/src/thread_metadata_sync.rs
@@ -27,11 +27,10 @@ const THREAD_UPDATED_AT_TOUCH_INTERVAL: Duration = Duration::from_secs(5);
 #[cfg(test)]
 const THREAD_UPDATED_AT_TOUCH_INTERVAL: Duration = Duration::from_millis(50);
 
-/// Live-thread helper that derives metadata updates from canonical rollout items.
+/// Local-store helper that derives SQLite metadata from canonical rollout items.
 ///
-/// Stores receive raw history plus explicit metadata patches. This helper keeps append-derived
-/// metadata observation in the live layer without owning persistence-policy filtering or making
-/// `append_items` infer metadata inside a `ThreadStore` implementation.
+/// This is private implementation state for [`crate::LocalThreadStore`]. Other stores receive raw
+/// history and may derive their own metadata, or none at all.
 pub(crate) struct ThreadMetadataSync {
     thread_id: ThreadId,
     cwd_seen: bool,

--- a/codex-rs/thread-store/src/thread_metadata_sync.rs
+++ b/codex-rs/thread-store/src/thread_metadata_sync.rs
@@ -27,10 +27,10 @@ const THREAD_UPDATED_AT_TOUCH_INTERVAL: Duration = Duration::from_secs(5);
 #[cfg(test)]
 const THREAD_UPDATED_AT_TOUCH_INTERVAL: Duration = Duration::from_millis(50);
 
-/// Local-store helper that derives SQLite metadata from canonical rollout items.
+/// Store implementation helper that derives query metadata from canonical rollout items.
 ///
-/// This is private implementation state for [`crate::LocalThreadStore`]. Other stores receive raw
-/// history and may derive their own metadata, or none at all.
+/// Stores may retain this as private per-thread state when they need the local metadata projection.
+/// Other stores receive raw history and may derive different metadata, or none at all.
 pub(crate) struct ThreadMetadataSync {
     thread_id: ThreadId,
     cwd_seen: bool,


### PR DESCRIPTION
## Summary

- keep `LiveThread` focused on forwarding history and explicit metadata operations
- move the existing append-derived metadata state and lifecycle handling into `LocalThreadStore`
- let remote and other `ThreadStore` implementations derive their own metadata, or none at all

This restores the ownership boundary that existed before #22236 without adding a store capability or metadata-policy API. It is the upstream counterpart to openai/openai#1082358.

## Testing

- `just test -p codex-thread-store` (88 passed)
- `just fix -p codex-thread-store`