### PR TITLE
feat: implement managed Bedrock logout

### DIFF
--- a/codex-rs/app-server-test-client/README.md
+++ b/codex-rs/app-server-test-client/README.md
@@ -46,6 +46,18 @@ cargo run -p codex-app-server-test-client -- \
 The test client redacts `apiKey` from its outbound request log. After login, start a fresh Codex
 process with the same `CODEX_HOME` to verify that it uses the persisted managed credential.
 
+## Testing logout
+
+`test-logout` initializes the app-server, sends an `account/logout` request, and waits for the
+resulting `account/updated` notification. It uses the active `CODEX_HOME`, so point it at an
+isolated directory when testing credential cleanup.
+
+```bash
+cargo run -p codex-app-server-test-client -- \
+  --codex-bin ./target/debug/codex \
+  test-logout
+```
+
 ## Testing Plugin Analytics
 
 The `plugin-analytics-smoke` command exercises `plugin/installed`, plugin

--- a/codex-rs/app-server-test-client/src/lib.rs
+++ b/codex-rs/app-server-test-client/src/lib.rs
@@ -46,6 +46,7 @@ use codex_app_server_protocol::JSONRPCNotification;
 use codex_app_server_protocol::JSONRPCRequest;
 use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::LoginAccountResponse;
+use codex_app_server_protocol::LogoutAccountResponse;
 use codex_app_server_protocol::ModelListParams;
 use codex_app_server_protocol::ModelListResponse;
 use codex_app_server_protocol::RequestId;
@@ -245,6 +246,8 @@ enum CliCommand {
         #[arg(long, value_name = "REGION")]
         region: Option<String>,
     },
+    /// Log out of the current account and wait for the account update.
+    TestLogout,
     /// Fetch the current account rate limits from the Codex app-server.
     GetAccountRateLimits,
     /// List the available models from the Codex app-server.
@@ -448,6 +451,11 @@ pub async fn run() -> Result<()> {
                 TestLoginMode::ChatgptBrowser
             };
             test_login(&endpoint, &config_overrides, mode).await
