### PR TITLE
ci: parameterize Cargo target paths

### DIFF
--- a/.github/actions/setup-ci/action.yml
+++ b/.github/actions/setup-ci/action.yml
@@ -8,7 +8,7 @@ runs:
     # shared build-path contract.
     - name: Configure Cargo target directory
       shell: bash
-      run: echo "CARGO_TARGET_DIR=$GITHUB_WORKSPACE/codex-rs/target" >> "$GITHUB_ENV"
+      run: echo "CARGO_TARGET_DIR=${CARGO_TARGET_DIR:-$GITHUB_WORKSPACE/codex-rs/target}" >> "$GITHUB_ENV"
 
     - name: Prefer the Git CLI for Cargo git dependencies
       shell: bash

--- a/.github/actions/setup-ci/action.yml
+++ b/.github/actions/setup-ci/action.yml
@@ -4,6 +4,12 @@ description: Prepare common tools and environment shared by CI jobs.
 runs:
   using: composite
   steps:
+    # TODO(anp): Move this under CI_BUILD_ROOT once all consumers use the
+    # shared build-path contract.
+    - name: Configure Cargo target directory
+      shell: bash
+      run: echo "CARGO_TARGET_DIR=$GITHUB_WORKSPACE/codex-rs/target" >> "$GITHUB_ENV"
+
     - name: Prefer the Git CLI for Cargo git dependencies
       shell: bash
       run: echo "CARGO_NET_GIT_FETCH_WITH_CLI=true" >> "$GITHUB_ENV"

--- a/.github/actions/windows-code-sign/action.yml
+++ b/.github/actions/windows-code-sign/action.yml
@@ -48,7 +48,7 @@ runs:
         {
           echo "files<<EOF"
           for binary in ${BINARIES}; do
-            echo "${GITHUB_WORKSPACE}/codex-rs/target/${TARGET}/release/${binary}.exe"
+            echo "${CARGO_TARGET_DIR}/${TARGET}/release/${binary}.exe"
           done
           echo "EOF"
         } >> "$GITHUB_OUTPUT"

--- a/.github/scripts/rusty_v8_bazel.py
+++ b/.github/scripts/rusty_v8_bazel.py
@@ -258,11 +258,16 @@ def stage_artifacts(
     print(staged_checksums)
 
 
-def upstream_release_pair_paths(source_root: Path, target: str) -> tuple[Path, Path]:
+def upstream_release_pair_paths(
+    source_root: Path,
+    target: str,
+    target_dir: Path | None = None,
+) -> tuple[Path, Path]:
     lib_name = (
         "rusty_v8.lib" if target.endswith("-pc-windows-msvc") else "librusty_v8.a"
     )
-    gn_out = source_root / "target" / target / "release" / "gn_out"
+    target_dir = source_root / "target" if target_dir is None else target_dir
+    gn_out = target_dir / target / "release" / "gn_out"
     return gn_out / "obj" / lib_name, gn_out / "src_binding.rs"
 
 
@@ -270,9 +275,14 @@ def stage_upstream_release_pair(
     source_root: Path,
     target: str,
     output_dir: Path,
+    target_dir: Path | None = None,
     sandbox: bool = False,
 ) -> None:
-    lib_path, binding_path = upstream_release_pair_paths(source_root, target)
+    lib_path, binding_path = upstream_release_pair_paths(
+        source_root,
+        target,
+        target_dir,
+    )
     stage_artifacts(target, lib_path, binding_path, output_dir, sandbox)
 
 
@@ -332,6 +342,7 @@ def parse_args() -> argparse.Namespace:
     stage_upstream_release_pair_parser.add_argument(
         "--source-root", type=Path, required=True
     )
+    stage_upstream_release_pair_parser.add_argument("--target-dir", type=Path)
     stage_upstream_release_pair_parser.add_argument("--target", required=True)
     stage_upstream_release_pair_parser.add_argument("--output-dir", required=True)
     stage_upstream_release_pair_parser.add_argument("--sandbox", action="store_true")
@@ -376,6 +387,7 @@ def main() -> int:
             source_root=args.source_root,
             target=args.target,
             output_dir=Path(args.output_dir),
+            target_dir=args.target_dir,
             sandbox=args.sandbox,
         )
         return 0

