### PR TITLE
[5/5] [codex] remove legacy enterprise-managed bundle lanes

### DIFF
--- a/codex-rs/app-server/src/config_manager_service_tests.rs
+++ b/codex-rs/app-server/src/config_manager_service_tests.rs
@@ -708,7 +708,7 @@ async fn write_value_rejects_feature_requirement_conflict() {
         tmp.path().to_path_buf(),
         vec![],
         LoaderOverrides::without_managed_config_for_tests(),
-        CloudConfigBundleFixture::loader_with_enterprise_requirement(
+        CloudConfigBundleFixture::loader_with_system_overlay_requirement(
             r#"
 [features]
 personality = true

--- a/codex-rs/cloud-config/src/backend.rs
+++ b/codex-rs/cloud-config/src/backend.rs
@@ -104,7 +104,6 @@ pub(crate) fn bundle_from_response(
                 "config_toml",
             )?;
             CloudConfigTomlBundle {
-                enterprise_managed: Vec::new(),
                 managed_layers: CloudConfigTomlManagedLayers {
                     baseline,
                     system_overlay,
@@ -121,7 +120,6 @@ pub(crate) fn bundle_from_response(
                 "requirements_toml",
             )?;
             CloudRequirementsTomlBundle {
-                enterprise_managed: Vec::new(),
                 managed_layers: CloudRequirementsTomlManagedLayers {
                     baseline,
                     system_overlay,

--- a/codex-rs/cloud-config/src/cache_tests.rs
+++ b/codex-rs/cloud-config/src/cache_tests.rs
@@ -13,7 +13,6 @@ use tempfile::tempdir;
 fn test_bundle() -> CloudConfigBundle {
     CloudConfigBundle {
         config_toml: CloudConfigTomlBundle {
-            enterprise_managed: Vec::new(),
             managed_layers: CloudConfigTomlManagedLayers {
                 baseline: vec![CloudConfigFragment {
                     id: "cfg_1".to_string(),
@@ -24,7 +23,6 @@ fn test_bundle() -> CloudConfigBundle {
             },
         },
         requirements_toml: CloudRequirementsTomlBundle {
-            enterprise_managed: Vec::new(),
             managed_layers: CloudRequirementsTomlManagedLayers {
                 baseline: Vec::new(),
                 system_overlay: vec![CloudRequirementsFragment {
@@ -89,8 +87,6 @@ async fn save_writes_signed_payload_and_loads_for_matching_identity() {
     let cache_file: CloudConfigBundleCacheFile =
         serde_json::from_slice(&std::fs::read(cache.path()).expect("read cache"))
             .expect("parse cache");
-    let cache_json = serde_json::to_string(&cache_file).expect("serialize cache as JSON");
-    assert!(!cache_json.contains("enterprise_managed"));
     assert!(
         cache_file.signed_payload.expires_at
             <= cache_file.signed_payload.cached_at + ChronoDuration::minutes(60)

--- a/codex-rs/cloud-config/src/service_tests.rs
+++ b/codex-rs/cloud-config/src/service_tests.rs
@@ -255,14 +255,12 @@ fn chatgpt_auth_json_with_mode(
 fn test_bundle() -> CloudConfigBundle {
     CloudConfigBundle {
         config_toml: CloudConfigTomlBundle {
-            enterprise_managed: Vec::new(),
             managed_layers: CloudConfigTomlManagedLayers {
                 baseline: vec![test_config_fragment()],
                 system_overlay: Vec::new(),
             },
         },
         requirements_toml: CloudRequirementsTomlBundle {
-            enterprise_managed: Vec::new(),
             managed_layers: CloudRequirementsTomlManagedLayers {
                 baseline: Vec::new(),
                 system_overlay: vec![test_requirements_fragment()],
@@ -321,7 +319,6 @@ fn replacement_requirements_bundle() -> CloudConfigBundle {
                     contents: "allowed_approval_policies = [\"on-request\"]".to_string(),
                 }],
             },
-            ..Default::default()
         },
     }
 }
@@ -337,7 +334,6 @@ fn invalid_config_bundle() -> CloudConfigBundle {
                 }],
                 system_overlay: Vec::new(),
             },
-            ..Default::default()
         },
         requirements_toml: CloudRequirementsTomlBundle::default(),
     }
@@ -369,7 +365,6 @@ windows_managed_dir = 'C:\managed\overlay'
                     .to_string(),
                 }],
             },
-            ..Default::default()
         },
     }
 }
@@ -484,14 +479,12 @@ fn bundle_shape_tag_describes_managed_documents() {
                     baseline: vec![test_config_fragment()],
                     system_overlay: vec![test_config_fragment()],
                 },
-                ..Default::default()
             },
             requirements_toml: CloudRequirementsTomlBundle {
                 managed_layers: CloudRequirementsTomlManagedLayers {
                     baseline: vec![test_requirements_fragment()],
                     system_overlay: vec![test_requirements_fragment()],
                 },
-                ..Default::default()
             },
         })),
         "cloud_managed_config,cloud_managed_requirements"
@@ -788,16 +781,6 @@ async fn get_bundle_treats_legacy_v1_cache_as_miss_and_rewrites_v2() {
     assert_eq!(cache_json["signed_payload"]["version"], 2);
     let bundle_json = &cache_json["signed_payload"]["bundle"];
     assert!(bundle_json["config_toml"]["managed_layers"].is_object());
-    assert!(
-        bundle_json["config_toml"]
-            .get("enterprise_managed")
-            .is_none()
-    );
-    assert!(
-        bundle_json["requirements_toml"]
-            .get("enterprise_managed")
-            .is_none()
-    );
 }
 
 #[tokio::test]
@@ -1250,7 +1233,6 @@ fn bundle_response_conversion_uses_only_managed_layers_and_preserves_order() {
                         config_fragment("low", "model = \"low\""),
                     ],
                 },
-                ..Default::default()
             },
             requirements_toml: CloudRequirementsTomlBundle {
                 managed_layers: CloudRequirementsTomlManagedLayers {
@@ -1260,7 +1242,6 @@ fn bundle_response_conversion_uses_only_managed_layers_and_preserves_order() {
                         "allowed_approval_policies = [\"never\"]",
                     )],
                 },
-                ..Default::default()
             },
         })
     );

