### PR TITLE
ci: run V8 source builds on Windows 2025

### DIFF
--- a/.github/workflows/v8-canary.yml
+++ b/.github/workflows/v8-canary.yml
@@ -314,9 +314,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: windows-2022
+          - runner: windows-2025
             target: x86_64-pc-windows-msvc
-          - runner: windows-2022
+          - runner: windows-2025
             target: aarch64-pc-windows-msvc
 
     steps:

--- a/.github/workflows/v8-canary.yml
+++ b/.github/workflows/v8-canary.yml
@@ -368,9 +368,9 @@ jobs:
           path: |
             ${{ env.CARGO_TARGET_DIR }}/sccache
             ${{ env.CARGO_TARGET_DIR }}/${{ matrix.target }}/release/gn_out
-          key: rusty-v8-source-${{ matrix.target }}-sandbox-${{ hashFiles('upstream-rusty-v8/Cargo.lock', 'upstream-rusty-v8/build.rs', 'upstream-rusty-v8/git_submodule_status.txt') }}
+          key: rusty-v8-source-${{ matrix.target }}-${{ matrix.runner }}-sandbox-${{ hashFiles('upstream-rusty-v8/Cargo.lock', 'upstream-rusty-v8/build.rs', 'upstream-rusty-v8/git_submodule_status.txt') }}
           restore-keys: |
-            rusty-v8-source-${{ matrix.target }}-sandbox-
+            rusty-v8-source-${{ matrix.target }}-${{ matrix.runner }}-sandbox-
 
       - name: Install and start sccache
         shell: pwsh


### PR DESCRIPTION
## Why

The V8 Windows source jobs need a runner image that can support the later Dev Drive setup.

## What

Move the two V8 Windows source-build matrix entries from `windows-2022` to `windows-2025`.
Namespace the canary source-build cache by runner image so it cannot restore Windows 2022 native outputs.

## Manual validation

- Ran `just fmt`.
- Ran `just test-github-scripts` (33 tests).
- Parsed GitHub Actions YAML with `yq`.
- Ran `git diff --check`.

## Stack

- [#31332](https://github.com/openai/codex/pull/31332) — parameterize Cargo target paths
- [#31356](https://github.com/openai/codex/pull/31356) — Windows 2025 runner bump
- [#31357](https://github.com/openai/codex/pull/31357) — Dev Drive I/O routing