--- a/.github/scripts/rusty_v8_bazel.py
+++ b/.github/scripts/rusty_v8_bazel.py
@@ -259,27 +259,23 @@ def stage_artifacts(
 
 
 def upstream_release_pair_paths(
-    source_root: Path,
     target: str,
-    target_dir: Path | None = None,
+    target_dir: Path,
 ) -> tuple[Path, Path]:
     lib_name = (
         "rusty_v8.lib" if target.endswith("-pc-windows-msvc") else "librusty_v8.a"
     )
-    target_dir = source_root / "target" if target_dir is None else target_dir
     gn_out = target_dir / target / "release" / "gn_out"
     return gn_out / "obj" / lib_name, gn_out / "src_binding.rs"
 
 
 def stage_upstream_release_pair(
-    source_root: Path,
     target: str,
     output_dir: Path,
-    target_dir: Path | None = None,
+    target_dir: Path,
     sandbox: bool = False,
 ) -> None:
     lib_path, binding_path = upstream_release_pair_paths(
-        source_root,
         target,
         target_dir,
     )
@@ -340,9 +336,8 @@ def parse_args() -> argparse.Namespace:
         "stage-upstream-release-pair"
     )
     stage_upstream_release_pair_parser.add_argument(
-        "--source-root", type=Path, required=True
+        "--target-dir", type=Path, required=True
     )
-    stage_upstream_release_pair_parser.add_argument("--target-dir", type=Path)
     stage_upstream_release_pair_parser.add_argument("--target", required=True)
     stage_upstream_release_pair_parser.add_argument("--output-dir", required=True)
     stage_upstream_release_pair_parser.add_argument("--sandbox", action="store_true")
@@ -384,7 +379,6 @@ def main() -> int:
         return 0
     if args.command == "stage-upstream-release-pair":
         stage_upstream_release_pair(
-            source_root=args.source_root,
             target=args.target,
             output_dir=Path(args.output_dir),
             target_dir=args.target_dir,

--- a/.github/scripts/test_rusty_v8_bazel.py
+++ b/.github/scripts/test_rusty_v8_bazel.py
@@ -205,8 +205,8 @@ class RustyV8BazelTest(unittest.TestCase):
                 ),
             ),
             rusty_v8_bazel.upstream_release_pair_paths(
-                Path("/tmp/rusty_v8"),
                 "x86_64-apple-darwin",
+                Path("/tmp/rusty_v8/target"),
             ),
         )
         self.assertEqual(
@@ -221,18 +221,16 @@ class RustyV8BazelTest(unittest.TestCase):
                 ),
             ),
             rusty_v8_bazel.upstream_release_pair_paths(
-                Path("/tmp/rusty_v8"),
                 "x86_64-pc-windows-msvc",
+                Path("/tmp/rusty_v8/target"),
             ),
         )
 
     def test_stage_upstream_release_pair(self) -> None:
         with (
-            TemporaryDirectory() as source_dir,
             TemporaryDirectory() as target_dir,
             TemporaryDirectory() as output_dir,
         ):
-            source_root = Path(source_dir)
             gn_out = (
                 Path(target_dir)
                 / "x86_64-pc-windows-msvc"
@@ -244,7 +242,6 @@ class RustyV8BazelTest(unittest.TestCase):
             (gn_out / "src_binding.rs").write_text("binding")
 
             rusty_v8_bazel.stage_upstream_release_pair(
-                source_root,
                 "x86_64-pc-windows-msvc",
                 Path(output_dir),
                 Path(target_dir),

--- a/.github/scripts/test_rusty_v8_bazel.py
+++ b/.github/scripts/test_rusty_v8_bazel.py
@@ -227,10 +227,17 @@ class RustyV8BazelTest(unittest.TestCase):
         )
 
     def test_stage_upstream_release_pair(self) -> None:
-        with TemporaryDirectory() as source_dir, TemporaryDirectory() as output_dir:
+        with (
+            TemporaryDirectory() as source_dir,
+            TemporaryDirectory() as target_dir,
+            TemporaryDirectory() as output_dir,
+        ):
             source_root = Path(source_dir)
             gn_out = (
-                source_root / "target" / "x86_64-pc-windows-msvc" / "release" / "gn_out"
+                Path(target_dir)
+                / "x86_64-pc-windows-msvc"
+                / "release"
+                / "gn_out"
             )
             (gn_out / "obj").mkdir(parents=True)
             (gn_out / "obj" / "rusty_v8.lib").write_bytes(b"archive")
@@ -240,6 +247,7 @@ class RustyV8BazelTest(unittest.TestCase):
                 source_root,
                 "x86_64-pc-windows-msvc",
                 Path(output_dir),
+                Path(target_dir),
                 sandbox=True,
             )
 

