### PR TITLE
Measure MCP UI URIs missing trusted connector IDs

### DIFF
--- a/codex-rs/app-server/src/request_processors.rs
+++ b/codex-rs/app-server/src/request_processors.rs
@@ -630,5 +630,42 @@ pub(crate) fn build_api_turns_from_rollout_items(items: &[RolloutItem]) -> Vec<T
             builder.handle_rollout_item(item);
         }
     }
-    builder.finish()
+    let turns = builder.finish();
+    if let Some(metrics) = codex_otel::global() {
+        for turn in &turns {
+            for item in &turn.items {
+                let ThreadItem::McpToolCall {
+                    server,
+                    app_context,
+                    mcp_app_resource_uri,
+                    plugin_id,
+                    ..
+                } = item
+                else {
+                    continue;
+                };
+                let has_mcp_app_resource_uri = mcp_app_resource_uri
+                    .as_deref()
+                    .is_some_and(|resource_uri| !resource_uri.is_empty());
+                let is_missing_trusted_connector_id = app_context
+                    .as_ref()
+                    .is_none_or(|context| context.connector_id.is_empty());
+                if has_mcp_app_resource_uri && is_missing_trusted_connector_id {
+                    let server_kind = if server == codex_mcp::CODEX_APPS_MCP_SERVER_NAME {
+                        "codex_apps"
+                    } else if plugin_id.is_some() {
+                        "selected_plugin"
+                    } else {
+                        "other"
+                    };
+                    let _ = metrics.counter(
+                        "codex.mcp.ui_resource_uri_without_trusted_connector_id",
+                        /*inc*/ 1,
+                        &[("server_kind", server_kind), ("source", "history")],
+                    );
+                }
+            }
+        }
+    }
+    turns
 }

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -96,6 +96,7 @@ mod telemetry;
 
 use telemetry::McpCallMetricOutcome;
 use telemetry::emit_mcp_call_metrics;
+use telemetry::emit_mcp_ui_resource_uri_without_trusted_connector_id_metric;
 use telemetry::mcp_call_metric_outcome;
 use telemetry::record_mcp_call_outcome_span_telemetry;
 
@@ -154,7 +155,30 @@ pub(crate) async fn handle_mcp_tool_call(
     )
     .await;
     let item_metadata = McpToolCallItemMetadata::from_tool_metadata(&server, metadata.as_ref());