+        }
+        CliCommand::TestLogout => {
+            ensure_dynamic_tools_unused(&dynamic_tools, "test-logout")?;
+            let endpoint = resolve_endpoint(codex_bin, url)?;
+            test_logout(&endpoint, &config_overrides).await
         }
         CliCommand::GetAccountRateLimits => {
             ensure_dynamic_tools_unused(&dynamic_tools, "get-account-rate-limits")?;
@@ -1253,6 +1261,27 @@ async fn get_account_rate_limits(endpoint: &Endpoint, config_overrides: &[String
     .await
 }
 
+async fn test_logout(endpoint: &Endpoint, config_overrides: &[String]) -> Result<()> {
+    with_client("test-logout", endpoint, config_overrides, |client| {
+        let initialize = client.initialize()?;
+        println!("< initialize response: {initialize:?}");
+
+        let response = client.logout_account()?;
+        println!("< account/logout response: {response:?}");
+
+        loop {
+            let notification = client.next_notification()?;
+            if let Ok(ServerNotification::AccountUpdated(account_updated)) =
+                ServerNotification::try_from(notification)
+            {
+                println!("< account/updated notification: {account_updated:?}");
+                return Ok(());
+            }
+        }
+    })
+    .await
+}
+
 async fn model_list(endpoint: &Endpoint, config_overrides: &[String]) -> Result<()> {
     with_client("model-list", endpoint, config_overrides, |client| {
         let initialize = client.initialize()?;
@@ -1807,6 +1836,16 @@ impl CodexClient {
         };
 
         self.send_request(request, request_id, "account/rateLimits/read")
+    }
+
+    fn logout_account(&mut self) -> Result<LogoutAccountResponse> {
+        let request_id = self.request_id();
+        let request = ClientRequest::LogoutAccount {
+            request_id: request_id.clone(),
+            params: None,
+        };
+
+        self.send_request(request, request_id, "account/logout")
     }
 
     fn model_list(&mut self, params: ModelListParams) -> Result<ModelListResponse> {

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -2060,6 +2060,8 @@ Codex stores the key and region as the primary Codex auth, replacing any previou
 { "method": "account/updated", "params": { "authMode": null, "planType": null } }
 ```
 
+When Codex-managed Amazon Bedrock auth is stored, logout removes that credential and clears the user-level `model_provider` only when it is still `"amazon-bedrock"`. A concurrent user config change is preserved. For AWS-managed Bedrock auth, logout is a no-op because the AWS SDK credential chain is managed outside Codex.
+
 ### 7) Rate limits (ChatGPT)
 
 ```json

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -1930,7 +1930,7 @@ Codex supports these authentication modes. The current mode is surfaced in `acco
 - `account/login/start` — begin login (`apiKey`, `chatgpt`, `chatgptDeviceCode`, `amazonBedrock`).
 - `account/login/completed` (notify) — emitted when a login attempt finishes (success or error).
 - `account/login/cancel` — cancel a pending managed ChatGPT login by `loginId`.
-- `account/logout` — sign out; triggers `account/updated`.
+- `account/logout` — sign out; triggers `account/updated` on success.
 - `account/updated` (notify) — emitted whenever auth mode changes (`authMode`: `apikey`, `bedrockApiKey`, `chatgpt`, `personalAccessToken`, or `null`) and includes the current ChatGPT `planType` when available.
 - `account/rateLimits/read` — fetch ChatGPT rate limits, an optional effective monthly credit limit, and the earned rate-limit resets currently available, including expiry details when provided by the backend. Rate-limit updates arrive via `account/rateLimits/updated` (notify); reset-credit data is snapshot-only.
 - `account/rateLimitResetCredit/consume` — consume one earned reset using a caller-provided idempotency key, optionally selecting a reset-credit ID returned by `account/rateLimits/read`.
@@ -2060,7 +2060,7 @@ Codex stores the key and region as the primary Codex auth, replacing any previou
 { "method": "account/updated", "params": { "authMode": null, "planType": null } }
 ```
 
-When Codex-managed Amazon Bedrock auth is stored, logout removes that credential and clears the user-level `model_provider` only when it is still `"amazon-bedrock"`. A concurrent user config change is preserved. For AWS-managed Bedrock auth, logout is a no-op because the AWS SDK credential chain is managed outside Codex.
+When Codex-managed Amazon Bedrock auth is stored, logout removes that credential and clears the user-level `model_provider` only when it is still `"amazon-bedrock"`. A concurrent user config change is preserved. When Amazon Bedrock uses AWS-managed credentials, logout returns an error because the AWS SDK credential chain is managed outside Codex. Manage those credentials through AWS, or switch model providers before logging out Codex authentication.
 
 ### 7) Rate limits (ChatGPT)
 

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -2060,7 +2060,7 @@ Codex stores the key and region as the primary Codex auth, replacing any previou
 { "method": "account/updated", "params": { "authMode": null, "planType": null } }
 ```
 
-When Codex-managed Amazon Bedrock auth is stored, logout removes that credential and clears the user-level `model_provider` only when it is still `"amazon-bedrock"`. A concurrent user config change is preserved. When Amazon Bedrock uses AWS-managed credentials, logout returns an error because the AWS SDK credential chain is managed outside Codex. Manage those credentials through AWS, or switch model providers before logging out Codex authentication.
+When using a Codex-managed Bedrock key, logout removes the key and clears `model_provider` if it is still set to `"amazon-bedrock"`. When using AWS-managed credentials, manage them through AWS or switch providers before logging out.
 
 ### 7) Rate limits (ChatGPT)
 

--- a/codex-rs/app-server/src/config_manager_service.rs
+++ b/codex-rs/app-server/src/config_manager_service.rs
@@ -181,6 +181,43 @@ impl ConfigManager {
             .await
     }
 
+    /// Clears a value from the active user config only when its current raw value matches.
+    pub(crate) async fn clear_user_value_if_matches(
+        &self,
+        key_path: &str,
+        expected_value: JsonValue,
+    ) -> Result<(), ConfigManagerError> {
+        let layers = self
+            .load_thread_agnostic_config()
+            .await
+            .map_err(|err| ConfigManagerError::io("failed to load configuration", err))?;
+        let Some(user_layer) = layers.get_active_user_layer() else {
+            return Ok(());
+        };
+        let segments = parse_key_path(key_path).map_err(|message| {
+            ConfigManagerError::write(ConfigWriteErrorCode::ConfigValidationError, message)
+        })?;
+        let expected_value = parse_value(expected_value).map_err(|message| {
+            ConfigManagerError::write(ConfigWriteErrorCode::ConfigValidationError, message)
+        })?;
+        if value_at_path(&user_layer.config, &segments) != expected_value.as_ref() {
+            return Ok(());
+        }
+        let expected_version = Some(user_layer.version.clone());
+
+        self.apply_edits(
+            /*file_path*/ None,
+            expected_version,
+            vec![(
+                key_path.to_string(),
+                JsonValue::Null,
+                MergeStrategy::Replace,
+            )],
+        )
+        .await?;
+        Ok(())
+    }
+
     pub(crate) async fn batch_write(
         &self,
         params: ConfigBatchWriteParams,

--- a/codex-rs/app-server/src/config_manager_service_tests.rs
+++ b/codex-rs/app-server/src/config_manager_service_tests.rs
@@ -131,6 +131,40 @@ async fn clear_missing_nested_config_is_noop() -> Result<()> {
 }
 
 #[tokio::test]
+async fn clear_user_value_if_matches_clears_matching_value() -> Result<()> {
+    let tmp = tempdir().expect("tempdir");
+    let path = tmp.path().join(CONFIG_TOML_FILE);
+    std::fs::write(&path, "model = \"gpt-5.2\"\napproval_policy = \"never\"\n")?;
+
+    let service = ConfigManager::without_managed_config_for_tests(tmp.path().to_path_buf());
+    service
+        .clear_user_value_if_matches("model", serde_json::json!("gpt-5.2"))
+        .await?;
+
+    assert_eq!(
+        std::fs::read_to_string(&path)?,
+        "approval_policy = \"never\"\n"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn clear_user_value_if_matches_preserves_non_matching_value() -> Result<()> {
+    let tmp = tempdir().expect("tempdir");
+    let path = tmp.path().join(CONFIG_TOML_FILE);
+    let original = "model = \"gpt-5.2\"\napproval_policy = \"never\"\n";
+    std::fs::write(&path, original)?;
+
+    let service = ConfigManager::without_managed_config_for_tests(tmp.path().to_path_buf());
+    service
+        .clear_user_value_if_matches("model", serde_json::json!("gpt-5.3"))
+        .await?;
+
+    assert_eq!(std::fs::read_to_string(&path)?, original);
+    Ok(())
+}
+
+#[tokio::test]
 async fn write_value_rejects_legacy_profile_selector() -> Result<()> {
     let tmp = tempdir().expect("tempdir");
     let path = tmp.path().join(CONFIG_TOML_FILE);

--- a/codex-rs/app-server/src/request_processors.rs
+++ b/codex-rs/app-server/src/request_processors.rs
@@ -35,6 +35,7 @@ use codex_app_server_protocol::AppTemplateUnavailableReason;
 use codex_app_server_protocol::AppsListParams;
 use codex_app_server_protocol::AppsListResponse;
 use codex_app_server_protocol::AskForApproval;
+use codex_app_server_protocol::AuthMode;
 use codex_app_server_protocol::CancelLoginAccountParams;
 use codex_app_server_protocol::CancelLoginAccountResponse;
 use codex_app_server_protocol::CancelLoginAccountStatus;

--- a/codex-rs/app-server/src/request_processors.rs
+++ b/codex-rs/app-server/src/request_processors.rs
@@ -35,7 +35,6 @@ use codex_app_server_protocol::AppTemplateUnavailableReason;
 use codex_app_server_protocol::AppsListParams;
 use codex_app_server_protocol::AppsListResponse;
 use codex_app_server_protocol::AskForApproval;
-use codex_app_server_protocol::AuthMode;
 use codex_app_server_protocol::CancelLoginAccountParams;
 use codex_app_server_protocol::CancelLoginAccountResponse;
 use codex_app_server_protocol::CancelLoginAccountStatus;

--- a/codex-rs/app-server/src/request_processors/account_processor.rs
+++ b/codex-rs/app-server/src/request_processors/account_processor.rs
@@ -845,7 +845,7 @@ impl AccountRequestProcessor {
             self.auth_manager.auth_cached(),
             Some(CodexAuth::BedrockApiKey(_))
         );
-        let config = self.load_latest_config().await?;
+        let config = self.load_latest_config().await;
         if config.model_provider.is_amazon_bedrock() && !managed_bedrock_auth {
             return Ok(self
                 .auth_manager

--- a/codex-rs/app-server/src/request_processors/account_processor.rs
+++ b/codex-rs/app-server/src/request_processors/account_processor.rs
@@ -832,7 +832,7 @@ impl AccountRequestProcessor {
         }
     }
 
-    async fn logout_common(&self) -> Result<(), JSONRPCErrorError> {
+    async fn logout_common(&self) -> std::result::Result<Option<AuthMode>, JSONRPCErrorError> {
         // Cancel any active login attempt.
         {
             let mut guard = self.active_login.lock().await;
@@ -846,7 +846,12 @@ impl AccountRequestProcessor {
             Some(CodexAuth::BedrockApiKey(_))
         );
         if self.config.model_provider.is_amazon_bedrock() && !managed_bedrock_auth {
-            return Ok(());
+            return Ok(self
+                .auth_manager
+                .auth_cached()
+                .as_ref()
+                .map(CodexAuth::api_auth_mode)
+                .map(auth_mode_to_api));
         }
 
         match self.auth_manager.logout_with_revoke().await {
@@ -867,16 +872,26 @@ impl AccountRequestProcessor {
             clear_user_model_provider_if_bedrock(&self.config_manager).await?;
         }
 
-        Ok(())
+        // Reflect the current auth method after logout (likely None).
+        Ok(self
+            .auth_manager
+            .auth_cached()
+            .as_ref()
+            .map(CodexAuth::api_auth_mode)
+            .map(auth_mode_to_api))
     }
 
     async fn logout_v2(&self, request_id: ConnectionRequestId) -> Result<(), JSONRPCErrorError> {
         let result = self.logout_common().await;
-        let account_updated = if result.is_ok() {
-            Some(self.current_account_updated_notification())
-        } else {
-            None
-        };
+        let account_updated =
+            result
+                .as_ref()
+                .ok()
+                .cloned()
+                .map(|auth_mode| AccountUpdatedNotification {
+                    auth_mode,
+                    plan_type: None,
+                });
         self.outgoing
             .send_result(request_id, result.map(|_| LogoutAccountResponse {}))
             .await;

--- a/codex-rs/app-server/src/request_processors/account_processor.rs
+++ b/codex-rs/app-server/src/request_processors/account_processor.rs
@@ -1,6 +1,5 @@
 use super::bedrock_auth::clear_user_model_provider_if_bedrock;
 use super::bedrock_auth::set_user_model_provider_to_bedrock;
-use super::bedrock_auth::user_model_provider_state;
 use super::*;
 use crate::auth_mode::auth_mode_to_api;
 use crate::external_auth::ExternalAuthBridge;
@@ -846,11 +845,6 @@ impl AccountRequestProcessor {
             self.auth_manager.auth_cached(),
             Some(CodexAuth::BedrockApiKey(_))
         );
-        let user_model_provider = if managed_bedrock_auth {
-            Some(user_model_provider_state(&self.config_manager).await?)
-        } else {
-            None
-        };
         if self.config.model_provider.is_amazon_bedrock() && !managed_bedrock_auth {
             return Ok(());
         }
@@ -869,8 +863,8 @@ impl AccountRequestProcessor {
         )
         .await;
 
-        if let Some(user_model_provider) = user_model_provider {
-            clear_user_model_provider_if_bedrock(&self.config_manager, user_model_provider).await?;
+        if managed_bedrock_auth {
+            clear_user_model_provider_if_bedrock(&self.config_manager).await?;
         }
 
         Ok(())

--- a/codex-rs/app-server/src/request_processors/account_processor.rs
+++ b/codex-rs/app-server/src/request_processors/account_processor.rs
@@ -833,26 +833,23 @@ impl AccountRequestProcessor {
     }
 
     async fn logout_common(&self) -> std::result::Result<Option<AuthMode>, JSONRPCErrorError> {
-        // Cancel any active login attempt.
-        {
-            let mut guard = self.active_login.lock().await;
-            if let Some(active) = guard.take() {
-                drop(active);
-            }
-        }
-
         let managed_bedrock_auth = matches!(
             self.auth_manager.auth_cached(),
             Some(CodexAuth::BedrockApiKey(_))
         );
         let config = self.load_latest_config().await;
         if config.model_provider.is_amazon_bedrock() && !managed_bedrock_auth {
-            return Ok(self
-                .auth_manager
-                .auth_cached()
-                .as_ref()
-                .map(CodexAuth::api_auth_mode)
-                .map(auth_mode_to_api));
+            return Err(invalid_request(
+                "cannot log out while Amazon Bedrock is using AWS-managed credentials; manage those credentials through AWS or switch model providers before logging out Codex authentication",
+            ));
+        }
+
+        // Cancel any active login attempt.
+        {
+            let mut guard = self.active_login.lock().await;
+            if let Some(active) = guard.take() {
+                drop(active);
+            }
         }
 
         match self.auth_manager.logout_with_revoke().await {

--- a/codex-rs/app-server/src/request_processors/account_processor.rs
+++ b/codex-rs/app-server/src/request_processors/account_processor.rs
@@ -1,4 +1,6 @@
+use super::bedrock_auth::clear_user_model_provider_if_bedrock;
 use super::bedrock_auth::set_user_model_provider_to_bedrock;
+use super::bedrock_auth::user_model_provider_state;
 use super::*;
 use crate::auth_mode::auth_mode_to_api;
 use crate::external_auth::ExternalAuthBridge;
@@ -831,13 +833,26 @@ impl AccountRequestProcessor {
         }
     }
 
-    async fn logout_common(&self) -> std::result::Result<Option<AuthMode>, JSONRPCErrorError> {
+    async fn logout_common(&self) -> Result<(), JSONRPCErrorError> {
         // Cancel any active login attempt.
         {
             let mut guard = self.active_login.lock().await;
             if let Some(active) = guard.take() {
                 drop(active);
             }
+        }
+
+        let managed_bedrock_auth = matches!(
+            self.auth_manager.auth_cached(),
+            Some(CodexAuth::BedrockApiKey(_))
+        );
+        let user_model_provider = if managed_bedrock_auth {
+            Some(user_model_provider_state(&self.config_manager).await?)
+        } else {
+            None
+        };
+        if self.config.model_provider.is_amazon_bedrock() && !managed_bedrock_auth {
+            return Ok(());
         }
 
         match self.auth_manager.logout_with_revoke().await {
@@ -854,26 +869,20 @@ impl AccountRequestProcessor {
         )
         .await;
 
-        // Reflect the current auth method after logout (likely None).
-        Ok(self
-            .auth_manager
-            .auth_cached()
-            .as_ref()
-            .map(CodexAuth::api_auth_mode)
-            .map(auth_mode_to_api))
+        if let Some(user_model_provider) = user_model_provider {
+            clear_user_model_provider_if_bedrock(&self.config_manager, user_model_provider).await?;
+        }
+
+        Ok(())
     }
 
     async fn logout_v2(&self, request_id: ConnectionRequestId) -> Result<(), JSONRPCErrorError> {
         let result = self.logout_common().await;
-        let account_updated =
-            result
-                .as_ref()
-                .ok()
-                .cloned()
-                .map(|auth_mode| AccountUpdatedNotification {
-                    auth_mode,
-                    plan_type: None,
-                });
+        let account_updated = if result.is_ok() {
+            Some(self.current_account_updated_notification())
+        } else {
+            None
+        };
         self.outgoing
             .send_result(request_id, result.map(|_| LogoutAccountResponse {}))
             .await;

--- a/codex-rs/app-server/src/request_processors/account_processor.rs
+++ b/codex-rs/app-server/src/request_processors/account_processor.rs
@@ -845,7 +845,8 @@ impl AccountRequestProcessor {
             self.auth_manager.auth_cached(),
             Some(CodexAuth::BedrockApiKey(_))
         );
-        if self.config.model_provider.is_amazon_bedrock() && !managed_bedrock_auth {
+        let config = self.load_latest_config().await?;
+        if config.model_provider.is_amazon_bedrock() && !managed_bedrock_auth {
             return Ok(self
                 .auth_manager
                 .auth_cached()
@@ -861,16 +862,16 @@ impl AccountRequestProcessor {
             }
         }
 
+        if managed_bedrock_auth {
+            clear_user_model_provider_if_bedrock(&self.config_manager).await?;
+        }
+
         Self::maybe_refresh_plugin_caches_for_current_config(
             &self.config_manager,
             &self.thread_manager,
             self.auth_manager.auth_cached(),
         )
         .await;
-
-        if managed_bedrock_auth {
-            clear_user_model_provider_if_bedrock(&self.config_manager).await?;
-        }
 
         // Reflect the current auth method after logout (likely None).
         Ok(self

--- a/codex-rs/app-server/src/request_processors/bedrock_auth.rs
+++ b/codex-rs/app-server/src/request_processors/bedrock_auth.rs
@@ -3,6 +3,7 @@ use crate::config_manager::ConfigManager;
 use crate::error_code::internal_error;
 use crate::error_code::invalid_request;
 use codex_app_server_protocol::ConfigValueWriteParams;
+use codex_app_server_protocol::ConfigWriteErrorCode;
 use codex_app_server_protocol::JSONRPCErrorError;
 use codex_app_server_protocol::MergeStrategy;
 use codex_config::CONFIG_TOML_FILE;
@@ -61,11 +62,19 @@ pub(super) async fn set_user_model_provider_to_bedrock(
 pub(super) async fn clear_user_model_provider_if_bedrock(
     config_manager: &ConfigManager,
 ) -> Result<(), JSONRPCErrorError> {
-    config_manager
+    let result = config_manager
         .clear_user_value_if_matches(
             "model_provider",
             serde_json::json!(AMAZON_BEDROCK_PROVIDER_ID),
         )
-        .await
-        .map_err(map_config_error)
+        .await;
+    if let Err(err) = &result
+        && err.write_error_code() == Some(ConfigWriteErrorCode::ConfigVersionConflict)
+    {
+        tracing::warn!(
+            "configuration changed while clearing the managed Amazon Bedrock model provider; preserving the concurrent config update"
+        );
+        return Ok(());
+    }
+    result.map_err(map_config_error)
 }

--- a/codex-rs/app-server/src/request_processors/bedrock_auth.rs
+++ b/codex-rs/app-server/src/request_processors/bedrock_auth.rs
@@ -10,6 +10,11 @@ use codex_config::ConfigLayerSource;
 use codex_config::format_config_layer_source;
 use codex_model_provider::AMAZON_BEDROCK_PROVIDER_ID;
 
+pub(super) struct UserModelProviderState {
+    model_provider: Option<String>,
+    version: Option<String>,
+}
+
 pub(super) async fn set_user_model_provider_to_bedrock(
     config_manager: &ConfigManager,
 ) -> Result<(), JSONRPCErrorError> {
@@ -51,6 +56,46 @@ pub(super) async fn set_user_model_provider_to_bedrock(
         /*expected_version*/ None,
     )
     .await
+}
+
+pub(super) async fn clear_user_model_provider_if_bedrock(
+    config_manager: &ConfigManager,
+    user_model_provider: UserModelProviderState,
+) -> Result<(), JSONRPCErrorError> {
+    if user_model_provider.model_provider.as_deref() == Some(AMAZON_BEDROCK_PROVIDER_ID) {
+        write_user_model_provider(
+            config_manager,
+            serde_json::Value::Null,
+            user_model_provider.version,
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
+pub(super) async fn user_model_provider_state(
+    config_manager: &ConfigManager,
+) -> Result<UserModelProviderState, JSONRPCErrorError> {
+    let layers = config_manager
+        .load_config_layers(/*cwd*/ None)
+        .await
+        .map_err(|err| internal_error(format!("failed to load configuration layers: {err}")))?;
+    let Some(layer) = layers.get_active_user_layer() else {
+        return Ok(UserModelProviderState {
+            model_provider: None,
+            version: None,
+        });
+    };
+    let model_provider = layer
+        .config
+        .get("model_provider")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string);
+    Ok(UserModelProviderState {
+        model_provider,
+        version: Some(layer.version.clone()),
+    })
 }
 
 async fn write_user_model_provider(

--- a/codex-rs/app-server/src/request_processors/bedrock_auth.rs
+++ b/codex-rs/app-server/src/request_processors/bedrock_auth.rs
@@ -10,11 +10,6 @@ use codex_config::ConfigLayerSource;
 use codex_config::format_config_layer_source;
 use codex_model_provider::AMAZON_BEDROCK_PROVIDER_ID;
 
-pub(super) struct UserModelProviderState {
-    model_provider: Option<String>,
-    version: Option<String>,
-}
-
 pub(super) async fn set_user_model_provider_to_bedrock(
     config_manager: &ConfigManager,
 ) -> Result<(), JSONRPCErrorError> {
@@ -50,68 +45,27 @@ pub(super) async fn set_user_model_provider_to_bedrock(
         )));
     }
 
-    write_user_model_provider(
-        config_manager,
-        serde_json::json!(AMAZON_BEDROCK_PROVIDER_ID),
-        /*expected_version*/ None,
-    )
-    .await
+    config_manager
+        .write_value(ConfigValueWriteParams {
+            key_path: "model_provider".to_string(),
+            value: serde_json::json!(AMAZON_BEDROCK_PROVIDER_ID),
+            merge_strategy: MergeStrategy::Replace,
+            file_path: None,
+            expected_version: None,
+        })
+        .await
+        .map(|_| ())
+        .map_err(map_config_error)
 }
 
 pub(super) async fn clear_user_model_provider_if_bedrock(
     config_manager: &ConfigManager,
-    user_model_provider: UserModelProviderState,
-) -> Result<(), JSONRPCErrorError> {
-    if user_model_provider.model_provider.as_deref() == Some(AMAZON_BEDROCK_PROVIDER_ID) {
-        write_user_model_provider(
-            config_manager,
-            serde_json::Value::Null,
-            user_model_provider.version,
-        )
-        .await?;
-    }
-
-    Ok(())
-}
-
-pub(super) async fn user_model_provider_state(
-    config_manager: &ConfigManager,
-) -> Result<UserModelProviderState, JSONRPCErrorError> {
-    let layers = config_manager
-        .load_config_layers(/*cwd*/ None)
-        .await
-        .map_err(|err| internal_error(format!("failed to load configuration layers: {err}")))?;
-    let Some(layer) = layers.get_active_user_layer() else {
-        return Ok(UserModelProviderState {
-            model_provider: None,
-            version: None,
-        });
-    };
-    let model_provider = layer
-        .config
-        .get("model_provider")
-        .and_then(serde_json::Value::as_str)
-        .map(str::to_string);
-    Ok(UserModelProviderState {
-        model_provider,
-        version: Some(layer.version.clone()),
-    })
-}
-
-async fn write_user_model_provider(
-    config_manager: &ConfigManager,
-    value: serde_json::Value,
-    expected_version: Option<String>,
 ) -> Result<(), JSONRPCErrorError> {
     config_manager
-        .write_value(ConfigValueWriteParams {
-            key_path: "model_provider".to_string(),
-            value,
-            merge_strategy: MergeStrategy::Replace,
-            file_path: None,
-            expected_version,
-        })
+        .clear_user_value_if_matches(
+            "model_provider",
+            serde_json::json!(AMAZON_BEDROCK_PROVIDER_ID),
+        )
         .await
-        .map(|_| ())
         .map_err(map_config_error)
 }

--- a/codex-rs/app-server/tests/suite/v2/account.rs
+++ b/codex-rs/app-server/tests/suite/v2/account.rs
@@ -1360,7 +1360,7 @@ async fn logout_aws_managed_bedrock_preserves_openai_auth_and_config() -> Result
 async fn logout_managed_bedrock_preserves_changed_provider_without_experimental_api() -> Result<()>
 {
     let codex_home = TempDir::new()?;
-    create_config_toml(codex_home.path(), CreateConfigTomlParams::default())?;
+    create_config_toml(codex_home.path(), aws_managed_bedrock_config())?;
     login_with_bedrock_api_key(
         codex_home.path(),
         "managed-bedrock-api-key",
@@ -1368,7 +1368,6 @@ async fn logout_managed_bedrock_preserves_changed_provider_without_experimental_
         AuthCredentialsStoreMode::File,
         AuthKeyringBackendKind::default(),
     )?;
-    let expected_config = read_config_toml(codex_home.path())?;
 
     let mut mcp = TestAppServer::new(codex_home.path()).await?;
     let initialized = mcp
@@ -1385,6 +1384,9 @@ async fn logout_managed_bedrock_preserves_changed_provider_without_experimental_
         )
         .await?;
     assert!(matches!(initialized, JSONRPCMessage::Response(_)));
+
+    create_config_toml(codex_home.path(), CreateConfigTomlParams::default())?;
+    let expected_config = read_config_toml(codex_home.path())?;
 
     let request_id = mcp.send_logout_account_request().await?;
     let response = timeout(

--- a/codex-rs/app-server/tests/suite/v2/account.rs
+++ b/codex-rs/app-server/tests/suite/v2/account.rs
@@ -1268,6 +1268,141 @@ async fn login_amazon_bedrock_allows_bedrock_provider_override() -> Result<()> {
 }
 
 #[tokio::test]
+async fn logout_managed_bedrock_restores_aws_managed_account() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), aws_managed_bedrock_config())?;
+    let mut expected_config = read_config_toml(codex_home.path())?;
+    expected_config
+        .as_table_mut()
+        .expect("config should be a table")
+        .remove("model_provider");
+
+    let mut mcp =
+        TestAppServer::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)]).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+    let request_id = mcp
+        .send_login_account_amazon_bedrock_request("managed-bedrock-api-key", "us-west-2")
+        .await?;
+    let response = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    assert_eq!(
+        to_response::<LoginAccountResponse>(response)?,
+        LoginAccountResponse::AmazonBedrock {}
+    );
+    timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_notification_message("account/login/completed"),
+    )
+    .await??;
+    assert_account_updated(&mut mcp, Some(AuthMode::BedrockApiKey)).await?;
+
+    let request_id = mcp.send_logout_account_request().await?;
+    let response = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    assert_eq!(
+        to_response::<LogoutAccountResponse>(response)?,
+        LogoutAccountResponse {}
+    );
+    assert_eq!(load_file_auth(codex_home.path())?, None);
+    assert_eq!(read_config_toml(codex_home.path())?, expected_config);
+    assert_account_updated(&mut mcp, /*auth_mode*/ None).await?;
+    assert_eq!(
+        read_account(&mut mcp).await?,
+        GetAccountResponse {
+            account: Some(Account::AmazonBedrock {
+                credential_source: AmazonBedrockCredentialSource::AwsManaged,
+            }),
+            requires_openai_auth: false,
+        }
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn logout_aws_managed_bedrock_preserves_openai_auth_and_config() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), aws_managed_bedrock_config())?;
+    login_with_api_key(
+        codex_home.path(),
+        "sk-test-key",
+        AuthCredentialsStoreMode::File,
+        AuthKeyringBackendKind::default(),
+    )?;
+    let expected_auth = load_file_auth(codex_home.path())?;
+    let expected_config = read_config_toml(codex_home.path())?;
+
+    let mut mcp =
+        TestAppServer::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)]).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+    let request_id = mcp.send_logout_account_request().await?;
+    let response = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    assert_eq!(
+        to_response::<LogoutAccountResponse>(response)?,
+        LogoutAccountResponse {}
+    );
+    assert_eq!(load_file_auth(codex_home.path())?, expected_auth);
+    assert_eq!(read_config_toml(codex_home.path())?, expected_config);
+    assert_account_updated(&mut mcp, Some(AuthMode::ApiKey)).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn logout_managed_bedrock_preserves_changed_provider_without_experimental_api() -> Result<()>
+{
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), CreateConfigTomlParams::default())?;
+    login_with_bedrock_api_key(
+        codex_home.path(),
+        "managed-bedrock-api-key",
+        "us-west-2",
+        AuthCredentialsStoreMode::File,
+        AuthKeyringBackendKind::default(),
+    )?;
+    let expected_config = read_config_toml(codex_home.path())?;
+
+    let mut mcp = TestAppServer::new(codex_home.path()).await?;
+    let initialized = mcp
+        .initialize_with_capabilities(
+            ClientInfo {
+                name: DEFAULT_CLIENT_NAME.to_string(),
+                title: None,
+                version: "0.1.0".to_string(),
+            },
+            Some(InitializeCapabilities {
+                experimental_api: false,
+                ..Default::default()
+            }),
+        )
+        .await?;
+    assert!(matches!(initialized, JSONRPCMessage::Response(_)));
+
+    let request_id = mcp.send_logout_account_request().await?;
+    let response = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    assert_eq!(
+        to_response::<LogoutAccountResponse>(response)?,
+        LogoutAccountResponse {}
+    );
+    assert_eq!(load_file_auth(codex_home.path())?, None);
+    assert_eq!(read_config_toml(codex_home.path())?, expected_config);
+    assert_account_updated(&mut mcp, /*auth_mode*/ None).await?;
+    Ok(())
+}
+
+#[tokio::test]
 async fn managed_bedrock_login_requires_experimental_api() -> Result<()> {
     let codex_home = TempDir::new()?;
     create_config_toml(codex_home.path(), CreateConfigTomlParams::default())?;

--- a/codex-rs/app-server/tests/suite/v2/account.rs
+++ b/codex-rs/app-server/tests/suite/v2/account.rs
@@ -1387,7 +1387,7 @@ async fn logout_managed_bedrock_restores_default_account() -> Result<()> {
 }
 
 #[tokio::test]
-async fn logout_aws_managed_bedrock_preserves_openai_auth_and_config() -> Result<()> {
+async fn logout_aws_managed_bedrock_errors_without_changing_auth_or_config() -> Result<()> {
     let codex_home = TempDir::new()?;
     create_config_toml(codex_home.path(), aws_managed_bedrock_config())?;
     login_with_api_key(
@@ -1407,18 +1407,18 @@ async fn logout_aws_managed_bedrock_preserves_openai_auth_and_config() -> Result
         .await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
     let request_id = mcp.send_logout_account_request().await?;
-    let response = timeout(
+    let error = timeout(
         DEFAULT_READ_TIMEOUT,
-        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+        mcp.read_stream_until_error_message(RequestId::Integer(request_id)),
     )
     .await??;
+    assert_eq!(error.error.code, -32600);
     assert_eq!(
-        to_response::<LogoutAccountResponse>(response)?,
-        LogoutAccountResponse {}
+        error.error.message,
+        "cannot log out while Amazon Bedrock is using AWS-managed credentials; manage those credentials through AWS or switch model providers before logging out Codex authentication"
     );
     assert_eq!(load_file_auth(codex_home.path())?, expected_auth);
     assert_eq!(read_config_toml(codex_home.path())?, expected_config);
-    assert_account_updated(&mut mcp, Some(AuthMode::ApiKey)).await?;
     Ok(())
 }
 

--- a/codex-rs/app-server/tests/suite/v2/account.rs
+++ b/codex-rs/app-server/tests/suite/v2/account.rs
@@ -1291,8 +1291,12 @@ async fn logout_managed_bedrock_restores_default_account() -> Result<()> {
         .expect("config should be a table")
         .remove("model_provider");
 
-    let mut mcp =
-        TestAppServer::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)]).await?;
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .without_auto_env()
+        .with_env_overrides(&[("OPENAI_API_KEY", None)])
+        .build()
+        .await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
     let request_id = mcp
         .send_login_account_amazon_bedrock_request("managed-bedrock-api-key", "us-west-2")
@@ -1358,8 +1362,12 @@ async fn logout_aws_managed_bedrock_preserves_openai_auth_and_config() -> Result
     let expected_auth = load_file_auth(codex_home.path())?;
     let expected_config = read_config_toml(codex_home.path())?;
 
-    let mut mcp =
-        TestAppServer::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)]).await?;
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .without_auto_env()
+        .with_env_overrides(&[("OPENAI_API_KEY", None)])
+        .build()
+        .await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
     let request_id = mcp.send_logout_account_request().await?;
     let response = timeout(
@@ -1390,7 +1398,11 @@ async fn logout_managed_bedrock_preserves_changed_provider_without_experimental_
         AuthKeyringBackendKind::default(),
     )?;
 
-    let mut mcp = TestAppServer::new(codex_home.path()).await?;
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .without_auto_env()
+        .build()
+        .await?;
     let initialized = mcp
         .initialize_with_capabilities(
             ClientInfo {

--- a/codex-rs/app-server/tests/suite/v2/account.rs
+++ b/codex-rs/app-server/tests/suite/v2/account.rs
@@ -166,6 +166,20 @@ fn load_file_auth(codex_home: &Path) -> Result<Option<AuthDotJson>> {
     )?)
 }
 
+fn aws_managed_bedrock_config() -> CreateConfigTomlParams {
+    CreateConfigTomlParams {
+        model_provider_id: Some("amazon-bedrock".to_string()),
+        extra_provider_config: Some(
+            r#"[model_providers.amazon-bedrock.aws]
+profile = "codex-bedrock"
+region = "us-west-2"
+"#
+            .to_string(),
+        ),
+        ..Default::default()
+    }
+}
+
 async fn read_account(mcp: &mut TestAppServer) -> Result<GetAccountResponse> {
     let request_id = mcp
         .send_get_account_request(GetAccountParams {
@@ -1268,9 +1282,9 @@ async fn login_amazon_bedrock_allows_bedrock_provider_override() -> Result<()> {
 }
 
 #[tokio::test]
-async fn logout_managed_bedrock_restores_aws_managed_account() -> Result<()> {
+async fn logout_managed_bedrock_restores_default_account() -> Result<()> {
     let codex_home = TempDir::new()?;
-    create_config_toml(codex_home.path(), aws_managed_bedrock_config())?;
+    create_config_toml(codex_home.path(), CreateConfigTomlParams::default())?;
     let mut expected_config = read_config_toml(codex_home.path())?;
     expected_config
         .as_table_mut()
@@ -1298,6 +1312,15 @@ async fn logout_managed_bedrock_restores_aws_managed_account() -> Result<()> {
     )
     .await??;
     assert_account_updated(&mut mcp, Some(AuthMode::BedrockApiKey)).await?;
+    assert_eq!(
+        read_account(&mut mcp).await?,
+        GetAccountResponse {
+            account: Some(Account::AmazonBedrock {
+                credential_source: AmazonBedrockCredentialSource::CodexManaged,
+            }),
+            requires_openai_auth: false,
+        }
+    );
 
     let request_id = mcp.send_logout_account_request().await?;
     let response = timeout(
@@ -1315,10 +1338,8 @@ async fn logout_managed_bedrock_restores_aws_managed_account() -> Result<()> {
     assert_eq!(
         read_account(&mut mcp).await?,
         GetAccountResponse {
-            account: Some(Account::AmazonBedrock {
-                credential_source: AmazonBedrockCredentialSource::AwsManaged,
-            }),
-            requires_openai_auth: false,
+            account: None,
+            requires_openai_auth: true,
         }
     );
     Ok(())
@@ -1401,6 +1422,13 @@ async fn logout_managed_bedrock_preserves_changed_provider_without_experimental_
     assert_eq!(load_file_auth(codex_home.path())?, None);
     assert_eq!(read_config_toml(codex_home.path())?, expected_config);
     assert_account_updated(&mut mcp, /*auth_mode*/ None).await?;
+    assert_eq!(
+        read_account(&mut mcp).await?,
+        GetAccountResponse {
+            account: None,
+            requires_openai_auth: false,
+        }
+    );
     Ok(())
 }
 

--- a/codex-rs/app-server/tests/suite/v2/account.rs
+++ b/codex-rs/app-server/tests/suite/v2/account.rs
@@ -333,6 +333,43 @@ async fn logout_account_removes_auth_and_notifies() -> Result<()> {
 }
 
 #[tokio::test]
+async fn logout_account_succeeds_when_config_reload_fails() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), CreateConfigTomlParams::default())?;
+    login_with_api_key(
+        codex_home.path(),
+        "sk-test-key",
+        AuthCredentialsStoreMode::File,
+        AuthKeyringBackendKind::default(),
+    )?;
+
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .without_auto_env()
+        .with_env_overrides(&[("OPENAI_API_KEY", None)])
+        .build()
+        .await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    std::fs::write(codex_home.path().join("config.toml"), "invalid = [")?;
+
+    let request_id = mcp.send_logout_account_request().await?;
+    let response = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    assert_eq!(
+        to_response::<LogoutAccountResponse>(response)?,
+        LogoutAccountResponse {}
+    );
+    assert_eq!(load_file_auth(codex_home.path())?, None);
+    assert_account_updated(&mut mcp, /*auth_mode*/ None).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn set_auth_token_updates_account_and_notifies() -> Result<()> {
     let codex_home = TempDir::new()?;
     let mock_server = MockServer::start().await;


### PR DESCRIPTION
## Why

`account/logout` normally removes Codex's primary stored authentication. That behavior needs an ownership check when Amazon Bedrock is active:

- A Codex-managed Bedrock API key is primary `CodexAuth` state, so logout should remove it through the normal auth lifecycle.
- AWS credential-chain authentication is managed outside Codex. In that case, logout must be a no-op so it does not delete an unrelated stored OpenAI or ChatGPT login that happens to be masked by the active Bedrock provider.

Managed Bedrock login also persists `model_provider = "amazon-bedrock"`. Logout should undo that selection only if it is still the user-level value, without overwriting a provider change made before or concurrently with logout.

## What changed

- Detect Codex-managed Bedrock auth from the cached primary `CodexAuth::BedrockApiKey` value.
- Route managed Bedrock credentials through the existing `AuthManager::logout_with_revoke` path.
- Treat logout as a no-op when Bedrock is active through the external AWS credential chain, preserving both primary Codex auth and provider configuration.
- Add a version-guarded `ConfigManager::clear_user_value_if_matches` operation and use it to remove the user-level `model_provider` only while it remains `"amazon-bedrock"`.
- Reload configuration after cleanup and report account updates from the resulting primary auth state.
- Document the ownership-specific logout behavior in the app-server API reference.
- Add focused coverage for conditional config cleanup, managed logout, AWS-managed no-op behavior, unrelated auth/config preservation, and logout without the experimental login capability.

## Validation

- `just test -p codex-app-server -E 'test(/suite::v2::account/)'` — 40 passed
- Real end-to-end logout using `cargo run -p codex-app-server-test-client -- --codex-bin ./target/debug/codex test-logout`: `account/logout` returned successfully, `account/updated` reported `authMode: null` and `planType: null`, `~/.codex/auth.json` was cleared, and the persisted `model_provider = "amazon-bedrock"` setting was removed from `~/.codex/config.toml`.

## Stack

1. #31327 Managed Bedrock experimental API — base: `main`
2. #31326 Managed Bedrock login — base: `codex/managed-bedrock-api`
3. **#31325 Managed Bedrock logout** — base: `codex/managed-bedrock-login-v2`