--- a/.github/workflows/rust-ci-full-nextest-platform.yml
+++ b/.github/workflows/rust-ci-full-nextest-platform.yml
@@ -57,7 +57,6 @@ jobs:
       run:
         working-directory: codex-rs
     env:
-      CARGO_TARGET_DIR: ${{ github.workspace }}/codex-rs/target
       # Windows ARM64 archives are built on Windows x64, while their shards run
       # on native Windows ARM64. Key producer-side caches by the archive runner
       # so the cross-compile build reuses the Windows x64 cache lineage.
@@ -290,7 +289,6 @@ jobs:
       run:
         working-directory: codex-rs
     env:
-      CARGO_TARGET_DIR: ${{ github.workspace }}/codex-rs/target
       NEXTEST_ARCHIVE_FILE: nextest-${{ inputs.artifact_id }}.tar.zst
       TEST_HELPERS_ARTIFACT: nextest-test-helpers-${{ inputs.artifact_id }}
     strategy:

--- a/.github/workflows/rust-ci-full-nextest-platform.yml
+++ b/.github/workflows/rust-ci-full-nextest-platform.yml
@@ -57,6 +57,7 @@ jobs:
       run:
         working-directory: codex-rs
     env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/codex-rs/target
       # Windows ARM64 archives are built on Windows x64, while their shards run
       # on native Windows ARM64. Key producer-side caches by the archive runner
       # so the cross-compile build reuses the Windows x64 cache lineage.
@@ -206,7 +207,7 @@ jobs:
               --profile ${{ inputs.profile }} \
               -p codex-linux-sandbox \
               --bin codex-linux-sandbox
-            cp "target/${{ inputs.target }}/${{ inputs.profile }}/codex-linux-sandbox" "${helper_dir}/"
+            cp "${CARGO_TARGET_DIR}/${{ inputs.target }}/${{ inputs.profile }}/codex-linux-sandbox" "${helper_dir}/"
           else
             cargo build \
               --target ${{ inputs.target }} \
@@ -214,8 +215,8 @@ jobs:
               -p codex-windows-sandbox \
               --bin codex-windows-sandbox-setup \
               --bin codex-command-runner
-            cp "target/${{ inputs.target }}/${{ inputs.profile }}/codex-windows-sandbox-setup.exe" "${helper_dir}/"
-            cp "target/${{ inputs.target }}/${{ inputs.profile }}/codex-command-runner.exe" "${helper_dir}/"
+            cp "${CARGO_TARGET_DIR}/${{ inputs.target }}/${{ inputs.profile }}/codex-windows-sandbox-setup.exe" "${helper_dir}/"
+            cp "${CARGO_TARGET_DIR}/${{ inputs.target }}/${{ inputs.profile }}/codex-command-runner.exe" "${helper_dir}/"
           fi
 
       - name: Upload Cargo timings (nextest)
@@ -223,7 +224,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: cargo-timings-rust-ci-nextest-${{ inputs.target }}-${{ inputs.profile }}
-          path: codex-rs/target/**/cargo-timings/cargo-timing.html
+          path: ${{ env.CARGO_TARGET_DIR }}/**/cargo-timings/cargo-timing.html
           if-no-files-found: warn
 
       - name: Upload nextest archive
