### PR TITLE
feat: add managed Amazon Bedrock login

### DIFF
--- a/codex-rs/app-server-test-client/README.md
+++ b/codex-rs/app-server-test-client/README.md
@@ -24,8 +24,9 @@ and the client will send the response and continue streaming the same turn.
 
 ## Testing Codex-managed Amazon Bedrock login
 
-`test-login --amazon-bedrock` initializes the experimental app-server API and sends an
-`account/login/start` request with an Amazon Bedrock API key. Login replaces the current primary
+`test-login --amazon-bedrock` initializes the experimental app-server API, sends an
+`account/login/start` request with an Amazon Bedrock API key, and waits for the
+`account/login/completed` and `account/updated` notifications. Login replaces the current primary
 credential and sets `model_provider = "amazon-bedrock"`, so use an isolated `CODEX_HOME` when
 testing.
 

--- a/codex-rs/app-server-test-client/README.md
+++ b/codex-rs/app-server-test-client/README.md
@@ -22,6 +22,30 @@ cargo run -p codex-app-server-test-client -- model-list
 When Codex asks a question, choose a numbered option (or `o` for a free-form answer when offered)
 and the client will send the response and continue streaming the same turn.
 
+## Testing Codex-managed Amazon Bedrock login
+
+`test-amazon-bedrock-login` initializes the experimental app-server API, logs in with an Amazon
+Bedrock API key, waits for the login completion notification, and verifies that `account/read`
+reports a Codex-managed Amazon Bedrock account. Login replaces the current primary credential and
+sets `model_provider = "amazon-bedrock"`, so use an isolated `CODEX_HOME` when testing.
+
+```bash
+export CODEX_HOME="$(mktemp -d)"
+printf 'cli_auth_credentials_store = "file"\n' > "$CODEX_HOME/config.toml"
+export AWS_BEARER_TOKEN_BEDROCK="<BEDROCK_API_KEY>"
+
+cargo build -p codex-cli --bin codex
+cargo run -p codex-app-server-test-client -- \
+  --codex-bin ./target/debug/codex \
+  test-amazon-bedrock-login \
+  --region us-west-2
+```
+
+The key can instead be passed with `--api-key`, but the environment variable avoids exposing it in
+shell history. The test client redacts `apiKey` from its outbound request log. After login, unset
+`AWS_BEARER_TOKEN_BEDROCK` and start a fresh Codex process with the same `CODEX_HOME` to verify that
+it uses the persisted managed credential.
+
 ## Testing Plugin Analytics
 
 The `plugin-analytics-smoke` command exercises `plugin/installed`, plugin

--- a/codex-rs/app-server-test-client/README.md
+++ b/codex-rs/app-server-test-client/README.md
@@ -24,10 +24,10 @@ and the client will send the response and continue streaming the same turn.
 
 ## Testing Codex-managed Amazon Bedrock login
 
-`test-amazon-bedrock-login` initializes the experimental app-server API, logs in with an Amazon
-Bedrock API key, waits for the login completion notification, and verifies that `account/read`
-reports a Codex-managed Amazon Bedrock account. Login replaces the current primary credential and
-sets `model_provider = "amazon-bedrock"`, so use an isolated `CODEX_HOME` when testing.
+`test-login --amazon-bedrock` initializes the experimental app-server API and sends an
+`account/login/start` request with an Amazon Bedrock API key. Login replaces the current primary
+credential and sets `model_provider = "amazon-bedrock"`, so use an isolated `CODEX_HOME` when
+testing.
 
 ```bash
 export CODEX_HOME="$(mktemp -d)"
@@ -37,7 +37,8 @@ export AWS_BEARER_TOKEN_BEDROCK="<BEDROCK_API_KEY>"
 cargo build -p codex-cli --bin codex
 cargo run -p codex-app-server-test-client -- \
   --codex-bin ./target/debug/codex \
-  test-amazon-bedrock-login \
+  test-login \
+  --amazon-bedrock \
   --region us-west-2
 ```
 

--- a/codex-rs/app-server-test-client/README.md
+++ b/codex-rs/app-server-test-client/README.md
@@ -32,20 +32,18 @@ testing.
 ```bash
 export CODEX_HOME="$(mktemp -d)"
 printf 'cli_auth_credentials_store = "file"\n' > "$CODEX_HOME/config.toml"
-export AWS_BEARER_TOKEN_BEDROCK="<BEDROCK_API_KEY>"
 
 cargo build -p codex-cli --bin codex
 cargo run -p codex-app-server-test-client -- \
   --codex-bin ./target/debug/codex \
   test-login \
   --amazon-bedrock \
+  --api-key "<BEDROCK_API_KEY>" \
   --region us-west-2
 ```
 
-The key can instead be passed with `--api-key`, but the environment variable avoids exposing it in
-shell history. The test client redacts `apiKey` from its outbound request log. After login, unset
-`AWS_BEARER_TOKEN_BEDROCK` and start a fresh Codex process with the same `CODEX_HOME` to verify that
-it uses the persisted managed credential.
+The test client redacts `apiKey` from its outbound request log. After login, start a fresh Codex
+process with the same `CODEX_HOME` to verify that it uses the persisted managed credential.
 
 ## Testing Plugin Analytics
 

--- a/codex-rs/app-server-test-client/src/lib.rs
+++ b/codex-rs/app-server-test-client/src/lib.rs
@@ -1180,6 +1180,20 @@ async fn test_login(
                     "account/login/start",
                 )?;
                 println!("< account/login/start response: {login_response:?}");
+
+                let completion =
+                    client.wait_for_account_login_completion(/*expected_login_id*/ None)?;
+                println!("< account/login/completed notification: {completion:?}");
+
+                loop {
+                    let notification = client.next_notification()?;
+                    if let Ok(ServerNotification::AccountUpdated(account_updated)) =
+                        ServerNotification::try_from(notification)
+                    {
+                        println!("< account/updated notification: {account_updated:?}");
+                        break;
+                    }
+                }
                 return Ok(());
             }
         };
@@ -1202,7 +1216,7 @@ async fn test_login(
             _ => bail!("expected chatgpt login response"),
         };
 
