### PR TITLE
ci: share common workflow setup

### DIFF
--- a/.github/actions/prepare-bazel-ci/action.yml
+++ b/.github/actions/prepare-bazel-ci/action.yml
@@ -7,10 +7,6 @@ inputs:
   cache-scope:
     description: Logical namespace used to keep concurrent Bazel jobs from reserving the same repository cache key.
     required: true
-  install-test-prereqs:
-    description: Install DotSlash for Bazel-backed test jobs.
-    required: false
-    default: "false"
 outputs:
   repository-cache-path:
     description: Filesystem path used for the Bazel repository cache.
@@ -30,7 +26,6 @@ runs:
       uses: ./.github/actions/setup-bazel-ci
       with:
         target: ${{ inputs.target }}
-        install-test-prereqs: ${{ inputs.install-test-prereqs }}
 
     - name: Compute bazel repository cache key
       id: cache_bazel_repository_key

--- a/.github/actions/run-argument-comment-lint/action.yml
+++ b/.github/actions/run-argument-comment-lint/action.yml
@@ -16,7 +16,6 @@ runs:
     - uses: ./.github/actions/setup-bazel-ci
       with:
         target: ${{ inputs.target }}
-        install-test-prereqs: true
 
     - name: Install Linux sandbox build dependencies
       if: ${{ runner.os == 'Linux' }}

--- a/.github/actions/setup-bazel-ci/action.yml
+++ b/.github/actions/setup-bazel-ci/action.yml
@@ -1,13 +1,9 @@
 name: setup-bazel-ci
-description: Prepare a Bazel CI runner with shared caches and optional test prerequisites.
+description: Prepare a Bazel CI runner with shared caches.
 inputs:
   target:
     description: Target triple used for cache namespacing.
     required: true
-  install-test-prereqs:
-    description: Install DotSlash for Bazel-backed test jobs.
-    required: false
-    default: "false"
 outputs:
   repository-cache-path:
     description: Filesystem path used for the Bazel repository cache.
@@ -16,21 +12,7 @@ outputs:
 runs:
   using: composite
   steps:
-    # Some integration tests rely on DotSlash being installed.
-    # See https://github.com/openai/codex/pull/7617.
-    - name: Install DotSlash
-      if: inputs.install-test-prereqs == 'true'
-      uses: facebook/install-dotslash@1e4e7b3e07eaca387acb98f1d4720e0bee8dbb6a # v2
-
-    - name: Make DotSlash available in PATH (Unix)
-      if: inputs.install-test-prereqs == 'true' && runner.os != 'Windows'
-      shell: bash
-      run: cp "$(which dotslash)" /usr/local/bin
-
-    - name: Make DotSlash available in PATH (Windows)
-      if: inputs.install-test-prereqs == 'true' && runner.os == 'Windows'
-      shell: pwsh
-      run: Copy-Item (Get-Command dotslash).Source -Destination "$env:LOCALAPPDATA\Microsoft\WindowsApps\dotslash.exe"
+    - uses: ./.github/actions/setup-ci
 
     - name: Set up Bazel
       uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86 # 0.19.0
@@ -124,8 +106,3 @@ runs:
       if: runner.os == 'Windows'
       shell: pwsh
       run: ./.github/scripts/compute-bazel-windows-path.ps1
-
-    - name: Enable Git long paths (Windows)
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: git config --global core.longpaths true