@@ -289,6 +290,7 @@ jobs:
       run:
         working-directory: codex-rs
     env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/codex-rs/target
       NEXTEST_ARCHIVE_FILE: nextest-${{ inputs.artifact_id }}.tar.zst
       TEST_HELPERS_ARTIFACT: nextest-test-helpers-${{ inputs.artifact_id }}
     strategy:
@@ -369,13 +371,13 @@ jobs:
 
           if [[ "${RUNNER_OS}" == "Linux" ]]; then
             helper_dir="${RUNNER_TEMP}/${TEST_HELPERS_ARTIFACT}"
-            helper_target_dir="$(pwd)/target/${{ inputs.target }}/${{ inputs.profile }}"
+            helper_target_dir="${CARGO_TARGET_DIR}/${{ inputs.target }}/${{ inputs.profile }}"
             mkdir -p "${helper_target_dir}"
             cp "${helper_dir}/codex-linux-sandbox" "${helper_target_dir}/"
             chmod +x "${helper_target_dir}/codex-linux-sandbox"
           elif [[ "${RUNNER_OS}" == "Windows" ]]; then
             helper_dir="${RUNNER_TEMP}/${TEST_HELPERS_ARTIFACT}"
-            helper_target_dir="$(pwd)/target/${{ inputs.target }}/${{ inputs.profile }}"
+            helper_target_dir="${CARGO_TARGET_DIR}/${{ inputs.target }}/${{ inputs.profile }}"
             mkdir -p "${helper_target_dir}"
             cp "${helper_dir}/codex-windows-sandbox-setup.exe" "${helper_target_dir}/"
             cp "${helper_dir}/codex-command-runner.exe" "${helper_target_dir}/"
@@ -423,7 +425,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: nextest-junit-rust-ci-${{ inputs.artifact_id }}-shard-${{ matrix.shard }}
-          path: codex-rs/target/nextest/default/junit.xml
+          path: ${{ env.CARGO_TARGET_DIR }}/nextest/default/junit.xml
           if-no-files-found: warn
 
       - name: Tear down remote test env

--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -158,7 +158,6 @@ jobs:
       run:
         working-directory: codex-rs
     env:
-      CARGO_TARGET_DIR: ${{ github.workspace }}/codex-rs/target
       # Speed up repeated builds across CI runs by caching compiled objects, except on
       # arm64 macOS runners cross-targeting x86_64 where ring/cc-rs can produce
       # mixed-architecture archives under sccache.

--- a/.github/workflows/rust-ci-full.yml
+++ b/.github/workflows/rust-ci-full.yml
@@ -158,6 +158,7 @@ jobs:
       run:
         working-directory: codex-rs
     env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/codex-rs/target
       # Speed up repeated builds across CI runs by caching compiled objects, except on
       # arm64 macOS runners cross-targeting x86_64 where ring/cc-rs can produce
       # mixed-architecture archives under sccache.
@@ -403,7 +404,7 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: cargo-timings-rust-ci-clippy-${{ matrix.target }}-${{ matrix.profile }}
-          path: codex-rs/target/**/cargo-timings/cargo-timing.html
+          path: ${{ env.CARGO_TARGET_DIR }}/**/cargo-timings/cargo-timing.html
           if-no-files-found: warn
 
       # Save caches explicitly; make non-fatal so cache packaging

--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -4,6 +4,7 @@ on:
   workflow_call:
 
 env:
+  CARGO_TARGET_DIR: ${{ github.workspace }}/codex-rs/target
   WINDOWS_BINARIES: "codex codex-code-mode-host codex-responses-api-proxy codex-windows-sandbox-setup codex-command-runner codex-app-server"
 
 jobs:
@@ -110,13 +111,13 @@ jobs:
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: cargo-timings-rust-release-windows-${{ matrix.target }}-${{ matrix.bundle }}
-          path: codex-rs/target/**/cargo-timings/cargo-timing.html
+          path: ${{ env.CARGO_TARGET_DIR }}/**/cargo-timings/cargo-timing.html
           if-no-files-found: warn
 
       - name: Stage Windows binaries
         shell: bash
         run: |