--- a/codex-rs/cloud-config/src/validation.rs
+++ b/codex-rs/cloud-config/src/validation.rs
@@ -20,10 +20,8 @@ pub(crate) fn validate_bundle(
     let CloudConfigBundleLayers {
         baseline_config: _,
         system_overlay_config: _,
-        enterprise_managed_config: _,
         mut baseline_requirements,
         system_overlay_requirements,
-        enterprise_managed_requirements: _,
     } = bundle_layers;
 
     baseline_requirements.extend(system_overlay_requirements);

--- a/codex-rs/config/src/cloud_config_bundle.rs
+++ b/codex-rs/config/src/cloud_config_bundle.rs
@@ -10,10 +10,8 @@ use crate::ConfigLayerEntry;
 use crate::RequirementSource;
 use crate::RequirementsLayerEntry;
 use crate::cloud_config_layers::CloudConfigLayerError;
-use crate::cloud_config_layers::cloud_config_layers_from_fragments_strict;
 use crate::cloud_config_layers::cloud_managed_config_layers_from_fragments;
 use crate::cloud_config_layers::cloud_managed_config_layers_from_fragments_strict;
-use crate::cloud_config_layers_from_fragments;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use futures::future::BoxFuture;
 use futures::future::FutureExt;
@@ -37,18 +35,14 @@ impl CloudConfigBundle {
             requirements_toml,
         } = self;
         let CloudConfigTomlBundle {
-            enterprise_managed: config_enterprise_managed,
             managed_layers: config_managed_layers,
         } = config_toml;
         let CloudRequirementsTomlBundle {
-            enterprise_managed: requirements_enterprise_managed,
             managed_layers: requirements_managed_layers,
         } = requirements_toml;
 
-        config_enterprise_managed.is_empty()
-            && config_managed_layers.baseline.is_empty()
+        config_managed_layers.baseline.is_empty()
             && config_managed_layers.system_overlay.is_empty()
-            && requirements_enterprise_managed.is_empty()
             && requirements_managed_layers.baseline.is_empty()
             && requirements_managed_layers.system_overlay.is_empty()
     }