-    let app_tool_policy = if server == CODEX_APPS_MCP_SERVER_NAME {
+    let is_codex_apps_server = server == CODEX_APPS_MCP_SERVER_NAME;
+    let has_mcp_app_resource_uri = item_metadata
+        .mcp_app_resource_uri
+        .as_deref()
+        .is_some_and(|resource_uri| !resource_uri.is_empty());
+    let is_missing_trusted_connector_id = item_metadata
+        .connector_id
+        .as_deref()
+        .is_none_or(str::is_empty);
+    // These calls cannot migrate from the deprecated top-level URI to appContext.resourceUri.
+    if has_mcp_app_resource_uri && is_missing_trusted_connector_id {
+        let server_kind = if is_codex_apps_server {
+            "codex_apps"
+        } else if manager.is_selected_plugin_mcp_server(&server) {
+            "selected_plugin"
+        } else {
+            "other"
+        };
+        emit_mcp_ui_resource_uri_without_trusted_connector_id_metric(
+            turn_context.as_ref(),
+            server_kind,
+        );
+    }
+    let app_tool_policy = if is_codex_apps_server {
         let annotations = metadata
             .as_ref()
             .and_then(|metadata| metadata.annotations.as_ref());
@@ -174,7 +198,7 @@ pub(crate) async fn handle_mcp_tool_call(
     } else {
         AppToolPolicy::default()
     };
-    let approval_mode = if server == CODEX_APPS_MCP_SERVER_NAME {
+    let approval_mode = if is_codex_apps_server {
         app_tool_policy.approval
     } else if let Some(approval_mode) = {
         // Selected-plugin registrations are absent from config.toml and the legacy plugin manager,
@@ -196,7 +220,7 @@ pub(crate) async fn handle_mcp_tool_call(
         .as_ref()
         .and_then(|metadata| metadata.connector_name.clone());
 
-    if server == CODEX_APPS_MCP_SERVER_NAME && !app_tool_policy.enabled {
+    if is_codex_apps_server && !app_tool_policy.enabled {
         let result = notify_mcp_tool_call_skip(
             sess.as_ref(),
             turn_context.as_ref(),

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -96,7 +96,6 @@ mod telemetry;
 
 use telemetry::McpCallMetricOutcome;
 use telemetry::emit_mcp_call_metrics;
-use telemetry::emit_mcp_ui_resource_uri_without_trusted_connector_id_metric;
 use telemetry::mcp_call_metric_outcome;
 use telemetry::record_mcp_call_outcome_span_telemetry;
 
@@ -173,9 +172,10 @@ pub(crate) async fn handle_mcp_tool_call(
         } else {
             "other"
         };
-        emit_mcp_ui_resource_uri_without_trusted_connector_id_metric(
-            turn_context.as_ref(),
-            server_kind,
+        turn_context.session_telemetry.counter(
+            "codex.mcp.ui_resource_uri_without_trusted_connector_id",
+            /*inc*/ 1,
+            &[("server_kind", server_kind)],
         );
     }
     let app_tool_policy = if is_codex_apps_server {

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -175,7 +175,7 @@ pub(crate) async fn handle_mcp_tool_call(
         turn_context.session_telemetry.counter(
             "codex.mcp.ui_resource_uri_without_trusted_connector_id",
             /*inc*/ 1,
-            &[("server_kind", server_kind)],
+            &[("server_kind", server_kind), ("source", "live")],
         );
     }
     let app_tool_policy = if is_codex_apps_server {

--- a/codex-rs/core/src/mcp_tool_call/telemetry.rs
+++ b/codex-rs/core/src/mcp_tool_call/telemetry.rs
@@ -10,8 +10,6 @@ use tracing::Span;
 const MCP_CALL_COUNT_METRIC: &str = "codex.mcp.call";
 const MCP_CALL_DURATION_METRIC: &str = "codex.mcp.call.duration_ms";
 const MCP_CALL_ERROR_COUNT_METRIC: &str = "codex.mcp.call.error";
-const MCP_UI_RESOURCE_URI_WITHOUT_TRUSTED_CONNECTOR_ID_METRIC: &str =
-    "codex.mcp.ui_resource_uri_without_trusted_connector_id";
 // No CallToolResult was received. This includes request setup, transport, timeout, protocol, and
 // JSON-RPC failures; it does not imply that the request never reached the MCP server.
 const MCP_CALL_ERROR_TYPE_MCP_REQUEST: &str = "mcp_request";
@@ -85,17 +83,6 @@ pub(super) fn emit_mcp_call_metrics(
         MCP_CALL_ERROR_COUNT_METRIC,
         /*inc*/ 1,
         &error_tag_refs,
-    );
-}
-
-pub(super) fn emit_mcp_ui_resource_uri_without_trusted_connector_id_metric(
-    turn_context: &TurnContext,
-    server_kind: &'static str,
-) {
-    turn_context.session_telemetry.counter(
-        MCP_UI_RESOURCE_URI_WITHOUT_TRUSTED_CONNECTOR_ID_METRIC,
-        /*inc*/ 1,
-        &[("server_kind", server_kind)],
     );
 }
 

--- a/codex-rs/core/src/mcp_tool_call/telemetry.rs
+++ b/codex-rs/core/src/mcp_tool_call/telemetry.rs
@@ -10,6 +10,8 @@ use tracing::Span;
 const MCP_CALL_COUNT_METRIC: &str = "codex.mcp.call";
 const MCP_CALL_DURATION_METRIC: &str = "codex.mcp.call.duration_ms";
 const MCP_CALL_ERROR_COUNT_METRIC: &str = "codex.mcp.call.error";
+const MCP_UI_RESOURCE_URI_WITHOUT_TRUSTED_CONNECTOR_ID_METRIC: &str =
+    "codex.mcp.ui_resource_uri_without_trusted_connector_id";
 // No CallToolResult was received. This includes request setup, transport, timeout, protocol, and
 // JSON-RPC failures; it does not imply that the request never reached the MCP server.
 const MCP_CALL_ERROR_TYPE_MCP_REQUEST: &str = "mcp_request";
@@ -83,6 +85,17 @@ pub(super) fn emit_mcp_call_metrics(
         MCP_CALL_ERROR_COUNT_METRIC,
         /*inc*/ 1,
         &error_tag_refs,
+    );
+}
+
+pub(super) fn emit_mcp_ui_resource_uri_without_trusted_connector_id_metric(
+    turn_context: &TurnContext,
+    server_kind: &'static str,
+) {
+    turn_context.session_telemetry.counter(
+        MCP_UI_RESOURCE_URI_WITHOUT_TRUSTED_CONNECTOR_ID_METRIC,
+        /*inc*/ 1,
+        &[("server_kind", server_kind)],
     );
 }
 


### PR DESCRIPTION
## Summary

- Emit `codex.mcp.ui_resource_uri_without_trusted_connector_id` when a tool has a non-empty UI resource URI but no non-empty trusted connector ID.
- Tag the counter with bounded `server_kind` values to distinguish Codex Apps, selected plugins, and other MCP servers.
- Reuse the Codex Apps server predicate across the existing policy branches.

## Why

This measures whether the  top-level `mcpAppResourceUri` can be removed safely in favor of `appContext.resourceUri`.

## Validation

- `cargo fmt --check`
- `git diff --check`
- Deep code simplifier and review ensembles completed with no remaining callouts.
- Focused `codex-core` test was not completed because the local volume ran out of space while compiling dependencies.