-          release_dir="target/${{ matrix.target }}/release"
+          release_dir="$CARGO_TARGET_DIR/${{ matrix.target }}/release"
           output_dir="$release_dir/staged-${{ matrix.bundle }}"
           mkdir -p "$output_dir"
           for binary in ${{ matrix.binaries }}; do
@@ -139,7 +140,7 @@ jobs:
         with:
           name: windows-binaries-${{ matrix.target }}-${{ matrix.bundle }}
           path: |
-            codex-rs/target/${{ matrix.target }}/release/staged-${{ matrix.bundle }}/*
+            ${{ env.CARGO_TARGET_DIR }}/${{ matrix.target }}/release/staged-${{ matrix.bundle }}/*
 
   build-windows-symbols:
     needs:
@@ -168,14 +169,14 @@ jobs:
         with:
           pattern: windows-binaries-${{ matrix.target }}-*
           merge-multiple: true
-          path: codex-rs/target/${{ matrix.target }}/release
+          path: ${{ env.CARGO_TARGET_DIR }}/${{ matrix.target }}/release
       - name: Build symbols archive
         shell: bash
         run: |
           bash "${GITHUB_WORKSPACE}/.github/scripts/archive-release-symbols-and-strip-binaries.sh" \
             --target "${{ matrix.target }}" \
             --artifact-name "${{ matrix.target }}" \
-            --release-dir "target/${{ matrix.target }}/release" \
+            --release-dir "${CARGO_TARGET_DIR}/${{ matrix.target }}/release" \
             --archive-dir "symbols-dist/${{ matrix.target }}" \
             --binaries "${WINDOWS_BINARIES}"
       - name: Upload symbols archive
@@ -226,26 +227,26 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: windows-binaries-${{ matrix.target }}-primary
-          path: codex-rs/target/${{ matrix.target }}/release
+          path: ${{ env.CARGO_TARGET_DIR }}/${{ matrix.target }}/release
 
       - name: Download prebuilt Windows helper binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: windows-binaries-${{ matrix.target }}-helpers
-          path: codex-rs/target/${{ matrix.target }}/release
+          path: ${{ env.CARGO_TARGET_DIR }}/${{ matrix.target }}/release
 
       - name: Download prebuilt Windows app-server binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: windows-binaries-${{ matrix.target }}-app-server
-          path: codex-rs/target/${{ matrix.target }}/release
+          path: ${{ env.CARGO_TARGET_DIR }}/${{ matrix.target }}/release
 
       - name: Verify binaries
         shell: bash
         run: |
           set -euo pipefail
           for binary in ${WINDOWS_BINARIES}; do
-            ls -lh "target/${{ matrix.target }}/release/${binary}.exe"
+            ls -lh "$CARGO_TARGET_DIR/${{ matrix.target }}/release/${binary}.exe"
           done
 
       - name: Sign Windows binaries with Azure Trusted Signing
@@ -267,7 +268,7 @@ jobs:
           mkdir -p "$dest"
 
           for binary in ${WINDOWS_BINARIES}; do
-            cp "target/${{ matrix.target }}/release/${binary}.exe" \
+            cp "$CARGO_TARGET_DIR/${{ matrix.target }}/release/${binary}.exe" \
               "$dest/${binary}-${{ matrix.target }}.exe"
           done
 
@@ -291,7 +292,7 @@ jobs:
               bash "$archive_script" \
                 --target "$target" \
                 --bundle "{}" \
-                --entrypoint-dir "target/$target/release" \
+                --entrypoint-dir "$CARGO_TARGET_DIR/$target/release" \
                 --archive-dir "dist/$target"
 
       - name: Build Python runtime wheel

--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -4,7 +4,6 @@ on:
   workflow_call:
 
 env:
-  CARGO_TARGET_DIR: ${{ github.workspace }}/codex-rs/target
   WINDOWS_BINARIES: "codex codex-code-mode-host codex-responses-api-proxy codex-windows-sandbox-setup codex-command-runner codex-app-server"
 
 jobs:

--- a/.github/workflows/rusty-v8-release.yml
+++ b/.github/workflows/rusty-v8-release.yml
@@ -392,7 +392,7 @@ jobs:
         run: |
           set -euo pipefail
           python3 .github/scripts/rusty_v8_bazel.py stage-upstream-release-pair \
-            --source-root upstream-rusty-v8 \
+            --target-dir upstream-rusty-v8/target \
             --target "${TARGET}" \
             --output-dir "dist/${TARGET}" \
             --sandbox

--- a/.github/workflows/v8-canary.yml
+++ b/.github/workflows/v8-canary.yml
@@ -308,6 +308,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/upstream-rusty-v8/target
     strategy:
       fail-fast: false
       matrix:
@@ -364,8 +366,8 @@ jobs:
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
         with:
           path: |
-            upstream-rusty-v8/target/sccache
-            upstream-rusty-v8/target/${{ matrix.target }}/release/gn_out
+            ${{ env.CARGO_TARGET_DIR }}/sccache
+            ${{ env.CARGO_TARGET_DIR }}/${{ matrix.target }}/release/gn_out
           key: rusty-v8-source-${{ matrix.target }}-sandbox-${{ hashFiles('upstream-rusty-v8/Cargo.lock', 'upstream-rusty-v8/build.rs', 'upstream-rusty-v8/git_submodule_status.txt') }}
           restore-keys: |
             rusty-v8-source-${{ matrix.target }}-sandbox-
@@ -374,7 +376,7 @@ jobs:
         shell: pwsh
         env:
           SCCACHE_CACHE_SIZE: 256M
-          SCCACHE_DIR: ${{ github.workspace }}/upstream-rusty-v8/target/sccache
+          SCCACHE_DIR: ${{ env.CARGO_TARGET_DIR }}/sccache
           SCCACHE_IDLE_TIMEOUT: 0
         run: |
           $version = "v0.8.2"
@@ -395,7 +397,6 @@ jobs:
 
       - name: Build upstream rusty_v8 sandbox release pair
         env:
-          CARGO_TARGET_DIR: ${{ github.workspace }}/upstream-rusty-v8/target
           SCCACHE_IDLE_TIMEOUT: 0
           TARGET: ${{ matrix.target }}
           V8_FROM_SOURCE: "1"
@@ -410,7 +411,7 @@ jobs:
         run: |
           set -euo pipefail
           python3 .github/scripts/rusty_v8_bazel.py stage-upstream-release-pair \
-            --target-dir upstream-rusty-v8/target \
+            --target-dir "${CARGO_TARGET_DIR}" \
             --target "${TARGET}" \
             --output-dir "dist/${TARGET}" \
             --sandbox

--- a/.github/workflows/v8-canary.yml
+++ b/.github/workflows/v8-canary.yml
@@ -395,6 +395,7 @@ jobs:
 
       - name: Build upstream rusty_v8 sandbox release pair
         env:
+          CARGO_TARGET_DIR: ${{ github.workspace }}/upstream-rusty-v8/target
           SCCACHE_IDLE_TIMEOUT: 0
           TARGET: ${{ matrix.target }}
           V8_FROM_SOURCE: "1"
@@ -409,7 +410,7 @@ jobs:
         run: |
           set -euo pipefail
           python3 .github/scripts/rusty_v8_bazel.py stage-upstream-release-pair \
-            --source-root upstream-rusty-v8 \
+            --target-dir upstream-rusty-v8/target \
             --target "${TARGET}" \
             --output-dir "dist/${TARGET}" \
             --sandbox


### PR DESCRIPTION
## Why

Prepare CI jobs for a later build-output relocation without changing where they write today.

## What

- Export `CARGO_TARGET_DIR` from `setup-ci` at the existing `codex-rs/target` path.
- Route nextest, release, artifact, and signing paths through `CARGO_TARGET_DIR`.
- Require V8 staging callers to pass an explicit target directory while preserving the existing upstream path.

## Manual validation

- Ran `just test-github-scripts`.
- Parsed GitHub Actions YAML with `yq`.

## Stack

- [#31332](https://github.com/openai/codex/pull/31332) — parameterize Cargo target paths
- [#31356](https://github.com/openai/codex/pull/31356) — Windows 2025 runner bump
- [#31357](https://github.com/openai/codex/pull/31357) — Dev Drive I/O routing