@@ -56,8 +50,6 @@ impl CloudConfigBundle {
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CloudConfigTomlBundle {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub enterprise_managed: Vec<CloudConfigFragment>,
     #[serde(
         default,
         skip_serializing_if = "CloudConfigTomlManagedLayers::is_empty"
@@ -79,8 +71,6 @@ impl CloudConfigTomlManagedLayers {
 
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CloudRequirementsTomlBundle {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub enterprise_managed: Vec<CloudRequirementsFragment>,
     #[serde(
         default,
         skip_serializing_if = "CloudRequirementsTomlManagedLayers::is_empty"
@@ -117,14 +107,10 @@ pub struct CloudConfigBundleLayers {
     pub baseline_config: Vec<ConfigLayerEntry>,
     /// System-overlay config layers in `ConfigLayerStack` order.
     pub system_overlay_config: Vec<ConfigLayerEntry>,
-    /// Enterprise-managed config layers in `ConfigLayerStack` order.
-    pub enterprise_managed_config: Vec<ConfigLayerEntry>,
     /// Baseline requirements layers in requirements merge order.
     pub baseline_requirements: Vec<RequirementsLayerEntry>,
     /// System-overlay requirements layers in requirements merge order.
     pub system_overlay_requirements: Vec<RequirementsLayerEntry>,
-    /// Enterprise-managed requirements layers in requirements merge order.
-    pub enterprise_managed_requirements: Vec<RequirementsLayerEntry>,
 }
 
 impl CloudConfigBundleLayers {
@@ -152,7 +138,6 @@ impl CloudConfigBundleLayers {
         let CloudConfigBundle {
             config_toml:
                 CloudConfigTomlBundle {
-                    enterprise_managed: config_enterprise_managed,
                     managed_layers:
                         CloudConfigTomlManagedLayers {
                             baseline: config_baseline,
@@ -161,7 +146,6 @@ impl CloudConfigBundleLayers {
                 },
             requirements_toml:
                 CloudRequirementsTomlBundle {
-                    enterprise_managed: requirements_enterprise_managed,
                     managed_layers:
                         CloudRequirementsTomlManagedLayers {
                             baseline: requirements_baseline,
@@ -179,11 +163,6 @@ impl CloudConfigBundleLayers {
         };
         let baseline_config =
             parse_managed_config_fragments(config_baseline, CloudManagedLayer::Baseline)?;
-        let enterprise_managed_config = if strict_config {
-            cloud_config_layers_from_fragments_strict(config_enterprise_managed, base_dir)?
-        } else {
-            cloud_config_layers_from_fragments(config_enterprise_managed, base_dir)?
-        };
         let system_overlay_config = parse_managed_config_fragments(
             config_system_overlay,
             CloudManagedLayer::SystemOverlay,
@@ -197,11 +176,6 @@ impl CloudConfigBundleLayers {
                     name,
                 }
             });
-        let enterprise_managed_requirements = requirements_layers_from_fragments(
-            requirements_enterprise_managed,
-            base_dir,
-            |id, name| RequirementSource::EnterpriseManaged { id, name },
-        );
         let system_overlay_requirements = requirements_layers_from_fragments(
             requirements_system_overlay,
             base_dir,
@@ -214,10 +188,8 @@ impl CloudConfigBundleLayers {
 
         Ok(Self {
             baseline_config,
-            enterprise_managed_config,
             system_overlay_config,
             baseline_requirements,
-            enterprise_managed_requirements,
             system_overlay_requirements,
         })
     }

--- a/codex-rs/config/src/cloud_config_bundle_tests.rs
+++ b/codex-rs/config/src/cloud_config_bundle_tests.rs
@@ -3,7 +3,6 @@ use crate::ConfigLayerSource;
 use crate::ConfigRequirementsToml;
 use crate::Sourced;
 use crate::compose_requirements;
-use codex_protocol::protocol::AskForApproval;
 use pretty_assertions::assert_eq;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
@@ -41,76 +40,6 @@ async fn shared_future_runs_once() {
 }
 
 #[test]
-fn bundle_layers_preserve_enterprise_managed_bucket_order() {
-    let tempdir = tempdir().expect("tempdir");
-    let base_dir = AbsolutePathBuf::from_absolute_path(tempdir.path()).expect("absolute path");
-    let layers = CloudConfigBundleLayers::from_bundle(
-        CloudConfigBundle {
-            config_toml: CloudConfigTomlBundle {
-                enterprise_managed: vec![
-                    CloudConfigFragment {
-                        id: "cfg_high".to_string(),
-                        name: "High config".to_string(),
-                        contents: "model = \"high\"".to_string(),
-                    },
-                    CloudConfigFragment {
-                        id: "cfg_low".to_string(),
-                        name: "Low config".to_string(),
-                        contents: "model = \"low\"".to_string(),
-                    },
-                ],
-                ..Default::default()
-            },
-            requirements_toml: CloudRequirementsTomlBundle {
-                enterprise_managed: vec![
-                    CloudRequirementsFragment {
-                        id: "req_high".to_string(),
-                        name: "High requirements".to_string(),
-                        contents: "allowed_approval_policies = [\"on-request\"]".to_string(),
-                    },
-                    CloudRequirementsFragment {
-                        id: "req_low".to_string(),
-                        name: "Low requirements".to_string(),
-                        contents: "allowed_approval_policies = [\"never\"]".to_string(),
-                    },
-                ],
-                ..Default::default()
-            },
-        },
-        &base_dir,
-    )
-    .expect("bundle should be converted into layers");
-
-    assert_eq!(
-        layers
-            .enterprise_managed_config
-            .iter()
-            .map(|layer| layer.name.clone())
-            .collect::<Vec<_>>(),
-        vec![
-            ConfigLayerSource::EnterpriseManaged {
-                id: "cfg_low".to_string(),
-                name: "Low config".to_string(),
-            },
-            ConfigLayerSource::EnterpriseManaged {
-                id: "cfg_high".to_string(),
-                name: "High config".to_string(),
-            },
-        ]
-    );
-    assert_eq!(
-        compose_requirements(layers.enterprise_managed_requirements)
-            .expect("requirements should compose")
-            .expect("requirements should be present")
-            .into_toml(),
-        ConfigRequirementsToml {
-            allowed_approval_policies: Some(vec![AskForApproval::OnRequest]),
-            ..Default::default()
-        }
-    );
-}
-
-#[test]
 fn bundle_layers_preserve_managed_bucket_order_and_provenance() {
     let tempdir = tempdir().expect("tempdir");
     let base_dir = AbsolutePathBuf::from_absolute_path(tempdir.path()).expect("absolute path");
@@ -127,7 +56,6 @@ fn bundle_layers_preserve_managed_bucket_order_and_provenance() {
                         config_fragment("overlay_low"),
                     ],
                 },
-                ..Default::default()
             },
             requirements_toml: CloudRequirementsTomlBundle {
                 managed_layers: CloudRequirementsTomlManagedLayers {
@@ -137,7 +65,6 @@ fn bundle_layers_preserve_managed_bucket_order_and_provenance() {
                         requirements_fragment("overlay_req_low"),
                     ],
                 },
-                ..Default::default()
             },
         },
         &base_dir,
@@ -191,18 +118,20 @@ fn bundle_layers_preserve_managed_bucket_order_and_provenance() {
 }
 
 #[test]
-fn bundle_layers_can_strict_validate_enterprise_managed_config() {
+fn bundle_layers_can_strict_validate_managed_config() {
     let tempdir = tempdir().expect("tempdir");
     let base_dir = AbsolutePathBuf::from_absolute_path(tempdir.path()).expect("absolute path");
     let err = CloudConfigBundleLayers::from_bundle_strict_config(
         CloudConfigBundle {
             config_toml: CloudConfigTomlBundle {
-                enterprise_managed: vec![CloudConfigFragment {
-                    id: "cfg".to_string(),
-                    name: "Cloud config".to_string(),
-                    contents: "unknown_key = true".to_string(),
-                }],
-                ..Default::default()
+                managed_layers: CloudConfigTomlManagedLayers {
+                    baseline: Vec::new(),
+                    system_overlay: vec![CloudConfigFragment {
+                        id: "cfg".to_string(),
+                        name: "Cloud config".to_string(),
+                        contents: "unknown_key = true".to_string(),
+                    }],
+                },
             },
             requirements_toml: CloudRequirementsTomlBundle::default(),
         },

--- a/codex-rs/config/src/cloud_config_layers.rs
+++ b/codex-rs/config/src/cloud_config_layers.rs
@@ -78,18 +78,6 @@ pub fn cloud_config_layers_from_fragments(
     )
 }
 
-pub(crate) fn cloud_config_layers_from_fragments_strict(
-    fragments: impl IntoIterator<Item = CloudConfigFragment>,
-    base_dir: &AbsolutePathBuf,
-) -> Result<Vec<ConfigLayerEntry>, CloudConfigLayerError> {
-    cloud_config_layers_from_fragments_impl(
-        fragments,
-        base_dir,
-        |id, name| ConfigLayerSource::EnterpriseManaged { id, name },
-        /*strict_config*/ true,
-    )
-}
-
 pub(crate) fn cloud_managed_config_layers_from_fragments(
     fragments: impl IntoIterator<Item = CloudConfigFragment>,
     base_dir: &AbsolutePathBuf,

--- a/codex-rs/config/src/cloud_config_layers_tests.rs
+++ b/codex-rs/config/src/cloud_config_layers_tests.rs
@@ -61,9 +61,10 @@ fn layers_are_returned_in_stack_order() {
 #[test]
 fn strict_layers_reject_unknown_config_fields() {
     let base_dir = base_dir();
-    let err = cloud_config_layers_from_fragments_strict(
+    let err = cloud_managed_config_layers_from_fragments_strict(
         vec![fragment("strict", "Strict layer", "unknown_key = true")],
         &base_dir,
+        CloudManagedLayer::SystemOverlay,
     )
     .expect_err("strict config should reject unknown fields");
 

--- a/codex-rs/config/src/loader/README.md
+++ b/codex-rs/config/src/loader/README.md
@@ -32,9 +32,8 @@ Precedence is **top overrides bottom**:
 5. `User` profile config, when present
 6. `User` config (`config.toml`)
 7. `CloudManaged(SystemOverlay)` config bundle layers
-8. `EnterpriseManaged` cloud-managed config bundle layers
-9. `System` config (`/etc/codex/config.toml` or the Windows system config path)
-10. `CloudManaged(Baseline)` config bundle layers
+8. `System` config (`/etc/codex/config.toml` or the Windows system config path)
+9. `CloudManaged(Baseline)` config bundle layers
 
 `ConfigLayerStack` stores layers in the opposite order internally: lowest
 precedence first, highest precedence last, so later layers override earlier

--- a/codex-rs/config/src/loader/mod.rs
+++ b/codex-rs/config/src/loader/mod.rs
@@ -85,7 +85,6 @@ async fn first_layer_config_error_from_entries(layers: &[ConfigLayerEntry]) -> O
 /// - baseline: cloud-managed baseline fragments
 /// - system:   `/etc/codex/requirements.toml` (Unix) or
 ///   `%ProgramData%\OpenAI\Codex\requirements.toml` (Windows)
-/// - cloud:    enterprise-managed cloud config bundle requirements
 /// - overlay:  cloud-managed system-overlay fragments
 /// - legacy:   managed_config.toml reinterpreted as requirements.toml
 /// - admin:    managed preferences (*)
@@ -99,7 +98,6 @@ async fn first_layer_config_error_from_entries(layers: &[ConfigLayerEntry]) -> O
 /// - admin:    managed preferences (*)
 /// - system    `/etc/codex/config.toml` (Unix) or
 ///   `%ProgramData%\OpenAI\Codex\config.toml` (Windows)
-/// - cloud:    enterprise-managed cloud config bundle fragments
 /// - overlay:  cloud-managed system-overlay fragments
 /// - user      `${CODEX_HOME}/config.toml`
 /// - profile   `${CODEX_HOME}/<name>.config.toml`, when selected
@@ -137,12 +135,10 @@ pub async fn load_config_layers_state(
         overrides.ignore_user_and_project_exec_policy_rules;
     let mut requirements_layers = Vec::new();
     let mut cloud_baseline_requirements_layers = Vec::new();
-    let mut enterprise_managed_requirements_layers = Vec::new();
     let mut cloud_system_overlay_requirements_layers = Vec::new();
     let mut system_requirements_layer = None;
     let managed_preferences_requirements_layer;
     let mut cloud_baseline_config_layers = Vec::new();
-    let mut enterprise_managed_config_layers = Vec::new();
     let mut cloud_system_overlay_config_layers = Vec::new();
 
     if !ignore_managed_requirements {
@@ -156,16 +152,12 @@ pub async fn load_config_layers_state(
             let CloudConfigBundleLayers {
                 baseline_config,
                 system_overlay_config,
-                enterprise_managed_config,
                 baseline_requirements,
                 system_overlay_requirements,
-                enterprise_managed_requirements,
             } = bundle_layers;
             cloud_baseline_requirements_layers = baseline_requirements;
-            enterprise_managed_requirements_layers = enterprise_managed_requirements;
             cloud_system_overlay_requirements_layers = system_overlay_requirements;
             cloud_baseline_config_layers = baseline_config;
-            enterprise_managed_config_layers = enterprise_managed_config;
             cloud_system_overlay_config_layers = system_overlay_config;
         }
 
@@ -196,7 +188,6 @@ pub async fn load_config_layers_state(
     if !ignore_managed_requirements {
         requirements_layers.extend(cloud_baseline_requirements_layers);
         requirements_layers.extend(system_requirements_layer);
-        requirements_layers.extend(enterprise_managed_requirements_layers);
         requirements_layers.extend(cloud_system_overlay_requirements_layers);
         // Continue to support the legacy `managed_config.toml` locations as
         // requirements layers for backwards compatibility.
@@ -255,7 +246,6 @@ pub async fn load_config_layers_state(
     .await?;
     layers.extend(cloud_baseline_config_layers);
     layers.push(system_layer);
-    layers.extend(enterprise_managed_config_layers);
     layers.extend(cloud_system_overlay_config_layers);
 
     // Add the base user config layer. When profile-v2 is selected, add the

--- a/codex-rs/config/src/loader/tests.rs
+++ b/codex-rs/config/src/loader/tests.rs
@@ -135,7 +135,6 @@ async fn managed_bundle_layers_follow_contract_precedence() {
             CloudManagedLayer::Baseline,
             "model = \"baseline\"\nmodel_provider = \"baseline\"",
         )
-        .add_enterprise_config("model_provider = \"enterprise\"\nreview_model = \"enterprise\"")
         .add_managed_config(
             CloudManagedLayer::SystemOverlay,
             "model_provider = \"overlay\"\nreview_model = \"overlay\"",
@@ -144,12 +143,9 @@ async fn managed_bundle_layers_follow_contract_precedence() {
             CloudManagedLayer::Baseline,
             "allow_appshots = true\nguardian_policy_config = \"baseline\"",
         )
-        .add_enterprise_requirement(
-            "allow_managed_hooks_only = true\nguardian_policy_config = \"enterprise\"",
-        )
         .add_managed_requirement(
             CloudManagedLayer::SystemOverlay,
-            "guardian_policy_config = \"overlay\"",
+            "allow_managed_hooks_only = true\nguardian_policy_config = \"overlay\"",
         )
         .into_loader();
 
@@ -186,10 +182,6 @@ async fn managed_bundle_layers_follow_contract_precedence() {
             ConfigLayerSource::System {
                 file: AbsolutePathBuf::from_absolute_path(&system_config_path)
                     .expect("absolute system config path"),
-            },
-            ConfigLayerSource::EnterpriseManaged {
-                id: "cfg_1".to_string(),
-                name: "Base config".to_string(),
             },
             ConfigLayerSource::CloudManaged {
                 layer: CloudManagedLayer::SystemOverlay,

--- a/codex-rs/config/src/test_support.rs
+++ b/codex-rs/config/src/test_support.rs
@@ -14,22 +14,12 @@ pub struct CloudConfigBundleFixture {
 }
 
 impl CloudConfigBundleFixture {
-    pub fn enterprise_requirement(contents: impl Into<String>) -> Self {
-        Self::default().add_enterprise_requirement(contents)
-    }
-
     pub fn system_overlay_requirement(contents: impl Into<String>) -> Self {
         Self::default().add_managed_requirement(CloudManagedLayer::SystemOverlay, contents)
     }
 
-    pub fn enterprise_config(contents: impl Into<String>) -> Self {
-        Self::default().add_enterprise_config(contents)
-    }
-
-    pub fn loader_with_enterprise_requirement(
-        contents: impl Into<String>,
-    ) -> CloudConfigBundleLoader {
-        Self::enterprise_requirement(contents).into_loader()
+    pub fn system_overlay_config(contents: impl Into<String>) -> Self {
+        Self::default().add_managed_config(CloudManagedLayer::SystemOverlay, contents)
     }
 
     pub fn loader_with_system_overlay_requirement(
@@ -38,42 +28,10 @@ impl CloudConfigBundleFixture {
         Self::system_overlay_requirement(contents).into_loader()
     }
 
-    pub fn loader_with_enterprise_config(contents: impl Into<String>) -> CloudConfigBundleLoader {
-        Self::enterprise_config(contents).into_loader()
-    }
-
-    pub fn add_enterprise_requirement(mut self, contents: impl Into<String>) -> Self {
-        let index = self.bundle.requirements_toml.enterprise_managed.len() + 1;
-        self.bundle
-            .requirements_toml
-            .enterprise_managed
-            .push(CloudRequirementsFragment {
-                id: format!("req_{index}"),
-                name: if index == 1 {
-                    "Base requirements".to_string()
-                } else {
-                    format!("Requirements {index}")
-                },
-                contents: contents.into(),
-            });
-        self
-    }
-
-    pub fn add_enterprise_config(mut self, contents: impl Into<String>) -> Self {
-        let index = self.bundle.config_toml.enterprise_managed.len() + 1;
-        self.bundle
-            .config_toml
-            .enterprise_managed
-            .push(CloudConfigFragment {
-                id: format!("cfg_{index}"),
-                name: if index == 1 {
-                    "Base config".to_string()
-                } else {
-                    format!("Config {index}")
-                },
-                contents: contents.into(),
-            });
-        self
+    pub fn loader_with_system_overlay_config(
+        contents: impl Into<String>,
+    ) -> CloudConfigBundleLoader {
+        Self::system_overlay_config(contents).into_loader()
     }
 
     pub fn add_managed_requirement(

--- a/codex-rs/config/src/test_support_tests.rs
+++ b/codex-rs/config/src/test_support_tests.rs
@@ -2,22 +2,22 @@ use super::*;
 use pretty_assertions::assert_eq;
 
 #[test]
-fn adds_enterprise_requirements_in_order() {
-    let bundle = CloudConfigBundleFixture::enterprise_requirement("first")
-        .add_enterprise_requirement("second")
+fn adds_system_overlay_requirements_in_order() {
+    let bundle = CloudConfigBundleFixture::system_overlay_requirement("first")
+        .add_managed_requirement(CloudManagedLayer::SystemOverlay, "second")
         .into_bundle();
 
     assert_eq!(
-        bundle.requirements_toml.enterprise_managed,
+        bundle.requirements_toml.managed_layers.system_overlay,
         vec![
             CloudRequirementsFragment {
-                id: "req_1".to_string(),
-                name: "Base requirements".to_string(),
+                id: "managed_req_1".to_string(),
+                name: "system-overlay requirements 1".to_string(),
                 contents: "first".to_string(),
             },
             CloudRequirementsFragment {
-                id: "req_2".to_string(),
-                name: "Requirements 2".to_string(),
+                id: "managed_req_2".to_string(),
+                name: "system-overlay requirements 2".to_string(),
                 contents: "second".to_string(),
             },
         ]

--- a/codex-rs/core/src/config/config_loader_tests.rs
+++ b/codex-rs/core/src/config/config_loader_tests.rs
@@ -6,6 +6,7 @@ use crate::config::permission_profile_catalog;
 use codex_config::CONFIG_TOML_FILE;
 use codex_config::CloudConfigBundleLoadError;
 use codex_config::CloudConfigBundleLoader;
+use codex_config::CloudManagedLayer;
 use codex_config::ConfigError;
 use codex_config::ConfigLayerEntry;
 use codex_config::ConfigLayerSource;
@@ -53,9 +54,10 @@ fn config_error_from_io(err: &std::io::Error) -> &ConfigError {
 }
 
 fn cloud_config_bundle_requirement_source() -> RequirementSource {
-    RequirementSource::EnterpriseManaged {
-        id: "req_1".to_string(),
-        name: "Base requirements".to_string(),
+    RequirementSource::CloudManaged {
+        layer: CloudManagedLayer::SystemOverlay,
+        id: "managed_req_1".to_string(),
+        name: "system-overlay requirements 1".to_string(),
     }
 }
 
@@ -1090,7 +1092,7 @@ allowed_approval_policies = ["on-request"]
         &[] as &[(String, TomlValue)],
         ConfigLoadOptions {
             loader_overrides,
-            cloud_config_bundle: CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            cloud_config_bundle: CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"allowed_approval_policies = ["never"]"#,
             ),
             ..Default::default()
@@ -1320,7 +1322,7 @@ async fn load_config_layers_includes_cloud_config_bundle() -> anyhow::Result<()>
     let requirements = r#"allowed_approval_policies = ["never"]"#;
     let expected: ConfigRequirementsToml = toml::from_str(requirements)?;
     let cloud_config_bundle =
-        CloudConfigBundleFixture::loader_with_enterprise_requirement(requirements);
+        CloudConfigBundleFixture::loader_with_system_overlay_requirement(requirements);
 
     let layers = load_config_layers_state(
         LOCAL_FS.as_ref(),
@@ -1933,7 +1935,7 @@ review_model = "system-review"
         &[] as &[(String, TomlValue)],
         ConfigLoadOptions {
             loader_overrides: overrides,
-            cloud_config_bundle: CloudConfigBundleFixture::loader_with_enterprise_config(
+            cloud_config_bundle: CloudConfigBundleFixture::loader_with_system_overlay_config(
                 r#"model = "cloud"
 model_provider = "cloud-provider"
 "#,
@@ -1968,9 +1970,10 @@ model_provider = "cloud-provider"
             ConfigLayerSource::System {
                 file: AbsolutePathBuf::from_absolute_path(&system_config_path)?,
             },
-            ConfigLayerSource::EnterpriseManaged {
-                id: "cfg_1".to_string(),
-                name: "Base config".to_string(),
+            ConfigLayerSource::CloudManaged {
+                layer: CloudManagedLayer::SystemOverlay,
+                id: "managed_cfg_1".to_string(),
+                name: "system-overlay config 1".to_string(),
             },
             ConfigLayerSource::User {
                 file: AbsolutePathBuf::from_absolute_path(codex_home.join(CONFIG_TOML_FILE))?,
@@ -2008,7 +2011,7 @@ async fn load_config_layers_can_ignore_managed_requirements() -> anyhow::Result<
     overrides.system_requirements_path = Some(system_requirements_path);
     overrides.ignore_managed_requirements = true;
 
-    let cloud_config_bundle = CloudConfigBundleFixture::loader_with_enterprise_requirement(
+    let cloud_config_bundle = CloudConfigBundleFixture::loader_with_system_overlay_requirement(
         r#"allowed_approval_policies = ["never"]"#,
     );
 
@@ -2065,7 +2068,7 @@ statusMessage = "checking"
     );
     let expected: ConfigRequirementsToml = toml::from_str(&requirements)?;
     let cloud_config_bundle =
-        CloudConfigBundleFixture::loader_with_enterprise_requirement(requirements);
+        CloudConfigBundleFixture::loader_with_system_overlay_requirement(requirements);
 
     let layers = load_config_layers_state(
         LOCAL_FS.as_ref(),
@@ -2106,7 +2109,7 @@ async fn load_config_layers_resolves_relative_bundle_requirements_paths_against_
 deny_read = ["secrets/**"]
 "#;
     let cloud_config_bundle =
-        CloudConfigBundleFixture::loader_with_enterprise_requirement(requirements);
+        CloudConfigBundleFixture::loader_with_system_overlay_requirement(requirements);
 
     let layers = load_config_layers_state(
         LOCAL_FS.as_ref(),
@@ -2159,7 +2162,7 @@ async fn strict_config_rejects_unknown_cloud_config_key() {
         ConfigLoadOptions {
             loader_overrides: LoaderOverrides::without_managed_config_for_tests(),
             strict_config: true,
-            cloud_config_bundle: CloudConfigBundleFixture::loader_with_enterprise_config(
+            cloud_config_bundle: CloudConfigBundleFixture::loader_with_system_overlay_config(
                 "unknown_key = true",
             ),
         },
@@ -2190,7 +2193,7 @@ async fn load_config_layers_applies_matching_remote_sandbox_config() -> anyhow::
             allowed_sandbox_modes = ["read-only", "workspace-write"]
         "#;
     let cloud_config_bundle =
-        CloudConfigBundleFixture::loader_with_enterprise_requirement(requirements);
+        CloudConfigBundleFixture::loader_with_system_overlay_requirement(requirements);
     let layers = load_config_layers_state(
         LOCAL_FS.as_ref(),
         &codex_home,

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -3,6 +3,7 @@ use crate::config::edit::ConfigEditsBuilder;
 use crate::config::edit::apply_blocking;
 use assert_matches::assert_matches;
 use codex_config::CONFIG_TOML_FILE;
+use codex_config::CloudManagedLayer;
 use codex_config::ConfigLayerEntry;
 use codex_config::ConfigLayerSource;
 use codex_config::ConfigLayerStack;
@@ -1666,7 +1667,7 @@ async fn experimental_network_requirements_enable_proxy_without_feature() -> std
         .codex_home(codex_home.path().to_path_buf())
         .fallback_cwd(Some(codex_home.path().to_path_buf()))
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"
 [experimental_network]
 enabled = true
@@ -4938,7 +4939,7 @@ enabled = true
     let config = ConfigBuilder::default()
         .codex_home(codex_home.path().to_path_buf())
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"
 [plugins."sample@test".mcp_servers.sample.identity]
 url = "https://sample.example/mcp"
@@ -4964,9 +4965,10 @@ url = "https://sample.example/mcp"
         Some((
             false,
             Some(McpServerDisabledReason::Requirements {
-                source: RequirementSource::EnterpriseManaged {
-                    id: "req_1".to_string(),
-                    name: "Base requirements".to_string(),
+                source: RequirementSource::CloudManaged {
+                    layer: CloudManagedLayer::SystemOverlay,
+                    id: "managed_req_1".to_string(),
+                    name: "system-overlay requirements 1".to_string(),
                 },
             })
         ))
@@ -5041,7 +5043,7 @@ enabled = true
     let config = ConfigBuilder::default()
         .codex_home(codex_home.path().to_path_buf())
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"
 [mcp_servers]
 "#,
@@ -5060,9 +5062,10 @@ enabled = true
         Some((
             false,
             Some(McpServerDisabledReason::Requirements {
-                source: RequirementSource::EnterpriseManaged {
-                    id: "req_1".to_string(),
-                    name: "Base requirements".to_string(),
+                source: RequirementSource::CloudManaged {
+                    layer: CloudManagedLayer::SystemOverlay,
+                    id: "managed_req_1".to_string(),
+                    name: "system-overlay requirements 1".to_string(),
                 },
             })
         ))
@@ -9505,7 +9508,7 @@ async fn requirements_disallowing_default_sandbox_falls_back_to_required_default
     let config = ConfigBuilder::without_managed_config_for_tests()
         .codex_home(codex_home.path().to_path_buf())
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"allowed_sandbox_modes = ["read-only"]"#,
             ),
         )
@@ -9531,7 +9534,7 @@ async fn explicit_sandbox_mode_falls_back_when_disallowed_by_requirements() -> s
         .codex_home(codex_home.path().to_path_buf())
         .fallback_cwd(Some(codex_home.path().to_path_buf()))
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"allowed_sandbox_modes = ["read-only"]"#,
             ),
         )
@@ -9558,7 +9561,7 @@ sandbox = "unelevated"
         .codex_home(codex_home.path().to_path_buf())
         .fallback_cwd(Some(codex_home.path().to_path_buf()))
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"[windows]
 allowed_sandbox_implementations = ["elevated"]
 "#,
@@ -9595,7 +9598,7 @@ sandbox_mode = "danger-full-access"
         .codex_home(codex_home.path().to_path_buf())
         .fallback_cwd(Some(codex_home.path().to_path_buf()))
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"allowed_sandbox_modes = ["read-only"]"#,
             ),
         )
@@ -9629,7 +9632,7 @@ default_permissions = "dev"
         .codex_home(codex_home.path().to_path_buf())
         .fallback_cwd(Some(codex_home.path().to_path_buf()))
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"allowed_sandbox_modes = ["read-only"]"#,
             ),
         )
@@ -9657,7 +9660,7 @@ async fn permission_profile_override_falls_back_when_disallowed_by_requirements(
             ..Default::default()
         })
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"allowed_sandbox_modes = ["read-only"]"#,
             ),
         )
@@ -9684,7 +9687,7 @@ async fn active_profile_is_cleared_when_requirements_force_fallback() -> std::io
             ..Default::default()
         })
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"allowed_sandbox_modes = ["read-only"]"#,
             ),
         )
@@ -9798,7 +9801,7 @@ async fn requirements_web_search_mode_overrides_danger_full_access_default() -> 
         .codex_home(codex_home.path().to_path_buf())
         .fallback_cwd(Some(codex_home.path().to_path_buf()))
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"allowed_web_search_modes = ["cached"]"#,
             ),
         )
@@ -9836,7 +9839,7 @@ trust_level = "untrusted"
         .codex_home(codex_home.path().to_path_buf())
         .fallback_cwd(Some(workspace.path().to_path_buf()))
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"allowed_approval_policies = ["on-request"]"#,
             ),
         )
@@ -9864,7 +9867,7 @@ async fn explicit_approval_policy_falls_back_when_disallowed_by_requirements() -
         .codex_home(codex_home.path().to_path_buf())
         .fallback_cwd(Some(codex_home.path().to_path_buf()))
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"allowed_approval_policies = ["on-request"]"#,
             ),
         )
@@ -9884,7 +9887,7 @@ async fn feature_requirements_normalize_effective_feature_values() -> std::io::R
     let config = ConfigBuilder::without_managed_config_for_tests()
         .codex_home(codex_home.path().to_path_buf())
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"
 [features]
 personality = true
@@ -9916,7 +9919,7 @@ async fn feature_requirements_auto_review_disables_guardian_approval() -> std::i
     let config = ConfigBuilder::without_managed_config_for_tests()
         .codex_home(codex_home.path().to_path_buf())
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"
 [features]
 auto_review = false
@@ -9938,7 +9941,7 @@ async fn browser_feature_requirements_are_valid() -> std::io::Result<()> {
     let config = ConfigBuilder::without_managed_config_for_tests()
         .codex_home(codex_home.path().to_path_buf())
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"
 [features]
 in_app_browser = false
@@ -10044,7 +10047,7 @@ shell_tool = true
         .codex_home(codex_home.path().to_path_buf())
         .fallback_cwd(Some(codex_home.path().to_path_buf()))
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"
 [features]
 personality = true
@@ -10162,7 +10165,7 @@ async fn requirements_disallowing_default_approvals_reviewer_falls_back_to_requi
     let config = ConfigBuilder::without_managed_config_for_tests()
         .codex_home(codex_home.path().to_path_buf())
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"allowed_approvals_reviewers = ["guardian_subagent"]"#,
             ),
         )
@@ -10187,7 +10190,7 @@ async fn root_approvals_reviewer_falls_back_when_disallowed_by_requirements() ->
         .codex_home(codex_home.path().to_path_buf())
         .fallback_cwd(Some(codex_home.path().to_path_buf()))
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"allowed_approvals_reviewers = ["guardian_subagent"]"#,
             ),
         )
@@ -10226,7 +10229,7 @@ async fn profile_approvals_reviewer_falls_back_when_disallowed_by_requirements()
             ..LoaderOverrides::without_managed_config_for_tests()
         })
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"allowed_approvals_reviewers = ["guardian_subagent"]"#,
             ),
         )
@@ -10251,7 +10254,7 @@ async fn approvals_reviewer_preserves_valid_user_choice_when_allowed_by_requirem
         .codex_home(codex_home.path().to_path_buf())
         .fallback_cwd(Some(codex_home.path().to_path_buf()))
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"allowed_approvals_reviewers = ["user", "guardian_subagent"]"#,
             ),
         )
@@ -10788,7 +10791,7 @@ async fn feature_requirements_normalize_runtime_feature_mutations() -> std::io::
     let mut config = ConfigBuilder::default()
         .codex_home(codex_home.path().to_path_buf())
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"
 [features]
 personality = true
@@ -10822,7 +10825,7 @@ async fn feature_requirements_warn_on_collab_legacy_alias() -> std::io::Result<(
     let config = ConfigBuilder::without_managed_config_for_tests()
         .codex_home(codex_home.path().to_path_buf())
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"
 [features]
 collab = true
@@ -10852,7 +10855,7 @@ async fn feature_requirements_warn_and_ignore_unknown_feature() -> std::io::Resu
     let config = ConfigBuilder::without_managed_config_for_tests()
         .codex_home(codex_home.path().to_path_buf())
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"
 [features]
 made_up_feature = true

--- a/codex-rs/core/src/connectors_tests.rs
+++ b/codex-rs/core/src/connectors_tests.rs
@@ -405,7 +405,7 @@ approvals_reviewer = "user"
     let config = ConfigBuilder::default()
         .codex_home(codex_home.path().to_path_buf())
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"allowed_approvals_reviewers = ["auto_review"]"#,
             ),
         )
@@ -435,7 +435,7 @@ approvals_reviewer = "user"
     let config = ConfigBuilder::default()
         .codex_home(codex_home.path().to_path_buf())
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"allowed_approvals_reviewers = ["auto_review"]"#,
             ),
         )

--- a/codex-rs/core/tests/suite/exec_policy.rs
+++ b/codex-rs/core/tests/suite/exec_policy.rs
@@ -266,7 +266,7 @@ async fn malformed_custom_rules_preserve_managed_forbidden_prefix() -> Result<()
 
     let mut builder = test_codex()
         .with_cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"
 [rules]
 prefix_rules = [

--- a/codex-rs/ext/mcp/tests/executor_plugin_mcp.rs
+++ b/codex-rs/ext/mcp/tests/executor_plugin_mcp.rs
@@ -55,7 +55,7 @@ async fn selected_plugin_servers_use_managed_requirements_for_the_selected_root_
         .codex_home(codex_home.path().to_path_buf())
         .fallback_cwd(Some(codex_home.path().to_path_buf()))
         .cloud_config_bundle(
-            CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"
 [plugins."selected-root".mcp_servers.allowed.identity]
 command = "allowed-command"

--- a/codex-rs/tui/src/app/config_persistence.rs
+++ b/codex-rs/tui/src/app/config_persistence.rs
@@ -1134,7 +1134,7 @@ mod tests {
         let codex_home = tempdir()?;
         let required_policy = codex_protocol::protocol::AskForApproval::Never;
         let cloud_config_bundle =
-            codex_config::test_support::CloudConfigBundleFixture::loader_with_enterprise_requirement(
+            codex_config::test_support::CloudConfigBundleFixture::loader_with_system_overlay_requirement(
                 r#"allowed_approval_policies = ["never"]"#,
             );
 


### PR DESCRIPTION
Stacked on #31288.

## Summary

- remove the legacy `enterprise_managed` buckets from the client-side cloud config bundle model
- remove the enterprise-managed config and requirements lanes from loader precedence
- migrate shared test fixtures to the cloud-managed system-overlay layer
- retain backend wire fields and App Server/provenance variants for compatibility

## Why

The client now consumes the managed `baseline` and `system_overlay` layers directly. Keeping the unused enterprise-managed bundle path adds ambiguity and maintenance cost. This cleanup is isolated from the adoption PR to keep both changes smaller and easier to review.

## Validation

- `just test -p codex-config -p codex-cloud-config` (235 passed)
- `just fix -p codex-config -p codex-cloud-config`
- `just fmt`
