### PR TITLE
fix: restore Codex environment setup table

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -2,6 +2,10 @@
 version = 1
 name = "codex"
 
+# TODO(anp) make it optional to specify this field
+[setup]
+script = ""
+
 [[actions]]
 name = "Run"
 icon = "run"


### PR DESCRIPTION
## Why

Creating a Codex worktree skips local environment setup because `.codex/environments/environment.toml` omits the required `setup` object.

## What

Restore an empty `[setup]` table with `script = ""`, preserving the intended no-op setup while satisfying the environment parser schema.

## Validation

- Parsed the final TOML and verified `setup.script` is present as a string.