--- a/.github/actions/setup-ci/action.yml
+++ b/.github/actions/setup-ci/action.yml
@@ -1,0 +1,39 @@
+name: setup-ci
+description: Prepare common tools and environment shared by CI jobs.
+
+runs:
+  using: composite
+  steps:
+    - name: Prefer the Git CLI for Cargo git dependencies
+      shell: bash
+      run: echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"
+
+    - name: Install DotSlash
+      uses: facebook/install-dotslash@1e4e7b3e07eaca387acb98f1d4720e0bee8dbb6a # v2
+
+    - name: Install just
+      uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
+      with:
+        tool: just@1.51.0
+
+    # Some integration tests spawn DotSlash from a stable system path rather
+    # than inheriting the action-local PATH entry.
+    - name: Make DotSlash available in PATH (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        if [[ -w /usr/local/bin ]]; then
+          cp "$(which dotslash)" /usr/local/bin
+        else
+          sudo cp "$(which dotslash)" /usr/local/bin
+        fi
+
+    - name: Make DotSlash available in PATH (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: Copy-Item (Get-Command dotslash).Source -Destination "$env:LOCALAPPDATA\Microsoft\WindowsApps\dotslash.exe"
+
+    - name: Enable Git long paths (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: git config --global core.longpaths true

--- a/.github/scripts/test_v8_canary_changes.py
+++ b/.github/scripts/test_v8_canary_changes.py
@@ -4,6 +4,7 @@ import unittest
 from pathlib import Path
 
 from v8_canary_changes import changed_files
+from v8_canary_changes import canary_required
 from v8_canary_changes import merge_base
 from v8_canary_changes import resolved_v8_version
 from v8_canary_changes import windows_source_required
@@ -44,6 +45,14 @@ version = "149.2.0"
                 "149.2.0",
                 "149.2.0",
             )
+        )
+
+    def test_setup_ci_change_requires_canary_and_source_build(self) -> None:
+        changed_files = {".github/actions/setup-ci/action.yml"}
+
+        self.assertTrue(canary_required(changed_files, "149.2.0", "149.2.0"))
+        self.assertTrue(
+            windows_source_required(changed_files, "149.2.0", "149.2.0")
         )
 
     def test_manual_dispatch_requires_source_build(self) -> None:

--- a/.github/scripts/v8_canary_changes.py
+++ b/.github/scripts/v8_canary_changes.py
@@ -21,6 +21,7 @@ ROOT = Path(__file__).resolve().parents[2]
 CANARY_PATH_PATTERNS = {
     ".bazelrc",
     ".github/actions/setup-bazel-ci/**",
+    ".github/actions/setup-ci/**",
     ".github/scripts/run_bazel_with_buildbuddy.py",
     ".github/scripts/rusty_v8_bazel.py",
     ".github/scripts/rusty_v8_module_bazel.py",
@@ -40,6 +41,7 @@ CANARY_PATH_PATTERNS = {
 # Windows source builds are a narrower, more expensive subset of the canary.
 # A V8 version change also requires them even when no path below changed.
 WINDOWS_SOURCE_BUILD_PATHS = {
+    ".github/actions/setup-ci/**",
     ".github/scripts/rusty_v8_bazel.py",
     ".github/scripts/rusty_v8_module_bazel.py",
     ".github/scripts/v8_canary_changes.py",
@@ -72,6 +74,15 @@ def canary_required(
     )
 
 
+def matching_windows_source_paths(changed_files: set[str]) -> set[str]:
+    """Return changed paths that require Windows rusty_v8 source builds."""
+    return {
+        path
+        for path in changed_files
+        if any(fnmatchcase(path, pattern) for pattern in WINDOWS_SOURCE_BUILD_PATHS)
+    }
+
+
 def resolved_v8_version(cargo_lock: bytes) -> str:
     versions = sorted(
         {
@@ -96,7 +107,7 @@ def windows_source_required(
     return (
         force
         or base_v8_version != head_v8_version
-        or not changed_files.isdisjoint(WINDOWS_SOURCE_BUILD_PATHS)
+        or bool(matching_windows_source_paths(changed_files))
     )
 
 
@@ -165,7 +176,7 @@ def main() -> None:
                 if matched_canary_paths
                 else "no relevant changes"
             )
-            matched_windows_paths = sorted(files & WINDOWS_SOURCE_BUILD_PATHS)
+            matched_windows_paths = sorted(matching_windows_source_paths(files))
             windows_source_reason = (
                 ", ".join(matched_windows_paths)
                 if matched_windows_paths

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -57,11 +57,6 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
-      - uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
-        if: matrix.os == 'ubuntu-24.04' && matrix.target == 'x86_64-unknown-linux-gnu'
-        with:
-          tool: just
-
       - name: Check rusty_v8 MODULE.bazel checksums
         if: matrix.os == 'ubuntu-24.04' && matrix.target == 'x86_64-unknown-linux-gnu'
         shell: bash
@@ -75,7 +70,6 @@ jobs:
         with:
           target: ${{ matrix.target }}
           cache-scope: bazel-${{ github.job }}
-          install-test-prereqs: "true"
       - name: Check MODULE.bazel.lock is up to date
         if: matrix.os == 'ubuntu-24.04' && matrix.target == 'x86_64-unknown-linux-gnu'
         shell: bash
@@ -176,7 +170,6 @@ jobs:
           # not save it from every shard below; duplicate uploads would sit on
           # the PR-blocking critical path after the useful test work is done.
           cache-scope: bazel-test
-          install-test-prereqs: "true"
 
       - name: bazel test shard
         env:
@@ -287,7 +280,6 @@ jobs:
         with:
           target: x86_64-pc-windows-gnullvm
           cache-scope: bazel-${{ github.job }}
-          install-test-prereqs: "true"
 
       - name: bazel test //...
         env:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -57,6 +57,13 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
+      - name: Prepare Bazel CI
+        id: prepare_bazel
+        uses: ./.github/actions/prepare-bazel-ci
+        with:
+          target: ${{ matrix.target }}
+          cache-scope: bazel-${{ github.job }}
+
       - name: Check rusty_v8 MODULE.bazel checksums
         if: matrix.os == 'ubuntu-24.04' && matrix.target == 'x86_64-unknown-linux-gnu'
         shell: bash
@@ -64,12 +71,6 @@ jobs:
           python3 .github/scripts/rusty_v8_bazel.py check-module-bazel
           just test-github-scripts
 
-      - name: Prepare Bazel CI
-        id: prepare_bazel
-        uses: ./.github/actions/prepare-bazel-ci
-        with:
-          target: ${{ matrix.target }}
-          cache-scope: bazel-${{ github.job }}
       - name: Check MODULE.bazel.lock is up to date
         if: matrix.os == 'ubuntu-24.04' && matrix.target == 'x86_64-unknown-linux-gnu'
         shell: bash

--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -3,11 +3,6 @@ name: cargo-deny
 on:
   workflow_call:
 
-# Cargo's libgit2 transport has been flaky when fetching git dependencies with
-# nested submodules. Prefer the system git CLI across every Cargo invocation.
-env:
-  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-
 jobs:
   cargo-deny:
     runs-on: ubuntu-latest
@@ -20,6 +15,8 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+
+      - uses: ./.github/actions/setup-ci
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0

--- a/.github/workflows/repo-checks.yml
+++ b/.github/workflows/repo-checks.yml
@@ -16,6 +16,8 @@ jobs:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
 
+      - uses: ./.github/actions/setup-ci
+
       - name: Verify codex-rs Cargo manifests inherit workspace settings
         run: python3 .github/scripts/verify_cargo_workspace_manifests.py
 
@@ -76,15 +78,10 @@ jobs:
       - name: Check root README ToC
         run: python3 scripts/readme_toc.py README.md
 
-      - uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
-        with:
-          tool: just@1.51.0
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "0.11.3"
-      - name: Install DotSlash
-        uses: facebook/install-dotslash@1e4e7b3e07eaca387acb98f1d4720e0bee8dbb6a # v2
       - name: Check formatting (run `just fmt` to fix)
         run: just fmt-check
 

--- a/.github/workflows/rust-ci-full-nextest-platform.yml
+++ b/.github/workflows/rust-ci-full-nextest-platform.yml
@@ -48,11 +48,6 @@ on:
         default: false
         type: boolean
 
-# Caller workflow-level env does not flow through workflow_call, so keep the
-# Cargo git transport hardening on the archive and shard jobs directly here.
-env:
-  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-
 jobs:
   archive:
     name: Build nextest archive
@@ -81,6 +76,8 @@ jobs:
         shell: pwsh
         run: ../.github/scripts/setup-dev-drive.ps1
 
+      - uses: ./.github/actions/setup-ci
+
       - name: Install Linux build dependencies
         if: ${{ runner.os == 'Linux' }}
         shell: bash
@@ -90,9 +87,6 @@ jobs:
             sudo apt-get update -y
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends pkg-config libcap-dev bubblewrap
           fi
-
-      - name: Install DotSlash
-        uses: facebook/install-dotslash@1e4e7b3e07eaca387acb98f1d4720e0bee8dbb6a # v2
 
       - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
@@ -306,6 +300,8 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: ./.github/actions/setup-ci
+
       - name: Install Linux build dependencies
         if: ${{ runner.os == 'Linux' }}
         shell: bash
@@ -315,9 +311,6 @@ jobs:
             sudo apt-get update -y
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends pkg-config libcap-dev bubblewrap
           fi
-
-      - name: Install DotSlash
-        uses: facebook/install-dotslash@1e4e7b3e07eaca387acb98f1d4720e0bee8dbb6a # v2
 
       - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:

--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -8,13 +8,6 @@ on:
       - "**full-ci**"
   workflow_dispatch:
 
-# CI builds in debug (dev) for faster signal.
-env:
-  # Cargo's libgit2 transport has been flaky on macOS when fetching git
-  # dependencies with nested submodules. Use the system git CLI, which has
-  # better network/proxy behavior and matches Cargo's own suggested fallback.
-  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-
 jobs:
   # --- CI that doesn't need specific targets ---------------------------------
   general:
@@ -27,12 +20,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - uses: ./.github/actions/setup-ci
       - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
           components: rustfmt
-      - uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
-        with:
-          tool: just
       - name: cargo fmt
         run: cargo fmt -- --config imports_granularity=Item --check
       - name: Rust benchmark smoke test
@@ -48,6 +39,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - uses: ./.github/actions/setup-ci
       - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
       - uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
         with:
@@ -65,6 +57,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - uses: ./.github/actions/setup-ci
       - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
           toolchain: nightly-2025-09-18
@@ -123,7 +116,6 @@ jobs:
       - uses: ./.github/actions/setup-bazel-ci
         with:
           target: ${{ runner.os }}
-          install-test-prereqs: true
       - name: Install Linux sandbox build dependencies
         if: ${{ runner.os == 'Linux' }}
         shell: bash
@@ -256,6 +248,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - uses: ./.github/actions/setup-ci
       - name: Install Linux build dependencies
         if: ${{ runner.os == 'Linux' }}
         shell: bash

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -3,11 +3,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-# Cargo's libgit2 transport has been flaky when fetching git dependencies with
-# nested submodules. Prefer the system git CLI across every Cargo invocation.
-env:
-  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-
 jobs:
   # --- Detect what changed so the fast PR workflow only runs relevant jobs ----
   changed:
@@ -76,12 +71,10 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+      - uses: ./.github/actions/setup-ci
       - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
           components: rustfmt
-      - uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
-        with:
-          tool: just
       - name: cargo fmt
         run: cargo fmt -- --config imports_granularity=Item --check
       - name: Rust benchmark smoke test
@@ -104,6 +97,7 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+      - uses: ./.github/actions/setup-ci
       - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
       - uses: taiki-e/install-action@44c6d64aa62cd779e873306675c7a58e86d6d532 # v2.62.49
         with:
@@ -128,6 +122,7 @@ jobs:
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
+      - uses: ./.github/actions/setup-ci
       - uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
       - name: Install nightly argument-comment-lint toolchain
         shell: bash

--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -3,10 +3,7 @@ name: rust-release-windows
 on:
   workflow_call:
 
-# Cargo's libgit2 transport has been flaky when fetching git dependencies with
-# nested submodules. Prefer the system git CLI across every Cargo invocation.
 env:
-  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
   WINDOWS_BINARIES: "codex codex-code-mode-host codex-responses-api-proxy codex-windows-sandbox-setup codex-command-runner codex-app-server"
 
 jobs:
@@ -72,6 +69,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - uses: ./.github/actions/setup-ci
       - name: Print runner specs (Windows)
         shell: powershell
         run: |
@@ -164,6 +162,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - uses: ./.github/actions/setup-ci
       - name: Download prebuilt Windows binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -221,6 +220,8 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: ./.github/actions/setup-ci
+
       - name: Download prebuilt Windows primary binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -269,9 +270,6 @@ jobs:
             cp "target/${{ matrix.target }}/release/${binary}.exe" \
               "$dest/${binary}-${{ matrix.target }}.exe"
           done
-
-      - name: Install DotSlash
-        uses: facebook/install-dotslash@1e4e7b3e07eaca387acb98f1d4720e0bee8dbb6a # v2
 
       - name: Build Codex package archives
         shell: bash

--- a/.github/workflows/v8-canary.yml
+++ b/.github/workflows/v8-canary.yml
@@ -9,11 +9,6 @@ on:
   pull_request: {}
   workflow_dispatch:
 
-# Cargo's libgit2 transport has been flaky when fetching git dependencies with
-# nested submodules. Prefer the system git CLI for Cargo builds and smoke tests.
-env:
-  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-
 concurrency:
   group: ${{ github.workflow }}::${{ github.event.pull_request.number > 0 && format('pr-{0}', github.event.pull_request.number) || github.ref_name }}
   cancel-in-progress: ${{ github.ref_name != 'main' }}
@@ -324,6 +319,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: ./.github/actions/setup-ci
 
       - name: Configure git for upstream checkout
         shell: bash


### PR DESCRIPTION
## Why

CI jobs repeat common bootstrap steps, which makes it harder to keep Bazel and Cargo lanes aligned. Centralizing the lightweight setup gives us one place for future runner-wide optimizations without adding Rust toolchain or component installation to the Windows Bazel long poles.

## What

- add zero-input `.github/actions/setup-ci` to set Cargo's git transport, install DotSlash and `just`, expose DotSlash from stable PATH locations, and enable Windows Git long paths
- have `setup-bazel-ci` compose the common setup, then remove its DotSlash/test-prerequisite plumbing
- migrate Bazel, Cargo CI, V8 canary, repo checks, nextest, and Windows release call sites while keeping Rust toolchain and MSVC setup explicit
- preserve the existing nextest Dev Drive setup unchanged

## Validation

- `just test-github-scripts` (30 tests)
- parsed workflow and composite-action YAML with `yq`
