### PR TITLE
exec-server: use virtual time in Noise relay test

### DIFF
--- a/codex-rs/exec-server/Cargo.toml
+++ b/codex-rs/exec-server/Cargo.toml
@@ -74,6 +74,7 @@ rustls = { workspace = true }
 serial_test = { workspace = true }
 tempfile = { workspace = true }
 test-case = "3.3.1"
+tokio = { workspace = true, features = ["test-util"] }
 tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }
 wiremock = { workspace = true }

--- a/codex-rs/exec-server/src/noise_relay/harness_tests.rs
+++ b/codex-rs/exec-server/src/noise_relay/harness_tests.rs
@@ -31,7 +31,7 @@ use crate::noise_channel::PendingResponderHandshake;
 const ENVIRONMENT_ID: &str = "environment-1";
 const EXECUTOR_REGISTRATION_ID: &str = "registration-1";
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn fragmented_writes_yield_to_keepalive_and_queued_pong() -> Result<()> {
     let (connection, mut control, mut outbound_rx) = connected_controlled_harness().await?;
 
@@ -48,7 +48,7 @@ async fn fragmented_writes_yield_to_keepalive_and_queued_pong() -> Result<()> {
         .await?;
 
     control.wait_for_blocked_write(/*expected*/ 1).await?;
-    tokio::time::sleep(WEBSOCKET_KEEPALIVE_INTERVAL + Duration::from_millis(10)).await;
+    tokio::time::advance(WEBSOCKET_KEEPALIVE_INTERVAL + Duration::from_millis(10)).await;
     control.grant_writes(/*count*/ 1);
     let first_data = read_outbound_data(&mut outbound_rx).await?;
     assert_eq!(first_data.seq, 0);
@@ -64,7 +64,7 @@ async fn fragmented_writes_yield_to_keepalive_and_queued_pong() -> Result<()> {
 
     control.wait_for_blocked_write(/*expected*/ 3).await?;
     control.send_inbound(Message::Pong(ping_payload))?;
-    tokio::time::sleep(WEBSOCKET_KEEPALIVE_INTERVAL + Duration::from_millis(10)).await;
+    tokio::time::advance(WEBSOCKET_KEEPALIVE_INTERVAL + Duration::from_millis(10)).await;
     control.grant_writes(/*count*/ 1);
     let second_data = read_outbound_data(&mut outbound_rx).await?;
     assert_eq!(second_data.seq, 1);


### PR DESCRIPTION
## Why

`fragmented_writes_yield_to_keepalive_and_queued_pong` deliberately blocks WebSocket writes while exercising keepalive and queued-Pong scheduling. It previously advanced those states with wall-clock sleeps. Under a sufficiently delayed CI worker, those sleeps and scheduling gaps could consume the test-only 100 ms Pong-watchdog budget, causing the relay to exit and the next write-permit send to fail with `TrySendError::Disconnected`.

The failure was therefore a timing flake in the harness test, not evidence that the production relay mishandled a Pong.

## What changed

- Run this test with Tokio time paused.
- Advance the virtual clock through its two keepalive transitions instead of sleeping in wall-clock time.
- Enable Tokio's `test-util` feature only for `codex-exec-server` dev dependencies.

No production code or timeout values change.

## Review guide

The behavioral change is confined to `noise_relay/harness_tests.rs`; the `Cargo.toml` change only exposes Tokio's paused-clock test APIs.

## Validation

- `just test -p codex-exec-server fragmented_writes_yield_to_keepalive_and_queued_pong`
- `just fix -p codex-exec-server`
- `just bazel-lock-update` (no lockfile changes)