-        let completion = client.wait_for_account_login_completion(&login_id)?;
+        let completion = client.wait_for_account_login_completion(Some(&login_id))?;
         println!("< account/login/completed notification: {completion:?}");
 
         if completion.success {
@@ -1843,7 +1857,7 @@ impl CodexClient {
 
     fn wait_for_account_login_completion(
         &mut self,
-        expected_login_id: &str,
+        expected_login_id: Option<&str>,
     ) -> Result<AccountLoginCompletedNotification> {
         loop {
             let notification = self.next_notification()?;
@@ -1851,7 +1865,7 @@ impl CodexClient {
             if let Ok(server_notification) = ServerNotification::try_from(notification) {
                 match server_notification {
                     ServerNotification::AccountLoginCompleted(completion) => {
-                        if completion.login_id.as_deref() == Some(expected_login_id) {
+                        if completion.login_id.as_deref() == expected_login_id {
                             return Ok(completion);
                         }
 

--- a/codex-rs/app-server-test-client/src/lib.rs
+++ b/codex-rs/app-server-test-client/src/lib.rs
@@ -25,7 +25,6 @@ use anyhow::bail;
 use clap::ArgAction;
 use clap::Parser;
 use clap::Subcommand;
-use codex_app_server_protocol::Account;
 use codex_app_server_protocol::AccountLoginCompletedNotification;
 use codex_app_server_protocol::AskForApproval;
 use codex_app_server_protocol::ClientInfo;
@@ -38,9 +37,7 @@ use codex_app_server_protocol::DynamicToolSpec;
 use codex_app_server_protocol::FileChangeApprovalDecision;
 use codex_app_server_protocol::FileChangeRequestApprovalParams;
 use codex_app_server_protocol::FileChangeRequestApprovalResponse;
-use codex_app_server_protocol::GetAccountParams;
 use codex_app_server_protocol::GetAccountRateLimitsResponse;
-use codex_app_server_protocol::GetAccountResponse;
 use codex_app_server_protocol::InitializeCapabilities;
 use codex_app_server_protocol::InitializeParams;
 use codex_app_server_protocol::InitializeResponse;
@@ -73,7 +70,6 @@ use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_core::config::Config;
 use codex_otel::OtelProvider;
 use codex_otel::current_span_w3c_trace_context;
-use codex_protocol::account::AmazonBedrockCredentialSource;
 use codex_protocol::dynamic_tools::normalize_dynamic_tool_specs;
 use codex_protocol::openai_models::ReasoningEffort;
 use codex_protocol::protocol::W3cTraceContext;
@@ -234,20 +230,20 @@ enum CliCommand {
         #[arg(long)]
         abort_on: Option<usize>,
     },
-    /// Trigger the ChatGPT login flow and wait for completion.
+    /// Trigger a ChatGPT or Amazon Bedrock login flow.
     TestLogin {
         /// Use the device-code login flow instead of the browser callback flow.
-        #[arg(long, default_value_t = false)]
+        #[arg(long, default_value_t = false, conflicts_with = "amazon_bedrock")]
         device_code: bool,
-    },
-    /// Log in with a Codex-managed Amazon Bedrock API key and verify the account state.
-    TestAmazonBedrockLogin {
+        /// Use a Codex-managed Amazon Bedrock API key.
+        #[arg(long, default_value_t = false, conflicts_with = "device_code")]
+        amazon_bedrock: bool,
         /// Amazon Bedrock API key. Defaults to AWS_BEARER_TOKEN_BEDROCK.
         #[arg(long, env = "AWS_BEARER_TOKEN_BEDROCK", hide_env_values = true)]
-        api_key: String,
+        api_key: Option<String>,
         /// AWS Region for the Amazon Bedrock Mantle endpoint.
         #[arg(long, env = "AWS_REGION")]
-        region: String,
+        region: Option<String>,
     },
     /// Fetch the current account rate limits from the Codex app-server.
     GetAccountRateLimits,
@@ -324,6 +320,12 @@ enum CliCommand {
         #[arg(long)]
         confirm_account_mutation: bool,
     },
+}
+
+enum TestLoginMode {
+    ChatgptBrowser,
+    ChatgptDeviceCode,
+    AmazonBedrock { api_key: String, region: String },
 }
 
 pub async fn run() -> Result<()> {
@@ -428,15 +430,27 @@ pub async fn run() -> Result<()> {
             )
             .await
         }
-        CliCommand::TestLogin { device_code } => {
+        CliCommand::TestLogin {
+            device_code,
+            amazon_bedrock,
+            api_key,
+            region,
+        } => {
             ensure_dynamic_tools_unused(&dynamic_tools, "test-login")?;
             let endpoint = resolve_endpoint(codex_bin, url)?;
-            test_login(&endpoint, &config_overrides, device_code).await
-        }
-        CliCommand::TestAmazonBedrockLogin { api_key, region } => {
-            ensure_dynamic_tools_unused(&dynamic_tools, "test-amazon-bedrock-login")?;
-            let endpoint = resolve_endpoint(codex_bin, url)?;
-            test_amazon_bedrock_login(&endpoint, &config_overrides, api_key, region).await
+            let mode = if amazon_bedrock {
+                let api_key = api_key.context(
+                    "--api-key or AWS_BEARER_TOKEN_BEDROCK is required with --amazon-bedrock",
+                )?;
+                let region =
+                    region.context("--region or AWS_REGION is required with --amazon-bedrock")?;
+                TestLoginMode::AmazonBedrock { api_key, region }
+            } else if device_code {
+                TestLoginMode::ChatgptDeviceCode
+            } else {
+                TestLoginMode::ChatgptBrowser
+            };
+            test_login(&endpoint, &config_overrides, mode).await
         }
         CliCommand::GetAccountRateLimits => {
             ensure_dynamic_tools_unused(&dynamic_tools, "get-account-rate-limits")?;
@@ -1146,16 +1160,31 @@ async fn send_follow_up_v2(
 async fn test_login(
     endpoint: &Endpoint,
     config_overrides: &[String],
-    device_code: bool,
+    mode: TestLoginMode,
 ) -> Result<()> {
     with_client("test-login", endpoint, config_overrides, |client| {
         let initialize = client.initialize()?;
         println!("< initialize response: {initialize:?}");
 
-        let login_response = if device_code {
-            client.login_account_chatgpt_device_code()?
-        } else {
-            client.login_account_chatgpt()?
+        let login_response = match mode {
+            TestLoginMode::ChatgptBrowser => client.login_account_chatgpt()?,
+            TestLoginMode::ChatgptDeviceCode => client.login_account_chatgpt_device_code()?,
+            TestLoginMode::AmazonBedrock { api_key, region } => {
+                let request_id = client.request_id();
+                let login_response: LoginAccountResponse = client.send_request(
+                    ClientRequest::LoginAccount {
+                        request_id: request_id.clone(),
+                        params: codex_app_server_protocol::LoginAccountParams::AmazonBedrock {
+                            api_key,
+                            region,
+                        },
+                    },
+                    request_id,
+                    "account/login/start",
+                )?;
+                println!("< account/login/start response: {login_response:?}");
+                return Ok(());
+            }
         };
         println!("< account/login/start response: {login_response:?}");
         let login_id = match login_response {
@@ -1176,7 +1205,7 @@ async fn test_login(
             _ => bail!("expected chatgpt login response"),
         };
 
-        let completion = client.wait_for_account_login_completion(Some(&login_id))?;
+        let completion = client.wait_for_account_login_completion(&login_id)?;
         println!("< account/login/completed notification: {completion:?}");
 
         if completion.success {
@@ -1192,80 +1221,6 @@ async fn test_login(
             );
         }
     })
-    .await
-}
-
-async fn test_amazon_bedrock_login(
-    endpoint: &Endpoint,
-    config_overrides: &[String],
-    api_key: String,
-    region: String,
-) -> Result<()> {
-    with_client(
-        "test-amazon-bedrock-login",
-        endpoint,
-        config_overrides,
-        |client| {
-            let initialize =
-                client.initialize_with_experimental_api(/*experimental_api*/ true)?;
-            println!("< initialize response: {initialize:?}");
-
-            let request_id = client.request_id();
-            let login_response: LoginAccountResponse = client.send_request(
-                ClientRequest::LoginAccount {
-                    request_id: request_id.clone(),
-                    params: codex_app_server_protocol::LoginAccountParams::AmazonBedrock {
-                        api_key,
-                        region,
-                    },
-                },
-                request_id,
-                "account/login/start",
-            )?;
-            println!("< account/login/start response: {login_response:?}");
-            if login_response != (LoginAccountResponse::AmazonBedrock {}) {
-                bail!("expected Amazon Bedrock login response, got {login_response:?}");
-            }
-
-            let completion =
-                client.wait_for_account_login_completion(/*expected_login_id*/ None)?;
-            println!("< account/login/completed notification: {completion:?}");
-            if !completion.success {
-                bail!(
-                    "Amazon Bedrock login failed: {}",
-                    completion
-                        .error
-                        .as_deref()
-                        .unwrap_or("unknown error from account/login/completed")
-                );
-            }
-
-            let request_id = client.request_id();
-            let account: GetAccountResponse = client.send_request(
-                ClientRequest::GetAccount {
-                    request_id: request_id.clone(),
-                    params: GetAccountParams {
-                        refresh_token: false,
-                    },
-                },
-                request_id,
-                "account/read",
-            )?;
-            println!("< account/read response: {account:?}");
-            let expected_account = GetAccountResponse {
-                account: Some(Account::AmazonBedrock {
-                    credential_source: AmazonBedrockCredentialSource::CodexManaged,
-                }),
-                requires_openai_auth: false,
-            };
-            if account != expected_account {
-                bail!("expected managed Amazon Bedrock account, got {account:?}");
-            }
-
-            println!("Amazon Bedrock login succeeded.");
-            Ok(())
-        },
-    )
     .await
 }
 
@@ -1891,7 +1846,7 @@ impl CodexClient {
 
     fn wait_for_account_login_completion(
         &mut self,
-        expected_login_id: Option<&str>,
+        expected_login_id: &str,
     ) -> Result<AccountLoginCompletedNotification> {
         loop {
             let notification = self.next_notification()?;
@@ -1899,7 +1854,7 @@ impl CodexClient {
             if let Ok(server_notification) = ServerNotification::try_from(notification) {
                 match server_notification {
                     ServerNotification::AccountLoginCompleted(completion) => {
-                        if completion.login_id.as_deref() == expected_login_id {
+                        if completion.login_id.as_deref() == Some(expected_login_id) {
                             return Ok(completion);
                         }
 

--- a/codex-rs/app-server-test-client/src/lib.rs
+++ b/codex-rs/app-server-test-client/src/lib.rs
@@ -25,6 +25,7 @@ use anyhow::bail;
 use clap::ArgAction;
 use clap::Parser;
 use clap::Subcommand;
+use codex_app_server_protocol::Account;
 use codex_app_server_protocol::AccountLoginCompletedNotification;
 use codex_app_server_protocol::AskForApproval;
 use codex_app_server_protocol::ClientInfo;
@@ -37,7 +38,9 @@ use codex_app_server_protocol::DynamicToolSpec;
 use codex_app_server_protocol::FileChangeApprovalDecision;
 use codex_app_server_protocol::FileChangeRequestApprovalParams;
 use codex_app_server_protocol::FileChangeRequestApprovalResponse;
+use codex_app_server_protocol::GetAccountParams;
 use codex_app_server_protocol::GetAccountRateLimitsResponse;
+use codex_app_server_protocol::GetAccountResponse;
 use codex_app_server_protocol::InitializeCapabilities;
 use codex_app_server_protocol::InitializeParams;
 use codex_app_server_protocol::InitializeResponse;
@@ -70,6 +73,7 @@ use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_core::config::Config;
 use codex_otel::OtelProvider;
 use codex_otel::current_span_w3c_trace_context;
+use codex_protocol::account::AmazonBedrockCredentialSource;
 use codex_protocol::dynamic_tools::normalize_dynamic_tool_specs;
 use codex_protocol::openai_models::ReasoningEffort;
 use codex_protocol::protocol::W3cTraceContext;
@@ -235,6 +239,15 @@ enum CliCommand {
         /// Use the device-code login flow instead of the browser callback flow.
         #[arg(long, default_value_t = false)]
         device_code: bool,
+    },
+    /// Log in with a Codex-managed Amazon Bedrock API key and verify the account state.
+    TestAmazonBedrockLogin {
+        /// Amazon Bedrock API key. Defaults to AWS_BEARER_TOKEN_BEDROCK.
+        #[arg(long, env = "AWS_BEARER_TOKEN_BEDROCK", hide_env_values = true)]
+        api_key: String,
+        /// AWS Region for the Amazon Bedrock Mantle endpoint.
+        #[arg(long, env = "AWS_REGION")]
+        region: String,
     },
     /// Fetch the current account rate limits from the Codex app-server.
     GetAccountRateLimits,
@@ -419,6 +432,11 @@ pub async fn run() -> Result<()> {
             ensure_dynamic_tools_unused(&dynamic_tools, "test-login")?;
             let endpoint = resolve_endpoint(codex_bin, url)?;
             test_login(&endpoint, &config_overrides, device_code).await
+        }
+        CliCommand::TestAmazonBedrockLogin { api_key, region } => {
+            ensure_dynamic_tools_unused(&dynamic_tools, "test-amazon-bedrock-login")?;
+            let endpoint = resolve_endpoint(codex_bin, url)?;
+            test_amazon_bedrock_login(&endpoint, &config_overrides, api_key, region).await
         }
         CliCommand::GetAccountRateLimits => {
             ensure_dynamic_tools_unused(&dynamic_tools, "get-account-rate-limits")?;
@@ -1158,7 +1176,7 @@ async fn test_login(
             _ => bail!("expected chatgpt login response"),
         };
 
-        let completion = client.wait_for_account_login_completion(&login_id)?;
+        let completion = client.wait_for_account_login_completion(Some(&login_id))?;
         println!("< account/login/completed notification: {completion:?}");
 
         if completion.success {
@@ -1174,6 +1192,80 @@ async fn test_login(
             );
         }
     })
+    .await
+}
+
+async fn test_amazon_bedrock_login(
+    endpoint: &Endpoint,
+    config_overrides: &[String],
+    api_key: String,
+    region: String,
+) -> Result<()> {
+    with_client(
+        "test-amazon-bedrock-login",
+        endpoint,
+        config_overrides,
+        |client| {
+            let initialize =
+                client.initialize_with_experimental_api(/*experimental_api*/ true)?;
+            println!("< initialize response: {initialize:?}");
+
+            let request_id = client.request_id();
+            let login_response: LoginAccountResponse = client.send_request(
+                ClientRequest::LoginAccount {
+                    request_id: request_id.clone(),
+                    params: codex_app_server_protocol::LoginAccountParams::AmazonBedrock {
+                        api_key,
+                        region,
+                    },
+                },
+                request_id,
+                "account/login/start",
+            )?;
+            println!("< account/login/start response: {login_response:?}");
+            if login_response != (LoginAccountResponse::AmazonBedrock {}) {
+                bail!("expected Amazon Bedrock login response, got {login_response:?}");
+            }
+
+            let completion =
+                client.wait_for_account_login_completion(/*expected_login_id*/ None)?;
+            println!("< account/login/completed notification: {completion:?}");
+            if !completion.success {
+                bail!(
+                    "Amazon Bedrock login failed: {}",
+                    completion
+                        .error
+                        .as_deref()
+                        .unwrap_or("unknown error from account/login/completed")
+                );
+            }
+
+            let request_id = client.request_id();
+            let account: GetAccountResponse = client.send_request(
+                ClientRequest::GetAccount {
+                    request_id: request_id.clone(),
+                    params: GetAccountParams {
+                        refresh_token: false,
+                    },
+                },
+                request_id,
+                "account/read",
+            )?;
+            println!("< account/read response: {account:?}");
+            let expected_account = GetAccountResponse {
+                account: Some(Account::AmazonBedrock {
+                    credential_source: AmazonBedrockCredentialSource::CodexManaged,
+                }),
+                requires_openai_auth: false,
+            };
+            if account != expected_account {
+                bail!("expected managed Amazon Bedrock account, got {account:?}");
+            }
+
+            println!("Amazon Bedrock login succeeded.");
+            Ok(())
+        },
+    )
     .await
 }
 
@@ -1799,7 +1891,7 @@ impl CodexClient {
 
     fn wait_for_account_login_completion(
         &mut self,
-        expected_login_id: &str,
+        expected_login_id: Option<&str>,
     ) -> Result<AccountLoginCompletedNotification> {
         loop {
             let notification = self.next_notification()?;
@@ -1807,7 +1899,7 @@ impl CodexClient {
             if let Ok(server_notification) = ServerNotification::try_from(notification) {
                 match server_notification {
                     ServerNotification::AccountLoginCompleted(completion) => {
-                        if completion.login_id.as_deref() == Some(expected_login_id) {
+                        if completion.login_id.as_deref() == expected_login_id {
                             return Ok(completion);
                         }
 
@@ -1956,7 +2048,13 @@ impl CodexClient {
             .context("client request was not a valid JSON-RPC request")?;
         request.trace = current_span_w3c_trace_context();
         let request_json = serde_json::to_string(&request)?;
-        let request_pretty = serde_json::to_string_pretty(&request)?;
+        let mut request_for_logging = serde_json::to_value(&request)?;
+        if request.method == "account/login/start"
+            && let Some(api_key) = request_for_logging.pointer_mut("/params/apiKey")
+        {
+            *api_key = Value::String("<redacted>".to_string());
+        }
+        let request_pretty = serde_json::to_string_pretty(&request_for_logging)?;
         print_multiline_with_prefix("> ", &request_pretty);
         self.write_payload(&request_json)
     }

--- a/codex-rs/app-server-test-client/src/lib.rs
+++ b/codex-rs/app-server-test-client/src/lib.rs
@@ -238,11 +238,11 @@ enum CliCommand {
         /// Use a Codex-managed Amazon Bedrock API key.
         #[arg(long, default_value_t = false, conflicts_with = "device_code")]
         amazon_bedrock: bool,
-        /// Amazon Bedrock API key. Defaults to AWS_BEARER_TOKEN_BEDROCK.
-        #[arg(long, env = "AWS_BEARER_TOKEN_BEDROCK", hide_env_values = true)]
+        /// Amazon Bedrock API key.
+        #[arg(long, value_name = "API_KEY")]
         api_key: Option<String>,
         /// AWS Region for the Amazon Bedrock Mantle endpoint.
-        #[arg(long, env = "AWS_REGION")]
+        #[arg(long, value_name = "REGION")]
         region: Option<String>,
     },
     /// Fetch the current account rate limits from the Codex app-server.
@@ -439,11 +439,8 @@ pub async fn run() -> Result<()> {
             ensure_dynamic_tools_unused(&dynamic_tools, "test-login")?;
             let endpoint = resolve_endpoint(codex_bin, url)?;
             let mode = if amazon_bedrock {
-                let api_key = api_key.context(
-                    "--api-key or AWS_BEARER_TOKEN_BEDROCK is required with --amazon-bedrock",
-                )?;
-                let region =
-                    region.context("--region or AWS_REGION is required with --amazon-bedrock")?;
+                let api_key = api_key.context("--api-key is required with --amazon-bedrock")?;
+                let region = region.context("--region is required with --amazon-bedrock")?;
                 TestLoginMode::AmazonBedrock { api_key, region }
             } else if device_code {
                 TestLoginMode::ChatgptDeviceCode

--- a/codex-rs/app-server/src/request_processors.rs
+++ b/codex-rs/app-server/src/request_processors.rs
@@ -387,6 +387,7 @@ use codex_login::ServerOptions as LoginServerOptions;
 use codex_login::ShutdownHandle;
 use codex_login::complete_device_code_login;
 use codex_login::login_with_api_key;
+use codex_login::login_with_bedrock_api_key;
 use codex_login::oauth_client_id;
 use codex_login::request_device_code;
 use codex_login::run_login_server;
@@ -497,6 +498,7 @@ use codex_app_server_protocol::ServerRequest;
 
 mod account_processor;
 mod apps_processor;
+mod bedrock_auth;
 mod catalog_processor;
 mod command_exec_processor;
 mod config_processor;

--- a/codex-rs/app-server/src/request_processors/account_processor.rs
+++ b/codex-rs/app-server/src/request_processors/account_processor.rs
@@ -406,6 +406,7 @@ impl AccountRequestProcessor {
                 }
             }
 
+            set_user_model_provider_to_bedrock(&self.config_manager).await?;
             login_with_bedrock_api_key(
                 &self.config.codex_home,
                 api_key,
@@ -414,7 +415,6 @@ impl AccountRequestProcessor {
                 self.config.auth_keyring_backend_kind(),
             )
             .map_err(|err| internal_error(format!("failed to save Amazon Bedrock auth: {err}")))?;
-            set_user_model_provider_to_bedrock(&self.config_manager).await?;
             self.auth_manager.reload().await;
             Ok(LoginAccountResponse::AmazonBedrock {})
         }

--- a/codex-rs/app-server/src/request_processors/account_processor.rs
+++ b/codex-rs/app-server/src/request_processors/account_processor.rs
@@ -193,6 +193,13 @@ impl AccountRequestProcessor {
         }
     }
 
+    async fn load_latest_config(&self) -> Result<Config, JSONRPCErrorError> {
+        self.config_manager
+            .load_latest_config(/*fallback_cwd*/ None)
+            .await
+            .map_err(|err| internal_error(format!("failed to reload config: {err}")))
+    }
+
     async fn maybe_refresh_plugin_caches_for_current_config(
         config_manager: &ConfigManager,
         thread_manager: &Arc<ThreadManager>,
@@ -899,7 +906,8 @@ impl AccountRequestProcessor {
         // Determine whether auth is required based on the active model provider.
         // If a custom provider is configured with `requires_openai_auth == false`,
         // then no auth step is required; otherwise, default to requiring auth.
-        let requires_openai_auth = self.config.model_provider.requires_openai_auth;
+        let config = self.load_latest_config().await?;
+        let requires_openai_auth = config.model_provider.requires_openai_auth;
 
         let response = if !requires_openai_auth {
             GetAuthStatusResponse {
@@ -967,10 +975,9 @@ impl AccountRequestProcessor {
 
         self.refresh_token_if_requested(do_refresh).await;
 
-        let provider = create_model_provider(
-            self.config.model_provider.clone(),
-            Some(self.auth_manager.clone()),
-        );
+        let config = self.load_latest_config().await?;
+        let provider =
+            create_model_provider(config.model_provider, Some(self.auth_manager.clone()));
         let account_state = match provider.account_state() {
             Ok(account_state) => account_state,
             Err(err) => return Err(invalid_request(err.to_string())),

--- a/codex-rs/app-server/src/request_processors/account_processor.rs
+++ b/codex-rs/app-server/src/request_processors/account_processor.rs
@@ -193,11 +193,18 @@ impl AccountRequestProcessor {
         }
     }
 
-    async fn load_latest_config(&self) -> Result<Config, JSONRPCErrorError> {
-        self.config_manager
+    async fn load_latest_config(&self) -> Config {
+        match self
+            .config_manager
             .load_latest_config(/*fallback_cwd*/ None)
             .await
-            .map_err(|err| internal_error(format!("failed to reload config: {err}")))
+        {
+            Ok(config) => config,
+            Err(err) => {
+                tracing::warn!("failed to reload config, using startup config: {err}");
+                self.config.as_ref().clone()
+            }
+        }
     }
 
     async fn maybe_refresh_plugin_caches_for_current_config(
@@ -906,7 +913,7 @@ impl AccountRequestProcessor {
         // Determine whether auth is required based on the active model provider.
         // If a custom provider is configured with `requires_openai_auth == false`,
         // then no auth step is required; otherwise, default to requiring auth.
-        let config = self.load_latest_config().await?;
+        let config = self.load_latest_config().await;
         let requires_openai_auth = config.model_provider.requires_openai_auth;
 
         let response = if !requires_openai_auth {
@@ -975,7 +982,7 @@ impl AccountRequestProcessor {
 
         self.refresh_token_if_requested(do_refresh).await;
 
-        let config = self.load_latest_config().await?;
+        let config = self.load_latest_config().await;
         let provider =
             create_model_provider(config.model_provider, Some(self.auth_manager.clone()));
         let account_state = match provider.account_state() {

--- a/codex-rs/app-server/src/request_processors/account_processor.rs
+++ b/codex-rs/app-server/src/request_processors/account_processor.rs
@@ -1,7 +1,9 @@
+use super::bedrock_auth::set_user_model_provider_to_bedrock;
 use super::*;
 use crate::auth_mode::auth_mode_to_api;
 use crate::external_auth::ExternalAuthBridge;
 use chrono::DateTime;
+use codex_model_provider::is_supported_amazon_bedrock_region;
 
 mod rate_limit_resets;
 
@@ -293,8 +295,9 @@ impl AccountRequestProcessor {
                 )
                 .await;
             }
-            LoginAccountParams::AmazonBedrock { .. } => {
-                return Err(invalid_request("Amazon Bedrock login is not implemented"));
+            LoginAccountParams::AmazonBedrock { api_key, region } => {
+                self.login_amazon_bedrock_v2(request_id, api_key, region)
+                    .await;
             }
         }
         Ok(())
@@ -350,6 +353,65 @@ impl AccountRequestProcessor {
             .login_api_key_common(&params)
             .await
             .map(|()| LoginAccountResponse::ApiKey {});
+        let logged_in = result.is_ok();
+        self.outgoing.send_result(request_id, result).await;
+
+        if logged_in {
+            self.send_login_success_notifications(/*login_id*/ None)
+                .await;
+        }
+    }
+
+    async fn login_amazon_bedrock_v2(
+        &self,
+        request_id: ConnectionRequestId,
+        api_key: String,
+        region: String,
+    ) {
+        let result = async {
+            if self.auth_manager.is_external_chatgpt_auth_active() {
+                return Err(self.external_auth_active_error());
+            }
+            if matches!(
+                self.config.forced_login_method,
+                Some(ForcedLoginMethod::Chatgpt)
+            ) {
+                return Err(invalid_request(
+                    "Amazon Bedrock login is disabled. Use ChatGPT login instead.",
+                ));
+            }
+
+            let api_key = api_key.trim();
+            if api_key.is_empty() {
+                return Err(invalid_request("Amazon Bedrock API key must not be empty."));
+            }
+            let region = region.trim();
+            if !is_supported_amazon_bedrock_region(region) {
+                return Err(invalid_request(format!(
+                    "Amazon Bedrock Mantle does not support region `{region}`"
+                )));
+            }
+
+            {
+                let mut guard = self.active_login.lock().await;
+                if let Some(active) = guard.take() {
+                    drop(active);
+                }
+            }
+
+            login_with_bedrock_api_key(
+                &self.config.codex_home,
+                api_key,
+                region,
+                self.config.cli_auth_credentials_store_mode,
+                self.config.auth_keyring_backend_kind(),
+            )
+            .map_err(|err| internal_error(format!("failed to save Amazon Bedrock auth: {err}")))?;
+            set_user_model_provider_to_bedrock(&self.config_manager).await?;
+            self.auth_manager.reload().await;
+            Ok(LoginAccountResponse::AmazonBedrock {})
+        }
+        .await;
         let logged_in = result.is_ok();
         self.outgoing.send_result(request_id, result).await;
 

--- a/codex-rs/app-server/src/request_processors/bedrock_auth.rs
+++ b/codex-rs/app-server/src/request_processors/bedrock_auth.rs
@@ -1,13 +1,50 @@
 use super::config_processor::map_error as map_config_error;
 use crate::config_manager::ConfigManager;
+use crate::error_code::internal_error;
+use crate::error_code::invalid_request;
 use codex_app_server_protocol::ConfigValueWriteParams;
 use codex_app_server_protocol::JSONRPCErrorError;
 use codex_app_server_protocol::MergeStrategy;
+use codex_config::CONFIG_TOML_FILE;
+use codex_config::ConfigLayerSource;
+use codex_config::format_config_layer_source;
 use codex_model_provider::AMAZON_BEDROCK_PROVIDER_ID;
 
 pub(super) async fn set_user_model_provider_to_bedrock(
     config_manager: &ConfigManager,
 ) -> Result<(), JSONRPCErrorError> {
+    let layers = config_manager
+        .load_config_layers(/*cwd*/ None)
+        .await
+        .map_err(|err| internal_error(format!("failed to load configuration layers: {err}")))?;
+    let user_precedence = match layers.get_active_user_layer() {
+        Some(layer) => layer.name.precedence(),
+        None => ConfigLayerSource::User {
+            file: config_manager.user_config_path().map_err(|err| {
+                internal_error(format!("failed to resolve user config path: {err}"))
+            })?,
+            profile: None,
+        }
+        .precedence(),
+    };
+    if let Some((overriding_layer, effective_provider)) = layers
+        .layers_high_to_low()
+        .into_iter()
+        .filter(|layer| layer.name.precedence() > user_precedence)
+        .find_map(|layer| {
+            layer
+                .config
+                .get("model_provider")
+                .map(|value| (layer, value))
+        })
+        && effective_provider.as_str() != Some(AMAZON_BEDROCK_PROVIDER_ID)
+    {
+        let source = format_config_layer_source(&overriding_layer.name, CONFIG_TOML_FILE);
+        return Err(invalid_request(format!(
+            "Amazon Bedrock login cannot select `{AMAZON_BEDROCK_PROVIDER_ID}` because {source} sets `model_provider` to {effective_provider}"
+        )));
+    }
+
     write_user_model_provider(
         config_manager,
         serde_json::json!(AMAZON_BEDROCK_PROVIDER_ID),

--- a/codex-rs/app-server/src/request_processors/bedrock_auth.rs
+++ b/codex-rs/app-server/src/request_processors/bedrock_auth.rs
@@ -1,0 +1,35 @@
+use super::config_processor::map_error as map_config_error;
+use crate::config_manager::ConfigManager;
+use codex_app_server_protocol::ConfigValueWriteParams;
+use codex_app_server_protocol::JSONRPCErrorError;
+use codex_app_server_protocol::MergeStrategy;
+use codex_model_provider::AMAZON_BEDROCK_PROVIDER_ID;
+
+pub(super) async fn set_user_model_provider_to_bedrock(
+    config_manager: &ConfigManager,
+) -> Result<(), JSONRPCErrorError> {
+    write_user_model_provider(
+        config_manager,
+        serde_json::json!(AMAZON_BEDROCK_PROVIDER_ID),
+        /*expected_version*/ None,
+    )
+    .await
+}
+
+async fn write_user_model_provider(
+    config_manager: &ConfigManager,
+    value: serde_json::Value,
+    expected_version: Option<String>,
+) -> Result<(), JSONRPCErrorError> {
+    config_manager
+        .write_value(ConfigValueWriteParams {
+            key_path: "model_provider".to_string(),
+            value,
+            merge_strategy: MergeStrategy::Replace,
+            file_path: None,
+            expected_version,
+        })
+        .await
+        .map(|_| ())
+        .map_err(map_config_error)
+}

--- a/codex-rs/app-server/src/request_processors/config_processor.rs
+++ b/codex-rs/app-server/src/request_processors/config_processor.rs
@@ -555,7 +555,7 @@ fn map_network_unix_socket_permission_to_api(
     }
 }
 
-fn map_error(err: ConfigManagerError) -> JSONRPCErrorError {
+pub(super) fn map_error(err: ConfigManagerError) -> JSONRPCErrorError {
     if let Some(code) = err.write_error_code() {
         return config_write_error(code, err.to_string());
     }

--- a/codex-rs/app-server/tests/common/test_app_server.rs
+++ b/codex-rs/app-server/tests/common/test_app_server.rs
@@ -1334,6 +1334,20 @@ impl TestAppServer {
         self.send_login_account_request(params).await
     }
 
+    /// Send an `account/login/start` JSON-RPC request for managed Amazon Bedrock login.
+    pub async fn send_login_account_amazon_bedrock_request(
+        &mut self,
+        api_key: &str,
+        region: &str,
+    ) -> anyhow::Result<i64> {
+        let params = serde_json::json!({
+            "type": "amazonBedrock",
+            "apiKey": api_key,
+            "region": region,
+        });
+        self.send_request("account/login/start", Some(params)).await
+    }
+
     /// Send an `account/login/start` JSON-RPC request for ChatGPT login.
     pub async fn send_login_account_chatgpt_request(&mut self) -> anyhow::Result<i64> {
         let params = serde_json::json!({

--- a/codex-rs/app-server/tests/suite/v2/account.rs
+++ b/codex-rs/app-server/tests/suite/v2/account.rs
@@ -1275,69 +1275,6 @@ async fn login_account_amazon_bedrock_rejects_invalid_credentials_without_change
 }
 
 #[tokio::test]
-async fn login_account_amazon_bedrock_persists_under_provider_override() -> Result<()> {
-    let codex_home = TempDir::new()?;
-    create_config_toml(codex_home.path(), CreateConfigTomlParams::default())?;
-
-    let mut mcp = TestAppServer::new_with_args(
-        codex_home.path(),
-        &["-c", "model_provider=\"mock_provider\""],
-    )
-    .await?;
-    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
-    let mut expected_config = read_config_toml(codex_home.path())?;
-    expected_config
-        .as_table_mut()
-        .expect("config should be a table")
-        .insert(
-            "model_provider".to_string(),
-            toml::Value::String("amazon-bedrock".to_string()),
-        );
-    let request_id = mcp
-        .send_login_account_amazon_bedrock_request("managed-bedrock-api-key", "us-west-2")
-        .await?;
-    let response: JSONRPCResponse = timeout(
-        DEFAULT_READ_TIMEOUT,
-        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
-    )
-    .await??;
-    assert_eq!(
-        to_response::<LoginAccountResponse>(response)?,
-        LoginAccountResponse::AmazonBedrock {}
-    );
-    assert_eq!(
-        load_file_auth(codex_home.path())?,
-        Some(AuthDotJson {
-            auth_mode: Some(DomainAuthMode::BedrockApiKey),
-            openai_api_key: None,
-            tokens: None,
-            last_refresh: None,
-            agent_identity: None,
-            personal_access_token: None,
-            bedrock_api_key: Some(BedrockApiKeyAuth {
-                api_key: "managed-bedrock-api-key".to_string(),
-                region: "us-west-2".to_string(),
-            }),
-        })
-    );
-    assert_eq!(read_config_toml(codex_home.path())?, expected_config);
-    timeout(
-        DEFAULT_READ_TIMEOUT,
-        mcp.read_stream_until_notification_message("account/login/completed"),
-    )
-    .await??;
-    assert_account_updated(&mut mcp, Some(AuthMode::BedrockApiKey)).await?;
-    assert_eq!(
-        read_account(&mut mcp).await?,
-        GetAccountResponse {
-            account: None,
-            requires_openai_auth: false,
-        }
-    );
-    Ok(())
-}
-
-#[tokio::test]
 async fn login_account_amazon_bedrock_rejected_when_forced_chatgpt() -> Result<()> {
     let codex_home = TempDir::new()?;
     create_config_toml(
@@ -1364,35 +1301,6 @@ async fn login_account_amazon_bedrock_rejected_when_forced_chatgpt() -> Result<(
         "Amazon Bedrock login is disabled. Use ChatGPT login instead."
     );
     assert_eq!(load_file_auth(codex_home.path())?, None);
-    Ok(())
-}
-
-#[tokio::test]
-async fn login_account_amazon_bedrock_allowed_when_forced_api() -> Result<()> {
-    let codex_home = TempDir::new()?;
-    create_config_toml(
-        codex_home.path(),
-        CreateConfigTomlParams {
-            forced_method: Some("api".to_string()),
-            ..Default::default()
-        },
-    )?;
-
-    let mut mcp = TestAppServer::new(codex_home.path()).await?;
-    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
-    let request_id = mcp
-        .send_login_account_amazon_bedrock_request("managed-bedrock-api-key", "us-west-2")
-        .await?;
-    let response = timeout(
-        DEFAULT_READ_TIMEOUT,
-        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
-    )
-    .await??;
-
-    assert_eq!(
-        to_response::<LoginAccountResponse>(response)?,
-        LoginAccountResponse::AmazonBedrock {}
-    );
     Ok(())
 }
 

--- a/codex-rs/app-server/tests/suite/v2/account.rs
+++ b/codex-rs/app-server/tests/suite/v2/account.rs
@@ -2378,6 +2378,66 @@ region = "us-west-2"
 }
 
 #[tokio::test]
+async fn account_reads_use_startup_config_when_config_reload_fails() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    create_config_toml(
+        codex_home.path(),
+        CreateConfigTomlParams {
+            model_provider_id: Some("amazon-bedrock".to_string()),
+            extra_provider_config: Some(
+                r#"[model_providers.amazon-bedrock.aws]
+profile = "codex-bedrock"
+region = "us-west-2"
+"#
+                .to_string(),
+            ),
+            ..Default::default()
+        },
+    )?;
+
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .without_auto_env()
+        .build()
+        .await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    std::fs::write(codex_home.path().join("config.toml"), "invalid = [")?;
+
+    assert_eq!(
+        read_account(&mut mcp).await?,
+        GetAccountResponse {
+            account: Some(Account::AmazonBedrock {
+                credential_source: AmazonBedrockCredentialSource::AwsManaged,
+            }),
+            requires_openai_auth: false,
+        }
+    );
+
+    let request_id = mcp
+        .send_get_auth_status_request(GetAuthStatusParams {
+            include_token: Some(false),
+            refresh_token: Some(false),
+        })
+        .await?;
+    let response = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    assert_eq!(
+        to_response::<GetAuthStatusResponse>(response)?,
+        GetAuthStatusResponse {
+            auth_method: None,
+            auth_token: None,
+            requires_openai_auth: Some(false),
+        }
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn get_account_with_managed_bedrock_provider() -> Result<()> {
     let codex_home = TempDir::new()?;
     create_config_toml(

--- a/codex-rs/app-server/tests/suite/v2/account.rs
+++ b/codex-rs/app-server/tests/suite/v2/account.rs
@@ -5,24 +5,30 @@ use app_test_support::to_response;
 
 use app_test_support::ChatGptAuthFixture;
 use app_test_support::ChatGptIdTokenClaims;
+use app_test_support::DEFAULT_CLIENT_NAME;
 use app_test_support::encode_id_token;
 use app_test_support::write_chatgpt_auth;
 use app_test_support::write_models_cache;
 use chrono::Duration as ChronoDuration;
 use chrono::Utc;
 use codex_app_server_protocol::Account;
+use codex_app_server_protocol::AccountLoginCompletedNotification;
+use codex_app_server_protocol::AccountUpdatedNotification;
 use codex_app_server_protocol::AuthMode;
 use codex_app_server_protocol::CancelLoginAccountParams;
 use codex_app_server_protocol::CancelLoginAccountResponse;
 use codex_app_server_protocol::CancelLoginAccountStatus;
 use codex_app_server_protocol::ChatgptAuthTokensRefreshReason;
 use codex_app_server_protocol::ChatgptAuthTokensRefreshResponse;
+use codex_app_server_protocol::ClientInfo;
 use codex_app_server_protocol::GetAccountParams;
 use codex_app_server_protocol::GetAccountResponse;
 use codex_app_server_protocol::GetAuthStatusParams;
 use codex_app_server_protocol::GetAuthStatusResponse;
+use codex_app_server_protocol::InitializeCapabilities;
 use codex_app_server_protocol::JSONRPCError;
 use codex_app_server_protocol::JSONRPCErrorError;
+use codex_app_server_protocol::JSONRPCMessage;
 use codex_app_server_protocol::JSONRPCNotification;
 use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::LoginAccountResponse;
@@ -33,13 +39,17 @@ use codex_app_server_protocol::ServerRequest;
 use codex_app_server_protocol::TurnCompletedNotification;
 use codex_app_server_protocol::TurnStatus;
 use codex_config::types::AuthCredentialsStoreMode;
+use codex_login::AuthDotJson;
 use codex_login::AuthKeyringBackendKind;
 use codex_login::CLIENT_ID_OVERRIDE_ENV_VAR;
 use codex_login::REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR;
+use codex_login::auth::BedrockApiKeyAuth;
+use codex_login::load_auth_dot_json;
 use codex_login::login_with_api_key;
 use codex_login::login_with_bedrock_api_key;
 use codex_protocol::account::AmazonBedrockCredentialSource;
 use codex_protocol::account::PlanType as AccountPlanType;
+use codex_protocol::auth::AuthMode as DomainAuthMode;
 use core_test_support::responses;
 use pretty_assertions::assert_eq;
 use serde_json::json;
@@ -140,6 +150,70 @@ shell_snapshot = false
 "#
     );
     std::fs::write(config_toml, contents)
+}
+
+fn read_config_toml(codex_home: &Path) -> Result<toml::Value> {
+    Ok(toml::from_str(&std::fs::read_to_string(
+        codex_home.join("config.toml"),
+    )?)?)
+}
+
+fn load_file_auth(codex_home: &Path) -> Result<Option<AuthDotJson>> {
+    Ok(load_auth_dot_json(
+        codex_home,
+        AuthCredentialsStoreMode::File,
+        AuthKeyringBackendKind::default(),
+    )?)
+}
+
+fn aws_managed_bedrock_config() -> CreateConfigTomlParams {
+    CreateConfigTomlParams {
+        model_provider_id: Some("amazon-bedrock".to_string()),
+        extra_provider_config: Some(
+            r#"[model_providers.amazon-bedrock.aws]
+profile = "codex-bedrock"
+region = "us-west-2"
+"#
+            .to_string(),
+        ),
+        ..Default::default()
+    }
+}
+
+async fn read_account(mcp: &mut TestAppServer) -> Result<GetAccountResponse> {
+    let request_id = mcp
+        .send_get_account_request(GetAccountParams {
+            refresh_token: false,
+        })
+        .await?;
+    let response = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    to_response(response)
+}
+
+async fn assert_account_updated(
+    mcp: &mut TestAppServer,
+    auth_mode: Option<AuthMode>,
+) -> Result<()> {
+    let notification = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_notification_message("account/updated"),
+    )
+    .await??;
+    let ServerNotification::AccountUpdated(payload) = notification.try_into()? else {
+        bail!("unexpected notification")
+    };
+    assert_eq!(
+        payload,
+        AccountUpdatedNotification {
+            auth_mode,
+            plan_type: None,
+        }
+    );
+    Ok(())
 }
 
 async fn mock_device_code_usercode(server: &MockServer, interval_seconds: u64) {
@@ -1008,6 +1082,368 @@ async fn login_account_api_key_succeeds_and_notifies() -> Result<()> {
     pretty_assertions::assert_eq!(payload.plan_type, None);
 
     assert!(codex_home.path().join("auth.json").exists());
+    Ok(())
+}
+
+#[tokio::test]
+async fn login_amazon_bedrock_replaces_primary_auth_and_persists_provider() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), CreateConfigTomlParams::default())?;
+    login_with_api_key(
+        codex_home.path(),
+        "sk-test-key",
+        AuthCredentialsStoreMode::File,
+        AuthKeyringBackendKind::default(),
+    )?;
+    let mut mcp =
+        TestAppServer::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)]).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+    let mut expected_config = read_config_toml(codex_home.path())?;
+    expected_config
+        .as_table_mut()
+        .expect("config should be a table")
+        .insert(
+            "model_provider".to_string(),
+            toml::Value::String("amazon-bedrock".to_string()),
+        );
+    let request_id = mcp
+        .send_login_account_amazon_bedrock_request(" managed-bedrock-api-key ", " us-west-2 ")
+        .await?;
+    let response: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    assert_eq!(
+        to_response::<LoginAccountResponse>(response)?,
+        LoginAccountResponse::AmazonBedrock {}
+    );
+
+    assert_eq!(
+        load_file_auth(codex_home.path())?,
+        Some(AuthDotJson {
+            auth_mode: Some(DomainAuthMode::BedrockApiKey),
+            openai_api_key: None,
+            tokens: None,
+            last_refresh: None,
+            agent_identity: None,
+            personal_access_token: None,
+            bedrock_api_key: Some(BedrockApiKeyAuth {
+                api_key: "managed-bedrock-api-key".to_string(),
+                region: "us-west-2".to_string(),
+            }),
+        })
+    );
+    assert_eq!(read_config_toml(codex_home.path())?, expected_config);
+
+    let notification = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_notification_message("account/login/completed"),
+    )
+    .await??;
+    let ServerNotification::AccountLoginCompleted(payload) = notification.try_into()? else {
+        bail!("unexpected notification")
+    };
+    assert_eq!(
+        payload,
+        AccountLoginCompletedNotification {
+            login_id: None,
+            success: true,
+            error: None,
+        }
+    );
+    assert_account_updated(&mut mcp, Some(AuthMode::BedrockApiKey)).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn managed_bedrock_login_requires_experimental_api() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), CreateConfigTomlParams::default())?;
+    let mut mcp = TestAppServer::new(codex_home.path()).await?;
+    let initialized = mcp
+        .initialize_with_capabilities(
+            ClientInfo {
+                name: DEFAULT_CLIENT_NAME.to_string(),
+                title: None,
+                version: "0.1.0".to_string(),
+            },
+            Some(InitializeCapabilities {
+                experimental_api: false,
+                ..Default::default()
+            }),
+        )
+        .await?;
+    assert!(matches!(initialized, JSONRPCMessage::Response(_)));
+
+    let request_id = mcp
+        .send_login_account_amazon_bedrock_request("managed-bedrock-api-key", "us-west-2")
+        .await?;
+    let error = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    assert_eq!(
+        error.error.message,
+        "account/login/start.amazonBedrock requires experimentalApi capability"
+    );
+    assert_eq!(load_file_auth(codex_home.path())?, None);
+    Ok(())
+}
+
+#[tokio::test]
+async fn login_managed_bedrock_updates_active_bedrock_account() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), aws_managed_bedrock_config())?;
+
+    let mut mcp =
+        TestAppServer::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)]).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+    let request_id = mcp
+        .send_login_account_amazon_bedrock_request("managed-bedrock-api-key", "us-west-2")
+        .await?;
+    let response: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    assert_eq!(
+        to_response::<LoginAccountResponse>(response)?,
+        LoginAccountResponse::AmazonBedrock {}
+    );
+    timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_notification_message("account/login/completed"),
+    )
+    .await??;
+    assert_account_updated(&mut mcp, Some(AuthMode::BedrockApiKey)).await?;
+    assert_eq!(
+        read_account(&mut mcp).await?,
+        GetAccountResponse {
+            account: Some(Account::AmazonBedrock {
+                credential_source: AmazonBedrockCredentialSource::CodexManaged,
+            }),
+            requires_openai_auth: false,
+        }
+    );
+
+    assert!(codex_home.path().join("auth.json").exists());
+    Ok(())
+}
+
+#[tokio::test]
+async fn login_account_amazon_bedrock_rejects_invalid_credentials_without_changes() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), CreateConfigTomlParams::default())?;
+
+    let mut mcp =
+        TestAppServer::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)]).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+    let expected_config = read_config_toml(codex_home.path())?;
+
+    let request_id = mcp
+        .send_login_account_amazon_bedrock_request("  ", "us-west-2")
+        .await?;
+    let error = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    assert_eq!(
+        error.error.message,
+        "Amazon Bedrock API key must not be empty."
+    );
+
+    let request_id = mcp
+        .send_login_account_amazon_bedrock_request("managed-bedrock-api-key", "us-west-1")
+        .await?;
+    let error = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    assert_eq!(
+        error.error.message,
+        "Amazon Bedrock Mantle does not support region `us-west-1`"
+    );
+    assert_eq!(load_file_auth(codex_home.path())?, None);
+    assert_eq!(read_config_toml(codex_home.path())?, expected_config);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn login_account_amazon_bedrock_persists_under_provider_override() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), CreateConfigTomlParams::default())?;
+
+    let mut mcp = TestAppServer::new_with_args(
+        codex_home.path(),
+        &["-c", "model_provider=\"mock_provider\""],
+    )
+    .await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+    let mut expected_config = read_config_toml(codex_home.path())?;
+    expected_config
+        .as_table_mut()
+        .expect("config should be a table")
+        .insert(
+            "model_provider".to_string(),
+            toml::Value::String("amazon-bedrock".to_string()),
+        );
+    let request_id = mcp
+        .send_login_account_amazon_bedrock_request("managed-bedrock-api-key", "us-west-2")
+        .await?;
+    let response: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    assert_eq!(
+        to_response::<LoginAccountResponse>(response)?,
+        LoginAccountResponse::AmazonBedrock {}
+    );
+    assert_eq!(
+        load_file_auth(codex_home.path())?,
+        Some(AuthDotJson {
+            auth_mode: Some(DomainAuthMode::BedrockApiKey),
+            openai_api_key: None,
+            tokens: None,
+            last_refresh: None,
+            agent_identity: None,
+            personal_access_token: None,
+            bedrock_api_key: Some(BedrockApiKeyAuth {
+                api_key: "managed-bedrock-api-key".to_string(),
+                region: "us-west-2".to_string(),
+            }),
+        })
+    );
+    assert_eq!(read_config_toml(codex_home.path())?, expected_config);
+    timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_notification_message("account/login/completed"),
+    )
+    .await??;
+    assert_account_updated(&mut mcp, Some(AuthMode::BedrockApiKey)).await?;
+    assert_eq!(
+        read_account(&mut mcp).await?,
+        GetAccountResponse {
+            account: None,
+            requires_openai_auth: false,
+        }
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn login_account_amazon_bedrock_rejected_when_forced_chatgpt() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    create_config_toml(
+        codex_home.path(),
+        CreateConfigTomlParams {
+            forced_method: Some("chatgpt".to_string()),
+            ..Default::default()
+        },
+    )?;
+
+    let mut mcp = TestAppServer::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+    let request_id = mcp
+        .send_login_account_amazon_bedrock_request("managed-bedrock-api-key", "us-west-2")
+        .await?;
+    let error = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+
+    assert_eq!(
+        error.error.message,
+        "Amazon Bedrock login is disabled. Use ChatGPT login instead."
+    );
+    assert_eq!(load_file_auth(codex_home.path())?, None);
+    Ok(())
+}
+
+#[tokio::test]
+async fn login_account_amazon_bedrock_allowed_when_forced_api() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    create_config_toml(
+        codex_home.path(),
+        CreateConfigTomlParams {
+            forced_method: Some("api".to_string()),
+            ..Default::default()
+        },
+    )?;
+
+    let mut mcp = TestAppServer::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+    let request_id = mcp
+        .send_login_account_amazon_bedrock_request("managed-bedrock-api-key", "us-west-2")
+        .await?;
+    let response = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+
+    assert_eq!(
+        to_response::<LoginAccountResponse>(response)?,
+        LoginAccountResponse::AmazonBedrock {}
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn login_account_amazon_bedrock_rejected_with_external_chatgpt_auth() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), CreateConfigTomlParams::default())?;
+    let access_token = encode_id_token(
+        &ChatGptIdTokenClaims::new()
+            .email("embedded@example.com")
+            .plan_type("pro")
+            .chatgpt_account_id(WORKSPACE_ID_EMBEDDED),
+    )?;
+
+    let mut mcp = TestAppServer::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+    let set_id = mcp
+        .send_chatgpt_auth_tokens_login_request(
+            access_token,
+            WORKSPACE_ID_EMBEDDED.to_string(),
+            Some("pro".to_string()),
+        )
+        .await?;
+    let set_response = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(set_id)),
+    )
+    .await??;
+    assert_eq!(
+        to_response::<LoginAccountResponse>(set_response)?,
+        LoginAccountResponse::ChatgptAuthTokens {}
+    );
+    timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_notification_message("account/updated"),
+    )
+    .await??;
+
+    let request_id = mcp
+        .send_login_account_amazon_bedrock_request("managed-bedrock-api-key", "us-west-2")
+        .await?;
+    let error = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    assert_eq!(
+        error.error.message,
+        "External auth is active. Use account/login/start (chatgptAuthTokens) to update it or account/logout to clear it."
+    );
+    assert_eq!(load_file_auth(codex_home.path())?, None);
     Ok(())
 }
 

--- a/codex-rs/app-server/tests/suite/v2/account.rs
+++ b/codex-rs/app-server/tests/suite/v2/account.rs
@@ -1081,8 +1081,12 @@ async fn login_amazon_bedrock_replaces_primary_auth_and_persists_provider() -> R
         AuthCredentialsStoreMode::File,
         AuthKeyringBackendKind::default(),
     )?;
-    let mut mcp =
-        TestAppServer::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)]).await?;
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .without_auto_env()
+        .with_env_overrides(&[("OPENAI_API_KEY", None)])
+        .build()
+        .await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
     let mut expected_config = read_config_toml(codex_home.path())?;
     expected_config
@@ -1147,7 +1151,11 @@ async fn login_amazon_bedrock_replaces_primary_auth_and_persists_provider() -> R
 async fn managed_bedrock_login_requires_experimental_api() -> Result<()> {
     let codex_home = TempDir::new()?;
     create_config_toml(codex_home.path(), CreateConfigTomlParams::default())?;
-    let mut mcp = TestAppServer::new(codex_home.path()).await?;
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .without_auto_env()
+        .build()
+        .await?;
     let initialized = mcp
         .initialize_with_capabilities(
             ClientInfo {
@@ -1184,8 +1192,12 @@ async fn login_managed_bedrock_updates_active_bedrock_account() -> Result<()> {
     let codex_home = TempDir::new()?;
     create_config_toml(codex_home.path(), CreateConfigTomlParams::default())?;
 
-    let mut mcp =
-        TestAppServer::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)]).await?;
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .without_auto_env()
+        .with_env_overrides(&[("OPENAI_API_KEY", None)])
+        .build()
+        .await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
     let request_id = mcp
         .send_login_account_amazon_bedrock_request("managed-bedrock-api-key", "us-west-2")
@@ -1224,8 +1236,12 @@ async fn login_account_amazon_bedrock_rejects_invalid_credentials_without_change
     let codex_home = TempDir::new()?;
     create_config_toml(codex_home.path(), CreateConfigTomlParams::default())?;
 
-    let mut mcp =
-        TestAppServer::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)]).await?;
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .without_auto_env()
+        .with_env_overrides(&[("OPENAI_API_KEY", None)])
+        .build()
+        .await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
     let expected_config = read_config_toml(codex_home.path())?;
 
@@ -1271,7 +1287,11 @@ async fn login_account_amazon_bedrock_rejected_when_forced_chatgpt() -> Result<(
         },
     )?;
 
-    let mut mcp = TestAppServer::new(codex_home.path()).await?;
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .without_auto_env()
+        .build()
+        .await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
     let request_id = mcp
         .send_login_account_amazon_bedrock_request("managed-bedrock-api-key", "us-west-2")
@@ -1301,7 +1321,11 @@ async fn login_account_amazon_bedrock_rejected_with_external_chatgpt_auth() -> R
             .chatgpt_account_id(WORKSPACE_ID_EMBEDDED),
     )?;
 
-    let mut mcp = TestAppServer::new(codex_home.path()).await?;
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .without_auto_env()
+        .build()
+        .await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
     let set_id = mcp
         .send_chatgpt_auth_tokens_login_request(

--- a/codex-rs/app-server/tests/suite/v2/account.rs
+++ b/codex-rs/app-server/tests/suite/v2/account.rs
@@ -166,20 +166,6 @@ fn load_file_auth(codex_home: &Path) -> Result<Option<AuthDotJson>> {
     )?)
 }
 
-fn aws_managed_bedrock_config() -> CreateConfigTomlParams {
-    CreateConfigTomlParams {
-        model_provider_id: Some("amazon-bedrock".to_string()),
-        extra_provider_config: Some(
-            r#"[model_providers.amazon-bedrock.aws]
-profile = "codex-bedrock"
-region = "us-west-2"
-"#
-            .to_string(),
-        ),
-        ..Default::default()
-    }
-}
-
 async fn read_account(mcp: &mut TestAppServer) -> Result<GetAccountResponse> {
     let request_id = mcp
         .send_get_account_request(GetAccountParams {
@@ -1196,7 +1182,7 @@ async fn managed_bedrock_login_requires_experimental_api() -> Result<()> {
 #[tokio::test]
 async fn login_managed_bedrock_updates_active_bedrock_account() -> Result<()> {
     let codex_home = TempDir::new()?;
-    create_config_toml(codex_home.path(), aws_managed_bedrock_config())?;
+    create_config_toml(codex_home.path(), CreateConfigTomlParams::default())?;
 
     let mut mcp =
         TestAppServer::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)]).await?;

--- a/codex-rs/app-server/tests/suite/v2/account.rs
+++ b/codex-rs/app-server/tests/suite/v2/account.rs
@@ -1148,6 +1148,126 @@ async fn login_amazon_bedrock_replaces_primary_auth_and_persists_provider() -> R
 }
 
 #[tokio::test]
+async fn login_amazon_bedrock_rejects_non_bedrock_provider_override_without_changes() -> Result<()>
+{
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), CreateConfigTomlParams::default())?;
+    login_with_api_key(
+        codex_home.path(),
+        "sk-test-key",
+        AuthCredentialsStoreMode::File,
+        AuthKeyringBackendKind::default(),
+    )?;
+    let expected_auth = load_file_auth(codex_home.path())?;
+    let expected_config = read_config_toml(codex_home.path())?;
+
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .without_auto_env()
+        .with_env_overrides(&[("OPENAI_API_KEY", None)])
+        .with_args(&["-c", "model_provider=\"mock_provider\""])
+        .build()
+        .await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let request_id = mcp
+        .send_login_account_amazon_bedrock_request("managed-bedrock-api-key", "us-west-2")
+        .await?;
+    let error = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    assert_eq!(
+        error.error.message,
+        "Amazon Bedrock login cannot select `amazon-bedrock` because session-flags sets `model_provider` to \"mock_provider\""
+    );
+    assert_eq!(load_file_auth(codex_home.path())?, expected_auth);
+    assert_eq!(read_config_toml(codex_home.path())?, expected_config);
+
+    let maybe_completed = timeout(
+        Duration::from_millis(500),
+        mcp.read_stream_until_notification_message("account/login/completed"),
+    )
+    .await;
+    assert!(
+        maybe_completed.is_err(),
+        "account/login/completed should not be emitted when the provider is overridden"
+    );
+    let maybe_updated = timeout(
+        Duration::from_millis(500),
+        mcp.read_stream_until_notification_message("account/updated"),
+    )
+    .await;
+    assert!(
+        maybe_updated.is_err(),
+        "account/updated should not be emitted when the provider is overridden"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn login_amazon_bedrock_allows_bedrock_provider_override() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), CreateConfigTomlParams::default())?;
+    let mut expected_config = read_config_toml(codex_home.path())?;
+    expected_config
+        .as_table_mut()
+        .expect("config should be a table")
+        .insert(
+            "model_provider".to_string(),
+            toml::Value::String("amazon-bedrock".to_string()),
+        );
+
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .without_auto_env()
+        .with_env_overrides(&[("OPENAI_API_KEY", None)])
+        .with_args(&["-c", "model_provider=\"amazon-bedrock\""])
+        .build()
+        .await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let request_id = mcp
+        .send_login_account_amazon_bedrock_request("managed-bedrock-api-key", "us-west-2")
+        .await?;
+    let response = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    assert_eq!(
+        to_response::<LoginAccountResponse>(response)?,
+        LoginAccountResponse::AmazonBedrock {}
+    );
+    assert_eq!(
+        load_file_auth(codex_home.path())?,
+        Some(AuthDotJson {
+            auth_mode: Some(DomainAuthMode::BedrockApiKey),
+            openai_api_key: None,
+            tokens: None,
+            last_refresh: None,
+            agent_identity: None,
+            personal_access_token: None,
+            bedrock_api_key: Some(BedrockApiKeyAuth {
+                api_key: "managed-bedrock-api-key".to_string(),
+                region: "us-west-2".to_string(),
+            }),
+        })
+    );
+    assert_eq!(read_config_toml(codex_home.path())?, expected_config);
+    timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_notification_message("account/login/completed"),
+    )
+    .await??;
+    assert_account_updated(&mut mcp, Some(AuthMode::BedrockApiKey)).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn managed_bedrock_login_requires_experimental_api() -> Result<()> {
     let codex_home = TempDir::new()?;
     create_config_toml(codex_home.path(), CreateConfigTomlParams::default())?;

--- a/codex-rs/model-provider/src/amazon_bedrock/mantle.rs
+++ b/codex-rs/model-provider/src/amazon_bedrock/mantle.rs
@@ -39,8 +39,13 @@ pub(super) fn region_from_config(aws: &ModelProviderAwsAuthInfo) -> Option<Strin
         .map(str::to_string)
 }
 
+/// Returns whether Amazon Bedrock Mantle is available in `region`.
+pub fn is_supported_amazon_bedrock_region(region: &str) -> bool {
+    BEDROCK_MANTLE_SUPPORTED_REGIONS.contains(&region)
+}
+
 pub(super) fn base_url(region: &str) -> Result<String> {
-    if BEDROCK_MANTLE_SUPPORTED_REGIONS.contains(&region) {
+    if is_supported_amazon_bedrock_region(region) {
         Ok(format!("https://bedrock-mantle.{region}.api.aws/openai/v1"))
     } else {
         Err(CodexErr::Fatal(format!(

--- a/codex-rs/model-provider/src/amazon_bedrock/mod.rs
+++ b/codex-rs/model-provider/src/amazon_bedrock/mod.rs
@@ -31,6 +31,7 @@ use crate::provider::ProviderCapabilities;
 use auth::resolve_provider_auth;
 pub(crate) use catalog::static_model_catalog;
 use catalog::with_default_only_service_tier;
+pub use mantle::is_supported_amazon_bedrock_region;
 use mantle::runtime_base_url;
 
 /// Runtime provider for Amazon Bedrock's OpenAI-compatible Mantle endpoint.

--- a/codex-rs/model-provider/src/lib.rs
+++ b/codex-rs/model-provider/src/lib.rs
@@ -4,6 +4,7 @@ mod bearer_auth_provider;
 mod models_endpoint;
 mod provider;
 
+pub use amazon_bedrock::is_supported_amazon_bedrock_region;
 pub use auth::AgentIdentitySessionFallback;
 pub use auth::ProviderAuthScope;
 pub use auth::ResolvedProviderAuth;
@@ -12,6 +13,7 @@ pub use auth::auth_provider_from_auth_manager;
 pub use auth::unauthenticated_auth_provider;
 pub use bearer_auth_provider::BearerAuthProvider;
 pub use bearer_auth_provider::BearerAuthProvider as CoreAuthProvider;
+pub use codex_model_provider_info::AMAZON_BEDROCK_PROVIDER_ID;
 pub use codex_model_provider_info::CHATGPT_CODEX_BASE_URL;
 pub use codex_protocol::account::ProviderAccount;
 pub use provider::ModelProvider;


### PR DESCRIPTION
## Why

The app-server protocol can describe a Codex-managed Amazon Bedrock login, but clients still need the server-side implementation to onboard users without manipulating `auth.json` or `config.toml` themselves.

Because a managed Bedrock API key is primary `CodexAuth` state, login should use the existing auth persistence and reload lifecycle. This keeps credential replacement, account reporting, and login notifications consistent with the other supported login methods instead of introducing a separate provider-specific credential cache.

## What changed

- Implement the experimental `amazonBedrock` branch of `account/login/start`.
- Trim and validate the API key and region, using the model provider's shared list of Bedrock Mantle regions.
- Reject login when external ChatGPT auth is active or ChatGPT login is forced, while continuing to allow the existing API-login policy.
- Cancel any pending ChatGPT login, persist the Bedrock key as primary Codex auth, and set the user-level `model_provider` to `amazon-bedrock` without overriding a command-line provider selection.
- Reload the shared `AuthManager`, and reload config for account reads so `account/read` and auth-status responses immediately reflect the selected Bedrock provider.
- Emit the standard `account/login/completed` and `account/updated` notifications.
- Add integration coverage for capability gating, validation, auth replacement, policy enforcement, provider overrides, persistence, notifications, and active Bedrock account reporting.

## Operational notes

Managed Bedrock login replaces the currently stored primary Codex login. Existing loaded sessions retain their provider selection, so clients should restart the app-server before sending further model requests. This will be fixed in a followup.

## Validation

- `just test -p codex-app-server -E 'test(/suite::v2::account/)'` — 40 passed
- Manual end-to-end test against Amazon Bedrock in `us-east-2`: ran `target/debug/codex-app-server-test-client` with `test-login --amazon-bedrock`, observed successful `account/login/start`, `account/login/completed`, and `account/updated` responses, confirmed `config.toml` selected `amazon-bedrock`, confirmed `auth.json` persisted only the managed Bedrock API-key auth and region with no OpenAI API key, and successfully completed a model request through a fresh `target/debug/codex` process. real events log:
```
> {
>   "id": "0a464d89-409f-49ab-9a4d-6979ebb26bc2",
>   "method": "account/login/start",
>   "params": {
>     "apiKey": "<redacted>",
>     "region": "us-east-2",
>     "type": "amazonBedrock"
>   },
>   "trace": {
>     "traceparent": "00-00b281562d823eca87c80aa12d40a3c0-b801b56390c177e9-01",
>     "tracestate": "dd=s:2;t.oai_ft:1"
>   }
> }
< {
<   "method": "remoteControl/status/changed",
<   "params": {
<     "environmentId": null,
<     "installationId": "55297f82-9485-4db0-8792-f903c50ab831",
<     "serverName": "com-92114",
<     "status": "disabled"
<   }
< }
< {
<   "id": "0a464d89-409f-49ab-9a4d-6979ebb26bc2",
<   "result": {
<     "type": "amazonBedrock"
<   }
< }
< account/login/start response: AmazonBedrock
< {
<   "method": "account/login/completed",
<   "params": {
<     "error": null,
<     "loginId": null,
<     "success": true
<   }
< }
< account/login/completed notification: AccountLoginCompletedNotification { login_id: None, success: true, error: None }
< {
<   "method": "account/updated",
<   "params": {
<     "authMode": "bedrockApiKey",
<     "planType": null
<   }
< }
```

## Stack

1. #31327 — managed Bedrock experimental API (base: `main`)
2. **#31326 — managed Bedrock login** (base: `codex/managed-bedrock-api`)
3. #31325 — managed Bedrock logout (base: `codex/managed-bedrock-login-v2`)
