### PR TITLE
core: move model state to step context

### DIFF
--- a/codex-rs/core/src/agent/control/residency_tests.rs
+++ b/codex-rs/core/src/agent/control/residency_tests.rs
@@ -156,9 +156,9 @@ async fn mark_thread_completed(thread: &CodexThread) {
         .codex
         .session
         .send_event(
-            turn.as_ref(),
+            turn.turn.as_ref(),
             EventMsg::TurnComplete(TurnCompleteEvent {
-                turn_id: turn.sub_id.clone(),
+                turn_id: turn.turn.sub_id.clone(),
                 last_agent_message: Some("done".to_string()),
                 completed_at: None,
                 duration_ms: None,
@@ -175,9 +175,9 @@ async fn mark_thread_interrupted(thread: &CodexThread) {
         .codex
         .session
         .send_event(
-            turn.as_ref(),
+            turn.turn.as_ref(),
             EventMsg::TurnAborted(TurnAbortedEvent {
-                turn_id: Some(turn.sub_id.clone()),
+                turn_id: Some(turn.turn.sub_id.clone()),
                 reason: TurnAbortReason::Interrupted,
                 completed_at: None,
                 duration_ms: None,

--- a/codex-rs/core/src/agent/control_tests.rs
+++ b/codex-rs/core/src/agent/control_tests.rs
@@ -11,6 +11,8 @@ use crate::config::ConfigBuilder;
 use crate::context::ContextualUserFragment;
 use crate::context::SubagentNotification;
 use crate::init_state_db;
+use crate::session::step_context::StepContext;
+use crate::session::step_context::StepContextSeed;
 use crate::thread_manager::StartThreadOptions;
 use assert_matches::assert_matches;
 use codex_extension_api::ExtensionDataInit;
@@ -84,6 +86,10 @@ fn assistant_message(text: &str, phase: Option<MessagePhase>) -> ResponseItem {
         phase,
         internal_chat_message_metadata_passthrough: None,
     }
+}
+
+fn step_context_for_seed(seed: &StepContextSeed) -> Arc<StepContext> {
+    StepContext::for_test_with_model(Arc::clone(&seed.turn), Arc::clone(&seed.model))
 }
 
 #[test]
@@ -948,7 +954,7 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
         .codex
         .session
         .record_conversation_items(
-            turn_context.as_ref(),
+            step_context_for_seed(&turn_context).as_ref(),
             &[
                 ResponseItem::Message {
                     id: None,
@@ -983,7 +989,7 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
             ],
         )
         .await;
-    let parent_reference_context_item = turn_context.to_turn_context_item();
+    let parent_reference_context_item = step_context_for_seed(&turn_context).to_turn_context_item();
     parent_thread
         .codex
         .session
@@ -1033,7 +1039,7 @@ async fn spawn_agent_can_fork_parent_thread_history_with_sanitized_items() {
     let history = child_thread.codex.session.clone_history().await;
     let mut expected_final_answer =
         assistant_message("parent final answer", Some(MessagePhase::FinalAnswer));
-    expected_final_answer.set_turn_id_if_missing(&turn_context.sub_id);
+    expected_final_answer.set_turn_id_if_missing(&turn_context.turn.sub_id);
     let expected_history = [
         expected_parent_seed,
         expected_final_answer,
@@ -1187,7 +1193,7 @@ async fn spawn_agent_fork_strips_parent_usage_hints_from_compacted_history() {
                 previous_window_id: None,
                 window_id: None,
             }),
-            RolloutItem::TurnContext(turn_context.to_turn_context_item()),
+            RolloutItem::TurnContext(step_context_for_seed(&turn_context).to_turn_context_item()),
             RolloutItem::ResponseItem(spawn_agent_call(&parent_spawn_call_id)),
         ])
         .await;
@@ -1265,7 +1271,7 @@ async fn spawn_agent_fork_flushes_parent_rollout_before_loading_history() {
         .codex
         .session
         .record_conversation_items(
-            turn_context.as_ref(),
+            step_context_for_seed(&turn_context).as_ref(),
             &[
                 assistant_message("unflushed final answer", Some(MessagePhase::FinalAnswer)),
                 spawn_agent_call(&parent_spawn_call_id),
@@ -1337,7 +1343,7 @@ async fn spawn_agent_fork_last_n_turns_keeps_only_recent_turns() {
         .codex
         .session
         .record_conversation_items(
-            queued_turn_context.as_ref(),
+            step_context_for_seed(&queued_turn_context).as_ref(),
             &[queued_communication.to_response_input_item().into()],
         )
         .await;
@@ -1354,7 +1360,7 @@ async fn spawn_agent_fork_last_n_turns_keeps_only_recent_turns() {
         .codex
         .session
         .record_conversation_items(
-            triggered_turn_context.as_ref(),
+            step_context_for_seed(&triggered_turn_context).as_ref(),
             &[triggered_communication.to_response_input_item().into()],
         )
         .await;
@@ -1367,7 +1373,7 @@ async fn spawn_agent_fork_last_n_turns_keeps_only_recent_turns() {
         .codex
         .session
         .record_conversation_items(
-            spawn_turn_context.as_ref(),
+            step_context_for_seed(&spawn_turn_context).as_ref(),
             &[spawn_agent_call(&parent_spawn_call_id)],
         )
         .await;
@@ -1375,7 +1381,7 @@ async fn spawn_agent_fork_last_n_turns_keeps_only_recent_turns() {
         .codex
         .session
         .persist_rollout_items(&[RolloutItem::TurnContext(
-            spawn_turn_context.to_turn_context_item(),
+            step_context_for_seed(&spawn_turn_context).to_turn_context_item(),
         )])
         .await;
     parent_thread
@@ -1493,7 +1499,7 @@ async fn spawn_agent_fork_last_n_turns_drops_parent_startup_prefix_when_under_li
         .codex
         .session
         .record_conversation_items(
-            startup_turn_context.as_ref(),
+            step_context_for_seed(&startup_turn_context).as_ref(),
             &[ResponseItem::Message {
                 id: None,
                 role: "developer".to_string(),
@@ -1514,7 +1520,7 @@ async fn spawn_agent_fork_last_n_turns_drops_parent_startup_prefix_when_under_li
         .codex
         .session
         .record_conversation_items(
-            spawn_turn_context.as_ref(),
+            step_context_for_seed(&spawn_turn_context).as_ref(),
             &[spawn_agent_call(&parent_spawn_call_id)],
         )
         .await;
@@ -1622,7 +1628,7 @@ async fn spawn_agent_fork_last_n_turns_strips_parent_usage_hints() {
         .codex
         .session
         .record_conversation_items(
-            turn_context.as_ref(),
+            step_context_for_seed(&turn_context).as_ref(),
             &[
                 ResponseItem::Message {
                     id: None,
@@ -2018,9 +2024,9 @@ async fn multi_agent_v2_completion_ignores_dead_direct_parent() {
         .codex
         .session
         .send_event(
-            tester_turn.as_ref(),
+            tester_turn.turn.as_ref(),
             EventMsg::TurnComplete(TurnCompleteEvent {
-                turn_id: tester_turn.sub_id.clone(),
+                turn_id: tester_turn.turn.sub_id.clone(),
                 last_agent_message: Some("done".to_string()),
                 completed_at: None,
                 duration_ms: None,
@@ -2105,9 +2111,9 @@ async fn multi_agent_v2_completion_queues_message_for_direct_parent() {
         .codex
         .session
         .send_event(
-            tester_turn.as_ref(),
+            tester_turn.turn.as_ref(),
             EventMsg::TurnComplete(TurnCompleteEvent {
-                turn_id: tester_turn.sub_id.clone(),
+                turn_id: tester_turn.turn.sub_id.clone(),
                 last_agent_message: Some("done".to_string()),
                 completed_at: None,
                 duration_ms: None,

--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -51,7 +51,7 @@ use crate::session::CodexSpawnOk;
 use crate::session::SUBMISSION_CHANNEL_CAPACITY;
 use crate::session::emit_subagent_session_started;
 use crate::session::session::Session;
-use crate::session::turn_context::TurnContext;
+use crate::session::step_context::StepContextSeed;
 use codex_login::AuthManager;
 use codex_models_manager::manager::SharedModelsManager;
 use codex_protocol::error::CodexErr;
@@ -78,11 +78,12 @@ pub(crate) async fn run_codex_thread_interactive(
     auth_manager: Arc<AuthManager>,
     models_manager: SharedModelsManager,
     parent_session: Arc<Session>,
-    parent_ctx: Arc<TurnContext>,
+    parent_ctx: StepContextSeed,
     cancel_token: CancellationToken,
     subagent_source: SubAgentSource,
     initial_history: Option<InitialHistory>,
 ) -> Result<Codex, CodexErr> {
+    let parent_turn = &parent_ctx.turn;
     let (tx_sub, rx_sub) = async_channel::bounded(SUBMISSION_CHANNEL_CAPACITY);
     let (tx_ops, rx_ops) = async_channel::bounded(SUBMISSION_CHANNEL_CAPACITY);
     let conversation_history = initial_history.unwrap_or(InitialHistory::New);
@@ -113,16 +114,16 @@ pub(crate) async fn run_codex_thread_interactive(
         forked_from_thread_id,
         parent_thread_id: Some(parent_session.thread_id),
         thread_source: Some(ThreadSource::Subagent),
-        originator: parent_ctx.originator.clone(),
+        originator: parent_turn.originator.clone(),
         agent_control: parent_session.services.agent_control.clone(),
         dynamic_tools: Vec::new(),
         metrics_service_name: None,
         user_shell_override: None,
-        inherited_environments: Some(parent_ctx.environments.clone()),
+        inherited_environments: Some(parent_turn.environments.clone()),
         inherited_exec_policy: Some(Arc::clone(&parent_session.services.exec_policy)),
         parent_rollout_thread_trace: codex_rollout_trace::ThreadTraceContext::disabled(),
         parent_trace: None,
-        environment_selections: parent_ctx.environments.to_selections(),
+        environment_selections: parent_turn.environments.to_selections(),
         thread_extension_init: codex_extension_api::ExtensionDataInit::default(),
         supports_openai_form_elicitation: parent_session
             .services
@@ -156,7 +157,7 @@ pub(crate) async fn run_codex_thread_interactive(
     // Forward events from the sub-agent to the consumer, filtering approvals and
     // routing them to the parent session for decisions.
     let parent_session_clone = Arc::clone(&parent_session);
-    let parent_ctx_clone = Arc::clone(&parent_ctx);
+    let parent_ctx_clone = parent_ctx.clone();
     let codex_for_events = Arc::clone(&codex);
     // Cache the child call's MCP metadata at begin time. The later legacy
     // RequestUserInput approval event only carries a call_id and question metadata.
@@ -199,7 +200,7 @@ pub(crate) async fn run_codex_thread_one_shot(
     models_manager: SharedModelsManager,
     input: Vec<UserInput>,
     parent_session: Arc<Session>,
-    parent_ctx: Arc<TurnContext>,
+    parent_ctx: StepContextSeed,
     cancel_token: CancellationToken,
     subagent_source: SubAgentSource,
     final_output_json_schema: Option<Value>,
@@ -278,7 +279,7 @@ async fn forward_events(
     codex: Arc<Codex>,
     tx_sub: Sender<Event>,
     parent_session: Arc<Session>,
-    parent_ctx: Arc<TurnContext>,
+    parent_ctx: StepContextSeed,
     pending_mcp_invocations: Arc<Mutex<HashMap<String, PendingMcpInvocation>>>,
     cancel_token: CancellationToken,
 ) {
@@ -492,10 +493,11 @@ async fn handle_exec_approval(
     codex: &Codex,
     turn_id: String,
     parent_session: &Arc<Session>,
-    parent_ctx: &Arc<TurnContext>,
+    parent_ctx: &StepContextSeed,
     event: ExecApprovalRequestEvent,
     cancel_token: &CancellationToken,
 ) {
+    let parent_turn = &parent_ctx.turn;
     let approval_id_for_op = event.effective_approval_id();
     let ExecApprovalRequestEvent {
         call_id,
@@ -510,11 +512,11 @@ async fn handle_exec_approval(
         available_decisions,
         ..
     } = event;
-    let decision = if routes_approval_to_guardian(parent_ctx) {
+    let decision = if routes_approval_to_guardian(parent_turn) {
         let review_cancel = cancel_token.child_token();
         let review_rx = spawn_approval_request_review(
             Arc::clone(parent_session),
-            Arc::clone(parent_ctx),
+            parent_ctx.clone(),
             new_guardian_review_id(),
             GuardianApprovalRequest::Shell {
                 id: call_id.clone(),
@@ -543,7 +545,7 @@ async fn handle_exec_approval(
     } else {
         await_approval_with_cancel(
             parent_session.request_command_approval(
-                parent_ctx,
+                parent_turn,
                 call_id,
                 approval_id,
                 environment_id,
@@ -577,10 +579,11 @@ async fn handle_patch_approval(
     codex: &Codex,
     _id: String,
     parent_session: &Arc<Session>,
-    parent_ctx: &Arc<TurnContext>,
+    parent_ctx: &StepContextSeed,
     event: ApplyPatchApprovalRequestEvent,
     cancel_token: &CancellationToken,
 ) {
+    let parent_turn = &parent_ctx.turn;
     let ApplyPatchApprovalRequestEvent {
         call_id,
         changes,
@@ -589,12 +592,12 @@ async fn handle_patch_approval(
         ..
     } = event;
     let approval_id = call_id.clone();
-    let guardian_decision = if routes_approval_to_guardian(parent_ctx) {
+    let guardian_decision = if routes_approval_to_guardian(parent_turn) {
         let files = changes
             .keys()
             .map(|path| {
                 #[allow(deprecated)]
-                parent_ctx.cwd.join(path)
+                parent_turn.cwd.join(path)
             })
             .collect::<Vec<_>>();
         let review_cancel = cancel_token.child_token();
@@ -627,12 +630,12 @@ async fn handle_patch_approval(
             .join("\n");
         let review_rx = spawn_approval_request_review(
             Arc::clone(parent_session),
-            Arc::clone(parent_ctx),
+            parent_ctx.clone(),
             new_guardian_review_id(),
             GuardianApprovalRequest::ApplyPatch {
                 id: approval_id.clone(),
                 #[allow(deprecated)]
-                cwd: parent_ctx.cwd.clone(),
+                cwd: parent_turn.cwd.clone(),
                 files,
                 patch,
             },
@@ -657,7 +660,7 @@ async fn handle_patch_approval(
         decision
     } else {
         let decision_rx = parent_session
-            .request_patch_approval(parent_ctx, call_id, changes, reason, grant_root)
+            .request_patch_approval(parent_turn, call_id, changes, reason, grant_root)
             .await;
         await_approval_with_cancel(
             async move { decision_rx.await.unwrap_or_default() },
@@ -680,11 +683,12 @@ async fn handle_request_user_input(
     codex: &Codex,
     id: String,
     parent_session: &Arc<Session>,
-    parent_ctx: &Arc<TurnContext>,
+    parent_ctx: &StepContextSeed,
     pending_mcp_invocations: &Arc<Mutex<HashMap<String, PendingMcpInvocation>>>,
     event: RequestUserInputEvent,
     cancel_token: &CancellationToken,
 ) {
+    let parent_turn = &parent_ctx.turn;
     if let Some(response) = maybe_auto_review_mcp_request_user_input(
         parent_session,
         parent_ctx,
@@ -703,11 +707,11 @@ async fn handle_request_user_input(
         auto_resolution_ms: event.auto_resolution_ms,
     };
     let response_fut =
-        parent_session.request_user_input(parent_ctx, parent_ctx.sub_id.clone(), args);
+        parent_session.request_user_input(parent_turn, parent_turn.sub_id.clone(), args);
     let response = await_user_input_with_cancel(
         response_fut,
         parent_session,
-        &parent_ctx.sub_id,
+        &parent_turn.sub_id,
         cancel_token,
     )
     .await;
@@ -723,11 +727,12 @@ async fn handle_request_user_input(
 /// `McpToolCallBegin` in order to rebuild the full guardian review request.
 async fn maybe_auto_review_mcp_request_user_input(
     parent_session: &Arc<Session>,
-    parent_ctx: &Arc<TurnContext>,
+    parent_ctx: &StepContextSeed,
     pending_mcp_invocations: &Arc<Mutex<HashMap<String, PendingMcpInvocation>>>,
     event: &RequestUserInputEvent,
     cancel_token: &CancellationToken,
 ) -> Option<RequestUserInputResponse> {
+    let parent_turn = &parent_ctx.turn;
     // TODO(ccunningham): Support delegated MCP approval elicitations here too after
     // coordinating with @fouad. Today guardian only auto-reviews the RequestUserInput
     // compatibility path for delegated MCP approvals.
@@ -743,14 +748,14 @@ async fn maybe_auto_review_mcp_request_user_input(
     let invocation = pending.invocation;
     let metadata = pending.metadata;
     let approvals_reviewer =
-        mcp_approvals_reviewer(parent_ctx, &invocation.server, metadata.as_ref());
-    if !routes_approval_to_guardian_with_reviewer(parent_ctx, approvals_reviewer) {
+        mcp_approvals_reviewer(parent_turn, &invocation.server, metadata.as_ref());
+    if !routes_approval_to_guardian_with_reviewer(parent_turn, approvals_reviewer) {
         return None;
     }
     let review_cancel = cancel_token.child_token();
     let review_rx = spawn_approval_request_review(
         Arc::clone(parent_session),
-        Arc::clone(parent_ctx),
+        parent_ctx.clone(),
         new_guardian_review_id(),
         build_guardian_mcp_tool_review_request(&event.call_id, &invocation, metadata.as_ref()),
         /*retry_reason*/ None,
@@ -796,10 +801,11 @@ async fn maybe_auto_review_mcp_request_user_input(
 async fn handle_request_permissions(
     codex: &Codex,
     parent_session: &Arc<Session>,
-    parent_ctx: &Arc<TurnContext>,
+    parent_ctx: &StepContextSeed,
     event: RequestPermissionsEvent,
     cancel_token: &CancellationToken,
 ) {
+    let parent_turn = &parent_ctx.turn;
     let call_id = event.call_id;
     let args = RequestPermissionsArgs {
         environment_id: event.environment_id,
@@ -808,7 +814,7 @@ async fn handle_request_permissions(
     };
     let cwd = event.cwd.unwrap_or_else(|| {
         #[allow(deprecated)]
-        parent_ctx.cwd.clone()
+        parent_turn.cwd.clone()
     });
     let response_fut = parent_session.request_permissions_for_cwd(
         parent_ctx,

--- a/codex-rs/core/src/codex_delegate_tests.rs
+++ b/codex-rs/core/src/codex_delegate_tests.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::mcp_tool_call::MCP_TOOL_APPROVAL_DECLINE_SYNTHETIC;
 use crate::mcp_tool_call::MCP_TOOL_APPROVAL_QUESTION_ID_PREFIX;
+use crate::session::step_context::StepContextSeed;
+use crate::session::step_model_context::StepModelContext;
 use async_channel::bounded;
 use codex_mcp::CODEX_APPS_MCP_SERVER_NAME;
 use codex_protocol::config_types::ApprovalsReviewer;
@@ -36,6 +38,11 @@ use tokio::sync::Mutex;
 use tokio::sync::watch;
 use tokio::time::timeout;
 
+fn step_context_seed(turn: Arc<crate::session::turn_context::TurnContext>) -> StepContextSeed {
+    let model = Arc::new(StepModelContext::for_test(&turn));
+    StepContextSeed::new(turn, model)
+}
+
 #[tokio::test]
 async fn forward_events_filters_private_events_before_blocked_send_is_cancelled() {
     let (tx_events, rx_events) = bounded(SUBMISSION_CHANNEL_CAPACITY);
@@ -65,6 +72,7 @@ async fn forward_events_filters_private_events_before_blocked_send_is_cancelled(
         .unwrap();
 
     let cancel = CancellationToken::new();
+    let ctx = step_context_seed(ctx);
     let forward = tokio::spawn(forward_events(
         Arc::clone(&codex),
         tx_out.clone(),
@@ -184,13 +192,15 @@ async fn forward_ops_preserves_submission_trace_context() {
 async fn run_codex_thread_interactive_respects_pre_cancelled_spawn() {
     let (parent_session, parent_ctx, _rx_events) =
         crate::session::tests::make_session_and_context_with_rx().await;
+    let config = parent_ctx.config.as_ref().clone();
+    let parent_ctx = step_context_seed(parent_ctx);
     let cancel_token = CancellationToken::new();
     cancel_token.cancel();
 
     let result = timeout(
         Duration::from_secs(/*secs*/ 1),
         run_codex_thread_interactive(
-            parent_ctx.config.as_ref().clone(),
+            config,
             Arc::clone(&parent_session.services.auth_manager),
             Arc::clone(&parent_session.services.models_manager),
             parent_session,
@@ -238,6 +248,7 @@ async fn handle_request_permissions_uses_tool_call_id_for_round_trip() {
     };
     #[allow(deprecated)]
     let delegated_cwd = parent_ctx.cwd.join("delegated-cwd");
+    let parent_ctx = step_context_seed(parent_ctx);
     let cancel_token = CancellationToken::new();
     let request_call_id = call_id.clone();
     let request_cwd = delegated_cwd.clone();
@@ -245,7 +256,7 @@ async fn handle_request_permissions_uses_tool_call_id_for_round_trip() {
     let handle = tokio::spawn({
         let codex = Arc::clone(&codex);
         let parent_session = Arc::clone(&parent_session);
-        let parent_ctx = Arc::clone(&parent_ctx);
+        let parent_ctx = parent_ctx.clone();
         let cancel_token = cancel_token.clone();
         async move {
             handle_request_permissions(
@@ -318,6 +329,7 @@ async fn handle_exec_approval_uses_call_id_for_guardian_review_and_approval_id_f
         .set(AskForApproval::OnRequest)
         .expect("set on-request policy");
     let parent_ctx = Arc::new(parent_ctx);
+    let parent_ctx = step_context_seed(parent_ctx);
 
     let (tx_sub, rx_sub) = bounded(SUBMISSION_CHANNEL_CAPACITY);
     let (_tx_events, rx_events_child) = bounded(SUBMISSION_CHANNEL_CAPACITY);
@@ -334,7 +346,7 @@ async fn handle_exec_approval_uses_call_id_for_guardian_review_and_approval_id_f
     let handle = tokio::spawn({
         let codex = Arc::clone(&codex);
         let parent_session = Arc::clone(&parent_session);
-        let parent_ctx = Arc::clone(&parent_ctx);
+        let parent_ctx = parent_ctx.clone();
         let cancel_token = cancel_token.clone();
         async move {
             handle_exec_approval(
@@ -387,7 +399,7 @@ async fn handle_exec_approval_uses_call_id_for_guardian_review_and_approval_id_f
         assessment_event.target_item_id.as_deref(),
         Some("command-item-1")
     );
-    assert_eq!(assessment_event.turn_id, parent_ctx.sub_id);
+    assert_eq!(assessment_event.turn_id, parent_ctx.turn.sub_id);
     assert_eq!(
         assessment_event.status,
         GuardianAssessmentStatus::InProgress
@@ -432,6 +444,7 @@ async fn delegated_mcp_guardian_abort_returns_synthetic_decline_answer() {
         .set(AskForApproval::OnRequest)
         .expect("set on-request policy");
     let parent_ctx = Arc::new(parent_ctx);
+    let parent_ctx = step_context_seed(parent_ctx);
 
     let pending_mcp_invocations = Arc::new(Mutex::new(HashMap::from([(
         "call-1".to_string(),
@@ -485,6 +498,7 @@ async fn delegated_mcp_guardian_abort_returns_synthetic_decline_answer() {
 async fn delegated_mcp_user_reviewer_returns_none_without_metadata() {
     let (parent_session, parent_ctx, _rx_events) =
         crate::session::tests::make_session_and_context_with_rx().await;
+    let parent_ctx = step_context_seed(parent_ctx);
     let pending_mcp_invocations = Arc::new(Mutex::new(HashMap::from([(
         "call-1".to_string(),
         PendingMcpInvocation {

--- a/codex-rs/core/src/codex_thread.rs
+++ b/codex-rs/core/src/codex_thread.rs
@@ -461,7 +461,7 @@ impl CodexThread {
         };
         self.codex
             .session
-            .inject_no_new_turn(vec![item], /*current_turn_context*/ None)
+            .inject_no_new_turn(vec![item], /*current_step_context_seed*/ None)
             .await;
     }
 
@@ -473,13 +473,13 @@ impl CodexThread {
             ));
         }
 
-        let turn_context = self.codex.session.new_default_turn().await;
+        let step_context_seed = self.codex.session.new_default_turn().await;
         if self.codex.session.reference_context_item().await.is_none() {
             // This history-only API runs without run_turn, so it owns its initial step.
             let step_context = self
                 .codex
                 .session
-                .capture_step_context(Arc::clone(&turn_context))
+                .capture_step_context(&step_context_seed)
                 .await;
             self.codex
                 .session
@@ -488,7 +488,7 @@ impl CodexThread {
         }
         self.codex
             .session
-            .inject_no_new_turn(items, Some(turn_context.as_ref()))
+            .inject_no_new_turn(items, Some(&step_context_seed))
             .await;
         self.codex.session.flush_rollout().await?;
         Ok(())
@@ -605,10 +605,10 @@ impl CodexThread {
 
     /// Returns the exact MCP config, environment bindings, and manager most recently published.
     pub async fn current_mcp_runtime(&self) -> Arc<crate::session::McpRuntimeSnapshot> {
-        let turn_context = self.codex.session.new_default_turn().await;
+        let step_context_seed = self.codex.session.new_default_turn().await;
         self.codex
             .session
-            .capture_step_context(turn_context)
+            .capture_step_context(&step_context_seed)
             .await
             .mcp
             .clone()

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -15,6 +15,8 @@ use crate::responses_metadata::CompactionTurnMetadata;
 #[cfg(test)]
 use crate::session::PreviousTurnSettings;
 use crate::session::session::Session;
+use crate::session::step_context::StepContext;
+use crate::session::step_context::StepContextSeed;
 use crate::session::turn::get_last_assistant_message_from_turn;
 use crate::session::turn_context::TurnContext;
 use crate::util::backoff;
@@ -69,14 +71,14 @@ pub(crate) enum InitialContextInjection {
 
 pub(crate) async fn build_compaction_initial_context(
     sess: &Session,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     initial_context_injection: &InitialContextInjection,
 ) -> (Vec<ResponseItem>, Option<Arc<WorldState>>) {
     // Return the rendered state with its items so history and its baseline stay identical.
     match initial_context_injection {
         InitialContextInjection::BeforeLastUserMessage(world_state) => {
             let items = sess
-                .build_initial_context_with_world_state(turn_context, world_state.as_ref())
+                .build_initial_context_with_world_state(step_context, world_state.as_ref())
                 .await;
             (items, Some(Arc::clone(world_state)))
         }
@@ -90,12 +92,13 @@ pub(crate) fn should_use_remote_compact_task(provider: &ModelProviderInfo) -> bo
 
 pub(crate) async fn run_inline_auto_compact_task(
     sess: Arc<Session>,
-    turn_context: Arc<TurnContext>,
+    step_context: Arc<StepContext>,
     initial_context_injection: InitialContextInjection,
     reason: CompactionReason,
     phase: CompactionPhase,
 ) -> CodexResult<()> {
-    let prompt = turn_context
+    let prompt = step_context
+        .turn
         .config
         .compact_prompt
         .as_deref()
@@ -109,7 +112,7 @@ pub(crate) async fn run_inline_auto_compact_task(
 
     run_compact_task_inner(
         sess,
-        turn_context,
+        step_context,
         input,
         initial_context_injection,
         CompactionTrigger::Auto,
@@ -122,20 +125,22 @@ pub(crate) async fn run_inline_auto_compact_task(
 
 pub(crate) async fn run_compact_task(
     sess: Arc<Session>,
-    turn_context: Arc<TurnContext>,
+    step_context_seed: StepContextSeed,
     input: Vec<UserInput>,
 ) -> CodexResult<()> {
+    let turn_context = &step_context_seed.turn;
     let start_event = EventMsg::TurnStarted(TurnStartedEvent {
         turn_id: turn_context.sub_id.clone(),
         trace_id: turn_context.trace_id.clone(),
         started_at: turn_context.turn_timing_state.started_at_unix_secs().await,
-        model_context_window: turn_context.model_context_window(),
-        collaboration_mode_kind: turn_context.collaboration_mode.mode,
+        model_context_window: step_context_seed.model.model_context_window(),
+        collaboration_mode_kind: step_context_seed.model.collaboration_mode.mode,
     });
-    sess.send_event(&turn_context, start_event).await;
+    sess.send_event(turn_context, start_event).await;
+    let step_context = sess.capture_step_context(&step_context_seed).await;
     run_compact_task_inner(
         sess.clone(),
-        turn_context,
+        step_context,
         input,
         InitialContextInjection::DoNotInject,
         CompactionTrigger::Manual,
@@ -148,13 +153,14 @@ pub(crate) async fn run_compact_task(
 
 async fn run_compact_task_inner(
     sess: Arc<Session>,
-    turn_context: Arc<TurnContext>,
+    step_context: Arc<StepContext>,
     input: Vec<UserInput>,
     initial_context_injection: InitialContextInjection,
     trigger: CompactionTrigger,
     reason: CompactionReason,
     phase: CompactionPhase,
 ) -> CodexResult<()> {
+    let turn_context = &step_context.turn;
     let compaction_metadata =
         CompactionTurnMetadata::new(trigger, reason, CompactionImplementation::Responses, phase);
     let attempt = CompactionAnalyticsAttempt::begin(
@@ -166,7 +172,7 @@ async fn run_compact_task_inner(
         phase,
     )
     .await;
-    let pre_compact_outcome = run_pre_compact_hooks(&sess, &turn_context, trigger).await;
+    let pre_compact_outcome = run_pre_compact_hooks(&sess, step_context.as_ref(), trigger).await;
     match pre_compact_outcome {
         PreCompactHookOutcome::Continue => {}
         PreCompactHookOutcome::Stopped => {
@@ -184,7 +190,7 @@ async fn run_compact_task_inner(
     }
     let result = run_compact_task_inner_impl(
         Arc::clone(&sess),
-        Arc::clone(&turn_context),
+        Arc::clone(&step_context),
         input,
         initial_context_injection,
         compaction_metadata,
@@ -193,7 +199,8 @@ async fn run_compact_task_inner(
     let status = compaction_status_from_result(&result);
     let codex_error = result.as_ref().err();
     if result.is_ok() {
-        let post_compact_outcome = run_post_compact_hooks(&sess, &turn_context, trigger).await;
+        let post_compact_outcome =
+            run_post_compact_hooks(&sess, step_context.as_ref(), trigger).await;
         if let PostCompactHookOutcome::Stopped = post_compact_outcome {
             attempt
                 .track(
@@ -219,20 +226,21 @@ async fn run_compact_task_inner(
 
 async fn run_compact_task_inner_impl(
     sess: Arc<Session>,
-    turn_context: Arc<TurnContext>,
+    step_context: Arc<StepContext>,
     input: Vec<UserInput>,
     initial_context_injection: InitialContextInjection,
     compaction_metadata: CompactionTurnMetadata,
 ) -> CodexResult<String> {
+    let turn_context = &step_context.turn;
     let compaction_item = TurnItem::ContextCompaction(ContextCompactionItem::new());
-    sess.emit_turn_item_started(&turn_context, &compaction_item)
+    sess.emit_turn_item_started(turn_context, &compaction_item)
         .await;
     let initial_input_for_turn: ResponseInputItem = ResponseInputItem::from(input);
 
     let mut history = sess.clone_history().await;
     history.record_items(
         &[initial_input_for_turn.into()],
-        turn_context.model_info.truncation_policy.into(),
+        step_context.model.model_info.truncation_policy.into(),
     );
 
     let max_retries = turn_context.provider.info().stream_max_retries();
@@ -252,7 +260,7 @@ async fn run_compact_task_inner_impl(
         // Clone is required because of the loop
         let turn_input = history
             .clone()
-            .for_prompt(&turn_context.model_info.input_modalities);
+            .for_prompt(&step_context.model.model_info.input_modalities);
         let turn_input_len = turn_input.len();
         let prompt = Prompt {
             input: turn_input,
@@ -261,7 +269,7 @@ async fn run_compact_task_inner_impl(
         };
         let attempt_result = drain_to_completed(
             &sess,
-            turn_context.as_ref(),
+            step_context.as_ref(),
             &mut client_session,
             &responses_metadata,
             &prompt,
@@ -278,7 +286,7 @@ async fn run_compact_task_inner_impl(
             Err(e @ CodexErr::SessionBudgetExceeded) => {
                 sess.track_turn_codex_error(turn_context.as_ref(), &e);
                 let event = EventMsg::Error(e.to_error_event(/*message_prefix*/ None));
-                sess.send_event(&turn_context, event).await;
+                sess.send_event(turn_context, event).await;
                 return Err(e);
             }
             Err(e @ CodexErr::ContextWindowExceeded) => {
@@ -291,10 +299,10 @@ async fn run_compact_task_inner_impl(
                     retries = 0;
                     continue;
                 }
-                sess.set_total_tokens_full(turn_context.as_ref()).await;
+                sess.set_total_tokens_full(step_context.as_ref()).await;
                 sess.track_turn_codex_error(turn_context.as_ref(), &e);
                 let event = EventMsg::Error(e.to_error_event(/*message_prefix*/ None));
-                sess.send_event(&turn_context, event).await;
+                sess.send_event(turn_context, event).await;
                 return Err(e);
             }
             Err(e) => {
@@ -312,7 +320,7 @@ async fn run_compact_task_inner_impl(
                 } else {
                     sess.track_turn_codex_error(turn_context.as_ref(), &e);
                     let event = EventMsg::Error(e.to_error_event(/*message_prefix*/ None));
-                    sess.send_event(&turn_context, event).await;
+                    sess.send_event(turn_context, event).await;
                     return Err(e);
                 }
             }
@@ -335,7 +343,7 @@ async fn run_compact_task_inner_impl(
 
     let (initial_context, world_state_baseline) = build_compaction_initial_context(
         sess.as_ref(),
-        turn_context.as_ref(),
+        step_context.as_ref(),
         &initial_context_injection,
     )
     .await;
@@ -346,7 +354,7 @@ async fn run_compact_task_inner_impl(
     let reference_context_item = match initial_context_injection {
         InitialContextInjection::DoNotInject => None,
         InitialContextInjection::BeforeLastUserMessage(_) => {
-            Some(turn_context.to_turn_context_item())
+            Some(step_context.to_turn_context_item())
         }
     };
     let compacted_item = CompactedItem {
@@ -365,14 +373,15 @@ async fn run_compact_task_inner_impl(
         compacted_item,
     )
     .await;
-    sess.recompute_token_usage(&turn_context).await;
+    sess.recompute_token_usage(turn_context, step_context.model.as_ref())
+        .await;
 
-    sess.emit_turn_item_completed(&turn_context, compaction_item)
+    sess.emit_turn_item_completed(turn_context, step_context.model.as_ref(), compaction_item)
         .await;
     let warning = EventMsg::Warning(WarningEvent {
         message: "Heads up: Long threads and multiple compactions can cause the model to be less accurate. Start a new thread when possible to keep threads small and targeted.".to_string(),
     });
-    sess.send_event(&turn_context, warning).await;
+    sess.send_event(turn_context, warning).await;
     Ok(summary_suffix)
 }
 
@@ -660,19 +669,21 @@ fn build_compacted_history_with_limit(
 
 async fn drain_to_completed(
     sess: &Session,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     client_session: &mut ModelClientSession,
     responses_metadata: &CodexResponsesMetadata,
     prompt: &Prompt,
 ) -> CodexResult<()> {
+    let turn_context = &step_context.turn;
+    let model_context = &step_context.model;
     let mut stream = client_session
         .stream(
             prompt,
-            &turn_context.model_info,
-            &turn_context.session_telemetry,
-            turn_context.reasoning_effort.clone(),
-            turn_context.reasoning_summary,
-            turn_context.config.service_tier.clone(),
+            &model_context.model_info,
+            &model_context.session_telemetry,
+            model_context.reasoning_effort(),
+            model_context.reasoning_summary,
+            model_context.service_tier.clone(),
             responses_metadata,
             // Rollout tracing currently models remote compaction only; local compaction streams
             // are left untraced until the reducer has a first-class local compaction lifecycle.
@@ -689,7 +700,7 @@ async fn drain_to_completed(
         };
         match event {
             Ok(ResponseEvent::OutputItemDone(item)) => {
-                sess.record_conversation_items(turn_context, std::slice::from_ref(&item))
+                sess.record_conversation_items(step_context, std::slice::from_ref(&item))
                     .await;
             }
             Ok(ResponseEvent::ServerReasoningIncluded(included)) => {
@@ -699,7 +710,7 @@ async fn drain_to_completed(
                 sess.update_rate_limits(turn_context, snapshot).await;
             }
             Ok(ResponseEvent::Completed { token_usage, .. }) => {
-                sess.update_token_usage_info(turn_context, token_usage.as_ref())
+                sess.update_token_usage_info(step_context, token_usage.as_ref())
                     .await?;
                 return Ok(());
             }

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -19,8 +19,8 @@ use crate::responses_metadata::CodexResponsesRequestKind;
 use crate::responses_metadata::CompactionTurnMetadata;
 use crate::session::session::Session;
 use crate::session::step_context::StepContext;
+use crate::session::step_context::StepContextSeed;
 use crate::session::turn::built_tools;
-use crate::session::turn_context::TurnContext;
 use codex_analytics::CompactionImplementation;
 use codex_analytics::CompactionPhase;
 use codex_analytics::CompactionReason;
@@ -67,18 +67,19 @@ pub(crate) async fn run_inline_remote_auto_compact_task(
 
 pub(crate) async fn run_remote_compact_task(
     sess: Arc<Session>,
-    turn_context: Arc<TurnContext>,
+    step_context_seed: StepContextSeed,
 ) -> CodexResult<()> {
     // Standalone compaction is its own request boundary, so it captures a fresh step.
-    let step_context = sess.capture_step_context(Arc::clone(&turn_context)).await;
+    let step_context = sess.capture_step_context(&step_context_seed).await;
+    let turn_context = &step_context.turn;
     let start_event = EventMsg::TurnStarted(TurnStartedEvent {
         turn_id: turn_context.sub_id.clone(),
         trace_id: turn_context.trace_id.clone(),
         started_at: turn_context.turn_timing_state.started_at_unix_secs().await,
-        model_context_window: turn_context.model_context_window(),
-        collaboration_mode_kind: turn_context.collaboration_mode.mode,
+        model_context_window: step_context.model.model_context_window(),
+        collaboration_mode_kind: step_context.model.collaboration_mode.mode,
     });
-    sess.send_event(&turn_context, start_event).await;
+    sess.send_event(turn_context, start_event).await;
 
     run_remote_compact_task_inner(
         &sess,
@@ -122,7 +123,7 @@ async fn run_remote_compact_task_inner(
         phase,
     )
     .await;
-    let pre_compact_outcome = run_pre_compact_hooks(sess, turn_context, trigger).await;
+    let pre_compact_outcome = run_pre_compact_hooks(sess, step_context.as_ref(), trigger).await;
     match pre_compact_outcome {
         PreCompactHookOutcome::Continue => {}
         PreCompactHookOutcome::Stopped => {
@@ -150,7 +151,8 @@ async fn run_remote_compact_task_inner(
     let status = compaction_status_from_result(&result);
     let codex_error = result.as_ref().err();
     if result.is_ok() {
-        let post_compact_outcome = run_post_compact_hooks(sess, turn_context, trigger).await;
+        let post_compact_outcome =
+            run_post_compact_hooks(sess, step_context.as_ref(), trigger).await;
         if let PostCompactHookOutcome::Stopped = post_compact_outcome {
             attempt
                 .track(sess.as_ref(), status, codex_error, analytics_details)
@@ -187,7 +189,7 @@ async fn run_remote_compact_task_inner_impl(
     let compaction_trace = sess.services.rollout_thread_trace.compaction_trace_context(
         turn_context.sub_id.as_str(),
         context_compaction_item.id.as_str(),
-        turn_context.model_info.slug.as_str(),
+        step_context.model.model_info.slug.as_str(),
         turn_context.provider.info().name.as_str(),
     );
     let compaction_item = TurnItem::ContextCompaction(context_compaction_item);
@@ -198,7 +200,7 @@ async fn run_remote_compact_task_inner_impl(
     let (rewritten_outputs, estimated_deleted_tokens) =
         trim_function_call_history_to_fit_context_window(
             &mut history,
-            turn_context.as_ref(),
+            step_context.as_ref(),
             &base_instructions,
         );
     if rewritten_outputs > 0 {
@@ -223,7 +225,7 @@ async fn run_remote_compact_task_inner_impl(
     // fit the compact endpoint. The checkpoint below records it separately from the next sampling
     // request, whose prompt will repeat current developer/context prefix items.
     let trace_input_history = history.raw_items().to_vec();
-    let prompt_input = history.for_prompt(&turn_context.model_info.input_modalities);
+    let prompt_input = history.for_prompt(&step_context.model.model_info.input_modalities);
     let tool_router = built_tools(
         sess.as_ref(),
         step_context.as_ref(),
@@ -233,7 +235,7 @@ async fn run_remote_compact_task_inner_impl(
     let prompt = Prompt {
         input: prompt_input,
         tools: tool_router.model_visible_specs(),
-        parallel_tool_calls: turn_context.model_info.supports_parallel_tool_calls,
+        parallel_tool_calls: step_context.model.model_info.supports_parallel_tool_calls,
         base_instructions,
         output_schema: None,
         output_schema_strict: true,
@@ -249,18 +251,18 @@ async fn run_remote_compact_task_inner_impl(
         .model_client
         .compact_conversation_history(
             &prompt,
-            &turn_context.model_info,
+            &step_context.model.model_info,
             turn_state,
             CompactConversationRequestSettings {
-                effort: turn_context.reasoning_effort.clone(),
-                summary: turn_context.reasoning_summary,
+                effort: step_context.model.reasoning_effort(),
+                summary: step_context.model.reasoning_summary,
                 service_tier: if sess.services.auth_manager.auth_mode() == Some(AuthMode::ApiKey) {
                     None
                 } else {
-                    turn_context.config.service_tier.clone()
+                    step_context.model.service_tier.clone()
                 },
             },
-            &turn_context.session_telemetry,
+            &step_context.model.session_telemetry,
             &compaction_trace,
             &responses_metadata,
         )
@@ -268,7 +270,7 @@ async fn run_remote_compact_task_inner_impl(
     let (new_window_number, new_window_ids) = sess.advance_auto_compact_window().await;
     let (new_history, world_state_baseline) = process_compacted_history(
         sess.as_ref(),
-        turn_context.as_ref(),
+        step_context.as_ref(),
         new_history,
         &initial_context_injection,
     )
@@ -277,7 +279,7 @@ async fn run_remote_compact_task_inner_impl(
     let reference_context_item = match initial_context_injection {
         InitialContextInjection::DoNotInject => None,
         InitialContextInjection::BeforeLastUserMessage(_) => {
-            Some(turn_context.to_turn_context_item())
+            Some(step_context.to_turn_context_item())
         }
     };
     let compacted_item = CompactedItem {
@@ -303,16 +305,17 @@ async fn run_remote_compact_task_inner_impl(
         compacted_item,
     )
     .await;
-    sess.recompute_token_usage(turn_context).await;
+    sess.recompute_token_usage(turn_context, step_context.model.as_ref())
+        .await;
 
-    sess.emit_turn_item_completed(turn_context, compaction_item)
+    sess.emit_turn_item_completed(turn_context, step_context.model.as_ref(), compaction_item)
         .await;
     Ok(())
 }
 
 pub(crate) async fn process_compacted_history(
     sess: &Session,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     mut compacted_history: Vec<ResponseItem>,
     initial_context_injection: &InitialContextInjection,
 ) -> (Vec<ResponseItem>, Option<Arc<WorldState>>) {
@@ -320,7 +323,7 @@ pub(crate) async fn process_compacted_history(
     // message in the replacement history. Pre-turn compaction instead injects context after the
     // compaction item, but mid-turn compaction keeps the compaction item last for model training.
     let (initial_context, world_state_baseline) =
-        build_compaction_initial_context(sess, turn_context, initial_context_injection).await;
+        build_compaction_initial_context(sess, step_context, initial_context_injection).await;
 
     compacted_history.retain(should_keep_compacted_history_item);
     (
@@ -376,10 +379,10 @@ pub(crate) fn should_keep_compacted_history_item(item: &ResponseItem) -> bool {
 
 pub(crate) fn trim_function_call_history_to_fit_context_window(
     history: &mut ContextManager,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     base_instructions: &BaseInstructions,
 ) -> (usize, i64) {
-    let Some(context_window) = turn_context.model_context_window() else {
+    let Some(context_window) = step_context.model.model_context_window() else {
         return (0, 0);
     };
     let mut rewritten_outputs = 0usize;

--- a/codex-rs/core/src/compact_remote_v2.rs
+++ b/codex-rs/core/src/compact_remote_v2.rs
@@ -22,8 +22,8 @@ use crate::responses_retry::ResponsesStreamRequest;
 use crate::responses_retry::handle_retryable_response_stream_error;
 use crate::session::session::Session;
 use crate::session::step_context::StepContext;
+use crate::session::step_context::StepContextSeed;
 use crate::session::turn::built_tools;
-use crate::session::turn_context::TurnContext;
 use codex_analytics::CompactionImplementation;
 use codex_analytics::CompactionPhase;
 use codex_analytics::CompactionReason;
@@ -76,16 +76,18 @@ pub(crate) async fn run_inline_remote_auto_compact_task(
 
 pub(crate) async fn run_remote_compact_task(
     sess: Arc<Session>,
-    turn_context: Arc<TurnContext>,
+    step_context_seed: StepContextSeed,
 ) -> CodexResult<()> {
     // Standalone compaction is its own request boundary, so it captures a fresh step.
-    let step_context = sess.capture_step_context(Arc::clone(&turn_context)).await;
+    let step_context = sess.capture_step_context(&step_context_seed).await;
+    let turn_context = &step_context_seed.turn;
+    let model_context = &step_context_seed.model;
     let start_event = EventMsg::TurnStarted(TurnStartedEvent {
         turn_id: turn_context.sub_id.clone(),
         trace_id: turn_context.trace_id.clone(),
         started_at: turn_context.turn_timing_state.started_at_unix_secs().await,
-        model_context_window: turn_context.model_context_window(),
-        collaboration_mode_kind: turn_context.collaboration_mode.mode,
+        model_context_window: model_context.model_context_window(),
+        collaboration_mode_kind: model_context.collaboration_mode.mode,
     });
     sess.send_event(&turn_context, start_event).await;
 
@@ -130,7 +132,7 @@ async fn run_remote_compact_task_inner(
         phase,
     )
     .await;
-    let pre_compact_outcome = run_pre_compact_hooks(sess, turn_context, trigger).await;
+    let pre_compact_outcome = run_pre_compact_hooks(sess, step_context, trigger).await;
     match pre_compact_outcome {
         PreCompactHookOutcome::Continue => {}
         PreCompactHookOutcome::Stopped => {
@@ -158,7 +160,7 @@ async fn run_remote_compact_task_inner(
     let status = compaction_status_from_result(&result);
     let codex_error = result.as_ref().err();
     if result.is_ok() {
-        let post_compact_outcome = run_post_compact_hooks(sess, turn_context, trigger).await;
+        let post_compact_outcome = run_post_compact_hooks(sess, step_context, trigger).await;
         if let PostCompactHookOutcome::Stopped = post_compact_outcome {
             attempt
                 .track(sess.as_ref(), status, codex_error, analytics_details)
@@ -196,7 +198,7 @@ async fn run_remote_compact_task_inner_impl(
     let compaction_trace = sess.services.rollout_thread_trace.compaction_trace_context(
         turn_context.sub_id.as_str(),
         context_compaction_item.id.as_str(),
-        turn_context.model_info.slug.as_str(),
+        step_context.model.model_info.slug.as_str(),
         turn_context.provider.info().name.as_str(),
     );
     let compaction_item = TurnItem::ContextCompaction(context_compaction_item);
@@ -208,7 +210,7 @@ async fn run_remote_compact_task_inner_impl(
     let (rewritten_outputs, estimated_deleted_tokens) =
         trim_function_call_history_to_fit_context_window(
             &mut history,
-            turn_context.as_ref(),
+            step_context.as_ref(),
             &base_instructions,
         );
     if rewritten_outputs > 0 {
@@ -231,7 +233,7 @@ async fn run_remote_compact_task_inner_impl(
     }
 
     let trace_input_history = history.raw_items().to_vec();
-    let prompt_input = history.for_prompt(&turn_context.model_info.input_modalities);
+    let prompt_input = history.for_prompt(&step_context.model.model_info.input_modalities);
     let tool_router = built_tools(
         sess.as_ref(),
         step_context.as_ref(),
@@ -243,7 +245,7 @@ async fn run_remote_compact_task_inner_impl(
     let prompt = Prompt {
         input,
         tools: tool_router.model_visible_specs(),
-        parallel_tool_calls: turn_context.model_info.supports_parallel_tool_calls,
+        parallel_tool_calls: step_context.model.model_info.supports_parallel_tool_calls,
         base_instructions,
         output_schema: None,
         output_schema_strict: true,
@@ -256,7 +258,7 @@ async fn run_remote_compact_task_inner_impl(
         CodexResponsesRequestKind::Compaction(compaction_metadata),
     );
     let trace_attempt = compaction_trace.start_attempt(&serde_json::json!({
-        "model": turn_context.model_info.slug.as_str(),
+        "model": step_context.model.model_info.slug.as_str(),
         "instructions": prompt.base_instructions.text.as_str(),
         "input": &prompt.input,
         "parallel_tool_calls": prompt.parallel_tool_calls,
@@ -272,7 +274,7 @@ async fn run_remote_compact_task_inner_impl(
     };
     let compaction_output_result = run_remote_compaction_request_v2(
         sess,
-        turn_context,
+        step_context,
         client_session,
         &prompt,
         &responses_metadata,
@@ -300,7 +302,7 @@ async fn run_remote_compact_task_inner_impl(
     let (new_window_number, new_window_ids) = sess.advance_auto_compact_window().await;
     let (new_history, world_state_baseline) = process_compacted_history(
         sess.as_ref(),
-        turn_context.as_ref(),
+        step_context.as_ref(),
         compacted_history,
         &initial_context_injection,
     )
@@ -309,7 +311,7 @@ async fn run_remote_compact_task_inner_impl(
     let reference_context_item = match initial_context_injection {
         InitialContextInjection::DoNotInject => None,
         InitialContextInjection::BeforeLastUserMessage(_) => {
-            Some(turn_context.to_turn_context_item())
+            Some(step_context.to_turn_context_item())
         }
     };
     let compacted_item = CompactedItem {
@@ -332,9 +334,10 @@ async fn run_remote_compact_task_inner_impl(
         compacted_item,
     )
     .await;
-    sess.recompute_token_usage(turn_context).await;
+    sess.recompute_token_usage(turn_context, step_context.model.as_ref())
+        .await;
 
-    sess.emit_turn_item_completed(turn_context, compaction_item)
+    sess.emit_turn_item_completed(turn_context, step_context.model.as_ref(), compaction_item)
         .await;
     Ok(())
 }
@@ -346,11 +349,13 @@ struct RemoteCompactionV2Output {
 
 async fn run_remote_compaction_request_v2(
     sess: &Session,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     client_session: &mut ModelClientSession,
     prompt: &Prompt,
     responses_metadata: &CodexResponsesMetadata,
 ) -> CodexResult<RemoteCompactionV2Output> {
+    let turn_context = step_context.turn.as_ref();
+    let model_context = step_context.model.as_ref();
     let max_retries = turn_context
         .provider
         .info()
@@ -361,11 +366,11 @@ async fn run_remote_compaction_request_v2(
         let result = match client_session
             .stream(
                 prompt,
-                &turn_context.model_info,
-                &turn_context.session_telemetry,
-                turn_context.reasoning_effort.clone(),
-                turn_context.reasoning_summary,
-                turn_context.config.service_tier.clone(),
+                &model_context.model_info,
+                &model_context.session_telemetry,
+                model_context.reasoning_effort(),
+                model_context.reasoning_summary,
+                model_context.service_tier.clone(),
                 responses_metadata,
                 &InferenceTraceContext::disabled(),
             )
@@ -386,6 +391,7 @@ async fn run_remote_compaction_request_v2(
                     client_session,
                     sess,
                     turn_context,
+                    model_context,
                     ResponsesStreamRequest::RemoteCompactionV2,
                 )
                 .await?;

--- a/codex-rs/core/src/compact_tests.rs
+++ b/codex-rs/core/src/compact_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::session::tests::build_world_state_from_turn_context;
+use crate::session::step_context::StepContext;
 use codex_model_provider_info::ModelProviderInfo;
 use codex_model_provider_info::WireApi;
 use codex_protocol::models::DEFAULT_IMAGE_DETAIL;
@@ -13,17 +13,18 @@ async fn process_compacted_history_with_test_session(
 ) -> (Vec<ResponseItem>, Vec<ResponseItem>) {
     let (session, turn_context) = crate::session::tests::make_session_and_context().await;
     let turn_context = Arc::new(turn_context);
+    let step_context = StepContext::for_test(Arc::clone(&turn_context));
     session
         .set_previous_turn_settings(previous_turn_settings.cloned())
         .await;
-    let world_state = Arc::new(build_world_state_from_turn_context(&session, &turn_context).await);
+    let world_state = Arc::new(session.build_world_state_for_step(&step_context).await);
     let initial_context = session
-        .build_initial_context_with_world_state(&turn_context, world_state.as_ref())
+        .build_initial_context_with_world_state(&step_context, world_state.as_ref())
         .await;
     let initial_context_injection = InitialContextInjection::BeforeLastUserMessage(world_state);
     let (refreshed, _) = crate::compact_remote::process_compacted_history(
         &session,
-        &turn_context,
+        &step_context,
         compacted_history,
         &initial_context_injection,
     )

--- a/codex-rs/core/src/compact_token_budget.rs
+++ b/codex-rs/core/src/compact_token_budget.rs
@@ -8,7 +8,7 @@ use crate::hook_runtime::run_post_compact_hooks;
 use crate::hook_runtime::run_pre_compact_hooks;
 use crate::session::session::Session;
 use crate::session::step_context::StepContext;
-use crate::session::turn_context::TurnContext;
+use crate::session::step_context::StepContextSeed;
 use codex_analytics::CompactionTrigger;
 use codex_protocol::error::CodexErr;
 use codex_protocol::error::Result as CodexResult;
@@ -24,21 +24,22 @@ use codex_protocol::protocol::TurnStartedEvent;
 /// observe the same lifecycle as local or remote compaction.
 pub(crate) async fn run_manual_compact_task(
     sess: Arc<Session>,
-    turn_context: Arc<TurnContext>,
+    step_context_seed: StepContextSeed,
 ) -> CodexResult<()> {
+    let turn_context = &step_context_seed.turn;
     let start_event = EventMsg::TurnStarted(TurnStartedEvent {
         turn_id: turn_context.sub_id.clone(),
         trace_id: turn_context.trace_id.clone(),
         started_at: turn_context.turn_timing_state.started_at_unix_secs().await,
-        model_context_window: turn_context.model_context_window(),
-        collaboration_mode_kind: turn_context.collaboration_mode.mode,
+        model_context_window: step_context_seed.model.model_context_window(),
+        collaboration_mode_kind: step_context_seed.model.collaboration_mode.mode,
     });
-    sess.send_event(&turn_context, start_event).await;
+    sess.send_event(turn_context, start_event).await;
 
     // Manual compaction runs outside run_turn, so it captures its own current step.
-    let step_context = sess.capture_step_context(Arc::clone(&turn_context)).await;
+    let step_context = sess.capture_step_context(&step_context_seed).await;
     let world_state = Arc::new(sess.build_world_state_for_step(&step_context).await);
-    run_compact_task_inner(&sess, &turn_context, world_state, CompactionTrigger::Manual).await
+    run_compact_task_inner(&sess, &step_context, world_state, CompactionTrigger::Manual).await
 }
 
 /// Runs token-budget inline auto-compaction as a normal compaction lifecycle.
@@ -51,23 +52,23 @@ pub(crate) async fn run_inline_auto_compact_task(
     step_context: Arc<StepContext>,
     initial_context_injection: InitialContextInjection,
 ) -> CodexResult<()> {
-    let turn_context = &step_context.turn;
     let world_state = match initial_context_injection {
         InitialContextInjection::BeforeLastUserMessage(world_state) => world_state,
         InitialContextInjection::DoNotInject => {
             Arc::new(sess.build_world_state_for_step(&step_context).await)
         }
     };
-    run_compact_task_inner(&sess, turn_context, world_state, CompactionTrigger::Auto).await
+    run_compact_task_inner(&sess, &step_context, world_state, CompactionTrigger::Auto).await
 }
 
 async fn run_compact_task_inner(
     sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
+    step_context: &Arc<StepContext>,
     world_state: Arc<WorldState>,
     trigger: CompactionTrigger,
 ) -> CodexResult<()> {
-    let pre_compact_outcome = run_pre_compact_hooks(sess, turn_context, trigger).await;
+    let turn_context = &step_context.turn;
+    let pre_compact_outcome = run_pre_compact_hooks(sess, step_context.as_ref(), trigger).await;
     match pre_compact_outcome {
         PreCompactHookOutcome::Continue => {}
         PreCompactHookOutcome::Stopped => return Err(CodexErr::TurnAborted),
@@ -76,12 +77,12 @@ async fn run_compact_task_inner(
     let compaction_item = TurnItem::ContextCompaction(ContextCompactionItem::new());
     sess.emit_turn_item_started(turn_context, &compaction_item)
         .await;
-    sess.start_new_context_window(turn_context.as_ref(), world_state)
+    sess.start_new_context_window(step_context.as_ref(), world_state)
         .await;
-    sess.emit_turn_item_completed(turn_context, compaction_item)
+    sess.emit_turn_item_completed(turn_context, step_context.model.as_ref(), compaction_item)
         .await;
 
-    let post_compact_outcome = run_post_compact_hooks(sess, turn_context, trigger).await;
+    let post_compact_outcome = run_post_compact_hooks(sess, step_context.as_ref(), trigger).await;
     if let PostCompactHookOutcome::Stopped = post_compact_outcome {
         return Err(CodexErr::TurnAborted);
     }

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -5,7 +5,7 @@ use crate::context_manager::normalize;
 use crate::event_mapping::has_non_contextual_dev_message_content;
 use crate::event_mapping::is_contextual_dev_message_content;
 use crate::event_mapping::is_contextual_user_message_content;
-use crate::session::turn_context::TurnContext;
+use crate::session::step_context::StepContext;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use codex_protocol::models::BaseInstructions;
@@ -159,8 +159,9 @@ impl ContextManager {
 
     // Estimate token usage using byte-based heuristics from the truncation helpers.
     // This is a coarse lower bound, not a tokenizer-accurate count.
-    pub(crate) fn estimate_token_count(&self, turn_context: &TurnContext) -> Option<i64> {
-        let model_info = &turn_context.model_info;
+    pub(crate) fn estimate_token_count(&self, step_context: &StepContext) -> Option<i64> {
+        let model_info = &step_context.model.model_info;
+        let turn_context = &step_context.turn;
         let personality = turn_context.personality.or(turn_context.config.personality);
         let base_instructions = BaseInstructions {
             text: model_info.get_model_instructions(personality),

--- a/codex-rs/core/src/context_manager/updates.rs
+++ b/codex-rs/core/src/context_manager/updates.rs
@@ -8,6 +8,7 @@ use crate::context::RealtimeEndInstructions;
 use crate::context::RealtimeStartInstructions;
 use crate::context::RealtimeStartWithInstructions;
 use crate::session::PreviousTurnSettings;
+use crate::session::step_context::StepContext;
 use crate::session::turn_context::TurnContext;
 use codex_execpolicy::Policy;
 use codex_features::Feature;
@@ -55,18 +56,18 @@ fn build_permissions_update_item(
 
 fn build_collaboration_mode_update_item(
     previous: Option<&TurnContextItem>,
-    next: &TurnContext,
+    next: &StepContext,
 ) -> Option<String> {
-    if !next.config.include_collaboration_mode_instructions {
+    if !next.turn.config.include_collaboration_mode_instructions {
         return None;
     }
 
     let prev = previous?;
-    if prev.collaboration_mode.as_ref() != Some(&next.collaboration_mode) {
+    if prev.collaboration_mode.as_ref() != Some(&next.model.collaboration_mode) {
         // If the next mode has empty developer instructions, this returns None and we emit no
         // update, so prior collaboration instructions remain in the prompt history.
         Some(
-            CollaborationModeInstructions::from_collaboration_mode(&next.collaboration_mode)?
+            CollaborationModeInstructions::from_collaboration_mode(&next.model.collaboration_mode)?
                 .render(),
         )
     } else {
@@ -76,7 +77,7 @@ fn build_collaboration_mode_update_item(
 
 fn build_multi_agent_mode_update_item(
     previous: Option<&TurnContextItem>,
-    next: &TurnContext,
+    next: &StepContext,
 ) -> Option<String> {
     let effective_multi_agent_mode = crate::session::multi_agents::effective_multi_agent_mode(next);
     let previous = previous?;
@@ -132,21 +133,21 @@ pub(crate) fn build_initial_realtime_item(
 
 fn build_personality_update_item(
     previous: Option<&TurnContextItem>,
-    next: &TurnContext,
+    next: &StepContext,
     personality_feature_enabled: bool,
 ) -> Option<String> {
     if !personality_feature_enabled {
         return None;
     }
     let previous = previous?;
-    if next.model_info.slug != previous.model {
+    if next.model.model_info.slug != previous.model {
         return None;
     }
 
-    if let Some(personality) = next.personality
-        && next.personality != previous.personality
+    if let Some(personality) = next.turn.personality
+        && next.turn.personality != previous.personality
     {
-        let model_info = &next.model_info;
+        let model_info = &next.model.model_info;
         let personality_message = personality_message_for(model_info, personality);
         personality_message.map(|message| PersonalitySpecInstructions::new(message).render())
     } else {
@@ -167,14 +168,17 @@ pub(crate) fn personality_message_for(
 
 pub(crate) fn build_model_instructions_update_item(
     previous_turn_settings: Option<&PreviousTurnSettings>,
-    next: &TurnContext,
+    next: &StepContext,
 ) -> Option<String> {
     let previous_turn_settings = previous_turn_settings?;
-    if previous_turn_settings.model == next.model_info.slug {
+    if previous_turn_settings.model == next.model.model_info.slug {
         return None;
     }
 
-    let model_instructions = next.model_info.get_model_instructions(next.personality);
+    let model_instructions = next
+        .model
+        .model_info
+        .get_model_instructions(next.turn.personality);
     if model_instructions.is_empty() {
         return None;
     }
@@ -232,7 +236,7 @@ fn build_text_message(role: &str, text_sections: Vec<String>) -> Option<Response
 pub(crate) fn build_settings_update_items(
     previous: Option<&TurnContextItem>,
     previous_turn_settings: Option<&PreviousTurnSettings>,
-    next: &TurnContext,
+    next: &StepContext,
     exec_policy: &Policy,
     personality_feature_enabled: bool,
 ) -> Vec<ResponseItem> {
@@ -244,10 +248,10 @@ pub(crate) fn build_settings_update_items(
         // Keep model-switch instructions first so model-specific guidance is read before
         // any other context diffs on this turn.
         build_model_instructions_update_item(previous_turn_settings, next),
-        build_permissions_update_item(previous, next, exec_policy),
+        build_permissions_update_item(previous, next.turn.as_ref(), exec_policy),
         build_collaboration_mode_update_item(previous, next),
         build_multi_agent_mode_update_item(previous, next),
-        build_realtime_update_item(previous, previous_turn_settings, next),
+        build_realtime_update_item(previous, previous_turn_settings, next.turn.as_ref()),
         build_personality_update_item(previous, next, personality_feature_enabled),
     ]
     .into_iter()

--- a/codex-rs/core/src/guardian/review.rs
+++ b/codex-rs/core/src/guardian/review.rs
@@ -25,6 +25,7 @@ use tokio::time::sleep_until;
 use tokio_util::sync::CancellationToken;
 
 use crate::session::session::Session;
+use crate::session::step_context::StepContextSeed;
 use crate::session::turn_context::TurnContext;
 use crate::turn_timing::now_unix_timestamp_ms;
 use crate::util::backoff;
@@ -274,13 +275,14 @@ pub(crate) async fn record_guardian_denial_for_test(
 /// caller as distinct from explicit guardian denials.
 async fn run_guardian_review(
     session: Arc<Session>,
-    turn: Arc<TurnContext>,
+    step_context_seed: StepContextSeed,
     review_id: String,
     request: GuardianApprovalRequest,
     retry_reason: Option<String>,
     approval_request_source: GuardianApprovalRequestSource,
     external_cancel: Option<CancellationToken>,
 ) -> ReviewDecision {
+    let turn = Arc::clone(&step_context_seed.turn);
     let target_item_id = guardian_request_target_item_id(&request).map(str::to_string);
     let assessment_turn_id = guardian_request_turn_id(&request, &turn.sub_id).to_string();
     let action_summary = guardian_assessment_action(&request);
@@ -358,7 +360,7 @@ async fn run_guardian_review(
     let terminal_action = action_summary.clone();
     let (outcome, analytics_result) = Box::pin(run_guardian_review_session_with_retry(
         session.clone(),
-        turn.clone(),
+        step_context_seed.clone(),
         request,
         retry_reason.clone(),
         schema,
@@ -593,7 +595,7 @@ async fn run_guardian_review(
 /// Public entrypoint for approval requests that should be reviewed by guardian.
 pub(crate) async fn review_approval_request(
     session: &Arc<Session>,
-    turn: &Arc<TurnContext>,
+    step_context_seed: &StepContextSeed,
     review_id: String,
     request: GuardianApprovalRequest,
     retry_reason: Option<String>,
@@ -602,7 +604,7 @@ pub(crate) async fn review_approval_request(
     // guardian session state machine into their own async stack.
     Box::pin(run_guardian_review(
         Arc::clone(session),
-        Arc::clone(turn),
+        step_context_seed.clone(),
         review_id,
         request,
         retry_reason,
@@ -614,7 +616,7 @@ pub(crate) async fn review_approval_request(
 
 pub(crate) async fn review_approval_request_with_cancel(
     session: &Arc<Session>,
-    turn: &Arc<TurnContext>,
+    step_context_seed: &StepContextSeed,
     review_id: String,
     request: GuardianApprovalRequest,
     retry_reason: Option<String>,
@@ -623,7 +625,7 @@ pub(crate) async fn review_approval_request_with_cancel(
 ) -> ReviewDecision {
     run_guardian_review(
         Arc::clone(session),
-        Arc::clone(turn),
+        step_context_seed.clone(),
         review_id,
         request,
         retry_reason,
@@ -635,7 +637,7 @@ pub(crate) async fn review_approval_request_with_cancel(
 
 pub(crate) fn spawn_approval_request_review(
     session: Arc<Session>,
-    turn: Arc<TurnContext>,
+    step_context_seed: StepContextSeed,
     review_id: String,
     request: GuardianApprovalRequest,
     retry_reason: Option<String>,
@@ -653,7 +655,7 @@ pub(crate) fn spawn_approval_request_review(
         };
         let decision = runtime.block_on(review_approval_request_with_cancel(
             &session,
-            &turn,
+            &step_context_seed,
             review_id,
             request,
             retry_reason,
@@ -677,8 +679,10 @@ pub(super) struct GuardianReviewSessionConfig {
 
 pub(super) async fn guardian_review_session_config(
     session: &Session,
-    turn: &TurnContext,
+    step_context_seed: &StepContextSeed,
 ) -> anyhow::Result<GuardianReviewSessionConfig> {
+    let turn = step_context_seed.turn.as_ref();
+    let model_context = step_context_seed.model.as_ref();
     let network_proxy = session.services.network_proxy.load_full();
     let live_network_config = match network_proxy.as_ref() {
         Some(network_proxy) => Some(network_proxy.proxy().current_cfg().await?),
@@ -697,7 +701,10 @@ pub(super) async fn guardian_review_session_config(
             fallback
         }
     };
-    let model_override = turn.model_info.auto_review_model_override.as_deref();
+    let model_override = model_context
+        .model_info
+        .auto_review_model_override
+        .as_deref();
     let review_model_id = model_override.unwrap_or(default_review_model_id);
     let review_model = available_models
         .iter()
@@ -718,17 +725,18 @@ pub(super) async fn guardian_review_session_config(
         (review_model_id.to_string(), reasoning_effort)
     } else {
         let reasoning_effort = preferred_reasoning_effort(
-            turn.model_info
+            model_context
+                .model_info
                 .supported_reasoning_levels
                 .iter()
                 .any(|preset| preset.effort == codex_protocol::openai_models::ReasoningEffort::Low),
-            turn.reasoning_effort
-                .clone()
-                .or_else(|| turn.model_info.default_reasoning_level.clone()),
+            model_context
+                .reasoning_effort()
+                .or_else(|| model_context.model_info.default_reasoning_level.clone()),
         );
         (
             model_override
-                .unwrap_or(turn.model_info.slug.as_str())
+                .unwrap_or(model_context.model_info.slug.as_str())
                 .to_string(),
             reasoning_effort,
         )
@@ -767,29 +775,29 @@ pub(super) async fn guardian_review_session_config(
 /// rules.
 async fn run_guardian_review_session_before_deadline(
     session: Arc<Session>,
-    turn: Arc<TurnContext>,
+    step_context_seed: StepContextSeed,
     request: GuardianApprovalRequest,
     retry_reason: Option<String>,
     schema: serde_json::Value,
     external_cancel: Option<CancellationToken>,
     deadline: Instant,
 ) -> (GuardianReviewOutcome, GuardianReviewAnalyticsResult) {
-    let session_config = match guardian_review_session_config(session.as_ref(), turn.as_ref()).await
-    {
-        Ok(session_config) => session_config,
-        Err(err) => {
-            return (
-                GuardianReviewOutcome::Error(GuardianReviewError::prompt_build(err)),
-                GuardianReviewAnalyticsResult::without_session(),
-            );
-        }
-    };
+    let session_config =
+        match guardian_review_session_config(session.as_ref(), &step_context_seed).await {
+            Ok(session_config) => session_config,
+            Err(err) => {
+                return (
+                    GuardianReviewOutcome::Error(GuardianReviewError::prompt_build(err)),
+                    GuardianReviewAnalyticsResult::without_session(),
+                );
+            }
+        };
     let (session_outcome, session_analytics_result) = Box::pin(
         session
             .guardian_review_session
             .run_review(GuardianReviewSessionParams {
                 parent_session: Arc::clone(&session),
-                parent_turn: turn.clone(),
+                parent_step_context: step_context_seed.clone(),
                 spawn_config: session_config.spawn_config,
                 request,
                 retry_reason,
@@ -800,8 +808,8 @@ async fn run_guardian_review_session_before_deadline(
                 guardian_catalog_contains_auto_review: session_config.catalog_contains_auto_review,
                 guardian_review_model_overridden: session_config.model_overridden,
                 guardian_review_model_override: session_config.model_override,
-                reasoning_summary: turn.reasoning_summary,
-                personality: turn.personality,
+                reasoning_summary: step_context_seed.model.reasoning_summary,
+                personality: step_context_seed.turn.personality,
                 external_cancel,
                 deadline,
             }),
@@ -861,7 +869,7 @@ async fn run_guardian_review_session_before_deadline(
 
 pub(super) async fn run_guardian_review_session_with_retry(
     session: Arc<Session>,
-    turn: Arc<TurnContext>,
+    step_context_seed: StepContextSeed,
     request: GuardianApprovalRequest,
     retry_reason: Option<String>,
     schema: serde_json::Value,
@@ -874,7 +882,7 @@ pub(super) async fn run_guardian_review_session_with_retry(
     loop {
         let (outcome, mut analytics_result) = run_guardian_review_session_before_deadline(
             Arc::clone(&session),
-            Arc::clone(&turn),
+            step_context_seed.clone(),
             request.clone(),
             retry_reason.clone(),
             schema.clone(),

--- a/codex-rs/core/src/guardian/review_session.rs
+++ b/codex-rs/core/src/guardian/review_session.rs
@@ -44,7 +44,7 @@ use crate::context::ContextualUserFragment;
 use crate::context::GuardianFollowupReviewReminder;
 use crate::session::Codex;
 use crate::session::session::Session;
-use crate::session::turn_context::TurnContext;
+use crate::session::step_context::StepContextSeed;
 use codex_config::types::McpServerConfig;
 use codex_features::Feature;
 use codex_model_provider_info::ModelProviderInfo;
@@ -74,7 +74,7 @@ pub(crate) enum GuardianReviewSessionOutcome {
 
 pub(crate) struct GuardianReviewSessionParams {
     pub(crate) parent_session: Arc<Session>,
-    pub(crate) parent_turn: Arc<TurnContext>,
+    pub(crate) parent_step_context: StepContextSeed,
     pub(crate) spawn_config: Config,
     pub(crate) request: GuardianApprovalRequest,
     pub(crate) retry_reason: Option<String>,
@@ -295,13 +295,14 @@ impl GuardianReviewSessionManager {
     pub(crate) fn initialize(
         &self,
         parent_session: Arc<Session>,
-        parent_turn: Arc<TurnContext>,
+        parent_step_context: StepContextSeed,
     ) -> BoxFuture<'_, anyhow::Result<()>> {
         // Boxing breaks the Session::new -> Guardian -> Session::new future recursion.
         Box::pin(async move {
-            let spawn_config = guardian_review_session_config(&parent_session, &parent_turn)
-                .await?
-                .spawn_config;
+            let spawn_config =
+                guardian_review_session_config(&parent_session, &parent_step_context)
+                    .await?
+                    .spawn_config;
             let reuse_key = GuardianReviewSessionReuseKey::from_spawn_config(
                 &spawn_config,
                 parent_session.user_instructions().await,
@@ -310,7 +311,7 @@ impl GuardianReviewSessionManager {
             let spawn_cancel_guard = spawn_cancel_token.clone().drop_guard();
             let review_session = spawn_guardian_review_session(
                 &parent_session,
-                &parent_turn,
+                &parent_step_context,
                 spawn_config,
                 reuse_key,
                 spawn_cancel_token.clone(),
@@ -395,7 +396,7 @@ impl GuardianReviewSessionManager {
                         &spawn_cancel_token,
                         Box::pin(spawn_guardian_review_session(
                             &params.parent_session,
-                            &params.parent_turn,
+                            &params.parent_step_context,
                             params.spawn_config.clone(),
                             next_reuse_key.clone(),
                             spawn_cancel_token.clone(),
@@ -606,7 +607,7 @@ impl GuardianReviewSessionManager {
             &spawn_cancel_token,
             Box::pin(spawn_guardian_review_session(
                 &params.parent_session,
-                &params.parent_turn,
+                &params.parent_step_context,
                 fork_config,
                 reuse_key,
                 spawn_cancel_token.clone(),
@@ -648,7 +649,7 @@ impl GuardianReviewSessionManager {
 
 async fn spawn_guardian_review_session(
     parent_session: &Arc<Session>,
-    parent_turn: &Arc<TurnContext>,
+    parent_step_context: &StepContextSeed,
     spawn_config: Config,
     reuse_key: GuardianReviewSessionReuseKey,
     cancel_token: CancellationToken,
@@ -667,7 +668,7 @@ async fn spawn_guardian_review_session(
         parent_session.services.auth_manager.clone(),
         parent_session.services.models_manager.clone(),
         Arc::clone(parent_session),
-        Arc::clone(parent_turn),
+        parent_step_context.clone(),
         cancel_token.clone(),
         SubAgentSource::Other(GUARDIAN_REVIEWER_NAME.to_string()),
         initial_history,
@@ -760,7 +761,7 @@ async fn run_review_on_session(
 
             build_guardian_prompt_items_with_parent_turn(
                 params.parent_session.as_ref(),
-                Some(params.parent_turn.as_ref()),
+                Some(params.parent_step_context.turn.as_ref()),
                 params.retry_reason.clone(),
                 params.request.clone(),
                 prompt_mode,
@@ -792,15 +793,16 @@ async fn run_review_on_session(
         .await
         .unwrap_or_default();
     let guardian_permission_profile = PermissionProfile::read_only();
-    let parent_turn_environments = params.parent_turn.environments.to_selections();
+    let parent_turn_environments = params.parent_step_context.turn.environments.to_selections();
     // TODO(anp): Migrate guardian review thread settings to a PathUri fallback cwd so foreign
     // parent environments do not fall back to the host-native config cwd.
     let parent_turn_legacy_fallback_cwd = params
-        .parent_turn
+        .parent_step_context
+        .turn
         .environments
         .primary()
         .and_then(|environment| environment.cwd().to_abs_path().ok())
-        .unwrap_or_else(|| params.parent_turn.config.cwd.clone());
+        .unwrap_or_else(|| params.parent_step_context.turn.config.cwd.clone());
 
     let submit_result = run_before_review_deadline(
         deadline,
@@ -878,7 +880,7 @@ async fn append_guardian_followup_reminder(review_session: &GuardianReviewSessio
     review_session
         .codex
         .session
-        .inject_no_new_turn(vec![reminder], /*current_turn_context*/ None)
+        .inject_no_new_turn(vec![reminder], /*current_step_context_seed*/ None)
         .await;
 }
 
@@ -1124,6 +1126,7 @@ async fn interrupt_and_drain_turn(codex: &Codex, expected_turn_id: &str) -> anyh
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::step_model_context::StepModelContext;
     use codex_protocol::protocol::AgentStatus;
     use codex_protocol::protocol::ErrorEvent;
     use codex_protocol::protocol::Submission;
@@ -1200,9 +1203,10 @@ mod tests {
 
     async fn test_review_params() -> GuardianReviewSessionParams {
         let (session, turn) = crate::session::tests::make_session_and_context().await;
-        let model = turn.model_info.slug.clone();
-        let reasoning_effort = turn.reasoning_effort.clone();
-        let reasoning_summary = turn.reasoning_summary;
+        let model_context = StepModelContext::for_test(&turn);
+        let model = model_context.model_info.slug.clone();
+        let reasoning_effort = model_context.reasoning_effort();
+        let reasoning_summary = model_context.reasoning_summary;
         let personality = turn.personality;
         #[allow(deprecated)]
         let cwd = turn.cwd.clone();
@@ -1216,7 +1220,7 @@ mod tests {
 
         GuardianReviewSessionParams {
             parent_session: Arc::new(session),
-            parent_turn: Arc::new(turn),
+            parent_step_context: StepContextSeed::new(Arc::new(turn), Arc::new(model_context)),
             spawn_config,
             request: GuardianApprovalRequest::Shell {
                 id: "shell-1".to_string(),

--- a/codex-rs/core/src/guardian/tests.rs
+++ b/codex-rs/core/src/guardian/tests.rs
@@ -7,6 +7,9 @@ use crate::config::NetworkProxySpec;
 use crate::config::test_config;
 use crate::guardian::approval_request::guardian_request_target_item_id;
 use crate::session::session::Session;
+use crate::session::step_context::StepContext;
+use crate::session::step_context::StepContextSeed;
+use crate::session::step_model_context::StepModelContext;
 use crate::session::turn_context::TurnContext;
 use crate::test_support;
 use codex_analytics::GuardianApprovalRequestSource;
@@ -111,6 +114,7 @@ impl codex_extension_api::ContextContributor for GuardianMemoryContextProbe {
         &'a self,
         _session_store: &'a codex_extension_api::ExtensionData,
         thread_store: &'a codex_extension_api::ExtensionData,
+        _model_info: &'a codex_protocol::openai_models::ModelInfo,
     ) -> codex_extension_api::ExtensionFuture<'a, Vec<codex_extension_api::PromptFragment>> {
         Box::pin(async move {
             if thread_store
@@ -283,10 +287,15 @@ async fn guardian_test_session_and_turn_with_base_url(
     (Arc::new(session), Arc::new(turn))
 }
 
+fn guardian_step_context_seed(turn: &Arc<TurnContext>) -> StepContextSeed {
+    StepContextSeed::new(Arc::clone(turn), Arc::new(StepModelContext::for_test(turn)))
+}
+
 async fn seed_guardian_parent_history(session: &Arc<Session>, turn: &Arc<TurnContext>) {
+    let step_context = StepContext::for_test(Arc::clone(turn));
     session
         .record_conversation_items(
-            turn.as_ref(),
+            step_context.as_ref(),
             &[
                 ResponseItem::Message {
                     id: None,
@@ -520,7 +529,7 @@ async fn build_guardian_prompt_delta_mode_preserves_original_numbering() -> anyh
     seed_guardian_parent_history(&session, &turn).await;
     session
         .record_conversation_items(
-            turn.as_ref(),
+            StepContext::for_test(Arc::clone(&turn)).as_ref(),
             &[
                 ResponseItem::Message {
                     id: None,
@@ -678,7 +687,7 @@ async fn build_guardian_prompt_stale_delta_version_falls_back_to_full_prompt() -
         .await;
     session
         .record_conversation_items(
-            turn.as_ref(),
+            StepContext::for_test(Arc::clone(&turn)).as_ref(),
             &[
                 ResponseItem::Message {
                     id: None,
@@ -1150,7 +1159,7 @@ async fn cancelled_guardian_review_emits_terminal_abort_without_warning() {
 
     let decision = review_approval_request_with_cancel(
         &session,
-        &turn,
+        &guardian_step_context_seed(&turn),
         "review-cancelled-guardian".to_string(),
         GuardianApprovalRequest::ApplyPatch {
             id: "patch-1".to_string(),
@@ -1442,11 +1451,12 @@ async fn guardian_request_model_for_auto_review(
     )
     .await;
 
-    let (mut session, mut turn) = guardian_test_session_and_turn(&server).await;
+    let (mut session, turn) = guardian_test_session_and_turn(&server).await;
+    let mut model_context = StepModelContext::for_test(&turn);
     match catalog {
         GuardianTestCatalog::Bundled => {}
         GuardianTestCatalog::ParentOnly => {
-            let parent_model = turn.model_info.clone();
+            let parent_model = model_context.model_info.clone();
             let auth_manager = Arc::clone(&session.services.auth_manager);
             let models_manager = StaticModelsManager::new(
                 Some(auth_manager),
@@ -1460,17 +1470,14 @@ async fn guardian_request_model_for_auto_review(
                 .models_manager = Arc::new(models_manager);
         }
     }
-    Arc::get_mut(&mut turn)
-        .expect("turn should be unique")
-        .model_info
-        .auto_review_model_override = auto_review_model_override;
-    let parent_model = turn.model_info.slug.clone();
+    model_context.model_info.auto_review_model_override = auto_review_model_override;
+    let parent_model = model_context.model_info.slug.clone();
     let preferred_model = turn.provider.approval_review_preferred_model().to_string();
     seed_guardian_parent_history(&session, &turn).await;
 
     let (outcome, analytics_result) = run_guardian_review_session_for_test(
         Arc::clone(&session),
-        turn,
+        StepContextSeed::new(turn, Arc::new(model_context)),
         GuardianApprovalRequest::Shell {
             id: "shell-1".to_string(),
             command: vec!["git".to_string(), "push".to_string()],
@@ -1688,7 +1695,7 @@ async fn guardian_review_request_layout_matches_model_visible_request_snapshot()
     seed_guardian_parent_history(&session, &turn).await;
     session
         .record_conversation_items(
-            turn.as_ref(),
+            StepContext::for_test(Arc::clone(&turn)).as_ref(),
             &[ResponseItem::Message {
                 id: None,
                 role: "user".to_string(),
@@ -1719,7 +1726,7 @@ async fn guardian_review_request_layout_matches_model_visible_request_snapshot()
 
     let outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
-        Arc::clone(&turn),
+        guardian_step_context_seed(&turn),
         request,
         Some("Sandbox denied outbound git push to github.com.".to_string()),
         guardian_output_schema(),
@@ -1911,7 +1918,7 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
     };
     let first_outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
-        Arc::clone(&turn),
+        guardian_step_context_seed(&turn),
         first_request,
         Some("First retry reason".to_string()),
         guardian_output_schema(),
@@ -1921,7 +1928,7 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
     .await;
     session
         .record_conversation_items(
-            turn.as_ref(),
+            StepContext::for_test(Arc::clone(&turn)).as_ref(),
             &[
                 ResponseItem::Message {
                     id: None,
@@ -1958,7 +1965,7 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
     };
     let second_outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
-        Arc::clone(&turn),
+        guardian_step_context_seed(&turn),
         second_request,
         Some("Second retry reason".to_string()),
         guardian_output_schema(),
@@ -1968,7 +1975,7 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
     .await;
     session
         .record_conversation_items(
-            turn.as_ref(),
+            StepContext::for_test(Arc::clone(&turn)).as_ref(),
             &[
                 ResponseItem::Message {
                     id: None,
@@ -2001,7 +2008,7 @@ async fn guardian_reuses_prompt_cache_key_and_appends_prior_reviews() -> anyhow:
     };
     let third_outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
-        Arc::clone(&turn),
+        guardian_step_context_seed(&turn),
         third_request,
         Some("Third retry reason".to_string()),
         guardian_output_schema(),
@@ -2186,7 +2193,7 @@ async fn guardian_reused_trunk_ignores_stale_prior_turn_completion() -> anyhow::
     let (session, turn) = guardian_test_session_and_turn(&server).await;
     let first_outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
-        Arc::clone(&turn),
+        guardian_step_context_seed(&turn),
         GuardianApprovalRequest::Shell {
             id: "shell-1".to_string(),
             command: vec!["git".to_string(), "push".to_string()],
@@ -2229,7 +2236,7 @@ async fn guardian_reused_trunk_ignores_stale_prior_turn_completion() -> anyhow::
 
     let second_outcome = run_guardian_review_session_for_test(
         Arc::clone(&session),
-        Arc::clone(&turn),
+        guardian_step_context_seed(&turn),
         GuardianApprovalRequest::Shell {
             id: "shell-2".to_string(),
             command: vec!["git".to_string(), "push".to_string()],
@@ -2308,7 +2315,7 @@ async fn guardian_review_surfaces_responses_api_errors_in_rejection_reason() -> 
 
     let decision = review_approval_request(
         &session,
-        &turn,
+        &guardian_step_context_seed(&turn),
         "review-shell-guardian-error".to_string(),
         GuardianApprovalRequest::Shell {
             id: "shell-guardian-error".to_string(),
@@ -2407,7 +2414,7 @@ async fn guardian_review_retries_transient_session_failure_then_approves() -> an
 
     let (outcome, metadata) = run_guardian_review_session_for_test(
         Arc::clone(&session),
-        Arc::clone(&turn),
+        guardian_step_context_seed(&turn),
         guardian_shell_request("shell-session-retry"),
         /*retry_reason*/ None,
         guardian_output_schema(),
@@ -2448,7 +2455,7 @@ async fn guardian_review_does_not_retry_missing_assessment_payload() -> anyhow::
 
     let decision = review_approval_request(
         &session,
-        &turn,
+        &guardian_step_context_seed(&turn),
         "review-missing-assessment".to_string(),
         guardian_shell_request("shell-missing-assessment"),
         /*retry_reason*/ None,
@@ -2498,7 +2505,7 @@ async fn guardian_review_retries_two_parse_failures_then_approves() -> anyhow::R
 
     let (outcome, metadata) = run_guardian_review_session_for_test(
         Arc::clone(&session),
-        Arc::clone(&turn),
+        guardian_step_context_seed(&turn),
         guardian_shell_request("shell-parse-retry"),
         /*retry_reason*/ None,
         guardian_output_schema(),
@@ -2552,7 +2559,7 @@ async fn guardian_review_exhausts_three_failures_with_one_terminal_event() -> an
 
     let decision = review_approval_request(
         &session,
-        &turn,
+        &guardian_step_context_seed(&turn),
         "review-exhausted-retry".to_string(),
         guardian_shell_request("shell-exhausted-retry"),
         /*retry_reason*/ None,
@@ -2603,7 +2610,7 @@ async fn guardian_review_does_not_retry_valid_denial() -> anyhow::Result<()> {
 
     let decision = review_approval_request(
         &session,
-        &turn,
+        &guardian_step_context_seed(&turn),
         "review-valid-denial".to_string(),
         guardian_shell_request("shell-valid-denial"),
         /*retry_reason*/ None,
@@ -2706,7 +2713,7 @@ async fn guardian_ephemeral_retry_preserves_parallel_trunk_and_fork_history() ->
         assert_eq!(
             review_approval_request(
                 &session,
-                &turn,
+                &guardian_step_context_seed(&turn),
                 "review-shell-guardian-1".to_string(),
                 initial_request,
                 /*retry_reason*/ None
@@ -2716,7 +2723,7 @@ async fn guardian_ephemeral_retry_preserves_parallel_trunk_and_fork_history() ->
         );
         session
             .record_conversation_items(
-                turn.as_ref(),
+                StepContext::for_test(Arc::clone(&turn)).as_ref(),
                 &[
                     ResponseItem::Message {
                         id: None,
@@ -2756,11 +2763,11 @@ async fn guardian_ephemeral_retry_preserves_parallel_trunk_and_fork_history() ->
         };
 
         let session_for_second = Arc::clone(&session);
-        let turn_for_second = Arc::clone(&turn);
+        let step_context_for_second = guardian_step_context_seed(&turn);
         let mut second_review = tokio::spawn(async move {
             review_approval_request(
                 &session_for_second,
-                &turn_for_second,
+                &step_context_for_second,
                 "review-shell-guardian-2".to_string(),
                 second_request,
                 Some("trunk follow-up".to_string()),
@@ -2783,7 +2790,7 @@ async fn guardian_ephemeral_retry_preserves_parallel_trunk_and_fork_history() ->
         );
         session
             .record_conversation_items(
-                turn.as_ref(),
+                StepContext::for_test(Arc::clone(&turn)).as_ref(),
                 &[
                     ResponseItem::Message {
                         id: None,
@@ -2807,7 +2814,7 @@ async fn guardian_ephemeral_retry_preserves_parallel_trunk_and_fork_history() ->
 
         let third_decision = review_approval_request(
             &session,
-            &turn,
+            &guardian_step_context_seed(&turn),
             "review-shell-guardian-3".to_string(),
             third_request,
             Some("parallel follow-up".to_string()),

--- a/codex-rs/core/src/hook_runtime.rs
+++ b/codex-rs/core/src/hook_runtime.rs
@@ -44,6 +44,9 @@ use crate::context::HookAdditionalContext;
 use crate::event_mapping::parse_turn_item;
 use crate::session::TurnInput;
 use crate::session::session::Session;
+use crate::session::step_context::StepContext;
+use crate::session::step_context::StepContextSeed;
+use crate::session::step_model_context::StepModelContext;
 use crate::session::turn_context::TurnContext;
 use crate::tools::hook_names::HookToolName;
 use crate::tools::sandboxing::PermissionRequestPayload;
@@ -102,8 +105,9 @@ impl From<UserPromptSubmitOutcome> for ContextInjectingHookOutcome {
 #[instrument(level = "trace", skip_all)]
 pub(crate) async fn run_pending_session_start_hooks(
     sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
+    step_context_seed: &StepContextSeed,
 ) -> bool {
+    let turn_context = &step_context_seed.turn;
     while let Some(session_start_source) = sess.take_pending_session_start_source().await {
         // Pending session-start hooks are reused to dispatch thread-spawn subagent
         // starts. Other subagent sessions are internal/system work and do not run
@@ -132,7 +136,7 @@ pub(crate) async fn run_pending_session_start_hooks(
             #[allow(deprecated)]
             cwd: turn_context.cwd.clone(),
             transcript_path: sess.hook_transcript_path().await,
-            model: turn_context.model_info.slug.clone(),
+            model: step_context_seed.model.model_info.slug.clone(),
             permission_mode: hook_permission_mode(turn_context),
             target,
         };
@@ -140,12 +144,12 @@ pub(crate) async fn run_pending_session_start_hooks(
         let preview_runs = hooks.preview_session_start(&request);
         if run_context_injecting_hook(
             sess,
-            turn_context,
+            step_context_seed,
             preview_runs,
             hooks.run_session_start(request, Some(turn_context.sub_id.clone())),
         )
         .await
-        .record_additional_contexts(sess, turn_context)
+        .record_additional_contexts(sess, step_context_seed)
         .await
         {
             return true;
@@ -162,11 +166,12 @@ pub(crate) async fn run_pending_session_start_hooks(
 /// handlers.
 pub(crate) async fn run_pre_tool_use_hooks(
     sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
+    step_context: &StepContext,
     tool_use_id: String,
     tool_name: &HookToolName,
     tool_input: &Value,
 ) -> PreToolUseHookResult {
+    let turn_context = &step_context.turn;
     let request = PreToolUseRequest {
         session_id: sess.session_id().into(),
         turn_id: turn_context.sub_id.clone(),
@@ -174,7 +179,7 @@ pub(crate) async fn run_pre_tool_use_hooks(
         #[allow(deprecated)]
         cwd: turn_context.cwd.clone(),
         transcript_path: sess.hook_transcript_path().await,
-        model: turn_context.model_info.slug.clone(),
+        model: step_context.model.model_info.slug.clone(),
         permission_mode: hook_permission_mode(turn_context),
         tool_name: tool_name.name().to_string(),
         matcher_aliases: tool_name.matcher_aliases().to_vec(),
@@ -192,8 +197,8 @@ pub(crate) async fn run_pre_tool_use_hooks(
         additional_contexts,
         updated_input,
     } = hooks.run_pre_tool_use(request).await;
-    emit_hook_completed_events(sess, turn_context, hook_events).await;
-    record_additional_contexts(sess, turn_context, additional_contexts).await;
+    emit_hook_completed_events(sess, turn_context, step_context.model.as_ref(), hook_events).await;
+    record_step_additional_contexts(sess, step_context, additional_contexts).await;
 
     if !should_block {
         return PreToolUseHookResult::Continue { updated_input };
@@ -224,10 +229,11 @@ pub(crate) async fn run_pre_tool_use_hooks(
 // tool input or post-run state.
 pub(crate) async fn run_permission_request_hooks(
     sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
+    step_context: &StepContext,
     run_id_suffix: &str,
     payload: PermissionRequestPayload,
 ) -> Option<PermissionRequestDecision> {
+    let turn_context = &step_context.turn;
     let request = PermissionRequestRequest {
         session_id: sess.session_id().into(),
         turn_id: turn_context.sub_id.clone(),
@@ -235,7 +241,7 @@ pub(crate) async fn run_permission_request_hooks(
         #[allow(deprecated)]
         cwd: turn_context.cwd.to_path_buf(),
         transcript_path: sess.hook_transcript_path().await,
-        model: turn_context.model_info.slug.clone(),
+        model: step_context.model.model_info.slug.clone(),
         permission_mode: hook_permission_mode(turn_context),
         tool_name: payload.tool_name.name().to_string(),
         matcher_aliases: payload.tool_name.matcher_aliases().to_vec(),
@@ -250,7 +256,7 @@ pub(crate) async fn run_permission_request_hooks(
         hook_events,
         decision,
     } = hooks.run_permission_request(request).await;
-    emit_hook_completed_events(sess, turn_context, hook_events).await;
+    emit_hook_completed_events(sess, turn_context, step_context.model.as_ref(), hook_events).await;
 
     decision
 }
@@ -263,13 +269,14 @@ pub(crate) async fn run_permission_request_hooks(
 /// matchers and hook logs.
 pub(crate) async fn run_post_tool_use_hooks(
     sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
+    step_context: &StepContext,
     tool_use_id: String,
     tool_name: String,
     matcher_aliases: Vec<String>,
     tool_input: Value,
     tool_response: Value,
 ) -> PostToolUseOutcome {
+    let turn_context = &step_context.turn;
     let request = PostToolUseRequest {
         session_id: sess.session_id().into(),
         turn_id: turn_context.sub_id.clone(),
@@ -277,7 +284,7 @@ pub(crate) async fn run_post_tool_use_hooks(
         #[allow(deprecated)]
         cwd: turn_context.cwd.clone(),
         transcript_path: sess.hook_transcript_path().await,
-        model: turn_context.model_info.slug.clone(),
+        model: step_context.model.model_info.slug.clone(),
         permission_mode: hook_permission_mode(turn_context),
         tool_name,
         matcher_aliases,
@@ -290,17 +297,24 @@ pub(crate) async fn run_post_tool_use_hooks(
     emit_hook_started_events(sess, turn_context, preview_runs).await;
 
     let outcome = hooks.run_post_tool_use(request).await;
-    emit_hook_completed_events(sess, turn_context, outcome.hook_events.clone()).await;
+    emit_hook_completed_events(
+        sess,
+        turn_context,
+        step_context.model.as_ref(),
+        outcome.hook_events.clone(),
+    )
+    .await;
     outcome
 }
 
 #[instrument(level = "trace", skip_all)]
 pub(crate) async fn run_turn_stop_hooks(
     sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
+    step_context: &StepContext,
     stop_hook_active: bool,
     last_assistant_message: Option<String>,
 ) -> StopOutcome {
+    let turn_context = &step_context.turn;
     // Resolve the stop hook kind from the session source before building the
     // request. Root turns run Stop; thread-spawned child turns run SubagentStop.
     let (target, transcript_path) = match &turn_context.session_source {
@@ -351,7 +365,7 @@ pub(crate) async fn run_turn_stop_hooks(
         #[allow(deprecated)]
         cwd: turn_context.cwd.clone(),
         transcript_path,
-        model: turn_context.model_info.slug.clone(),
+        model: step_context.model.model_info.slug.clone(),
         permission_mode: hook_permission_mode(turn_context),
         stop_hook_active,
         last_assistant_message,
@@ -361,15 +375,22 @@ pub(crate) async fn run_turn_stop_hooks(
     emit_hook_started_events(sess, turn_context, hooks.preview_stop(&request)).await;
 
     let mut outcome = hooks.run_stop(request).await;
-    emit_hook_completed_events(sess, turn_context, std::mem::take(&mut outcome.hook_events)).await;
+    emit_hook_completed_events(
+        sess,
+        turn_context,
+        step_context.model.as_ref(),
+        std::mem::take(&mut outcome.hook_events),
+    )
+    .await;
     outcome
 }
 
 pub(crate) async fn run_pre_compact_hooks(
     sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
+    step_context: &StepContext,
     trigger: CompactionTrigger,
 ) -> PreCompactHookOutcome {
+    let turn_context = &step_context.turn;
     let request = codex_hooks::PreCompactRequest {
         session_id: sess.session_id().into(),
         turn_id: turn_context.sub_id.clone(),
@@ -377,14 +398,20 @@ pub(crate) async fn run_pre_compact_hooks(
         #[allow(deprecated)]
         cwd: turn_context.cwd.clone(),
         transcript_path: sess.hook_transcript_path().await,
-        model: turn_context.model_info.slug.clone(),
+        model: step_context.model.model_info.slug.clone(),
         trigger: compaction_trigger_label(trigger).to_string(),
     };
     let preview_runs = sess.hooks().preview_pre_compact(&request);
     emit_hook_started_events(sess, turn_context, preview_runs).await;
 
     let outcome = sess.hooks().run_pre_compact(request).await;
-    emit_hook_completed_events(sess, turn_context, outcome.hook_events).await;
+    emit_hook_completed_events(
+        sess,
+        turn_context,
+        step_context.model.as_ref(),
+        outcome.hook_events,
+    )
+    .await;
     if outcome.should_stop {
         PreCompactHookOutcome::Stopped
     } else {
@@ -404,9 +431,10 @@ pub(crate) enum PostCompactHookOutcome {
 
 pub(crate) async fn run_post_compact_hooks(
     sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
+    step_context: &StepContext,
     trigger: CompactionTrigger,
 ) -> PostCompactHookOutcome {
+    let turn_context = &step_context.turn;
     let request = codex_hooks::PostCompactRequest {
         session_id: sess.session_id().into(),
         turn_id: turn_context.sub_id.clone(),
@@ -414,14 +442,20 @@ pub(crate) async fn run_post_compact_hooks(
         #[allow(deprecated)]
         cwd: turn_context.cwd.clone(),
         transcript_path: sess.hook_transcript_path().await,
-        model: turn_context.model_info.slug.clone(),
+        model: step_context.model.model_info.slug.clone(),
         trigger: compaction_trigger_label(trigger).to_string(),
     };
     let preview_runs = sess.hooks().preview_post_compact(&request);
     emit_hook_started_events(sess, turn_context, preview_runs).await;
 
     let outcome = sess.hooks().run_post_compact(request).await;
-    emit_hook_completed_events(sess, turn_context, outcome.hook_events).await;
+    emit_hook_completed_events(
+        sess,
+        turn_context,
+        step_context.model.as_ref(),
+        outcome.hook_events,
+    )
+    .await;
     if outcome.should_stop {
         PostCompactHookOutcome::Stopped
     } else {
@@ -499,9 +533,10 @@ pub(crate) async fn run_legacy_after_agent_hook(
 
 pub(crate) async fn inspect_pending_input(
     sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
+    step_context_seed: &StepContextSeed,
     pending_input_item: &TurnInput,
 ) -> HookRuntimeOutcome {
+    let turn_context = &step_context_seed.turn;
     match pending_input_item {
         TurnInput::UserInput { content, .. } => {
             let request = UserPromptSubmitRequest {
@@ -511,7 +546,7 @@ pub(crate) async fn inspect_pending_input(
                 #[allow(deprecated)]
                 cwd: turn_context.cwd.clone(),
                 transcript_path: sess.hook_transcript_path().await,
-                model: turn_context.model_info.slug.clone(),
+                model: step_context_seed.model.model_info.slug.clone(),
                 permission_mode: hook_permission_mode(turn_context),
                 prompt: UserMessageItem::new(content).message(),
             };
@@ -519,7 +554,7 @@ pub(crate) async fn inspect_pending_input(
             let preview_runs = hooks.preview_user_prompt_submit(&request);
             run_context_injecting_hook(
                 sess,
-                turn_context,
+                step_context_seed,
                 preview_runs,
                 hooks.run_user_prompt_submit(request),
             )
@@ -538,34 +573,34 @@ pub(crate) async fn inspect_pending_input(
 
 pub(crate) async fn record_pending_input(
     sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
+    step_context_seed: &StepContextSeed,
     pending_input: TurnInput,
     additional_contexts: Vec<String>,
 ) {
     match pending_input {
         TurnInput::UserInput { content, client_id } => {
             sess.record_user_prompt_and_emit_turn_item(
-                turn_context.as_ref(),
+                step_context_seed,
                 content.as_slice(),
                 client_id,
             )
             .await;
         }
         TurnInput::ResponseItem(item) => {
-            sess.record_conversation_items(turn_context, std::slice::from_ref(&item))
+            sess.record_conversation_items_for_seed(step_context_seed, std::slice::from_ref(&item))
                 .await;
         }
         TurnInput::InterAgentCommunication(communication) => {
-            sess.record_inter_agent_communication(turn_context, communication)
+            sess.record_inter_agent_communication(step_context_seed, communication)
                 .await;
         }
     }
-    record_additional_contexts(sess, turn_context, additional_contexts).await;
+    record_additional_contexts(sess, step_context_seed, additional_contexts).await;
 }
 
 async fn run_context_injecting_hook<Fut, Outcome>(
     sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
+    step_context_seed: &StepContextSeed,
     preview_runs: Vec<HookRunSummary>,
     outcome_future: Fut,
 ) -> HookRuntimeOutcome
@@ -573,10 +608,16 @@ where
     Fut: Future<Output = Outcome>,
     Outcome: Into<ContextInjectingHookOutcome>,
 {
-    emit_hook_started_events(sess, turn_context, preview_runs).await;
+    emit_hook_started_events(sess, step_context_seed.turn.as_ref(), preview_runs).await;
 
     let outcome = outcome_future.await.into();
-    emit_hook_completed_events(sess, turn_context, outcome.hook_events).await;
+    emit_hook_completed_events(
+        sess,
+        step_context_seed.turn.as_ref(),
+        step_context_seed.model.as_ref(),
+        outcome.hook_events,
+    )
+    .await;
     outcome.outcome
 }
 
@@ -584,9 +625,9 @@ impl HookRuntimeOutcome {
     async fn record_additional_contexts(
         self,
         sess: &Arc<Session>,
-        turn_context: &Arc<TurnContext>,
+        step_context_seed: &StepContextSeed,
     ) -> bool {
-        record_additional_contexts(sess, turn_context, self.additional_contexts).await;
+        record_additional_contexts(sess, step_context_seed, self.additional_contexts).await;
 
         self.should_stop
     }
@@ -594,7 +635,7 @@ impl HookRuntimeOutcome {
 
 pub(crate) async fn record_additional_contexts(
     sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
+    step_context_seed: &StepContextSeed,
     additional_contexts: Vec<String>,
 ) {
     let developer_messages = additional_context_messages(additional_contexts);
@@ -602,7 +643,21 @@ pub(crate) async fn record_additional_contexts(
         return;
     }
 
-    sess.record_conversation_items(turn_context, developer_messages.as_slice())
+    sess.record_conversation_items_for_seed(step_context_seed, developer_messages.as_slice())
+        .await;
+}
+
+pub(crate) async fn record_step_additional_contexts(
+    sess: &Arc<Session>,
+    step_context: &StepContext,
+    additional_contexts: Vec<String>,
+) {
+    let developer_messages = additional_context_messages(additional_contexts);
+    if developer_messages.is_empty() {
+        return;
+    }
+
+    sess.record_conversation_items(step_context, developer_messages.as_slice())
         .await;
 }
 
@@ -616,7 +671,7 @@ fn additional_context_messages(additional_contexts: Vec<String>) -> Vec<Response
 
 async fn emit_hook_started_events(
     sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
+    turn_context: &TurnContext,
     preview_runs: Vec<HookRunSummary>,
 ) {
     for run in preview_runs {
@@ -631,28 +686,29 @@ async fn emit_hook_started_events(
     }
 }
 
-pub(crate) async fn emit_hook_completed_events(
+async fn emit_hook_completed_events(
     sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
+    turn_context: &TurnContext,
+    model_context: &StepModelContext,
     completed_events: Vec<HookCompletedEvent>,
 ) {
     for completed in completed_events {
-        emit_hook_completed_metrics(turn_context, &completed);
-        track_hook_completed_analytics(sess, turn_context, &completed);
+        emit_hook_completed_metrics(model_context, &completed);
+        track_hook_completed_analytics(sess, turn_context, model_context, &completed);
         sess.send_event(turn_context, EventMsg::HookCompleted(completed))
             .await;
     }
 }
 
-fn emit_hook_completed_metrics(turn_context: &TurnContext, completed: &HookCompletedEvent) {
+fn emit_hook_completed_metrics(model_context: &StepModelContext, completed: &HookCompletedEvent) {
     let tags = hook_run_metric_tags(&completed.run);
-    turn_context
+    model_context
         .session_telemetry
         .counter(HOOK_RUN_METRIC, /*inc*/ 1, &tags);
     if let Some(duration_ms) = completed.run.duration_ms
         && let Ok(duration_ms) = u64::try_from(duration_ms)
     {
-        turn_context.session_telemetry.record_duration(
+        model_context.session_telemetry.record_duration(
             HOOK_RUN_DURATION_METRIC,
             Duration::from_millis(duration_ms),
             &tags,
@@ -662,11 +718,16 @@ fn emit_hook_completed_metrics(turn_context: &TurnContext, completed: &HookCompl
 
 fn track_hook_completed_analytics(
     sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
+    turn_context: &TurnContext,
+    model_context: &StepModelContext,
     completed: &HookCompletedEvent,
 ) {
-    let (tracking, hook) =
-        hook_run_analytics_payload(sess.thread_id.to_string(), turn_context, completed);
+    let (tracking, hook) = hook_run_analytics_payload(
+        sess.thread_id.to_string(),
+        turn_context,
+        model_context,
+        completed,
+    );
     sess.services
         .analytics_events_client
         .track_hook_run(tracking, hook);
@@ -675,11 +736,12 @@ fn track_hook_completed_analytics(
 fn hook_run_analytics_payload(
     thread_id: String,
     turn_context: &TurnContext,
+    model_context: &StepModelContext,
     completed: &HookCompletedEvent,
 ) -> (codex_analytics::TrackEventsContext, HookRunFact) {
     (
         build_track_events_context(
-            turn_context.model_info.slug.clone(),
+            model_context.model_info.slug.clone(),
             thread_id,
             completed
                 .turn_id
@@ -788,6 +850,7 @@ mod tests {
     use super::additional_context_messages;
     use super::hook_run_analytics_payload;
     use super::hook_run_metric_tags;
+    use crate::session::step_model_context::StepModelContext;
     use crate::session::tests::make_session_and_context;
     use codex_protocol::protocol::HookCompletedEvent;
     use codex_protocol::protocol::HookRunSummary;
@@ -831,17 +894,22 @@ mod tests {
     #[tokio::test]
     async fn hook_run_analytics_payload_uses_completed_turn_id() {
         let (_session, turn_context) = make_session_and_context().await;
+        let model_context = StepModelContext::for_test(&turn_context);
         let completed = HookCompletedEvent {
             turn_id: Some("turn-from-hook".to_string()),
             run: sample_hook_run(HookRunStatus::Blocked, HookSource::Project),
         };
 
-        let (tracking, hook) =
-            hook_run_analytics_payload("thread-123".to_string(), &turn_context, &completed);
+        let (tracking, hook) = hook_run_analytics_payload(
+            "thread-123".to_string(),
+            &turn_context,
+            &model_context,
+            &completed,
+        );
 
         assert_eq!(tracking.thread_id, "thread-123");
         assert_eq!(tracking.turn_id, "turn-from-hook");
-        assert_eq!(tracking.model_slug, turn_context.model_info.slug);
+        assert_eq!(tracking.model_slug, model_context.model_info.slug);
         assert_eq!(hook.event_name, HookEventName::Stop);
         assert_eq!(hook.hook_source, HookSource::Project);
         assert_eq!(hook.status, HookRunStatus::Blocked);
@@ -850,13 +918,18 @@ mod tests {
     #[tokio::test]
     async fn hook_run_analytics_payload_falls_back_to_turn_context_id() {
         let (_session, turn_context) = make_session_and_context().await;
+        let model_context = StepModelContext::for_test(&turn_context);
         let completed = HookCompletedEvent {
             turn_id: None,
             run: sample_hook_run(HookRunStatus::Failed, HookSource::Unknown),
         };
 
-        let (tracking, hook) =
-            hook_run_analytics_payload("thread-123".to_string(), &turn_context, &completed);
+        let (tracking, hook) = hook_run_analytics_payload(
+            "thread-123".to_string(),
+            &turn_context,
+            &model_context,
+            &completed,
+        );
 
         assert_eq!(tracking.turn_id, turn_context.sub_id);
         assert_eq!(hook.hook_source, HookSource::Unknown);

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -19,6 +19,8 @@ use crate::mcp_tool_approval_templates::RenderedMcpToolApprovalParam;
 use crate::mcp_tool_approval_templates::render_mcp_tool_approval_template;
 use crate::session::session::Session;
 use crate::session::step_context::StepContext;
+use crate::session::step_context::StepContextSeed;
+use crate::session::step_model_context::StepModelContext;
 use crate::session::turn_context::TurnContext;
 use crate::tools::hook_names::HookToolName;
 use crate::tools::sandboxing::PermissionRequestPayload;
@@ -200,6 +202,7 @@ pub(crate) async fn handle_mcp_tool_call(
         let result = notify_mcp_tool_call_skip(
             sess.as_ref(),
             turn_context.as_ref(),
+            step_context.model.as_ref(),
             &call_id,
             invocation,
             item_metadata.clone(),
@@ -210,7 +213,7 @@ pub(crate) async fn handle_mcp_tool_call(
         let status = if result.is_ok() { "ok" } else { "error" };
         let outcome = McpCallMetricOutcome::from_status(status);
         emit_mcp_call_metrics(
-            turn_context.as_ref(),
+            step_context.model.as_ref(),
             &outcome,
             &server,
             &tool_name,
@@ -263,6 +266,7 @@ pub(crate) async fn handle_mcp_tool_call(
                 notify_mcp_tool_call_skip(
                     sess.as_ref(),
                     turn_context.as_ref(),
+                    step_context.model.as_ref(),
                     &call_id,
                     invocation,
                     item_metadata.clone(),
@@ -276,6 +280,7 @@ pub(crate) async fn handle_mcp_tool_call(
                 notify_mcp_tool_call_skip(
                     sess.as_ref(),
                     turn_context.as_ref(),
+                    step_context.model.as_ref(),
                     &call_id,
                     invocation,
                     item_metadata.clone(),
@@ -289,7 +294,7 @@ pub(crate) async fn handle_mcp_tool_call(
         let status = if result.is_ok() { "ok" } else { "error" };
         let outcome = McpCallMetricOutcome::from_status(status);
         emit_mcp_call_metrics(
-            turn_context.as_ref(),
+            step_context.model.as_ref(),
             &outcome,
             &server,
             &tool_name,
@@ -394,8 +399,13 @@ async fn handle_approved_mcp_tool_call(
     let result = async {
         let result = async {
             let rewritten_arguments = rewrite?;
-            let request_meta =
-                build_mcp_tool_call_request_meta(turn_context, &server, call_id, metadata);
+            let request_meta = build_mcp_tool_call_request_meta(
+                turn_context,
+                step_context.model.as_ref(),
+                &server,
+                call_id,
+                metadata,
+            );
             execute_mcp_tool_call(
                 sess,
                 step_context,
@@ -431,6 +441,7 @@ async fn handle_approved_mcp_tool_call(
     notify_mcp_tool_call_completed(
         sess,
         turn_context,
+        step_context.model.as_ref(),
         call_id,
         invocation,
         item_metadata,
@@ -438,11 +449,19 @@ async fn handle_approved_mcp_tool_call(
         truncate_mcp_tool_result_for_event(&result),
     )
     .await;
-    maybe_track_codex_app_used(sess, turn_context, manager, &server, &tool_name).await;
+    maybe_track_codex_app_used(
+        sess,
+        turn_context,
+        step_context.model.as_ref(),
+        manager,
+        &server,
+        &tool_name,
+    )
+    .await;
 
     let outcome = mcp_call_metric_outcome(&result);
     emit_mcp_call_metrics(
-        turn_context,
+        step_context.model.as_ref(),
         &outcome,
         &server,
         &tool_name,
@@ -598,7 +617,8 @@ async fn execute_mcp_tool_call(
         .await
         .map_err(|e| format!("tool call error: {e:?}"))?;
     let result = sanitize_mcp_tool_result_for_model(
-        turn_context
+        step_context
+            .model
             .model_info
             .input_modalities
             .contains(&InputModality::Image),
@@ -908,6 +928,7 @@ async fn notify_mcp_tool_call_started(
 async fn notify_mcp_tool_call_completed(
     sess: &Session,
     turn_context: &TurnContext,
+    model_context: &StepModelContext,
     call_id: &str,
     invocation: McpInvocation,
     item_metadata: McpToolCallItemMetadata,
@@ -947,7 +968,8 @@ async fn notify_mcp_tool_call_completed(
         error,
         duration: Some(duration),
     });
-    sess.emit_turn_item_completed(turn_context, item).await;
+    sess.emit_turn_item_completed(turn_context, model_context, item)
+        .await;
 }
 
 struct McpAppUsageMetadata {
@@ -958,6 +980,7 @@ struct McpAppUsageMetadata {
 async fn maybe_track_codex_app_used(
     sess: &Session,
     turn_context: &TurnContext,
+    model: &StepModelContext,
     manager: &McpConnectionManager,
     server: &str,
     tool_name: &str,
@@ -981,7 +1004,7 @@ async fn maybe_track_codex_app_used(
     };
 
     let tracking = build_track_events_context(
-        turn_context.model_info.slug.clone(),
+        model.model_info.slug.clone(),
         sess.thread_id.to_string(),
         turn_context.sub_id.clone(),
         turn_context.originator.clone(),
@@ -1082,6 +1105,7 @@ async fn custom_mcp_tool_approval_mode(
 
 fn build_mcp_tool_call_request_meta(
     turn_context: &TurnContext,
+    model: &StepModelContext,
     server: &str,
     call_id: &str,
     metadata: Option<&McpToolApprovalMetadata>,
@@ -1091,8 +1115,8 @@ fn build_mcp_tool_call_request_meta(
     if let Some(turn_metadata) = turn_context
         .turn_metadata_state
         .current_meta_value_for_mcp_request(McpTurnMetadataContext {
-            model: turn_context.model_info.slug.as_str(),
-            reasoning_effort: turn_context.effective_reasoning_effort(),
+            model: model.model_info.slug.as_str(),
+            reasoning_effort: model.effective_reasoning_effort(),
         })
     {
         request_meta.insert(
@@ -1242,7 +1266,7 @@ async fn maybe_request_mcp_tool_approval(
 
     match run_permission_request_hooks(
         sess,
-        turn_context,
+        step_context.as_ref(),
         call_id,
         PermissionRequestPayload {
             tool_name: hook_tool_name.clone(),
@@ -1274,7 +1298,7 @@ async fn maybe_request_mcp_tool_approval(
         let review_id = new_guardian_review_id();
         let decision = review_approval_request(
             sess,
-            turn_context,
+            &StepContextSeed::from(step_context.as_ref()),
             review_id.clone(),
             build_guardian_mcp_tool_review_request(call_id, invocation, metadata),
             /*retry_reason*/ None,
@@ -2182,6 +2206,7 @@ fn requires_mcp_tool_approval(annotations: Option<&ToolAnnotations>) -> bool {
 async fn notify_mcp_tool_call_skip(
     sess: &Session,
     turn_context: &TurnContext,
+    model_context: &StepModelContext,
     call_id: &str,
     invocation: McpInvocation,
     item_metadata: McpToolCallItemMetadata,
@@ -2202,6 +2227,7 @@ async fn notify_mcp_tool_call_skip(
     notify_mcp_tool_call_completed(
         sess,
         turn_context,
+        model_context,
         call_id,
         invocation,
         item_metadata,

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -591,7 +591,6 @@ async fn execute_mcp_tool_call(
     metadata: Option<&McpToolApprovalMetadata>,
     request_meta: Option<JsonValue>,
 ) -> Result<CallToolResult, String> {
-    let turn_context = step_context.turn.as_ref();
     let manager = step_context.mcp.manager();
     let request_meta = with_mcp_tool_call_thread_id_meta(request_meta, &sess.thread_id.to_string());
     let request_meta = augment_mcp_tool_request_meta_with_sandbox_state(
@@ -626,7 +625,7 @@ async fn execute_mcp_tool_call(
     )?;
     Ok(maybe_request_codex_apps_auth_elicitation(
         sess,
-        turn_context,
+        step_context,
         manager,
         call_id,
         &invocation.server,
@@ -638,13 +637,14 @@ async fn execute_mcp_tool_call(
 
 async fn maybe_request_codex_apps_auth_elicitation(
     sess: &Session,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     manager: &McpConnectionManager,
     call_id: &str,
     server: &str,
     metadata: Option<&McpToolApprovalMetadata>,
     result: CallToolResult,
 ) -> CallToolResult {
+    let turn_context = step_context.turn.as_ref();
     if !manager.is_host_owned_codex_apps_server(server) {
         return result;
     }
@@ -689,7 +689,7 @@ async fn maybe_request_codex_apps_auth_elicitation(
     };
     let response = sess
         .request_mcp_server_elicitation(
-            turn_context,
+            step_context,
             CODEX_APPS_MCP_SERVER_NAME.to_string(),
             request_id,
             request,
@@ -1364,7 +1364,7 @@ async fn maybe_request_mcp_tool_approval(
             });
         let decision = parse_mcp_tool_approval_elicitation_response(
             sess.request_mcp_server_elicitation(
-                turn_context.as_ref(),
+                step_context.as_ref(),
                 invocation.server.clone(),
                 request_id,
                 request,

--- a/codex-rs/core/src/mcp_tool_call/telemetry.rs
+++ b/codex-rs/core/src/mcp_tool_call/telemetry.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use crate::session::turn_context::TurnContext;
+use crate::session::step_model_context::StepModelContext;
 use codex_mcp::MCP_TOOL_CODEX_APPS_META_KEY;
 use codex_otel::sanitize_metric_tag_value;
 use codex_protocol::mcp::CallToolResult;
@@ -38,7 +38,7 @@ impl McpCallMetricOutcome {
 }
 
 pub(super) fn emit_mcp_call_metrics(
-    turn_context: &TurnContext,
+    model: &StepModelContext,
     outcome: &McpCallMetricOutcome,
     server_name: &str,
     tool_name: &str,
@@ -57,15 +57,13 @@ pub(super) fn emit_mcp_call_metrics(
         .iter()
         .map(|(key, value)| (*key, value.as_str()))
         .collect();
-    turn_context
+    model
         .session_telemetry
         .counter(MCP_CALL_COUNT_METRIC, /*inc*/ 1, &tag_refs);
     if let Some(duration) = duration {
-        turn_context.session_telemetry.record_duration(
-            MCP_CALL_DURATION_METRIC,
-            duration,
-            &tag_refs,
-        );
+        model
+            .session_telemetry
+            .record_duration(MCP_CALL_DURATION_METRIC, duration, &tag_refs);
     }
 
     let (Some(error_type), Some(error_code)) = (outcome.error_type, outcome.error_code.as_deref())
@@ -79,11 +77,9 @@ pub(super) fn emit_mcp_call_metrics(
         .iter()
         .map(|(key, value)| (*key, value.as_str()))
         .collect();
-    turn_context.session_telemetry.counter(
-        MCP_CALL_ERROR_COUNT_METRIC,
-        /*inc*/ 1,
-        &error_tag_refs,
-    );
+    model
+        .session_telemetry
+        .counter(MCP_CALL_ERROR_COUNT_METRIC, /*inc*/ 1, &error_tag_refs);
 }
 
 fn mcp_call_metric_tags(

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::config::ConfigBuilder;
 use crate::config::ManagedFeatures;
 use crate::session::step_context::StepContext;
+use crate::session::step_model_context::StepModelContext;
 use crate::session::tests::make_session_and_context;
 use crate::session::tests::make_session_and_context_with_rx;
 use crate::session::turn_context::TurnEnvironment;
@@ -93,10 +94,10 @@ fn approval_metadata(
     }
 }
 
-fn mcp_turn_metadata_context(turn_context: &TurnContext) -> McpTurnMetadataContext<'_> {
+fn mcp_turn_metadata_context(model: &StepModelContext) -> McpTurnMetadataContext<'_> {
     McpTurnMetadataContext {
-        model: turn_context.model_info.slug.as_str(),
-        reasoning_effort: turn_context.effective_reasoning_effort(),
+        model: model.model_info.slug.as_str(),
+        reasoning_effort: model.effective_reasoning_effort(),
     }
 }
 
@@ -1068,13 +1069,15 @@ fn truncate_mcp_tool_result_for_event_bounds_large_error() {
 #[tokio::test]
 async fn mcp_tool_call_request_meta_includes_turn_metadata_for_custom_server() {
     let (_, turn_context) = make_session_and_context().await;
+    let model = StepModelContext::for_test(&turn_context);
     let expected_turn_metadata = turn_context
         .turn_metadata_state
-        .current_meta_value_for_mcp_request(mcp_turn_metadata_context(&turn_context))
+        .current_meta_value_for_mcp_request(mcp_turn_metadata_context(&model))
         .expect("turn metadata");
 
     let meta = build_mcp_tool_call_request_meta(
         &turn_context,
+        &model,
         "custom_server",
         "call-custom",
         /*metadata*/ None,
@@ -1088,13 +1091,13 @@ async fn mcp_tool_call_request_meta_includes_turn_metadata_for_custom_server() {
         turn_metadata
             .get("model")
             .and_then(serde_json::Value::as_str),
-        Some(turn_context.model_info.slug.as_str())
+        Some(model.model_info.slug.as_str())
     );
     assert_eq!(
         turn_metadata
             .get("reasoning_effort")
             .and_then(serde_json::Value::as_str),
-        turn_context
+        model
             .effective_reasoning_effort()
             .map(|effort| effort.to_string())
             .as_deref()
@@ -1111,12 +1114,14 @@ async fn mcp_tool_call_request_meta_includes_turn_metadata_for_custom_server() {
 #[tokio::test]
 async fn mcp_tool_call_request_meta_includes_turn_started_at_unix_ms() {
     let (_, turn_context) = make_session_and_context().await;
+    let model = StepModelContext::for_test(&turn_context);
     turn_context
         .turn_metadata_state
         .set_turn_started_at_unix_ms(/*turn_started_at_unix_ms*/ 1_700_000_000_123);
 
     let meta = build_mcp_tool_call_request_meta(
         &turn_context,
+        &model,
         "custom_server",
         "call-custom",
         /*metadata*/ None,
@@ -1172,9 +1177,10 @@ async fn mcp_sandbox_cwd_is_none_for_unselected_server_environment() -> anyhow::
 #[tokio::test]
 async fn plugin_mcp_tool_call_request_meta_includes_plugin_id() {
     let (_, turn_context) = make_session_and_context().await;
+    let model = StepModelContext::for_test(&turn_context);
     let expected_turn_metadata = turn_context
         .turn_metadata_state
-        .current_meta_value_for_mcp_request(mcp_turn_metadata_context(&turn_context))
+        .current_meta_value_for_mcp_request(mcp_turn_metadata_context(&model))
         .expect("turn metadata");
     let mut metadata = approval_metadata(
         /*connector_id*/ None, /*connector_name*/ None,
@@ -1184,7 +1190,13 @@ async fn plugin_mcp_tool_call_request_meta_includes_plugin_id() {
     metadata.plugin_id = Some("sample@test".to_string());
 
     assert_eq!(
-        build_mcp_tool_call_request_meta(&turn_context, "sample", "call-plugin", Some(&metadata),),
+        build_mcp_tool_call_request_meta(
+            &turn_context,
+            &model,
+            "sample",
+            "call-plugin",
+            Some(&metadata),
+        ),
         Some(serde_json::json!({
             crate::X_CODEX_TURN_METADATA_HEADER: expected_turn_metadata,
             MCP_TOOL_PLUGIN_ID_META_KEY: "sample@test",
@@ -1291,9 +1303,10 @@ async fn mcp_tool_call_item_includes_app_identity() {
 #[tokio::test]
 async fn codex_apps_tool_call_request_meta_includes_turn_metadata_and_codex_apps_meta() {
     let (_, turn_context) = make_session_and_context().await;
+    let model = StepModelContext::for_test(&turn_context);
     let expected_turn_metadata = turn_context
         .turn_metadata_state
-        .current_meta_value_for_mcp_request(mcp_turn_metadata_context(&turn_context))
+        .current_meta_value_for_mcp_request(mcp_turn_metadata_context(&model))
         .expect("turn metadata");
     let metadata = McpToolApprovalMetadata {
         annotations: None,
@@ -1323,6 +1336,7 @@ async fn codex_apps_tool_call_request_meta_includes_turn_metadata_and_codex_apps
     assert_eq!(
         build_mcp_tool_call_request_meta(
             &turn_context,
+            &model,
             CODEX_APPS_MCP_SERVER_NAME,
             "call_abc123xyz789",
             Some(&metadata),
@@ -1342,14 +1356,16 @@ async fn codex_apps_tool_call_request_meta_includes_turn_metadata_and_codex_apps
 #[tokio::test]
 async fn codex_apps_tool_call_request_meta_includes_call_id_without_existing_codex_apps_meta() {
     let (_, turn_context) = make_session_and_context().await;
+    let model = StepModelContext::for_test(&turn_context);
     let expected_turn_metadata = turn_context
         .turn_metadata_state
-        .current_meta_value_for_mcp_request(mcp_turn_metadata_context(&turn_context))
+        .current_meta_value_for_mcp_request(mcp_turn_metadata_context(&model))
         .expect("turn metadata");
 
     assert_eq!(
         build_mcp_tool_call_request_meta(
             &turn_context,
+            &model,
             CODEX_APPS_MCP_SERVER_NAME,
             "call_abc123xyz789",
             /*metadata*/ None,
@@ -2610,6 +2626,7 @@ async fn permission_request_hook_allows_mcp_tool_call() {
     );
     let session = Arc::new(session);
     let turn_context = Arc::new(turn_context);
+    let step_context = StepContext::for_test(Arc::clone(&turn_context));
     let invocation = McpInvocation {
         server: "memory".to_string(),
         tool: "create_entities".to_string(),
@@ -2642,7 +2659,7 @@ async fn permission_request_hook_allows_mcp_tool_call() {
 
     let decision = maybe_request_mcp_tool_approval(
         &session,
-        &StepContext::for_test(Arc::clone(&turn_context)),
+        &step_context,
         "call-mcp-hook",
         &invocation,
         &HookToolName::new("mcp__memory__create_entities"),
@@ -2666,7 +2683,7 @@ async fn permission_request_hook_allows_mcp_tool_call() {
             "turn_id": "turn_id",
             "cwd": turn_cwd,
             "transcript_path": null,
-            "model": turn_context.model_info.slug,
+            "model": step_context.model.model_info.slug.as_str(),
             "permission_mode": "default",
             "tool_name": "mcp__memory__create_entities",
             "hook_event_name": "PermissionRequest",
@@ -2696,6 +2713,7 @@ async fn permission_request_hook_uses_hook_tool_name_without_metadata() {
     );
     let session = Arc::new(session);
     let turn_context = Arc::new(turn_context);
+    let step_context = StepContext::for_test(Arc::clone(&turn_context));
     let invocation = McpInvocation {
         server: "memory".to_string(),
         tool: "create_entities".to_string(),
@@ -2704,7 +2722,7 @@ async fn permission_request_hook_uses_hook_tool_name_without_metadata() {
 
     let decision = maybe_request_mcp_tool_approval(
         &session,
-        &StepContext::for_test(Arc::clone(&turn_context)),
+        &step_context,
         "call-mcp-hook-no-metadata",
         &invocation,
         &HookToolName::new("mcp__memory__create_entities"),
@@ -2728,7 +2746,7 @@ async fn permission_request_hook_uses_hook_tool_name_without_metadata() {
             "turn_id": "turn_id",
             "cwd": turn_cwd,
             "transcript_path": null,
-            "model": turn_context.model_info.slug,
+            "model": step_context.model.model_info.slug.as_str(),
             "permission_mode": "default",
             "tool_name": "mcp__memory__create_entities",
             "hook_event_name": "PermissionRequest",

--- a/codex-rs/core/src/memory_usage.rs
+++ b/codex-rs/core/src/memory_usage.rs
@@ -14,7 +14,7 @@ pub(crate) fn emit_metric_for_tool_read(invocation: &ToolInvocation, success: bo
     let success = if success { "true" } else { "false" };
     let tool_name = flat_tool_name(&invocation.tool_name);
     for kind in memories_usage_kinds_from_command(&command) {
-        invocation.turn.session_telemetry.counter(
+        invocation.step_context.model.session_telemetry.counter(
             MEMORIES_USAGE_METRIC,
             /*inc*/ 1,
             &[

--- a/codex-rs/core/src/prompt_debug.rs
+++ b/codex-rs/core/src/prompt_debug.rs
@@ -76,28 +76,28 @@ pub(crate) async fn build_prompt_input_from_session(
     sess: &Arc<Session>,
     input: Vec<UserInput>,
 ) -> CodexResult<Vec<ResponseItem>> {
-    let turn_context = sess.new_default_turn().await;
+    let step_context_seed = sess.new_default_turn().await;
     // Prompt debugging builds a standalone request without entering run_turn.
-    let step_context = sess.capture_step_context(Arc::clone(&turn_context)).await;
+    let step_context = sess.capture_step_context(&step_context_seed).await;
     sess.record_context_updates_and_set_reference_context_item(step_context.as_ref())
         .await;
 
     if !input.is_empty() {
         let response_item = sess.response_item_from_user_input(input);
-        sess.record_conversation_items(turn_context.as_ref(), std::slice::from_ref(&response_item))
+        sess.record_conversation_items(step_context.as_ref(), std::slice::from_ref(&response_item))
             .await;
     }
 
     let prompt_input = sess
         .clone_history()
         .await
-        .for_prompt(&turn_context.model_info.input_modalities);
+        .for_prompt(&step_context.model.model_info.input_modalities);
     let router = built_tools(sess, step_context.as_ref(), &CancellationToken::new()).await?;
     let base_instructions = sess.get_base_instructions().await;
     let prompt = build_prompt(
         prompt_input,
         router.as_ref(),
-        turn_context.as_ref(),
+        step_context.as_ref(),
         base_instructions,
     );
 

--- a/codex-rs/core/src/responses_retry.rs
+++ b/codex-rs/core/src/responses_retry.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use crate::client::ModelClientSession;
 use crate::session::session::Session;
+use crate::session::step_model_context::StepModelContext;
 use crate::session::turn_context::TurnContext;
 use crate::util::backoff;
 use codex_protocol::error::CodexErr;
@@ -26,13 +27,11 @@ pub(crate) async fn handle_retryable_response_stream_error(
     client_session: &mut ModelClientSession,
     sess: &Session,
     turn_context: &TurnContext,
+    model: &StepModelContext,
     request: ResponsesStreamRequest,
 ) -> Result<(), CodexErr> {
     if *retries >= max_retries
-        && client_session.try_switch_fallback_transport(
-            &turn_context.session_telemetry,
-            &turn_context.model_info,
-        )
+        && client_session.try_switch_fallback_transport(&model.session_telemetry, &model.model_info)
     {
         sess.send_event(
             turn_context,

--- a/codex-rs/core/src/session/context_window.rs
+++ b/codex-rs/core/src/session/context_window.rs
@@ -1,4 +1,5 @@
 use super::session::Session;
+use super::step_model_context::StepModelContext;
 use super::turn_context::TurnContext;
 use codex_protocol::config_types::AutoCompactTokenLimitScope;
 
@@ -24,6 +25,7 @@ struct BodyAfterPrefixWindowStatus {
 pub(crate) async fn context_window_token_status(
     sess: &Session,
     turn_context: &TurnContext,
+    model_context: &StepModelContext,
 ) -> ContextWindowTokenStatus {
     let active_context_tokens = sess.get_total_token_usage().await;
 
@@ -31,7 +33,7 @@ pub(crate) async fn context_window_token_status(
         match turn_context.config.model_auto_compact_token_limit_scope {
             AutoCompactTokenLimitScope::Total => (
                 active_context_tokens,
-                turn_context.model_info.auto_compact_token_limit(),
+                model_context.model_info.auto_compact_token_limit(),
                 None,
             ),
             AutoCompactTokenLimitScope::BodyAfterPrefix => {
@@ -41,8 +43,8 @@ pub(crate) async fn context_window_token_status(
                 let scope_limit = turn_context
                     .config
                     .model_auto_compact_token_limit
-                    .or_else(|| turn_context.model_info.auto_compact_token_limit());
-                let full_context_window_limit = turn_context.model_context_window();
+                    .or_else(|| model_context.model_info.auto_compact_token_limit());
+                let full_context_window_limit = model_context.model_context_window();
 
                 (
                     active_context_tokens.saturating_sub(baseline),

--- a/codex-rs/core/src/session/handlers.rs
+++ b/codex-rs/core/src/session/handlers.rs
@@ -204,7 +204,7 @@ pub(super) async fn user_input_or_turn_inner(
     };
     updates.final_output_json_schema = Some(final_output_json_schema);
 
-    let Ok(current_context) = sess.new_turn_with_sub_id(sub_id.clone(), updates).await else {
+    let Ok(step_context_seed) = sess.new_turn_with_sub_id(sub_id.clone(), updates).await else {
         // new_turn_with_sub_id already emits the error event.
         return;
     };
@@ -215,7 +215,7 @@ pub(super) async fn user_input_or_turn_inner(
         })
         .await;
     }
-    sess.maybe_emit_model_warnings_for_turn(current_context.as_ref())
+    sess.maybe_emit_model_warnings_for_turn(&step_context_seed)
         .await;
     match sess
         .steer_input(
@@ -228,17 +228,24 @@ pub(super) async fn user_input_or_turn_inner(
         .await
     {
         Ok(_) => {
-            current_context.session_telemetry.user_prompt(&items);
+            step_context_seed
+                .model
+                .session_telemetry
+                .user_prompt(&items);
         }
         Err(SteerInputError::NoActiveTurn(items)) => {
             if let Some(responsesapi_client_metadata) = responsesapi_client_metadata {
-                current_context
+                step_context_seed
+                    .turn
                     .turn_metadata_state
                     .set_responsesapi_client_metadata(responsesapi_client_metadata);
             }
-            current_context.session_telemetry.user_prompt(&items);
+            step_context_seed
+                .model
+                .session_telemetry
+                .user_prompt(&items);
             sess.refresh_mcp_servers_if_requested(
-                &current_context,
+                step_context_seed.turn.as_ref(),
                 Some(sess.mcp_elicitation_reviewer()),
             )
             .await;
@@ -258,7 +265,7 @@ pub(super) async fn user_input_or_turn_inner(
                 });
             }
             sess.spawn_task(
-                Arc::clone(&current_context),
+                step_context_seed,
                 task_input,
                 crate::tasks::RegularTask::new(),
             )
@@ -293,14 +300,14 @@ pub async fn inter_agent_communication(
 }
 
 pub async fn run_user_shell_command(sess: &Arc<Session>, sub_id: String, command: String) {
-    if let Some((turn_context, cancellation_token)) =
+    if let Some((step_context_seed, cancellation_token)) =
         sess.active_turn_context_and_cancellation_token().await
     {
         let session = Arc::clone(sess);
         tokio::spawn(async move {
             execute_user_shell_command(
                 session,
-                turn_context,
+                step_context_seed,
                 command,
                 cancellation_token,
                 UserShellCommandMode::ActiveTurnAuxiliary,
@@ -310,9 +317,9 @@ pub async fn run_user_shell_command(sess: &Arc<Session>, sub_id: String, command
         return;
     }
 
-    let turn_context = sess.new_default_turn_with_sub_id(sub_id).await;
+    let step_context_seed = sess.new_default_turn_with_sub_id(sub_id).await;
     sess.spawn_task(
-        Arc::clone(&turn_context),
+        step_context_seed,
         Vec::new(),
         UserShellCommandTask::new(command),
     )
@@ -443,9 +450,9 @@ pub async fn reload_user_config(sess: &Arc<Session>) {
 }
 
 pub async fn compact(sess: &Arc<Session>, sub_id: String) {
-    let turn_context = sess.new_default_turn_with_sub_id(sub_id).await;
+    let step_context_seed = sess.new_default_turn_with_sub_id(sub_id).await;
 
-    sess.spawn_task(Arc::clone(&turn_context), Vec::new(), CompactTask)
+    sess.spawn_task(step_context_seed, Vec::new(), CompactTask)
         .await;
 }
 
@@ -475,7 +482,8 @@ pub async fn thread_rollback(sess: &Arc<Session>, sub_id: String, num_turns: u32
         return;
     }
 
-    let turn_context = sess.new_default_turn_with_sub_id(sub_id).await;
+    let step_context_seed = sess.new_default_turn_with_sub_id(sub_id).await;
+    let turn_context = &step_context_seed.turn;
     let live_thread = match sess.live_thread_for_persistence("rollback thread") {
         Ok(live_thread) => live_thread,
         Err(_) => {
@@ -524,13 +532,17 @@ pub async fn thread_rollback(sess: &Arc<Session>, sub_id: String, num_turns: u32
         .into_iter()
         .chain(std::iter::once(RolloutItem::EventMsg(rollback_msg.clone())))
         .collect::<Vec<_>>();
-    sess.apply_rollout_reconstruction(turn_context.as_ref(), replay_items.as_slice())
+    sess.apply_rollout_reconstruction(&step_context_seed, replay_items.as_slice())
         .await;
     sess.services
         .agent_control
         .rollout_budget()
         .rearm_reminder(sess.thread_id());
-    sess.recompute_token_usage(turn_context.as_ref()).await;
+    sess.recompute_token_usage(
+        step_context_seed.turn.as_ref(),
+        step_context_seed.model.as_ref(),
+    )
+    .await;
 
     sess.persist_rollout_items(&[RolloutItem::EventMsg(rollback_msg.clone())])
         .await;
@@ -670,18 +682,21 @@ pub async fn review(
     sub_id: String,
     review_request: ReviewRequest,
 ) {
-    let turn_context = sess.new_default_turn_with_sub_id(sub_id.clone()).await;
-    sess.maybe_emit_model_warnings_for_turn(turn_context.as_ref())
+    let step_context_seed = sess.new_default_turn_with_sub_id(sub_id.clone()).await;
+    sess.maybe_emit_model_warnings_for_turn(&step_context_seed)
         .await;
-    sess.refresh_mcp_servers_if_requested(&turn_context, Some(sess.mcp_elicitation_reviewer()))
-        .await;
+    sess.refresh_mcp_servers_if_requested(
+        step_context_seed.turn.as_ref(),
+        Some(sess.mcp_elicitation_reviewer()),
+    )
+    .await;
     #[allow(deprecated)]
-    match resolve_review_request(review_request, &turn_context.cwd) {
+    match resolve_review_request(review_request, &step_context_seed.turn.cwd) {
         Ok(resolved) => {
             spawn_review_thread(
                 Arc::clone(sess),
                 Arc::clone(config),
-                turn_context.clone(),
+                step_context_seed.clone(),
                 sub_id,
                 resolved,
             )
@@ -695,7 +710,8 @@ pub async fn review(
                     codex_error_info: Some(CodexErrorInfo::Other),
                 }),
             };
-            sess.send_event(&turn_context, event.msg).await;
+            sess.send_event(step_context_seed.turn.as_ref(), event.msg)
+                .await;
         }
     }
 }
@@ -896,7 +912,7 @@ Approved action:
         phase: None,
     })];
 
-    sess.inject_no_new_turn(items, /*current_turn_context*/ None)
+    sess.inject_no_new_turn(items, /*current_step_context_seed*/ None)
         .await;
 }
 

--- a/codex-rs/core/src/session/inject.rs
+++ b/codex-rs/core/src/session/inject.rs
@@ -1,6 +1,6 @@
 use super::input_queue::TurnInput;
 use super::session::Session;
-use super::turn_context::TurnContext;
+use super::step_context::StepContextSeed;
 use crate::codex_thread::TryStartTurnIfIdleError;
 use crate::codex_thread::TryStartTurnIfIdleRejectionReason;
 use crate::state::ActiveTurn;
@@ -83,10 +83,10 @@ impl Session {
             ));
         }
 
-        let turn_context = self
+        let step_context_seed = self
             .new_default_turn_with_sub_id(uuid::Uuid::new_v4().to_string())
             .await;
-        if turn_context.collaboration_mode.mode == ModeKind::Plan {
+        if step_context_seed.model.collaboration_mode.mode == ModeKind::Plan {
             self.clear_reserved_idle_turn(&turn_state).await;
             self.maybe_start_turn_for_pending_work().await;
             return Err(TryStartTurnIfIdleError::new(
@@ -94,7 +94,7 @@ impl Session {
                 input,
             ));
         }
-        self.maybe_emit_model_warnings_for_turn(turn_context.as_ref())
+        self.maybe_emit_model_warnings_for_turn(&step_context_seed)
             .await;
         if self.input_queue.has_trigger_turn_mailbox_items().await {
             self.clear_reserved_idle_turn(&turn_state).await;
@@ -124,7 +124,7 @@ impl Session {
                 input.into_iter().map(TurnInput::ResponseItem).collect(),
             )
             .await;
-        self.start_task(turn_context, Vec::new(), RegularTask::new())
+        self.start_task(step_context_seed, Vec::new(), RegularTask::new())
             .await;
         Ok(())
     }
@@ -143,19 +143,20 @@ impl Session {
     pub(crate) async fn inject_no_new_turn(
         &self,
         items: Vec<ResponseItem>,
-        current_turn_context: Option<&TurnContext>,
+        current_step_context_seed: Option<&StepContextSeed>,
     ) {
         let Err(items) = self.inject_if_running(items).await else {
             return;
         };
-        let default_turn_context;
-        let turn_context = match current_turn_context {
-            Some(turn_context) => turn_context,
+        let default_step_context_seed;
+        let step_context_seed = match current_step_context_seed {
+            Some(step_context_seed) => step_context_seed,
             None => {
-                default_turn_context = self.new_default_turn().await;
-                default_turn_context.as_ref()
+                default_step_context_seed = self.new_default_turn().await;
+                &default_step_context_seed
             }
         };
-        self.record_conversation_items(turn_context, &items).await;
+        self.record_conversation_items_for_seed(step_context_seed, &items)
+            .await;
     }
 }

--- a/codex-rs/core/src/session/input_queue.rs
+++ b/codex-rs/core/src/session/input_queue.rs
@@ -111,7 +111,7 @@ impl InputQueue {
             active_turn
                 .task
                 .as_ref()
-                .is_some_and(|task| task.turn_context.sub_id == sub_id)
+                .is_some_and(|task| task.step_context_seed.turn.sub_id == sub_id)
                 .then(|| Arc::clone(&active_turn.turn_state))
         })
     }

--- a/codex-rs/core/src/session/mcp.rs
+++ b/codex-rs/core/src/session/mcp.rs
@@ -206,11 +206,12 @@ impl Session {
     )]
     pub async fn request_mcp_server_elicitation(
         &self,
-        turn_context: &TurnContext,
+        step_context: &StepContext,
         server_name: String,
         request_id: RequestId,
         request: ElicitationRequest,
     ) -> McpServerElicitationOutcome {
+        let turn_context = step_context.turn.as_ref();
         if self
             .services
             .latest_mcp_runtime()
@@ -268,7 +269,8 @@ impl Session {
             .mark_user_input_requested_during_turn();
         self.send_event(turn_context, event).await;
         if let Some(plugin_install_telemetry) = plugin_install_telemetry {
-            turn_context
+            step_context
+                .model
                 .session_telemetry
                 .record_plugin_install_elicitation_sent(
                     plugin_install_telemetry.tool_type.as_str(),
@@ -588,19 +590,19 @@ async fn review_guardian_mcp_elicitation(
     session: Arc<Session>,
     request: ElicitationReviewRequest,
 ) -> anyhow::Result<Option<ElicitationResponse>> {
-    let Some((turn_context, _cancellation_token)) =
+    let Some((step_context_seed, _cancellation_token)) =
         session.active_turn_context_and_cancellation_token().await
     else {
         return Ok(None);
     };
 
     let approvals_reviewer = crate::connectors::mcp_approvals_reviewer(
-        turn_context.config.as_ref(),
+        step_context_seed.turn.config.as_ref(),
         request.server_name.as_str(),
         elicitation_connector_id(&request.elicitation),
     );
     if !crate::guardian::routes_approval_to_guardian_with_reviewer(
-        turn_context.as_ref(),
+        step_context_seed.turn.as_ref(),
         approvals_reviewer,
     ) {
         return Ok(None);
@@ -623,7 +625,7 @@ async fn review_guardian_mcp_elicitation(
     let review_id = crate::guardian::new_guardian_review_id();
     let decision = crate::guardian::review_approval_request(
         &session,
-        &turn_context,
+        &step_context_seed,
         review_id.clone(),
         guardian_request,
         /*retry_reason*/ None,

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -39,6 +39,8 @@ use crate::image_preparation::prepare_response_items;
 use crate::parse_turn_item;
 use crate::realtime_conversation::RealtimeConversationManager;
 use crate::session::step_context::StepContext;
+use crate::session::step_context::StepContextSeed;
+use crate::session::step_model_context::StepModelContext;
 use crate::session::turn_context::TurnEnvironment;
 use crate::session_prefix::format_inter_agent_completion_message;
 use crate::skills::SkillRenderSideEffects;
@@ -212,6 +214,7 @@ mod rollout_reconstruction;
 #[allow(clippy::module_inception)]
 pub(crate) mod session;
 pub(crate) mod step_context;
+pub(crate) mod step_model_context;
 pub(crate) mod time_reminder;
 mod token_budget;
 pub(crate) mod turn;
@@ -1274,10 +1277,10 @@ impl Session {
 
     pub(crate) async fn get_estimated_token_count(
         &self,
-        turn_context: &TurnContext,
+        step_context: &StepContext,
     ) -> Option<i64> {
         let state = self.state.lock().await;
-        state.history.estimate_token_count(turn_context)
+        state.history.estimate_token_count(step_context)
     }
 
     pub(crate) async fn get_base_instructions(&self) -> BaseInstructions {
@@ -1334,14 +1337,14 @@ impl Session {
                     .await;
             }
             InitialHistory::Resumed(resumed_history) => {
-                let turn_context = self.new_default_turn().await;
+                let step_context_seed = self.new_default_turn().await;
                 let rollout_items = resumed_history.history;
                 let previous_turn_settings = self
-                    .apply_rollout_reconstruction(&turn_context, &rollout_items)
+                    .apply_rollout_reconstruction(&step_context_seed, &rollout_items)
                     .await;
 
                 // If resuming, warn when the last recorded model differs from the current one.
-                let curr: &str = turn_context.model_info.slug.as_str();
+                let curr: &str = step_context_seed.model.model_info.slug.as_str();
                 if let Some(prev) = previous_turn_settings
                     .as_ref()
                     .map(|settings| settings.model.as_str())
@@ -1349,7 +1352,7 @@ impl Session {
                 {
                     warn!("resuming session with different model: previous={prev}, current={curr}");
                     self.send_event(
-                        &turn_context,
+                        step_context_seed.turn.as_ref(),
                         EventMsg::Warning(WarningEvent {
                             message: format!(
                                 "This session was recorded with model `{prev}` but is resuming with `{curr}`. \
@@ -1374,15 +1377,20 @@ impl Session {
                 }
             }
             InitialHistory::Forked(mut rollout_items) => {
-                let turn_context = self.new_default_turn().await;
-                if turn_context.config.features.enabled(Feature::ItemIds) {
+                let step_context_seed = self.new_default_turn().await;
+                if step_context_seed
+                    .turn
+                    .config
+                    .features
+                    .enabled(Feature::ItemIds)
+                {
                     for rollout_item in &mut rollout_items {
                         if let RolloutItem::ResponseItem(response_item) = rollout_item {
                             Self::assign_missing_response_item_id(response_item);
                         }
                     }
                 }
-                self.apply_rollout_reconstruction(&turn_context, &rollout_items)
+                self.apply_rollout_reconstruction(&step_context_seed, &rollout_items)
                     .await;
 
                 // Seed usage info from the recorded rollout so UIs can show token counts
@@ -1418,7 +1426,7 @@ impl Session {
     )]
     async fn apply_rollout_reconstruction(
         &self,
-        turn_context: &TurnContext,
+        step_context_seed: &StepContextSeed,
         rollout_items: &[RolloutItem],
     ) -> Option<PreviousTurnSettings> {
         let rollout_reconstruction::RolloutReconstruction {
@@ -1431,7 +1439,7 @@ impl Session {
             previous_window_id,
             window_id,
         } = self
-            .reconstruct_history_from_rollout(turn_context, rollout_items)
+            .reconstruct_history_from_rollout(step_context_seed, rollout_items)
             .await;
         // Keep the recorded rollout unchanged. Prepare its reconstructed history before
         // installing it, so legacy images are processed once for this resume or fork and
@@ -1457,7 +1465,10 @@ impl Session {
             state.set_previous_turn_settings(previous_turn_settings.clone());
         }
         let prefix_tokens = if matches!(
-            turn_context.config.model_auto_compact_token_limit_scope,
+            step_context_seed
+                .turn
+                .config
+                .model_auto_compact_token_limit_scope,
             AutoCompactTokenLimitScope::BodyAfterPrefix
         ) {
             let history = self.clone_history().await;
@@ -1467,8 +1478,11 @@ impl Session {
             None
         };
         if let Some(prefix_tokens) = prefix_tokens {
-            self.set_auto_compact_window_estimated_prefill_for_scope(turn_context, prefix_tokens)
-                .await;
+            self.set_auto_compact_window_estimated_prefill_for_scope(
+                step_context_seed.turn.as_ref(),
+                prefix_tokens,
+            )
+            .await;
         }
         previous_turn_settings
     }
@@ -1728,7 +1742,7 @@ impl Session {
     async fn build_settings_update_items(
         &self,
         reference_context_item: Option<&TurnContextItem>,
-        current_context: &TurnContext,
+        current_context: &StepContext,
     ) -> Vec<ResponseItem> {
         // TODO: Make context updates a pure diff of persisted previous/current TurnContextItem
         // state so replay/backtracking is deterministic. Runtime inputs that affect model-visible
@@ -1975,9 +1989,10 @@ impl Session {
     pub(crate) async fn emit_turn_item_completed(
         &self,
         turn_context: &TurnContext,
+        model_context: &StepModelContext,
         item: TurnItem,
     ) {
-        record_turn_ttfm_metric(turn_context, &item).await;
+        record_turn_ttfm_metric(turn_context, model_context, &item).await;
         self.send_event(
             turn_context,
             EventMsg::ItemCompleted(ItemCompletedEvent {
@@ -2013,21 +2028,30 @@ impl Session {
     }
 
     pub(crate) async fn turn_context_for_sub_id(&self, sub_id: &str) -> Option<Arc<TurnContext>> {
+        self.step_context_seed_for_sub_id(sub_id)
+            .await
+            .map(|seed| seed.turn)
+    }
+
+    pub(crate) async fn step_context_seed_for_sub_id(
+        &self,
+        sub_id: &str,
+    ) -> Option<StepContextSeed> {
         let active = self.active_turn.lock().await;
         active
             .as_ref()
             .and_then(|turn| turn.task.as_ref())
-            .filter(|task| task.turn_context.sub_id == sub_id)
-            .map(|task| Arc::clone(&task.turn_context))
+            .filter(|task| task.step_context_seed.turn.sub_id == sub_id)
+            .map(|task| task.step_context_seed.clone())
     }
 
     async fn active_turn_context_and_cancellation_token(
         &self,
-    ) -> Option<(Arc<TurnContext>, CancellationToken)> {
+    ) -> Option<(StepContextSeed, CancellationToken)> {
         let active = self.active_turn.lock().await;
         let task = active.as_ref()?.task.as_ref()?;
         Some((
-            Arc::clone(&task.turn_context),
+            task.step_context_seed.clone(),
             task.cancellation_token.child_token(),
         ))
     }
@@ -2043,8 +2067,8 @@ impl Session {
         };
         let message: ResponseItem =
             ContextualUserFragment::into(ApprovedCommandPrefixSaved::new(prefixes));
-        let turn_context = self.turn_context_for_sub_id(sub_id).await;
-        self.inject_no_new_turn(vec![message], turn_context.as_deref())
+        let step_context_seed = self.step_context_seed_for_sub_id(sub_id).await;
+        self.inject_no_new_turn(vec![message], step_context_seed.as_ref())
             .await;
     }
 
@@ -2123,8 +2147,8 @@ impl Session {
         amendment: &NetworkPolicyAmendment,
     ) {
         let message: ResponseItem = ContextualUserFragment::into(NetworkRuleSaved::new(amendment));
-        let turn_context = self.turn_context_for_sub_id(sub_id).await;
-        self.inject_no_new_turn(vec![message], turn_context.as_deref())
+        let step_context_seed = self.step_context_seed_for_sub_id(sub_id).await;
+        self.inject_no_new_turn(vec![message], step_context_seed.as_ref())
             .await;
     }
 
@@ -2264,12 +2288,13 @@ impl Session {
     )]
     pub(crate) async fn request_permissions_for_environment(
         self: &Arc<Self>,
-        turn_context: &Arc<TurnContext>,
+        step_context_seed: &StepContextSeed,
         call_id: String,
         args: RequestPermissionsArgs,
         environment: TurnEnvironmentSelection,
         cancellation_token: CancellationToken,
     ) -> Option<RequestPermissionsResponse> {
+        let turn_context = &step_context_seed.turn;
         match turn_context.as_ref().approval_policy.value() {
             AskForApproval::Never => {
                 return Some(RequestPermissionsResponse {
@@ -2313,7 +2338,6 @@ impl Session {
             };
             let review_id = crate::guardian::new_guardian_review_id();
             let session = Arc::clone(self);
-            let turn = Arc::clone(turn_context);
             let request = crate::guardian::GuardianApprovalRequest::RequestPermissions {
                 id: call_id,
                 turn_id: turn_context.sub_id.clone(),
@@ -2322,7 +2346,7 @@ impl Session {
             };
             let review_rx = crate::guardian::spawn_approval_request_review(
                 session,
-                turn,
+                step_context_seed.clone(),
                 review_id,
                 request,
                 /*retry_reason*/ None,
@@ -2431,12 +2455,13 @@ impl Session {
 
     pub(crate) async fn request_permissions_for_cwd(
         self: &Arc<Self>,
-        turn_context: &Arc<TurnContext>,
+        step_context_seed: &StepContextSeed,
         call_id: String,
         args: RequestPermissionsArgs,
         cwd: AbsolutePathBuf,
         cancellation_token: CancellationToken,
     ) -> Option<RequestPermissionsResponse> {
+        let turn_context = &step_context_seed.turn;
         let turn_environment = match args.environment_id.as_deref() {
             Some(environment_id) => turn_context
                 .environments
@@ -2455,7 +2480,7 @@ impl Session {
         let mut environment = turn_environment.selection();
         environment.cwd = PathUri::from_abs_path(&cwd);
         self.request_permissions_for_environment(
-            turn_context,
+            step_context_seed,
             call_id,
             args,
             environment,
@@ -2798,9 +2823,10 @@ impl Session {
     }
 
     #[tracing::instrument(level = "trace", skip_all, fields(item_count = items.len()))]
-    pub(crate) async fn record_conversation_items(
+    async fn record_conversation_items_with_model(
         &self,
         turn_context: &TurnContext,
+        model_context: &StepModelContext,
         items: &[ResponseItem],
     ) {
         let items = self.prepare_conversation_items_for_history(turn_context, items);
@@ -2810,11 +2836,37 @@ impl Session {
             state.current_time_reminder.note_recorded_items(items);
             state.record_items(
                 items.iter(),
-                turn_context.model_info.truncation_policy.into(),
+                model_context.model_info.truncation_policy.into(),
             );
         }
         self.persist_rollout_response_items(items).await;
         self.send_raw_response_items(turn_context, items).await;
+    }
+
+    pub(crate) async fn record_conversation_items(
+        &self,
+        step_context: &StepContext,
+        items: &[ResponseItem],
+    ) {
+        self.record_conversation_items_with_model(
+            step_context.turn.as_ref(),
+            step_context.model.as_ref(),
+            items,
+        )
+        .await;
+    }
+
+    pub(crate) async fn record_conversation_items_for_seed(
+        &self,
+        step_context_seed: &StepContextSeed,
+        items: &[ResponseItem],
+    ) {
+        self.record_conversation_items_with_model(
+            step_context_seed.turn.as_ref(),
+            step_context_seed.model.as_ref(),
+            items,
+        )
+        .await;
     }
 
     pub(crate) async fn record_step_world_state_if_changed(
@@ -2835,7 +2887,7 @@ impl Session {
             world_state.render_diff(&previous_snapshot),
         );
         if !items.is_empty() {
-            self.record_conversation_items(turn_context, &items).await;
+            self.record_conversation_items(step_context, &items).await;
         }
 
         // ContextManager remembers this for later turns; run_turn owns the live value.
@@ -2860,8 +2912,9 @@ impl Session {
     #[tracing::instrument(name = "step_context.capture", level = "info", skip_all)]
     pub(crate) async fn capture_step_context(
         self: &Arc<Self>,
-        turn_context: Arc<TurnContext>,
+        seed: &StepContextSeed,
     ) -> Arc<StepContext> {
+        let turn_context = &seed.turn;
         let deferred_executor_enabled = turn_context
             .config
             .features
@@ -2890,7 +2943,8 @@ impl Session {
             )
             .await;
         Arc::new(StepContext::new(
-            turn_context,
+            Arc::clone(&seed.turn),
+            Arc::clone(&seed.model),
             environments,
             selected_capability_roots,
             mcp,
@@ -2900,9 +2954,10 @@ impl Session {
 
     pub(crate) async fn record_inter_agent_communication(
         &self,
-        turn_context: &TurnContext,
+        step_context_seed: &StepContextSeed,
         mut communication: InterAgentCommunication,
     ) {
+        let turn_context = step_context_seed.turn.as_ref();
         communication.set_turn_id_if_missing(&turn_context.sub_id);
         let response_item = communication.to_model_input_item();
         let items = self.prepare_conversation_items_for_history(
@@ -2916,7 +2971,7 @@ impl Session {
             state.current_time_reminder.note_recorded_items(items);
             state.record_items(
                 items.iter(),
-                turn_context.model_info.truncation_policy.into(),
+                step_context_seed.model.model_info.truncation_policy.into(),
             );
         }
         self.persist_rollout_items(&[
@@ -2931,10 +2986,11 @@ impl Session {
 
     async fn maybe_warn_on_server_model_mismatch(
         self: &Arc<Self>,
-        turn_context: &Arc<TurnContext>,
+        step_context: &Arc<StepContext>,
         server_model: String,
     ) -> bool {
-        let requested_model = turn_context.model_info.slug.clone();
+        let turn_context = &step_context.turn;
+        let requested_model = step_context.model.model_info.slug.clone();
         let server_model_normalized = server_model.to_ascii_lowercase();
         let requested_model_normalized = requested_model.to_ascii_lowercase();
         if server_model_normalized == requested_model_normalized {
@@ -3107,8 +3163,9 @@ impl Session {
 
     async fn build_turn_context_contribution_items(
         &self,
-        turn_context: &TurnContext,
+        step_context: &StepContext,
     ) -> Vec<ResponseItem> {
+        let turn_context = step_context.turn.as_ref();
         let mut developer_sections = Vec::new();
         let mut contextual_user_sections = Vec::new();
         let mut separate_developer_sections = Vec::new();
@@ -3122,7 +3179,7 @@ impl Session {
                     session_store: &self.services.session_extension_data,
                     thread_store: &self.services.thread_extension_data,
                     turn_store: turn_context.extension_data.as_ref(),
-                    model_context_window: turn_context.model_context_window(),
+                    model_context_window: step_context.model.model_context_window(),
                 })
                 .await
             {
@@ -3158,27 +3215,27 @@ impl Session {
 
     pub(crate) async fn build_initial_context_with_world_state(
         &self,
-        turn_context: &TurnContext,
+        step_context: &StepContext,
         world_state: &WorldState,
     ) -> Vec<ResponseItem> {
         let mcp = self.services.latest_mcp_runtime();
-        self.build_initial_context_with_world_state_and_mcp(turn_context, world_state, &mcp)
+        self.build_initial_context_with_world_state_and_mcp(step_context, world_state, &mcp)
             .await
     }
 
     async fn build_initial_context_with_world_state_and_mcp(
         &self,
-        turn_context: &TurnContext,
+        step_context: &StepContext,
         world_state: &WorldState,
         mcp: &McpRuntimeSnapshot,
     ) -> Vec<ResponseItem> {
+        let turn_context = step_context.turn.as_ref();
         let mut developer_sections = Vec::<String>::with_capacity(8);
         let mut contextual_user_sections = Vec::<String>::with_capacity(2);
         let mut separate_developer_sections = Vec::<String>::new();
         let (
             reference_context_item,
             previous_turn_settings,
-            collaboration_mode,
             base_instructions,
             session_source,
             auto_compact_window_ids,
@@ -3187,7 +3244,6 @@ impl Session {
             (
                 state.reference_context_item(),
                 state.previous_turn_settings(),
-                state.session_configuration.collaboration_mode.clone(),
                 state.session_configuration.base_instructions.clone(),
                 state.session_configuration.session_source.clone(),
                 state.auto_compact_window_ids(),
@@ -3196,7 +3252,7 @@ impl Session {
         if let Some(model_switch_message) =
             crate::context_manager::updates::build_model_instructions_update_item(
                 previous_turn_settings.as_ref(),
-                turn_context,
+                step_context,
             )
         {
             developer_sections.push(model_switch_message);
@@ -3235,7 +3291,9 @@ impl Session {
         // Add developer instructions from collaboration_mode if they exist and are non-empty
         if turn_context.config.include_collaboration_mode_instructions
             && let Some(collab_instructions) =
-                CollaborationModeInstructions::from_collaboration_mode(&collaboration_mode)
+                CollaborationModeInstructions::from_collaboration_mode(
+                    &step_context.model.collaboration_mode,
+                )
         {
             developer_sections.push(collab_instructions.render());
         }
@@ -3249,7 +3307,7 @@ impl Session {
         if self.features.enabled(Feature::Personality)
             && let Some(personality) = turn_context.personality
         {
-            let model_info = turn_context.model_info.clone();
+            let model_info = step_context.model.model_info.clone();
             let has_baked_personality = model_info.supports_personality()
                 && base_instructions == model_info.get_model_instructions(Some(personality));
             if !has_baked_personality
@@ -3266,7 +3324,7 @@ impl Session {
         if turn_context.config.include_skill_instructions {
             let available_skills = build_available_skills(
                 turn_context.turn_skills.snapshot.outcome(),
-                default_skill_metadata_budget(turn_context.model_info.context_window),
+                default_skill_metadata_budget(step_context.model.model_info.context_window),
                 SkillRenderSideEffects::ThreadStart {
                     session_telemetry: &self.services.session_telemetry,
                 },
@@ -3275,7 +3333,10 @@ impl Session {
                 let warning_message = available_skills.warning_message.clone();
                 let skills_instructions = AvailableSkillsInstructions::from_available_skills(
                     &available_skills,
-                    turn_context.model_info.include_skills_usage_instructions,
+                    step_context
+                        .model
+                        .model_info
+                        .include_skills_usage_instructions,
                 );
                 if let Some(warning_message) = warning_message {
                     self.send_event_raw(Event {
@@ -3323,6 +3384,7 @@ impl Session {
                 .contribute_thread_context(
                     &self.services.session_extension_data,
                     &self.services.thread_extension_data,
+                    &step_context.model.model_info,
                 )
                 .await
             {
@@ -3342,7 +3404,7 @@ impl Session {
                     session_store: &self.services.session_extension_data,
                     thread_store: &self.services.thread_extension_data,
                     turn_store: turn_context.extension_data.as_ref(),
-                    model_context_window: turn_context.model_context_window(),
+                    model_context_window: step_context.model.model_context_window(),
                 })
                 .await
             {
@@ -3356,7 +3418,7 @@ impl Session {
         }
         // This is full-context metadata. Steady-state context diffs should not re-emit it.
         if turn_context.config.features.enabled(Feature::TokenBudget)
-            && turn_context.model_context_window().is_some()
+            && step_context.model.model_context_window().is_some()
         {
             let mcp_result = mcp
                 .manager()
@@ -3435,7 +3497,7 @@ impl Session {
         {
             items.push(usage_hint_message);
         }
-        if let Some(multi_agent_mode) = multi_agents::effective_multi_agent_mode(turn_context) {
+        if let Some(multi_agent_mode) = multi_agents::effective_multi_agent_mode(step_context) {
             items.push(ContextualUserFragment::into(
                 MultiAgentModeInstructions::new(multi_agent_mode),
             ));
@@ -3502,18 +3564,19 @@ impl Session {
 
     pub(crate) async fn start_new_context_window(
         &self,
-        turn_context: &TurnContext,
+        step_context: &StepContext,
         world_state: Arc<WorldState>,
     ) -> u64 {
+        let turn_context = step_context.turn.as_ref();
         let window = {
             let mut state = self.state.lock().await;
             state.start_new_context_window()
         };
         let (window_number, window_ids) = window;
         let context_items = self
-            .build_initial_context_with_world_state(turn_context, world_state.as_ref())
+            .build_initial_context_with_world_state(step_context, world_state.as_ref())
             .await;
-        let turn_context_item = turn_context.to_turn_context_item();
+        let turn_context_item = step_context.to_turn_context_item();
         self.replace_compacted_history(
             turn_context,
             context_items,
@@ -3529,7 +3592,8 @@ impl Session {
             },
         )
         .await;
-        self.recompute_token_usage(turn_context).await;
+        self.recompute_token_usage(turn_context, step_context.model.as_ref())
+            .await;
         window_number
     }
 
@@ -3561,7 +3625,7 @@ impl Session {
             let state = self.state.lock().await;
             state.reference_context_item()
         };
-        let turn_context_item = turn_context.to_turn_context_item();
+        let turn_context_item = step_context.to_turn_context_item();
         let turn_context_changed = reference_context_item.as_ref() != Some(&turn_context_item);
         let should_inject_full_context = reference_context_item.is_none();
         let world_state = Arc::new(self.build_world_state_for_step(step_context).await);
@@ -3569,7 +3633,7 @@ impl Session {
         let (mut context_items, world_state_item) = if should_inject_full_context {
             let context_items = self
                 .build_initial_context_with_world_state_and_mcp(
-                    turn_context,
+                    step_context,
                     world_state.as_ref(),
                     step_context.mcp.as_ref(),
                 )
@@ -3588,7 +3652,7 @@ impl Session {
             // Steady-state path: append only built-in context diffs here; turn-scoped extension
             // context is added below.
             let mut context_items = self
-                .build_settings_update_items(reference_context_item.as_ref(), turn_context)
+                .build_settings_update_items(reference_context_item.as_ref(), step_context)
                 .await;
             let (world_state_items, world_state_item) = {
                 let mut state = self.state.lock().await;
@@ -3604,7 +3668,7 @@ impl Session {
         };
         if !should_inject_full_context && turn_context_changed {
             context_items.extend(
-                self.build_turn_context_contribution_items(turn_context)
+                self.build_turn_context_contribution_items(step_context)
                     .await,
             );
         }
@@ -3614,7 +3678,7 @@ impl Session {
             return world_state;
         }
         if !context_items.is_empty() {
-            self.record_conversation_items(turn_context, &context_items)
+            self.record_conversation_items(step_context, &context_items)
                 .await;
         }
         // Persist state only after any model-visible context generated from it.
@@ -3640,26 +3704,30 @@ impl Session {
 
     pub(crate) async fn update_token_usage_info(
         &self,
-        turn_context: &TurnContext,
+        step_context: &StepContext,
         token_usage: Option<&TokenUsage>,
     ) -> CodexResult<()> {
         let result = self
-            .record_token_usage_info(turn_context, token_usage)
+            .record_token_usage_info(step_context, token_usage)
             .await;
-        self.send_token_count_event(turn_context).await;
+        self.send_token_count_event(step_context.turn.as_ref())
+            .await;
         result
     }
 
     pub(crate) async fn record_token_usage_info(
         &self,
-        turn_context: &TurnContext,
+        step_context: &StepContext,
         token_usage: Option<&TokenUsage>,
     ) -> CodexResult<()> {
+        let turn_context = step_context.turn.as_ref();
         if let Some(token_usage) = token_usage {
             let token_info = {
                 let mut state = self.state.lock().await;
-                state
-                    .update_token_info_from_usage(token_usage, turn_context.model_context_window());
+                state.update_token_info_from_usage(
+                    token_usage,
+                    step_context.model.model_context_window(),
+                );
                 if matches!(
                     turn_context.config.model_auto_compact_token_limit_scope,
                     AutoCompactTokenLimitScope::BodyAfterPrefix
@@ -3686,7 +3754,11 @@ impl Session {
         Ok(())
     }
 
-    pub(crate) async fn recompute_token_usage(&self, turn_context: &TurnContext) {
+    pub(crate) async fn recompute_token_usage(
+        &self,
+        turn_context: &TurnContext,
+        model_context: &StepModelContext,
+    ) {
         let history = self.clone_history().await;
         let base_instructions = self.get_base_instructions().await;
         let Some(estimated_total_tokens) =
@@ -3710,7 +3782,7 @@ impl Session {
                 total_tokens: estimated_total_tokens.max(0),
             };
 
-            if let Some(model_context_window) = turn_context.model_context_window() {
+            if let Some(model_context_window) = model_context.model_context_window() {
                 info.model_context_window = Some(model_context_window);
             }
 
@@ -3767,8 +3839,9 @@ impl Session {
         self.send_event(turn_context, event).await;
     }
 
-    pub(crate) async fn set_total_tokens_full(&self, turn_context: &TurnContext) {
-        if let Some(context_window) = turn_context.model_context_window() {
+    pub(crate) async fn set_total_tokens_full(&self, step_context: &StepContext) {
+        let turn_context = step_context.turn.as_ref();
+        if let Some(context_window) = step_context.model.model_context_window() {
             let mut state = self.state.lock().await;
             state.set_token_usage_full(context_window);
         }
@@ -3777,37 +3850,47 @@ impl Session {
 
     pub(crate) async fn record_response_item_and_emit_turn_item(
         &self,
-        turn_context: &TurnContext,
+        step_context_seed: &StepContextSeed,
         response_item: ResponseItem,
     ) {
+        let turn_context = step_context_seed.turn.as_ref();
         // Add to conversation history and persist response item to rollout.
-        self.record_conversation_items(turn_context, std::slice::from_ref(&response_item))
-            .await;
+        self.record_conversation_items_for_seed(
+            step_context_seed,
+            std::slice::from_ref(&response_item),
+        )
+        .await;
 
         // Derive a turn item and emit lifecycle events if applicable.
         if let Some(item) = parse_turn_item(&response_item) {
             self.emit_turn_item_started(turn_context, &item).await;
-            self.emit_turn_item_completed(turn_context, item).await;
+            self.emit_turn_item_completed(turn_context, step_context_seed.model.as_ref(), item)
+                .await;
         }
     }
 
     pub(crate) async fn record_user_prompt_and_emit_turn_item(
         &self,
-        turn_context: &TurnContext,
+        step_context_seed: &StepContextSeed,
         input: &[UserInput],
         client_id: Option<String>,
     ) {
+        let turn_context = step_context_seed.turn.as_ref();
         // Persist the user message to history, but emit the turn item from `UserInput` so
         // UI-only `text_elements` are preserved. `ResponseItem::Message` does not carry
         // those spans, and `record_response_item_and_emit_turn_item` would drop them.
         let response_item = self.response_item_from_user_input(input.to_vec());
-        self.record_conversation_items(turn_context, std::slice::from_ref(&response_item))
-            .await;
+        self.record_conversation_items_for_seed(
+            step_context_seed,
+            std::slice::from_ref(&response_item),
+        )
+        .await;
         let mut user_message_item = UserMessageItem::new(input);
         user_message_item.client_id = client_id;
         let turn_item = TurnItem::UserMessage(user_message_item);
         self.emit_turn_item_started(turn_context, &turn_item).await;
-        self.emit_turn_item_completed(turn_context, turn_item).await;
+        self.emit_turn_item_completed(turn_context, step_context_seed.model.as_ref(), turn_item)
+            .await;
         self.ensure_rollout_materialized().await;
     }
 
@@ -3852,7 +3935,7 @@ impl Session {
         let Some(active_task) = active_turn.task.as_ref() else {
             return Err(SteerInputError::NoActiveTurn(input));
         };
-        let active_turn_id = &active_task.turn_context.sub_id;
+        let active_turn_id = &active_task.step_context_seed.turn.sub_id;
 
         if let Some(expected_turn_id) = expected_turn_id
             && expected_turn_id != active_turn_id
@@ -3888,7 +3971,8 @@ impl Session {
 
         if let Some(responsesapi_client_metadata) = responsesapi_client_metadata {
             active_task
-                .turn_context
+                .step_context_seed
+                .turn
                 .turn_metadata_state
                 .set_responsesapi_client_metadata(responsesapi_client_metadata);
         }

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -346,7 +346,6 @@ use codex_protocol::config_types::WindowsSandboxLevel;
 use codex_protocol::models::LocalImagePreparation;
 use codex_protocol::models::ResponseInputItem;
 use codex_protocol::models::ResponseItem;
-use codex_protocol::openai_models::ReasoningEffort as ReasoningEffortConfig;
 use codex_protocol::protocol::ApplyPatchApprovalRequestEvent;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::CodexErrorInfo;
@@ -2874,7 +2873,6 @@ impl Session {
         previous_world_state: &Arc<WorldState>,
         step_context: &step_context::StepContext,
     ) -> Arc<WorldState> {
-        let turn_context = step_context.turn.as_ref();
         // Render model-visible state from the same step used to build and run tools.
         let world_state = Arc::new(self.build_world_state_for_step(step_context).await);
         // Derive the model update and persisted patch from the same two snapshots.
@@ -3620,7 +3618,6 @@ impl Session {
         &self,
         step_context: &StepContext,
     ) -> Arc<WorldState> {
-        let turn_context = step_context.turn.as_ref();
         let reference_context_item = {
             let state = self.state.lock().await;
             state.reference_context_item()

--- a/codex-rs/core/src/session/multi_agents.rs
+++ b/codex-rs/core/src/session/multi_agents.rs
@@ -1,4 +1,5 @@
 use crate::config::MultiAgentV2Config;
+use crate::session::step_context::StepContext;
 use crate::session::turn_context::TurnContext;
 use codex_protocol::config_types::MultiAgentMode;
 use codex_protocol::openai_models::ReasoningEffort;
@@ -36,7 +37,8 @@ fn configured_usage_hint_text_for_source<'a>(
     }
 }
 
-pub(crate) fn effective_multi_agent_mode(turn_context: &TurnContext) -> Option<MultiAgentMode> {
+pub(crate) fn effective_multi_agent_mode(step_context: &StepContext) -> Option<MultiAgentMode> {
+    let turn_context = step_context.turn.as_ref();
     if turn_context.multi_agent_version != MultiAgentVersion::V2 {
         return None;
     }
@@ -49,7 +51,7 @@ pub(crate) fn effective_multi_agent_mode(turn_context: &TurnContext) -> Option<M
         .multi_agent_mode_hint_text
     {
         Some(hint_text) => MultiAgentMode::Custom(hint_text.clone()),
-        None => match turn_context.effective_reasoning_effort() {
+        None => match step_context.model.effective_reasoning_effort() {
             Some(ReasoningEffort::Ultra) => MultiAgentMode::Proactive,
             _ => MultiAgentMode::ExplicitRequestOnly,
         },

--- a/codex-rs/core/src/session/review.rs
+++ b/codex-rs/core/src/session/review.rs
@@ -5,14 +5,15 @@ use std::sync::atomic::AtomicBool;
 pub(super) async fn spawn_review_thread(
     sess: Arc<Session>,
     config: Arc<Config>,
-    parent_turn_context: Arc<TurnContext>,
+    parent_step_context: StepContextSeed,
     sub_id: String,
     resolved: crate::review_prompts::ResolvedReviewRequest,
 ) {
+    let parent_turn_context = &parent_step_context.turn;
     let model = config
         .review_model
         .clone()
-        .unwrap_or_else(|| parent_turn_context.model_info.slug.clone());
+        .unwrap_or_else(|| parent_step_context.model.model_info.slug.clone());
     let review_model_info = sess
         .services
         .models_manager
@@ -63,7 +64,8 @@ pub(super) async fn spawn_review_thread(
         );
     }
 
-    let session_telemetry = parent_turn_context
+    let session_telemetry = parent_step_context
+        .model
         .session_telemetry
         .clone()
         .with_model(model.as_str(), review_model_info.slug.as_str());
@@ -74,6 +76,12 @@ pub(super) async fn spawn_review_thread(
     let reasoning_summary = per_turn_config
         .model_reasoning_summary
         .unwrap_or(model_info.default_reasoning_summary);
+    let collaboration_mode = parent_step_context.model.collaboration_mode.with_updates(
+        Some(model.clone()),
+        Some(reasoning_effort.clone()),
+        /*developer_instructions*/ None,
+    );
+    let service_tier = per_turn_config.service_tier.clone();
     let session_source = parent_turn_context.session_source.clone();
     let (forked_from_thread_id, thread_source) = {
         let state = sess.state.lock().await;
@@ -111,11 +119,7 @@ pub(super) async fn spawn_review_thread(
         realtime_active: parent_turn_context.realtime_active,
         config: per_turn_config,
         auth_manager: auth_manager_for_context,
-        model_info: model_info.clone(),
-        session_telemetry: session_telemetry_for_context,
         provider: provider_for_context,
-        reasoning_effort,
-        reasoning_summary,
         session_source,
         parent_thread_id: parent_turn_context.parent_thread_id,
         originator: parent_turn_context.originator.clone(),
@@ -126,7 +130,6 @@ pub(super) async fn spawn_review_thread(
         timezone: parent_turn_context.timezone.clone(),
         app_server_client_name: parent_turn_context.app_server_client_name.clone(),
         developer_instructions: None,
-        collaboration_mode: parent_turn_context.collaboration_mode.clone(),
         multi_agent_version: MultiAgentVersion::Disabled,
         personality: parent_turn_context.personality,
         approval_policy: parent_turn_context.approval_policy.clone(),
@@ -142,6 +145,13 @@ pub(super) async fn spawn_review_thread(
         turn_skills: TurnSkillsContext::new(parent_turn_context.turn_skills.snapshot.clone()),
         turn_timing_state: Arc::new(TurnTimingState::default()),
         terminal_error: Arc::new(Mutex::new(None)),
+    };
+    let review_model_context = StepModelContext {
+        model_info,
+        collaboration_mode,
+        reasoning_summary,
+        service_tier,
+        session_telemetry: session_telemetry_for_context,
         server_model_warning_emitted: AtomicBool::new(false),
         model_verification_emitted: AtomicBool::new(false),
     };
@@ -155,20 +165,35 @@ pub(super) async fn spawn_review_thread(
         }],
         client_id: None,
     }];
-    let tc = Arc::new(review_turn_context);
-    if tc.environments.single_local_environment_cwd().is_some() {
-        tc.turn_metadata_state.spawn_git_enrichment_task();
+    let step_context_seed = StepContextSeed::new(
+        Arc::new(review_turn_context),
+        Arc::new(review_model_context),
+    );
+    if step_context_seed
+        .turn
+        .environments
+        .single_local_environment_cwd()
+        .is_some()
+    {
+        step_context_seed
+            .turn
+            .turn_metadata_state
+            .spawn_git_enrichment_task();
     }
     // TODO(ccunningham): Review turns currently rely on `spawn_task` for TurnComplete but do not
     // emit a parent TurnStarted. Consider giving review a full parent turn lifecycle
     // (TurnStarted + TurnComplete) for consistency with other standalone tasks.
-    sess.spawn_task(tc.clone(), input, ReviewTask::new()).await;
+    sess.spawn_task(step_context_seed.clone(), input, ReviewTask::new())
+        .await;
 
     // Announce entering review mode so UIs can switch modes.
     let review_request = ReviewRequest {
         target: resolved.target,
         user_facing_hint: Some(resolved.user_facing_hint),
     };
-    sess.send_event(&tc, EventMsg::EnteredReviewMode(review_request))
-        .await;
+    sess.send_event(
+        step_context_seed.turn.as_ref(),
+        EventMsg::EnteredReviewMode(review_request),
+    )
+    .await;
 }

--- a/codex-rs/core/src/session/rollout_budget.rs
+++ b/codex-rs/core/src/session/rollout_budget.rs
@@ -10,7 +10,6 @@ pub(super) async fn maybe_record_reminder(
     step_context: &StepContext,
     window_id: &str,
 ) {
-    let turn_context = step_context.turn.as_ref();
     let budget = sess.services.agent_control.rollout_budget();
     let Some(reminder) = budget.pending_reminder(sess.thread_id(), window_id) else {
         return;

--- a/codex-rs/core/src/session/rollout_budget.rs
+++ b/codex-rs/core/src/session/rollout_budget.rs
@@ -1,5 +1,5 @@
 use super::session::Session;
-use super::turn_context::TurnContext;
+use super::step_context::StepContext;
 use crate::context::ContextualUserFragment;
 use codex_protocol::error::CodexErr;
 use codex_protocol::error::Result as CodexResult;
@@ -7,9 +7,10 @@ use codex_protocol::protocol::TokenUsage;
 
 pub(super) async fn maybe_record_reminder(
     sess: &Session,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     window_id: &str,
 ) {
+    let turn_context = step_context.turn.as_ref();
     let budget = sess.services.agent_control.rollout_budget();
     let Some(reminder) = budget.pending_reminder(sess.thread_id(), window_id) else {
         return;
@@ -17,7 +18,7 @@ pub(super) async fn maybe_record_reminder(
     let response_item = ContextualUserFragment::into(crate::context::RolloutBudgetContext {
         remaining_tokens: reminder.remaining_tokens,
     });
-    sess.record_conversation_items(turn_context, std::slice::from_ref(&response_item))
+    sess.record_conversation_items(step_context, std::slice::from_ref(&response_item))
         .await;
     budget.mark_reminder_delivered(sess.thread_id(), window_id, reminder);
 }

--- a/codex-rs/core/src/session/rollout_reconstruction.rs
+++ b/codex-rs/core/src/session/rollout_reconstruction.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::context::world_state::WorldStateSnapshot;
 use crate::context_manager::is_user_turn_boundary;
+use crate::session::step_context::StepContextSeed;
 use codex_protocol::protocol::SessionContextWindow;
 use uuid::Uuid;
 
@@ -112,9 +113,10 @@ fn finalize_active_segment<'a>(
 impl Session {
     pub(super) async fn reconstruct_history_from_rollout(
         &self,
-        turn_context: &TurnContext,
+        step_context_seed: &StepContextSeed,
         rollout_items: &[RolloutItem],
     ) -> RolloutReconstruction {
+        let turn_context = step_context_seed.turn.as_ref();
         // Replay metadata should already match the shape of the future lazy reverse loader, even
         // while history materialization still uses an eager bridge. Scan newest-to-oldest,
         // stopping once a surviving replacement-history checkpoint and the required resume metadata
@@ -327,14 +329,14 @@ impl Session {
                 RolloutItem::ResponseItem(response_item) => {
                     history.record_items(
                         std::iter::once(response_item),
-                        turn_context.model_info.truncation_policy.into(),
+                        step_context_seed.model.model_info.truncation_policy.into(),
                     );
                 }
                 RolloutItem::InterAgentCommunication(communication) => {
                     let response_item = communication.to_model_input_item();
                     history.record_items(
                         std::iter::once(&response_item),
-                        turn_context.model_info.truncation_policy.into(),
+                        step_context_seed.model.model_info.truncation_policy.into(),
                     );
                 }
                 RolloutItem::InterAgentCommunicationMetadata { .. } => {}

--- a/codex-rs/core/src/session/rollout_reconstruction.rs
+++ b/codex-rs/core/src/session/rollout_reconstruction.rs
@@ -116,7 +116,6 @@ impl Session {
         step_context_seed: &StepContextSeed,
         rollout_items: &[RolloutItem],
     ) -> RolloutReconstruction {
-        let turn_context = step_context_seed.turn.as_ref();
         // Replay metadata should already match the shape of the future lazy reverse loader, even
         // while history materialization still uses an eager bridge. Scan newest-to-oldest,
         // stopping once a surviving replacement-history checkpoint and the required resume metadata

--- a/codex-rs/core/src/session/rollout_reconstruction_tests.rs
+++ b/codex-rs/core/src/session/rollout_reconstruction_tests.rs
@@ -2,6 +2,8 @@ use super::*;
 
 use super::tests::build_world_state_from_turn_context;
 use super::tests::make_session_and_context;
+use super::tests::step_context_seed_for_test;
+use super::tests::turn_context_item_for_test;
 use codex_protocol::AgentPath;
 use codex_protocol::ThreadId;
 use codex_protocol::models::ContentItem;
@@ -17,7 +19,19 @@ use codex_protocol::protocol::WorldStateItem;
 use pretty_assertions::assert_eq;
 use serde_json::json;
 use std::path::PathBuf;
+use std::sync::Arc;
 use uuid::Uuid;
+
+async fn reconstruct_history_from_rollout_for_test(
+    session: &Session,
+    turn_context: &Arc<TurnContext>,
+    rollout_items: &[RolloutItem],
+) -> super::rollout_reconstruction::RolloutReconstruction {
+    let step_context_seed = step_context_seed_for_test(Arc::clone(turn_context));
+    session
+        .reconstruct_history_from_rollout(&step_context_seed, rollout_items)
+        .await
+}
 
 fn user_message(text: &str) -> ResponseItem {
     ResponseItem::Message {
@@ -138,7 +152,7 @@ async fn record_initial_history_restores_world_state_baseline() {
     let turn_context = Arc::new(turn_context);
     let world_state = build_world_state_from_turn_context(&session, &turn_context).await;
     let rollout_items = completed_user_turn_rollout(
-        turn_context.to_turn_context_item(),
+        turn_context_item_for_test(&turn_context),
         vec![RolloutItem::WorldState(WorldStateItem::full(
             world_state.snapshot().into_value(),
         ))],
@@ -163,6 +177,7 @@ async fn record_initial_history_restores_world_state_baseline() {
 async fn record_initial_history_resumed_bare_turn_context_does_not_hydrate_previous_turn_settings()
 {
     let (session, turn_context) = make_session_and_context().await;
+    let turn_context = Arc::new(turn_context);
     let previous_model = "previous-rollout-model";
     let previous_context_item = TurnContextItem {
         turn_id: Some(turn_context.sub_id.clone()),
@@ -179,18 +194,21 @@ async fn record_initial_history_resumed_bare_turn_context_does_not_hydrate_previ
         model: previous_model.to_string(),
         comp_hash: None,
         personality: turn_context.personality,
-        collaboration_mode: Some(turn_context.collaboration_mode.clone()),
+        collaboration_mode: Some(
+            StepModelContext::for_test(&turn_context)
+                .collaboration_mode
+                .clone(),
+        ),
         multi_agent_version: None,
         multi_agent_mode: None,
         realtime_active: Some(turn_context.realtime_active),
-        effort: turn_context.reasoning_effort.clone(),
+        effort: StepModelContext::for_test(&turn_context).reasoning_effort(),
         summary: codex_protocol::config_types::ReasoningSummary::Auto,
     };
     let rollout_items = vec![RolloutItem::TurnContext(previous_context_item)];
 
-    let reconstructed = session
-        .reconstruct_history_from_rollout(&turn_context, &rollout_items)
-        .await;
+    let reconstructed =
+        reconstruct_history_from_rollout_for_test(&session, &turn_context, &rollout_items).await;
     assert_eq!(reconstructed.world_state_baseline, None);
 
     session
@@ -209,6 +227,7 @@ async fn record_initial_history_resumed_bare_turn_context_does_not_hydrate_previ
 async fn record_initial_history_resumed_hydrates_previous_turn_settings_from_lifecycle_turn_with_missing_turn_context_id()
  {
     let (session, turn_context) = make_session_and_context().await;
+    let turn_context = Arc::new(turn_context);
     let previous_model = "previous-rollout-model";
     let mut previous_context_item = TurnContextItem {
         turn_id: Some(turn_context.sub_id.clone()),
@@ -225,11 +244,15 @@ async fn record_initial_history_resumed_hydrates_previous_turn_settings_from_lif
         model: previous_model.to_string(),
         comp_hash: Some("comp-hash-a".to_string()),
         personality: turn_context.personality,
-        collaboration_mode: Some(turn_context.collaboration_mode.clone()),
+        collaboration_mode: Some(
+            StepModelContext::for_test(&turn_context)
+                .collaboration_mode
+                .clone(),
+        ),
         multi_agent_version: None,
         multi_agent_mode: None,
         realtime_active: Some(turn_context.realtime_active),
-        effort: turn_context.reasoning_effort.clone(),
+        effort: StepModelContext::for_test(&turn_context).reasoning_effort(),
         summary: codex_protocol::config_types::ReasoningSummary::Auto,
     };
     let turn_id = previous_context_item
@@ -291,7 +314,8 @@ async fn record_initial_history_resumed_hydrates_previous_turn_settings_from_lif
 #[tokio::test]
 async fn reconstruct_history_rollback_keeps_history_and_metadata_in_sync_for_completed_turns() {
     let (session, turn_context) = make_session_and_context().await;
-    let first_context_item = turn_context.to_turn_context_item();
+    let turn_context = Arc::new(turn_context);
+    let first_context_item = turn_context_item_for_test(&turn_context);
     let first_turn_id = first_context_item
         .turn_id
         .clone()
@@ -382,9 +406,8 @@ async fn reconstruct_history_rollback_keeps_history_and_metadata_in_sync_for_com
         )),
     ];
 
-    let reconstructed = session
-        .reconstruct_history_from_rollout(&turn_context, &rollout_items)
-        .await;
+    let reconstructed =
+        reconstruct_history_from_rollout_for_test(&session, &turn_context, &rollout_items).await;
 
     assert_eq!(
         reconstructed.history,
@@ -393,7 +416,10 @@ async fn reconstruct_history_rollback_keeps_history_and_metadata_in_sync_for_com
     assert_eq!(
         reconstructed.previous_turn_settings,
         Some(PreviousTurnSettings {
-            model: turn_context.model_info.slug.clone(),
+            model: StepModelContext::for_test(&turn_context)
+                .model_info
+                .slug
+                .clone(),
             comp_hash: None,
             realtime_active: Some(turn_context.realtime_active),
         })
@@ -414,7 +440,8 @@ async fn reconstruct_history_rollback_keeps_history_and_metadata_in_sync_for_com
 #[tokio::test]
 async fn reconstruct_history_rollback_keeps_history_and_metadata_in_sync_for_incomplete_turn() {
     let (session, turn_context) = make_session_and_context().await;
-    let first_context_item = turn_context.to_turn_context_item();
+    let turn_context = Arc::new(turn_context);
+    let first_context_item = turn_context_item_for_test(&turn_context);
     let first_turn_id = first_context_item
         .turn_id
         .clone()
@@ -481,9 +508,8 @@ async fn reconstruct_history_rollback_keeps_history_and_metadata_in_sync_for_inc
         )),
     ];
 
-    let reconstructed = session
-        .reconstruct_history_from_rollout(&turn_context, &rollout_items)
-        .await;
+    let reconstructed =
+        reconstruct_history_from_rollout_for_test(&session, &turn_context, &rollout_items).await;
 
     assert_eq!(
         reconstructed.history,
@@ -492,7 +518,10 @@ async fn reconstruct_history_rollback_keeps_history_and_metadata_in_sync_for_inc
     assert_eq!(
         reconstructed.previous_turn_settings,
         Some(PreviousTurnSettings {
-            model: turn_context.model_info.slug.clone(),
+            model: StepModelContext::for_test(&turn_context)
+                .model_info
+                .slug
+                .clone(),
             comp_hash: None,
             realtime_active: Some(turn_context.realtime_active),
         })
@@ -508,7 +537,8 @@ async fn reconstruct_history_rollback_keeps_history_and_metadata_in_sync_for_inc
 #[tokio::test]
 async fn reconstruct_history_rollback_skips_non_user_turns_for_history_and_metadata() {
     let (session, turn_context) = make_session_and_context().await;
-    let first_context_item = turn_context.to_turn_context_item();
+    let turn_context = Arc::new(turn_context);
+    let first_context_item = turn_context_item_for_test(&turn_context);
     let first_turn_id = first_context_item
         .turn_id
         .clone()
@@ -607,9 +637,8 @@ async fn reconstruct_history_rollback_skips_non_user_turns_for_history_and_metad
         )),
     ];
 
-    let reconstructed = session
-        .reconstruct_history_from_rollout(&turn_context, &rollout_items)
-        .await;
+    let reconstructed =
+        reconstruct_history_from_rollout_for_test(&session, &turn_context, &rollout_items).await;
 
     assert_eq!(
         reconstructed.history,
@@ -618,7 +647,10 @@ async fn reconstruct_history_rollback_skips_non_user_turns_for_history_and_metad
     assert_eq!(
         reconstructed.previous_turn_settings,
         Some(PreviousTurnSettings {
-            model: turn_context.model_info.slug.clone(),
+            model: StepModelContext::for_test(&turn_context)
+                .model_info
+                .slug
+                .clone(),
             comp_hash: None,
             realtime_active: Some(turn_context.realtime_active),
         })
@@ -634,7 +666,8 @@ async fn reconstruct_history_rollback_skips_non_user_turns_for_history_and_metad
 #[tokio::test]
 async fn reconstruct_history_rollback_counts_inter_agent_assistant_turns() {
     let (session, turn_context) = make_session_and_context().await;
-    let first_context_item = turn_context.to_turn_context_item();
+    let turn_context = Arc::new(turn_context);
+    let first_context_item = turn_context_item_for_test(&turn_context);
     let first_turn_id = first_context_item
         .turn_id
         .clone()
@@ -705,9 +738,8 @@ async fn reconstruct_history_rollback_counts_inter_agent_assistant_turns() {
         )),
     ];
 
-    let reconstructed = session
-        .reconstruct_history_from_rollout(&turn_context, &rollout_items)
-        .await;
+    let reconstructed =
+        reconstruct_history_from_rollout_for_test(&session, &turn_context, &rollout_items).await;
 
     assert_eq!(
         reconstructed.history,
@@ -719,7 +751,10 @@ async fn reconstruct_history_rollback_counts_inter_agent_assistant_turns() {
     assert_eq!(
         reconstructed.previous_turn_settings,
         Some(PreviousTurnSettings {
-            model: turn_context.model_info.slug.clone(),
+            model: StepModelContext::for_test(&turn_context)
+                .model_info
+                .slug
+                .clone(),
             comp_hash: None,
             realtime_active: Some(turn_context.realtime_active),
         })
@@ -735,7 +770,8 @@ async fn reconstruct_history_rollback_counts_inter_agent_assistant_turns() {
 #[tokio::test]
 async fn reconstruct_history_rollback_clears_history_and_metadata_when_exceeding_user_turns() {
     let (session, turn_context) = make_session_and_context().await;
-    let only_context_item = turn_context.to_turn_context_item();
+    let turn_context = Arc::new(turn_context);
+    let only_context_item = turn_context_item_for_test(&turn_context);
     let only_turn_id = only_context_item
         .turn_id
         .clone()
@@ -777,9 +813,8 @@ async fn reconstruct_history_rollback_clears_history_and_metadata_when_exceeding
         )),
     ];
 
-    let reconstructed = session
-        .reconstruct_history_from_rollout(&turn_context, &rollout_items)
-        .await;
+    let reconstructed =
+        reconstruct_history_from_rollout_for_test(&session, &turn_context, &rollout_items).await;
 
     assert_eq!(reconstructed.history, Vec::new());
     assert_eq!(reconstructed.previous_turn_settings, None);
@@ -789,7 +824,8 @@ async fn reconstruct_history_rollback_clears_history_and_metadata_when_exceeding
 #[tokio::test]
 async fn record_initial_history_resumed_rollback_skips_only_user_turns() {
     let (session, turn_context) = make_session_and_context().await;
-    let previous_context_item = turn_context.to_turn_context_item();
+    let turn_context = Arc::new(turn_context);
+    let previous_context_item = turn_context_item_for_test(&turn_context);
     let user_turn_id = previous_context_item
         .turn_id
         .clone()
@@ -864,7 +900,8 @@ async fn record_initial_history_resumed_rollback_skips_only_user_turns() {
 #[tokio::test]
 async fn record_initial_history_resumed_rollback_drops_incomplete_user_turn_compaction_metadata() {
     let (session, turn_context) = make_session_and_context().await;
-    let previous_context_item = turn_context.to_turn_context_item();
+    let turn_context = Arc::new(turn_context);
+    let previous_context_item = turn_context_item_for_test(&turn_context);
     let previous_turn_id = previous_context_item
         .turn_id
         .clone()
@@ -944,7 +981,10 @@ async fn record_initial_history_resumed_rollback_drops_incomplete_user_turn_comp
     assert_eq!(
         session.previous_turn_settings().await,
         Some(PreviousTurnSettings {
-            model: turn_context.model_info.slug.clone(),
+            model: StepModelContext::for_test(&turn_context)
+                .model_info
+                .slug
+                .clone(),
             comp_hash: None,
             realtime_active: Some(turn_context.realtime_active),
         })
@@ -960,7 +1000,8 @@ async fn record_initial_history_resumed_rollback_drops_incomplete_user_turn_comp
 #[tokio::test]
 async fn record_initial_history_resumed_bare_turn_context_does_not_seed_reference_context_item() {
     let (session, turn_context) = make_session_and_context().await;
-    let previous_context_item = turn_context.to_turn_context_item();
+    let turn_context = Arc::new(turn_context);
+    let previous_context_item = turn_context_item_for_test(&turn_context);
     let rollout_items = vec![RolloutItem::TurnContext(previous_context_item.clone())];
 
     session
@@ -977,7 +1018,8 @@ async fn record_initial_history_resumed_bare_turn_context_does_not_seed_referenc
 #[tokio::test]
 async fn record_initial_history_resumed_does_not_seed_reference_context_item_after_compaction() {
     let (session, turn_context) = make_session_and_context().await;
-    let previous_context_item = turn_context.to_turn_context_item();
+    let turn_context = Arc::new(turn_context);
+    let previous_context_item = turn_context_item_for_test(&turn_context);
     let rollout_items = vec![
         RolloutItem::TurnContext(previous_context_item),
         RolloutItem::Compacted(CompactedItem {
@@ -1005,6 +1047,7 @@ async fn record_initial_history_resumed_does_not_seed_reference_context_item_aft
 #[tokio::test]
 async fn reconstruct_history_restores_initial_window_from_session_meta() {
     let (session, turn_context) = make_session_and_context().await;
+    let turn_context = Arc::new(turn_context);
     let thread_id = ThreadId::default();
     let initial_window_id = Uuid::now_v7();
     let rollout_items = vec![RolloutItem::SessionMeta(SessionMetaLine {
@@ -1019,9 +1062,8 @@ async fn reconstruct_history_restores_initial_window_from_session_meta() {
         git: None,
     })];
 
-    let reconstructed = session
-        .reconstruct_history_from_rollout(&turn_context, &rollout_items)
-        .await;
+    let reconstructed =
+        reconstruct_history_from_rollout_for_test(&session, &turn_context, &rollout_items).await;
 
     assert_eq!(reconstructed.window_number, 0);
     assert_eq!(reconstructed.first_window_id, Some(initial_window_id));
@@ -1032,6 +1074,7 @@ async fn reconstruct_history_restores_initial_window_from_session_meta() {
 #[tokio::test]
 async fn reconstruct_history_prefers_compacted_window_over_session_meta() {
     let (session, turn_context) = make_session_and_context().await;
+    let turn_context = Arc::new(turn_context);
     let thread_id = ThreadId::default();
     let initial_window_id = Uuid::now_v7();
     let compacted_first_window_id = Uuid::now_v7();
@@ -1059,9 +1102,8 @@ async fn reconstruct_history_prefers_compacted_window_over_session_meta() {
         }),
     ];
 
-    let reconstructed = session
-        .reconstruct_history_from_rollout(&turn_context, &rollout_items)
-        .await;
+    let reconstructed =
+        reconstruct_history_from_rollout_for_test(&session, &turn_context, &rollout_items).await;
 
     assert_eq!(reconstructed.window_number, 2);
     assert_eq!(
@@ -1078,8 +1120,9 @@ async fn reconstruct_history_prefers_compacted_window_over_session_meta() {
 #[tokio::test]
 async fn reconstruct_history_replays_world_state_from_latest_compaction_window() {
     let (session, turn_context) = make_session_and_context().await;
+    let turn_context = Arc::new(turn_context);
     let rollout_items = completed_user_turn_rollout(
-        turn_context.to_turn_context_item(),
+        turn_context_item_for_test(&turn_context),
         vec![
             RolloutItem::WorldState(WorldStateItem::full(json!({
                 "environment": {"status": "old"}
@@ -1101,9 +1144,8 @@ async fn reconstruct_history_replays_world_state_from_latest_compaction_window()
         ],
     );
 
-    let reconstructed = session
-        .reconstruct_history_from_rollout(&turn_context, &rollout_items)
-        .await;
+    let reconstructed =
+        reconstruct_history_from_rollout_for_test(&session, &turn_context, &rollout_items).await;
 
     assert_eq!(
         serde_json::to_value(reconstructed.world_state_baseline)
@@ -1117,6 +1159,7 @@ async fn reconstruct_history_replays_world_state_from_latest_compaction_window()
 #[tokio::test]
 async fn reconstruct_history_preserves_legacy_compaction_count_with_session_meta_window() {
     let (session, turn_context) = make_session_and_context().await;
+    let turn_context = Arc::new(turn_context);
     let thread_id = ThreadId::default();
     let initial_window_id = Uuid::now_v7();
     let rollout_items = vec![
@@ -1141,9 +1184,8 @@ async fn reconstruct_history_preserves_legacy_compaction_count_with_session_meta
         }),
     ];
 
-    let reconstructed = session
-        .reconstruct_history_from_rollout(&turn_context, &rollout_items)
-        .await;
+    let reconstructed =
+        reconstruct_history_from_rollout_for_test(&session, &turn_context, &rollout_items).await;
 
     assert_eq!(reconstructed.window_number, 1);
     assert_eq!(reconstructed.first_window_id, None);
@@ -1155,6 +1197,7 @@ async fn reconstruct_history_preserves_legacy_compaction_count_with_session_meta
 async fn reconstruct_history_legacy_compaction_without_replacement_history_does_not_inject_current_initial_context()
  {
     let (session, turn_context) = make_session_and_context().await;
+    let turn_context = Arc::new(turn_context);
     let rollout_items = vec![
         RolloutItem::ResponseItem(user_message("before compact")),
         RolloutItem::ResponseItem(assistant_message("assistant reply")),
@@ -1168,9 +1211,8 @@ async fn reconstruct_history_legacy_compaction_without_replacement_history_does_
         }),
     ];
 
-    let reconstructed = session
-        .reconstruct_history_from_rollout(&turn_context, &rollout_items)
-        .await;
+    let reconstructed =
+        reconstruct_history_from_rollout_for_test(&session, &turn_context, &rollout_items).await;
 
     assert_eq!(
         reconstructed.history,
@@ -1186,7 +1228,8 @@ async fn reconstruct_history_legacy_compaction_without_replacement_history_does_
 async fn reconstruct_history_legacy_compaction_without_replacement_history_clears_later_reference_context_item()
  {
     let (session, turn_context) = make_session_and_context().await;
-    let current_context_item = turn_context.to_turn_context_item();
+    let turn_context = Arc::new(turn_context);
+    let current_context_item = turn_context_item_for_test(&turn_context);
     let current_turn_id = current_context_item
         .turn_id
         .clone()
@@ -1232,9 +1275,8 @@ async fn reconstruct_history_legacy_compaction_without_replacement_history_clear
         )),
     ];
 
-    let reconstructed = session
-        .reconstruct_history_from_rollout(&turn_context, &rollout_items)
-        .await;
+    let reconstructed =
+        reconstruct_history_from_rollout_for_test(&session, &turn_context, &rollout_items).await;
 
     assert!(reconstructed.reference_context_item.is_none());
 }
@@ -1243,6 +1285,7 @@ async fn reconstruct_history_legacy_compaction_without_replacement_history_clear
 async fn record_initial_history_resumed_turn_context_after_compaction_reestablishes_reference_context_item()
  {
     let (session, turn_context) = make_session_and_context().await;
+    let turn_context = Arc::new(turn_context);
     let previous_model = "previous-rollout-model";
     let previous_context_item = TurnContextItem {
         turn_id: Some(turn_context.sub_id.clone()),
@@ -1259,11 +1302,15 @@ async fn record_initial_history_resumed_turn_context_after_compaction_reestablis
         model: previous_model.to_string(),
         comp_hash: None,
         personality: turn_context.personality,
-        collaboration_mode: Some(turn_context.collaboration_mode.clone()),
+        collaboration_mode: Some(
+            StepModelContext::for_test(&turn_context)
+                .collaboration_mode
+                .clone(),
+        ),
         multi_agent_version: None,
         multi_agent_mode: None,
         realtime_active: Some(turn_context.realtime_active),
-        effort: turn_context.reasoning_effort.clone(),
+        effort: StepModelContext::for_test(&turn_context).reasoning_effort(),
         summary: codex_protocol::config_types::ReasoningSummary::Auto,
     };
     let previous_turn_id = previous_context_item
@@ -1345,11 +1392,15 @@ async fn record_initial_history_resumed_turn_context_after_compaction_reestablis
             model: previous_model.to_string(),
             comp_hash: None,
             personality: turn_context.personality,
-            collaboration_mode: Some(turn_context.collaboration_mode.clone()),
+            collaboration_mode: Some(
+                StepModelContext::for_test(&turn_context)
+                    .collaboration_mode
+                    .clone(),
+            ),
             multi_agent_version: None,
             multi_agent_mode: None,
             realtime_active: Some(turn_context.realtime_active),
-            effort: turn_context.reasoning_effort.clone(),
+            effort: StepModelContext::for_test(&turn_context).reasoning_effort(),
             summary: codex_protocol::config_types::ReasoningSummary::Auto,
         }))
         .expect("serialize expected reference context item")
@@ -1360,6 +1411,7 @@ async fn record_initial_history_resumed_turn_context_after_compaction_reestablis
 async fn record_initial_history_resumed_aborted_turn_without_id_clears_active_turn_for_compaction_accounting()
  {
     let (session, turn_context) = make_session_and_context().await;
+    let turn_context = Arc::new(turn_context);
     let previous_model = "previous-rollout-model";
     let previous_context_item = TurnContextItem {
         turn_id: Some(turn_context.sub_id.clone()),
@@ -1376,11 +1428,15 @@ async fn record_initial_history_resumed_aborted_turn_without_id_clears_active_tu
         model: previous_model.to_string(),
         comp_hash: None,
         personality: turn_context.personality,
-        collaboration_mode: Some(turn_context.collaboration_mode.clone()),
+        collaboration_mode: Some(
+            StepModelContext::for_test(&turn_context)
+                .collaboration_mode
+                .clone(),
+        ),
         multi_agent_version: None,
         multi_agent_mode: None,
         realtime_active: Some(turn_context.realtime_active),
-        effort: turn_context.reasoning_effort.clone(),
+        effort: StepModelContext::for_test(&turn_context).reasoning_effort(),
         summary: codex_protocol::config_types::ReasoningSummary::Auto,
     };
     let previous_turn_id = previous_context_item
@@ -1479,7 +1535,8 @@ async fn record_initial_history_resumed_aborted_turn_without_id_clears_active_tu
 async fn record_initial_history_resumed_unmatched_abort_preserves_active_turn_for_later_turn_context()
  {
     let (session, turn_context) = make_session_and_context().await;
-    let previous_context_item = turn_context.to_turn_context_item();
+    let turn_context = Arc::new(turn_context);
+    let previous_context_item = turn_context_item_for_test(&turn_context);
     let previous_turn_id = previous_context_item
         .turn_id
         .clone()
@@ -1502,11 +1559,15 @@ async fn record_initial_history_resumed_unmatched_abort_preserves_active_turn_fo
         model: current_model.to_string(),
         comp_hash: None,
         personality: turn_context.personality,
-        collaboration_mode: Some(turn_context.collaboration_mode.clone()),
+        collaboration_mode: Some(
+            StepModelContext::for_test(&turn_context)
+                .collaboration_mode
+                .clone(),
+        ),
         multi_agent_version: None,
         multi_agent_mode: None,
         realtime_active: Some(turn_context.realtime_active),
-        effort: turn_context.reasoning_effort.clone(),
+        effort: StepModelContext::for_test(&turn_context).reasoning_effort(),
         summary: codex_protocol::config_types::ReasoningSummary::Auto,
     };
 
@@ -1607,6 +1668,7 @@ async fn record_initial_history_resumed_unmatched_abort_preserves_active_turn_fo
 async fn record_initial_history_resumed_trailing_incomplete_turn_compaction_clears_reference_context_item()
  {
     let (session, turn_context) = make_session_and_context().await;
+    let turn_context = Arc::new(turn_context);
     let previous_model = "previous-rollout-model";
     let previous_context_item = TurnContextItem {
         turn_id: Some(turn_context.sub_id.clone()),
@@ -1623,11 +1685,15 @@ async fn record_initial_history_resumed_trailing_incomplete_turn_compaction_clea
         model: previous_model.to_string(),
         comp_hash: None,
         personality: turn_context.personality,
-        collaboration_mode: Some(turn_context.collaboration_mode.clone()),
+        collaboration_mode: Some(
+            StepModelContext::for_test(&turn_context)
+                .collaboration_mode
+                .clone(),
+        ),
         multi_agent_version: None,
         multi_agent_mode: None,
         realtime_active: Some(turn_context.realtime_active),
-        effort: turn_context.reasoning_effort.clone(),
+        effort: StepModelContext::for_test(&turn_context).reasoning_effort(),
         summary: codex_protocol::config_types::ReasoningSummary::Auto,
     };
     let previous_turn_id = previous_context_item
@@ -1717,7 +1783,8 @@ async fn record_initial_history_resumed_trailing_incomplete_turn_compaction_clea
 #[tokio::test]
 async fn record_initial_history_resumed_trailing_incomplete_turn_preserves_turn_context_item() {
     let (session, turn_context) = make_session_and_context().await;
-    let current_context_item = turn_context.to_turn_context_item();
+    let turn_context = Arc::new(turn_context);
+    let current_context_item = turn_context_item_for_test(&turn_context);
     let current_turn_id = current_context_item
         .turn_id
         .clone()
@@ -1757,7 +1824,10 @@ async fn record_initial_history_resumed_trailing_incomplete_turn_preserves_turn_
     assert_eq!(
         session.previous_turn_settings().await,
         Some(PreviousTurnSettings {
-            model: turn_context.model_info.slug.clone(),
+            model: StepModelContext::for_test(&turn_context)
+                .model_info
+                .slug
+                .clone(),
             comp_hash: None,
             realtime_active: Some(turn_context.realtime_active),
         })
@@ -1774,6 +1844,7 @@ async fn record_initial_history_resumed_trailing_incomplete_turn_preserves_turn_
 async fn record_initial_history_resumed_replaced_incomplete_compacted_turn_clears_reference_context_item()
  {
     let (session, turn_context) = make_session_and_context().await;
+    let turn_context = Arc::new(turn_context);
     let previous_model = "previous-rollout-model";
     let previous_context_item = TurnContextItem {
         turn_id: Some(turn_context.sub_id.clone()),
@@ -1790,11 +1861,15 @@ async fn record_initial_history_resumed_replaced_incomplete_compacted_turn_clear
         model: previous_model.to_string(),
         comp_hash: None,
         personality: turn_context.personality,
-        collaboration_mode: Some(turn_context.collaboration_mode.clone()),
+        collaboration_mode: Some(
+            StepModelContext::for_test(&turn_context)
+                .collaboration_mode
+                .clone(),
+        ),
         multi_agent_version: None,
         multi_agent_mode: None,
         realtime_active: Some(turn_context.realtime_active),
-        effort: turn_context.reasoning_effort.clone(),
+        effort: StepModelContext::for_test(&turn_context).reasoning_effort(),
         summary: codex_protocol::config_types::ReasoningSummary::Auto,
     };
     let previous_turn_id = previous_context_item

--- a/codex-rs/core/src/session/step_context.rs
+++ b/codex-rs/core/src/session/step_context.rs
@@ -1,15 +1,22 @@
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
 
 use crate::agents_md::LoadedAgentsMd;
 use crate::environment_selection::TurnEnvironmentSnapshot;
 use crate::session::McpRuntimeSnapshot;
+use crate::session::step_model_context::StepModelContext;
 use crate::session::turn_context::TurnContext;
 use codex_exec_server::ResolvedSelectedCapabilityRoot;
+use codex_models_manager::manager::SharedModelsManager;
+use codex_protocol::config_types::ReasoningSummary as ReasoningSummaryConfig;
+use codex_protocol::protocol::TurnContextItem;
 
 /// Request-scoped state that may change between model sampling requests.
 #[derive(Debug)]
 pub(crate) struct StepContext {
     pub(crate) turn: Arc<TurnContext>,
+    pub(crate) model: Arc<StepModelContext>,
     pub(crate) environments: TurnEnvironmentSnapshot,
     /// Capability roots bound to ready environments in this exact step.
     pub(crate) selected_capability_roots: Vec<ResolvedSelectedCapabilityRoot>,
@@ -22,6 +29,7 @@ pub(crate) struct StepContext {
 impl StepContext {
     pub(crate) fn new(
         turn: Arc<TurnContext>,
+        model: Arc<StepModelContext>,
         environments: TurnEnvironmentSnapshot,
         selected_capability_roots: Vec<ResolvedSelectedCapabilityRoot>,
         mcp: Arc<McpRuntimeSnapshot>,
@@ -29,10 +37,120 @@ impl StepContext {
     ) -> Self {
         Self {
             turn,
+            model,
             environments,
             selected_capability_roots,
             mcp,
             loaded_agents_md,
         }
+    }
+
+    pub(crate) fn to_turn_context_item(&self) -> TurnContextItem {
+        let workspace_roots = self.turn.config.effective_workspace_roots();
+        #[allow(deprecated)]
+        let cwd = self.turn.cwd.clone();
+        TurnContextItem {
+            turn_id: Some(self.turn.sub_id.clone()),
+            cwd,
+            workspace_roots: (!workspace_roots.is_empty()).then_some(workspace_roots),
+            current_date: self.turn.current_date.clone(),
+            timezone: self.turn.timezone.clone(),
+            approval_policy: self.turn.approval_policy.value(),
+            sandbox_policy: self.turn.sandbox_policy(),
+            permission_profile: Some(self.turn.permission_profile()),
+            network: self.turn.turn_context_network_item(),
+            file_system_sandbox_policy: self.turn.non_legacy_file_system_sandbox_policy(),
+            model: self.model.model_info.slug.clone(),
+            comp_hash: self.model.model_info.comp_hash.clone(),
+            personality: self.turn.personality,
+            collaboration_mode: Some(self.model.collaboration_mode.clone()),
+            multi_agent_version: Some(self.turn.multi_agent_version),
+            multi_agent_mode: super::multi_agents::effective_multi_agent_mode(self),
+            realtime_active: Some(self.turn.realtime_active),
+            effort: self.model.reasoning_effort(),
+            summary: ReasoningSummaryConfig::Auto,
+        }
+    }
+}
+
+/// Frozen turn-start inputs used to capture request-scoped [`StepContext`] values.
+#[derive(Clone, Debug)]
+pub(crate) struct StepContextSeed {
+    pub(crate) turn: Arc<TurnContext>,
+    pub(crate) model: Arc<StepModelContext>,
+}
+
+impl StepContextSeed {
+    pub(crate) fn new(turn: Arc<TurnContext>, model: Arc<StepModelContext>) -> Self {
+        Self { turn, model }
+    }
+
+    pub(crate) async fn with_model(
+        &self,
+        model: String,
+        models_manager: &SharedModelsManager,
+    ) -> Self {
+        let mut config = (*self.turn.config).clone();
+        config.model = Some(model.clone());
+        let model_info = models_manager
+            .get_model_info(model.as_str(), &config.to_models_manager_config())
+            .await;
+        let supported_reasoning_levels = model_info
+            .supported_reasoning_levels
+            .iter()
+            .map(|preset| preset.effort.clone())
+            .collect::<Vec<_>>();
+        let reasoning_effort = if let Some(current_reasoning_effort) = self.model.reasoning_effort()
+        {
+            if supported_reasoning_levels.contains(&current_reasoning_effort) {
+                Some(current_reasoning_effort)
+            } else {
+                supported_reasoning_levels
+                    .get(supported_reasoning_levels.len().saturating_sub(1) / 2)
+                    .cloned()
+                    .or_else(|| model_info.default_reasoning_level.clone())
+            }
+        } else {
+            supported_reasoning_levels
+                .get(supported_reasoning_levels.len().saturating_sub(1) / 2)
+                .cloned()
+                .or_else(|| model_info.default_reasoning_level.clone())
+        };
+        let collaboration_mode = self.model.collaboration_mode.with_updates(
+            Some(model.clone()),
+            Some(reasoning_effort),
+            /*developer_instructions*/ None,
+        );
+        let model_context = StepModelContext {
+            session_telemetry: self
+                .model
+                .session_telemetry
+                .clone()
+                .with_model(model.as_str(), model_info.slug.as_str()),
+            model_info,
+            collaboration_mode,
+            reasoning_summary: self.model.reasoning_summary,
+            service_tier: self.model.service_tier.clone(),
+            server_model_warning_emitted: AtomicBool::new(
+                self.model
+                    .server_model_warning_emitted
+                    .load(Ordering::Relaxed),
+            ),
+            model_verification_emitted: AtomicBool::new(
+                self.model
+                    .model_verification_emitted
+                    .load(Ordering::Relaxed),
+            ),
+        };
+        Self::new(Arc::clone(&self.turn), Arc::new(model_context))
+    }
+}
+
+impl From<&StepContext> for StepContextSeed {
+    fn from(step_context: &StepContext) -> Self {
+        Self::new(
+            Arc::clone(&step_context.turn),
+            Arc::clone(&step_context.model),
+        )
     }
 }

--- a/codex-rs/core/src/session/step_model_context.rs
+++ b/codex-rs/core/src/session/step_model_context.rs
@@ -1,0 +1,52 @@
+use std::sync::atomic::AtomicBool;
+
+use codex_otel::SessionTelemetry;
+use codex_protocol::config_types::CollaborationMode;
+use codex_protocol::config_types::ReasoningSummary as ReasoningSummaryConfig;
+use codex_protocol::openai_models::ModelInfo;
+use codex_protocol::openai_models::ReasoningEffort as ReasoningEffortConfig;
+
+/// Immutable model selection and model-derived state used by one sampling step.
+///
+/// Steps may share the same context when the selection is unchanged. Mutable warning flags are
+/// therefore scoped to the selected model context rather than recreated for every request.
+#[derive(Debug)]
+pub(crate) struct StepModelContext {
+    pub(crate) model_info: ModelInfo,
+    pub(crate) collaboration_mode: CollaborationMode,
+    pub(crate) reasoning_summary: ReasoningSummaryConfig,
+    pub(crate) service_tier: Option<String>,
+    pub(crate) session_telemetry: SessionTelemetry,
+    pub(crate) server_model_warning_emitted: AtomicBool,
+    pub(crate) model_verification_emitted: AtomicBool,
+}
+
+impl StepModelContext {
+    pub(crate) fn reasoning_effort(&self) -> Option<ReasoningEffortConfig> {
+        self.collaboration_mode.reasoning_effort()
+    }
+
+    pub(crate) fn effective_reasoning_effort(&self) -> Option<ReasoningEffortConfig> {
+        if self.model_info.supports_reasoning_summaries {
+            self.reasoning_effort()
+                .or_else(|| self.model_info.default_reasoning_level.clone())
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn effective_reasoning_effort_for_tracing(&self) -> String {
+        self.effective_reasoning_effort()
+            .map(|effort| effort.to_string())
+            .unwrap_or_else(|| "default".to_string())
+    }
+
+    pub(crate) fn model_context_window(&self) -> Option<i64> {
+        let effective_context_window_percent = self.model_info.effective_context_window_percent;
+        self.model_info
+            .resolved_context_window()
+            .map(|context_window| {
+                context_window.saturating_mul(effective_context_window_percent) / 100
+            })
+    }
+}

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -187,19 +187,97 @@ use serde_json::json;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::OnceLock;
+use std::sync::atomic::AtomicBool;
 use std::time::Duration as StdDuration;
+
+impl StepModelContext {
+    pub(crate) fn for_test(turn: &TurnContext) -> Self {
+        let model = get_model_offline_for_tests(turn.config.model.as_deref());
+        let model_info = construct_model_info_offline_for_tests(
+            model.as_str(),
+            &turn.config.to_models_manager_config(),
+        );
+        let collaboration_mode = CollaborationMode {
+            mode: ModeKind::Default,
+            settings: Settings {
+                model: model.clone(),
+                reasoning_effort: turn.config.model_reasoning_effort.clone(),
+                developer_instructions: None,
+            },
+        };
+        let reasoning_summary = turn
+            .config
+            .model_reasoning_summary
+            .unwrap_or(model_info.default_reasoning_summary);
+        let service_tier = get_service_tier(
+            turn.config.service_tier.clone(),
+            turn.config.features.enabled(Feature::FastMode),
+            &model_info,
+        );
+        let session_telemetry = SessionTelemetry::new(
+            ThreadId::new(),
+            model.as_str(),
+            model_info.slug.as_str(),
+            /*account_id*/ None,
+            /*account_email*/ None,
+            /*auth_mode*/ None,
+            turn.originator.clone(),
+            /*log_user_prompts*/ false,
+            "test".to_string(),
+            turn.session_source.clone(),
+        );
+        Self {
+            model_info,
+            collaboration_mode,
+            reasoning_summary,
+            service_tier,
+            session_telemetry,
+            server_model_warning_emitted: AtomicBool::new(false),
+            model_verification_emitted: AtomicBool::new(false),
+        }
+    }
+}
 
 impl StepContext {
     pub(crate) fn for_test(turn: Arc<TurnContext>) -> Arc<Self> {
+        let model = Arc::new(StepModelContext::for_test(&turn));
+        Self::for_test_with_model(turn, model)
+    }
+
+    pub(crate) fn for_test_with_model(
+        turn: Arc<TurnContext>,
+        model: Arc<StepModelContext>,
+    ) -> Arc<Self> {
         let environments = turn.environments.clone();
         Arc::new(Self::new(
             Arc::clone(&turn),
+            model,
             environments,
             Vec::new(),
             crate::session::McpRuntimeSnapshot::new_uninitialized_for_test(&turn.config),
             /*loaded_agents_md*/ None,
         ))
     }
+}
+
+pub(crate) fn step_context_seed_for_test(turn: Arc<TurnContext>) -> StepContextSeed {
+    let model = Arc::new(StepModelContext::for_test(&turn));
+    StepContextSeed::new(turn, model)
+}
+
+pub(crate) fn turn_context_item_for_test(turn: &Arc<TurnContext>) -> TurnContextItem {
+    StepContext::for_test(Arc::clone(turn)).to_turn_context_item()
+}
+
+fn step_model_context_with_window_for_test(
+    turn: &TurnContext,
+    context_window: i64,
+    effective_context_window_percent: i64,
+) -> Arc<StepModelContext> {
+    let mut model_context = StepModelContext::for_test(turn);
+    model_context.model_info.context_window = Some(context_window);
+    model_context.model_info.effective_context_window_percent = effective_context_window_percent;
+    Arc::new(model_context)
 }
 
 mod guardian_tests;
@@ -361,7 +439,7 @@ async fn regular_turn_emits_turn_started_with_trace_id_without_waiting_for_start
     )
     .await;
     sess.spawn_task(
-        Arc::clone(&tc),
+        step_context_seed_for_test(Arc::clone(&tc)),
         Vec::new(),
         crate::tasks::RegularTask::new(),
     )
@@ -383,6 +461,7 @@ async fn regular_turn_emits_turn_started_with_trace_id_without_waiting_for_start
 #[tokio::test]
 async fn request_mcp_server_elicitation_auto_accepts_when_auto_deny_is_enabled() {
     let (session, turn_context, rx) = make_session_and_context_with_rx().await;
+    let step_context = StepContext::for_test(Arc::clone(&turn_context));
     session
         .services
         .latest_mcp_runtime()
@@ -391,7 +470,7 @@ async fn request_mcp_server_elicitation_auto_accepts_when_auto_deny_is_enabled()
 
     let response = session
         .request_mcp_server_elicitation(
-            turn_context.as_ref(),
+            &step_context,
             "codex_apps".to_string(),
             RequestId::String("request-1".into()),
             ElicitationRequest::Form {
@@ -435,7 +514,7 @@ async fn interrupting_regular_turn_waiting_on_startup_prewarm_emits_turn_aborted
     )
     .await;
     sess.spawn_task(
-        Arc::clone(&tc),
+        step_context_seed_for_test(Arc::clone(&tc)),
         Vec::new(),
         crate::tasks::RegularTask::new(),
     )
@@ -1017,8 +1096,8 @@ async fn danger_full_access_turns_do_not_expose_managed_network_proxy() -> anyho
     })
     .await?;
 
-    let turn_context = session.new_default_turn().await;
-    assert!(turn_context.network.is_none());
+    let step_context_seed = session.new_default_turn().await;
+    assert!(step_context_seed.turn.network.is_none());
     Ok(())
 }
 
@@ -1053,7 +1132,7 @@ async fn danger_full_access_tool_attempts_do_not_enforce_managed_network() -> an
                 id: ctx.call_id.to_string(),
                 command: Vec::new(),
                 #[allow(deprecated)]
-                cwd: ctx.turn.cwd.clone(),
+                cwd: ctx.step_context.turn.cwd.clone(),
                 sandbox_permissions: crate::sandboxing::SandboxPermissions::UseDefault,
                 additional_permissions: None,
                 justification: None,
@@ -1123,26 +1202,21 @@ async fn danger_full_access_tool_attempts_do_not_enforce_managed_network() -> an
     })
     .await?;
 
-    let turn = session.new_default_turn().await;
-    assert!(turn.network.is_none());
+    let step_context_seed = session.new_default_turn().await;
+    assert!(step_context_seed.turn.network.is_none());
+    let step_context = session.capture_step_context(&step_context_seed).await;
 
     let mut orchestrator = crate::tools::orchestrator::ToolOrchestrator::new();
     let mut tool = ProbeToolRuntime::default();
     let tool_ctx = crate::tools::sandboxing::ToolCtx {
         session: Arc::clone(&session),
-        turn: Arc::clone(&turn),
+        step_context,
         call_id: "probe-call".to_string(),
         tool_name: codex_tools::ToolName::plain("probe"),
     };
 
     orchestrator
-        .run(
-            &mut tool,
-            &(),
-            &tool_ctx,
-            turn.as_ref(),
-            AskForApproval::Never,
-        )
+        .run(&mut tool, &(), &tool_ctx)
         .await
         .expect("probe runtime should succeed");
 
@@ -1172,8 +1246,8 @@ async fn workspace_write_turns_continue_to_expose_managed_network_proxy() -> any
     })
     .await?;
 
-    let turn_context = session.new_default_turn().await;
-    assert!(turn_context.network.is_some());
+    let step_context_seed = session.new_default_turn().await;
+    assert!(step_context_seed.turn.network.is_some());
     Ok(())
 }
 
@@ -1198,8 +1272,8 @@ async fn user_shell_commands_do_not_inherit_managed_network_proxy() -> anyhow::R
     })
     .await?;
 
-    let turn_context = session.new_default_turn().await;
-    assert!(turn_context.network.is_some());
+    let step_context_seed = session.new_default_turn().await;
+    assert!(step_context_seed.turn.network.is_some());
 
     #[cfg(windows)]
     let command = r#"$val = $env:HTTP_PROXY; if ([string]::IsNullOrEmpty($val)) { $val = 'not-set' } ; [System.Console]::Write($val)"#.to_string();
@@ -1208,7 +1282,7 @@ async fn user_shell_commands_do_not_inherit_managed_network_proxy() -> anyhow::R
 
     execute_user_shell_command(
         Arc::clone(&session),
-        turn_context,
+        step_context_seed,
         command,
         CancellationToken::new(),
         UserShellCommandMode::StandaloneTurn,
@@ -1664,7 +1738,7 @@ async fn reconstruct_history_matches_live_compactions() {
 
     let reconstruction_turn = session.new_default_turn().await;
     let reconstructed = session
-        .reconstruct_history_from_rollout(reconstruction_turn.as_ref(), &rollout_items)
+        .reconstruct_history_from_rollout(&reconstruction_turn, &rollout_items)
         .await;
 
     assert_eq!(expected, reconstructed.history);
@@ -1715,8 +1789,9 @@ async fn reconstruct_history_uses_replacement_history_verbatim() {
         window_id: Some(window_id.to_string()),
     })];
 
+    let step_context_seed = step_context_seed_for_test(Arc::new(turn_context));
     let reconstructed = session
-        .reconstruct_history_from_rollout(&turn_context, &rollout_items)
+        .reconstruct_history_from_rollout(&step_context_seed, &rollout_items)
         .await;
 
     assert_eq!(reconstructed.history, replacement_history);
@@ -1746,12 +1821,14 @@ async fn record_initial_history_reconstructs_resumed_transcript() {
 #[tokio::test]
 async fn record_conversation_items_stamps_missing_turn_id_and_preserves_existing_turn_id() {
     let (session, turn_context) = make_session_and_context().await;
+    let turn_context = Arc::new(turn_context);
+    let step_context = StepContext::for_test(Arc::clone(&turn_context));
     let fresh_item = user_message("fresh");
     let mut existing_item = assistant_message("existing");
     existing_item.set_turn_id_if_missing("older-turn");
 
     session
-        .record_conversation_items(&turn_context, &[fresh_item.clone(), existing_item.clone()])
+        .record_conversation_items(&step_context, &[fresh_item.clone(), existing_item.clone()])
         .await;
 
     let mut expected_fresh_item = fresh_item;
@@ -1766,6 +1843,8 @@ async fn record_conversation_items_stamps_missing_turn_id_and_preserves_existing
 #[tokio::test]
 async fn record_inter_agent_communication_sets_turn_id_in_rollout_and_resume() {
     let (mut session, turn_context) = make_session_and_context().await;
+    let turn_context = Arc::new(turn_context);
+    let step_context_seed = step_context_seed_for_test(Arc::clone(&turn_context));
     let rollout_path = attach_thread_persistence(&mut session).await;
     let communication = InterAgentCommunication::new(
         AgentPath::root().join("worker").expect("worker path"),
@@ -1778,7 +1857,7 @@ async fn record_inter_agent_communication_sets_turn_id_in_rollout_and_resume() {
     expected_item.set_turn_id_if_missing(&turn_context.sub_id);
 
     session
-        .record_inter_agent_communication(&turn_context, communication)
+        .record_inter_agent_communication(&step_context_seed, communication)
         .await;
 
     assert_eq!(
@@ -1846,9 +1925,10 @@ async fn record_inter_agent_communication_preserves_item_id_in_rollout_and_resum
         "child done".to_string(),
         /*trigger_turn*/ false,
     );
+    let step_context_seed = step_context_seed_for_test(Arc::clone(&turn_context));
 
     session
-        .record_inter_agent_communication(&turn_context, communication)
+        .record_inter_agent_communication(&step_context_seed, communication)
         .await;
 
     let live_history = session.clone_history().await;
@@ -1924,9 +2004,10 @@ async fn prepares_image_failures_before_history_insertion() {
         },
         internal_chat_message_metadata_passthrough: None,
     };
+    let step_context = StepContext::for_test(Arc::clone(&turn_context));
 
     session
-        .record_conversation_items(turn_context.as_ref(), std::slice::from_ref(&item))
+        .record_conversation_items(&step_context, std::slice::from_ref(&item))
         .await;
 
     let history = session.state.lock().await.clone_history();
@@ -2225,6 +2306,8 @@ async fn record_initial_history_seeds_token_info_from_rollout() {
 #[tokio::test]
 async fn recompute_token_usage_uses_session_base_instructions() {
     let (session, turn_context) = make_session_and_context().await;
+    let turn_context = Arc::new(turn_context);
+    let step_context = StepContext::for_test(Arc::clone(&turn_context));
 
     let override_instructions = "SESSION_OVERRIDE_INSTRUCTIONS_ONLY".repeat(120);
     {
@@ -2234,7 +2317,7 @@ async fn recompute_token_usage_uses_session_base_instructions() {
 
     let item = user_message("hello");
     session
-        .record_conversation_items(&turn_context, std::slice::from_ref(&item))
+        .record_conversation_items(&step_context, std::slice::from_ref(&item))
         .await;
 
     let history = session.clone_history().await;
@@ -2245,11 +2328,13 @@ async fn recompute_token_usage_uses_session_base_instructions() {
         .estimate_token_count_with_base_instructions(&session_base_instructions)
         .expect("estimate with session base instructions");
     let model_estimated_tokens = history
-        .estimate_token_count(&turn_context)
+        .estimate_token_count(&step_context)
         .expect("estimate with model instructions");
     assert_ne!(expected_tokens, model_estimated_tokens);
 
-    session.recompute_token_usage(&turn_context).await;
+    session
+        .recompute_token_usage(step_context.turn.as_ref(), step_context.model.as_ref())
+        .await;
 
     let actual_tokens = session
         .state
@@ -2264,7 +2349,9 @@ async fn recompute_token_usage_uses_session_base_instructions() {
 
 #[tokio::test]
 async fn recompute_token_usage_updates_model_context_window() {
-    let (session, mut turn_context) = make_session_and_context().await;
+    let (session, turn_context) = make_session_and_context().await;
+    let turn_context = Arc::new(turn_context);
+    let mut model_context = StepModelContext::for_test(&turn_context);
 
     {
         let mut state = session.state.lock().await;
@@ -2275,10 +2362,13 @@ async fn recompute_token_usage_updates_model_context_window() {
         }));
     }
 
-    turn_context.model_info.context_window = Some(128_000);
-    turn_context.model_info.effective_context_window_percent = 100;
+    model_context.model_info.context_window = Some(128_000);
+    model_context.model_info.effective_context_window_percent = 100;
+    let step_context = StepContext::for_test_with_model(turn_context, Arc::new(model_context));
 
-    session.recompute_token_usage(&turn_context).await;
+    session
+        .recompute_token_usage(step_context.turn.as_ref(), step_context.model.as_ref())
+        .await;
 
     let actual = session.state.lock().await.token_info().expect("token info");
     assert_eq!(actual.model_context_window, Some(128_000));
@@ -2357,13 +2447,15 @@ async fn record_token_usage_info_notifies_extension_contributors() {
         reasoning_output_tokens: 5,
         total_tokens: 20,
     };
+    let turn_context = Arc::new(turn_context);
+    let step_context = StepContext::for_test(Arc::clone(&turn_context));
 
     session
-        .record_token_usage_info(&turn_context, Some(&first_usage))
+        .record_token_usage_info(&step_context, Some(&first_usage))
         .await
         .expect("first usage should be recorded");
     session
-        .record_token_usage_info(&turn_context, Some(&second_usage))
+        .record_token_usage_info(&step_context, Some(&second_usage))
         .await
         .expect("second usage should be recorded");
 
@@ -2377,7 +2469,7 @@ async fn record_token_usage_info_notifies_extension_contributors() {
             token_usage: TokenUsageInfo {
                 total_token_usage: first_usage.clone(),
                 last_token_usage: first_usage,
-                model_context_window: turn_context.model_context_window(),
+                model_context_window: step_context.model.model_context_window(),
             },
             saw_session_store: true,
             saw_thread_store: true,
@@ -2389,7 +2481,7 @@ async fn record_token_usage_info_notifies_extension_contributors() {
             token_usage: TokenUsageInfo {
                 total_token_usage: expected_total_usage,
                 last_token_usage: second_usage,
-                model_context_window: turn_context.model_context_window(),
+                model_context_window: step_context.model.model_context_window(),
             },
             saw_session_store: true,
             saw_thread_store: true,
@@ -2478,12 +2570,14 @@ async fn turn_start_lifecycle_exposes_turn_metadata_and_token_baseline() {
     };
     set_total_token_usage(&session, token_usage_at_turn_start.clone()).await;
 
+    let turn_context = Arc::new(turn_context);
+    let step_context_seed = step_context_seed_for_test(Arc::clone(&turn_context));
     let expected = RecordedTurnStart {
         session_level_id: session.session_id().to_string(),
         thread_level_id: session.thread_id.to_string(),
         turn_level_id: turn_context.sub_id.clone(),
         turn_id: turn_context.sub_id.clone(),
-        collaboration_mode: turn_context.collaboration_mode.clone(),
+        collaboration_mode: step_context_seed.model.collaboration_mode.clone(),
         token_usage_at_turn_start,
         saw_session_store: true,
         saw_thread_store: true,
@@ -2491,7 +2585,7 @@ async fn turn_start_lifecycle_exposes_turn_metadata_and_token_baseline() {
 
     let sess = Arc::new(session);
     sess.spawn_task(
-        Arc::new(turn_context),
+        step_context_seed,
         Vec::new(),
         NeverEndingTask {
             kind: TaskKind::Regular,
@@ -2747,11 +2841,11 @@ async fn start_new_context_window_assigns_and_persists_item_ids() {
     .await;
     let rollout_path =
         attach_thread_persistence(Arc::get_mut(&mut session).expect("unique session")).await;
-    let world_state =
-        Arc::new(build_world_state_from_turn_context(session.as_ref(), &turn_context).await);
+    let step_context = StepContext::for_test(Arc::clone(&turn_context));
+    let world_state = Arc::new(session.build_world_state_for_step(&step_context).await);
 
     session
-        .start_new_context_window(turn_context.as_ref(), world_state)
+        .start_new_context_window(&step_context, world_state)
         .await;
 
     let live_history = session.clone_history().await;
@@ -3033,6 +3127,7 @@ async fn fork_startup_context_then_first_turn_diff_snapshot() -> anyhow::Result<
 #[tokio::test]
 async fn record_initial_history_forked_hydrates_previous_turn_settings() {
     let (session, turn_context) = make_session_and_context().await;
+    let model_context = StepModelContext::for_test(&turn_context);
     let previous_model = "forked-rollout-model";
     let previous_context_item = TurnContextItem {
         turn_id: Some(turn_context.sub_id.clone()),
@@ -3049,11 +3144,11 @@ async fn record_initial_history_forked_hydrates_previous_turn_settings() {
         model: previous_model.to_string(),
         comp_hash: None,
         personality: turn_context.personality,
-        collaboration_mode: Some(turn_context.collaboration_mode.clone()),
+        collaboration_mode: Some(model_context.collaboration_mode.clone()),
         multi_agent_version: None,
         multi_agent_mode: None,
         realtime_active: Some(turn_context.realtime_active),
-        effort: turn_context.reasoning_effort.clone(),
+        effort: model_context.reasoning_effort(),
         summary: codex_protocol::config_types::ReasoningSummary::Auto,
     };
     let turn_id = previous_context_item
@@ -3135,7 +3230,7 @@ async fn thread_rollback_drops_last_turn_from_history() {
     full_history.extend(initial_context.clone());
     full_history.extend(turn_1.clone());
     full_history.extend(turn_2);
-    sess.replace_history(full_history.clone(), Some(tc.to_turn_context_item()))
+    sess.replace_history(full_history.clone(), Some(turn_context_item_for_test(&tc)))
         .await;
     let rollout_items: Vec<RolloutItem> = full_history
         .into_iter()
@@ -3150,7 +3245,7 @@ async fn thread_rollback_drops_last_turn_from_history() {
     .await;
     {
         let mut state = sess.state.lock().await;
-        state.set_reference_context_item(Some(tc.to_turn_context_item()));
+        state.set_reference_context_item(Some(turn_context_item_for_test(&tc)));
     }
 
     handlers::thread_rollback(&sess, "sub-1".to_string(), /*num_turns*/ 1).await;
@@ -3195,7 +3290,7 @@ async fn thread_rollback_clears_history_when_num_turns_exceeds_existing_turns() 
     let mut full_history = Vec::new();
     full_history.extend(initial_context.clone());
     full_history.extend(turn_1);
-    sess.replace_history(full_history.clone(), Some(tc.to_turn_context_item()))
+    sess.replace_history(full_history.clone(), Some(turn_context_item_for_test(&tc)))
         .await;
     let rollout_items: Vec<RolloutItem> = full_history
         .into_iter()
@@ -3217,7 +3312,8 @@ async fn thread_rollback_fails_without_persisted_thread_history() {
     let (sess, tc, rx) = make_session_and_context_with_rx().await;
 
     let initial_context = build_initial_context(&sess, &tc).await;
-    sess.record_conversation_items(tc.as_ref(), &initial_context)
+    let step_context = StepContext::for_test(Arc::clone(&tc));
+    sess.record_conversation_items(&step_context, &initial_context)
         .await;
 
     handlers::thread_rollback(&sess, "sub-1".to_string(), /*num_turns*/ 1).await;
@@ -3242,7 +3338,7 @@ async fn thread_rollback_recomputes_previous_turn_settings_and_reference_context
     )
     .await;
 
-    let first_context_item = tc.to_turn_context_item();
+    let first_context_item = turn_context_item_for_test(&tc);
     let first_turn_id = first_context_item
         .turn_id
         .clone()
@@ -3343,7 +3439,7 @@ async fn thread_rollback_recomputes_previous_turn_settings_and_reference_context
     assert_eq!(
         sess.previous_turn_settings().await,
         Some(PreviousTurnSettings {
-            model: tc.model_info.slug.clone(),
+            model: first_context_item.model.clone(),
             comp_hash: None,
             realtime_active: Some(tc.realtime_active),
         })
@@ -3364,7 +3460,7 @@ async fn thread_rollback_restores_cleared_reference_context_item_after_compactio
     )
     .await;
 
-    let first_context_item = tc.to_turn_context_item();
+    let first_context_item = turn_context_item_for_test(&tc);
     let first_turn_id = first_context_item
         .turn_id
         .clone()
@@ -3506,7 +3602,7 @@ async fn thread_rollback_persists_marker_and_replays_cumulatively() {
         Arc::get_mut(&mut sess).expect("session should not have additional references"),
     )
     .await;
-    let turn_context_item = tc.to_turn_context_item();
+    let turn_context_item = turn_context_item_for_test(&tc);
 
     sess.persist_rollout_items(&[
         RolloutItem::EventMsg(EventMsg::TurnStarted(
@@ -3627,7 +3723,8 @@ async fn thread_rollback_fails_when_turn_in_progress() {
     let (sess, tc, rx) = make_session_and_context_with_rx().await;
 
     let initial_context = build_initial_context(&sess, &tc).await;
-    sess.record_conversation_items(tc.as_ref(), &initial_context)
+    let step_context = StepContext::for_test(Arc::clone(&tc));
+    sess.record_conversation_items(&step_context, &initial_context)
         .await;
 
     *sess.active_turn.lock().await = Some(crate::state::ActiveTurn::default());
@@ -3648,7 +3745,8 @@ async fn thread_rollback_fails_when_num_turns_is_zero() {
     let (sess, tc, rx) = make_session_and_context_with_rx().await;
 
     let initial_context = build_initial_context(&sess, &tc).await;
-    sess.record_conversation_items(tc.as_ref(), &initial_context)
+    let step_context = StepContext::for_test(Arc::clone(&tc));
+    sess.record_conversation_items(&step_context, &initial_context)
         .await;
 
     handlers::thread_rollback(&sess, "sub-1".to_string(), /*num_turns*/ 0).await;
@@ -3917,8 +4015,9 @@ async fn includes_timed_out_message() {
         timed_out: true,
     };
     let (_, turn_context) = make_session_and_context().await;
+    let model_context = StepModelContext::for_test(&turn_context);
 
-    let out = format_exec_output_str(&exec, turn_context.model_info.truncation_policy.into());
+    let out = format_exec_output_str(&exec, model_context.model_info.truncation_policy.into());
 
     assert_eq!(
         out,
@@ -3927,10 +4026,15 @@ async fn includes_timed_out_message() {
 }
 
 #[tokio::test]
-async fn turn_context_with_model_updates_model_fields() {
-    let (session, mut turn_context) = make_session_and_context().await;
-    turn_context.reasoning_effort = Some(ReasoningEffortConfig::Minimal);
-    let updated = turn_context
+async fn step_context_seed_with_model_updates_model_fields() {
+    let (session, turn_context) = make_session_and_context().await;
+    let turn_context = Arc::new(turn_context);
+    let mut model_context = StepModelContext::for_test(&turn_context);
+    model_context.collaboration_mode.settings.reasoning_effort =
+        Some(ReasoningEffortConfig::Minimal);
+    let step_context_seed =
+        StepContextSeed::new(Arc::clone(&turn_context), Arc::new(model_context));
+    let updated = step_context_seed
         .with_model("gpt-5.4".to_string(), &session.services.models_manager)
         .await;
     let expected_model_info = session
@@ -3938,23 +4042,15 @@ async fn turn_context_with_model_updates_model_fields() {
         .models_manager
         .get_model_info(
             "gpt-5.4",
-            &updated.config.as_ref().to_models_manager_config(),
+            &updated.turn.config.as_ref().to_models_manager_config(),
         )
         .await;
 
-    assert_eq!(updated.config.model.as_deref(), Some("gpt-5.4"));
-    assert_eq!(updated.collaboration_mode.model(), "gpt-5.4");
-    assert_eq!(updated.model_info, expected_model_info);
+    assert!(Arc::ptr_eq(&updated.turn, &turn_context));
+    assert_eq!(updated.model.collaboration_mode.model(), "gpt-5.4");
+    assert_eq!(updated.model.model_info, expected_model_info);
     assert_eq!(
-        updated.reasoning_effort,
-        Some(ReasoningEffortConfig::Medium)
-    );
-    assert_eq!(
-        updated.collaboration_mode.reasoning_effort(),
-        Some(ReasoningEffortConfig::Medium)
-    );
-    assert_eq!(
-        updated.config.model_reasoning_effort,
+        updated.model.reasoning_effort(),
         Some(ReasoningEffortConfig::Medium)
     );
 }
@@ -4886,6 +4982,7 @@ enabled = false
         .new_default_turn_with_sub_id("role-skill-turn".to_string())
         .await;
     let child_skill = child_turn
+        .turn
         .turn_skills
         .snapshot
         .outcome()
@@ -4895,6 +4992,7 @@ enabled = false
         .expect("demo skill should be discovered");
     assert_eq!(
         child_turn
+            .turn
             .turn_skills
             .snapshot
             .outcome()
@@ -5063,10 +5161,10 @@ async fn session_update_settings_does_not_rewrite_sticky_environment_cwds() {
     #[allow(deprecated)]
     let turn_cwd = turn_context.cwd.clone();
     #[allow(deprecated)]
-    let next_turn_cwd = next_turn.cwd.clone();
+    let next_turn_cwd = next_turn.turn.cwd.clone();
     assert_eq!(config.cwd, turn_cwd);
     assert_eq!(next_turn_cwd, turn_cwd);
-    assert_eq!(next_turn.config.cwd, turn_cwd);
+    assert_eq!(next_turn.turn.config.cwd, turn_cwd);
 }
 
 #[tokio::test]
@@ -5155,7 +5253,8 @@ async fn absolute_cwd_update_with_turn_environment_is_allowed() {
             },
         )
         .await
-        .expect("absolute cwd with explicit environments should succeed");
+        .expect("absolute cwd with explicit environments should succeed")
+        .turn;
 
     #[allow(deprecated)]
     let turn_cwd = turn_context.cwd.clone();
@@ -5281,9 +5380,19 @@ async fn build_initial_context(
     session: &Session,
     turn_context: &Arc<TurnContext>,
 ) -> Vec<ResponseItem> {
-    let world_state = build_world_state_from_turn_context(session, turn_context).await;
+    let model_context = Arc::new(StepModelContext::for_test(turn_context));
+    build_initial_context_with_model(session, turn_context, model_context).await
+}
+
+async fn build_initial_context_with_model(
+    session: &Session,
+    turn_context: &Arc<TurnContext>,
+    model_context: Arc<StepModelContext>,
+) -> Vec<ResponseItem> {
+    let step_context = StepContext::for_test_with_model(Arc::clone(turn_context), model_context);
+    let world_state = session.build_world_state_for_step(&step_context).await;
     session
-        .build_initial_context_with_world_state(turn_context.as_ref(), &world_state)
+        .build_initial_context_with_world_state(&step_context, &world_state)
         .await
 }
 
@@ -5495,7 +5604,7 @@ pub(crate) async fn make_session_and_context() -> (Session, TurnContext) {
         .skills_service
         .snapshot_for_config(&skills_input, Some(Arc::clone(&skill_fs)))
         .await;
-    let turn_context = Session::make_turn_context(
+    let (turn_context, _model_context) = Session::make_turn_context(
         thread_id,
         SessionId::from(thread_id),
         Some(Arc::clone(&auth_manager)),
@@ -6056,6 +6165,7 @@ async fn request_permissions_emits_event_when_granular_policy_allows_requests() 
 
     let session = Arc::new(session);
     let turn_context = Arc::new(turn_context);
+    let step_context_seed = step_context_seed_for_test(Arc::clone(&turn_context));
     let call_id = "call-1".to_string();
     let expected_response = codex_protocol::request_permissions::RequestPermissionsResponse {
         permissions: RequestPermissionProfile {
@@ -6071,6 +6181,7 @@ async fn request_permissions_emits_event_when_granular_policy_allows_requests() 
     let handle = tokio::spawn({
         let session = Arc::clone(&session);
         let turn_context = Arc::clone(&turn_context);
+        let step_context_seed = step_context_seed.clone();
         let call_id = call_id.clone();
         async move {
             let environment = turn_context
@@ -6080,7 +6191,7 @@ async fn request_permissions_emits_event_when_granular_policy_allows_requests() 
                 .selection();
             session
                 .request_permissions_for_environment(
-                    &turn_context,
+                    &step_context_seed,
                     call_id,
                     codex_protocol::request_permissions::RequestPermissionsArgs {
                         environment_id: None,
@@ -6162,7 +6273,6 @@ async fn request_permissions_tool_resolves_relative_paths_against_selected_envir
     let step_context = StepContext::for_test(Arc::clone(&turn_context));
     let handle = tokio::spawn({
         let session = Arc::clone(&session);
-        let turn_context = Arc::clone(&turn_context);
         let step_context = Arc::clone(&step_context);
         let tracker = Arc::clone(&tracker);
         let call_id = call_id.clone();
@@ -6171,7 +6281,6 @@ async fn request_permissions_tool_resolves_relative_paths_against_selected_envir
                 .handle(ToolInvocation {
                     session,
                     step_context,
-                    turn: turn_context,
                     cancellation_token: CancellationToken::new(),
                     tracker,
                     call_id,
@@ -6248,7 +6357,6 @@ async fn request_permissions_tool_rejects_unknown_environment_id() {
         .handle(ToolInvocation {
             session: Arc::new(session),
             step_context,
-            turn: turn_context,
             cancellation_token: CancellationToken::new(),
             tracker: Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new())),
             call_id: "call-1".to_string(),
@@ -6292,6 +6400,7 @@ async fn request_permissions_response_materializes_session_cwd_grants_before_rec
 
     let session = Arc::new(session);
     let turn_context = Arc::new(turn_context);
+    let step_context_seed = step_context_seed_for_test(Arc::clone(&turn_context));
     let call_id = "call-1".to_string();
     let requested_permissions = RequestPermissionProfile {
         file_system: Some(FileSystemPermissions {
@@ -6309,6 +6418,7 @@ async fn request_permissions_response_materializes_session_cwd_grants_before_rec
     let handle = tokio::spawn({
         let session = Arc::clone(&session);
         let turn_context = Arc::clone(&turn_context);
+        let step_context_seed = step_context_seed.clone();
         let call_id = call_id.clone();
         let requested_permissions = requested_permissions.clone();
         async move {
@@ -6319,7 +6429,7 @@ async fn request_permissions_response_materializes_session_cwd_grants_before_rec
                 .selection();
             session
                 .request_permissions_for_environment(
-                    &turn_context,
+                    &step_context_seed,
                     call_id,
                     codex_protocol::request_permissions::RequestPermissionsArgs {
                         environment_id: None,
@@ -6402,6 +6512,7 @@ async fn request_permissions_is_auto_denied_when_granular_policy_blocks_tool_req
 
     let session = Arc::new(session);
     let turn_context = Arc::new(turn_context);
+    let step_context_seed = step_context_seed_for_test(Arc::clone(&turn_context));
     let call_id = "call-1".to_string();
     let environment = turn_context
         .environments
@@ -6410,7 +6521,7 @@ async fn request_permissions_is_auto_denied_when_granular_policy_blocks_tool_req
         .selection();
     let response = session
         .request_permissions_for_environment(
-            &turn_context,
+            &step_context_seed,
             call_id,
             codex_protocol::request_permissions::RequestPermissionsArgs {
                 environment_id: None,
@@ -6515,9 +6626,9 @@ async fn new_default_turn_captures_current_span_trace_id() {
             .span_context()
             .trace_id()
             .to_string();
-        let turn_context = session.new_default_turn().await;
-        assert_eq!(turn_context.trace_id, Some(expected_trace_id));
-        turn_context.trace_id.clone()
+        let step_context_seed = session.new_default_turn().await;
+        assert_eq!(step_context_seed.turn.trace_id, Some(expected_trace_id));
+        step_context_seed.turn.trace_id.clone()
     }
     .instrument(request_span)
     .await;
@@ -6635,7 +6746,10 @@ async fn user_turn_updates_approvals_reviewer() {
                 collaboration_mode: Some(codex_protocol::config_types::CollaborationMode {
                     mode: codex_protocol::config_types::ModeKind::Default,
                     settings: codex_protocol::config_types::Settings {
-                        model: turn_context.model_info.slug.clone(),
+                        model: StepModelContext::for_test(&turn_context)
+                            .model_info
+                            .slug
+                            .clone(),
                         reasoning_effort: config.model_reasoning_effort.clone(),
                         developer_instructions: None,
                     },
@@ -6673,7 +6787,8 @@ async fn turn_environments_set_primary_environment() {
             },
         )
         .await
-        .expect("turn should start");
+        .expect("turn should start")
+        .turn;
 
     let turn_environments = &turn_context.environments;
     assert_eq!(turn_environments.turn_environments.len(), 1);
@@ -6709,6 +6824,7 @@ async fn turn_environments_set_primary_environment() {
     assert!(Arc::ptr_eq(
         &stored_environment,
         &default_turn
+            .turn
             .environments
             .primary()
             .expect("default turn primary environment")
@@ -6731,7 +6847,7 @@ async fn default_turn_does_not_overlay_legacy_fallback_cwd_onto_stored_thread_en
         state.session_configuration.environments.environments = vec![local(selected_cwd.clone())];
     }
 
-    let turn_context = session.new_default_turn().await;
+    let turn_context = session.new_default_turn().await.turn;
 
     let turn_environments = &turn_context.environments;
     assert_eq!(turn_environments.turn_environments.len(), 1);
@@ -6760,7 +6876,7 @@ async fn default_turn_honors_empty_stored_thread_environments() {
         state.session_configuration.environments.environments = Vec::new();
     }
 
-    let turn_context = session.new_default_turn().await;
+    let turn_context = session.new_default_turn().await.turn;
 
     assert!(turn_context.environments.primary().is_none());
     assert!(turn_context.environments.turn_environments.is_empty());
@@ -6829,7 +6945,8 @@ async fn empty_turn_environments_clear_primary_environment() {
             },
         )
         .await
-        .expect("turn should start");
+        .expect("turn should start")
+        .turn;
 
     assert!(turn_context.environments.primary().is_none());
     assert!(turn_context.environments.turn_environments.is_empty());
@@ -6857,7 +6974,7 @@ async fn spawn_task_turn_span_inherits_dispatch_trace_context() {
         async fn run(
             self: Arc<Self>,
             _session: Arc<SessionTaskContext>,
-            _ctx: Arc<TurnContext>,
+            _ctx: StepContextSeed,
             _input: Vec<TurnInput>,
             _cancellation_token: CancellationToken,
         ) -> SessionTaskResult {
@@ -6900,7 +7017,7 @@ async fn spawn_task_turn_span_inherits_dispatch_trace_context() {
 
     async {
         sess.spawn_task(
-            Arc::clone(&tc),
+            step_context_seed_for_test(Arc::clone(&tc)),
             vec![TurnInput::UserInput {
                 content: vec![UserInput::Text {
                     text: "hello".to_string(),
@@ -7151,7 +7268,7 @@ async fn submission_loop_channel_close_aborts_active_turn_before_thread_stop_lif
     let session = Arc::new(session);
     session
         .spawn_task(
-            Arc::new(turn_context),
+            step_context_seed_for_test(Arc::new(turn_context)),
             Vec::new(),
             NeverEndingTask {
                 kind: TaskKind::Regular,
@@ -7626,7 +7743,7 @@ where
         .skills_service
         .snapshot_for_config(&skills_input, Some(Arc::clone(&skill_fs)))
         .await;
-    let turn_context = Arc::new(Session::make_turn_context(
+    let (turn_context, _model_context) = Session::make_turn_context(
         thread_id,
         SessionId::from(thread_id),
         Some(Arc::clone(&auth_manager)),
@@ -7645,7 +7762,8 @@ where
         session_configuration.cwd().clone(),
         "turn_id".to_string(),
         skills_snapshot,
-    ));
+    );
+    let turn_context = Arc::new(turn_context);
     let session = Arc::new(Session {
         thread_id,
         installation_id: "11111111-1111-4111-8111-111111111111".to_string(),
@@ -7697,10 +7815,9 @@ async fn refresh_mcp_servers_keeps_the_previous_runtime_alive() {
     let (session, turn_context) = make_session_and_context().await;
     let session = Arc::new(session);
     let turn_context = Arc::new(turn_context);
+    let step_context_seed = step_context_seed_for_test(Arc::clone(&turn_context));
     let old_runtime = session.services.latest_mcp_runtime();
-    let step_context = session
-        .capture_step_context(Arc::clone(&turn_context))
-        .await;
+    let step_context = session.capture_step_context(&step_context_seed).await;
     assert!(Arc::ptr_eq(&step_context.mcp, &old_runtime));
     let old_token = session.mcp_startup_cancellation_token().await;
     assert!(!old_token.is_cancelled());
@@ -7849,7 +7966,8 @@ async fn built_tools_uses_the_step_mcp_runtime() -> anyhow::Result<()> {
     let (session, turn_context) = make_session_and_context().await;
     let session = Arc::new(session);
     let turn_context = Arc::new(turn_context);
-    let step_context = session.capture_step_context(turn_context).await;
+    let step_context_seed = step_context_seed_for_test(turn_context);
+    let step_context = session.capture_step_context(&step_context_seed).await;
 
     let mut refresh_config = step_context.turn.config.as_ref().clone();
     refresh_config.mcp_servers.set(HashMap::from([(
@@ -7915,8 +8033,9 @@ async fn spawn_task_does_not_update_previous_turn_settings_for_non_run_turn_task
         client_id: None,
     }];
 
+    let step_context_seed = step_context_seed_for_test(Arc::clone(&tc));
     sess.spawn_task(
-        Arc::clone(&tc),
+        step_context_seed,
         input,
         NeverEndingTask {
             kind: TaskKind::Regular,
@@ -7929,16 +8048,16 @@ async fn spawn_task_does_not_update_previous_turn_settings_for_non_run_turn_task
     assert_eq!(sess.previous_turn_settings().await, None);
 }
 
+async fn fresh_turn_context(session: &Session) -> TurnContext {
+    Arc::try_unwrap(session.new_default_turn().await.turn)
+        .expect("fresh turn context should have one owner")
+}
+
 #[tokio::test]
 async fn record_context_updates_emits_environment_item_for_network_changes() {
     let (session, previous_context) = make_session_and_context().await;
     let previous_context = Arc::new(previous_context);
-    let mut current_context = previous_context
-        .with_model(
-            previous_context.model_info.slug.clone(),
-            &session.services.models_manager,
-        )
-        .await;
+    let mut current_context = fresh_turn_context(&session).await;
 
     let mut config = (*current_context.config).clone();
     let mut requirements = config.config_layer_stack.requirements().clone();
@@ -7993,12 +8112,7 @@ async fn record_context_updates_emits_environment_item_for_network_changes() {
 async fn record_context_updates_emits_environment_item_for_cwd_changes() {
     let (session, previous_context) = make_session_and_context().await;
     let previous_context = Arc::new(previous_context);
-    let mut current_context = previous_context
-        .with_model(
-            previous_context.model_info.slug.clone(),
-            &session.services.models_manager,
-        )
-        .await;
+    let mut current_context = fresh_turn_context(&session).await;
     let cwd = test_path_buf("/new-repo").abs();
     let environment = current_context.environments.turn_environments[0].clone();
     current_context.environments.turn_environments[0] = TurnEnvironment::new(
@@ -8026,12 +8140,7 @@ async fn record_context_updates_emits_environment_item_for_cwd_changes() {
 async fn record_context_updates_emits_environment_item_for_time_changes() {
     let (session, previous_context) = make_session_and_context().await;
     let previous_context = Arc::new(previous_context);
-    let mut current_context = previous_context
-        .with_model(
-            previous_context.model_info.slug.clone(),
-            &session.services.models_manager,
-        )
-        .await;
+    let mut current_context = fresh_turn_context(&session).await;
     current_context.current_date = Some("2026-02-27".to_string());
     current_context.timezone = Some("Europe/Berlin".to_string());
 
@@ -8050,12 +8159,7 @@ async fn record_context_updates_emits_environment_item_for_time_changes() {
 async fn record_context_updates_omits_environment_item_when_disabled() {
     let (session, previous_context) = make_session_and_context().await;
     let previous_context = Arc::new(previous_context);
-    let mut current_context = previous_context
-        .with_model(
-            previous_context.model_info.slug.clone(),
-            &session.services.models_manager,
-        )
-        .await;
+    let mut current_context = fresh_turn_context(&session).await;
     let mut config = (*current_context.config).clone();
     config.include_environment_context = false;
     current_context.config = Arc::new(config);
@@ -8102,17 +8206,13 @@ async fn record_context_update_items(
 async fn build_settings_update_items_emits_realtime_start_when_session_becomes_live() {
     let (session, previous_context) = make_session_and_context().await;
     let previous_context = Arc::new(previous_context);
-    let mut current_context = previous_context
-        .with_model(
-            previous_context.model_info.slug.clone(),
-            &session.services.models_manager,
-        )
-        .await;
+    let mut current_context = fresh_turn_context(&session).await;
     current_context.realtime_active = true;
+    let current_context = StepContext::for_test(Arc::new(current_context));
 
     let update_items = session
         .build_settings_update_items(
-            Some(&previous_context.to_turn_context_item()),
+            Some(&turn_context_item_for_test(&previous_context)),
             &current_context,
         )
         .await;
@@ -8130,17 +8230,14 @@ async fn build_settings_update_items_emits_realtime_start_when_session_becomes_l
 async fn build_settings_update_items_emits_realtime_end_when_session_stops_being_live() {
     let (session, mut previous_context) = make_session_and_context().await;
     previous_context.realtime_active = true;
-    let mut current_context = previous_context
-        .with_model(
-            previous_context.model_info.slug.clone(),
-            &session.services.models_manager,
-        )
-        .await;
+    let previous_context = Arc::new(previous_context);
+    let mut current_context = fresh_turn_context(&session).await;
     current_context.realtime_active = false;
+    let current_context = StepContext::for_test(Arc::new(current_context));
 
     let update_items = session
         .build_settings_update_items(
-            Some(&previous_context.to_turn_context_item()),
+            Some(&turn_context_item_for_test(&previous_context)),
             &current_context,
         )
         .await;
@@ -8157,20 +8254,17 @@ async fn build_settings_update_items_emits_realtime_end_when_session_stops_being
 #[tokio::test]
 async fn build_settings_update_items_uses_previous_turn_settings_for_realtime_end() {
     let (session, previous_context) = make_session_and_context().await;
-    let mut previous_context_item = previous_context.to_turn_context_item();
+    let previous_context = Arc::new(previous_context);
+    let mut previous_context_item = turn_context_item_for_test(&previous_context);
     previous_context_item.realtime_active = None;
     let previous_turn_settings = PreviousTurnSettings {
-        model: previous_context.model_info.slug.clone(),
+        model: previous_context_item.model.clone(),
         comp_hash: None,
         realtime_active: Some(true),
     };
-    let mut current_context = previous_context
-        .with_model(
-            previous_context.model_info.slug.clone(),
-            &session.services.models_manager,
-        )
-        .await;
+    let mut current_context = fresh_turn_context(&session).await;
     current_context.realtime_active = false;
+    let current_context = StepContext::for_test(Arc::new(current_context));
 
     session
         .set_previous_turn_settings(Some(previous_turn_settings))
@@ -8203,7 +8297,7 @@ async fn build_initial_context_uses_previous_realtime_state() {
         "expected initial context to describe active realtime state, got {developer_texts:?}"
     );
 
-    let previous_context_item = turn_context.to_turn_context_item();
+    let previous_context_item = turn_context_item_for_test(&turn_context);
     {
         let mut state = session.state.lock().await;
         state.set_reference_context_item(Some(previous_context_item));
@@ -8248,6 +8342,7 @@ impl codex_extension_api::ContextContributor for PromptExtensionTestContributor 
         &'a self,
         _session_store: &'a codex_extension_api::ExtensionData,
         thread_store: &'a codex_extension_api::ExtensionData,
+        _model_info: &'a codex_protocol::openai_models::ModelInfo,
     ) -> std::pin::Pin<
         Box<dyn std::future::Future<Output = Vec<codex_extension_api::PromptFragment>> + Send + 'a>,
     > {
@@ -8322,12 +8417,11 @@ async fn build_initial_context_includes_prompt_fragments_from_extensions() {
 
 #[tokio::test]
 async fn build_initial_context_includes_turn_context_fragments_from_extensions() {
-    let (mut session, mut turn_context) = make_session_and_context().await;
+    let (mut session, turn_context) = make_session_and_context().await;
     let mut builder = codex_extension_api::ExtensionRegistryBuilder::new();
     builder.prompt_contributor(Arc::new(TurnContextExtensionTestContributor));
     session.services.extensions = Arc::new(builder.build());
-    turn_context.model_info.context_window = Some(100);
-    turn_context.model_info.effective_context_window_percent = 50;
+    let model_context = step_model_context_with_window_for_test(&turn_context, 100, 50);
     turn_context
         .extension_data
         .insert(TurnContextExtensionTestState {
@@ -8335,7 +8429,8 @@ async fn build_initial_context_includes_turn_context_fragments_from_extensions()
         });
     let turn_context = Arc::new(turn_context);
 
-    let initial_context = build_initial_context(&session, &turn_context).await;
+    let initial_context =
+        build_initial_context_with_model(&session, &turn_context, model_context).await;
     let developer_messages = developer_message_texts(&initial_context);
 
     assert!(
@@ -8349,21 +8444,21 @@ async fn build_initial_context_includes_turn_context_fragments_from_extensions()
 
 #[tokio::test]
 async fn record_context_updates_includes_turn_context_fragments_on_steady_state_turns() {
-    let (mut session, mut turn_context) = make_session_and_context().await;
+    let (mut session, turn_context) = make_session_and_context().await;
     let mut builder = codex_extension_api::ExtensionRegistryBuilder::new();
     builder.prompt_contributor(Arc::new(TurnContextExtensionTestContributor));
     session.services.extensions = Arc::new(builder.build());
-    turn_context.model_info.context_window = Some(200);
-    turn_context.model_info.effective_context_window_percent = 25;
+    let model_context = step_model_context_with_window_for_test(&turn_context, 200, 25);
     turn_context
         .extension_data
         .insert(TurnContextExtensionTestState {
             expected_model_context_window: Some(50),
         });
-    let mut previous_context_item = turn_context.to_turn_context_item();
-    previous_context_item.turn_id = Some("previous-turn-id".to_string());
     let turn_context = Arc::new(turn_context);
-    let world_state = build_world_state_from_turn_context(&session, &turn_context).await;
+    let step_context = StepContext::for_test_with_model(Arc::clone(&turn_context), model_context);
+    let mut previous_context_item = step_context.to_turn_context_item();
+    previous_context_item.turn_id = Some("previous-turn-id".to_string());
+    let world_state = session.build_world_state_for_step(&step_context).await;
     {
         let mut state = session.state.lock().await;
         state.set_reference_context_item(Some(previous_context_item));
@@ -8372,7 +8467,6 @@ async fn record_context_updates_includes_turn_context_fragments_on_steady_state_
             .set_world_state_baseline(world_state.snapshot());
     }
 
-    let step_context = StepContext::for_test(Arc::clone(&turn_context));
     session
         .record_context_updates_and_set_reference_context_item(&step_context)
         .await;
@@ -8583,11 +8677,12 @@ async fn build_initial_context_trims_skill_metadata_from_context_window_budget()
             plugin_id: None,
         },
     ];
-    turn_context.model_info.context_window = Some(100);
+    let model_context = step_model_context_with_window_for_test(&turn_context, 100, 100);
     turn_context.turn_skills = TurnSkillsContext::new(HostSkillsSnapshot::new(Arc::new(outcome)));
     let turn_context = Arc::new(turn_context);
 
-    let initial_context = build_initial_context(&session, &turn_context).await;
+    let initial_context =
+        build_initial_context_with_model(&session, &turn_context, model_context).await;
     let developer_texts = developer_input_texts(&initial_context);
 
     assert!(
@@ -8735,11 +8830,12 @@ async fn build_initial_context_emits_thread_start_skill_warning_on_repeated_buil
             plugin_id: None,
         },
     ];
-    turn_context.model_info.context_window = Some(100);
+    let model_context = step_model_context_with_window_for_test(&turn_context, 100, 100);
     turn_context.turn_skills = TurnSkillsContext::new(HostSkillsSnapshot::new(Arc::new(outcome)));
     let turn_context = Arc::new(turn_context);
 
-    let _ = build_initial_context(&session, &turn_context).await;
+    let _ =
+        build_initial_context_with_model(&session, &turn_context, Arc::clone(&model_context)).await;
     let warning_event = timeout(Duration::from_secs(1), rx.recv())
         .await
         .expect("warning event should arrive")
@@ -8750,7 +8846,7 @@ async fn build_initial_context_emits_thread_start_skill_warning_on_repeated_buil
             if message == "Exceeded skills context budget of 2%. All skill descriptions were removed and 2 additional skills were not included in the model-visible skills list."
     ));
 
-    let _ = build_initial_context(&session, &turn_context).await;
+    let _ = build_initial_context_with_model(&session, &turn_context, model_context).await;
     let warning_event = timeout(Duration::from_secs(1), rx.recv())
         .await
         .expect("warning event should arrive on repeated build")
@@ -8782,9 +8878,10 @@ async fn handle_output_item_done_records_image_save_history_message() {
         internal_chat_message_metadata_passthrough: None,
     };
 
+    let step_context = StepContext::for_test(Arc::clone(&turn_context));
     let mut ctx = HandleOutputCtx {
         sess: Arc::clone(&session),
-        turn_context: Arc::clone(&turn_context),
+        step_context,
         turn_store: Arc::new(codex_extension_api::ExtensionData::new(
             turn_context.sub_id.clone(),
         )),
@@ -8839,9 +8936,10 @@ async fn handle_output_item_done_skips_image_save_message_when_save_fails() {
         internal_chat_message_metadata_passthrough: None,
     };
 
+    let step_context = StepContext::for_test(Arc::clone(&turn_context));
     let mut ctx = HandleOutputCtx {
         sess: Arc::clone(&session),
-        turn_context: Arc::clone(&turn_context),
+        step_context,
         turn_store: Arc::new(codex_extension_api::ExtensionData::new(
             turn_context.sub_id.clone(),
         )),
@@ -8861,8 +8959,9 @@ async fn handle_output_item_done_skips_image_save_message_when_save_fails() {
 #[tokio::test]
 async fn build_initial_context_uses_previous_turn_settings_for_realtime_end() {
     let (session, turn_context) = make_session_and_context().await;
+    let model_context = StepModelContext::for_test(&turn_context);
     let previous_turn_settings = PreviousTurnSettings {
-        model: turn_context.model_info.slug.clone(),
+        model: model_context.model_info.slug.clone(),
         comp_hash: None,
         realtime_active: Some(true),
     };
@@ -8885,8 +8984,9 @@ async fn build_initial_context_uses_previous_turn_settings_for_realtime_end() {
 async fn build_initial_context_restates_realtime_start_when_reference_context_is_missing() {
     let (session, mut turn_context) = make_session_and_context().await;
     turn_context.realtime_active = true;
+    let model_context = StepModelContext::for_test(&turn_context);
     let previous_turn_settings = PreviousTurnSettings {
-        model: turn_context.model_info.slug.clone(),
+        model: model_context.model_info.slug.clone(),
         comp_hash: None,
         realtime_active: Some(true),
     };
@@ -8936,14 +9036,16 @@ async fn turn_context_item_stores_local_cwd() {
 
     #[allow(deprecated)]
     let local_cwd = turn_context.cwd.clone();
-    assert_eq!(turn_context.to_turn_context_item().cwd, local_cwd);
+    let turn_context = Arc::new(turn_context);
+    assert_eq!(turn_context_item_for_test(&turn_context).cwd, local_cwd);
 }
 
 #[tokio::test]
 async fn turn_context_item_omits_legacy_equivalent_file_system_sandbox_policy() {
     let (_session, turn_context) = make_session_and_context().await;
+    let turn_context = Arc::new(turn_context);
 
-    let item = turn_context.to_turn_context_item();
+    let item = turn_context_item_for_test(&turn_context);
 
     assert_eq!(item.file_system_sandbox_policy, None);
     assert_eq!(
@@ -8962,7 +9064,8 @@ async fn turn_context_item_stores_split_file_system_sandbox_policy_when_differen
         turn_context.network_sandbox_policy(),
     );
 
-    let item = turn_context.to_turn_context_item();
+    let turn_context = Arc::new(turn_context);
+    let item = turn_context_item_for_test(&turn_context);
 
     assert_eq!(
         item.file_system_sandbox_policy,
@@ -8990,7 +9093,7 @@ async fn record_context_updates_and_set_reference_context_item_injects_full_cont
     let current_context = session.reference_context_item().await;
     assert_eq!(
         serde_json::to_value(current_context).expect("serialize current context item"),
-        serde_json::to_value(Some(turn_context.to_turn_context_item()))
+        serde_json::to_value(Some(step_context.to_turn_context_item()))
             .expect("serialize expected context item")
     );
 }
@@ -9011,7 +9114,7 @@ async fn record_context_updates_and_set_reference_context_item_reinjects_full_co
         internal_chat_message_metadata_passthrough: None,
     };
     session
-        .record_conversation_items(&turn_context, std::slice::from_ref(&compacted_summary))
+        .record_conversation_items(&step_context, std::slice::from_ref(&compacted_summary))
         .await;
     session
         .record_context_updates_and_set_reference_context_item(&step_context)
@@ -9042,17 +9145,26 @@ async fn record_context_updates_and_set_reference_context_item_reinjects_full_co
 async fn record_context_updates_and_set_reference_context_item_persists_baseline_without_emitting_diffs()
  {
     let (mut session, previous_context) = make_session_and_context().await;
-    let next_model = if previous_context.model_info.slug == "gpt-5.4" {
+    let previous_context = Arc::new(previous_context);
+    let previous_seed = step_context_seed_for_test(Arc::clone(&previous_context));
+    let previous_step = StepContext::for_test_with_model(
+        Arc::clone(&previous_seed.turn),
+        Arc::clone(&previous_seed.model),
+    );
+    let next_model = if previous_seed.model.model_info.slug == "gpt-5.4" {
         "gpt-5.2"
     } else {
         "gpt-5.4"
     };
-    let turn_context = previous_context
+    let current_seed = previous_seed
         .with_model(next_model.to_string(), &session.services.models_manager)
         .await;
-    let previous_context_item = previous_context.to_turn_context_item();
-    let previous_context = Arc::new(previous_context);
-    let world_state = build_world_state_from_turn_context(&session, &previous_context).await;
+    let current_step = StepContext::for_test_with_model(
+        Arc::clone(&current_seed.turn),
+        Arc::clone(&current_seed.model),
+    );
+    let previous_context_item = previous_step.to_turn_context_item();
+    let world_state = session.build_world_state_for_step(&previous_step).await;
     {
         let mut state = session.state.lock().await;
         state.set_reference_context_item(Some(previous_context_item.clone()));
@@ -9063,14 +9175,12 @@ async fn record_context_updates_and_set_reference_context_item_persists_baseline
     let rollout_path = attach_thread_persistence(&mut session).await;
 
     let update_items = session
-        .build_settings_update_items(Some(&previous_context_item), &turn_context)
+        .build_settings_update_items(Some(&previous_context_item), &current_step)
         .await;
     assert_eq!(update_items, Vec::new());
 
-    let turn_context = Arc::new(turn_context);
-    let step_context = StepContext::for_test(Arc::clone(&turn_context));
     session
-        .record_context_updates_and_set_reference_context_item(&step_context)
+        .record_context_updates_and_set_reference_context_item(&current_step)
         .await;
 
     assert_eq!(
@@ -9080,7 +9190,7 @@ async fn record_context_updates_and_set_reference_context_item_persists_baseline
     assert_eq!(
         serde_json::to_value(session.reference_context_item().await)
             .expect("serialize current context item"),
-        serde_json::to_value(Some(turn_context.to_turn_context_item()))
+        serde_json::to_value(Some(current_step.to_turn_context_item()))
             .expect("serialize expected context item")
     );
     session.ensure_rollout_materialized().await;
@@ -9099,7 +9209,7 @@ async fn record_context_updates_and_set_reference_context_item_persists_baseline
     assert_eq!(
         serde_json::to_value(persisted_turn_context)
             .expect("serialize persisted turn context item"),
-        serde_json::to_value(Some(turn_context.to_turn_context_item()))
+        serde_json::to_value(Some(current_step.to_turn_context_item()))
             .expect("serialize expected turn context item")
     );
 }
@@ -9169,12 +9279,14 @@ async fn build_initial_context_prepends_model_switch_message() {
 async fn record_context_updates_and_set_reference_context_item_persists_full_reinjection_to_rollout()
  {
     let (mut session, previous_context) = make_session_and_context().await;
-    let next_model = if previous_context.model_info.slug == "gpt-5.4" {
+    let previous_context = Arc::new(previous_context);
+    let previous_seed = step_context_seed_for_test(previous_context);
+    let next_model = if previous_seed.model.model_info.slug == "gpt-5.4" {
         "gpt-5.2"
     } else {
         "gpt-5.4"
     };
-    let turn_context = previous_context
+    let current_seed = previous_seed
         .with_model(next_model.to_string(), &session.services.models_manager)
         .await;
     let rollout_path = attach_thread_persistence(&mut session).await;
@@ -9198,13 +9310,12 @@ async fn record_context_updates_and_set_reference_context_item_persists_full_rei
 
     session
         .set_previous_turn_settings(Some(PreviousTurnSettings {
-            model: previous_context.model_info.slug.clone(),
+            model: previous_seed.model.model_info.slug.clone(),
             comp_hash: None,
-            realtime_active: Some(previous_context.realtime_active),
+            realtime_active: Some(previous_seed.turn.realtime_active),
         }))
         .await;
-    let turn_context = Arc::new(turn_context);
-    let step_context = StepContext::for_test(Arc::clone(&turn_context));
+    let step_context = StepContext::for_test_with_model(current_seed.turn, current_seed.model);
     session
         .record_context_updates_and_set_reference_context_item(&step_context)
         .await;
@@ -9225,7 +9336,7 @@ async fn record_context_updates_and_set_reference_context_item_persists_full_rei
     assert_eq!(
         serde_json::to_value(persisted_turn_context)
             .expect("serialize persisted turn context item"),
-        serde_json::to_value(Some(turn_context.to_turn_context_item()))
+        serde_json::to_value(Some(step_context.to_turn_context_item()))
             .expect("serialize expected turn context item")
     );
 }
@@ -9320,7 +9431,7 @@ impl SessionTask for CompletingTask {
     async fn run(
         self: Arc<Self>,
         _session: Arc<SessionTaskContext>,
-        _ctx: Arc<TurnContext>,
+        _ctx: StepContextSeed,
         _input: Vec<TurnInput>,
         _cancellation_token: CancellationToken,
     ) -> SessionTaskResult {
@@ -9431,7 +9542,7 @@ impl SessionTask for NeverEndingTask {
     async fn run(
         self: Arc<Self>,
         _session: Arc<SessionTaskContext>,
-        _ctx: Arc<TurnContext>,
+        _ctx: StepContextSeed,
         _input: Vec<TurnInput>,
         cancellation_token: CancellationToken,
     ) -> SessionTaskResult {
@@ -9460,13 +9571,14 @@ impl SessionTask for GuardianDeniedApprovalTask {
     async fn run(
         self: Arc<Self>,
         session: Arc<SessionTaskContext>,
-        ctx: Arc<TurnContext>,
+        ctx: StepContextSeed,
         _input: Vec<TurnInput>,
         cancellation_token: CancellationToken,
     ) -> SessionTaskResult {
         let session = session.clone_session();
         for _ in 0..3 {
-            crate::guardian::record_guardian_denial_for_test(&session, &ctx, &ctx.sub_id).await;
+            crate::guardian::record_guardian_denial_for_test(&session, &ctx.turn, &ctx.turn.sub_id)
+                .await;
         }
 
         cancellation_token.cancelled().await;
@@ -9484,8 +9596,12 @@ async fn guardian_auto_review_interrupts_after_three_consecutive_denials() {
         }],
         client_id: None,
     }];
-    sess.spawn_task(Arc::clone(&tc), input, GuardianDeniedApprovalTask)
-        .await;
+    sess.spawn_task(
+        step_context_seed_for_test(Arc::clone(&tc)),
+        input,
+        GuardianDeniedApprovalTask,
+    )
+    .await;
 
     let mut observed = Vec::new();
     let aborted = tokio::time::timeout(std::time::Duration::from_secs(5), async {
@@ -9519,7 +9635,7 @@ async fn guardian_helper_review_interrupts_after_three_consecutive_denials() {
         client_id: None,
     }];
     sess.spawn_task(
-        Arc::clone(&tc),
+        step_context_seed_for_test(Arc::clone(&tc)),
         input,
         NeverEndingTask {
             kind: TaskKind::Regular,
@@ -9585,8 +9701,12 @@ async fn turn_complete_flushes_terminal_event_after_delivery() {
         }],
         client_id: None,
     }];
-    sess.spawn_task(Arc::clone(&tc), input, CompletingTask)
-        .await;
+    sess.spawn_task(
+        step_context_seed_for_test(Arc::clone(&tc)),
+        input,
+        CompletingTask,
+    )
+    .await;
 
     let event = recv_terminal_event(&rx, TerminalEventKind::TurnComplete).await;
     assert!(matches!(event.msg, EventMsg::TurnComplete(_)));
@@ -9613,7 +9733,7 @@ async fn turn_aborted_flushes_terminal_event_after_delivery() {
         client_id: None,
     }];
     sess.spawn_task(
-        Arc::clone(&tc),
+        step_context_seed_for_test(Arc::clone(&tc)),
         input,
         NeverEndingTask {
             kind: TaskKind::Regular,
@@ -9655,7 +9775,7 @@ async fn abort_regular_task_emits_marker_before_turn_aborted() {
         client_id: None,
     }];
     sess.spawn_task(
-        Arc::clone(&tc),
+        step_context_seed_for_test(Arc::clone(&tc)),
         input,
         NeverEndingTask {
             kind: TaskKind::Regular,
@@ -9696,7 +9816,7 @@ async fn abort_gracefully_emits_marker_before_turn_aborted() {
         client_id: None,
     }];
     sess.spawn_task(
-        Arc::clone(&tc),
+        step_context_seed_for_test(Arc::clone(&tc)),
         input,
         NeverEndingTask {
             kind: TaskKind::Regular,
@@ -9737,7 +9857,7 @@ async fn task_finish_emits_turn_item_lifecycle_for_leftover_pending_user_input()
         client_id: None,
     }];
     sess.spawn_task(
-        Arc::clone(&tc),
+        step_context_seed_for_test(Arc::clone(&tc)),
         input,
         NeverEndingTask {
             kind: TaskKind::Regular,
@@ -9766,8 +9886,11 @@ async fn task_finish_emits_turn_item_lifecycle_for_leftover_pending_user_input()
     .await
     .expect("steer pending input into active turn");
 
-    sess.on_task_finished(Arc::clone(&tc), /*task_result*/ Ok(None))
-        .await;
+    sess.on_task_finished(
+        step_context_seed_for_test(Arc::clone(&tc)),
+        /*task_result*/ Ok(None),
+    )
+    .await;
 
     let history = sess.clone_history().await;
     let expected = ResponseItem::Message {
@@ -9885,7 +10008,11 @@ async fn task_finish_emits_thread_idle_lifecycle_after_active_turn_clears() {
 
     let session = Arc::new(session);
     session
-        .spawn_task(Arc::new(turn_context), Vec::new(), CompletingTask)
+        .spawn_task(
+            step_context_seed_for_test(Arc::new(turn_context)),
+            Vec::new(),
+            CompletingTask,
+        )
         .await;
 
     timeout(StdDuration::from_secs(2), idle_rx.recv())
@@ -9940,7 +10067,7 @@ async fn thread_idle_lifecycle_waits_for_trigger_turn_mailbox_work() {
 async fn try_start_turn_if_idle_rejects_active_turn_without_injecting() {
     let (sess, tc, _rx) = make_session_and_context_with_rx().await;
     sess.spawn_task(
-        Arc::clone(&tc),
+        step_context_seed_for_test(Arc::clone(&tc)),
         Vec::new(),
         NeverEndingTask {
             kind: TaskKind::Regular,
@@ -10022,7 +10149,7 @@ async fn try_start_turn_if_idle_rejects_pending_trigger_turn_without_injecting()
 async fn try_start_turn_if_idle_rejects_active_review_turn_without_injecting() {
     let (sess, tc, _rx) = make_session_and_context_with_rx().await;
     sess.spawn_task(
-        Arc::clone(&tc),
+        step_context_seed_for_test(Arc::clone(&tc)),
         Vec::new(),
         NeverEndingTask {
             kind: TaskKind::Review,
@@ -10080,7 +10207,7 @@ async fn steer_input_enforces_expected_turn_id() {
         client_id: None,
     }];
     sess.spawn_task(
-        Arc::clone(&tc),
+        step_context_seed_for_test(Arc::clone(&tc)),
         input,
         NeverEndingTask {
             kind: TaskKind::Regular,
@@ -10172,7 +10299,7 @@ async fn steer_input_returns_active_turn_id() {
         client_id: None,
     }];
     sess.spawn_task(
-        Arc::clone(&tc),
+        step_context_seed_for_test(Arc::clone(&tc)),
         input,
         NeverEndingTask {
             kind: TaskKind::Regular,
@@ -10255,7 +10382,7 @@ async fn queue_only_mailbox_mail_waits_for_next_turn_after_answer_boundary() {
         /*trigger_turn*/ false,
     );
     sess.spawn_task(
-        Arc::clone(&tc),
+        step_context_seed_for_test(Arc::clone(&tc)),
         Vec::new(),
         NeverEndingTask {
             kind: TaskKind::Regular,
@@ -10292,7 +10419,7 @@ async fn queue_only_mailbox_mail_waits_for_next_turn_after_answer_boundary() {
 async fn trigger_turn_mailbox_mail_waits_for_next_turn_after_answer_boundary() {
     let (sess, tc, _rx) = make_session_and_context_with_rx().await;
     sess.spawn_task(
-        Arc::clone(&tc),
+        step_context_seed_for_test(Arc::clone(&tc)),
         Vec::new(),
         NeverEndingTask {
             kind: TaskKind::Regular,
@@ -10335,7 +10462,7 @@ async fn steered_input_reopens_mailbox_delivery_for_current_turn() {
         /*trigger_turn*/ false,
     );
     sess.spawn_task(
-        Arc::clone(&tc),
+        step_context_seed_for_test(Arc::clone(&tc)),
         Vec::new(),
         NeverEndingTask {
             kind: TaskKind::Regular,
@@ -10389,7 +10516,7 @@ async fn stale_defer_mailbox_delivery_does_not_override_steered_input() {
         /*trigger_turn*/ false,
     );
     sess.spawn_task(
-        Arc::clone(&tc),
+        step_context_seed_for_test(Arc::clone(&tc)),
         Vec::new(),
         NeverEndingTask {
             kind: TaskKind::Regular,
@@ -10447,7 +10574,7 @@ async fn tool_calls_reopen_mailbox_delivery_for_current_turn() {
         /*trigger_turn*/ false,
     );
     sess.spawn_task(
-        Arc::clone(&tc),
+        step_context_seed_for_test(Arc::clone(&tc)),
         Vec::new(),
         NeverEndingTask {
             kind: TaskKind::Regular,
@@ -10471,9 +10598,10 @@ async fn tool_calls_reopen_mailbox_delivery_for_current_turn() {
         call_id: "call-1".to_string(),
         internal_chat_message_metadata_passthrough: None,
     };
+    let step_context = StepContext::for_test(Arc::clone(&tc));
     let mut ctx = HandleOutputCtx {
         sess: Arc::clone(&sess),
-        turn_context: Arc::clone(&tc),
+        step_context,
         turn_store: Arc::new(codex_extension_api::ExtensionData::new(tc.sub_id.clone())),
         tool_runtime: test_tool_runtime(Arc::clone(&sess), Arc::clone(&tc)),
         cancellation_token: CancellationToken::new(),
@@ -10501,8 +10629,12 @@ async fn abort_review_task_emits_exited_then_aborted_and_records_history() {
         }],
         client_id: None,
     }];
-    sess.spawn_task(Arc::clone(&tc), input, ReviewTask::new())
-        .await;
+    sess.spawn_task(
+        step_context_seed_for_test(Arc::clone(&tc)),
+        input,
+        ReviewTask::new(),
+    )
+    .await;
 
     sess.abort_all_tasks(TurnAbortReason::Interrupted).await;
 
@@ -10640,7 +10772,12 @@ async fn sample_rollout(
     // Use the same turn_context source as record_initial_history so model_info (and thus
     // personality_spec) matches reconstruction.
     let reconstruction_turn = session.new_default_turn().await;
-    let mut initial_context = build_initial_context(session, &reconstruction_turn).await;
+    let mut initial_context = build_initial_context_with_model(
+        session,
+        &reconstruction_turn.turn,
+        Arc::clone(&reconstruction_turn.model),
+    )
+    .await;
     // Ensure personality_spec is present when Personality is enabled, so expected matches
     // what reconstruction produces (build_initial_context may omit it when baked into model).
     if !initial_context.iter().any(|m| {
@@ -10649,9 +10786,10 @@ async fn sample_rollout(
             && content.iter().any(|c| {
                 matches!(c, ContentItem::InputText { text } if text.contains("<personality_spec>"))
             }))
-    }) && let Some(p) = reconstruction_turn.personality
+    }) && let Some(p) = reconstruction_turn.turn.personality
         && session.features.enabled(Feature::Personality)
         && let Some(personality_message) = reconstruction_turn
+            .model
             .model_info
             .model_messages
             .as_ref()
@@ -10672,7 +10810,11 @@ async fn sample_rollout(
     }
     live_history.record_items(
         initial_context.iter(),
-        reconstruction_turn.model_info.truncation_policy.into(),
+        reconstruction_turn
+            .model
+            .model_info
+            .truncation_policy
+            .into(),
     );
 
     let user1 = ResponseItem::Message {
@@ -10686,7 +10828,11 @@ async fn sample_rollout(
     };
     live_history.record_items(
         std::iter::once(&user1),
-        reconstruction_turn.model_info.truncation_policy.into(),
+        reconstruction_turn
+            .model
+            .model_info
+            .truncation_policy
+            .into(),
     );
     rollout_items.push(RolloutItem::ResponseItem(user1.clone()));
 
@@ -10701,14 +10847,18 @@ async fn sample_rollout(
     };
     live_history.record_items(
         std::iter::once(&assistant1),
-        reconstruction_turn.model_info.truncation_policy.into(),
+        reconstruction_turn
+            .model
+            .model_info
+            .truncation_policy
+            .into(),
     );
     rollout_items.push(RolloutItem::ResponseItem(assistant1.clone()));
 
     let summary1 = "summary one";
     let snapshot1 = live_history
         .clone()
-        .for_prompt(&reconstruction_turn.model_info.input_modalities);
+        .for_prompt(&reconstruction_turn.model.model_info.input_modalities);
     let user_messages1 = collect_user_messages(&snapshot1);
     let rebuilt1 = compact::build_compacted_history(Vec::new(), &user_messages1, summary1);
     live_history.replace(rebuilt1);
@@ -10733,7 +10883,11 @@ async fn sample_rollout(
     };
     live_history.record_items(
         std::iter::once(&user2),
-        reconstruction_turn.model_info.truncation_policy.into(),
+        reconstruction_turn
+            .model
+            .model_info
+            .truncation_policy
+            .into(),
     );
     rollout_items.push(RolloutItem::ResponseItem(user2.clone()));
 
@@ -10748,14 +10902,18 @@ async fn sample_rollout(
     };
     live_history.record_items(
         std::iter::once(&assistant2),
-        reconstruction_turn.model_info.truncation_policy.into(),
+        reconstruction_turn
+            .model
+            .model_info
+            .truncation_policy
+            .into(),
     );
     rollout_items.push(RolloutItem::ResponseItem(assistant2.clone()));
 
     let summary2 = "summary two";
     let snapshot2 = live_history
         .clone()
-        .for_prompt(&reconstruction_turn.model_info.input_modalities);
+        .for_prompt(&reconstruction_turn.model.model_info.input_modalities);
     let user_messages2 = collect_user_messages(&snapshot2);
     let rebuilt2 = compact::build_compacted_history(Vec::new(), &user_messages2, summary2);
     live_history.replace(rebuilt2);
@@ -10780,7 +10938,11 @@ async fn sample_rollout(
     };
     live_history.record_items(
         std::iter::once(&user3),
-        reconstruction_turn.model_info.truncation_policy.into(),
+        reconstruction_turn
+            .model
+            .model_info
+            .truncation_policy
+            .into(),
     );
     rollout_items.push(RolloutItem::ResponseItem(user3));
 
@@ -10795,13 +10957,17 @@ async fn sample_rollout(
     };
     live_history.record_items(
         std::iter::once(&assistant3),
-        reconstruction_turn.model_info.truncation_policy.into(),
+        reconstruction_turn
+            .model
+            .model_info
+            .truncation_policy
+            .into(),
     );
     rollout_items.push(RolloutItem::ResponseItem(assistant3));
 
     (
         rollout_items,
-        live_history.for_prompt(&reconstruction_turn.model_info.input_modalities),
+        live_history.for_prompt(&reconstruction_turn.model.model_info.input_modalities),
     )
 }
 
@@ -10839,7 +11005,6 @@ async fn rejects_escalated_permissions_when_policy_not_on_request() {
     let resp = handler
         .handle(ToolInvocation {
             session: Arc::clone(&session),
-            turn: Arc::clone(&turn_context),
             step_context,
             cancellation_token: CancellationToken::new(),
             tracker: Arc::clone(&turn_diff_tracker),
@@ -10915,9 +11080,9 @@ async fn shell_tool_cancellation_waits_for_runtime_cleanup() -> anyhow::Result<(
             .expect("test setup should allow sandbox policy");
     })
     .await?;
-    let turn_context = session.new_default_turn().await;
+    let step_context_seed = session.new_default_turn().await;
     let session = Arc::new(session);
-    let turn_context = Arc::new(turn_context);
+    let turn_context = Arc::clone(&step_context_seed.turn);
     let temp_dir = tempfile::TempDir::new()?;
     let ready_marker = temp_dir.path().join("ready");
     let cleanup_marker = temp_dir.path().join("cleanup");
@@ -10994,7 +11159,6 @@ async fn unified_exec_rejects_escalated_permissions_when_policy_not_on_request()
     let resp = handler
         .handle(ToolInvocation {
             session: Arc::clone(&session),
-            turn: Arc::clone(&turn_context),
             step_context,
             cancellation_token: CancellationToken::new(),
             tracker: Arc::clone(&tracker),

--- a/codex-rs/core/src/session/tests/guardian_tests.rs
+++ b/codex-rs/core/src/session/tests/guardian_tests.rs
@@ -117,6 +117,7 @@ async fn request_permissions_routes_to_guardian_when_reviewer_is_enabled() {
     );
     let session = Arc::new(session);
     let turn_context = Arc::new(turn_context_raw);
+    let step_context_seed = step_context_seed_for_test(Arc::clone(&turn_context));
 
     let requested_permissions = RequestPermissionProfile {
         network: Some(NetworkPermissions {
@@ -132,7 +133,7 @@ async fn request_permissions_routes_to_guardian_when_reviewer_is_enabled() {
     let response = tokio::time::timeout(
         Duration::from_secs(45),
         session.request_permissions_for_environment(
-            &turn_context,
+            &step_context_seed,
             "perm-call-1".to_string(),
             RequestPermissionsArgs {
                 environment_id: None,
@@ -213,10 +214,12 @@ async fn request_permissions_guardian_review_stops_when_cancelled() {
         }),
         ..RequestPermissionProfile::default()
     };
+    let step_context_seed = step_context_seed_for_test(Arc::clone(&turn_context));
     let cancellation_token = CancellationToken::new();
     let request_handle = tokio::spawn({
         let session = Arc::clone(&session);
         let turn_context = Arc::clone(&turn_context);
+        let step_context_seed = step_context_seed.clone();
         let requested_permissions = requested_permissions.clone();
         let cancellation_token = cancellation_token.clone();
         async move {
@@ -227,7 +230,7 @@ async fn request_permissions_guardian_review_stops_when_cancelled() {
                 .selection();
             session
                 .request_permissions_for_environment(
-                    &turn_context,
+                    &step_context_seed,
                     "perm-call-cancelled".to_string(),
                     RequestPermissionsArgs {
                         environment_id: None,
@@ -334,7 +337,6 @@ async fn guardian_allows_shell_command_additional_permissions_requests_past_poli
     let resp = handler
         .handle(ToolInvocation {
             session: Arc::clone(&session),
-            turn: Arc::clone(&turn_context),
             step_context,
             cancellation_token: CancellationToken::new(),
             tracker: Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new())),
@@ -440,7 +442,6 @@ async fn strict_auto_review_turn_grant_forces_guardian_for_shell_command_policy_
     let resp = handler
         .handle(ToolInvocation {
             session: Arc::clone(&session),
-            turn: Arc::clone(&turn_context),
             step_context,
             cancellation_token: CancellationToken::new(),
             tracker: Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new())),
@@ -489,7 +490,6 @@ async fn guardian_allows_unified_exec_additional_permissions_requests_past_polic
     let resp = handler
         .handle(ToolInvocation {
             session: Arc::clone(&session),
-            turn: Arc::clone(&turn_context),
             step_context,
             cancellation_token: CancellationToken::new(),
             tracker: Arc::clone(&tracker),
@@ -531,12 +531,13 @@ async fn process_compacted_history_preserves_separate_guardian_developer_message
     turn_context.session_source = guardian_source;
     turn_context.developer_instructions = Some(guardian_policy.clone());
     let turn_context = Arc::new(turn_context);
-    let world_state = Arc::new(build_world_state_from_turn_context(&session, &turn_context).await);
+    let step_context = StepContext::for_test(Arc::clone(&turn_context));
+    let world_state = Arc::new(session.build_world_state_for_step(&step_context).await);
     let initial_context_injection = InitialContextInjection::BeforeLastUserMessage(world_state);
 
     let (refreshed, _) = crate::compact_remote::process_compacted_history(
         &session,
-        &turn_context,
+        &step_context,
         vec![
             ResponseItem::Message {
                 id: None,
@@ -620,7 +621,6 @@ async fn shell_command_allows_sticky_turn_permissions_without_inline_request_per
     let resp = handler
         .handle(ToolInvocation {
             session: Arc::clone(&session),
-            turn: Arc::clone(&turn_context),
             step_context,
             cancellation_token: CancellationToken::new(),
             tracker: Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new())),

--- a/codex-rs/core/src/session/time_reminder.rs
+++ b/codex-rs/core/src/session/time_reminder.rs
@@ -6,7 +6,7 @@ use codex_protocol::error::Result as CodexResult;
 use codex_protocol::models::ResponseItem;
 
 use super::session::Session;
-use super::turn_context::TurnContext;
+use super::step_context::StepContext;
 use crate::context::ContextualUserFragment;
 use crate::context_manager::is_user_turn_boundary;
 
@@ -70,9 +70,10 @@ impl CurrentTimeReminderState {
 
 pub(super) async fn maybe_record_current_time_reminder(
     sess: &Session,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     window_id: &str,
 ) -> CodexResult<()> {
+    let turn_context = step_context.turn.as_ref();
     let Some(config) = turn_context.config.current_time_reminder else {
         return Ok(());
     };
@@ -99,7 +100,7 @@ pub(super) async fn maybe_record_current_time_reminder(
 
     let response_item =
         ContextualUserFragment::into(crate::context::CurrentTimeReminder::new(current_time));
-    sess.record_conversation_items(turn_context, std::slice::from_ref(&response_item))
+    sess.record_conversation_items(step_context, std::slice::from_ref(&response_item))
         .await;
 
     Ok(())

--- a/codex-rs/core/src/session/token_budget.rs
+++ b/codex-rs/core/src/session/token_budget.rs
@@ -1,13 +1,14 @@
 use super::session::Session;
-use super::turn_context::TurnContext;
+use super::step_context::StepContext;
 use crate::context::ContextualUserFragment;
 use codex_features::Feature;
 
 pub(super) async fn maybe_record(
     sess: &Session,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     tokens_until_compaction: Option<i64>,
 ) {
+    let turn_context = step_context.turn.as_ref();
     if !turn_context.config.features.enabled(Feature::TokenBudget) {
         return;
     }
@@ -35,6 +36,6 @@ pub(super) async fn maybe_record(
         &config.reminder_message_template,
         tokens_until_compaction,
     ));
-    sess.record_conversation_items(turn_context, std::slice::from_ref(&response_item))
+    sess.record_conversation_items(step_context, std::slice::from_ref(&response_item))
         .await;
 }

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -1833,7 +1833,6 @@ async fn handle_assistant_item_done_in_plan_mode(
     previously_active_item: Option<&TurnItem>,
     last_agent_message: &mut Option<String>,
 ) -> bool {
-    let turn_context = step_context.turn.as_ref();
     if let ResponseItem::Message { role, .. } = item
         && role == "assistant"
     {

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -43,6 +43,7 @@ use crate::session::PreviousTurnSettings;
 use crate::session::TurnInput;
 use crate::session::session::Session;
 use crate::session::step_context::StepContext;
+use crate::session::step_context::StepContextSeed;
 use crate::session::turn_context::TurnContext;
 use crate::stream_events_utils::HandleOutputCtx;
 use crate::stream_events_utils::TurnItemContributorPolicy;
@@ -141,19 +142,21 @@ use tracing::warn;
 ///
 pub(crate) async fn run_turn(
     sess: Arc<Session>,
-    turn_context: Arc<TurnContext>,
+    step_context_seed: StepContextSeed,
     turn_extension_data: Arc<codex_extension_api::ExtensionData>,
     input: Vec<TurnInput>,
     prewarmed_client_session: Option<ModelClientSession>,
     cancellation_token: CancellationToken,
 ) -> CodexResult<Option<String>> {
+    let turn_context = Arc::clone(&step_context_seed.turn);
     let mut client_session =
         prewarmed_client_session.unwrap_or_else(|| sess.services.model_client.new_session());
     // TODO(ccunningham): Pre-turn compaction runs before context updates and the
     // new user message are recorded. Estimate pending incoming items (context
     // diffs/full reinjection + user input) and trigger compaction preemptively
     // when they would push the thread over the compaction threshold.
-    if let Err(err) = run_pre_sampling_compact(&sess, &turn_context, &mut client_session).await {
+    if let Err(err) = run_pre_sampling_compact(&sess, &step_context_seed, &mut client_session).await
+    {
         if matches!(err, CodexErr::TurnAborted) {
             return Err(err);
         }
@@ -165,7 +168,7 @@ pub(crate) async fn run_turn(
     }
 
     // run_turn owns the step used to seed context and make the first sampling request.
-    let first_step_context = sess.capture_step_context(Arc::clone(&turn_context)).await;
+    let first_step_context = sess.capture_step_context(&step_context_seed).await;
     // Keep the exact model-visible state used by this turn and its inline compactions.
     let (mut world_state, display_roots) = tokio::join!(
         sess.record_context_updates_and_set_reference_context_item(first_step_context.as_ref()),
@@ -183,28 +186,31 @@ pub(crate) async fn run_turn(
         return Ok(None);
     };
 
-    if run_pending_session_start_hooks(&sess, &turn_context).await {
+    if run_pending_session_start_hooks(&sess, &step_context_seed).await {
         return Ok(None);
     }
     let mut can_drain_pending_input = input.is_empty();
-    if run_hooks_and_record_inputs(&sess, &turn_context, &input).await {
+    if run_hooks_and_record_inputs(&sess, &step_context_seed, &input).await {
         return Ok(None);
     }
 
     sess.merge_connector_selection(explicitly_enabled_connectors.clone())
         .await;
     sess.set_previous_turn_settings(Some(PreviousTurnSettings {
-        model: turn_context.model_info.slug.clone(),
-        comp_hash: turn_context.model_info.comp_hash.clone(),
+        model: first_step_context.model.model_info.slug.clone(),
+        comp_hash: first_step_context.model.model_info.comp_hash.clone(),
         realtime_active: Some(turn_context.realtime_active),
     }))
     .await;
     for response_item in injection_items {
-        sess.record_conversation_items(&turn_context, std::slice::from_ref(&response_item))
-            .await;
+        sess.record_conversation_items(
+            first_step_context.as_ref(),
+            std::slice::from_ref(&response_item),
+        )
+        .await;
     }
 
-    track_turn_resolved_config_analytics(&sess, &turn_context, &input).await;
+    track_turn_resolved_config_analytics(&sess, first_step_context.as_ref(), &input).await;
 
     let mut last_agent_message: Option<String> = None;
     let mut stop_hook_active = false;
@@ -232,27 +238,26 @@ pub(crate) async fn run_turn(
             Vec::new()
         };
 
-        if run_hooks_and_record_inputs(&sess, &turn_context, &pending_input).await {
+        if run_hooks_and_record_inputs(&sess, &step_context_seed, &pending_input).await {
             break;
         }
-
-        let window_id = sess.current_window_id().await;
-        super::rollout_budget::maybe_record_reminder(
-            sess.as_ref(),
-            turn_context.as_ref(),
-            &window_id,
-        )
-        .await;
 
         // Capture once so context, advertised tools, and tool calls share one request view.
         let step_context = match next_step_context.take() {
             Some(step_context) => step_context,
-            None => sess.capture_step_context(Arc::clone(&turn_context)).await,
+            None => sess.capture_step_context(&step_context_seed).await,
         };
+        let window_id = sess.current_window_id().await;
+        super::rollout_budget::maybe_record_reminder(
+            sess.as_ref(),
+            step_context.as_ref(),
+            &window_id,
+        )
+        .await;
         let sampling_request_result: CodexResult<_> = async {
             super::time_reminder::maybe_record_current_time_reminder(
                 sess.as_ref(),
-                turn_context.as_ref(),
+                step_context.as_ref(),
                 &window_id,
             )
             .await?;
@@ -271,7 +276,7 @@ pub(crate) async fn run_turn(
             let sampling_request_input: Vec<ResponseItem> = async {
                 sess.clone_history()
                     .await
-                    .for_prompt(&turn_context.model_info.input_modalities)
+                    .for_prompt(&step_context.model.model_info.input_modalities)
             }
             .instrument(trace_span!("run_turn.prepare_sampling_request_input"))
             .await;
@@ -306,11 +311,12 @@ pub(crate) async fn run_turn(
                         sess.input_queue.has_pending_input(&sess.active_turn).await;
                     let token_status = super::context_window::context_window_token_status(
                         sess.as_ref(),
-                        turn_context.as_ref(),
+                        step_context.turn.as_ref(),
+                        step_context.model.as_ref(),
                     )
                     .await;
                     let estimated_token_count =
-                        sess.get_estimated_token_count(turn_context.as_ref()).await;
+                        sess.get_estimated_token_count(step_context.as_ref()).await;
                     (has_pending_input, token_status, estimated_token_count)
                 }
                 .instrument(trace_span!("run_turn.collect_post_sampling_state"))
@@ -337,7 +343,7 @@ pub(crate) async fn run_turn(
 
                 super::token_budget::maybe_record(
                     sess.as_ref(),
-                    turn_context.as_ref(),
+                    step_context.as_ref(),
                     token_status.tokens_until_compaction,
                 )
                 .await;
@@ -372,7 +378,7 @@ pub(crate) async fn run_turn(
                     last_agent_message = sampling_request_last_agent_message;
                     let stop_outcome = run_turn_stop_hooks(
                         &sess,
-                        &turn_context,
+                        step_context.as_ref(),
                         stop_hook_active,
                         last_agent_message.clone(),
                     )
@@ -382,7 +388,7 @@ pub(crate) async fn run_turn(
                             build_hook_prompt_message(&stop_outcome.continuation_fragments)
                         {
                             sess.record_conversation_items(
-                                &turn_context,
+                                step_context.as_ref(),
                                 std::slice::from_ref(&hook_prompt_message),
                             )
                             .await;
@@ -480,23 +486,24 @@ async fn turn_diff_display_roots(turn_context: &TurnContext) -> Vec<(String, Pat
 #[instrument(level = "trace", skip_all)]
 async fn run_hooks_and_record_inputs(
     sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
+    step_context_seed: &StepContextSeed,
     input: &[TurnInput],
 ) -> bool {
     let mut blocked_input = false;
     let mut accepted_user_input = false;
     for input_item in input {
-        let hook_outcome = inspect_pending_input(sess, turn_context, input_item).await;
+        let hook_outcome = inspect_pending_input(sess, step_context_seed, input_item).await;
         if hook_outcome.should_stop {
             blocked_input = true;
-            record_additional_contexts(sess, turn_context, hook_outcome.additional_contexts).await;
+            record_additional_contexts(sess, step_context_seed, hook_outcome.additional_contexts)
+                .await;
         } else {
             if matches!(input_item, TurnInput::UserInput { content, .. } if !content.is_empty()) {
                 accepted_user_input = true;
             }
             record_pending_input(
                 sess,
-                turn_context,
+                step_context_seed,
                 input_item.clone(),
                 hook_outcome.additional_contexts,
             )
@@ -530,7 +537,7 @@ async fn build_skills_and_plugins(
         .cloned()
         .collect::<Vec<_>>();
     let tracking = build_track_events_context(
-        turn_context.model_info.slug.clone(),
+        step_context.model.model_info.slug.clone(),
         sess.thread_id.to_string(),
         turn_context.sub_id.clone(),
         turn_context.originator.clone(),
@@ -578,7 +585,7 @@ async fn build_skills_and_plugins(
     let skills_outcome = turn_context.turn_skills.snapshot.outcome();
     let connector_slug_counts = build_connector_slug_counts(&available_connectors);
     let extension_injection_items =
-        build_extension_turn_input_items(sess, turn_context, &user_input, cancellation_token)
+        build_extension_turn_input_items(sess, step_context, &user_input, cancellation_token)
             .await?;
     let skill_name_counts_lower =
         build_skill_name_counts(&skills_outcome.skills, &skills_outcome.disabled_paths).1;
@@ -606,7 +613,7 @@ async fn build_skills_and_plugins(
     } = build_skill_injections(
         &mentioned_skills,
         Some(skills_outcome),
-        Some(&turn_context.session_telemetry),
+        Some(&step_context.model.session_telemetry),
         &sess.services.analytics_events_client,
         tracking.clone(),
     )
@@ -681,10 +688,11 @@ async fn build_skills_and_plugins(
 )]
 async fn build_extension_turn_input_items(
     sess: &Arc<Session>,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     user_input: &[UserInput],
     cancellation_token: &CancellationToken,
 ) -> Option<Vec<ResponseItem>> {
+    let turn_context = step_context.turn.as_ref();
     let contributors = sess.services.extensions.turn_input_contributors().to_vec();
     if contributors.is_empty() {
         return Some(Vec::new());
@@ -717,6 +725,7 @@ async fn build_extension_turn_input_items(
         let contributed_fragments = contributor
             .contribute(
                 input.clone(),
+                &step_context.model.model_info,
                 &sess.services.session_extension_data,
                 &sess.services.thread_extension_data,
                 turn_context.extension_data.as_ref(),
@@ -741,9 +750,10 @@ async fn build_extension_turn_input_items(
 )]
 async fn track_turn_resolved_config_analytics(
     sess: &Session,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     input: &[TurnInput],
 ) {
+    let turn_context = step_context.turn.as_ref();
     let thread_config = {
         let state = sess.state.lock().await;
         state.session_configuration.thread_config_snapshot()
@@ -771,22 +781,22 @@ async fn track_turn_resolved_config_analytics(
             submission_type: None,
             ephemeral: thread_config.ephemeral,
             session_source: thread_config.session_source,
-            model: turn_context.model_info.slug.clone(),
+            model: step_context.model.model_info.slug.clone(),
             model_provider: turn_context.config.model_provider_id.clone(),
             permission_profile: turn_context.permission_profile(),
             #[allow(deprecated)]
             permission_profile_cwd: turn_context.cwd.to_path_buf(),
-            reasoning_effort: turn_context.reasoning_effort.clone(),
-            reasoning_summary: Some(turn_context.reasoning_summary),
-            service_tier: turn_context
-                .config
+            reasoning_effort: step_context.model.reasoning_effort(),
+            reasoning_summary: Some(step_context.model.reasoning_summary),
+            service_tier: step_context
+                .model
                 .service_tier
                 .as_deref()
                 .and_then(ServiceTier::from_request_value),
             approval_policy: turn_context.approval_policy.value(),
             approvals_reviewer: turn_context.config.approvals_reviewer,
             sandbox_network_access: turn_context.network_sandbox_policy().is_enabled(),
-            collaboration_mode: turn_context.collaboration_mode.mode,
+            collaboration_mode: step_context.model.collaboration_mode.mode,
             personality: turn_context.personality,
             workspace_kind: turn_context.turn_metadata_state.workspace_kind(),
             is_first_turn,
@@ -796,17 +806,20 @@ async fn track_turn_resolved_config_analytics(
 #[instrument(level = "trace", skip_all)]
 async fn run_pre_sampling_compact(
     sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
+    step_context_seed: &StepContextSeed,
     client_session: &mut ModelClientSession,
 ) -> CodexResult<()> {
-    maybe_run_previous_model_inline_compact(sess, turn_context, client_session).await?;
-    let token_status =
-        super::context_window::context_window_token_status(sess.as_ref(), turn_context.as_ref())
-            .await;
+    maybe_run_previous_model_inline_compact(sess, step_context_seed, client_session).await?;
+    let token_status = super::context_window::context_window_token_status(
+        sess.as_ref(),
+        step_context_seed.turn.as_ref(),
+        step_context_seed.model.as_ref(),
+    )
+    .await;
     // Compact if the configured auto-compaction budget or usable context window is exhausted.
     if token_status.token_limit_reached {
         // Pre-turn compaction runs before run_turn creates the normal sampling step.
-        let step_context = sess.capture_step_context(Arc::clone(turn_context)).await;
+        let step_context = sess.capture_step_context(step_context_seed).await;
         run_auto_compact(
             sess,
             step_context,
@@ -834,26 +847,26 @@ fn comp_hash_changed(previous: Option<&str>, current: Option<&str>) -> bool {
 /// Returns `Err(_)` only when compaction was attempted and failed.
 async fn maybe_run_previous_model_inline_compact(
     sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
+    step_context_seed: &StepContextSeed,
     client_session: &mut ModelClientSession,
 ) -> CodexResult<()> {
+    let turn_context = step_context_seed.turn.as_ref();
+    let model_context = step_context_seed.model.as_ref();
     let Some(previous_turn_settings) = sess.previous_turn_settings().await else {
         return Ok(());
     };
     let should_compact_for_comp_hash_change = comp_hash_changed(
         previous_turn_settings.comp_hash.as_deref(),
-        turn_context.model_info.comp_hash.as_deref(),
+        model_context.model_info.comp_hash.as_deref(),
     );
-    let previous_model_turn_context = Arc::new(
-        turn_context
-            .with_model(previous_turn_settings.model, &sess.services.models_manager)
-            .await,
-    );
+    let previous_model_step_context_seed = step_context_seed
+        .with_model(previous_turn_settings.model, &sess.services.models_manager)
+        .await;
 
     if should_compact_for_comp_hash_change {
-        // This pre-turn request needs a step built from the previous model's turn context.
+        // This pre-turn request needs a step built from the previous model snapshot.
         let step_context = sess
-            .capture_step_context(Arc::clone(&previous_model_turn_context))
+            .capture_step_context(&previous_model_step_context_seed)
             .await;
         run_auto_compact(
             sess,
@@ -867,10 +880,13 @@ async fn maybe_run_previous_model_inline_compact(
         return Ok(());
     }
 
-    let Some(old_context_window) = previous_model_turn_context.model_context_window() else {
+    let Some(old_context_window) = previous_model_step_context_seed
+        .model
+        .model_context_window()
+    else {
         return Ok(());
     };
-    let Some(new_context_window) = turn_context.model_context_window() else {
+    let Some(new_context_window) = model_context.model_context_window() else {
         return Ok(());
     };
     let active_context_tokens = sess.get_total_token_usage().await;
@@ -879,7 +895,7 @@ async fn maybe_run_previous_model_inline_compact(
         .model_auto_compact_token_limit_scope
     {
         AutoCompactTokenLimitScope::Total => {
-            let new_auto_compact_limit = turn_context
+            let new_auto_compact_limit = model_context
                 .model_info
                 .auto_compact_token_limit()
                 .unwrap_or(i64::MAX);
@@ -889,12 +905,12 @@ async fn maybe_run_previous_model_inline_compact(
         AutoCompactTokenLimitScope::BodyAfterPrefix => active_context_tokens >= new_context_window,
     };
     let should_run = previous_model_limit_reached
-        && previous_model_turn_context.model_info.slug != turn_context.model_info.slug
+        && previous_model_step_context_seed.model.model_info.slug != model_context.model_info.slug
         && old_context_window > new_context_window;
     if should_run {
-        // This pre-turn request needs a step built from the previous model's turn context.
+        // This pre-turn request needs a step built from the previous model snapshot.
         let step_context = sess
-            .capture_step_context(Arc::clone(&previous_model_turn_context))
+            .capture_step_context(&previous_model_step_context_seed)
             .await;
         run_auto_compact(
             sess,
@@ -979,7 +995,7 @@ async fn run_auto_compact(
         );
         run_inline_auto_compact_task(
             Arc::clone(sess),
-            Arc::clone(turn_context),
+            step_context,
             initial_context_injection,
             reason,
             phase,
@@ -1044,13 +1060,14 @@ pub(super) fn collect_explicit_app_ids_from_skill_items(
 pub(crate) fn build_prompt(
     input: Vec<ResponseItem>,
     router: &ToolRouter,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     base_instructions: BaseInstructions,
 ) -> Prompt {
+    let turn_context = step_context.turn.as_ref();
     Prompt {
         input,
         tools: router.model_visible_specs(),
-        parallel_tool_calls: turn_context.model_info.supports_parallel_tool_calls,
+        parallel_tool_calls: step_context.model.model_info.supports_parallel_tool_calls,
         base_instructions,
         output_schema: turn_context.final_output_json_schema.clone(),
         output_schema_strict: !crate::guardian::is_guardian_reviewer_source(
@@ -1065,7 +1082,7 @@ pub(crate) fn build_prompt(
     skip_all,
     fields(
         turn_id = %step_context.turn.sub_id,
-        model = %step_context.turn.model_info.slug,
+        model = %step_context.model.model_info.slug,
         cwd = %step_context.turn.cwd.display()
     )
 )]
@@ -1106,18 +1123,18 @@ async fn run_sampling_request(
         } else {
             sess.clone_history()
                 .await
-                .for_prompt(&turn_context.model_info.input_modalities)
+                .for_prompt(&step_context.model.model_info.input_modalities)
         };
         let prompt = build_prompt(
             prompt_input,
             router.as_ref(),
-            turn_context.as_ref(),
+            step_context.as_ref(),
             base_instructions.clone(),
         );
         let err = match try_run_sampling_request(
             tool_runtime.clone(),
             Arc::clone(&sess),
-            Arc::clone(&turn_context),
+            Arc::clone(&step_context),
             Arc::clone(&turn_store),
             client_session,
             responses_metadata,
@@ -1131,7 +1148,7 @@ async fn run_sampling_request(
                 return Ok((output, original_input.unwrap_or(prompt.input)));
             }
             Err(CodexErr::ContextWindowExceeded) => {
-                sess.set_total_tokens_full(&turn_context).await;
+                sess.set_total_tokens_full(step_context.as_ref()).await;
                 return Err(CodexErr::ContextWindowExceeded);
             }
             Err(CodexErr::UsageLimitReached(e)) => {
@@ -1159,6 +1176,7 @@ async fn run_sampling_request(
             client_session,
             &sess,
             &turn_context,
+            step_context.model.as_ref(),
             ResponsesStreamRequest::Sampling,
         )
         .await?;
@@ -1170,7 +1188,7 @@ async fn run_sampling_request(
     skip_all,
     fields(
         turn_id = %step_context.turn.sub_id,
-        model = %step_context.turn.model_info.slug,
+        model = %step_context.model.model_info.slug,
         apps_enabled = step_context.turn.apps_enabled()
     )
 )]
@@ -1292,7 +1310,7 @@ pub(crate) async fn built_tools(
         &all_mcp_tools,
         connectors.as_deref(),
         &turn_context.config,
-        search_tool_enabled(turn_context),
+        search_tool_enabled(turn_context, step_context.model.as_ref()),
     );
     let mcp_tools = has_mcp_servers.then_some(mcp_tool_exposure.direct_tools);
     let deferred_mcp_tools = mcp_tool_exposure.deferred_tools;
@@ -1442,6 +1460,7 @@ impl ProposedPlanItemState {
         &mut self,
         sess: &Session,
         turn_context: &TurnContext,
+        model_context: &crate::session::step_model_context::StepModelContext,
         text: String,
     ) {
         if self.completed || !self.started {
@@ -1452,7 +1471,8 @@ impl ProposedPlanItemState {
             id: self.item_id.clone(),
             text,
         });
-        sess.emit_turn_item_completed(turn_context, item).await;
+        sess.emit_turn_item_completed(turn_context, model_context, item)
+            .await;
     }
 }
 
@@ -1705,10 +1725,11 @@ async fn flush_assistant_text_segments_all(
 /// Emit completion for plan items by parsing the finalized assistant message.
 async fn maybe_complete_plan_item_from_message(
     sess: &Session,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     state: &mut PlanModeStreamState,
     item: &ResponseItem,
 ) {
+    let turn_context = step_context.turn.as_ref();
     if let ResponseItem::Message { role, content, .. } = item
         && role == "assistant"
     {
@@ -1725,7 +1746,7 @@ async fn maybe_complete_plan_item_from_message(
             }
             state
                 .plan_item_state
-                .complete_with_text(sess, turn_context, plan_text)
+                .complete_with_text(sess, turn_context, step_context.model.as_ref(), plan_text)
                 .await;
         }
     }
@@ -1734,10 +1755,11 @@ async fn maybe_complete_plan_item_from_message(
 /// Emit a completed agent message in plan mode, respecting deferred starts.
 async fn emit_agent_message_in_plan_mode(
     sess: &Session,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     agent_message: codex_protocol::items::AgentMessageItem,
     state: &mut PlanModeStreamState,
 ) {
+    let turn_context = step_context.turn.as_ref();
     let agent_message_id = agent_message.id.clone();
     let text = agent_message_text(&agent_message);
     if text.trim().is_empty() {
@@ -1769,28 +1791,34 @@ async fn emit_agent_message_in_plan_mode(
             .insert(agent_message_id.clone());
     }
 
-    sess.emit_turn_item_completed(turn_context, TurnItem::AgentMessage(agent_message))
-        .await;
+    sess.emit_turn_item_completed(
+        turn_context,
+        step_context.model.as_ref(),
+        TurnItem::AgentMessage(agent_message),
+    )
+    .await;
     state.started_agent_message_items.remove(&agent_message_id);
 }
 
 /// Emit completion for a plan-mode turn item, handling agent messages specially.
 async fn emit_turn_item_in_plan_mode(
     sess: &Session,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     turn_item: TurnItem,
     previously_active_item: Option<&TurnItem>,
     state: &mut PlanModeStreamState,
 ) {
+    let turn_context = step_context.turn.as_ref();
     match turn_item {
         TurnItem::AgentMessage(agent_message) => {
-            emit_agent_message_in_plan_mode(sess, turn_context, agent_message, state).await;
+            emit_agent_message_in_plan_mode(sess, step_context, agent_message, state).await;
         }
         _ => {
             if previously_active_item.is_none() {
                 sess.emit_turn_item_started(turn_context, &turn_item).await;
             }
-            sess.emit_turn_item_completed(turn_context, turn_item).await;
+            sess.emit_turn_item_completed(turn_context, step_context.model.as_ref(), turn_item)
+                .await;
         }
     }
 }
@@ -1798,22 +1826,23 @@ async fn emit_turn_item_in_plan_mode(
 /// Handle a completed assistant response item in plan mode, returning true if handled.
 async fn handle_assistant_item_done_in_plan_mode(
     sess: &Session,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     turn_store: &codex_extension_api::ExtensionData,
     item: &ResponseItem,
     state: &mut PlanModeStreamState,
     previously_active_item: Option<&TurnItem>,
     last_agent_message: &mut Option<String>,
 ) -> bool {
+    let turn_context = step_context.turn.as_ref();
     if let ResponseItem::Message { role, .. } = item
         && role == "assistant"
     {
-        maybe_complete_plan_item_from_message(sess, turn_context, state, item).await;
+        maybe_complete_plan_item_from_message(sess, step_context, state, item).await;
 
         let mut finalized_facts = None;
         if let Some(finalized_turn_item) = finalize_non_tool_response_item(
             sess,
-            turn_context,
+            step_context,
             TurnItemContributorPolicy::Run(turn_store),
             item,
             /*plan_mode*/ true,
@@ -1823,7 +1852,7 @@ async fn handle_assistant_item_done_in_plan_mode(
             finalized_facts = Some(finalized_turn_item.facts.clone());
             emit_turn_item_in_plan_mode(
                 sess,
-                turn_context,
+                step_context,
                 finalized_turn_item.turn_item,
                 previously_active_item,
                 state,
@@ -1836,7 +1865,7 @@ async fn handle_assistant_item_done_in_plan_mode(
 
         record_completed_response_item_with_finalized_facts(
             sess,
-            turn_context,
+            step_context,
             item,
             finalized_facts.as_ref(),
         )
@@ -1853,14 +1882,18 @@ async fn handle_assistant_item_done_in_plan_mode(
 async fn drain_in_flight(
     in_flight: &mut FuturesOrdered<BoxFuture<'static, CodexResult<ResponseInputItem>>>,
     sess: Arc<Session>,
-    turn_context: Arc<TurnContext>,
+    step_context: Arc<StepContext>,
 ) -> CodexResult<()> {
+    let turn_context = &step_context.turn;
     while let Some(res) = in_flight.next().await {
         match res {
             Ok(response_input) => {
                 let response_item = response_input.into();
-                sess.record_conversation_items(&turn_context, std::slice::from_ref(&response_item))
-                    .await;
+                sess.record_conversation_items(
+                    step_context.as_ref(),
+                    std::slice::from_ref(&response_item),
+                )
+                .await;
                 mark_thread_memory_mode_polluted_if_external_context(
                     sess.as_ref(),
                     turn_context.as_ref(),
@@ -1880,14 +1913,14 @@ async fn drain_in_flight(
 #[instrument(level = "trace",
     skip_all,
     fields(
-        turn_id = %turn_context.sub_id,
-        model = %turn_context.model_info.slug
+        turn_id = %step_context.turn.sub_id,
+        model = %step_context.model.model_info.slug
     )
 )]
 async fn try_run_sampling_request(
     tool_runtime: ToolCallRuntime,
     sess: Arc<Session>,
-    turn_context: Arc<TurnContext>,
+    step_context: Arc<StepContext>,
     turn_store: Arc<codex_extension_api::ExtensionData>,
     client_session: &mut ModelClientSession,
     responses_metadata: &CodexResponsesMetadata,
@@ -1895,17 +1928,19 @@ async fn try_run_sampling_request(
     prompt: &Prompt,
     cancellation_token: CancellationToken,
 ) -> CodexResult<SamplingRequestResult> {
+    let turn_context = Arc::clone(&step_context.turn);
+    let model_context = Arc::clone(&step_context.model);
     feedback_tags!(
-        model = turn_context.model_info.slug.clone(),
+        model = model_context.model_info.slug.clone(),
         approval_policy = turn_context.approval_policy.value(),
         sandbox_policy = &turn_context.sandbox_policy(),
-        effort = turn_context.reasoning_effort,
+        effort = model_context.reasoning_effort(),
         auth_mode = sess.services.auth_manager.auth_mode(),
         features = sess.features.enabled_features(),
     );
     let inference_trace = sess.services.rollout_thread_trace.inference_trace_context(
         turn_context.sub_id.as_str(),
-        turn_context.model_info.slug.as_str(),
+        model_context.model_info.slug.as_str(),
         turn_context.provider.info().name.as_str(),
     );
     let sampling_timing_guard = turn_context.turn_timing_state.begin_sampling();
@@ -1917,11 +1952,11 @@ async fn try_run_sampling_request(
     let mut stream = client_session
         .stream(
             prompt,
-            &turn_context.model_info,
-            &turn_context.session_telemetry,
-            turn_context.reasoning_effort.clone(),
-            turn_context.reasoning_summary,
-            turn_context.config.service_tier.clone(),
+            &model_context.model_info,
+            &model_context.session_telemetry,
+            model_context.reasoning_effort(),
+            model_context.reasoning_summary,
+            model_context.service_tier.clone(),
             responses_metadata,
             &inference_trace,
         )
@@ -1939,8 +1974,8 @@ async fn try_run_sampling_request(
     )> = None;
     let mut should_emit_turn_diff = false;
     let mut should_emit_token_count = false;
-    let reasoning_effort = turn_context.effective_reasoning_effort_for_tracing();
-    let plan_mode = turn_context.collaboration_mode.mode == ModeKind::Plan;
+    let reasoning_effort = model_context.effective_reasoning_effort_for_tracing();
+    let plan_mode = model_context.collaboration_mode.mode == ModeKind::Plan;
     let mut assistant_message_stream_parsers = AssistantMessageStreamParsers::new(plan_mode);
     let mut plan_mode_state = plan_mode.then(|| PlanModeStreamState::new(&turn_context.sub_id));
     let defer_streamed_turn_items_for_contributors =
@@ -1986,7 +2021,12 @@ async fn try_run_sampling_request(
         sess.services
             .session_telemetry
             .record_responses(&handle_responses, &event);
-        record_turn_ttft_metric(&turn_context, &event).await;
+        record_turn_ttft_metric(
+            step_context.turn.as_ref(),
+            step_context.model.as_ref(),
+            &event,
+        )
+        .await;
 
         match event {
             ResponseEvent::Created => {}
@@ -2019,7 +2059,7 @@ async fn try_run_sampling_request(
                 if let Some(state) = plan_mode_state.as_mut()
                     && handle_assistant_item_done_in_plan_mode(
                         &sess,
-                        &turn_context,
+                        step_context.as_ref(),
                         turn_store.as_ref(),
                         &item,
                         state,
@@ -2033,7 +2073,7 @@ async fn try_run_sampling_request(
 
                 let mut ctx = HandleOutputCtx {
                     sess: sess.clone(),
-                    turn_context: turn_context.clone(),
+                    step_context: Arc::clone(&step_context),
                     turn_store: Arc::clone(&turn_store),
                     tool_runtime: tool_runtime.clone(),
                     cancellation_token: cancellation_token.child_token(),
@@ -2101,7 +2141,7 @@ async fn try_run_sampling_request(
                 }
                 if let Some(turn_item) = handle_non_tool_response_item(
                     sess.as_ref(),
-                    turn_context.as_ref(),
+                    step_context.as_ref(),
                     TurnItemContributorPolicy::Skip,
                     &item,
                     plan_mode,
@@ -2163,20 +2203,20 @@ async fn try_run_sampling_request(
                 }
             }
             ResponseEvent::ServerModel(server_model) => {
-                if !turn_context
+                if !model_context
                     .server_model_warning_emitted
                     .load(Ordering::Relaxed)
                     && sess
-                        .maybe_warn_on_server_model_mismatch(&turn_context, server_model)
+                        .maybe_warn_on_server_model_mismatch(&step_context, server_model)
                         .await
                 {
-                    turn_context
+                    model_context
                         .server_model_warning_emitted
                         .store(true, Ordering::Relaxed);
                 }
             }
             ResponseEvent::ModelVerifications(verifications) => {
-                if !turn_context
+                if !model_context
                     .model_verification_emitted
                     .swap(true, Ordering::Relaxed)
                 {
@@ -2192,7 +2232,7 @@ async fn try_run_sampling_request(
                 sess.send_event(
                     &turn_context,
                     EventMsg::SafetyBuffering(SafetyBufferingEvent {
-                        model: turn_context.model_info.slug.clone(),
+                        model: model_context.model_info.slug.clone(),
                         use_cases: buffering.use_cases,
                         reasons: buffering.reasons,
                         show_buffering_ui: buffering.show_buffering_ui,
@@ -2227,7 +2267,7 @@ async fn try_run_sampling_request(
                 )
                 .await;
                 let budget_result = sess
-                    .record_token_usage_info(&turn_context, token_usage.as_ref())
+                    .record_token_usage_info(step_context.as_ref(), token_usage.as_ref())
                     .await;
                 should_emit_token_count = true;
                 should_emit_turn_diff = true;
@@ -2406,7 +2446,7 @@ async fn try_run_sampling_request(
     } else {
         Some(turn_context.turn_timing_state.begin_tool_blocking())
     };
-    drain_in_flight(&mut in_flight, sess.clone(), turn_context.clone()).await?;
+    drain_in_flight(&mut in_flight, sess.clone(), Arc::clone(&step_context)).await?;
     drop(tool_blocking_timing_guard);
 
     if should_emit_token_count {

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::environment_selection::TurnEnvironmentSnapshot;
+use crate::session::step_context::StepContextSeed;
+use crate::session::step_model_context::StepModelContext;
 use crate::shell_snapshot::ShellSnapshotFile;
 use codex_core_skills::HostSkillsSnapshot;
 use codex_file_system::FileSystemSandboxContext;
@@ -19,7 +21,6 @@ use futures::FutureExt;
 use futures::future::BoxFuture;
 use futures::future::Shared;
 use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
 use tracing::instrument;
 
 #[derive(Clone, Debug)]
@@ -105,11 +106,7 @@ pub struct TurnContext {
     pub(crate) realtime_active: bool,
     pub config: Arc<Config>,
     pub(crate) auth_manager: Option<Arc<AuthManager>>,
-    pub(crate) model_info: ModelInfo,
-    pub(crate) session_telemetry: SessionTelemetry,
     pub(crate) provider: SharedModelProvider,
-    pub(crate) reasoning_effort: Option<ReasoningEffortConfig>,
-    pub(crate) reasoning_summary: ReasoningSummaryConfig,
     pub(crate) session_source: SessionSource,
     pub(crate) parent_thread_id: Option<ThreadId>,
     pub(crate) originator: String,
@@ -123,7 +120,6 @@ pub struct TurnContext {
     pub(crate) timezone: Option<String>,
     pub(crate) app_server_client_name: Option<String>,
     pub(crate) developer_instructions: Option<String>,
-    pub(crate) collaboration_mode: CollaborationMode,
     pub(crate) multi_agent_version: MultiAgentVersion,
     pub(crate) personality: Option<Personality>,
     pub(crate) approval_policy: Constrained<AskForApproval>,
@@ -139,8 +135,6 @@ pub struct TurnContext {
     pub(crate) turn_skills: TurnSkillsContext,
     pub(crate) turn_timing_state: Arc<TurnTimingState>,
     pub(crate) terminal_error: Arc<Mutex<Option<String>>>,
-    pub(crate) server_model_warning_emitted: AtomicBool,
-    pub(crate) model_verification_emitted: AtomicBool,
 }
 
 enum TurnMultiAgentRuntime {
@@ -169,31 +163,6 @@ impl TurnContext {
         )
     }
 
-    pub(crate) fn effective_reasoning_effort(&self) -> Option<ReasoningEffortConfig> {
-        if self.model_info.supports_reasoning_summaries {
-            self.reasoning_effort
-                .clone()
-                .or_else(|| self.model_info.default_reasoning_level.clone())
-        } else {
-            None
-        }
-    }
-
-    pub(crate) fn effective_reasoning_effort_for_tracing(&self) -> String {
-        self.effective_reasoning_effort()
-            .map(|effort| effort.to_string())
-            .unwrap_or_else(|| "default".to_string())
-    }
-
-    pub(crate) fn model_context_window(&self) -> Option<i64> {
-        let effective_context_window_percent = self.model_info.effective_context_window_percent;
-        self.model_info
-            .resolved_context_window()
-            .map(|context_window| {
-                context_window.saturating_mul(effective_context_window_percent) / 100
-            })
-    }
-
     pub(crate) fn apps_enabled(&self) -> bool {
         let uses_codex_backend = self
             .auth_manager
@@ -203,97 +172,6 @@ impl TurnContext {
             .features
             .apps_enabled_for_auth(uses_codex_backend)
             && self.config.orchestrator_mcp_enabled
-    }
-
-    pub(crate) async fn with_model(
-        &self,
-        model: String,
-        models_manager: &SharedModelsManager,
-    ) -> Self {
-        let mut config = (*self.config).clone();
-        config.model = Some(model.clone());
-        let model_info = models_manager
-            .get_model_info(model.as_str(), &config.to_models_manager_config())
-            .await;
-        let supported_reasoning_levels = model_info
-            .supported_reasoning_levels
-            .iter()
-            .map(|preset| preset.effort.clone())
-            .collect::<Vec<_>>();
-        let reasoning_effort = if let Some(current_reasoning_effort) = self.reasoning_effort.clone()
-        {
-            if supported_reasoning_levels.contains(&current_reasoning_effort) {
-                Some(current_reasoning_effort)
-            } else {
-                supported_reasoning_levels
-                    .get(supported_reasoning_levels.len().saturating_sub(1) / 2)
-                    .cloned()
-                    .or_else(|| model_info.default_reasoning_level.clone())
-            }
-        } else {
-            supported_reasoning_levels
-                .get(supported_reasoning_levels.len().saturating_sub(1) / 2)
-                .cloned()
-                .or_else(|| model_info.default_reasoning_level.clone())
-        };
-        config.model_reasoning_effort = reasoning_effort.clone();
-
-        let collaboration_mode = self.collaboration_mode.with_updates(
-            Some(model.clone()),
-            Some(reasoning_effort.clone()),
-            /*developer_instructions*/ None,
-        );
-        let available_models = models_manager
-            .list_models(RefreshStrategy::OnlineIfUncached)
-            .await;
-
-        Self {
-            sub_id: self.sub_id.clone(),
-            trace_id: self.trace_id.clone(),
-            realtime_active: self.realtime_active,
-            config: Arc::new(config),
-            auth_manager: self.auth_manager.clone(),
-            model_info: model_info.clone(),
-            session_telemetry: self
-                .session_telemetry
-                .clone()
-                .with_model(model.as_str(), model_info.slug.as_str()),
-            provider: self.provider.clone(),
-            reasoning_effort,
-            reasoning_summary: self.reasoning_summary,
-            session_source: self.session_source.clone(),
-            parent_thread_id: self.parent_thread_id,
-            originator: self.originator.clone(),
-            environments: self.environments.clone(),
-            #[allow(deprecated)]
-            cwd: self.cwd.clone(),
-            current_date: self.current_date.clone(),
-            timezone: self.timezone.clone(),
-            app_server_client_name: self.app_server_client_name.clone(),
-            developer_instructions: self.developer_instructions.clone(),
-            collaboration_mode,
-            multi_agent_version: self.multi_agent_version,
-            personality: self.personality,
-            approval_policy: self.approval_policy.clone(),
-            permission_profile: self.permission_profile.clone(),
-            network: self.network.clone(),
-            windows_sandbox_level: self.windows_sandbox_level,
-            available_models,
-            unified_exec_shell_mode: self.unified_exec_shell_mode.clone(),
-            final_output_json_schema: self.final_output_json_schema.clone(),
-            dynamic_tools: self.dynamic_tools.clone(),
-            turn_metadata_state: self.turn_metadata_state.clone(),
-            extension_data: Arc::clone(&self.extension_data),
-            turn_skills: self.turn_skills.clone(),
-            turn_timing_state: Arc::clone(&self.turn_timing_state),
-            terminal_error: Arc::clone(&self.terminal_error),
-            server_model_warning_emitted: AtomicBool::new(
-                self.server_model_warning_emitted.load(Ordering::Relaxed),
-            ),
-            model_verification_emitted: AtomicBool::new(
-                self.model_verification_emitted.load(Ordering::Relaxed),
-            ),
-        }
     }
 
     pub(crate) fn file_system_sandbox_context(
@@ -334,7 +212,7 @@ impl TurnContext {
         }
     }
 
-    fn non_legacy_file_system_sandbox_policy(&self) -> Option<FileSystemSandboxPolicy> {
+    pub(super) fn non_legacy_file_system_sandbox_policy(&self) -> Option<FileSystemSandboxPolicy> {
         // Omit the derived split filesystem policy when it is equivalent to
         // the legacy sandbox policy. This keeps turn-context payloads stable
         // while both fields exist; once callers consume only the split policy,
@@ -350,34 +228,7 @@ impl TurnContext {
             .then_some(file_system_sandbox_policy)
     }
 
-    pub(crate) fn to_turn_context_item(&self) -> TurnContextItem {
-        let workspace_roots = self.config.effective_workspace_roots();
-        #[allow(deprecated)]
-        let cwd = self.cwd.clone();
-        TurnContextItem {
-            turn_id: Some(self.sub_id.clone()),
-            cwd,
-            workspace_roots: (!workspace_roots.is_empty()).then_some(workspace_roots),
-            current_date: self.current_date.clone(),
-            timezone: self.timezone.clone(),
-            approval_policy: self.approval_policy.value(),
-            sandbox_policy: self.sandbox_policy(),
-            permission_profile: Some(self.permission_profile()),
-            network: self.turn_context_network_item(),
-            file_system_sandbox_policy: self.non_legacy_file_system_sandbox_policy(),
-            model: self.model_info.slug.clone(),
-            comp_hash: self.model_info.comp_hash.clone(),
-            personality: self.personality,
-            collaboration_mode: Some(self.collaboration_mode.clone()),
-            multi_agent_version: Some(self.multi_agent_version),
-            multi_agent_mode: super::multi_agents::effective_multi_agent_mode(self),
-            realtime_active: Some(self.realtime_active),
-            effort: self.reasoning_effort.clone(),
-            summary: ReasoningSummaryConfig::Auto,
-        }
-    }
-
-    fn turn_context_network_item(&self) -> Option<TurnContextNetworkItem> {
+    pub(super) fn turn_context_network_item(&self) -> Option<TurnContextNetworkItem> {
         let network = self
             .config
             .config_layer_stack
@@ -484,8 +335,7 @@ impl Session {
         cwd: AbsolutePathBuf,
         sub_id: String,
         skills_snapshot: HostSkillsSnapshot,
-    ) -> TurnContext {
-        let reasoning_effort = session_configuration.collaboration_mode.reasoning_effort();
+    ) -> (TurnContext, StepModelContext) {
         let reasoning_summary = session_configuration
             .model_reasoning_summary
             .unwrap_or(model_info.default_reasoning_summary);
@@ -496,7 +346,6 @@ impl Session {
         let session_source = session_configuration.session_source.clone();
         let auth_manager_for_context = auth_manager.clone();
         let provider_for_context = create_model_provider(provider, auth_manager);
-        let session_telemetry_for_context = session_telemetry;
         let available_models = models_manager.try_list_models().unwrap_or_default();
         let unified_exec_shell_mode = UnifiedExecShellMode::for_session(
             codex_tools::unified_exec_feature_mode_for_features(per_turn_config.features.get()),
@@ -505,9 +354,8 @@ impl Session {
             main_execve_wrapper_exe,
         );
 
-        let mut per_turn_config = per_turn_config;
-        per_turn_config.service_tier = get_service_tier(
-            per_turn_config.service_tier,
+        let service_tier = get_service_tier(
+            per_turn_config.service_tier.clone(),
             per_turn_config.features.enabled(Feature::FastMode),
             &model_info,
         );
@@ -528,17 +376,13 @@ impl Session {
         let (current_date, timezone) = local_time_context();
         let extension_data = Arc::new(codex_extension_api::ExtensionData::new(sub_id.clone()));
         extension_data.insert(skills_snapshot.clone());
-        TurnContext {
+        let turn_context = TurnContext {
             sub_id,
             trace_id: current_span_trace_id(),
             realtime_active: false,
             config: per_turn_config,
             auth_manager: auth_manager_for_context,
-            model_info,
-            session_telemetry: session_telemetry_for_context,
             provider: provider_for_context,
-            reasoning_effort,
-            reasoning_summary,
             session_source,
             parent_thread_id: session_configuration.parent_thread_id,
             originator: session_configuration.originator.clone(),
@@ -549,7 +393,6 @@ impl Session {
             timezone: Some(timezone),
             app_server_client_name: session_configuration.app_server_client_name.clone(),
             developer_instructions: session_configuration.developer_instructions.clone(),
-            collaboration_mode: session_configuration.collaboration_mode.clone(),
             multi_agent_version,
             personality: session_configuration.personality,
             approval_policy: session_configuration.approval_policy.clone(),
@@ -565,16 +408,24 @@ impl Session {
             turn_skills: TurnSkillsContext::new(skills_snapshot),
             turn_timing_state: Arc::new(TurnTimingState::default()),
             terminal_error: Arc::new(Mutex::new(None)),
+        };
+        let model_context = StepModelContext {
+            model_info,
+            collaboration_mode: session_configuration.collaboration_mode.clone(),
+            reasoning_summary,
+            service_tier,
+            session_telemetry,
             server_model_warning_emitted: AtomicBool::new(false),
             model_verification_emitted: AtomicBool::new(false),
-        }
+        };
+        (turn_context, model_context)
     }
 
     pub(crate) async fn new_turn_with_sub_id(
         &self,
         sub_id: String,
         updates: SessionSettingsUpdate,
-    ) -> CodexResult<Arc<TurnContext>> {
+    ) -> CodexResult<StepContextSeed> {
         let notify_config_contributors = !self.services.extensions.config_contributors().is_empty();
         let update_result: CodexResult<_> = {
             let mut state = self.state.lock().await;
@@ -644,7 +495,7 @@ impl Session {
         sub_id: String,
         session_configuration: SessionConfiguration,
         final_output_json_schema: Option<Option<Value>>,
-    ) -> Arc<TurnContext> {
+    ) -> StepContextSeed {
         self.new_turn_context_from_configuration(
             sub_id,
             session_configuration,
@@ -658,7 +509,7 @@ impl Session {
         &self,
         sub_id: String,
         session_configuration: SessionConfiguration,
-    ) -> Arc<TurnContext> {
+    ) -> StepContextSeed {
         self.new_turn_context_from_configuration(
             sub_id,
             session_configuration,
@@ -675,7 +526,7 @@ impl Session {
         session_configuration: SessionConfiguration,
         final_output_json_schema: Option<Option<Value>>,
         multi_agent_runtime: TurnMultiAgentRuntime,
-    ) -> Arc<TurnContext> {
+    ) -> StepContextSeed {
         let turn_environments = self.services.turn_environments.snapshot().await;
         let primary_turn_environment = turn_environments.primary().cloned();
         // TODO(anp): Migrate per-turn config and legacy TurnContext cwd consumers to PathUri so
@@ -701,10 +552,6 @@ impl Session {
                 &per_turn_config.to_models_manager_config(),
             )
             .await;
-        self.services
-            .thread_extension_data
-            .insert(model_info.clone());
-
         let multi_agent_version = match multi_agent_runtime {
             TurnMultiAgentRuntime::ResolveAndStore => {
                 self.resolve_multi_agent_version_for_model(&model_info, &per_turn_config)
@@ -734,7 +581,7 @@ impl Session {
             .skills_service
             .snapshot_for_config(&skills_input, fs)
             .await;
-        let mut turn_context: TurnContext = Self::make_turn_context(
+        let (mut turn_context, model_context) = Self::make_turn_context(
             self.thread_id(),
             self.session_id(),
             Some(Arc::clone(&self.services.auth_manager)),
@@ -776,17 +623,19 @@ impl Session {
         {
             turn_context.turn_metadata_state.spawn_git_enrichment_task();
         }
-        turn_context
+        StepContextSeed::new(turn_context, Arc::new(model_context))
     }
 
-    pub(crate) async fn maybe_emit_model_warnings_for_turn(&self, tc: &TurnContext) {
-        if tc.model_info.used_fallback_model_metadata {
+    pub(crate) async fn maybe_emit_model_warnings_for_turn(&self, seed: &StepContextSeed) {
+        let turn = seed.turn.as_ref();
+        let model = seed.model.as_ref();
+        if model.model_info.used_fallback_model_metadata {
             self.send_event(
-                tc,
+                turn,
                 EventMsg::Warning(WarningEvent {
                     message: format!(
                         "Model metadata for `{}` not found. Defaulting to fallback metadata; this can degrade performance and cause issues.",
-                        tc.model_info.slug
+                        model.model_info.slug
                     ),
                 }),
             )
@@ -794,19 +643,19 @@ impl Session {
         }
 
         if let Some(message) =
-            unsupported_code_mode_warning(&tc.model_info, tc.config.features.get())
+            unsupported_code_mode_warning(&model.model_info, turn.config.features.get())
         {
-            self.send_event(tc, EventMsg::Warning(WarningEvent { message }))
+            self.send_event(turn, EventMsg::Warning(WarningEvent { message }))
                 .await;
         }
     }
 
-    pub(crate) async fn new_default_turn(&self) -> Arc<TurnContext> {
+    pub(crate) async fn new_default_turn(&self) -> StepContextSeed {
         self.new_default_turn_with_sub_id(self.next_internal_sub_id())
             .await
     }
 
-    pub(crate) async fn new_default_turn_with_sub_id(&self, sub_id: String) -> Arc<TurnContext> {
+    pub(crate) async fn new_default_turn_with_sub_id(&self, sub_id: String) -> StepContextSeed {
         let session_configuration = self.default_turn_configuration().await;
         self.new_turn_from_configuration(
             sub_id,
@@ -819,7 +668,7 @@ impl Session {
     pub(crate) async fn new_startup_prewarm_turn_with_sub_id(
         &self,
         sub_id: String,
-    ) -> Arc<TurnContext> {
+    ) -> StepContextSeed {
         let session_configuration = self.default_turn_configuration().await;
         self.new_startup_prewarm_turn_from_configuration(sub_id, session_configuration)
             .await

--- a/codex-rs/core/src/session/world_state.rs
+++ b/codex-rs/core/src/session/world_state.rs
@@ -66,6 +66,7 @@ impl Session {
                 .contribute_world_state(WorldStateContributionInput {
                     thread_id: self.thread_id(),
                     turn_id: turn_context.sub_id.as_str(),
+                    model_info: &step_context.model.model_info,
                     environments: &environments,
                     ready_selected_capability_roots: &ready_selected_capability_roots,
                     session_store: &self.services.session_extension_data,

--- a/codex-rs/core/src/session_startup_prewarm.rs
+++ b/codex-rs/core/src/session_startup_prewarm.rs
@@ -243,21 +243,24 @@ async fn schedule_startup_prewarm_inner(
     base_instructions: String,
 ) -> CodexResult<ModelClientSession> {
     let prewarm_started_at = Instant::now();
-    let startup_turn_context = session
+    let startup_step_context_seed = session
         .new_startup_prewarm_turn_with_sub_id(INITIAL_SUBMIT_ID.to_owned())
         .await;
-    startup_turn_context.session_telemetry.record_startup_phase(
-        "startup_prewarm_create_turn_context",
-        prewarm_started_at.elapsed(),
-        /*status*/ None,
-    );
-    if routes_approval_to_guardian(&startup_turn_context) {
+    startup_step_context_seed
+        .model
+        .session_telemetry
+        .record_startup_phase(
+            "startup_prewarm_create_turn_context",
+            prewarm_started_at.elapsed(),
+            /*status*/ None,
+        );
+    if routes_approval_to_guardian(startup_step_context_seed.turn.as_ref()) {
         let guardian_session = Arc::clone(&session);
-        let guardian_parent_turn = Arc::clone(&startup_turn_context);
+        let guardian_parent_step_context = startup_step_context_seed.clone();
         drop(tokio::spawn(async move {
             if let Err(err) = guardian_session
                 .guardian_review_session
-                .initialize(Arc::clone(&guardian_session), guardian_parent_turn)
+                .initialize(Arc::clone(&guardian_session), guardian_parent_step_context)
                 .await
             {
                 warn!("failed to initialize guardian review session: {err:#}");
@@ -268,7 +271,7 @@ async fn schedule_startup_prewarm_inner(
     let built_tools_started_at = Instant::now();
     // Startup prewarm runs before run_turn and needs its own tool-building snapshot.
     let step_context = session
-        .capture_step_context(Arc::clone(&startup_turn_context))
+        .capture_step_context(&startup_step_context_seed)
         .await;
     let startup_router = built_tools(
         session.as_ref(),
@@ -276,27 +279,34 @@ async fn schedule_startup_prewarm_inner(
         &startup_cancellation_token,
     )
     .await?;
-    startup_turn_context.session_telemetry.record_startup_phase(
-        "startup_prewarm_build_tools",
-        built_tools_started_at.elapsed(),
-        /*status*/ None,
-    );
+    startup_step_context_seed
+        .model
+        .session_telemetry
+        .record_startup_phase(
+            "startup_prewarm_build_tools",
+            built_tools_started_at.elapsed(),
+            /*status*/ None,
+        );
     let build_prompt_started_at = Instant::now();
     let startup_prompt = build_prompt(
         Vec::new(),
         startup_router.as_ref(),
-        startup_turn_context.as_ref(),
+        step_context.as_ref(),
         BaseInstructions {
             text: base_instructions,
         },
     );
-    startup_turn_context.session_telemetry.record_startup_phase(
-        "startup_prewarm_build_prompt",
-        build_prompt_started_at.elapsed(),
-        /*status*/ None,
-    );
+    startup_step_context_seed
+        .model
+        .session_telemetry
+        .record_startup_phase(
+            "startup_prewarm_build_prompt",
+            build_prompt_started_at.elapsed(),
+            /*status*/ None,
+        );
     let window_id = session.current_window_id().await;
-    let responses_metadata = startup_turn_context
+    let responses_metadata = startup_step_context_seed
+        .turn
         .turn_metadata_state
         .to_responses_metadata(
             session.installation_id.clone(),
@@ -308,18 +318,21 @@ async fn schedule_startup_prewarm_inner(
     client_session
         .prewarm_websocket(
             &startup_prompt,
-            &startup_turn_context.model_info,
-            &startup_turn_context.session_telemetry,
-            startup_turn_context.reasoning_effort.clone(),
-            startup_turn_context.reasoning_summary,
-            startup_turn_context.config.service_tier.clone(),
+            &startup_step_context_seed.model.model_info,
+            &startup_step_context_seed.model.session_telemetry,
+            startup_step_context_seed.model.reasoning_effort(),
+            startup_step_context_seed.model.reasoning_summary,
+            startup_step_context_seed.model.service_tier.clone(),
             &responses_metadata,
         )
         .await?;
-    startup_turn_context.session_telemetry.record_startup_phase(
-        "startup_prewarm_websocket_warmup",
-        websocket_warmup_started_at.elapsed(),
-        /*status*/ None,
-    );
+    startup_step_context_seed
+        .model
+        .session_telemetry
+        .record_startup_phase(
+            "startup_prewarm_websocket_warmup",
+            websocket_warmup_started_at.elapsed(),
+            /*status*/ None,
+        );
     Ok(client_session)
 }

--- a/codex-rs/core/src/skills.rs
+++ b/codex-rs/core/src/skills.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use crate::session::session::Session;
-use crate::session::turn_context::TurnContext;
+use crate::session::step_context::StepContext;
 use codex_analytics::InvocationType;
 use codex_analytics::SkillInvocation;
 use codex_analytics::build_track_events_context;
@@ -47,10 +47,11 @@ pub(crate) fn skills_load_input_from_config(
 
 pub(crate) async fn maybe_emit_implicit_skill_invocation(
     sess: &Session,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     command: &str,
     workdir: &AbsolutePathBuf,
 ) {
+    let turn_context = step_context.turn.as_ref();
     let Some(candidate) = detect_implicit_skill_invocation_for_command(
         turn_context.turn_skills.snapshot.outcome(),
         command,
@@ -86,7 +87,7 @@ pub(crate) async fn maybe_emit_implicit_skill_invocation(
         return;
     }
 
-    turn_context.session_telemetry.counter(
+    step_context.model.session_telemetry.counter(
         "codex.skill.injected",
         /*inc*/ 1,
         &[
@@ -99,7 +100,7 @@ pub(crate) async fn maybe_emit_implicit_skill_invocation(
         .analytics_events_client
         .track_skill_invocations(
             build_track_events_context(
-                turn_context.model_info.slug.clone(),
+                step_context.model.model_info.slug.clone(),
                 sess.thread_id.to_string(),
                 turn_context.sub_id.clone(),
                 turn_context.originator.clone(),

--- a/codex-rs/core/src/state/turn.rs
+++ b/codex-rs/core/src/state/turn.rs
@@ -20,7 +20,7 @@ use tokio::sync::oneshot;
 
 use crate::agent::control::AgentExecutionGuard;
 use crate::session::TurnInputQueue;
-use crate::session::turn_context::TurnContext;
+use crate::session::step_context::StepContextSeed;
 use crate::tasks::AnySessionTask;
 use codex_protocol::models::AdditionalPermissionProfile;
 use codex_protocol::protocol::ReviewDecision;
@@ -75,7 +75,7 @@ pub(crate) struct RunningTask {
     pub(crate) task: Arc<dyn AnySessionTask>,
     pub(crate) cancellation_token: CancellationToken,
     pub(crate) handle: AbortOnDropHandle<()>,
-    pub(crate) turn_context: Arc<TurnContext>,
+    pub(crate) step_context_seed: StepContextSeed,
     pub(crate) turn_extension_data: Arc<ExtensionData>,
     pub(crate) _agent_execution_guard: Option<AgentExecutionGuard>,
     // Timer recorded when the task drops to capture the full turn duration.

--- a/codex-rs/core/src/stream_events_utils.rs
+++ b/codex-rs/core/src/stream_events_utils.rs
@@ -15,6 +15,7 @@ use crate::context::ImageGenerationInstructions;
 use crate::function_tool::FunctionCallError;
 use crate::parse_turn_item;
 use crate::session::session::Session;
+use crate::session::step_context::StepContext;
 use crate::session::turn_context::TurnContext;
 use crate::tools::parallel::ToolCallRuntime;
 use crate::tools::router::ToolRouter;
@@ -167,9 +168,10 @@ pub(crate) async fn persist_image_generation_item(
 
 async fn record_image_generation_instructions(
     sess: &Session,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     image_item: &ImageGenerationItem,
 ) {
+    let turn_context = step_context.turn.as_ref();
     if image_item.saved_path.is_none() {
         return;
     }
@@ -183,19 +185,19 @@ async fn record_image_generation_instructions(
         image_output_dir.display(),
         image_output_path.display(),
     ));
-    sess.record_conversation_items(turn_context, &[message])
+    sess.record_conversation_items(step_context, &[message])
         .await;
 }
 
 /// Persist a completed model response item and record any cited memory usage.
 pub(crate) async fn record_completed_response_item(
     sess: &Session,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     item: &ResponseItem,
 ) {
     record_completed_response_item_with_finalized_facts(
         sess,
-        turn_context,
+        step_context,
         item,
         /*finalized_facts*/ None,
     )
@@ -204,17 +206,18 @@ pub(crate) async fn record_completed_response_item(
 
 pub(crate) async fn record_completed_response_item_with_finalized_facts(
     sess: &Session,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     item: &ResponseItem,
     finalized_facts: Option<&FinalizedTurnItemFacts>,
 ) {
-    sess.record_conversation_items(turn_context, std::slice::from_ref(item))
+    let turn_context = step_context.turn.as_ref();
+    sess.record_conversation_items(step_context, std::slice::from_ref(item))
         .await;
     let defers_mailbox_delivery = finalized_facts.map_or_else(
         || {
             completed_item_defers_mailbox_delivery_to_next_turn(
                 item,
-                turn_context.collaboration_mode.mode == ModeKind::Plan,
+                step_context.model.collaboration_mode.mode == ModeKind::Plan,
             )
         },
         |facts| facts.defers_mailbox_delivery_to_next_turn,
@@ -315,7 +318,7 @@ pub(crate) struct OutputItemResult {
 
 pub(crate) struct HandleOutputCtx {
     pub sess: Arc<Session>,
-    pub turn_context: Arc<TurnContext>,
+    pub step_context: Arc<StepContext>,
     pub turn_store: Arc<ExtensionData>,
     pub tool_runtime: ToolCallRuntime,
     pub cancellation_token: CancellationToken,
@@ -356,13 +359,13 @@ pub(crate) struct FinalizedTurnItemFacts {
 
 pub(crate) async fn finalize_non_tool_response_item(
     sess: &Session,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     contributor_policy: TurnItemContributorPolicy<'_>,
     item: &ResponseItem,
     plan_mode: bool,
 ) -> Option<FinalizedTurnItem> {
     let turn_item =
-        handle_non_tool_response_item(sess, turn_context, contributor_policy, item, plan_mode)
+        handle_non_tool_response_item(sess, step_context, contributor_policy, item, plan_mode)
             .await?;
     let (memory_citation, last_agent_message, defers_mailbox_delivery_to_next_turn) =
         match &turn_item {
@@ -408,7 +411,8 @@ pub(crate) async fn handle_output_item_done(
     previously_active_item: Option<TurnItem>,
 ) -> Result<OutputItemResult> {
     let mut output = OutputItemResult::default();
-    let plan_mode = ctx.turn_context.collaboration_mode.mode == ModeKind::Plan;
+    let turn_context = &ctx.step_context.turn;
+    let plan_mode = ctx.step_context.model.collaboration_mode.mode == ModeKind::Plan;
 
     match ToolRouter::build_tool_call(item.clone()) {
         // The model emitted a tool call; log it, persist the item immediately, and queue the tool execution.
@@ -417,7 +421,7 @@ pub(crate) async fn handle_output_item_done(
                 .input_queue
                 .accept_mailbox_delivery_for_current_turn(
                     &ctx.sess.active_turn,
-                    &ctx.turn_context.sub_id,
+                    &turn_context.sub_id,
                 )
                 .await;
 
@@ -429,7 +433,7 @@ pub(crate) async fn handle_output_item_done(
                 payload_preview
             );
 
-            record_completed_response_item(ctx.sess.as_ref(), ctx.turn_context.as_ref(), &item)
+            record_completed_response_item(ctx.sess.as_ref(), ctx.step_context.as_ref(), &item)
                 .await;
 
             let cancellation_token = ctx.cancellation_token.child_token();
@@ -446,7 +450,7 @@ pub(crate) async fn handle_output_item_done(
         Ok(None) => {
             let finalized_turn_item = finalize_non_tool_response_item(
                 ctx.sess.as_ref(),
-                ctx.turn_context.as_ref(),
+                ctx.step_context.as_ref(),
                 TurnItemContributorPolicy::Run(ctx.turn_store.as_ref()),
                 &item,
                 plan_mode,
@@ -465,17 +469,21 @@ pub(crate) async fn handle_output_item_done(
                         item.saved_path = None;
                     }
                     ctx.sess
-                        .emit_turn_item_started(&ctx.turn_context, &started_item)
+                        .emit_turn_item_started(turn_context, &started_item)
                         .await;
                 }
 
                 ctx.sess
-                    .emit_turn_item_completed(&ctx.turn_context, finalized_turn_item.turn_item)
+                    .emit_turn_item_completed(
+                        turn_context,
+                        ctx.step_context.model.as_ref(),
+                        finalized_turn_item.turn_item,
+                    )
                     .await;
             }
             record_completed_response_item_with_finalized_facts(
                 ctx.sess.as_ref(),
-                ctx.turn_context.as_ref(),
+                ctx.step_context.as_ref(),
                 &item,
                 finalized_facts.as_ref(),
             )
@@ -492,12 +500,12 @@ pub(crate) async fn handle_output_item_done(
                     ..Default::default()
                 },
             };
-            record_completed_response_item(ctx.sess.as_ref(), ctx.turn_context.as_ref(), &item)
+            record_completed_response_item(ctx.sess.as_ref(), ctx.step_context.as_ref(), &item)
                 .await;
             if let Some(response_item) = response_input_to_response_item(&response) {
                 ctx.sess
                     .record_conversation_items(
-                        &ctx.turn_context,
+                        ctx.step_context.as_ref(),
                         std::slice::from_ref(&response_item),
                     )
                     .await;
@@ -516,7 +524,7 @@ pub(crate) async fn handle_output_item_done(
 
 pub(crate) async fn handle_non_tool_response_item(
     sess: &Session,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     contributor_policy: TurnItemContributorPolicy<'_>,
     item: &ResponseItem,
     plan_mode: bool,
@@ -531,14 +539,14 @@ pub(crate) async fn handle_non_tool_response_item(
             let mut turn_item = parse_turn_item(item)?;
             finalize_turn_item(
                 sess,
-                turn_context,
+                step_context,
                 contributor_policy,
                 &mut turn_item,
                 plan_mode,
             )
             .await;
             if let TurnItem::ImageGeneration(image_item) = &turn_item {
-                record_image_generation_instructions(sess, turn_context, image_item).await;
+                record_image_generation_instructions(sess, step_context, image_item).await;
             }
             Some(turn_item)
         }
@@ -554,11 +562,12 @@ pub(crate) async fn handle_non_tool_response_item(
 
 pub(crate) async fn finalize_turn_item(
     sess: &Session,
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     contributor_policy: TurnItemContributorPolicy<'_>,
     turn_item: &mut TurnItem,
     plan_mode: bool,
 ) {
+    let turn_context = step_context.turn.as_ref();
     if let TurnItemContributorPolicy::Run(turn_store) = contributor_policy {
         apply_turn_item_contributors(sess, turn_store, turn_item).await;
     }

--- a/codex-rs/core/src/stream_events_utils_tests.rs
+++ b/codex-rs/core/src/stream_events_utils_tests.rs
@@ -140,13 +140,14 @@ fn external_context_pollution_items_exclude_local_tool_calls() {
 #[tokio::test]
 async fn handle_non_tool_response_item_strips_citations_from_assistant_message() {
     let (session, turn_context) = make_session_and_context().await;
+    let step_context = StepContext::for_test(Arc::new(turn_context));
     let item = assistant_output_text(
         "hello<oai-mem-citation><citation_entries>\nMEMORY.md:1-2|note=[x]\n</citation_entries>\n<rollout_ids>\n019cc2ea-1dff-7902-8d40-c8f6e5d83cc4\n</rollout_ids></oai-mem-citation> world",
     );
 
     let turn_item = handle_non_tool_response_item(
         &session,
-        &turn_context,
+        step_context.as_ref(),
         TurnItemContributorPolicy::Skip,
         &item,
         /*plan_mode*/ false,
@@ -228,13 +229,14 @@ async fn handle_non_tool_response_item_runs_turn_item_contributors_only_when_req
     builder.turn_item_contributor(Arc::new(TestTurnItemContributor));
     session.services.extensions = Arc::new(builder.build());
     let turn_store = ExtensionData::new(turn_context.sub_id.clone());
+    let step_context = StepContext::for_test(Arc::new(turn_context));
     let item = assistant_output_text(
         "hello<oai-mem-citation>ignored by memory parser</oai-mem-citation> world",
     );
 
     let provisional_turn_item = handle_non_tool_response_item(
         &session,
-        &turn_context,
+        step_context.as_ref(),
         TurnItemContributorPolicy::Skip,
         &item,
         /*plan_mode*/ false,
@@ -250,7 +252,7 @@ async fn handle_non_tool_response_item_runs_turn_item_contributors_only_when_req
 
     let turn_item = handle_non_tool_response_item(
         &session,
-        &turn_context,
+        step_context.as_ref(),
         TurnItemContributorPolicy::Run(&turn_store),
         &item,
         /*plan_mode*/ false,
@@ -294,11 +296,16 @@ async fn handle_output_item_done_returns_contributed_last_agent_message() {
         &Default::default(),
     ));
     let tracker = Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new()));
-    let tool_runtime = ToolCallRuntime::new(router, Arc::clone(&session), step_context, tracker);
+    let tool_runtime = ToolCallRuntime::new(
+        router,
+        Arc::clone(&session),
+        Arc::clone(&step_context),
+        tracker,
+    );
     let item = assistant_output_text("original assistant text");
     let mut ctx = HandleOutputCtx {
         sess: session,
-        turn_context: Arc::clone(&turn_context),
+        step_context,
         turn_store: Arc::new(ExtensionData::new(turn_context.sub_id.clone())),
         tool_runtime,
         cancellation_token: CancellationToken::new(),
@@ -321,11 +328,12 @@ async fn finalized_turn_item_defers_mailbox_for_contributed_visible_text() {
     builder.turn_item_contributor(Arc::new(RewriteAgentMessageContributor));
     session.services.extensions = Arc::new(builder.build());
     let turn_store = ExtensionData::new(turn_context.sub_id.clone());
+    let step_context = StepContext::for_test(Arc::new(turn_context));
     let item = assistant_output_text("<oai-mem-citation>hidden only</oai-mem-citation>");
 
     let finalized = finalize_non_tool_response_item(
         &session,
-        &turn_context,
+        step_context.as_ref(),
         TurnItemContributorPolicy::Run(&turn_store),
         &item,
         /*plan_mode*/ false,
@@ -347,11 +355,12 @@ async fn finalized_turn_item_keeps_mailbox_open_for_commentary_text() {
     builder.turn_item_contributor(Arc::new(RewriteAgentMessageContributor));
     session.services.extensions = Arc::new(builder.build());
     let turn_store = ExtensionData::new(turn_context.sub_id.clone());
+    let step_context = StepContext::for_test(Arc::new(turn_context));
     let item = assistant_output_text_with_phase("still working", Some(MessagePhase::Commentary));
 
     let finalized = finalize_non_tool_response_item(
         &session,
-        &turn_context,
+        step_context.as_ref(),
         TurnItemContributorPolicy::Run(&turn_store),
         &item,
         /*plan_mode*/ false,

--- a/codex-rs/core/src/tasks/compact.rs
+++ b/codex-rs/core/src/tasks/compact.rs
@@ -5,7 +5,7 @@ use super::SessionTaskContext;
 use super::SessionTaskResult;
 use super::emit_compact_metric;
 use crate::session::TurnInput;
-use crate::session::turn_context::TurnContext;
+use crate::session::step_context::StepContextSeed;
 use crate::state::TaskKind;
 use codex_features::Feature;
 use codex_protocol::error::CodexErr;
@@ -27,18 +27,19 @@ impl SessionTask for CompactTask {
     async fn run(
         self: Arc<Self>,
         session: Arc<SessionTaskContext>,
-        ctx: Arc<TurnContext>,
+        ctx: StepContextSeed,
         _input: Vec<TurnInput>,
         _cancellation_token: CancellationToken,
     ) -> SessionTaskResult {
         let session = session.clone_session();
-        if ctx.config.features.enabled(Feature::TokenBudget) {
+        if ctx.turn.config.features.enabled(Feature::TokenBudget) {
             crate::compact_token_budget::run_manual_compact_task(session, ctx).await?;
             return Ok(None);
         }
 
-        let result = if crate::compact::should_use_remote_compact_task(ctx.provider.info()) {
+        let result = if crate::compact::should_use_remote_compact_task(ctx.turn.provider.info()) {
             if ctx
+                .turn
                 .config
                 .features
                 .enabled(codex_features::Feature::RemoteCompactionV2)
@@ -65,6 +66,7 @@ impl SessionTask for CompactTask {
             );
             let input = vec![UserInput::Text {
                 text: ctx
+                    .turn
                     .config
                     .compact_prompt
                     .as_deref()

--- a/codex-rs/core/src/tasks/lifecycle.rs
+++ b/codex-rs/core/src/tasks/lifecycle.rs
@@ -4,19 +4,21 @@ use codex_protocol::protocol::TokenUsage;
 use codex_protocol::protocol::TurnAbortReason;
 
 use crate::session::session::Session;
+use crate::session::step_context::StepContextSeed;
 use crate::session::turn_context::TurnContext;
 
 impl Session {
     pub(super) async fn emit_turn_start_lifecycle(
         &self,
-        turn_context: &TurnContext,
+        step_context_seed: &StepContextSeed,
         token_usage_at_turn_start: &TokenUsage,
     ) {
+        let turn_context = step_context_seed.turn.as_ref();
         for contributor in self.services.extensions.turn_lifecycle_contributors() {
             contributor
                 .on_turn_start(codex_extension_api::TurnStartInput {
                     turn_id: turn_context.sub_id.as_str(),
-                    collaboration_mode: &turn_context.collaboration_mode,
+                    collaboration_mode: &step_context_seed.model.collaboration_mode,
                     token_usage_at_turn_start,
                     session_store: &self.services.session_extension_data,
                     thread_store: &self.services.thread_extension_data,

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -30,7 +30,7 @@ use crate::hook_runtime::record_additional_contexts;
 use crate::hook_runtime::record_pending_input;
 use crate::session::TurnInput;
 use crate::session::session::Session;
-use crate::session::turn_context::TurnContext;
+use crate::session::step_context::StepContextSeed;
 use crate::state::ActiveTurn;
 use crate::state::RunningTask;
 use crate::state::TaskKind;
@@ -232,7 +232,7 @@ pub(crate) trait SessionTask: Send + Sync + 'static {
     fn run(
         self: Arc<Self>,
         session: Arc<SessionTaskContext>,
-        ctx: Arc<TurnContext>,
+        ctx: StepContextSeed,
         input: Vec<TurnInput>,
         cancellation_token: CancellationToken,
     ) -> impl std::future::Future<Output = SessionTaskResult> + Send;
@@ -245,7 +245,7 @@ pub(crate) trait SessionTask: Send + Sync + 'static {
     fn abort(
         &self,
         session: Arc<SessionTaskContext>,
-        ctx: Arc<TurnContext>,
+        ctx: StepContextSeed,
     ) -> impl std::future::Future<Output = ()> + Send {
         async move {
             let _ = (session, ctx);
@@ -261,7 +261,7 @@ pub(crate) trait AnySessionTask: Send + Sync + 'static {
     fn run(
         self: Arc<Self>,
         session: Arc<SessionTaskContext>,
-        ctx: Arc<TurnContext>,
+        ctx: StepContextSeed,
         input: Vec<TurnInput>,
         cancellation_token: CancellationToken,
     ) -> BoxFuture<'static, SessionTaskResult>;
@@ -269,7 +269,7 @@ pub(crate) trait AnySessionTask: Send + Sync + 'static {
     fn abort<'a>(
         &'a self,
         session: Arc<SessionTaskContext>,
-        ctx: Arc<TurnContext>,
+        ctx: StepContextSeed,
     ) -> BoxFuture<'a, ()>;
 }
 
@@ -288,7 +288,7 @@ where
     fn run(
         self: Arc<Self>,
         session: Arc<SessionTaskContext>,
-        ctx: Arc<TurnContext>,
+        ctx: StepContextSeed,
         input: Vec<TurnInput>,
         cancellation_token: CancellationToken,
     ) -> BoxFuture<'static, SessionTaskResult> {
@@ -304,7 +304,7 @@ where
     fn abort<'a>(
         &'a self,
         session: Arc<SessionTaskContext>,
-        ctx: Arc<TurnContext>,
+        ctx: StepContextSeed,
     ) -> BoxFuture<'a, ()> {
         Box::pin(SessionTask::abort(self, session, ctx))
     }
@@ -313,21 +313,23 @@ where
 impl Session {
     pub async fn spawn_task<T: SessionTask>(
         self: &Arc<Self>,
-        turn_context: Arc<TurnContext>,
+        step_context_seed: StepContextSeed,
         input: Vec<TurnInput>,
         task: T,
     ) {
         self.abort_all_tasks(TurnAbortReason::Replaced).await;
         self.clear_connector_selection().await;
-        self.start_task(turn_context, input, task).await;
+        self.start_task(step_context_seed, input, task).await;
     }
 
     pub(crate) async fn start_task<T: SessionTask>(
         self: &Arc<Self>,
-        turn_context: Arc<TurnContext>,
+        step_context_seed: StepContextSeed,
         input: Vec<TurnInput>,
         task: T,
     ) {
+        let turn_context = &step_context_seed.turn;
+        let model_context = &step_context_seed.model;
         let task: Arc<dyn AnySessionTask> = Arc::new(task);
         let task_kind = task.kind();
         let span_name = task.span_name();
@@ -361,7 +363,7 @@ impl Session {
         self.input_queue
             .extend_pending_input_for_turn_state(turn_state.as_ref(), pending_items)
             .await;
-        self.emit_turn_start_lifecycle(turn_context.as_ref(), &token_usage_at_turn_start)
+        self.emit_turn_start_lifecycle(&step_context_seed, &token_usage_at_turn_start)
             .await;
 
         let turn_extension_data = Arc::clone(&turn_context.extension_data);
@@ -377,19 +379,19 @@ impl Session {
             Arc::clone(self),
             Arc::clone(&turn_extension_data),
         ));
-        let ctx = Arc::clone(&turn_context);
+        let ctx = step_context_seed.clone();
         let task_for_run = Arc::clone(&task);
         let task_input = input;
         let task_cancellation_token = cancellation_token.child_token();
         // Task-owned turn spans keep a core-owned span open for the
         // full task lifecycle after the submission dispatch span ends.
-        let reasoning_effort = turn_context.effective_reasoning_effort_for_tracing();
+        let reasoning_effort = model_context.effective_reasoning_effort_for_tracing();
         let task_span = info_span!(
             "turn",
             otel.name = span_name,
             thread.id = %self.thread_id,
             turn.id = %turn_context.sub_id,
-            model = %turn_context.model_info.slug,
+            model = %model_context.model_info.slug,
             codex.turn.reasoning_effort = %reasoning_effort,
             codex.turn.token_usage.input_tokens = field::Empty,
             codex.turn.token_usage.cached_input_tokens = field::Empty,
@@ -400,7 +402,7 @@ impl Session {
         );
         let handle = tokio::spawn(
             async move {
-                let ctx_for_finish = Arc::clone(&ctx);
+                let ctx_for_finish = ctx.clone();
                 let task_result = task_for_run
                     .run(
                         Arc::clone(&session_ctx),
@@ -414,7 +416,7 @@ impl Session {
                 if let Err(err) = sess.flush_rollout().await {
                     warn!("failed to flush rollout before completing turn: {err}");
                     sess.send_event(
-                        ctx_for_finish.as_ref(),
+                        ctx_for_finish.turn.as_ref(),
                         EventMsg::Warning(WarningEvent {
                             message: format!(
                                 "Failed to save the conversation transcript; Codex will continue retrying. Error: {err}"
@@ -425,14 +427,14 @@ impl Session {
                 }
                 if !task_cancellation_token.is_cancelled() {
                     // Finish uniformly from the spawn site so all tasks share the same lifecycle.
-                    sess.on_task_finished(Arc::clone(&ctx_for_finish), task_result)
+                    sess.on_task_finished(ctx_for_finish.clone(), task_result)
                         .await;
                 }
                 done_clone.notify_waiters();
             }
             .instrument(task_span),
         );
-        let timer = turn_context
+        let timer = model_context
             .session_telemetry
             .start_timer(TURN_E2E_DURATION_METRIC, &[])
             .ok();
@@ -442,7 +444,7 @@ impl Session {
             kind: task_kind,
             task,
             cancellation_token,
-            turn_context: Arc::clone(&turn_context),
+            step_context_seed,
             turn_extension_data,
             _agent_execution_guard: agent_execution_guard,
             _timer: timer,
@@ -482,21 +484,21 @@ impl Session {
             *active_turn = Some(ActiveTurn::default());
         }
 
-        let turn_context = self.new_default_turn_with_sub_id(sub_id).await;
-        self.maybe_emit_model_warnings_for_turn(turn_context.as_ref())
+        let step_context_seed = self.new_default_turn_with_sub_id(sub_id).await;
+        self.maybe_emit_model_warnings_for_turn(&step_context_seed)
             .await;
-        self.start_task(turn_context, Vec::new(), RegularTask::new())
+        self.start_task(step_context_seed, Vec::new(), RegularTask::new())
             .await;
     }
 
     pub async fn abort_all_tasks(self: &Arc<Self>, reason: TurnAbortReason) {
         let mut aborted_turn = false;
         let mut active_turn_to_clear = None;
-        let mut turn_context = None;
+        let mut step_context_seed = None;
         if let Some(mut active_turn) = self.take_active_turn().await {
             let task = active_turn.task.take();
             aborted_turn = task.is_some();
-            turn_context = task.as_ref().map(|task| Arc::clone(&task.turn_context));
+            step_context_seed = task.as_ref().map(|task| task.step_context_seed.clone());
             if let Some(task) = task {
                 self.handle_task_abort(task, reason.clone()).await;
             }
@@ -505,9 +507,12 @@ impl Session {
             }
         }
 
-        if let Some(turn_context) = turn_context.as_deref() {
-            self.emit_turn_abort_lifecycle(reason.clone(), turn_context.extension_data.as_ref())
-                .await;
+        if let Some(step_context_seed) = step_context_seed.as_ref() {
+            self.emit_turn_abort_lifecycle(
+                reason.clone(),
+                step_context_seed.turn.extension_data.as_ref(),
+            )
+            .await;
         }
         if let Some(active_turn) = active_turn_to_clear {
             // Let interrupted tasks observe cancellation before dropping pending approvals, or an
@@ -529,7 +534,7 @@ impl Session {
             if active
                 .as_ref()
                 .and_then(|active_turn| active_turn.task.as_ref())
-                .is_some_and(|task| task.turn_context.sub_id == turn_id)
+                .is_some_and(|task| task.step_context_seed.turn.sub_id == turn_id)
             {
                 active.take()
             } else {
@@ -541,13 +546,16 @@ impl Session {
         };
 
         let task = active_turn.task.take();
-        let turn_context = task.as_ref().map(|task| Arc::clone(&task.turn_context));
+        let step_context_seed = task.as_ref().map(|task| task.step_context_seed.clone());
         if let Some(task) = task {
             self.handle_task_abort(task, reason.clone()).await;
         }
-        if let Some(turn_context) = turn_context.as_deref() {
-            self.emit_turn_abort_lifecycle(reason.clone(), turn_context.extension_data.as_ref())
-                .await;
+        if let Some(step_context_seed) = step_context_seed.as_ref() {
+            self.emit_turn_abort_lifecycle(
+                reason.clone(),
+                step_context_seed.turn.extension_data.as_ref(),
+            )
+            .await;
         }
         // Let interrupted tasks observe cancellation before dropping pending approvals, or an
         // in-flight approval wait can surface as a model-visible rejection before TurnAborted.
@@ -562,9 +570,10 @@ impl Session {
 
     pub async fn on_task_finished(
         self: &Arc<Self>,
-        turn_context: Arc<TurnContext>,
+        step_context_seed: StepContextSeed,
         task_result: SessionTaskResult,
     ) {
+        let turn_context = &step_context_seed.turn;
         let (last_agent_message, abort_reason) = match task_result {
             Ok(last_agent_message) => (last_agent_message, None),
             Err(CodexErr::TurnAborted) => (None, Some(TurnAbortReason::Interrupted)),
@@ -603,18 +612,18 @@ impl Session {
         if !pending_input.is_empty() {
             for pending_input_item in pending_input {
                 let hook_outcome =
-                    inspect_pending_input(self, &turn_context, &pending_input_item).await;
+                    inspect_pending_input(self, &step_context_seed, &pending_input_item).await;
                 if hook_outcome.should_stop {
                     record_additional_contexts(
                         self,
-                        &turn_context,
+                        &step_context_seed,
                         hook_outcome.additional_contexts,
                     )
                     .await;
                 } else {
                     record_pending_input(
                         self,
-                        &turn_context,
+                        &step_context_seed,
                         pending_input_item,
                         hook_outcome.additional_contexts,
                     )
@@ -827,14 +836,16 @@ impl Session {
     }
 
     async fn handle_task_abort(self: &Arc<Self>, task: RunningTask, reason: TurnAbortReason) {
-        let sub_id = task.turn_context.sub_id.clone();
+        let step_context_seed = task.step_context_seed.clone();
+        let turn_context = &step_context_seed.turn;
+        let sub_id = turn_context.sub_id.clone();
         if task.cancellation_token.is_cancelled() {
             return;
         }
 
         trace!(task_kind = ?task.kind, sub_id, "aborting running task");
         task.cancellation_token.cancel();
-        task.turn_context
+        turn_context
             .turn_metadata_state
             .cancel_git_enrichment_task();
         let session_task = task.task;
@@ -854,19 +865,19 @@ impl Session {
             Arc::clone(&task.turn_extension_data),
         ));
         session_task
-            .abort(session_ctx, Arc::clone(&task.turn_context))
+            .abort(session_ctx, step_context_seed.clone())
             .await;
 
         if reason == TurnAbortReason::Interrupted
             && let Some(marker) = interrupted_turn_history_marker(
                 InterruptedTurnHistoryMarker::from_config_and_version(
-                    task.turn_context.config.as_ref(),
-                    task.turn_context.multi_agent_version,
+                    turn_context.config.as_ref(),
+                    turn_context.multi_agent_version,
                 ),
             )
         {
-            self.record_conversation_items(
-                task.turn_context.as_ref(),
+            self.record_conversation_items_for_seed(
+                &step_context_seed,
                 std::slice::from_ref(&marker),
             )
             .await;
@@ -877,29 +888,28 @@ impl Session {
             }
         }
 
-        let (completed_at, duration_ms) = task
-            .turn_context
+        let (completed_at, duration_ms) = turn_context
             .turn_timing_state
             .completed_at_and_duration_ms()
             .await;
         self.services
             .analytics_events_client
             .track_turn_profile(TurnProfileFact {
-                turn_id: task.turn_context.sub_id.clone(),
-                profile: task.turn_context.turn_timing_state.complete_profile(),
+                turn_id: turn_context.sub_id.clone(),
+                profile: turn_context.turn_timing_state.complete_profile(),
             });
         let event = EventMsg::TurnAborted(TurnAbortedEvent {
-            turn_id: Some(task.turn_context.sub_id.clone()),
+            turn_id: Some(turn_context.sub_id.clone()),
             reason,
             completed_at,
             duration_ms,
         });
-        self.send_event(task.turn_context.as_ref(), event).await;
+        self.send_event(turn_context.as_ref(), event).await;
         self.services
             .guardian_rejection_circuit_breaker
             .lock()
             .await
-            .clear_turn(&task.turn_context.sub_id);
+            .clear_turn(&turn_context.sub_id);
         // Regular items were flushed before this terminal event was appended; buffering
         // thread writers may not flush it without another explicit barrier.
         if let Err(err) = self.flush_rollout().await {

--- a/codex-rs/core/src/tasks/regular.rs
+++ b/codex-rs/core/src/tasks/regular.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 use crate::session::TurnInput;
+use crate::session::step_context::StepContextSeed;
 use crate::session::turn::run_turn;
-use crate::session::turn_context::TurnContext;
 use crate::session_startup_prewarm::SessionStartupPrewarmResolution;
 use crate::state::TaskKind;
 use codex_protocol::protocol::EventMsg;
@@ -37,24 +37,26 @@ impl SessionTask for RegularTask {
     async fn run(
         self: Arc<Self>,
         session: Arc<SessionTaskContext>,
-        ctx: Arc<TurnContext>,
+        ctx: StepContextSeed,
         input: Vec<TurnInput>,
         cancellation_token: CancellationToken,
     ) -> SessionTaskResult {
         let sess = session.clone_session();
+        let turn_context = &ctx.turn;
+        let model_context = &ctx.model;
         let turn_extension_data = session.turn_extension_data();
         let run_turn_span = trace_span!("run_turn");
         // Regular turns emit `TurnStarted` inline so first-turn lifecycle does
         // not wait on startup prewarm resolution.
         let prewarmed_client_session = async {
             let event = EventMsg::TurnStarted(TurnStartedEvent {
-                turn_id: ctx.sub_id.clone(),
-                trace_id: ctx.trace_id.clone(),
-                started_at: ctx.turn_timing_state.started_at_unix_secs().await,
-                model_context_window: ctx.model_context_window(),
-                collaboration_mode_kind: ctx.collaboration_mode.mode,
+                turn_id: turn_context.sub_id.clone(),
+                trace_id: turn_context.trace_id.clone(),
+                started_at: turn_context.turn_timing_state.started_at_unix_secs().await,
+                model_context_window: model_context.model_context_window(),
+                collaboration_mode_kind: model_context.collaboration_mode.mode,
             });
-            sess.send_event(ctx.as_ref(), event).await;
+            sess.send_event(turn_context.as_ref(), event).await;
             sess.set_server_reasoning_included(/*included*/ false).await;
             sess.consume_startup_prewarm_for_regular_turn(&cancellation_token)
                 .await
@@ -73,7 +75,7 @@ impl SessionTask for RegularTask {
         loop {
             let last_agent_message = run_turn(
                 Arc::clone(&sess),
-                Arc::clone(&ctx),
+                ctx.clone(),
                 Arc::clone(&turn_extension_data),
                 next_input,
                 prewarmed_client_session.take(),

--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -22,7 +22,7 @@ use crate::review_format::format_review_findings_block;
 use crate::review_format::render_review_output_text;
 use crate::session::TurnInput;
 use crate::session::session::Session;
-use crate::session::turn_context::TurnContext;
+use crate::session::step_context::StepContextSeed;
 use crate::state::TaskKind;
 use codex_features::Feature;
 use codex_protocol::user_input::UserInput;
@@ -52,7 +52,7 @@ impl SessionTask for ReviewTask {
     async fn run(
         self: Arc<Self>,
         session: Arc<SessionTaskContext>,
-        ctx: Arc<TurnContext>,
+        ctx: StepContextSeed,
         input: Vec<TurnInput>,
         cancellation_token: CancellationToken,
     ) -> SessionTaskResult {
@@ -88,18 +88,18 @@ impl SessionTask for ReviewTask {
         Ok(None)
     }
 
-    async fn abort(&self, session: Arc<SessionTaskContext>, ctx: Arc<TurnContext>) {
+    async fn abort(&self, session: Arc<SessionTaskContext>, ctx: StepContextSeed) {
         exit_review_mode(session.clone_session(), /*review_output*/ None, ctx).await;
     }
 }
 
 async fn start_review_conversation(
     session: Arc<SessionTaskContext>,
-    ctx: Arc<TurnContext>,
+    ctx: StepContextSeed,
     input: Vec<UserInput>,
     cancellation_token: CancellationToken,
 ) -> Option<async_channel::Receiver<Event>> {
-    let config = ctx.config.clone();
+    let config = ctx.turn.config.clone();
     let mut sub_agent_config = config.as_ref().clone();
     // Carry over review-only feature restrictions so the delegate cannot
     // re-enable blocked tools (web search, collab tools, view image).
@@ -120,7 +120,7 @@ async fn start_review_conversation(
     let model = config
         .review_model
         .clone()
-        .unwrap_or_else(|| ctx.model_info.slug.clone());
+        .unwrap_or_else(|| ctx.model.model_info.slug.clone());
     sub_agent_config.model = Some(model);
     (run_codex_thread_one_shot(
         sub_agent_config,
@@ -141,7 +141,7 @@ async fn start_review_conversation(
 
 async fn process_review_events(
     session: Arc<SessionTaskContext>,
-    ctx: Arc<TurnContext>,
+    ctx: StepContextSeed,
     receiver: async_channel::Receiver<Event>,
 ) -> Option<ReviewOutputEvent> {
     let mut prev_agent_message: Option<Event> = None;
@@ -151,7 +151,7 @@ async fn process_review_events(
                 if let Some(prev) = prev_agent_message.take() {
                     session
                         .clone_session()
-                        .send_event(ctx.as_ref(), prev.msg)
+                        .send_event(ctx.turn.as_ref(), prev.msg)
                         .await;
                 }
                 prev_agent_message = Some(event);
@@ -179,7 +179,7 @@ async fn process_review_events(
             other => {
                 session
                     .clone_session()
-                    .send_event(ctx.as_ref(), other)
+                    .send_event(ctx.turn.as_ref(), other)
                     .await;
             }
         }
@@ -215,7 +215,7 @@ fn parse_review_output_event(text: &str) -> ReviewOutputEvent {
 pub(crate) async fn exit_review_mode(
     session: Arc<Session>,
     review_output: Option<ReviewOutputEvent>,
-    ctx: Arc<TurnContext>,
+    ctx: StepContextSeed,
 ) {
     const REVIEW_USER_MESSAGE_ID: &str = "review_rollout_user";
     const REVIEW_ASSISTANT_MESSAGE_ID: &str = "review_rollout_assistant";
@@ -241,7 +241,7 @@ pub(crate) async fn exit_review_mode(
     };
 
     session
-        .record_conversation_items(
+        .record_conversation_items_for_seed(
             &ctx,
             &[ResponseItem::Message {
                 id: Some(REVIEW_USER_MESSAGE_ID.to_string()),
@@ -255,13 +255,13 @@ pub(crate) async fn exit_review_mode(
 
     session
         .send_event(
-            ctx.as_ref(),
+            ctx.turn.as_ref(),
             EventMsg::ExitedReviewMode(ExitedReviewModeEvent { review_output }),
         )
         .await;
     session
         .record_response_item_and_emit_turn_item(
-            ctx.as_ref(),
+            &ctx,
             ResponseItem::Message {
                 id: Some(REVIEW_ASSISTANT_MESSAGE_ID.to_string()),
                 role: "assistant".to_string(),

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -451,7 +451,6 @@ async fn persist_user_shell_output(
     exec_output: &ExecToolCallOutput,
     mode: UserShellCommandMode,
 ) {
-    let turn_context = step_context_seed.turn.as_ref();
     let output_item =
         user_shell_command_record_item(raw_command, exec_output, step_context_seed.model.as_ref());
 

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -16,6 +16,7 @@ use crate::exec::execute_exec_request;
 use crate::exec_env::create_env;
 use crate::sandboxing::ExecRequest;
 use crate::session::TurnInput;
+use crate::session::step_context::StepContextSeed;
 use crate::session::turn_context::TurnContext;
 use crate::shell::Shell;
 use crate::state::TaskKind;
@@ -79,13 +80,13 @@ impl SessionTask for UserShellCommandTask {
     async fn run(
         self: Arc<Self>,
         session: Arc<SessionTaskContext>,
-        turn_context: Arc<TurnContext>,
+        step_context_seed: StepContextSeed,
         _input: Vec<TurnInput>,
         cancellation_token: CancellationToken,
     ) -> SessionTaskResult {
         execute_user_shell_command(
             session.clone_session(),
-            turn_context,
+            step_context_seed,
             self.command.clone(),
             cancellation_token,
             UserShellCommandMode::StandaloneTurn,
@@ -97,11 +98,13 @@ impl SessionTask for UserShellCommandTask {
 
 pub(crate) async fn execute_user_shell_command(
     session: Arc<Session>,
-    turn_context: Arc<TurnContext>,
+    step_context_seed: StepContextSeed,
     command: String,
     cancellation_token: CancellationToken,
     mode: UserShellCommandMode,
 ) {
+    let turn_context = &step_context_seed.turn;
+    let model_context = &step_context_seed.model;
     session
         .services
         .session_telemetry
@@ -119,8 +122,8 @@ pub(crate) async fn execute_user_shell_command(
             turn_id: turn_context.sub_id.clone(),
             trace_id: turn_context.trace_id.clone(),
             started_at: turn_context.turn_timing_state.started_at_unix_secs().await,
-            model_context_window: turn_context.model_context_window(),
-            collaboration_mode_kind: turn_context.collaboration_mode.mode,
+            model_context_window: model_context.model_context_window(),
+            collaboration_mode_kind: model_context.collaboration_mode.mode,
         });
         session.send_event(turn_context.as_ref(), event).await;
     }
@@ -256,7 +259,7 @@ pub(crate) async fn execute_user_shell_command(
             };
             persist_user_shell_output(
                 &session,
-                turn_context.as_ref(),
+                &step_context_seed,
                 &raw_command,
                 &exec_output,
                 mode,
@@ -265,6 +268,7 @@ pub(crate) async fn execute_user_shell_command(
             session
                 .emit_turn_item_completed(
                     turn_context.as_ref(),
+                    model_context.as_ref(),
                     TurnItem::CommandExecution(CommandExecutionItem {
                         id: call_id,
                         process_id: None,
@@ -288,6 +292,7 @@ pub(crate) async fn execute_user_shell_command(
             session
                 .emit_turn_item_completed(
                     turn_context.as_ref(),
+                    model_context.as_ref(),
                     TurnItem::CommandExecution(CommandExecutionItem {
                         id: call_id.clone(),
                         process_id: None,
@@ -308,13 +313,13 @@ pub(crate) async fn execute_user_shell_command(
                         duration: Some(output.duration),
                         formatted_output: Some(format_exec_output_str(
                             &output,
-                            turn_context.model_info.truncation_policy.into(),
+                            model_context.model_info.truncation_policy.into(),
                         )),
                     }),
                 )
                 .await;
 
-            persist_user_shell_output(&session, turn_context.as_ref(), &raw_command, &output, mode)
+            persist_user_shell_output(&session, &step_context_seed, &raw_command, &output, mode)
                 .await;
         }
         Ok(Err(err)) => {
@@ -331,6 +336,7 @@ pub(crate) async fn execute_user_shell_command(
             session
                 .emit_turn_item_completed(
                     turn_context.as_ref(),
+                    model_context.as_ref(),
                     TurnItem::CommandExecution(CommandExecutionItem {
                         id: call_id,
                         process_id: None,
@@ -347,14 +353,14 @@ pub(crate) async fn execute_user_shell_command(
                         duration: Some(exec_output.duration),
                         formatted_output: Some(format_exec_output_str(
                             &exec_output,
-                            turn_context.model_info.truncation_policy.into(),
+                            model_context.model_info.truncation_policy.into(),
                         )),
                     }),
                 )
                 .await;
             persist_user_shell_output(
                 &session,
-                turn_context.as_ref(),
+                &step_context_seed,
                 &raw_command,
                 &exec_output,
                 mode,
@@ -440,16 +446,21 @@ fn prepare_user_shell_exec_command_with_path_prepend(
 
 async fn persist_user_shell_output(
     session: &Session,
-    turn_context: &TurnContext,
+    step_context_seed: &StepContextSeed,
     raw_command: &str,
     exec_output: &ExecToolCallOutput,
     mode: UserShellCommandMode,
 ) {
-    let output_item = user_shell_command_record_item(raw_command, exec_output, turn_context);
+    let turn_context = step_context_seed.turn.as_ref();
+    let output_item =
+        user_shell_command_record_item(raw_command, exec_output, step_context_seed.model.as_ref());
 
     if mode == UserShellCommandMode::StandaloneTurn {
         session
-            .record_conversation_items(turn_context, std::slice::from_ref(&output_item))
+            .record_conversation_items_for_seed(
+                step_context_seed,
+                std::slice::from_ref(&output_item),
+            )
             .await;
         // Standalone shell turns can run before any regular user turn, so
         // explicitly materialize rollout persistence after recording output.
@@ -458,7 +469,7 @@ async fn persist_user_shell_output(
     }
 
     session
-        .inject_no_new_turn(vec![output_item], Some(turn_context))
+        .inject_no_new_turn(vec![output_item], Some(step_context_seed))
         .await;
 }
 

--- a/codex-rs/core/src/thread_manager_tests.rs
+++ b/codex-rs/core/src/thread_manager_tests.rs
@@ -4,7 +4,7 @@ use crate::init_state_db;
 use crate::installation_id::INSTALLATION_ID_FILENAME;
 use crate::rollout::RolloutRecorder;
 use crate::session::session::SessionSettingsUpdate;
-use crate::session::tests::build_world_state_from_turn_context;
+use crate::session::step_context::StepContext;
 use crate::session::tests::make_session_and_context;
 use crate::tasks::InterruptedTurnHistoryMarker;
 use crate::tasks::interrupted_turn_history_marker;
@@ -319,9 +319,10 @@ fn out_of_range_truncation_drops_pre_user_active_turn_prefix() {
 async fn ignores_session_prefix_messages_when_truncating() {
     let (session, turn_context) = make_session_and_context().await;
     let turn_context = Arc::new(turn_context);
-    let world_state = build_world_state_from_turn_context(&session, &turn_context).await;
+    let step_context = StepContext::for_test(Arc::clone(&turn_context));
+    let world_state = session.build_world_state_for_step(&step_context).await;
     let mut items = session
-        .build_initial_context_with_world_state(&turn_context, &world_state)
+        .build_initial_context_with_world_state(&step_context, &world_state)
         .await;
     items.push(user_msg("feature request"));
     items.push(assistant_msg("ack"));
@@ -860,13 +861,13 @@ async fn resume_and_fork_do_not_restore_thread_environments_from_rollout() {
         .new_turn_with_sub_id("resume-turn".to_string(), SessionSettingsUpdate::default())
         .await
         .expect("build resumed turn context");
-    assert_eq!(resumed_turn.environments.turn_environments.len(), 1);
+    assert_eq!(resumed_turn.turn.environments.turn_environments.len(), 1);
     assert_eq!(
-        resumed_turn.environments.turn_environments[0].cwd(),
+        resumed_turn.turn.environments.turn_environments[0].cwd(),
         &PathUri::from_abs_path(&default_cwd)
     );
     assert_ne!(
-        resumed_turn.environments.turn_environments[0].cwd(),
+        resumed_turn.turn.environments.turn_environments[0].cwd(),
         &PathUri::from_abs_path(&selected_cwd)
     );
 
@@ -887,13 +888,13 @@ async fn resume_and_fork_do_not_restore_thread_environments_from_rollout() {
         .new_turn_with_sub_id("fork-turn".to_string(), SessionSettingsUpdate::default())
         .await
         .expect("build forked turn context");
-    assert_eq!(forked_turn.environments.turn_environments.len(), 1);
+    assert_eq!(forked_turn.turn.environments.turn_environments.len(), 1);
     assert_eq!(
-        forked_turn.environments.turn_environments[0].cwd(),
+        forked_turn.turn.environments.turn_environments[0].cwd(),
         &PathUri::from_abs_path(&default_cwd)
     );
     assert_ne!(
-        forked_turn.environments.turn_environments[0].cwd(),
+        forked_turn.turn.environments.turn_environments[0].cwd(),
         &PathUri::from_abs_path(&selected_cwd)
     );
 }

--- a/codex-rs/core/src/thread_rollout_truncation_tests.rs
+++ b/codex-rs/core/src/thread_rollout_truncation_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::session::tests::build_world_state_from_turn_context;
+use crate::session::step_context::StepContext;
 use crate::session::tests::make_session_and_context;
 use codex_protocol::AgentPath;
 use codex_protocol::models::ContentItem;
@@ -270,9 +270,10 @@ fn truncates_rollout_from_start_applies_thread_rollback_markers() {
 async fn ignores_session_prefix_messages_when_truncating_rollout_from_start() {
     let (session, turn_context) = make_session_and_context().await;
     let turn_context = Arc::new(turn_context);
-    let world_state = build_world_state_from_turn_context(&session, &turn_context).await;
+    let step_context = StepContext::for_test(Arc::clone(&turn_context));
+    let world_state = session.build_world_state_for_step(&step_context).await;
     let mut items = session
-        .build_initial_context_with_world_state(&turn_context, &world_state)
+        .build_initial_context_with_world_state(&step_context, &world_state)
         .await;
     items.push(user_msg("feature request"));
     items.push(assistant_msg("ack"));

--- a/codex-rs/core/src/tools/code_mode/execute_handler.rs
+++ b/codex-rs/core/src/tools/code_mode/execute_handler.rs
@@ -29,13 +29,16 @@ impl CodeModeExecuteHandler {
     async fn execute(
         &self,
         session: std::sync::Arc<crate::session::session::Session>,
-        turn: std::sync::Arc<crate::session::turn_context::TurnContext>,
+        step_context: std::sync::Arc<crate::session::step_context::StepContext>,
         call_id: String,
         code: String,
     ) -> Result<FunctionToolOutput, FunctionCallError> {
         let args =
             codex_code_mode::parse_exec_source(&code).map_err(FunctionCallError::RespondToModel)?;
-        let exec = ExecContext { session, turn };
+        let exec = ExecContext {
+            session,
+            step_context,
+        };
         let enabled_tools =
             codex_tools::collect_code_mode_tool_definitions(&self.nested_tool_specs);
         let started_at = std::time::Instant::now();
@@ -59,7 +62,7 @@ impl CodeModeExecuteHandler {
             .services
             .rollout_thread_trace
             .start_code_cell_trace(
-                exec.turn.sub_id.as_str(),
+                exec.step_context.turn.sub_id.as_str(),
                 runtime_cell_id.as_str(),
                 call_id.as_str(),
                 args.code.as_str(),
@@ -113,7 +116,7 @@ impl CodeModeExecuteHandler {
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
-            turn,
+            step_context,
             call_id,
             tool_name,
             payload,
@@ -122,7 +125,7 @@ impl CodeModeExecuteHandler {
 
         match payload {
             ToolPayload::Custom { input } if is_exec_tool_name(&tool_name) => self
-                .execute(session, turn, call_id, input)
+                .execute(session, step_context, call_id, input)
                 .await
                 .map(boxed_tool_output),
             _ => Err(FunctionCallError::RespondToModel(format!(

--- a/codex-rs/core/src/tools/code_mode/mod.rs
+++ b/codex-rs/core/src/tools/code_mode/mod.rs
@@ -26,7 +26,7 @@ use crate::original_image_detail::can_request_original_image_detail;
 use crate::original_image_detail::sanitize_original_image_detail as sanitize_image_detail_items;
 use crate::session::session::Session;
 use crate::session::step_context::StepContext;
-use crate::session::turn_context::TurnContext;
+use crate::session::step_model_context::StepModelContext;
 use crate::tools::ToolRouter;
 use crate::tools::context::FunctionToolOutput;
 use crate::tools::context::SharedTurnDiffTracker;
@@ -60,7 +60,7 @@ pub(crate) fn is_exec_tool_name(tool_name: &ToolName) -> bool {
 #[derive(Clone)]
 pub(crate) struct ExecContext {
     pub(super) session: Arc<Session>,
-    pub(super) turn: Arc<TurnContext>,
+    pub(super) step_context: Arc<StepContext>,
 }
 
 pub(crate) struct CodeModeService {
@@ -139,14 +139,14 @@ impl CodeModeService {
         tracker: SharedTurnDiffTracker,
     ) -> Option<CodeModeDispatchWorker> {
         let turn = &step_context.turn;
-        let tool_mode = effective_tool_mode(turn);
+        let tool_mode = effective_tool_mode(step_context.model.as_ref(), &turn.config.features);
         if !matches!(tool_mode, ToolMode::CodeMode | ToolMode::CodeModeOnly) {
             return None;
         }
 
         let exec = ExecContext {
             session: Arc::clone(session),
-            turn: Arc::clone(turn),
+            step_context: Arc::clone(&step_context),
         };
         Some(
             self.dispatch_broker
@@ -189,14 +189,14 @@ pub(super) async fn handle_runtime_response(
     match response {
         RuntimeResponse::Yielded { content_items, .. } => {
             let mut content_items = into_function_call_output_content_items(content_items);
-            sanitize_runtime_image_detail(exec.turn.as_ref(), &mut content_items);
+            sanitize_runtime_image_detail(exec.step_context.model.as_ref(), &mut content_items);
             content_items = truncate_code_mode_result(content_items, max_output_tokens);
             prepend_script_status(&mut content_items, &script_status, started_at.elapsed());
             Ok(FunctionToolOutput::from_content(content_items, Some(true)))
         }
         RuntimeResponse::Terminated { content_items, .. } => {
             let mut content_items = into_function_call_output_content_items(content_items);
-            sanitize_runtime_image_detail(exec.turn.as_ref(), &mut content_items);
+            sanitize_runtime_image_detail(exec.step_context.model.as_ref(), &mut content_items);
             content_items = truncate_code_mode_result(content_items, max_output_tokens);
             prepend_script_status(&mut content_items, &script_status, started_at.elapsed());
             Ok(FunctionToolOutput::from_content(content_items, Some(true)))
@@ -207,7 +207,7 @@ pub(super) async fn handle_runtime_response(
             ..
         } => {
             let mut content_items = into_function_call_output_content_items(content_items);
-            sanitize_runtime_image_detail(exec.turn.as_ref(), &mut content_items);
+            sanitize_runtime_image_detail(exec.step_context.model.as_ref(), &mut content_items);
             let success = error_text.is_none();
             if let Some(error_text) = error_text {
                 content_items.push(FunctionCallOutputContentItem::InputText {
@@ -224,8 +224,11 @@ pub(super) async fn handle_runtime_response(
     }
 }
 
-fn sanitize_runtime_image_detail(turn: &TurnContext, items: &mut [FunctionCallOutputContentItem]) {
-    sanitize_image_detail_items(can_request_original_image_detail(&turn.model_info), items);
+fn sanitize_runtime_image_detail(
+    model: &StepModelContext,
+    items: &mut [FunctionCallOutputContentItem],
+) {
+    sanitize_image_detail_items(can_request_original_image_detail(&model.model_info), items);
 }
 
 fn format_script_status(response: &RuntimeResponse) -> String {

--- a/codex-rs/core/src/tools/code_mode/wait_handler.rs
+++ b/codex-rs/core/src/tools/code_mode/wait_handler.rs
@@ -65,7 +65,7 @@ impl CodeModeWaitHandler {
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
-            turn,
+            step_context,
             tool_name,
             payload,
             ..
@@ -76,7 +76,10 @@ impl CodeModeWaitHandler {
                 if tool_name.namespace.is_none() && tool_name.name.as_str() == WAIT_TOOL_NAME =>
             {
                 let args: ExecWaitArgs = parse_arguments(&arguments)?;
-                let exec = ExecContext { session, turn };
+                let exec = ExecContext {
+                    session,
+                    step_context,
+                };
                 let started_at = std::time::Instant::now();
                 let cell_id = codex_code_mode::CellId::new(args.cell_id);
                 let wait_response = if args.terminate {
@@ -111,7 +114,7 @@ impl CodeModeWaitHandler {
                         .services
                         .rollout_thread_trace
                         .code_cell_trace_context(
-                            exec.turn.sub_id.as_str(),
+                            exec.step_context.turn.sub_id.as_str(),
                             runtime_cell_id.as_str(),
                         )
                         .record_ended(response);

--- a/codex-rs/core/src/tools/context.rs
+++ b/codex-rs/core/src/tools/context.rs
@@ -2,7 +2,6 @@ use crate::context_manager::truncate_function_output_payload;
 use crate::original_image_detail::sanitize_original_image_detail;
 use crate::session::session::Session;
 use crate::session::step_context::StepContext;
-use crate::session::turn_context::TurnContext;
 use crate::tools::TELEMETRY_PREVIEW_MAX_BYTES;
 use crate::tools::TELEMETRY_PREVIEW_MAX_LINES;
 use crate::tools::TELEMETRY_PREVIEW_TRUNCATION_NOTICE;
@@ -54,8 +53,6 @@ pub enum ToolCallSource {
 #[derive(Clone)]
 pub struct ToolInvocation {
     pub session: Arc<Session>,
-    // TODO(sayan): Remove this compatibility field once handlers use `step_context.turn`.
-    pub turn: Arc<TurnContext>,
     pub(crate) step_context: Arc<StepContext>,
     pub cancellation_token: CancellationToken,
     pub tracker: SharedTurnDiffTracker,

--- a/codex-rs/core/src/tools/events.rs
+++ b/codex-rs/core/src/tools/events.rs
@@ -1,6 +1,6 @@
 use crate::function_tool::FunctionCallError;
 use crate::session::session::Session;
-use crate::session::turn_context::TurnContext;
+use crate::session::step_context::StepContext;
 use crate::tools::context::SharedTurnDiffTracker;
 use crate::tools::sandboxing::ToolError;
 use crate::turn_timing::now_unix_timestamp_ms;
@@ -33,7 +33,7 @@ use super::format_exec_output_str;
 #[derive(Clone, Copy)]
 pub(crate) struct ToolEventCtx<'a> {
     pub session: &'a Session,
-    pub turn: &'a TurnContext,
+    pub step_context: &'a StepContext,
     pub call_id: &'a str,
     pub turn_diff_tracker: Option<&'a SharedTurnDiffTracker>,
 }
@@ -41,13 +41,13 @@ pub(crate) struct ToolEventCtx<'a> {
 impl<'a> ToolEventCtx<'a> {
     pub fn new(
         session: &'a Session,
-        turn: &'a TurnContext,
+        step_context: &'a StepContext,
         call_id: &'a str,
         turn_diff_tracker: Option<&'a SharedTurnDiffTracker>,
     ) -> Self {
         Self {
             session,
-            turn,
+            step_context,
             call_id,
             turn_diff_tracker,
         }
@@ -107,11 +107,11 @@ pub(crate) async fn emit_exec_command_begin(
     if matches!(source, ExecCommandSource::UnifiedExecInteraction) {
         ctx.session
             .send_event(
-                ctx.turn,
+                ctx.step_context.turn.as_ref(),
                 EventMsg::ExecCommandBegin(ExecCommandBeginEvent {
                     call_id: ctx.call_id.to_string(),
                     process_id: process_id.map(str::to_owned),
-                    turn_id: ctx.turn.sub_id.clone(),
+                    turn_id: ctx.step_context.turn.sub_id.clone(),
                     started_at_ms: now_unix_timestamp_ms(),
                     command: command.to_vec(),
                     cwd: cwd.clone(),
@@ -125,7 +125,7 @@ pub(crate) async fn emit_exec_command_begin(
     }
     ctx.session
         .emit_turn_item_started(
-            ctx.turn,
+            ctx.step_context.turn.as_ref(),
             &TurnItem::CommandExecution(CommandExecutionItem {
                 id: ctx.call_id.to_string(),
                 process_id: process_id.map(str::to_owned),
@@ -239,7 +239,7 @@ impl ToolEmitter {
             ) => {
                 ctx.session
                     .emit_turn_item_started(
-                        ctx.turn,
+                        ctx.step_context.turn.as_ref(),
                         &TurnItem::FileChange(FileChangeItem {
                             id: ctx.call_id.to_string(),
                             changes: changes.clone(),
@@ -373,7 +373,10 @@ impl ToolEmitter {
         output: &ExecToolCallOutput,
         ctx: ToolEventCtx<'_>,
     ) -> String {
-        super::format_exec_output_for_model(output, ctx.turn.model_info.truncation_policy.into())
+        super::format_exec_output_for_model(
+            output,
+            ctx.step_context.model.model_info.truncation_policy.into(),
+        )
     }
 
     pub async fn finish(
@@ -524,7 +527,7 @@ async fn emit_exec_stage(
                 duration: output.duration,
                 formatted_output: format_exec_output_str(
                     &output,
-                    ctx.turn.model_info.truncation_policy.into(),
+                    ctx.step_context.model.model_info.truncation_policy.into(),
                 ),
                 status: if output.exit_code == 0 {
                     ExecCommandStatus::Completed
@@ -571,11 +574,11 @@ async fn emit_exec_end(
     if matches!(exec_input.source, ExecCommandSource::UnifiedExecInteraction) {
         ctx.session
             .send_event(
-                ctx.turn,
+                ctx.step_context.turn.as_ref(),
                 EventMsg::ExecCommandEnd(ExecCommandEndEvent {
                     call_id: ctx.call_id.to_string(),
                     process_id: exec_input.process_id.map(str::to_owned),
-                    turn_id: ctx.turn.sub_id.clone(),
+                    turn_id: ctx.step_context.turn.sub_id.clone(),
                     completed_at_ms: now_unix_timestamp_ms(),
                     command: exec_input.command.to_vec(),
                     cwd: exec_input.cwd.clone(),
@@ -596,7 +599,8 @@ async fn emit_exec_end(
     }
     ctx.session
         .emit_turn_item_completed(
-            ctx.turn,
+            ctx.step_context.turn.as_ref(),
+            ctx.step_context.model.as_ref(),
             TurnItem::CommandExecution(CommandExecutionItem {
                 id: ctx.call_id.to_string(),
                 process_id: exec_input.process_id.map(str::to_owned),
@@ -627,7 +631,8 @@ async fn emit_patch_end(
 ) {
     ctx.session
         .emit_turn_item_completed(
-            ctx.turn,
+            ctx.step_context.turn.as_ref(),
+            ctx.step_context.model.as_ref(),
             TurnItem::FileChange(FileChangeItem {
                 id: ctx.call_id.to_string(),
                 changes,
@@ -665,7 +670,10 @@ async fn emit_patch_end(
         };
         if should_emit_turn_diff {
             ctx.session
-                .send_event(ctx.turn, EventMsg::TurnDiff(TurnDiffEvent { unified_diff }))
+                .send_event(
+                    ctx.step_context.turn.as_ref(),
+                    EventMsg::TurnDiff(TurnDiffEvent { unified_diff }),
+                )
                 .await;
         }
     }
@@ -674,6 +682,7 @@ async fn emit_patch_end(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::step_context::StepContext;
     use crate::session::tests::make_session_and_context_with_dynamic_tools_and_rx;
     use crate::turn_diff_tracker::TurnDiffTracker;
     use codex_exec_server::LOCAL_FS;
@@ -693,6 +702,7 @@ mod tests {
     ) {
         let (session, turn, rx_event) =
             make_session_and_context_with_dynamic_tools_and_rx(Vec::new()).await;
+        let step_context = StepContext::for_test(Arc::clone(&turn));
         let tracker = Arc::new(Mutex::new(TurnDiffTracker::new()));
         let dir = tempdir().expect("tempdir");
         let cwd = PathUri::from_host_native_path(dir.path()).expect("absolute cwd");
@@ -715,7 +725,12 @@ mod tests {
             environment_id: None,
         }
         .finish(
-            ToolEventCtx::new(session.as_ref(), turn.as_ref(), "call-id", Some(&tracker)),
+            ToolEventCtx::new(
+                session.as_ref(),
+                step_context.as_ref(),
+                "call-id",
+                Some(&tracker),
+            ),
             out,
             Some(&delta),
         )
@@ -777,6 +792,7 @@ mod tests {
     async fn net_zero_patch_emits_empty_turn_diff() {
         let (session, turn, rx_event) =
             make_session_and_context_with_dynamic_tools_and_rx(Vec::new()).await;
+        let step_context = StepContext::for_test(Arc::clone(&turn));
         let tracker = Arc::new(Mutex::new(TurnDiffTracker::new()));
         let dir = tempdir().expect("tempdir");
         let cwd = PathUri::from_host_native_path(dir.path()).expect("absolute cwd");
@@ -799,7 +815,12 @@ mod tests {
             .expect("apply patch");
 
             emit_patch_end(
-                ToolEventCtx::new(session.as_ref(), turn.as_ref(), "call-id", Some(&tracker)),
+                ToolEventCtx::new(
+                    session.as_ref(),
+                    step_context.as_ref(),
+                    "call-id",
+                    Some(&tracker),
+                ),
                 HashMap::new(),
                 String::new(),
                 String::new(),
@@ -830,6 +851,7 @@ mod tests {
     async fn invalidation_emits_empty_turn_diff() {
         let (session, turn, rx_event) =
             make_session_and_context_with_dynamic_tools_and_rx(Vec::new()).await;
+        let step_context = StepContext::for_test(Arc::clone(&turn));
         let tracker = Arc::new(Mutex::new(TurnDiffTracker::new()));
         let dir = tempdir().expect("tempdir");
         let cwd = PathUri::from_host_native_path(dir.path()).expect("absolute cwd");
@@ -848,7 +870,12 @@ mod tests {
         tracker.lock().await.track_delta("", &delta);
 
         emit_patch_end(
-            ToolEventCtx::new(session.as_ref(), turn.as_ref(), "call-id", Some(&tracker)),
+            ToolEventCtx::new(
+                session.as_ref(),
+                step_context.as_ref(),
+                "call-id",
+                Some(&tracker),
+            ),
             HashMap::new(),
             String::new(),
             String::new(),

--- a/codex-rs/core/src/tools/handlers/agent_jobs.rs
+++ b/codex-rs/core/src/tools/handlers/agent_jobs.rs
@@ -3,6 +3,7 @@ use crate::agent::status::is_final;
 use crate::config::Config;
 use crate::function_tool::FunctionCallError;
 use crate::session::session::Session;
+use crate::session::step_context::StepContext;
 use crate::session::turn_context::TurnContext;
 use crate::tools::handlers::multi_agents::build_agent_spawn_config;
 use crate::tools::handlers::parse_arguments;
@@ -107,9 +108,10 @@ fn required_state_db(
 
 async fn build_runner_options(
     session: &Arc<Session>,
-    turn: &Arc<TurnContext>,
+    step_context: &StepContext,
     requested_concurrency: Option<usize>,
 ) -> Result<JobRunnerOptions, FunctionCallError> {
+    let turn = &step_context.turn;
     let multi_agent_version = turn.multi_agent_version;
     if multi_agent_version == MultiAgentVersion::Disabled {
         return Err(FunctionCallError::RespondToModel(
@@ -124,7 +126,7 @@ async fn build_runner_options(
     }
     let max_concurrency = normalize_concurrency(requested_concurrency, agent_max_threads);
     let base_instructions = session.get_base_instructions().await;
-    let spawn_config = build_agent_spawn_config(&base_instructions, turn.as_ref())?;
+    let spawn_config = build_agent_spawn_config(&base_instructions, step_context)?;
     Ok(JobRunnerOptions {
         max_concurrency,
         spawn_config,

--- a/codex-rs/core/src/tools/handlers/agent_jobs/spawn_agents_on_csv.rs
+++ b/codex-rs/core/src/tools/handlers/agent_jobs/spawn_agents_on_csv.rs
@@ -35,7 +35,7 @@ impl SpawnAgentsOnCsvHandler {
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
-            turn,
+            step_context,
             payload,
             ..
         } = invocation;
@@ -49,7 +49,7 @@ impl SpawnAgentsOnCsvHandler {
             }
         };
 
-        handle(session, turn, arguments)
+        handle(session, step_context, arguments)
             .await
             .map(boxed_tool_output)
     }
@@ -68,9 +68,10 @@ impl CoreToolRuntime for SpawnAgentsOnCsvHandler {
 /// `report_agent_job_result`, then exported to CSV on completion.
 pub async fn handle(
     session: Arc<Session>,
-    turn: Arc<TurnContext>,
+    step_context: Arc<StepContext>,
     arguments: String,
 ) -> Result<FunctionToolOutput, FunctionCallError> {
+    let turn = Arc::clone(&step_context.turn);
     let args: SpawnAgentsOnCsvArgs = parse_arguments(arguments.as_str())?;
     if args.instruction.trim().is_empty() {
         return Err(FunctionCallError::RespondToModel(
@@ -182,16 +183,17 @@ pub async fn handle(
         })?;
 
     let requested_concurrency = args.max_concurrency.or(args.max_workers);
-    let options = match build_runner_options(&session, &turn, requested_concurrency).await {
-        Ok(options) => options,
-        Err(err) => {
-            let error_message = err.to_string();
-            let _ = db
-                .mark_agent_job_failed(job_id.as_str(), error_message.as_str())
-                .await;
-            return Err(err);
-        }
-    };
+    let options =
+        match build_runner_options(&session, step_context.as_ref(), requested_concurrency).await {
+            Ok(options) => options,
+            Err(err) => {
+                let error_message = err.to_string();
+                let _ = db
+                    .mark_agent_job_failed(job_id.as_str(), error_message.as_str())
+                    .await;
+                return Err(err);
+            }
+        };
     db.mark_agent_job_running(job_id.as_str())
         .await
         .map_err(|err| {

--- a/codex-rs/core/src/tools/handlers/apply_patch.rs
+++ b/codex-rs/core/src/tools/handlers/apply_patch.rs
@@ -11,6 +11,7 @@ use crate::apply_patch::InternalApplyPatchInvocation;
 use crate::apply_patch::convert_apply_patch_to_protocol;
 use crate::function_tool::FunctionCallError;
 use crate::session::session::Session;
+use crate::session::step_context::StepContext;
 use crate::session::turn_context::TurnContext;
 use crate::session::turn_context::TurnEnvironment;
 use crate::tools::context::ApplyPatchToolOutput;
@@ -347,7 +348,6 @@ impl ApplyPatchHandler {
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
-            turn,
             step_context,
             tracker,
             call_id,
@@ -355,6 +355,7 @@ impl ApplyPatchHandler {
             payload,
             ..
         } = invocation;
+        let turn = Arc::clone(&step_context.turn);
 
         let ToolPayload::Custom { input: patch_input } = payload else {
             return Err(FunctionCallError::RespondToModel(
@@ -422,7 +423,7 @@ impl ApplyPatchHandler {
                         );
                         let event_ctx = ToolEventCtx::new(
                             session.as_ref(),
-                            turn.as_ref(),
+                            step_context.as_ref(),
                             &call_id,
                             Some(&tracker),
                         );
@@ -444,18 +445,12 @@ impl ApplyPatchHandler {
                         let mut runtime = ApplyPatchRuntime::new();
                         let tool_ctx = ToolCtx {
                             session: session.clone(),
-                            turn: turn.clone(),
+                            step_context: step_context.clone(),
                             call_id: call_id.clone(),
                             tool_name: tool_name.clone(),
                         };
                         let out = orchestrator
-                            .run(
-                                &mut runtime,
-                                &req,
-                                &tool_ctx,
-                                turn.as_ref(),
-                                turn.approval_policy.value(),
-                            )
+                            .run(&mut runtime, &req, &tool_ctx)
                             .await
                             .map(|result| result.output);
                         let (out, delta) = match out {
@@ -464,7 +459,7 @@ impl ApplyPatchHandler {
                         };
                         let event_ctx = ToolEventCtx::new(
                             session.as_ref(),
-                            turn.as_ref(),
+                            step_context.as_ref(),
                             &call_id,
                             Some(&tracker),
                         );
@@ -549,11 +544,12 @@ pub(crate) async fn intercept_apply_patch(
     fs: &dyn ExecutorFileSystem,
     turn_environment: TurnEnvironment,
     session: Arc<Session>,
-    turn: Arc<TurnContext>,
+    step_context: Arc<StepContext>,
     tracker: Option<&SharedTurnDiffTracker>,
     call_id: &str,
     tool_name: &str,
 ) -> Result<Option<FunctionToolOutput>, FunctionCallError> {
+    let turn = &step_context.turn;
     let sandbox = turn.file_system_sandbox_context(/*additional_permissions*/ None, cwd);
     match codex_apply_patch::maybe_parse_apply_patch_verified(command, cwd, fs, Some(&sandbox))
         .await
@@ -585,7 +581,7 @@ pub(crate) async fn intercept_apply_patch(
                     );
                     let event_ctx = ToolEventCtx::new(
                         session.as_ref(),
-                        turn.as_ref(),
+                        step_context.as_ref(),
                         call_id,
                         tracker.as_ref().copied(),
                     );
@@ -607,18 +603,12 @@ pub(crate) async fn intercept_apply_patch(
                     let mut runtime = ApplyPatchRuntime::new();
                     let tool_ctx = ToolCtx {
                         session: session.clone(),
-                        turn: turn.clone(),
+                        step_context: step_context.clone(),
                         call_id: call_id.to_string(),
                         tool_name: ToolName::plain(tool_name),
                     };
                     let out = orchestrator
-                        .run(
-                            &mut runtime,
-                            &req,
-                            &tool_ctx,
-                            turn.as_ref(),
-                            turn.approval_policy.value(),
-                        )
+                        .run(&mut runtime, &req, &tool_ctx)
                         .await
                         .map(|result| result.output);
                     let (out, delta) = match out {
@@ -627,7 +617,7 @@ pub(crate) async fn intercept_apply_patch(
                     };
                     let event_ctx = ToolEventCtx::new(
                         session.as_ref(),
-                        turn.as_ref(),
+                        step_context.as_ref(),
                         call_id,
                         tracker.as_ref().copied(),
                     );

--- a/codex-rs/core/src/tools/handlers/apply_patch_tests.rs
+++ b/codex-rs/core/src/tools/handlers/apply_patch_tests.rs
@@ -34,7 +34,6 @@ async fn invocation_for_payload(payload: ToolPayload) -> ToolInvocation {
     ToolInvocation {
         session: session.into(),
         step_context: StepContext::for_test(Arc::clone(&turn)),
-        turn,
         cancellation_token: tokio_util::sync::CancellationToken::new(),
         tracker: Arc::new(Mutex::new(TurnDiffTracker::new())),
         call_id: "call-apply-patch".to_string(),

--- a/codex-rs/core/src/tools/handlers/dynamic.rs
+++ b/codex-rs/core/src/tools/handlers/dynamic.rs
@@ -118,11 +118,12 @@ impl DynamicToolHandler {
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
-            turn,
+            step_context,
             call_id,
             payload,
             ..
         } = invocation;
+        let turn = std::sync::Arc::clone(&step_context.turn);
 
         let arguments = match payload {
             ToolPayload::Function { arguments } => arguments,

--- a/codex-rs/core/src/tools/handlers/extension_tools.rs
+++ b/codex-rs/core/src/tools/handlers/extension_tools.rs
@@ -14,7 +14,7 @@ use codex_tools::TurnItemEmitter;
 
 use crate::sandboxing::SandboxPermissions;
 use crate::session::session::Session;
-use crate::session::turn_context::TurnContext;
+use crate::session::step_context::StepContext;
 use crate::stream_events_utils::TurnItemContributorPolicy;
 use crate::stream_events_utils::apply_turn_item_contributors;
 use crate::stream_events_utils::finalize_turn_item;
@@ -66,7 +66,7 @@ impl CoreToolRuntime for ExtensionToolAdapter {
 
 struct CoreTurnItemEmitter {
     session: Weak<Session>,
-    turn: Weak<TurnContext>,
+    step_context: Weak<StepContext>,
 }
 
 fn extension_turn_item(item: ExtensionTurnItem) -> TurnItem {
@@ -79,9 +79,12 @@ fn extension_turn_item(item: ExtensionTurnItem) -> TurnItem {
 impl TurnItemEmitter for CoreTurnItemEmitter {
     fn emit_started<'a>(&'a self, item: ExtensionTurnItem) -> TurnItemEmissionFuture<'a> {
         Box::pin(async move {
-            let (Some(session), Some(turn)) = (self.session.upgrade(), self.turn.upgrade()) else {
+            let (Some(session), Some(step_context)) =
+                (self.session.upgrade(), self.step_context.upgrade())
+            else {
                 return;
             };
+            let turn = &step_context.turn;
             session
                 .emit_turn_item_started(turn.as_ref(), &extension_turn_item(item))
                 .await;
@@ -90,9 +93,12 @@ impl TurnItemEmitter for CoreTurnItemEmitter {
 
     fn emit_completed<'a>(&'a self, item: ExtensionTurnItem) -> TurnItemEmissionFuture<'a> {
         Box::pin(async move {
-            let (Some(session), Some(turn)) = (self.session.upgrade(), self.turn.upgrade()) else {
+            let (Some(session), Some(step_context)) =
+                (self.session.upgrade(), self.step_context.upgrade())
+            else {
                 return;
             };
+            let turn = &step_context.turn;
             let item = match item {
                 ExtensionTurnItem::ImageGeneration(item) => {
                     let mut item = TurnItem::ImageGeneration(item);
@@ -108,17 +114,19 @@ impl TurnItemEmitter for CoreTurnItemEmitter {
                     let mut item = TurnItem::WebSearch(item);
                     finalize_turn_item(
                         session.as_ref(),
-                        turn.as_ref(),
+                        step_context.as_ref(),
                         TurnItemContributorPolicy::Run(turn.extension_data.as_ref()),
                         &mut item,
-                        turn.collaboration_mode.mode
+                        step_context.model.collaboration_mode.mode
                             == codex_protocol::config_types::ModeKind::Plan,
                     )
                     .await;
                     item
                 }
             };
-            session.emit_turn_item_completed(turn.as_ref(), item).await;
+            session
+                .emit_turn_item_completed(turn.as_ref(), step_context.model.as_ref(), item)
+                .await;
         })
     }
 }
@@ -154,15 +162,20 @@ async fn to_extension_call(invocation: &ToolInvocation) -> ExtensionToolCall {
         });
     }
     ExtensionToolCall {
-        turn_id: invocation.turn.sub_id.clone(),
+        turn_id: invocation.step_context.turn.sub_id.clone(),
         call_id: invocation.call_id.clone(),
         tool_name: invocation.tool_name.clone(),
-        model: invocation.turn.model_info.slug.clone(),
-        truncation_policy: invocation.turn.model_info.truncation_policy.into(),
+        model: invocation.step_context.model.model_info.slug.clone(),
+        truncation_policy: invocation
+            .step_context
+            .model
+            .model_info
+            .truncation_policy
+            .into(),
         conversation_history,
         turn_item_emitter: Arc::new(CoreTurnItemEmitter {
             session: Arc::downgrade(&invocation.session),
-            turn: Arc::downgrade(&invocation.turn),
+            step_context: Arc::downgrade(&invocation.step_context),
         }),
         environments,
         payload: invocation.payload.clone(),
@@ -292,7 +305,6 @@ mod tests {
         let invocation = ToolInvocation {
             session: session.into(),
             step_context: StepContext::for_test(Arc::clone(&turn)),
-            turn,
             cancellation_token: tokio_util::sync::CancellationToken::new(),
             tracker: Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new())),
             call_id: "call-extension".to_string(),
@@ -329,11 +341,12 @@ mod tests {
             captured_call: Arc::clone(&captured_call),
         }));
         let (session, turn, rx) = crate::session::tests::make_session_and_context_with_rx().await;
+        let step_context = StepContext::for_test(Arc::clone(&turn));
         let weak_session = Arc::downgrade(&session);
         let weak_turn = Arc::downgrade(&turn);
         let turn_id = turn.sub_id.clone();
-        let model = turn.model_info.slug.clone();
-        let truncation_policy = turn.model_info.truncation_policy.into();
+        let model = step_context.model.model_info.slug.clone();
+        let truncation_policy = step_context.model.model_info.truncation_policy.into();
         let expected_sandbox_cwds = turn
             .environments
             .turn_environments
@@ -350,7 +363,7 @@ mod tests {
             internal_chat_message_metadata_passthrough: None,
         };
         session
-            .record_conversation_items(&turn, std::slice::from_ref(&history_item))
+            .record_conversation_items(step_context.as_ref(), std::slice::from_ref(&history_item))
             .await;
         let mut expected_history_item = history_item.clone();
         expected_history_item.set_turn_id_if_missing(&turn_id);
@@ -359,11 +372,9 @@ mod tests {
             panic!("expected raw response item event");
         };
         assert_eq!(raw_history_item.item, expected_history_item);
-        let step_context = StepContext::for_test(Arc::clone(&turn));
         let invocation = ToolInvocation {
             session,
             step_context,
-            turn,
             cancellation_token: tokio_util::sync::CancellationToken::new(),
             tracker: Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new())),
             call_id: "call-extension".to_string(),
@@ -373,6 +384,7 @@ mod tests {
                 arguments: json!({ "message": "hello" }).to_string(),
             },
         };
+        drop(turn);
 
         crate::tools::registry::ToolExecutor::handle(&handler, invocation)
             .await
@@ -476,9 +488,10 @@ mod tests {
         session.services.extensions = Arc::new(builder.build());
         let session = Arc::new(session);
         let turn = Arc::new(turn);
+        let step_context = StepContext::for_test(Arc::clone(&turn));
         let emitter = CoreTurnItemEmitter {
             session: Arc::downgrade(&session),
-            turn: Arc::downgrade(&turn),
+            step_context: Arc::downgrade(&step_context),
         };
 
         codex_tools::TurnItemEmitter::emit_completed(
@@ -567,7 +580,6 @@ mod tests {
         let invocation = ToolInvocation {
             session,
             step_context,
-            turn,
             cancellation_token: tokio_util::sync::CancellationToken::new(),
             tracker: Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new())),
             call_id: "call-image".to_string(),

--- a/codex-rs/core/src/tools/handlers/extension_tools.rs
+++ b/codex-rs/core/src/tools/handlers/extension_tools.rs
@@ -152,6 +152,7 @@ async fn to_extension_call(invocation: &ToolInvocation) -> ExtensionToolCall {
         .await
         .additional_permissions;
         let file_system_sandbox_context = invocation
+            .step_context
             .turn
             .file_system_sandbox_context(additional_permissions, environment.cwd());
         environments.push(ToolEnvironment {

--- a/codex-rs/core/src/tools/handlers/get_context_remaining.rs
+++ b/codex-rs/core/src/tools/handlers/get_context_remaining.rs
@@ -77,7 +77,7 @@ impl ToolExecutor<ToolInvocation> for GetContextRemainingHandler {
 
             let token_status = crate::session::context_window::context_window_token_status(
                 invocation.session.as_ref(),
-                invocation.turn.as_ref(),
+                invocation.step_context.turn.as_ref(),
             )
             .await;
 

--- a/codex-rs/core/src/tools/handlers/get_context_remaining.rs
+++ b/codex-rs/core/src/tools/handlers/get_context_remaining.rs
@@ -78,6 +78,7 @@ impl ToolExecutor<ToolInvocation> for GetContextRemainingHandler {
             let token_status = crate::session::context_window::context_window_token_status(
                 invocation.session.as_ref(),
                 invocation.step_context.turn.as_ref(),
+                invocation.step_context.model.as_ref(),
             )
             .await;
 

--- a/codex-rs/core/src/tools/handlers/mcp.rs
+++ b/codex-rs/core/src/tools/handlers/mcp.rs
@@ -129,7 +129,7 @@ impl McpHandler {
             payload,
             ..
         } = invocation;
-        let turn = Arc::clone(&step_context.turn);
+        let model = &step_context.model.model_info;
 
         let payload = match payload {
             ToolPayload::Function { arguments } => arguments,
@@ -157,8 +157,8 @@ impl McpHandler {
             result: result.result,
             tool_input: result.tool_input,
             wall_time: started.elapsed(),
-            original_image_detail_supported: can_request_original_image_detail(&turn.model_info),
-            truncation_policy: turn.model_info.truncation_policy.into(),
+            original_image_detail_supported: can_request_original_image_detail(model),
+            truncation_policy: model.truncation_policy.into(),
         }))
     }
 }
@@ -350,7 +350,6 @@ mod tests {
             handler.pre_tool_use_payload(&ToolInvocation {
                 session: session.into(),
                 step_context: StepContext::for_test(Arc::clone(&turn)),
-                turn,
                 cancellation_token: tokio_util::sync::CancellationToken::new(),
                 tracker: Arc::new(Mutex::new(TurnDiffTracker::new())),
                 call_id: "call-mcp-pre".to_string(),
@@ -384,7 +383,6 @@ mod tests {
             handler.pre_tool_use_payload(&ToolInvocation {
                 session: session.into(),
                 step_context: StepContext::for_test(Arc::clone(&turn)),
-                turn,
                 cancellation_token: tokio_util::sync::CancellationToken::new(),
                 tracker: Arc::new(Mutex::new(TurnDiffTracker::new())),
                 call_id: "call-mcp-pre-builtin-like".to_string(),
@@ -414,7 +412,6 @@ mod tests {
                 ToolInvocation {
                     session: session.into(),
                     step_context: StepContext::for_test(Arc::clone(&turn)),
-                    turn,
                     cancellation_token: tokio_util::sync::CancellationToken::new(),
                     tracker: Arc::new(Mutex::new(TurnDiffTracker::new())),
                     call_id: "call-mcp-rewrite-builtin-like".to_string(),
@@ -463,7 +460,6 @@ mod tests {
         let invocation = ToolInvocation {
             session: session.into(),
             step_context: StepContext::for_test(Arc::clone(&turn)),
-            turn,
             cancellation_token: tokio_util::sync::CancellationToken::new(),
             tracker: Arc::new(Mutex::new(TurnDiffTracker::new())),
             call_id: "call-mcp-post".to_string(),

--- a/codex-rs/core/src/tools/handlers/mcp_resource.rs
+++ b/codex-rs/core/src/tools/handlers/mcp_resource.rs
@@ -239,6 +239,7 @@ async fn emit_tool_call_begin(
 async fn emit_tool_call_end(
     session: &Arc<Session>,
     turn: &TurnContext,
+    model: &crate::session::step_model_context::StepModelContext,
     call_id: &str,
     invocation: McpInvocation,
     duration: Duration,
@@ -277,7 +278,7 @@ async fn emit_tool_call_end(
         error,
         duration: Some(duration),
     });
-    session.emit_turn_item_completed(turn, item).await;
+    session.emit_turn_item_completed(turn, model, item).await;
 }
 
 fn normalize_optional_string(input: Option<String>) -> Option<String> {

--- a/codex-rs/core/src/tools/handlers/mcp_resource/list_mcp_resource_templates.rs
+++ b/codex-rs/core/src/tools/handlers/mcp_resource/list_mcp_resource_templates.rs
@@ -119,7 +119,7 @@ impl ListMcpResourceTemplatesHandler {
             }
         }
         .await;
-        let truncation_policy = turn.model_info.truncation_policy.into();
+        let truncation_policy = step_context.model.model_info.truncation_policy.into();
 
         match payload_result {
             Ok(payload) => match serialize_function_output(payload, truncation_policy) {
@@ -130,6 +130,7 @@ impl ListMcpResourceTemplatesHandler {
                     emit_tool_call_end(
                         &session,
                         turn.as_ref(),
+                        step_context.model.as_ref(),
                         &call_id,
                         invocation,
                         duration,
@@ -144,6 +145,7 @@ impl ListMcpResourceTemplatesHandler {
                     emit_tool_call_end(
                         &session,
                         turn.as_ref(),
+                        step_context.model.as_ref(),
                         &call_id,
                         invocation,
                         duration,
@@ -159,6 +161,7 @@ impl ListMcpResourceTemplatesHandler {
                 emit_tool_call_end(
                     &session,
                     turn.as_ref(),
+                    step_context.model.as_ref(),
                     &call_id,
                     invocation,
                     duration,

--- a/codex-rs/core/src/tools/handlers/mcp_resource/list_mcp_resources.rs
+++ b/codex-rs/core/src/tools/handlers/mcp_resource/list_mcp_resources.rs
@@ -117,7 +117,7 @@ impl ListMcpResourcesHandler {
             }
         }
         .await;
-        let truncation_policy = turn.model_info.truncation_policy.into();
+        let truncation_policy = step_context.model.model_info.truncation_policy.into();
 
         match payload_result {
             Ok(payload) => match serialize_function_output(payload, truncation_policy) {
@@ -128,6 +128,7 @@ impl ListMcpResourcesHandler {
                     emit_tool_call_end(
                         &session,
                         turn.as_ref(),
+                        step_context.model.as_ref(),
                         &call_id,
                         invocation,
                         duration,
@@ -142,6 +143,7 @@ impl ListMcpResourcesHandler {
                     emit_tool_call_end(
                         &session,
                         turn.as_ref(),
+                        step_context.model.as_ref(),
                         &call_id,
                         invocation,
                         duration,
@@ -157,6 +159,7 @@ impl ListMcpResourcesHandler {
                 emit_tool_call_end(
                     &session,
                     turn.as_ref(),
+                    step_context.model.as_ref(),
                     &call_id,
                     invocation,
                     duration,

--- a/codex-rs/core/src/tools/handlers/mcp_resource/read_mcp_resource.rs
+++ b/codex-rs/core/src/tools/handlers/mcp_resource/read_mcp_resource.rs
@@ -100,7 +100,7 @@ impl ReadMcpResourceHandler {
             })
         }
         .await;
-        let truncation_policy = turn.model_info.truncation_policy.into();
+        let truncation_policy = step_context.model.model_info.truncation_policy.into();
 
         match payload_result {
             Ok(payload) => match serialize_function_output(payload, truncation_policy) {
@@ -111,6 +111,7 @@ impl ReadMcpResourceHandler {
                     emit_tool_call_end(
                         &session,
                         turn.as_ref(),
+                        step_context.model.as_ref(),
                         &call_id,
                         invocation,
                         duration,
@@ -125,6 +126,7 @@ impl ReadMcpResourceHandler {
                     emit_tool_call_end(
                         &session,
                         turn.as_ref(),
+                        step_context.model.as_ref(),
                         &call_id,
                         invocation,
                         duration,
@@ -140,6 +142,7 @@ impl ReadMcpResourceHandler {
                 emit_tool_call_end(
                     &session,
                     turn.as_ref(),
+                    step_context.model.as_ref(),
                     &call_id,
                     invocation,
                     duration,

--- a/codex-rs/core/src/tools/handlers/multi_agents.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents.rs
@@ -9,7 +9,6 @@ use crate::agent::AgentStatus;
 use crate::agent::exceeds_thread_spawn_depth_limit;
 use crate::function_tool::FunctionCallError;
 use crate::session::session::Session;
-use crate::session::turn_context::TurnContext;
 use crate::tools::context::ToolInvocation;
 use crate::tools::context::ToolOutput;
 use crate::tools::context::ToolPayload;

--- a/codex-rs/core/src/tools/handlers/multi_agents/close_agent.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents/close_agent.rs
@@ -32,11 +32,12 @@ async fn handle_close_agent(
 ) -> Result<CloseAgentResult, FunctionCallError> {
     let ToolInvocation {
         session,
-        turn,
+        step_context,
         payload,
         call_id,
         ..
     } = invocation;
+    let turn = std::sync::Arc::clone(&step_context.turn);
     let arguments = function_arguments(payload)?;
     let args: CloseAgentArgs = parse_arguments(&arguments)?;
     let agent_id = parse_agent_id_target(&args.target)?;

--- a/codex-rs/core/src/tools/handlers/multi_agents/resume_agent.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents/resume_agent.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::agent::next_thread_spawn_depth;
+use crate::session::step_context::StepContext;
 use crate::tools::handlers::multi_agents_spec::create_resume_agent_tool;
 use crate::turn_timing::now_unix_timestamp_ms;
 use codex_tools::ToolSpec;
@@ -33,11 +34,12 @@ async fn handle_resume_agent(
 ) -> Result<ResumeAgentResult, FunctionCallError> {
     let ToolInvocation {
         session,
-        turn,
+        step_context,
         payload,
         call_id,
         ..
     } = invocation;
+    let turn = std::sync::Arc::clone(&step_context.turn);
     let arguments = function_arguments(payload)?;
     let args: ResumeAgentArgs = parse_arguments(&arguments)?;
     let receiver_thread_id = ThreadId::from_string(&args.id).map_err(|err| {
@@ -79,7 +81,7 @@ async fn handle_resume_agent(
     let (receiver_agent, error) = if matches!(status, AgentStatus::NotFound) {
         match Box::pin(try_resume_closed_agent(
             &session,
-            &turn,
+            step_context.as_ref(),
             receiver_thread_id,
             child_depth,
         ))
@@ -131,7 +133,9 @@ async fn handle_resume_agent(
     if let Some(err) = error {
         return Err(err);
     }
-    turn.session_telemetry
+    step_context
+        .model
+        .session_telemetry
         .counter("codex.multi_agent.resume", /*inc*/ 1, &[]);
 
     Ok(ResumeAgentResult { status })
@@ -173,11 +177,12 @@ impl ToolOutput for ResumeAgentResult {
 
 async fn try_resume_closed_agent(
     session: &Arc<Session>,
-    turn: &Arc<TurnContext>,
+    step_context: &StepContext,
     receiver_thread_id: ThreadId,
     child_depth: i32,
 ) -> Result<(), FunctionCallError> {
-    let config = build_agent_resume_config(turn.as_ref())?;
+    let turn = step_context.turn.as_ref();
+    let config = build_agent_resume_config(step_context)?;
     Box::pin(session.services.agent_control.resume_agent_from_rollout(
         config,
         receiver_thread_id,

--- a/codex-rs/core/src/tools/handlers/multi_agents/send_input.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents/send_input.rs
@@ -34,11 +34,12 @@ impl Handler {
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
-            turn,
+            step_context,
             payload,
             call_id,
             ..
         } = invocation;
+        let turn = std::sync::Arc::clone(&step_context.turn);
         let arguments = function_arguments(payload)?;
         let args: SendInputArgs = parse_arguments(&arguments)?;
         let receiver_thread_id = parse_agent_id_target(&args.target)?;
@@ -49,7 +50,7 @@ impl Handler {
             .agent_control
             .get_agent_metadata(receiver_thread_id);
         if receiver_agent.is_some() {
-            let resume_config = build_agent_resume_config(turn.as_ref())?;
+            let resume_config = build_agent_resume_config(step_context.as_ref())?;
             session
                 .services
                 .agent_control

--- a/codex-rs/core/src/tools/handlers/multi_agents/spawn.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents/spawn.rs
@@ -48,11 +48,12 @@ async fn handle_spawn_agent(
 ) -> Result<SpawnAgentResult, FunctionCallError> {
     let ToolInvocation {
         session,
-        turn,
+        step_context,
         payload,
         call_id,
         ..
     } = invocation;
+    let turn = std::sync::Arc::clone(&step_context.turn);
     let arguments = function_arguments(payload)?;
     let args: SpawnAgentArgs = parse_arguments(&arguments)?;
     let role_name = args
@@ -84,8 +85,10 @@ async fn handle_spawn_agent(
             .into(),
         )
         .await;
-    let mut config =
-        build_agent_spawn_config(&session.get_base_instructions().await, turn.as_ref())?;
+    let mut config = build_agent_spawn_config(
+        &session.get_base_instructions().await,
+        step_context.as_ref(),
+    )?;
     if let Some(service_tier) = args.service_tier.as_ref() {
         config.service_tier = Some(service_tier.clone());
     }
@@ -98,7 +101,7 @@ async fn handle_spawn_agent(
     } else {
         apply_requested_spawn_agent_model_overrides(
             &session,
-            turn.as_ref(),
+            step_context.model.as_ref(),
             &mut config,
             args.model.as_deref(),
             args.reasoning_effort.clone(),
@@ -111,7 +114,7 @@ async fn handle_spawn_agent(
     apply_spawn_agent_service_tier(
         &session,
         &mut config,
-        turn.config.service_tier.as_deref(),
+        step_context.model.service_tier.as_deref(),
         args.service_tier.as_deref(),
     )
     .await?;
@@ -197,7 +200,7 @@ async fn handle_spawn_agent(
         .await;
     let new_thread_id = result?.thread_id;
     let role_tag = role_name.unwrap_or(DEFAULT_ROLE_NAME);
-    turn.session_telemetry.counter(
+    step_context.model.session_telemetry.counter(
         "codex.multi_agent.spawn",
         /*inc*/ 1,
         &[("role", role_tag), ("version", "v1")],

--- a/codex-rs/core/src/tools/handlers/multi_agents/wait.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents/wait.rs
@@ -55,11 +55,12 @@ impl Handler {
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
-            turn,
+            step_context,
             payload,
             call_id,
             ..
         } = invocation;
+        let turn = std::sync::Arc::clone(&step_context.turn);
         let arguments = function_arguments(payload)?;
         let args: WaitArgs = parse_arguments(&arguments)?;
         let receiver_thread_ids = parse_agent_id_targets(args.targets)?;

--- a/codex-rs/core/src/tools/handlers/multi_agents_common.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_common.rs
@@ -4,6 +4,8 @@ use crate::config::DEFAULT_MULTI_AGENT_V2_MIN_WAIT_TIMEOUT_MS;
 use crate::config::HARD_MAX_MULTI_AGENT_V2_TIMEOUT_MS;
 use crate::function_tool::FunctionCallError;
 use crate::session::session::Session;
+use crate::session::step_context::StepContext;
+use crate::session::step_model_context::StepModelContext;
 use crate::session::turn_context::TurnContext;
 use crate::tools::context::FunctionToolOutput;
 use crate::tools::context::ToolOutput;
@@ -195,36 +197,41 @@ pub(crate) fn parse_collab_input(
 /// Builds the base config snapshot for a newly spawned sub-agent.
 ///
 /// The returned config starts from the parent's effective config and then refreshes the
-/// runtime-owned fields carried on `turn`, including model selection, reasoning settings,
-/// approval policy, sandbox, and cwd. Role-specific overrides are layered after this step;
+/// runtime-owned fields carried by the turn and step model contexts, including model selection,
+/// reasoning settings, approval policy, sandbox, and cwd. Role-specific overrides are layered
+/// after this step;
 /// skipping this helper and cloning stale config state directly can send the child agent out with
 /// the wrong provider or runtime policy.
 pub(crate) fn build_agent_spawn_config(
     base_instructions: &BaseInstructions,
-    turn: &TurnContext,
+    step_context: &StepContext,
 ) -> Result<Config, FunctionCallError> {
-    let mut config = build_agent_shared_config(turn)?;
+    let mut config = build_agent_shared_config(step_context)?;
     config.base_instructions = Some(base_instructions.text.clone());
     Ok(config)
 }
 
-pub(crate) fn build_agent_resume_config(turn: &TurnContext) -> Result<Config, FunctionCallError> {
-    let mut config = build_agent_shared_config(turn)?;
+pub(crate) fn build_agent_resume_config(
+    step_context: &StepContext,
+) -> Result<Config, FunctionCallError> {
+    let mut config = build_agent_shared_config(step_context)?;
     // For resume, keep base instructions sourced from rollout/session metadata.
     config.base_instructions = None;
     Ok(config)
 }
 
-fn build_agent_shared_config(turn: &TurnContext) -> Result<Config, FunctionCallError> {
+fn build_agent_shared_config(step_context: &StepContext) -> Result<Config, FunctionCallError> {
+    let turn = step_context.turn.as_ref();
+    let model = step_context.model.as_ref();
     let base_config = turn.config.clone();
     let mut config = (*base_config).clone();
-    config.model = Some(turn.model_info.slug.clone());
+    config.model = Some(model.model_info.slug.clone());
     config.model_provider = turn.provider.info().clone();
-    config.model_reasoning_effort = turn
-        .reasoning_effort
-        .clone()
-        .or_else(|| turn.model_info.default_reasoning_level.clone());
-    config.model_reasoning_summary = Some(turn.reasoning_summary);
+    config.model_reasoning_effort = model
+        .reasoning_effort()
+        .or_else(|| model.model_info.default_reasoning_level.clone());
+    config.model_reasoning_summary = Some(model.reasoning_summary);
+    config.service_tier = model.service_tier.clone();
     config.developer_instructions = turn.developer_instructions.clone();
     apply_spawn_agent_runtime_overrides(&mut config, turn)?;
 
@@ -274,7 +281,7 @@ pub(crate) fn apply_spawn_agent_runtime_overrides(
 
 pub(crate) async fn apply_requested_spawn_agent_model_overrides(
     session: &Session,
-    turn: &TurnContext,
+    model: &StepModelContext,
     config: &mut Config,
     requested_model: Option<&str>,
     requested_reasoning_effort: Option<ReasoningEffort>,
@@ -313,8 +320,8 @@ pub(crate) async fn apply_requested_spawn_agent_model_overrides(
 
     if let Some(reasoning_effort) = requested_reasoning_effort {
         validate_spawn_agent_reasoning_effort(
-            &turn.model_info.slug,
-            &turn.model_info.supported_reasoning_levels,
+            &model.model_info.slug,
+            &model.model_info.supported_reasoning_levels,
             &reasoning_effort,
         )?;
         config.model_reasoning_effort = Some(reasoning_effort);

--- a/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_tests.rs
@@ -6,6 +6,8 @@ use crate::function_tool::FunctionCallError;
 use crate::init_state_db;
 use crate::local_agent_graph_store_from_state_db;
 use crate::session::step_context::StepContext;
+use crate::session::step_context::StepContextSeed;
+use crate::session::step_model_context::StepModelContext;
 use crate::session::tests::make_session_and_context;
 use crate::session_prefix::format_inter_agent_completion_message;
 use crate::thread_manager::thread_store_from_config;
@@ -74,11 +76,19 @@ fn invocation(
     tool_name: &str,
     payload: ToolPayload,
 ) -> ToolInvocation {
-    let step_context = StepContext::for_test(Arc::clone(&turn));
+    let step_context = StepContext::for_test(turn);
+    invocation_with_step_context(session, step_context, tool_name, payload)
+}
+
+fn invocation_with_step_context(
+    session: Arc<crate::session::session::Session>,
+    step_context: Arc<StepContext>,
+    tool_name: &str,
+    payload: ToolPayload,
+) -> ToolInvocation {
     ToolInvocation {
         session,
         step_context,
-        turn,
         cancellation_token: CancellationToken::new(),
         tracker: Arc::new(Mutex::new(TurnDiffTracker::default())),
         call_id: "call-1".to_string(),
@@ -86,6 +96,27 @@ fn invocation(
         source: crate::tools::context::ToolCallSource::Direct,
         payload,
     }
+}
+
+async fn turn_and_model_with_model(
+    session: &crate::session::session::Session,
+    turn: TurnContext,
+    model: &str,
+) -> (TurnContext, StepModelContext) {
+    let requested_model = model.to_string();
+    let turn = Arc::new(turn);
+    let model_context = Arc::new(StepModelContext::for_test(turn.as_ref()));
+    let step_context_seed = StepContextSeed::new(turn, model_context)
+        .with_model(requested_model.clone(), &session.services.models_manager)
+        .await;
+    let StepContextSeed { turn, model } = step_context_seed;
+    let mut turn = Arc::try_unwrap(turn).expect("test turn should have a single owner");
+    let model = Arc::try_unwrap(model).expect("test model should have a single owner");
+    let mut config = (*turn.config).clone();
+    config.model = Some(requested_model);
+    config.model_reasoning_effort = model.reasoning_effort();
+    turn.config = Arc::new(config);
+    (turn, model)
 }
 
 fn function_payload(args: serde_json::Value) -> ToolPayload {
@@ -574,12 +605,11 @@ async fn spawn_agent_service_tier_inheritance_preserves_supported_or_configured_
 
     {
         let (mut session, turn) = make_session_and_context().await;
-        let mut turn = turn
-            .with_model("gpt-5.4".to_string(), &session.services.models_manager)
-            .await;
+        let (mut turn, mut model) = turn_and_model_with_model(&session, turn, "gpt-5.4").await;
         let mut config = (*turn.config).clone();
         config.service_tier = Some(ServiceTier::Fast.request_value().to_string());
         turn.config = Arc::new(config);
+        model.service_tier = Some(ServiceTier::Fast.request_value().to_string());
         let manager = thread_manager();
         let root = manager
             .start_thread((*turn.config).clone())
@@ -587,11 +617,12 @@ async fn spawn_agent_service_tier_inheritance_preserves_supported_or_configured_
             .expect("root thread should start");
         session.services.agent_control = manager.agent_control();
         session.thread_id = root.thread_id;
+        let step_context = StepContext::for_test_with_model(Arc::new(turn), Arc::new(model));
 
         let output = SpawnAgentHandler::default()
-            .handle(invocation(
+            .handle(invocation_with_step_context(
                 Arc::new(session),
-                Arc::new(turn),
+                step_context,
                 "spawn_agent",
                 function_payload(json!({"message": "inspect this repo"})),
             ))
@@ -615,12 +646,11 @@ async fn spawn_agent_service_tier_inheritance_preserves_supported_or_configured_
 
     {
         let (mut session, turn) = make_session_and_context().await;
-        let mut turn = turn
-            .with_model("gpt-5.4".to_string(), &session.services.models_manager)
-            .await;
+        let (mut turn, mut model) = turn_and_model_with_model(&session, turn, "gpt-5.4").await;
         let mut config = (*turn.config).clone();
         config.service_tier = Some(ServiceTier::Fast.request_value().to_string());
         turn.config = Arc::new(config);
+        model.service_tier = Some(ServiceTier::Fast.request_value().to_string());
         let manager = thread_manager();
         let root = manager
             .start_thread((*turn.config).clone())
@@ -628,11 +658,12 @@ async fn spawn_agent_service_tier_inheritance_preserves_supported_or_configured_
             .expect("root thread should start");
         session.services.agent_control = manager.agent_control();
         session.thread_id = root.thread_id;
+        let step_context = StepContext::for_test_with_model(Arc::new(turn), Arc::new(model));
 
         let output = SpawnAgentHandler::default()
-            .handle(invocation(
+            .handle(invocation_with_step_context(
                 Arc::new(session),
-                Arc::new(turn),
+                step_context,
                 "spawn_agent",
                 function_payload(json!({
                     "message": "inspect this repo",
@@ -729,9 +760,7 @@ async fn spawn_agent_role_service_tier_falls_back_to_supported_parent_tier() {
     }
 
     let (mut session, turn) = make_session_and_context().await;
-    let mut turn = turn
-        .with_model("gpt-5.4".to_string(), &session.services.models_manager)
-        .await;
+    let (mut turn, mut model) = turn_and_model_with_model(&session, turn, "gpt-5.4").await;
     tokio::fs::create_dir_all(&turn.config.codex_home)
         .await
         .expect("codex home should be created");
@@ -757,6 +786,7 @@ service_tier = "turbo"
         },
     );
     turn.config = Arc::new(config);
+    model.service_tier = Some(ServiceTier::Fast.request_value().to_string());
     let manager = thread_manager();
     let root = manager
         .start_thread((*turn.config).clone())
@@ -764,11 +794,12 @@ service_tier = "turbo"
         .expect("root thread should start");
     session.services.agent_control = manager.agent_control();
     session.thread_id = root.thread_id;
+    let step_context = StepContext::for_test_with_model(Arc::new(turn), Arc::new(model));
 
     let output = SpawnAgentHandler::default()
-        .handle(invocation(
+        .handle(invocation_with_step_context(
             Arc::new(session),
-            Arc::new(turn),
+            step_context,
             "spawn_agent",
             function_payload(json!({
                 "message": "inspect this repo",
@@ -851,9 +882,7 @@ async fn spawn_agent_full_history_fork_accepts_explicit_service_tier() {
     }
 
     let (mut session, turn) = make_session_and_context().await;
-    let turn = turn
-        .with_model("gpt-5.4".to_string(), &session.services.models_manager)
-        .await;
+    let (turn, model) = turn_and_model_with_model(&session, turn, "gpt-5.4").await;
     let manager = thread_manager();
     let root = manager
         .start_thread((*turn.config).clone())
@@ -861,11 +890,12 @@ async fn spawn_agent_full_history_fork_accepts_explicit_service_tier() {
         .expect("root thread should start");
     session.services.agent_control = manager.agent_control();
     session.thread_id = root.thread_id;
+    let step_context = StepContext::for_test_with_model(Arc::new(turn), Arc::new(model));
 
     let output = SpawnAgentHandler::default()
-        .handle(invocation(
+        .handle(invocation_with_step_context(
             Arc::new(session),
-            Arc::new(turn),
+            step_context,
             "spawn_agent",
             function_payload(json!({
                 "message": "inspect this repo",
@@ -899,9 +929,7 @@ async fn multi_agent_v2_full_history_fork_accepts_explicit_service_tier() {
     }
 
     let (mut session, turn) = make_session_and_context().await;
-    let mut turn = turn
-        .with_model("gpt-5.4".to_string(), &session.services.models_manager)
-        .await;
+    let (mut turn, model) = turn_and_model_with_model(&session, turn, "gpt-5.4").await;
     let mut config = (*turn.config).clone();
     config
         .features
@@ -917,11 +945,12 @@ async fn multi_agent_v2_full_history_fork_accepts_explicit_service_tier() {
     session.thread_id = root.thread_id;
     let session = Arc::new(session);
     let turn = Arc::new(turn);
+    let step_context = StepContext::for_test_with_model(Arc::clone(&turn), Arc::new(model));
 
     let output = SpawnAgentHandlerV2::default()
-        .handle(invocation(
+        .handle(invocation_with_step_context(
             session.clone(),
-            turn.clone(),
+            step_context,
             "spawn_agent",
             function_payload(json!({
                 "message": "inspect this repo",
@@ -1549,7 +1578,7 @@ async fn multi_agent_v2_list_agents_returns_completed_status_without_encrypted_s
         .get_thread(agent_id)
         .await
         .expect("child thread should exist");
-    let child_turn = child_thread.codex.session.new_default_turn().await;
+    let child_turn = child_thread.codex.session.new_default_turn().await.turn;
     child_thread
         .codex
         .session
@@ -1998,7 +2027,7 @@ async fn multi_agent_v2_followup_task_completion_notifies_parent_on_every_turn()
         .expect("worker thread should exist");
     let worker_path = AgentPath::try_from("/root/worker").expect("worker path");
 
-    let first_turn = thread.codex.session.new_default_turn().await;
+    let first_turn = thread.codex.session.new_default_turn().await.turn;
     thread
         .codex
         .session
@@ -2039,7 +2068,7 @@ async fn multi_agent_v2_followup_task_completion_notifies_parent_on_every_turn()
             )
     }));
 
-    let second_turn = thread.codex.session.new_default_turn().await;
+    let second_turn = thread.codex.session.new_default_turn().await.turn;
     thread
         .codex
         .session
@@ -2201,7 +2230,7 @@ async fn multi_agent_v2_interrupted_turn_does_not_notify_parent() {
         .await
         .expect("worker thread should exist");
 
-    let aborted_turn = thread.codex.session.new_default_turn().await;
+    let aborted_turn = thread.codex.session.new_default_turn().await.turn;
     thread
         .codex
         .session
@@ -2395,7 +2424,7 @@ async fn spawn_agent_reapplies_runtime_sandbox_after_role_config() {
         .get_thread(agent_id)
         .await
         .expect("spawned agent thread should exist");
-    let child_turn = child_thread.codex.session.new_default_turn().await;
+    let child_turn = child_thread.codex.session.new_default_turn().await.turn;
     assert_eq!(
         child_turn.file_system_sandbox_policy(),
         expected_file_system_sandbox_policy
@@ -3846,7 +3875,7 @@ async fn multi_agent_v2_interrupt_agent_accepts_task_name_target() {
     SpawnAgentHandlerV2::default()
         .handle(invocation(
             worker_session.clone(),
-            worker_session.new_default_turn().await,
+            worker_session.new_default_turn().await.turn,
             "spawn_agent",
             function_payload(json!({
                 "message": "inspect a child task",
@@ -4272,7 +4301,7 @@ async fn tool_handlers_cascade_close_and_resume_and_keep_explicitly_closed_subtr
     let parent_thread_id = parent.thread_id;
     let parent_session = parent.thread.codex.session.clone();
 
-    let child_turn = parent_session.new_default_turn().await;
+    let child_turn = parent_session.new_default_turn().await.turn;
     let child_spawn_output = SpawnAgentHandler::default()
         .handle(invocation(
             parent_session.clone(),
@@ -4301,7 +4330,7 @@ async fn tool_handlers_cascade_close_and_resume_and_keep_explicitly_closed_subtr
     let grandchild_spawn_output = SpawnAgentHandler::default()
         .handle(invocation(
             child_session.clone(),
-            child_session.new_default_turn().await,
+            child_session.new_default_turn().await.turn,
             "spawn_agent",
             function_payload(json!({"message": "hello grandchild"})),
         ))
@@ -4321,7 +4350,7 @@ async fn tool_handlers_cascade_close_and_resume_and_keep_explicitly_closed_subtr
     let close_output = CloseAgentHandler
         .handle(invocation(
             parent_session.clone(),
-            parent_session.new_default_turn().await,
+            parent_session.new_default_turn().await.turn,
             "close_agent",
             function_payload(json!({"target": child_thread_id.to_string()})),
         ))
@@ -4347,7 +4376,7 @@ async fn tool_handlers_cascade_close_and_resume_and_keep_explicitly_closed_subtr
     let child_resume_output = ResumeAgentHandler
         .handle(invocation(
             parent_session.clone(),
-            parent_session.new_default_turn().await,
+            parent_session.new_default_turn().await.turn,
             "resume_agent",
             function_payload(json!({"id": child_thread_id.to_string()})),
         ))
@@ -4373,7 +4402,7 @@ async fn tool_handlers_cascade_close_and_resume_and_keep_explicitly_closed_subtr
     let close_again_output = CloseAgentHandler
         .handle(invocation(
             parent_session.clone(),
-            parent_session.new_default_turn().await,
+            parent_session.new_default_turn().await.turn,
             "close_agent",
             function_payload(json!({"target": child_thread_id.to_string()})),
         ))
@@ -4415,7 +4444,7 @@ async fn tool_handlers_cascade_close_and_resume_and_keep_explicitly_closed_subtr
     let parent_resume_output = ResumeAgentHandler
         .handle(invocation(
             operator_session,
-            operator.thread.codex.session.new_default_turn().await,
+            operator.thread.codex.session.new_default_turn().await.turn,
             "resume_agent",
             function_payload(json!({"id": parent_thread_id.to_string()})),
         ))
@@ -4512,13 +4541,20 @@ async fn build_agent_spawn_config_uses_turn_context_values() {
         .set(AskForApproval::OnRequest)
         .expect("approval policy set");
 
-    let config = build_agent_spawn_config(&base_instructions, &turn).expect("spawn config");
+    let turn = Arc::new(turn);
+    let step_context = StepContext::for_test(Arc::clone(&turn));
+    let model = step_context.model.as_ref();
+    let config =
+        build_agent_spawn_config(&base_instructions, step_context.as_ref()).expect("spawn config");
     let mut expected = (*turn.config).clone();
     expected.base_instructions = Some(base_instructions.text);
-    expected.model = Some(turn.model_info.slug.clone());
+    expected.model = Some(model.model_info.slug.clone());
     expected.model_provider = turn.provider.info().clone();
-    expected.model_reasoning_effort = turn.reasoning_effort.clone();
-    expected.model_reasoning_summary = Some(turn.reasoning_summary);
+    expected.model_reasoning_effort = model
+        .reasoning_effort()
+        .or_else(|| model.model_info.default_reasoning_level.clone());
+    expected.model_reasoning_summary = Some(model.reasoning_summary);
+    expected.service_tier = model.service_tier.clone();
     expected.developer_instructions = turn.developer_instructions.clone();
     #[allow(deprecated)]
     {
@@ -4546,14 +4582,20 @@ async fn build_agent_resume_config_clears_base_instructions() {
         .set(AskForApproval::OnRequest)
         .expect("approval policy set");
 
-    let config = build_agent_resume_config(&turn).expect("resume config");
+    let turn = Arc::new(turn);
+    let step_context = StepContext::for_test(Arc::clone(&turn));
+    let model = step_context.model.as_ref();
+    let config = build_agent_resume_config(step_context.as_ref()).expect("resume config");
 
     let mut expected = (*turn.config).clone();
     expected.base_instructions = None;
-    expected.model = Some(turn.model_info.slug.clone());
+    expected.model = Some(model.model_info.slug.clone());
     expected.model_provider = turn.provider.info().clone();
-    expected.model_reasoning_effort = turn.reasoning_effort.clone();
-    expected.model_reasoning_summary = Some(turn.reasoning_summary);
+    expected.model_reasoning_effort = model
+        .reasoning_effort()
+        .or_else(|| model.model_info.default_reasoning_level.clone());
+    expected.model_reasoning_summary = Some(model.reasoning_summary);
+    expected.service_tier = model.service_tier.clone();
     expected.developer_instructions = turn.developer_instructions.clone();
     #[allow(deprecated)]
     {

--- a/codex-rs/core/src/tools/handlers/multi_agents_v2/interrupt_agent.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_v2/interrupt_agent.rs
@@ -29,11 +29,12 @@ async fn handle_interrupt_agent(
 ) -> Result<InterruptAgentResult, FunctionCallError> {
     let ToolInvocation {
         session,
-        turn,
+        step_context,
         payload,
         call_id,
         ..
     } = invocation;
+    let turn = std::sync::Arc::clone(&step_context.turn);
     let arguments = function_arguments(payload)?;
     let args: InterruptAgentArgs = parse_arguments(&arguments)?;
     let agent_id = resolve_agent_target(&session, &turn, &args.target).await?;

--- a/codex-rs/core/src/tools/handlers/multi_agents_v2/list_agents.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_v2/list_agents.rs
@@ -26,10 +26,11 @@ impl Handler {
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
-            turn,
+            step_context,
             payload,
             ..
         } = invocation;
+        let turn = std::sync::Arc::clone(&step_context.turn);
         let arguments = function_arguments(payload)?;
         let args: ListAgentsArgs = parse_arguments(&arguments)?;
         session

--- a/codex-rs/core/src/tools/handlers/multi_agents_v2/message_tool.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_v2/message_tool.rs
@@ -67,10 +67,11 @@ pub(crate) async fn handle_message_string_tool(
     let message = message_content(message)?;
     let ToolInvocation {
         session,
-        turn,
+        step_context,
         call_id,
         ..
     } = invocation;
+    let turn = std::sync::Arc::clone(&step_context.turn);
     let receiver_thread_id = resolve_agent_target(&session, &turn, &target).await?;
     let receiver_agent = session
         .services
@@ -90,7 +91,7 @@ pub(crate) async fn handle_message_string_tool(
     let receiver_agent_path = receiver_agent.agent_path.clone().ok_or_else(|| {
         FunctionCallError::RespondToModel("target agent is missing an agent_path".to_string())
     })?;
-    let resume_config = build_agent_resume_config(turn.as_ref())?;
+    let resume_config = build_agent_resume_config(step_context.as_ref())?;
     session
         .services
         .agent_control

--- a/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_v2/spawn.rs
@@ -43,11 +43,12 @@ async fn handle_spawn_agent(
 ) -> Result<SpawnAgentResult, FunctionCallError> {
     let ToolInvocation {
         session,
-        turn,
+        step_context,
         payload,
         call_id,
         ..
     } = invocation;
+    let turn = std::sync::Arc::clone(&step_context.turn);
     let arguments = function_arguments(payload)?;
     let args: SpawnAgentArgs = parse_arguments(&arguments)?;
     let fork_mode = args.fork_mode()?;
@@ -60,8 +61,10 @@ async fn handle_spawn_agent(
     let message = message_content(args.message)?;
     let session_source = turn.session_source.clone();
     let child_depth = next_thread_spawn_depth(&session_source);
-    let mut config =
-        build_agent_spawn_config(&session.get_base_instructions().await, turn.as_ref())?;
+    let mut config = build_agent_spawn_config(
+        &session.get_base_instructions().await,
+        step_context.as_ref(),
+    )?;
     if let Some(service_tier) = args.service_tier.as_ref() {
         config.service_tier = Some(service_tier.clone());
     }
@@ -74,7 +77,7 @@ async fn handle_spawn_agent(
     } else {
         apply_requested_spawn_agent_model_overrides(
             &session,
-            turn.as_ref(),
+            step_context.model.as_ref(),
             &mut config,
             args.model.as_deref(),
             args.reasoning_effort.clone(),
@@ -87,7 +90,7 @@ async fn handle_spawn_agent(
     apply_spawn_agent_service_tier(
         &session,
         &mut config,
-        turn.config.service_tier.as_deref(),
+        step_context.model.service_tier.as_deref(),
         args.service_tier.as_deref(),
     )
     .await?;
@@ -154,7 +157,7 @@ async fn handle_spawn_agent(
         )
         .await;
     let role_tag = role_name.unwrap_or(DEFAULT_ROLE_NAME);
-    turn.session_telemetry.counter(
+    step_context.model.session_telemetry.counter(
         "codex.multi_agent.spawn",
         /*inc*/ 1,
         &[("role", role_tag), ("version", "v2")],

--- a/codex-rs/core/src/tools/handlers/multi_agents_v2/wait.rs
+++ b/codex-rs/core/src/tools/handlers/multi_agents_v2/wait.rs
@@ -41,11 +41,12 @@ impl Handler {
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
-            turn,
+            step_context,
             payload,
             call_id,
             ..
         } = invocation;
+        let turn = std::sync::Arc::clone(&step_context.turn);
         let arguments = function_arguments(payload)?;
         let args: WaitArgs = parse_arguments(&arguments)?;
         let min_timeout_ms = turn.config.multi_agent_v2.min_wait_timeout_ms;

--- a/codex-rs/core/src/tools/handlers/plan.rs
+++ b/codex-rs/core/src/tools/handlers/plan.rs
@@ -66,11 +66,12 @@ impl PlanHandler {
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
-            turn,
+            step_context,
             call_id: _,
             payload,
             ..
         } = invocation;
+        let turn = std::sync::Arc::clone(&step_context.turn);
 
         let arguments = match payload {
             ToolPayload::Function { arguments } => arguments,
@@ -81,7 +82,7 @@ impl PlanHandler {
             }
         };
 
-        if turn.collaboration_mode.mode == ModeKind::Plan {
+        if step_context.model.collaboration_mode.mode == ModeKind::Plan {
             return Err(FunctionCallError::RespondToModel(
                 "update_plan is a TODO/checklist tool and is not allowed in Plan mode".to_string(),
             ));

--- a/codex-rs/core/src/tools/handlers/request_permissions.rs
+++ b/codex-rs/core/src/tools/handlers/request_permissions.rs
@@ -2,6 +2,7 @@ use codex_protocol::request_permissions::RequestPermissionsArgs;
 use codex_sandboxing::policy_transforms::normalize_additional_permissions;
 
 use crate::function_tool::FunctionCallError;
+use crate::session::step_context::StepContextSeed;
 use crate::tools::context::FunctionToolOutput;
 use crate::tools::context::ToolInvocation;
 use crate::tools::context::ToolPayload;
@@ -46,7 +47,6 @@ impl RequestPermissionsHandler {
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
-            turn,
             step_context,
             cancellation_token,
             call_id,
@@ -94,7 +94,7 @@ impl RequestPermissionsHandler {
 
         let response = session
             .request_permissions_for_environment(
-                &turn,
+                &StepContextSeed::from(step_context.as_ref()),
                 call_id,
                 args,
                 turn_environment.selection(),

--- a/codex-rs/core/src/tools/handlers/request_plugin_install.rs
+++ b/codex-rs/core/src/tools/handlers/request_plugin_install.rs
@@ -192,7 +192,7 @@ impl RequestPluginInstallHandler {
                 .analytics_events_client
                 .track_plugin_install_requested(
                     build_track_events_context(
-                        turn.model_info.slug.clone(),
+                        step_context.model.model_info.slug.clone(),
                         session.thread_id.to_string(),
                         turn.sub_id.clone(),
                         turn.originator.clone(),
@@ -253,14 +253,17 @@ impl RequestPluginInstallHandler {
                 Some(ElicitationAction::Cancel) => "cancel",
                 None => "unavailable",
             };
-            turn.session_telemetry.record_plugin_install_suggestion(
-                tool_type,
-                tool.id(),
-                tool.name(),
-                response_action,
-                user_confirmed,
-                completed,
-            );
+            step_context
+                .model
+                .session_telemetry
+                .record_plugin_install_suggestion(
+                    tool_type,
+                    tool.id(),
+                    tool.name(),
+                    response_action,
+                    user_confirmed,
+                    completed,
+                );
         }
 
         let content = serde_json::to_string(&RequestPluginInstallResult {

--- a/codex-rs/core/src/tools/handlers/request_plugin_install.rs
+++ b/codex-rs/core/src/tools/handlers/request_plugin_install.rs
@@ -214,7 +214,7 @@ impl RequestPluginInstallHandler {
         let request = build_request_plugin_install_elicitation_request(suggest_reason, &tool);
         let elicitation = session
             .request_mcp_server_elicitation(
-                turn.as_ref(),
+                step_context.as_ref(),
                 CODEX_APPS_MCP_SERVER_NAME.to_string(),
                 request_id,
                 request,

--- a/codex-rs/core/src/tools/handlers/request_user_input.rs
+++ b/codex-rs/core/src/tools/handlers/request_user_input.rs
@@ -41,11 +41,12 @@ impl RequestUserInputHandler {
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
-            turn,
+            step_context,
             call_id,
             payload,
             ..
         } = invocation;
+        let turn = std::sync::Arc::clone(&step_context.turn);
 
         let arguments = match payload {
             ToolPayload::Function { arguments } => arguments,
@@ -62,7 +63,7 @@ impl RequestUserInputHandler {
             ));
         }
 
-        let mode = session.collaboration_mode().await.mode;
+        let mode = step_context.model.collaboration_mode.mode;
         if let Some(message) = request_user_input_unavailable_message(mode, &self.available_modes) {
             return Err(FunctionCallError::RespondToModel(message));
         }

--- a/codex-rs/core/src/tools/handlers/request_user_input_tests.rs
+++ b/codex-rs/core/src/tools/handlers/request_user_input_tests.rs
@@ -30,7 +30,6 @@ async fn multi_agent_v2_request_user_input_rejects_subagent_threads() {
     .handle(ToolInvocation {
         session: Arc::new(session),
         step_context: StepContext::for_test(Arc::clone(&turn)),
-        turn,
         cancellation_token: tokio_util::sync::CancellationToken::new(),
         tracker: Arc::new(Mutex::new(TurnDiffTracker::default())),
         call_id: "call-1".to_string(),

--- a/codex-rs/core/src/tools/handlers/shell.rs
+++ b/codex-rs/core/src/tools/handlers/shell.rs
@@ -7,7 +7,7 @@ use tokio_util::sync::CancellationToken;
 use crate::exec::ExecParams;
 use crate::exec_policy::ExecApprovalRequest;
 use crate::function_tool::FunctionCallError;
-use crate::session::turn_context::TurnContext;
+use crate::session::step_context::StepContext;
 use crate::session::turn_context::TurnEnvironment;
 use crate::shell::ShellType;
 use crate::tools::context::FunctionToolOutput;
@@ -53,7 +53,7 @@ struct RunExecLikeArgs {
     additional_permissions: Option<AdditionalPermissionProfile>,
     prefix_rule: Option<Vec<String>>,
     session: Arc<crate::session::session::Session>,
-    turn: Arc<TurnContext>,
+    step_context: Arc<StepContext>,
     turn_environment: TurnEnvironment,
     tracker: crate::tools::context::SharedTurnDiffTracker,
     call_id: String,
@@ -70,12 +70,13 @@ async fn run_exec_like(args: RunExecLikeArgs) -> Result<FunctionToolOutput, Func
         additional_permissions,
         prefix_rule,
         session,
-        turn,
+        step_context,
         turn_environment,
         tracker,
         call_id,
         shell_runtime_backend,
     } = args;
+    let turn = &step_context.turn;
 
     let fs = turn_environment.environment.get_filesystem();
 
@@ -145,7 +146,7 @@ async fn run_exec_like(args: RunExecLikeArgs) -> Result<FunctionToolOutput, Func
         fs.as_ref(),
         turn_environment.clone(),
         session.clone(),
-        turn.clone(),
+        step_context.clone(),
         Some(&tracker),
         &call_id,
         tool_name.name.as_str(),
@@ -159,7 +160,7 @@ async fn run_exec_like(args: RunExecLikeArgs) -> Result<FunctionToolOutput, Func
     let emitter = ToolEmitter::shell(exec_params.command.clone(), exec_params.cwd.clone(), source);
     let event_ctx = ToolEventCtx::new(
         session.as_ref(),
-        turn.as_ref(),
+        step_context.as_ref(),
         &call_id,
         /*turn_diff_tracker*/ None,
     );
@@ -205,23 +206,17 @@ async fn run_exec_like(args: RunExecLikeArgs) -> Result<FunctionToolOutput, Func
     let mut runtime = ShellRuntime::for_shell_command(shell_runtime_backend);
     let tool_ctx = ToolCtx {
         session: session.clone(),
-        turn: turn.clone(),
+        step_context: step_context.clone(),
         call_id: call_id.clone(),
         tool_name,
     };
     let out = orchestrator
-        .run(
-            &mut runtime,
-            &req,
-            &tool_ctx,
-            &turn,
-            turn.approval_policy.value(),
-        )
+        .run(&mut runtime, &req, &tool_ctx)
         .await
         .map(|result| result.output);
     let event_ctx = ToolEventCtx::new(
         session.as_ref(),
-        turn.as_ref(),
+        step_context.as_ref(),
         &call_id,
         /*turn_diff_tracker*/ None,
     );
@@ -229,7 +224,10 @@ async fn run_exec_like(args: RunExecLikeArgs) -> Result<FunctionToolOutput, Func
         .as_ref()
         .ok()
         .map(|output| {
-            crate::tools::format_exec_output_str(output, turn.model_info.truncation_policy.into())
+            crate::tools::format_exec_output_str(
+                output,
+                step_context.model.model_info.truncation_policy.into(),
+            )
         })
         .map(JsonValue::String);
     let content = emitter

--- a/codex-rs/core/src/tools/handlers/shell/shell_command.rs
+++ b/codex-rs/core/src/tools/handlers/shell/shell_command.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use codex_protocol::models::ShellCommandToolCallParams;
 use codex_tools::ShellCommandBackendConfig;
 use codex_tools::ToolName;

--- a/codex-rs/core/src/tools/handlers/shell/shell_command.rs
+++ b/codex-rs/core/src/tools/handlers/shell/shell_command.rs
@@ -165,7 +165,6 @@ impl ShellCommandHandler {
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
-            turn,
             step_context,
             cancellation_token,
             tracker,
@@ -173,6 +172,7 @@ impl ShellCommandHandler {
             payload,
             ..
         } = invocation;
+        let turn = Arc::clone(&step_context.turn);
 
         let tool_name = self.tool_name();
         let ToolPayload::Function { arguments } = payload else {
@@ -197,7 +197,7 @@ impl ShellCommandHandler {
         let params: ShellCommandToolCallParams = parse_arguments_with_base_path(&arguments, &cwd)?;
         maybe_emit_implicit_skill_invocation(
             session.as_ref(),
-            turn.as_ref(),
+            step_context.as_ref(),
             &params.command,
             &cwd,
         )
@@ -226,7 +226,7 @@ impl ShellCommandHandler {
             additional_permissions: params.additional_permissions.clone(),
             prefix_rule,
             session,
-            turn,
+            step_context,
             turn_environment,
             tracker,
             call_id,

--- a/codex-rs/core/src/tools/handlers/shell_tests.rs
+++ b/codex-rs/core/src/tools/handlers/shell_tests.rs
@@ -254,7 +254,6 @@ async fn shell_command_pre_tool_use_payload_uses_raw_command() {
         handler.pre_tool_use_payload(&ToolInvocation {
             session: session.into(),
             step_context: StepContext::for_test(Arc::clone(&turn)),
-            turn,
             cancellation_token: tokio_util::sync::CancellationToken::new(),
             tracker: Arc::new(Mutex::new(TurnDiffTracker::new())),
             call_id: "call-42".to_string(),
@@ -285,7 +284,6 @@ async fn build_post_tool_use_payload_uses_tool_output_wire_value() {
     let invocation = ToolInvocation {
         session: session.into(),
         step_context: StepContext::for_test(Arc::clone(&turn)),
-        turn,
         cancellation_token: tokio_util::sync::CancellationToken::new(),
         tracker: Arc::new(Mutex::new(TurnDiffTracker::new())),
         call_id: "call-42".to_string(),

--- a/codex-rs/core/src/tools/handlers/sleep.rs
+++ b/codex-rs/core/src/tools/handlers/sleep.rs
@@ -71,11 +71,12 @@ impl ToolExecutor<ToolInvocation> for SleepHandler {
         Box::pin(async move {
             let ToolInvocation {
                 session,
-                turn,
+                step_context,
                 call_id,
                 payload,
                 ..
             } = invocation;
+            let turn = std::sync::Arc::clone(&step_context.turn);
             let ToolPayload::Function { arguments } = payload else {
                 return Err(FunctionCallError::RespondToModel(format!(
                     "{TOOL_NAME} handler received unsupported payload"
@@ -130,7 +131,9 @@ impl ToolExecutor<ToolInvocation> for SleepHandler {
                     }
                 }
             };
-            session.emit_turn_item_completed(turn.as_ref(), item).await;
+            session
+                .emit_turn_item_completed(turn.as_ref(), step_context.model.as_ref(), item)
+                .await;
             let interrupted = sleep_result?;
 
             let message = if interrupted {

--- a/codex-rs/core/src/tools/handlers/unified_exec/exec_command.rs
+++ b/codex-rs/core/src/tools/handlers/unified_exec/exec_command.rs
@@ -109,13 +109,13 @@ impl ExecCommandHandler {
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
-            turn,
             step_context,
             tracker,
             call_id,
             payload,
             ..
         } = invocation;
+        let turn = Arc::clone(&step_context.turn);
 
         let arguments = match payload {
             ToolPayload::Function { arguments } => arguments,
@@ -127,7 +127,8 @@ impl ExecCommandHandler {
         };
 
         let manager: &UnifiedExecProcessManager = &session.services.unified_exec_manager;
-        let context = UnifiedExecContext::new(session.clone(), turn.clone(), call_id.clone());
+        let context =
+            UnifiedExecContext::new(session.clone(), step_context.clone(), call_id.clone());
         let environment_args: ExecCommandEnvironmentArgs = parse_arguments(&arguments)?;
         let Some(turn_environment) = resolve_tool_environment(
             &step_context.environments,
@@ -194,7 +195,7 @@ impl ExecCommandHandler {
         if let Some(native_cwd) = native_cwd.as_ref() {
             maybe_emit_implicit_skill_invocation(
                 session.as_ref(),
-                context.turn.as_ref(),
+                context.step_context.as_ref(),
                 &hook_command,
                 native_cwd,
             )
@@ -275,11 +276,11 @@ impl ExecCommandHandler {
             .requests_sandbox_override()
             && !effective_additional_permissions.permissions_preapproved
             && !matches!(
-                context.turn.approval_policy.value(),
+                turn.approval_policy.value(),
                 codex_protocol::protocol::AskForApproval::OnRequest
             )
         {
-            let approval_policy = context.turn.approval_policy.value();
+            let approval_policy = turn.approval_policy.value();
             manager.release_process_id(process_id).await;
             return Err(FunctionCallError::RespondToModel(format!(
                 "approval policy is {approval_policy:?}; reject command — you cannot ask for escalated permissions if the approval policy is {approval_policy:?}"
@@ -295,7 +296,7 @@ impl ExecCommandHandler {
             || {
                 normalize_and_validate_additional_permissions(
                     additional_permissions_allowed,
-                    context.turn.approval_policy.value(),
+                    turn.approval_policy.value(),
                     effective_additional_permissions.sandbox_permissions,
                     effective_additional_permissions.additional_permissions,
                     effective_additional_permissions.permissions_preapproved,
@@ -317,7 +318,7 @@ impl ExecCommandHandler {
             fs.as_ref(),
             turn_environment.clone(),
             context.session.clone(),
-            context.turn.clone(),
+            context.step_context.clone(),
             Some(&tracker),
             &context.call_id,
             "exec_command",
@@ -330,7 +331,12 @@ impl ExecCommandHandler {
                 chunk_id: String::new(),
                 wall_time: std::time::Duration::ZERO,
                 raw_output: output.into_text().into_bytes(),
-                truncation_policy: turn.model_info.truncation_policy.into(),
+                truncation_policy: context
+                    .step_context
+                    .model
+                    .model_info
+                    .truncation_policy
+                    .into(),
                 max_output_tokens,
                 process_id: None,
                 exit_code: None,
@@ -339,7 +345,7 @@ impl ExecCommandHandler {
             }));
         }
 
-        emit_unified_exec_tty_metric(&turn.session_telemetry, tty);
+        emit_unified_exec_tty_metric(&context.step_context.model.session_telemetry, tty);
         match manager
             .exec_command(
                 ExecCommandRequest {
@@ -353,7 +359,7 @@ impl ExecCommandHandler {
                     sandbox_cwd: native_environment_cwd,
                     turn_environment: turn_environment.clone(),
                     shell_mode,
-                    network: context.turn.network.clone(),
+                    network: turn.network.clone(),
                     tty,
                     sandbox_permissions: effective_additional_permissions.sandbox_permissions,
                     additional_permissions: normalized_additional_permissions,
@@ -375,7 +381,12 @@ impl ExecCommandHandler {
                     chunk_id: generate_chunk_id(),
                     wall_time: output.duration,
                     raw_output: output_text.into_bytes(),
-                    truncation_policy: turn.model_info.truncation_policy.into(),
+                    truncation_policy: context
+                        .step_context
+                        .model
+                        .model_info
+                        .truncation_policy
+                        .into(),
                     max_output_tokens,
                     // Sandbox denial is terminal, so there is no live
                     // process for write_stdin to resume.

--- a/codex-rs/core/src/tools/handlers/unified_exec/write_stdin.rs
+++ b/codex-rs/core/src/tools/handlers/unified_exec/write_stdin.rs
@@ -94,7 +94,10 @@ impl WriteStdinHandler {
                 stdin: args.chars.clone(),
             };
             session
-                .send_event(turn.as_ref(), EventMsg::TerminalInteraction(interaction))
+                .send_event(
+                    step_context.turn.as_ref(),
+                    EventMsg::TerminalInteraction(interaction),
+                )
                 .await;
         }
 

--- a/codex-rs/core/src/tools/handlers/unified_exec/write_stdin.rs
+++ b/codex-rs/core/src/tools/handlers/unified_exec/write_stdin.rs
@@ -52,7 +52,7 @@ impl WriteStdinHandler {
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         let ToolInvocation {
             session,
-            turn,
+            step_context,
             payload,
             ..
         } = invocation;
@@ -75,7 +75,7 @@ impl WriteStdinHandler {
                 input: &args.chars,
                 yield_time_ms: args.yield_time_ms,
                 max_output_tokens: args.max_output_tokens,
-                truncation_policy: turn.model_info.truncation_policy.into(),
+                truncation_policy: step_context.model.model_info.truncation_policy.into(),
             })
             .await
             .map_err(|err| {

--- a/codex-rs/core/src/tools/handlers/unified_exec_tests.rs
+++ b/codex-rs/core/src/tools/handlers/unified_exec_tests.rs
@@ -32,7 +32,6 @@ async fn invocation_for_payload(
     ToolInvocation {
         session: session.into(),
         step_context: StepContext::for_test(Arc::clone(&turn)),
-        turn,
         cancellation_token: tokio_util::sync::CancellationToken::new(),
         tracker: Arc::new(Mutex::new(TurnDiffTracker::new())),
         call_id: call_id.to_string(),
@@ -246,7 +245,6 @@ async fn exec_command_pre_tool_use_payload_uses_raw_command() {
         handler.pre_tool_use_payload(&ToolInvocation {
             session: session.into(),
             step_context: StepContext::for_test(Arc::clone(&turn)),
-            turn,
             cancellation_token: tokio_util::sync::CancellationToken::new(),
             tracker: Arc::new(Mutex::new(TurnDiffTracker::new())),
             call_id: "call-43".to_string(),
@@ -274,7 +272,6 @@ async fn exec_command_pre_tool_use_payload_skips_write_stdin() {
         handler.pre_tool_use_payload(&ToolInvocation {
             session: session.into(),
             step_context: StepContext::for_test(Arc::clone(&turn)),
-            turn,
             cancellation_token: tokio_util::sync::CancellationToken::new(),
             tracker: Arc::new(Mutex::new(TurnDiffTracker::new())),
             call_id: "call-44".to_string(),

--- a/codex-rs/core/src/tools/handlers/view_image.rs
+++ b/codex-rs/core/src/tools/handlers/view_image.rs
@@ -87,7 +87,8 @@ impl ViewImageHandler {
         invocation: ToolInvocation,
     ) -> Result<Box<dyn crate::tools::context::ToolOutput>, FunctionCallError> {
         if !invocation
-            .turn
+            .step_context
+            .model
             .model_info
             .input_modalities
             .contains(&InputModality::Image)
@@ -99,12 +100,12 @@ impl ViewImageHandler {
 
         let ToolInvocation {
             session,
-            turn,
             step_context,
             payload,
             call_id,
             ..
         } = invocation;
+        let turn = Arc::clone(&step_context.turn);
 
         let arguments = match payload {
             ToolPayload::Function { arguments } => arguments,
@@ -176,7 +177,8 @@ impl ViewImageHandler {
                 ))
             })?;
 
-        let can_request_original_detail = can_request_original_image_detail(&turn.model_info);
+        let can_request_original_detail =
+            can_request_original_image_detail(&step_context.model.model_info);
         let use_original_detail =
             can_request_original_detail && matches!(detail, Some(ViewImageDetail::Original));
         let image_detail = if use_original_detail {
@@ -193,7 +195,9 @@ impl ViewImageHandler {
             path: path_uri,
         });
         session.emit_turn_item_started(turn.as_ref(), &item).await;
-        session.emit_turn_item_completed(turn.as_ref(), item).await;
+        session
+            .emit_turn_item_completed(turn.as_ref(), step_context.model.as_ref(), item)
+            .await;
 
         Ok(boxed_tool_output(ViewImageOutput {
             image_url,
@@ -322,7 +326,6 @@ mod tests {
             .handle(ToolInvocation {
                 session: Arc::new(session),
                 step_context: StepContext::for_test(Arc::clone(&turn)),
-                turn,
                 cancellation_token: tokio_util::sync::CancellationToken::new(),
                 tracker: Arc::new(Mutex::new(TurnDiffTracker::new())),
                 call_id: "call-view-image".to_string(),
@@ -352,7 +355,6 @@ mod tests {
             .handle(ToolInvocation {
                 session: Arc::new(session),
                 step_context: StepContext::for_test(Arc::clone(&turn)),
-                turn,
                 cancellation_token: tokio_util::sync::CancellationToken::new(),
                 tracker: Arc::new(Mutex::new(TurnDiffTracker::new())),
                 call_id: "call-view-image".to_string(),
@@ -389,7 +391,6 @@ mod tests {
             .handle(ToolInvocation {
                 session: Arc::new(session),
                 step_context: StepContext::for_test(Arc::clone(&turn)),
-                turn,
                 cancellation_token: tokio_util::sync::CancellationToken::new(),
                 tracker: Arc::new(Mutex::new(TurnDiffTracker::new())),
                 call_id: "call-view-image".to_string(),

--- a/codex-rs/core/src/tools/handlers/view_image.rs
+++ b/codex-rs/core/src/tools/handlers/view_image.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use codex_protocol::items::ImageViewItem;
 use codex_protocol::items::TurnItem;
 use codex_protocol::models::DEFAULT_IMAGE_DETAIL;

--- a/codex-rs/core/src/tools/lifecycle.rs
+++ b/codex-rs/core/src/tools/lifecycle.rs
@@ -20,8 +20,8 @@ pub(crate) async fn notify_tool_start(invocation: &ToolInvocation) {
             .on_tool_start(ToolStartInput {
                 session_store: &invocation.session.services.session_extension_data,
                 thread_store: &invocation.session.services.thread_extension_data,
-                turn_store: invocation.turn.extension_data.as_ref(),
-                turn_id: invocation.turn.sub_id.as_str(),
+                turn_store: invocation.step_context.turn.extension_data.as_ref(),
+                turn_id: invocation.step_context.turn.sub_id.as_str(),
                 call_id: invocation.call_id.as_str(),
                 tool_name: &invocation.tool_name,
                 source: extension_tool_call_source(invocation.source.clone()),
@@ -33,7 +33,7 @@ pub(crate) async fn notify_tool_start(invocation: &ToolInvocation) {
 pub(crate) async fn notify_tool_finish(invocation: &ToolInvocation, outcome: ToolCallOutcome) {
     notify_tool_finish_parts(
         invocation.session.as_ref(),
-        invocation.turn.as_ref(),
+        invocation.step_context.turn.as_ref(),
         invocation.call_id.as_str(),
         &invocation.tool_name,
         invocation.source.clone(),

--- a/codex-rs/core/src/tools/mod.rs
+++ b/codex-rs/core/src/tools/mod.rs
@@ -17,7 +17,8 @@ pub(crate) mod tool_dispatch_trace;
 
 use std::borrow::Cow;
 
-use crate::session::turn_context::TurnContext;
+use crate::config::ManagedFeatures;
+use crate::session::step_model_context::StepModelContext;
 use codex_features::Feature;
 use codex_protocol::exec_output::ExecToolCallOutput;
 use codex_protocol::openai_models::ToolMode;
@@ -60,11 +61,11 @@ pub(crate) fn tool_user_shell_type(
     }
 }
 
-fn effective_tool_mode(turn_context: &TurnContext) -> ToolMode {
-    turn_context.model_info.tool_mode.unwrap_or_else(|| {
-        if turn_context.config.features.enabled(Feature::CodeModeOnly) {
+fn effective_tool_mode(model: &StepModelContext, features: &ManagedFeatures) -> ToolMode {
+    model.model_info.tool_mode.unwrap_or_else(|| {
+        if features.enabled(Feature::CodeModeOnly) {
             ToolMode::CodeModeOnly
-        } else if turn_context.config.features.enabled(Feature::CodeMode) {
+        } else if features.enabled(Feature::CodeMode) {
             ToolMode::CodeMode
         } else {
             ToolMode::Direct

--- a/codex-rs/core/src/tools/network_approval.rs
+++ b/codex-rs/core/src/tools/network_approval.rs
@@ -8,6 +8,8 @@ use crate::guardian::routes_approval_to_guardian;
 use crate::hook_runtime::run_permission_request_hooks;
 use crate::network_policy_decision::denied_network_policy_message;
 use crate::session::session::Session;
+use crate::session::step_context::StepContext;
+use crate::session::step_context::StepContextSeed;
 use crate::tools::sandboxing::PermissionRequestPayload;
 use crate::tools::sandboxing::ToolError;
 use codex_hooks::PermissionRequestDecision;
@@ -243,6 +245,7 @@ struct ActiveNetworkApprovalCall {
     command: String,
     environment_id: String,
     cancellation_token: CancellationToken,
+    step_context: Arc<StepContext>,
 }
 
 enum ActiveNetworkApprovalAttribution {
@@ -298,6 +301,7 @@ impl NetworkApprovalService {
         command: String,
         environment_id: String,
         cancellation_token: CancellationToken,
+        step_context: Arc<StepContext>,
     ) {
         let mut calls = self.calls.lock().await;
         let key = registration_id.clone();
@@ -310,6 +314,7 @@ impl NetworkApprovalService {
                 command,
                 environment_id,
                 cancellation_token,
+                step_context,
             }),
         );
     }
@@ -475,14 +480,12 @@ impl NetworkApprovalService {
         }
     }
 
-    async fn active_turn_context(
-        session: &Session,
-    ) -> Option<Arc<crate::session::turn_context::TurnContext>> {
+    async fn active_step_context_seed(session: &Session) -> Option<StepContextSeed> {
         let active_turn = session.active_turn.lock().await;
         active_turn
             .as_ref()
             .and_then(|turn| turn.task.as_ref())
-            .map(|task| Arc::clone(&task.turn_context))
+            .map(|task| task.step_context_seed.clone())
     }
 
     fn format_network_target(protocol: &str, host: &str, port: u16) -> String {
@@ -516,11 +519,20 @@ impl NetworkApprovalService {
         else {
             return NetworkDecision::deny(REASON_NOT_ALLOWED);
         };
-        let turn_context = Self::active_turn_context(session.as_ref()).await;
+        let step_context = match owner_call.as_ref() {
+            Some(owner_call) => Some(Arc::clone(&owner_call.step_context)),
+            None => {
+                let seed = Self::active_step_context_seed(session.as_ref()).await;
+                match seed {
+                    Some(seed) => Some(session.capture_step_context(&seed).await),
+                    None => None,
+                }
+            }
+        };
         let Some(environment_id) = active_environment_id.or_else(|| {
-            turn_context
+            step_context
                 .as_ref()
-                .and_then(|turn_context| turn_context.environments.primary())
+                .and_then(|step_context| step_context.environments.primary())
                 .map(|environment| environment.environment_id.clone())
         }) else {
             return NetworkDecision::deny(REASON_NOT_ALLOWED);
@@ -551,7 +563,7 @@ impl NetworkApprovalService {
             format!("Network access to \"{target}\" was blocked by policy.");
         let prompt_reason = format!("{} is not in the allowed_domains", request.host);
 
-        let Some(turn_context) = turn_context else {
+        let Some(step_context) = step_context else {
             pending.set_decision(PendingApprovalDecision::Deny).await;
             self.pending_host_approvals.lock().await.remove(&key);
             if let Some(owner_call) = owner_call.as_ref() {
@@ -563,6 +575,7 @@ impl NetworkApprovalService {
             }
             return NetworkDecision::deny(REASON_NOT_ALLOWED);
         };
+        let turn_context = &step_context.turn;
         if !permission_profile_allows_network_approval_flow(&turn_context.permission_profile()) {
             pending.set_decision(PendingApprovalDecision::Deny).await;
             self.pending_host_approvals.lock().await.remove(&key);
@@ -599,7 +612,7 @@ impl NetworkApprovalService {
             .map_or_else(|| prompt_command.join(" "), |call| call.command.clone());
         if let Some(permission_request_decision) = run_permission_request_hooks(
             &session,
-            &turn_context,
+            step_context.as_ref(),
             &guardian_approval_id,
             PermissionRequestPayload::bash(command, Some(format!("network-access {target}"))),
         )
@@ -629,12 +642,12 @@ impl NetworkApprovalService {
                 }
             }
         }
-        let use_guardian = routes_approval_to_guardian(&turn_context);
+        let use_guardian = routes_approval_to_guardian(turn_context.as_ref());
         let guardian_review_id = use_guardian.then(new_guardian_review_id);
         let approval_decision = if let Some(review_id) = guardian_review_id.clone() {
             review_approval_request(
                 &session,
-                &turn_context,
+                &StepContextSeed::from(step_context.as_ref()),
                 review_id,
                 GuardianApprovalRequest::NetworkAccess {
                     id: guardian_approval_id.clone(),
@@ -655,7 +668,7 @@ impl NetworkApprovalService {
             let cwd = if let Some(owner_call) = owner_call.as_ref() {
                 owner_call.trigger.cwd.clone()
             } else {
-                turn_context
+                step_context
                     .environments
                     .turn_environments
                     .iter()
@@ -849,7 +862,7 @@ pub(crate) fn build_network_policy_decider(
 
 pub(crate) async fn begin_network_approval(
     session: &Session,
-    turn_id: &str,
+    step_context: Arc<StepContext>,
     managed_network_active: bool,
     selected_sandbox: SandboxType,
     spec: Option<NetworkApprovalSpec>,
@@ -890,11 +903,12 @@ pub(crate) async fn begin_network_approval(
         .network_approval
         .register_call(
             registration_id.clone(),
-            turn_id.to_string(),
+            step_context.turn.sub_id.clone(),
             trigger,
             command,
             environment_id,
             cancellation_token.clone(),
+            step_context,
         )
         .await;
 

--- a/codex-rs/core/src/tools/network_approval_tests.rs
+++ b/codex-rs/core/src/tools/network_approval_tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::sandboxing::SandboxPermissions;
+use crate::session::step_context::StepContext;
+use crate::session::tests::make_session_and_context;
 use codex_network_proxy::BlockedRequestArgs;
 use codex_protocol::models::PermissionProfile;
 use codex_protocol::permissions::NetworkSandboxPolicy;
@@ -295,6 +297,8 @@ async fn register_call_with_default_shell_trigger(
     service: &NetworkApprovalService,
     registration_id: &str,
 ) -> CancellationToken {
+    let (_session, turn) = make_session_and_context().await;
+    let step_context = StepContext::for_test(Arc::new(turn));
     let cancellation_token = CancellationToken::new();
     service
         .register_call(
@@ -313,6 +317,7 @@ async fn register_call_with_default_shell_trigger(
             "curl https://example.com".to_string(),
             "local".to_string(),
             cancellation_token.clone(),
+            step_context,
         )
         .await;
     cancellation_token
@@ -321,6 +326,8 @@ async fn register_call_with_default_shell_trigger(
 #[tokio::test]
 async fn active_call_preserves_triggering_command_context() {
     let service = NetworkApprovalService::default();
+    let (_session, turn) = make_session_and_context().await;
+    let step_context = StepContext::for_test(Arc::new(turn));
     let expected = GuardianNetworkAccessTrigger {
         call_id: "call-1".to_string(),
         tool_name: "shell_command".to_string(),
@@ -340,6 +347,7 @@ async fn active_call_preserves_triggering_command_context() {
             "curl https://example.com".to_string(),
             "remote".to_string(),
             CancellationToken::new(),
+            step_context,
         )
         .await;
 

--- a/codex-rs/core/src/tools/orchestrator.rs
+++ b/codex-rs/core/src/tools/orchestrator.rs
@@ -41,6 +41,7 @@ use codex_protocol::protocol::ReviewDecision;
 use codex_sandboxing::SandboxManager;
 use codex_sandboxing::SandboxType;
 use codex_utils_path_uri::PathUri;
+use std::sync::Arc;
 use std::time::Instant;
 
 pub(crate) struct ToolOrchestrator {
@@ -71,7 +72,7 @@ impl ToolOrchestrator {
     {
         let network_approval = match begin_network_approval(
             &tool_ctx.session,
-            &tool_ctx.turn.sub_id,
+            Arc::clone(&tool_ctx.step_context),
             managed_network_active,
             attempt.sandbox,
             tool.network_approval_spec(req, tool_ctx),
@@ -84,7 +85,7 @@ impl ToolOrchestrator {
 
         let attempt_tool_ctx = ToolCtx {
             session: tool_ctx.session.clone(),
-            turn: tool_ctx.turn.clone(),
+            step_context: tool_ctx.step_context.clone(),
             call_id: tool_ctx.call_id.clone(),
             tool_name: tool_ctx.tool_name.clone(),
         };
@@ -145,13 +146,13 @@ impl ToolOrchestrator {
         tool: &mut T,
         req: &Rq,
         tool_ctx: &ToolCtx,
-        turn_ctx: &crate::session::turn_context::TurnContext,
-        approval_policy: AskForApproval,
     ) -> Result<OrchestratorRunResult<Out>, ToolError>
     where
         T: ToolRuntime<Rq, Out>,
     {
-        let otel = turn_ctx.session_telemetry.clone();
+        let turn_ctx = tool_ctx.step_context.turn.as_ref();
+        let approval_policy = turn_ctx.approval_policy.value();
+        let otel = tool_ctx.step_context.model.session_telemetry.clone();
         let otel_tn = flat_tool_name(&tool_ctx.tool_name).into_owned();
         let otel_ci = &tool_ctx.call_id;
         let strict_auto_review = tool_ctx.session.strict_auto_review_enabled_for_turn().await;
@@ -171,7 +172,7 @@ impl ToolOrchestrator {
                     let guardian_review_id = Some(new_guardian_review_id());
                     let approval_ctx = ApprovalCtx {
                         session: &tool_ctx.session,
-                        turn: &tool_ctx.turn,
+                        step_context: &tool_ctx.step_context,
                         call_id: &tool_ctx.call_id,
                         guardian_review_id: guardian_review_id.clone(),
                         retry_reason: None,
@@ -206,7 +207,7 @@ impl ToolOrchestrator {
                 let guardian_review_id = use_guardian.then(new_guardian_review_id);
                 let approval_ctx = ApprovalCtx {
                     session: &tool_ctx.session,
-                    turn: &tool_ctx.turn,
+                    step_context: &tool_ctx.step_context,
                     call_id: &tool_ctx.call_id,
                     guardian_review_id: guardian_review_id.clone(),
                     retry_reason: reason.clone(),
@@ -403,7 +404,7 @@ impl ToolOrchestrator {
                     let guardian_review_id = use_guardian.then(new_guardian_review_id);
                     let approval_ctx = ApprovalCtx {
                         session: &tool_ctx.session,
-                        turn: &tool_ctx.turn,
+                        step_context: &tool_ctx.step_context,
                         call_id: &tool_ctx.call_id,
                         guardian_review_id: guardian_review_id.clone(),
                         retry_reason: Some(retry_reason),
@@ -539,7 +540,7 @@ impl ToolOrchestrator {
             let tool_name = flat_tool_name(&tool_ctx.tool_name);
             match run_permission_request_hooks(
                 approval_ctx.session,
-                approval_ctx.turn,
+                approval_ctx.step_context.as_ref(),
                 permission_request_run_id,
                 permission_request,
             )
@@ -579,7 +580,9 @@ impl ToolOrchestrator {
                 Ok(action) => {
                     review_approval_request(
                         approval_ctx.session,
-                        approval_ctx.turn,
+                        &crate::session::step_context::StepContextSeed::from(
+                            approval_ctx.step_context.as_ref(),
+                        ),
                         review_id,
                         action,
                         approval_ctx.retry_reason.clone(),

--- a/codex-rs/core/src/tools/registry.rs
+++ b/codex-rs/core/src/tools/registry.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use crate::function_tool::FunctionCallError;
 use crate::hook_runtime::PreToolUseHookResult;
-use crate::hook_runtime::record_additional_contexts;
+use crate::hook_runtime::record_step_additional_contexts;
 use crate::hook_runtime::run_post_tool_use_hooks;
 use crate::hook_runtime::run_pre_tool_use_hooks;
 use crate::memory_usage::emit_metric_for_tool_read;
@@ -410,22 +410,22 @@ impl ToolRegistry {
         let tool_name = invocation.tool_name.clone();
         let tool_name_flat = flat_tool_name(&tool_name);
         let call_id_owned = invocation.call_id.clone();
-        let otel = invocation.turn.session_telemetry.clone();
+        let otel = invocation.step_context.model.session_telemetry.clone();
         let base_tool_result_tags = [
             (
                 "sandbox",
                 permission_profile_sandbox_tag(
-                    &invocation.turn.permission_profile,
-                    invocation.turn.windows_sandbox_level,
-                    invocation.turn.network.is_some(),
+                    &invocation.step_context.turn.permission_profile,
+                    invocation.step_context.turn.windows_sandbox_level,
+                    invocation.step_context.turn.network.is_some(),
                 ),
             ),
             (
                 "sandbox_policy",
                 permission_profile_policy_tag(
-                    &invocation.turn.permission_profile,
+                    &invocation.step_context.turn.permission_profile,
                     #[allow(deprecated)]
-                    invocation.turn.cwd.as_path(),
+                    invocation.step_context.turn.cwd.as_path(),
                 ),
             ),
         ];
@@ -495,7 +495,7 @@ impl ToolRegistry {
         if let Some(pre_tool_use_payload) = tool.pre_tool_use_payload(&invocation) {
             match run_pre_tool_use_hooks(
                 &invocation.session,
-                &invocation.turn,
+                invocation.step_context.as_ref(),
                 invocation.call_id.clone(),
                 &pre_tool_use_payload.tool_name,
                 &pre_tool_use_payload.tool_input,
@@ -584,7 +584,7 @@ impl ToolRegistry {
             Some(
                 run_post_tool_use_hooks(
                     &invocation.session,
-                    &invocation.turn,
+                    invocation.step_context.as_ref(),
                     post_tool_use_payload.tool_use_id,
                     post_tool_use_payload.tool_name.name().to_string(),
                     post_tool_use_payload.tool_name.matcher_aliases().to_vec(),
@@ -597,9 +597,9 @@ impl ToolRegistry {
             None
         };
         if let Some(outcome) = &post_tool_use_outcome {
-            record_additional_contexts(
+            record_step_additional_contexts(
                 &invocation.session,
-                &invocation.turn,
+                invocation.step_context.as_ref(),
                 outcome.additional_contexts.clone(),
             )
             .await;
@@ -691,7 +691,12 @@ async fn handle_any_tool(
     let payload = invocation.payload.clone();
     let output = tool.handle(invocation.clone()).await?;
     if output.contains_external_context()
-        && invocation.turn.config.memories.disable_on_external_context
+        && invocation
+            .step_context
+            .turn
+            .config
+            .memories
+            .disable_on_external_context
     {
         state_db::mark_thread_memory_mode_polluted(
             invocation.session.services.state_db.as_deref(),

--- a/codex-rs/core/src/tools/registry_tests.rs
+++ b/codex-rs/core/src/tools/registry_tests.rs
@@ -462,7 +462,6 @@ fn test_invocation(
     ToolInvocation {
         session,
         step_context,
-        turn,
         cancellation_token: tokio_util::sync::CancellationToken::new(),
         tracker: Arc::new(tokio::sync::Mutex::new(
             crate::turn_diff_tracker::TurnDiffTracker::new(),

--- a/codex-rs/core/src/tools/router.rs
+++ b/codex-rs/core/src/tools/router.rs
@@ -224,11 +224,8 @@ impl ToolRouter {
             payload,
         } = call;
 
-        // Keep the legacy ToolInvocation.turn field tied to the same request state until handlers migrate.
-        let turn = Arc::clone(&step_context.turn);
         let invocation = ToolInvocation {
             session,
-            turn,
             step_context,
             cancellation_token,
             tracker,

--- a/codex-rs/core/src/tools/router_tests.rs
+++ b/codex-rs/core/src/tools/router_tests.rs
@@ -383,7 +383,7 @@ async fn extension_tool_executors_are_model_visible_and_dispatchable() -> anyhow
         internal_chat_message_metadata_passthrough: None,
     };
     session
-        .record_conversation_items(&turn, std::slice::from_ref(&history_item))
+        .record_conversation_items(step_context.as_ref(), std::slice::from_ref(&history_item))
         .await;
     let mut expected_history_item = history_item.clone();
     expected_history_item.set_turn_id_if_missing(&turn.sub_id);

--- a/codex-rs/core/src/tools/runtimes/apply_patch.rs
+++ b/codex-rs/core/src/tools/runtimes/apply_patch.rs
@@ -146,7 +146,7 @@ impl Approvable<ApplyPatchRequest> for ApplyPatchRuntime {
         ctx: ApprovalCtx<'a>,
     ) -> BoxFuture<'a, ReviewDecision> {
         let session = ctx.session;
-        let turn = ctx.turn;
+        let turn = &ctx.step_context.turn;
         let call_id = ctx.call_id.to_string();
         let retry_reason = ctx.retry_reason.clone();
         let approval_keys = self.approval_keys(req);

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -106,7 +106,7 @@ impl ShellRuntime {
 
     fn stdout_stream(ctx: &ToolCtx) -> Option<crate::exec::StdoutStream> {
         Some(crate::exec::StdoutStream {
-            sub_id: ctx.turn.sub_id.clone(),
+            sub_id: ctx.step_context.turn.sub_id.clone(),
             call_id: ctx.call_id.clone(),
             tx_event: ctx.session.get_tx_event(),
         })
@@ -149,7 +149,7 @@ impl Approvable<ShellRequest> for ShellRuntime {
             .clone()
             .or_else(|| req.justification.clone());
         let session = ctx.session;
-        let turn = ctx.turn;
+        let turn = &ctx.step_context.turn;
         let call_id = ctx.call_id.to_string();
         Box::pin(async move {
             with_cached_approval(&session.services, "shell", keys, move || async move {
@@ -213,7 +213,7 @@ impl ToolRuntime<ShellRequest, ExecToolCallOutput> for ShellRuntime {
         req: &ShellRequest,
         ctx: &ToolCtx,
     ) -> Option<NetworkApprovalSpec> {
-        let file_system_sandbox_policy = ctx.turn.file_system_sandbox_policy();
+        let file_system_sandbox_policy = ctx.step_context.turn.file_system_sandbox_policy();
         let sandbox_permissions = sandbox_permissions_preserving_denied_reads(
             req.sandbox_permissions,
             &file_system_sandbox_policy,

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
@@ -13,6 +13,8 @@ use crate::hook_runtime::run_permission_request_hooks;
 use crate::sandboxing::ExecOptions;
 use crate::sandboxing::ExecRequest;
 use crate::sandboxing::SandboxPermissions;
+use crate::session::step_context::StepContext;
+use crate::session::step_context::StepContextSeed;
 use crate::shell::ShellType;
 use crate::tools::runtimes::build_sandbox_command;
 use crate::tools::runtimes::exec_env_for_sandbox_permissions;
@@ -200,8 +202,8 @@ pub(super) async fn try_run_zsh_fork(
         arg0,
         sandbox_policy_cwd,
         windows_sandbox_workspace_roots,
-        codex_linux_sandbox_exe: ctx.turn.config.codex_linux_sandbox_exe.clone(),
-        use_legacy_landlock: ctx.turn.config.features.use_legacy_landlock(),
+        codex_linux_sandbox_exe: ctx.step_context.turn.config.codex_linux_sandbox_exe.clone(),
+        use_legacy_landlock: ctx.step_context.turn.config.features.use_legacy_landlock(),
     };
     let main_execve_wrapper_exe = ctx
         .session
@@ -235,11 +237,10 @@ pub(super) async fn try_run_zsh_fork(
     let escalation_policy = CoreShellActionProvider {
         policy: Arc::clone(&exec_policy),
         session: Arc::clone(&ctx.session),
-        turn: Arc::clone(&ctx.turn),
+        step_context: Arc::clone(&ctx.step_context),
         call_id: ctx.call_id.clone(),
         environment_id: req.turn_environment.environment_id.clone(),
         tool_name: GuardianCommandSource::Shell,
-        approval_policy: ctx.turn.approval_policy.value(),
         permission_profile: command_executor.permission_profile.clone(),
         file_system_sandbox_policy: command_executor.file_system_sandbox_policy.clone(),
         sandbox_permissions: req.sandbox_permissions,
@@ -313,17 +314,16 @@ pub(crate) async fn prepare_unified_exec_zsh_fork(
         arg0: exec_request.arg0.clone(),
         sandbox_policy_cwd,
         windows_sandbox_workspace_roots: exec_request.windows_sandbox_workspace_roots.clone(),
-        codex_linux_sandbox_exe: ctx.turn.config.codex_linux_sandbox_exe.clone(),
-        use_legacy_landlock: ctx.turn.config.features.use_legacy_landlock(),
+        codex_linux_sandbox_exe: ctx.step_context.turn.config.codex_linux_sandbox_exe.clone(),
+        use_legacy_landlock: ctx.step_context.turn.config.features.use_legacy_landlock(),
     };
     let escalation_policy = CoreShellActionProvider {
         policy: Arc::clone(&exec_policy),
         session: Arc::clone(&ctx.session),
-        turn: Arc::clone(&ctx.turn),
+        step_context: Arc::clone(&ctx.step_context),
         call_id: ctx.call_id.clone(),
         environment_id: req.turn_environment.environment_id.clone(),
         tool_name: GuardianCommandSource::UnifiedExec,
-        approval_policy: ctx.turn.approval_policy.value(),
         permission_profile: exec_request.permission_profile.clone(),
         file_system_sandbox_policy: exec_request.file_system_sandbox_policy.clone(),
         sandbox_permissions: req.sandbox_permissions,
@@ -354,11 +354,10 @@ pub(crate) async fn prepare_unified_exec_zsh_fork(
 struct CoreShellActionProvider {
     policy: Arc<RwLock<Policy>>,
     session: Arc<crate::session::session::Session>,
-    turn: Arc<crate::session::turn_context::TurnContext>,
+    step_context: Arc<StepContext>,
     call_id: String,
     environment_id: String,
     tool_name: GuardianCommandSource,
-    approval_policy: AskForApproval,
     permission_profile: PermissionProfile,
     file_system_sandbox_policy: FileSystemSandboxPolicy,
     sandbox_permissions: SandboxPermissions,
@@ -450,7 +449,8 @@ impl CoreShellActionProvider {
         let command = join_program_and_argv(program, argv);
         let workdir = workdir.clone();
         let session = self.session.clone();
-        let turn = self.turn.clone();
+        let turn = Arc::clone(&self.step_context.turn);
+        let step_context = self.step_context.clone();
         let call_id = self.call_id.clone();
         let approval_id = Some(Uuid::new_v4().to_string());
         let environment_id = Some(self.environment_id.clone());
@@ -466,7 +466,7 @@ impl CoreShellActionProvider {
                 let effective_approval_id = approval_id.clone().unwrap_or_else(|| call_id.clone());
                 match run_permission_request_hooks(
                     &session,
-                    &turn,
+                    step_context.as_ref(),
                     &effective_approval_id,
                     permission_request,
                 )
@@ -493,7 +493,7 @@ impl CoreShellActionProvider {
                 if let Some(review_id) = guardian_review_id.clone() {
                     let decision = review_approval_request(
                         &session,
-                        &turn,
+                        &StepContextSeed::from(step_context.as_ref()),
                         review_id.clone(),
                         GuardianApprovalRequest::Execve {
                             id: call_id.clone(),
@@ -555,8 +555,11 @@ impl CoreShellActionProvider {
                 EscalationDecision::deny(Some("Execution forbidden by policy".to_string()))
             }
             Decision::Prompt => {
-                if execve_prompt_is_rejected_by_policy(self.approval_policy, &decision_source)
-                    .is_some()
+                if execve_prompt_is_rejected_by_policy(
+                    self.step_context.turn.approval_policy.value(),
+                    &decision_source,
+                )
+                .is_some()
                 {
                     EscalationDecision::deny(Some("Execution forbidden by policy".to_string()))
                 } else {
@@ -649,9 +652,9 @@ impl CoreShellActionProvider {
                 program,
                 argv,
                 InterceptedExecPolicyContext {
-                    approval_policy: self.approval_policy,
+                    approval_policy: self.step_context.turn.approval_policy.value(),
                     permission_profile: self.permission_profile.clone(),
-                    windows_sandbox_level: self.turn.windows_sandbox_level,
+                    windows_sandbox_level: self.step_context.turn.windows_sandbox_level,
                     sandbox_permissions: self.approval_sandbox_permissions,
                     enable_shell_wrapper_parsing:
                         ENABLE_INTERCEPTED_EXEC_POLICY_SHELL_WRAPPER_PARSING,

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation_tests.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation_tests.rs
@@ -9,6 +9,7 @@ use super::join_program_and_argv;
 use super::map_exec_result;
 use crate::config::Constrained;
 use crate::sandboxing::SandboxPermissions;
+use crate::session::step_context::StepContext;
 use crate::session::tests::make_session_and_context;
 use anyhow::Context;
 use codex_execpolicy::Decision;
@@ -406,7 +407,7 @@ async fn unsandboxed_intercepted_exec_strips_managed_network_env() -> anyhow::Re
 
 #[tokio::test]
 async fn preapproved_additional_permissions_escalate_intercepted_exec() -> anyhow::Result<()> {
-    let (session, turn_context) = make_session_and_context().await;
+    let (session, mut turn_context) = make_session_and_context().await;
     let requested_permissions = AdditionalPermissionProfile {
         file_system: Some(FileSystemPermissions::from_read_write_roots(
             /*read*/ None,
@@ -421,14 +422,16 @@ async fn preapproved_additional_permissions_escalate_intercepted_exec() -> anyho
         &PermissionProfile::workspace_write(),
         Some(&requested_permissions),
     );
+    turn_context.approval_policy = Constrained::allow_any(AskForApproval::OnRequest);
+    let turn_context = Arc::new(turn_context);
+    let step_context = StepContext::for_test(Arc::clone(&turn_context));
     let provider = CoreShellActionProvider {
         policy: Arc::new(RwLock::new(codex_execpolicy::Policy::empty())),
         session: Arc::new(session),
-        turn: Arc::new(turn_context),
+        step_context,
         call_id: "preapproved-additional-permissions".to_string(),
         environment_id: "local".to_string(),
         tool_name: GuardianCommandSource::Shell,
-        approval_policy: AskForApproval::OnRequest,
         permission_profile: permission_profile.clone(),
         file_system_sandbox_policy: read_only_file_system_sandbox_policy(),
         sandbox_permissions: SandboxPermissions::WithAdditionalPermissions,
@@ -557,14 +560,15 @@ async fn execve_permission_request_hook_short_circuits_prompt() -> anyhow::Resul
     let command = vec!["touch".to_string(), target_str.clone()];
     let expected_hook_command =
         codex_shell_command::parse_command::shlex_join(&["/usr/bin/touch".to_string(), target_str]);
+    let turn_context = Arc::new(turn_context);
+    let step_context = StepContext::for_test(Arc::clone(&turn_context));
     let provider = CoreShellActionProvider {
         policy: std::sync::Arc::new(RwLock::new(codex_execpolicy::Policy::empty())),
         session: std::sync::Arc::new(session),
-        turn: std::sync::Arc::new(turn_context),
+        step_context,
         call_id: "execve-hook-call".to_string(),
         environment_id: "local".to_string(),
         tool_name: GuardianCommandSource::Shell,
-        approval_policy: AskForApproval::OnRequest,
         permission_profile: PermissionProfile::read_only(),
         file_system_sandbox_policy: read_only_file_system_sandbox_policy(),
         sandbox_permissions: SandboxPermissions::RequireEscalated,
@@ -761,21 +765,23 @@ prefix_rule(pattern = ["{cat_path_literal}"], decision = "allow")
     parser.parse("test.rules", &policy_src).unwrap();
     let policy = parser.build();
 
-    let (session, turn_context) = make_session_and_context().await;
+    let (session, mut turn_context) = make_session_and_context().await;
     let file_system_sandbox_policy = denied_read_file_system_sandbox_policy();
     let permission_profile = PermissionProfile::from_runtime_permissions(
         &file_system_sandbox_policy,
         NetworkSandboxPolicy::Restricted,
     );
     let workdir = test_sandbox_cwd();
+    turn_context.approval_policy = Constrained::allow_any(AskForApproval::OnRequest);
+    let turn_context = Arc::new(turn_context);
+    let step_context = StepContext::for_test(Arc::clone(&turn_context));
     let provider = CoreShellActionProvider {
         policy: Arc::new(RwLock::new(policy)),
         session: Arc::new(session),
-        turn: Arc::new(turn_context),
+        step_context,
         call_id: "deny-read-prefix-allow".to_string(),
         environment_id: "local".to_string(),
         tool_name: GuardianCommandSource::Shell,
-        approval_policy: AskForApproval::OnRequest,
         permission_profile,
         file_system_sandbox_policy,
         sandbox_permissions: SandboxPermissions::UseDefault,
@@ -798,27 +804,30 @@ prefix_rule(pattern = ["{cat_path_literal}"], decision = "allow")
 
 #[tokio::test(flavor = "current_thread")]
 async fn denied_reads_keep_granular_sandbox_rejection_for_escalation() -> anyhow::Result<()> {
-    let (session, turn_context) = make_session_and_context().await;
+    let (session, mut turn_context) = make_session_and_context().await;
     let file_system_sandbox_policy = denied_read_file_system_sandbox_policy();
     let permission_profile = PermissionProfile::from_runtime_permissions(
         &file_system_sandbox_policy,
         NetworkSandboxPolicy::Restricted,
     );
     let workdir = test_sandbox_cwd();
-    let provider = CoreShellActionProvider {
-        policy: Arc::new(RwLock::new(PolicyParser::new().build())),
-        session: Arc::new(session),
-        turn: Arc::new(turn_context),
-        call_id: "deny-read-granular-sandbox-reject".to_string(),
-        environment_id: "local".to_string(),
-        tool_name: GuardianCommandSource::Shell,
-        approval_policy: AskForApproval::Granular(GranularApprovalConfig {
+    turn_context.approval_policy =
+        Constrained::allow_any(AskForApproval::Granular(GranularApprovalConfig {
             sandbox_approval: false,
             rules: true,
             skill_approval: true,
             request_permissions: true,
             mcp_elicitations: true,
-        }),
+        }));
+    let turn_context = Arc::new(turn_context);
+    let step_context = StepContext::for_test(Arc::clone(&turn_context));
+    let provider = CoreShellActionProvider {
+        policy: Arc::new(RwLock::new(PolicyParser::new().build())),
+        session: Arc::new(session),
+        step_context,
+        call_id: "deny-read-granular-sandbox-reject".to_string(),
+        environment_id: "local".to_string(),
+        tool_name: GuardianCommandSource::Shell,
         permission_profile,
         file_system_sandbox_policy,
         sandbox_permissions: SandboxPermissions::RequireEscalated,

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -174,7 +174,7 @@ impl Approvable<UnifiedExecRequest> for UnifiedExecRuntime<'_> {
     ) -> BoxFuture<'b, ReviewDecision> {
         let keys = self.approval_keys(req);
         let session = ctx.session;
-        let turn = ctx.turn;
+        let turn = &ctx.step_context.turn;
         let call_id = ctx.call_id.to_string();
         let command = req.command.clone();
         let environment_id = Some(req.turn_environment.environment_id.clone());
@@ -264,7 +264,7 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
         req: &UnifiedExecRequest,
         ctx: &ToolCtx,
     ) -> Option<NetworkApprovalSpec> {
-        let file_system_sandbox_policy = ctx.turn.file_system_sandbox_policy();
+        let file_system_sandbox_policy = ctx.step_context.turn.file_system_sandbox_policy();
         let sandbox_permissions = sandbox_permissions_preserving_denied_reads(
             req.sandbox_permissions,
             &file_system_sandbox_policy,

--- a/codex-rs/core/src/tools/sandboxing.rs
+++ b/codex-rs/core/src/tools/sandboxing.rs
@@ -7,7 +7,7 @@
 use crate::sandboxing::ExecOptions;
 use crate::sandboxing::SandboxPermissions;
 use crate::session::session::Session;
-use crate::session::turn_context::TurnContext;
+use crate::session::step_context::StepContext;
 use crate::state::SessionServices;
 use crate::tools::hook_names::HookToolName;
 use crate::tools::network_approval::NetworkApprovalSpec;
@@ -120,7 +120,7 @@ where
 #[derive(Clone)]
 pub(crate) struct ApprovalCtx<'a> {
     pub session: &'a Arc<Session>,
-    pub turn: &'a Arc<TurnContext>,
+    pub step_context: &'a Arc<StepContext>,
     pub call_id: &'a str,
     /// Guardian review lifecycle ID for this approval, when guardian is reviewing it.
     ///
@@ -383,7 +383,7 @@ pub(crate) trait Sandboxable {
 
 pub(crate) struct ToolCtx {
     pub session: Arc<Session>,
-    pub turn: Arc<TurnContext>,
+    pub step_context: Arc<StepContext>,
     pub call_id: String,
     pub tool_name: ToolName,
 }

--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -1,6 +1,7 @@
 use crate::agent::exceeds_thread_spawn_depth_limit;
 use crate::agent::next_thread_spawn_depth;
 use crate::session::step_context::StepContext;
+use crate::session::step_model_context::StepModelContext;
 use crate::session::turn_context::TurnContext;
 use crate::tools::code_mode::execute_spec::create_code_mode_tool;
 use crate::tools::context::ToolInvocation;
@@ -199,7 +200,7 @@ fn build_tool_specs_and_registry(
     apply_direct_model_only_namespace_overrides(turn_context, &mut planned_tools);
     append_tool_search_executor(&context, &mut planned_tools);
     prepend_code_mode_executors(&context, &mut planned_tools);
-    build_model_visible_specs_and_registry(turn_context, planned_tools)
+    build_model_visible_specs_and_registry(step_context, planned_tools)
 }
 
 fn apply_direct_model_only_namespace_overrides(
@@ -233,9 +234,10 @@ fn apply_direct_model_only_namespace_overrides(
 
 #[instrument(level = "trace", skip_all)]
 fn build_model_visible_specs_and_registry(
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     planned_tools: PlannedTools,
 ) -> (Vec<ToolSpec>, ToolRegistry) {
+    let turn_context = step_context.turn.as_ref();
     let PlannedTools {
         runtimes,
         hosted_specs,
@@ -248,11 +250,11 @@ fn build_model_visible_specs_and_registry(
             continue;
         }
         let exposure = runtime.exposure();
-        if exposure.is_direct() && !is_hidden_by_code_mode_only(turn_context, &tool_name, exposure)
+        if exposure.is_direct() && !is_hidden_by_code_mode_only(step_context, &tool_name, exposure)
         {
             let spec = runtime.spec();
             specs.push(spec_for_model_request(
-                turn_context,
+                step_context,
                 exposure,
                 &tool_name,
                 spec,
@@ -273,12 +275,13 @@ fn build_model_visible_specs_and_registry(
 }
 
 fn spec_for_model_request(
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     exposure: ToolExposure,
     tool_name: &ToolName,
     spec: ToolSpec,
 ) -> ToolSpec {
-    let tool_mode = effective_tool_mode(turn_context);
+    let turn_context = step_context.turn.as_ref();
+    let tool_mode = effective_tool_mode(step_context.model.as_ref(), &turn_context.config.features);
     if matches!(tool_mode, ToolMode::CodeMode | ToolMode::CodeModeOnly)
         && exposure != ToolExposure::DirectModelOnly
         && !is_excluded_from_code_mode(turn_context, tool_name)
@@ -293,13 +296,14 @@ fn spec_for_model_request(
 #[instrument(level = "trace", skip_all)]
 fn hosted_model_tool_specs(context: &CoreToolPlanContext<'_>) -> Vec<ToolSpec> {
     let turn_context = context.step_context.turn.as_ref();
+    let model = context.step_context.model.as_ref();
     // Responses Lite accepts schemas for client-executed tools, not hosted Responses tools.
-    if turn_context.model_info.use_responses_lite {
+    if model.model_info.use_responses_lite {
         return Vec::new();
     }
 
     let mut specs = Vec::new();
-    let standalone_web_search_available = standalone_web_search_enabled(turn_context)
+    let standalone_web_search_available = standalone_web_search_enabled(turn_context, model)
         && context
             .extension_tool_executors
             .iter()
@@ -315,21 +319,25 @@ fn hosted_model_tool_specs(context: &CoreToolPlanContext<'_>) -> Vec<ToolSpec> {
     if let Some(hosted_web_search_tool) = create_web_search_tool(WebSearchToolOptions {
         web_search_mode,
         web_search_config,
-        web_search_tool_type: turn_context.model_info.web_search_tool_type,
+        web_search_tool_type: model.model_info.web_search_tool_type,
     }) {
         specs.push(hosted_web_search_tool);
     }
     // TODO: Remove hosted image generation once the standalone extension is ready.
-    if image_generation_tool_enabled(turn_context)
-        && !standalone_image_generation_available(turn_context, context.extension_tool_executors)
+    if image_generation_tool_enabled(turn_context, model)
+        && !standalone_image_generation_available(
+            turn_context,
+            model,
+            context.extension_tool_executors,
+        )
     {
         specs.push(create_image_generation_tool("png"));
     }
     specs
 }
 
-pub(crate) fn search_tool_enabled(turn_context: &TurnContext) -> bool {
-    turn_context.model_info.supports_search_tool && namespace_tools_enabled(turn_context)
+pub(crate) fn search_tool_enabled(turn_context: &TurnContext, model: &StepModelContext) -> bool {
+    model.model_info.supports_search_tool && namespace_tools_enabled(turn_context)
 }
 
 pub(crate) fn tool_suggest_enabled(turn_context: &TurnContext) -> bool {
@@ -376,8 +384,8 @@ fn agent_jobs_worker_tools_enabled(turn_context: &TurnContext) -> bool {
         )
 }
 
-fn image_generation_tool_enabled(turn_context: &TurnContext) -> bool {
-    image_generation_runtime_enabled(turn_context)
+fn image_generation_tool_enabled(turn_context: &TurnContext, model: &StepModelContext) -> bool {
+    image_generation_runtime_enabled(turn_context, model)
         && turn_context
             .config
             .features
@@ -385,7 +393,7 @@ fn image_generation_tool_enabled(turn_context: &TurnContext) -> bool {
             .enabled(Feature::ImageGeneration)
 }
 
-fn image_generation_runtime_enabled(turn_context: &TurnContext) -> bool {
+fn image_generation_runtime_enabled(turn_context: &TurnContext, model: &StepModelContext) -> bool {
     (turn_context
         .provider
         .info()
@@ -396,18 +404,23 @@ fn image_generation_runtime_enabled(turn_context: &TurnContext) -> bool {
                 .as_deref()
                 .is_some_and(AuthManager::current_auth_uses_codex_backend)))
         && turn_context.provider.capabilities().image_generation
-        && turn_context
+        && model
             .model_info
             .input_modalities
             .contains(&InputModality::Image)
 }
 
-fn standalone_image_generation_model_visible(turn_context: &TurnContext) -> bool {
-    if !image_generation_runtime_enabled(turn_context) || !namespace_tools_enabled(turn_context) {
+fn standalone_image_generation_model_visible(
+    turn_context: &TurnContext,
+    model: &StepModelContext,
+) -> bool {
+    if !image_generation_runtime_enabled(turn_context, model)
+        || !namespace_tools_enabled(turn_context)
+    {
         return false;
     }
 
-    if turn_context.model_info.use_responses_lite {
+    if model.model_info.use_responses_lite {
         return true;
     }
 
@@ -420,9 +433,10 @@ fn standalone_image_generation_model_visible(turn_context: &TurnContext) -> bool
 
 fn standalone_image_generation_available(
     turn_context: &TurnContext,
+    model: &StepModelContext,
     extension_tools: &[Arc<dyn ToolExecutor<ExtensionToolCall>>],
 ) -> bool {
-    standalone_image_generation_model_visible(turn_context)
+    standalone_image_generation_model_visible(turn_context, model)
         && extension_tools.iter().any(|executor| {
             executor.tool_name() == ToolName::namespaced(IMAGE_GEN_NAMESPACE, IMAGEGEN_TOOL_NAME)
         })
@@ -458,11 +472,14 @@ fn agent_type_description(
 }
 
 fn is_hidden_by_code_mode_only(
-    turn_context: &TurnContext,
+    step_context: &StepContext,
     tool_name: &ToolName,
     exposure: ToolExposure,
 ) -> bool {
-    let tool_mode = effective_tool_mode(turn_context);
+    let tool_mode = effective_tool_mode(
+        step_context.model.as_ref(),
+        &step_context.turn.config.features,
+    );
     tool_mode == ToolMode::CodeModeOnly
         && exposure != ToolExposure::DirectModelOnly
         && codex_code_mode::is_code_mode_nested_tool(&codex_tools::code_mode_name_for_tool_name(
@@ -482,9 +499,10 @@ fn is_excluded_from_code_mode(turn_context: &TurnContext, tool_name: &ToolName) 
 
 fn build_code_mode_executors(
     turn_context: &TurnContext,
+    model: &StepModelContext,
     executors: &[Arc<dyn CoreToolRuntime>],
 ) -> Vec<Arc<dyn CoreToolRuntime>> {
-    let tool_mode = effective_tool_mode(turn_context);
+    let tool_mode = effective_tool_mode(model, &turn_context.config.features);
     if !matches!(tool_mode, ToolMode::CodeMode | ToolMode::CodeModeOnly) {
         return vec![];
     }
@@ -492,7 +510,7 @@ fn build_code_mode_executors(
     let mut code_mode_nested_tool_specs = Vec::new();
     let mut exec_prompt_tool_specs = Vec::new();
     let mut deferred_tools_available = false;
-    let deferred_tools_guidance_enabled = search_tool_enabled(turn_context);
+    let deferred_tools_guidance_enabled = search_tool_enabled(turn_context, model);
     for executor in executors {
         let exposure = executor.exposure();
         if exposure == ToolExposure::DirectModelOnly {
@@ -623,9 +641,9 @@ fn add_tool_sources(context: &CoreToolPlanContext<'_>, planned_tools: &mut Plann
     }
 }
 
-fn standalone_web_search_enabled(turn_context: &TurnContext) -> bool {
+fn standalone_web_search_enabled(turn_context: &TurnContext, model: &StepModelContext) -> bool {
     namespace_tools_enabled(turn_context)
-        && (turn_context.model_info.use_responses_lite
+        && (model.model_info.use_responses_lite
             || turn_context
                 .config
                 .features
@@ -640,6 +658,7 @@ fn tool_environment_mode(step_context: &StepContext) -> ToolEnvironmentMode {
 #[instrument(level = "trace", skip_all)]
 fn add_shell_tools(context: &CoreToolPlanContext<'_>, planned_tools: &mut PlannedTools) {
     let turn_context = context.step_context.turn.as_ref();
+    let model = context.step_context.model.as_ref();
     let features = turn_context.config.features.get();
     let environment_mode = tool_environment_mode(context.step_context);
     if !environment_mode.has_environment() {
@@ -655,14 +674,13 @@ fn add_shell_tools(context: &CoreToolPlanContext<'_>, planned_tools: &mut Planne
         exec_permission_approvals_enabled,
     };
 
-    match shell_type_for_model_and_features(&turn_context.model_info, features) {
+    match shell_type_for_model_and_features(&model.model_info, features) {
         ConfigShellToolType::UnifiedExec => {
             planned_tools.add(ExecCommandHandler::new(ExecCommandHandlerOptions {
                 allow_login_shell,
                 exec_permission_approvals_enabled,
                 include_environment_id,
                 include_shell_parameter: unified_exec_should_include_shell_parameter(
-                    turn_context,
                     context.step_context,
                 ),
             }));
@@ -681,12 +699,9 @@ fn add_shell_tools(context: &CoreToolPlanContext<'_>, planned_tools: &mut Planne
     }
 }
 
-fn unified_exec_should_include_shell_parameter(
-    turn_context: &TurnContext,
-    step_context: &StepContext,
-) -> bool {
+fn unified_exec_should_include_shell_parameter(step_context: &StepContext) -> bool {
     !matches!(
-        &turn_context.unified_exec_shell_mode,
+        &step_context.turn.unified_exec_shell_mode,
         UnifiedExecShellMode::ZshFork(_)
     ) || step_context
         .environments
@@ -707,6 +722,7 @@ fn add_mcp_resource_tools(context: &CoreToolPlanContext<'_>, planned_tools: &mut
 #[instrument(level = "trace", skip_all)]
 fn add_core_utility_tools(context: &CoreToolPlanContext<'_>, planned_tools: &mut PlannedTools) {
     let turn_context = context.step_context.turn.as_ref();
+    let model = context.step_context.model.as_ref();
     let features = turn_context.config.features.get();
     let environment_mode = tool_environment_mode(context.step_context);
 
@@ -762,13 +778,12 @@ fn add_core_utility_tools(context: &CoreToolPlanContext<'_>, planned_tools: &mut
         ));
     }
 
-    if environment_mode.has_environment() && turn_context.model_info.apply_patch_tool_type.is_some()
-    {
+    if environment_mode.has_environment() && model.model_info.apply_patch_tool_type.is_some() {
         let include_environment_id = matches!(environment_mode, ToolEnvironmentMode::Multiple);
         planned_tools.add(ApplyPatchHandler::new(include_environment_id));
     }
 
-    if turn_context
+    if model
         .model_info
         .experimental_supported_tools
         .iter()
@@ -780,9 +795,7 @@ fn add_core_utility_tools(context: &CoreToolPlanContext<'_>, planned_tools: &mut
     if environment_mode.has_environment() {
         let include_environment_id = matches!(environment_mode, ToolEnvironmentMode::Multiple);
         planned_tools.add(ViewImageHandler::new(ViewImageToolOptions {
-            can_request_original_image_detail: can_request_original_image_detail(
-                &turn_context.model_info,
-            ),
+            can_request_original_image_detail: can_request_original_image_detail(&model.model_info),
             include_environment_id,
         }));
     }
@@ -791,6 +804,7 @@ fn add_core_utility_tools(context: &CoreToolPlanContext<'_>, planned_tools: &mut
 #[instrument(level = "trace", skip_all)]
 fn add_collaboration_tools(context: &CoreToolPlanContext<'_>, planned_tools: &mut PlannedTools) {
     let turn_context = context.step_context.turn.as_ref();
+    let model = context.step_context.model.as_ref();
     if collab_tools_enabled(turn_context) {
         if multi_agent_v2_enabled(turn_context) {
             let exposure = if turn_context.config.multi_agent_v2.non_code_mode_only {
@@ -844,7 +858,7 @@ fn add_collaboration_tools(context: &CoreToolPlanContext<'_>, planned_tools: &mu
         } else {
             let agent_type_description =
                 agent_type_description(turn_context, context.default_agent_type_description);
-            let exposure = if search_tool_enabled(turn_context) {
+            let exposure = if search_tool_enabled(turn_context, model) {
                 ToolExposure::Deferred
             } else {
                 ToolExposure::Direct
@@ -955,6 +969,7 @@ fn add_extension_tools(context: &CoreToolPlanContext<'_>, planned_tools: &mut Pl
     // before planning. Core only adapts those executors into its runtime set.
     append_extension_tool_executors(
         context.step_context.turn.as_ref(),
+        context.step_context.model.as_ref(),
         context.extension_tool_executors,
         planned_tools,
     );
@@ -966,7 +981,7 @@ fn append_tool_search_executor(
     planned_tools: &mut PlannedTools,
 ) {
     let turn_context = context.step_context.turn.as_ref();
-    if !search_tool_enabled(turn_context) {
+    if !search_tool_enabled(turn_context, context.step_context.model.as_ref()) {
         return;
     }
 
@@ -989,12 +1004,17 @@ fn prepend_code_mode_executors(
     planned_tools: &mut PlannedTools,
 ) {
     let turn_context = context.step_context.turn.as_ref();
-    let code_mode_executors = build_code_mode_executors(turn_context, planned_tools.runtimes());
+    let code_mode_executors = build_code_mode_executors(
+        turn_context,
+        context.step_context.model.as_ref(),
+        planned_tools.runtimes(),
+    );
     planned_tools.runtimes.splice(0..0, code_mode_executors);
 }
 
 fn append_extension_tool_executors(
     turn_context: &TurnContext,
+    model: &StepModelContext,
     executors: &[Arc<dyn ToolExecutor<ExtensionToolCall>>],
     planned_tools: &mut PlannedTools,
 ) {
@@ -1007,12 +1027,12 @@ fn append_extension_tool_executors(
         .iter()
         .map(|executor| executor.tool_name())
         .collect::<HashSet<_>>();
-    let tool_mode = effective_tool_mode(turn_context);
+    let tool_mode = effective_tool_mode(model, &turn_context.config.features);
     if matches!(tool_mode, ToolMode::CodeMode | ToolMode::CodeModeOnly) {
         reserved_tool_names.insert(ToolName::plain(codex_code_mode::PUBLIC_TOOL_NAME));
         reserved_tool_names.insert(ToolName::plain(codex_code_mode::WAIT_TOOL_NAME));
     }
-    if search_tool_enabled(turn_context)
+    if search_tool_enabled(turn_context, model)
         && planned_tools
             .runtimes()
             .iter()
@@ -1021,7 +1041,7 @@ fn append_extension_tool_executors(
         reserved_tool_names.insert(ToolName::plain(TOOL_SEARCH_TOOL_NAME));
     }
 
-    let standalone_web_search_enabled = standalone_web_search_enabled(turn_context);
+    let standalone_web_search_enabled = standalone_web_search_enabled(turn_context, model);
     let web_search_mode_on = turn_context.config.web_search_mode.value() != WebSearchMode::Disabled;
 
     for executor in executors.iter().cloned() {
@@ -1032,7 +1052,7 @@ fn append_extension_tool_executors(
             continue;
         }
         if tool_name == ToolName::namespaced(IMAGE_GEN_NAMESPACE, IMAGEGEN_TOOL_NAME)
-            && !standalone_image_generation_model_visible(turn_context)
+            && !standalone_image_generation_model_visible(turn_context, model)
         {
             continue;
         }

--- a/codex-rs/core/src/tools/spec_plan_tests.rs
+++ b/codex-rs/core/src/tools/spec_plan_tests.rs
@@ -33,6 +33,7 @@ use serde_json::json;
 
 use crate::config::CurrentTimeReminderConfig;
 use crate::session::step_context::StepContext;
+use crate::session::step_model_context::StepModelContext;
 use crate::session::tests::make_session_and_context;
 use crate::session::turn_context::TurnContext;
 use crate::tools::handlers::ToolSearchHandlerCache;
@@ -181,10 +182,18 @@ async fn probe_with(
     configure_turn: impl FnOnce(&mut TurnContext),
     inputs: ToolPlanInputs,
 ) -> ToolPlanProbe {
+    probe_with_context(|turn, _model| configure_turn(turn), inputs).await
+}
+
+async fn probe_with_context(
+    configure_context: impl FnOnce(&mut TurnContext, &mut StepModelContext),
+    inputs: ToolPlanInputs,
+) -> ToolPlanProbe {
     let (_session, mut turn) = make_session_and_context().await;
-    configure_turn(&mut turn);
+    let mut model = StepModelContext::for_test(&turn);
+    configure_context(&mut turn, &mut model);
     let turn = Arc::new(turn);
-    let step_context = StepContext::for_test(Arc::clone(&turn));
+    let step_context = StepContext::for_test_with_model(Arc::clone(&turn), Arc::new(model));
     let router = ToolRouter::from_context(
         step_context.as_ref(),
         ToolRouterParams {
@@ -201,6 +210,12 @@ async fn probe_with(
 
 async fn probe(configure_turn: impl FnOnce(&mut TurnContext)) -> ToolPlanProbe {
     probe_with(configure_turn, ToolPlanInputs::default()).await
+}
+
+async fn probe_context(
+    configure_context: impl FnOnce(&mut TurnContext, &mut StepModelContext),
+) -> ToolPlanProbe {
+    probe_with_context(configure_context, ToolPlanInputs::default()).await
 }
 
 fn set_feature(turn: &mut TurnContext, feature: Feature, enabled: bool) {
@@ -497,10 +512,10 @@ async fn request_user_input_stays_direct_in_code_mode_only() {
 
 #[tokio::test]
 async fn shell_family_registers_visible_unified_exec_and_hidden_legacy_shell() {
-    let plan = probe(|turn| {
+    let plan = probe_context(|turn, model| {
         set_features(turn, &[Feature::ShellTool, Feature::UnifiedExec]);
         set_feature(turn, Feature::ShellZshFork, /*enabled*/ false);
-        turn.model_info.shell_type = ConfigShellToolType::ShellCommand;
+        model.model_info.shell_type = ConfigShellToolType::ShellCommand;
     })
     .await;
 
@@ -513,11 +528,11 @@ async fn shell_family_registers_visible_unified_exec_and_hidden_legacy_shell() {
 
 #[tokio::test]
 async fn shell_zsh_fork_stays_standalone_until_unified_exec_composition_is_enabled() {
-    let standalone = probe(|turn| {
+    let standalone = probe_context(|turn, model| {
         set_features(turn, &[Feature::ShellTool, Feature::UnifiedExec]);
         set_feature(turn, Feature::ShellZshFork, /*enabled*/ true);
         set_feature(turn, Feature::UnifiedExecZshFork, /*enabled*/ false);
-        turn.model_info.shell_type = ConfigShellToolType::ShellCommand;
+        model.model_info.shell_type = ConfigShellToolType::ShellCommand;
     })
     .await;
 
@@ -526,7 +541,7 @@ async fn shell_zsh_fork_stays_standalone_until_unified_exec_composition_is_enabl
     standalone.assert_registered_contains(&["shell_command"]);
     standalone.assert_registered_lacks(&["exec_command", "write_stdin"]);
 
-    let composed = probe(|turn| {
+    let composed = probe_context(|turn, model| {
         set_features(
             turn,
             &[
@@ -536,7 +551,7 @@ async fn shell_zsh_fork_stays_standalone_until_unified_exec_composition_is_enabl
                 Feature::UnifiedExecZshFork,
             ],
         );
-        turn.model_info.shell_type = ConfigShellToolType::ShellCommand;
+        model.model_info.shell_type = ConfigShellToolType::ShellCommand;
     })
     .await;
 
@@ -626,11 +641,11 @@ async fn zsh_fork_unified_exec_keeps_shell_parameter_when_remote_environment_ava
 
 #[tokio::test]
 async fn environment_count_controls_environment_backed_tools() {
-    let no_environment = probe(|turn| {
+    let no_environment = probe_context(|turn, model| {
         turn.environments.turn_environments.clear();
         set_feature(turn, Feature::ShellTool, /*enabled*/ true);
         set_feature(turn, Feature::RequestPermissionsTool, /*enabled*/ true);
-        turn.model_info.apply_patch_tool_type = Some(ApplyPatchToolType::Freeform);
+        model.model_info.apply_patch_tool_type = Some(ApplyPatchToolType::Freeform);
     })
     .await;
     no_environment.assert_visible_lacks(&[
@@ -648,12 +663,12 @@ async fn environment_count_controls_environment_backed_tools() {
         "request_permissions",
     ]);
 
-    let multiple_environments = probe(|turn| {
+    let multiple_environments = probe_context(|turn, model| {
         duplicate_primary_environment(turn);
         set_feature(turn, Feature::ShellTool, /*enabled*/ true);
         set_feature(turn, Feature::UnifiedExec, /*enabled*/ true);
         set_feature(turn, Feature::RequestPermissionsTool, /*enabled*/ true);
-        turn.model_info.apply_patch_tool_type = Some(ApplyPatchToolType::Freeform);
+        model.model_info.apply_patch_tool_type = Some(ApplyPatchToolType::Freeform);
     })
     .await;
     multiple_environments.assert_visible_contains(&[
@@ -679,13 +694,15 @@ async fn environment_count_controls_environment_backed_tools() {
 async fn environment_tools_follow_the_step_context() {
     let (_session, mut turn) = make_session_and_context().await;
     set_feature(&mut turn, Feature::UnifiedExec, /*enabled*/ true);
-    turn.model_info.apply_patch_tool_type = Some(ApplyPatchToolType::Freeform);
+    let mut model = StepModelContext::for_test(&turn);
+    model.model_info.apply_patch_tool_type = Some(ApplyPatchToolType::Freeform);
 
     let environments = turn.environments.clone();
     turn.environments.turn_environments.clear();
     let turn = Arc::new(turn);
     let step_context = Arc::new(StepContext::new(
         Arc::clone(&turn),
+        Arc::new(model),
         environments,
         Vec::new(),
         crate::session::McpRuntimeSnapshot::new_uninitialized_for_test(&turn.config),
@@ -774,9 +791,9 @@ async fn mcp_and_tool_search_follow_direct_and_deferred_tool_exposure() {
         ..ToolPlanInputs::default()
     };
 
-    let missing_model_capability = probe_with(
-        |turn| {
-            turn.model_info.supports_search_tool = false;
+    let missing_model_capability = probe_with_context(
+        |_turn, model| {
+            model.model_info.supports_search_tool = false;
         },
         ToolPlanInputs {
             deferred_mcp_tools: searchable_mcp.deferred_mcp_tools.clone(),
@@ -786,9 +803,9 @@ async fn mcp_and_tool_search_follow_direct_and_deferred_tool_exposure() {
     .await;
     missing_model_capability.assert_visible_lacks(&["tool_search"]);
 
-    let missing_deferred_tools = probe(|turn| {
+    let missing_deferred_tools = probe_context(|turn, model| {
         set_feature(turn, Feature::Collab, /*enabled*/ false);
-        turn.model_info.supports_search_tool = true;
+        model.model_info.supports_search_tool = true;
     })
     .await;
     missing_deferred_tools.assert_visible_lacks(&["tool_search"]);
@@ -798,9 +815,9 @@ async fn mcp_and_tool_search_follow_direct_and_deferred_tool_exposure() {
         "read_mcp_resource",
     ]);
 
-    let bedrock_namespace_capability = probe_with(
-        |turn| {
-            turn.model_info.supports_search_tool = true;
+    let bedrock_namespace_capability = probe_with_context(
+        |turn, model| {
+            model.model_info.supports_search_tool = true;
             use_bedrock_provider(turn);
         },
         ToolPlanInputs {
@@ -811,9 +828,9 @@ async fn mcp_and_tool_search_follow_direct_and_deferred_tool_exposure() {
     .await;
     bedrock_namespace_capability.assert_visible_contains(&["tool_search"]);
 
-    let enabled = probe_with(
-        |turn| {
-            turn.model_info.supports_search_tool = true;
+    let enabled = probe_with_context(
+        |_turn, model| {
+            model.model_info.supports_search_tool = true;
         },
         searchable_mcp,
     )
@@ -827,9 +844,9 @@ async fn mcp_and_tool_search_follow_direct_and_deferred_tool_exposure() {
 
 #[tokio::test]
 async fn deferred_extension_tools_are_discoverable_with_tool_search() {
-    let plan = probe_with(
-        |turn| {
-            turn.model_info.supports_search_tool = true;
+    let plan = probe_with_context(
+        |_turn, model| {
+            model.model_info.supports_search_tool = true;
         },
         ToolPlanInputs {
             extension_tool_executors: vec![Arc::new(DeferredExtensionTool)],
@@ -848,10 +865,12 @@ async fn deferred_extension_tools_are_discoverable_with_tool_search() {
 async fn tool_search_cache_rebuilds_when_deferred_sources_change() {
     let cache = ToolSearchHandlerCache::default();
 
-    let (_session, mut first_turn) = make_session_and_context().await;
-    first_turn.model_info.supports_search_tool = true;
+    let (_session, first_turn) = make_session_and_context().await;
+    let mut first_model = StepModelContext::for_test(&first_turn);
+    first_model.model_info.supports_search_tool = true;
     let first_turn = Arc::new(first_turn);
-    let first_step_context = StepContext::for_test(Arc::clone(&first_turn));
+    let first_step_context =
+        StepContext::for_test_with_model(Arc::clone(&first_turn), Arc::new(first_model));
     let first_router = ToolRouter::from_context(
         first_step_context.as_ref(),
         ToolRouterParams {
@@ -865,10 +884,12 @@ async fn tool_search_cache_rebuilds_when_deferred_sources_change() {
     );
     let first_plan = ToolPlanProbe::from_router(first_router);
 
-    let (_session, mut second_turn) = make_session_and_context().await;
-    second_turn.model_info.supports_search_tool = true;
+    let (_session, second_turn) = make_session_and_context().await;
+    let mut second_model = StepModelContext::for_test(&second_turn);
+    second_model.model_info.supports_search_tool = true;
     let second_turn = Arc::new(second_turn);
-    let second_step_context = StepContext::for_test(Arc::clone(&second_turn));
+    let second_step_context =
+        StepContext::for_test_with_model(Arc::clone(&second_turn), Arc::new(second_model));
     let second_router = ToolRouter::from_context(
         second_step_context.as_ref(),
         ToolRouterParams {
@@ -988,9 +1009,9 @@ async fn request_plugin_install_requires_all_discovery_features() {
 
 #[tokio::test]
 async fn request_plugin_install_stays_visible_without_tool_search() {
-    let plan = probe_with(
-        |turn| {
-            turn.model_info.supports_search_tool = false;
+    let plan = probe_with_context(
+        |turn, model| {
+            model.model_info.supports_search_tool = false;
             set_features(
                 turn,
                 &[Feature::ToolSuggest, Feature::Apps, Feature::Plugins],
@@ -1094,10 +1115,10 @@ async fn code_mode_only_exposes_code_executor_and_hides_nested_tools() {
 
 #[tokio::test]
 async fn code_mode_only_exposes_configured_dynamic_namespace_directly() {
-    let plan = probe_with(
-        |turn| {
+    let plan = probe_with_context(
+        |turn, model| {
             set_features(turn, &[Feature::CodeMode, Feature::CodeModeOnly]);
-            turn.model_info.supports_search_tool = true;
+            model.model_info.supports_search_tool = true;
             update_config(turn, |config| {
                 config.code_mode.direct_only_tool_namespaces = vec!["direct_only".to_string()];
             });
@@ -1136,11 +1157,11 @@ async fn code_mode_only_exposes_configured_dynamic_namespace_directly() {
 
 #[tokio::test]
 async fn excluded_deferred_namespaces_do_not_enable_nested_tool_guidance() {
-    let plan = probe_with(
-        |turn| {
+    let plan = probe_with_context(
+        |turn, model| {
             set_features(turn, &[Feature::CodeMode, Feature::CodeModeOnly]);
             set_feature(turn, Feature::Collab, /*enabled*/ false);
-            turn.model_info.supports_search_tool = true;
+            model.model_info.supports_search_tool = true;
             update_config(turn, |config| {
                 config.code_mode.excluded_tool_namespaces = vec!["excluded".to_string()];
             });
@@ -1336,9 +1357,9 @@ async fn multi_agent_v2_message_schemas_are_encrypted() {
 
 #[tokio::test]
 async fn tool_mode_selector_overrides_feature_flags() {
-    let direct = probe(|turn| {
+    let direct = probe_context(|turn, model| {
         set_features(turn, &[Feature::CodeMode, Feature::CodeModeOnly]);
-        turn.model_info.tool_mode = Some(ToolMode::Direct);
+        model.model_info.tool_mode = Some(ToolMode::Direct);
     })
     .await;
     direct.assert_visible_lacks(&[
@@ -1349,8 +1370,8 @@ async fn tool_mode_selector_overrides_feature_flags() {
 
 #[tokio::test]
 async fn v1_multi_agent_tools_defer_when_tool_search_available() {
-    let plan = probe(|turn| {
-        turn.model_info.supports_search_tool = true;
+    let plan = probe_context(|turn, model| {
+        model.model_info.supports_search_tool = true;
         set_feature(turn, Feature::Collab, /*enabled*/ true);
         set_feature(turn, Feature::MultiAgentV2, /*enabled*/ false);
     })
@@ -1527,14 +1548,14 @@ async fn code_mode_only_can_expose_namespaced_multi_agent_v2_as_normal_tools() {
 
 #[tokio::test]
 async fn hosted_tools_follow_provider_auth_model_and_config_gates() {
-    let api_key_auth = probe(|turn| {
+    let api_key_auth = probe_context(|turn, model| {
         set_feature(turn, Feature::ImageGeneration, /*enabled*/ true);
-        turn.model_info.input_modalities = vec![InputModality::Image];
+        model.model_info.input_modalities = vec![InputModality::Image];
     })
     .await;
     api_key_auth.assert_visible_lacks(&["image_generation"]);
 
-    let unrelated_chatgpt_auth = probe(|turn| {
+    let unrelated_chatgpt_auth = probe_context(|turn, model| {
         use_chatgpt_auth(turn);
         set_feature(turn, Feature::ImageGeneration, /*enabled*/ true);
         let mut provider_info = turn.provider.info().clone();
@@ -1544,65 +1565,65 @@ async fn hosted_tools_follow_provider_auth_model_and_config_gates() {
             config.model_provider = provider_info.clone();
         });
         turn.provider = create_model_provider(provider_info, turn.auth_manager.clone());
-        turn.model_info.input_modalities = vec![InputModality::Image];
+        model.model_info.input_modalities = vec![InputModality::Image];
     })
     .await;
     unrelated_chatgpt_auth.assert_visible_lacks(&["image_generation"]);
 
-    let actor_authorized_provider = probe(|turn| {
+    let actor_authorized_provider = probe_context(|turn, model| {
         set_feature(turn, Feature::ImageGeneration, /*enabled*/ true);
         use_actor_authorized_provider(turn);
-        turn.model_info.input_modalities = vec![InputModality::Image];
+        model.model_info.input_modalities = vec![InputModality::Image];
     })
     .await;
     actor_authorized_provider.assert_visible_contains(&["image_generation"]);
 
-    let feature_disabled = probe(|turn| {
+    let feature_disabled = probe_context(|turn, model| {
         set_feature(turn, Feature::ImageGeneration, /*enabled*/ false);
         use_actor_authorized_provider(turn);
-        turn.model_info.input_modalities = vec![InputModality::Image];
+        model.model_info.input_modalities = vec![InputModality::Image];
     })
     .await;
     feature_disabled.assert_visible_lacks(&["image_generation"]);
 
-    let text_only_model = probe(|turn| {
+    let text_only_model = probe_context(|turn, model| {
         set_feature(turn, Feature::ImageGeneration, /*enabled*/ true);
         use_actor_authorized_provider(turn);
-        turn.model_info.input_modalities = vec![];
+        model.model_info.input_modalities = vec![];
     })
     .await;
     text_only_model.assert_visible_lacks(&["image_generation"]);
 
-    let unsupported_image_generation_provider = probe(|turn| {
+    let unsupported_image_generation_provider = probe_context(|turn, model| {
         set_feature(turn, Feature::ImageGeneration, /*enabled*/ true);
         use_bedrock_provider(turn);
         use_actor_authorized_provider(turn);
-        turn.model_info.input_modalities = vec![InputModality::Image];
+        model.model_info.input_modalities = vec![InputModality::Image];
     })
     .await;
     unsupported_image_generation_provider.assert_visible_lacks(&["image_generation"]);
 
-    let image_generation = probe(|turn| {
+    let image_generation = probe_context(|turn, model| {
         use_chatgpt_auth(turn);
         set_feature(turn, Feature::ImageGeneration, /*enabled*/ true);
-        turn.model_info.input_modalities = vec![InputModality::Image];
+        model.model_info.input_modalities = vec![InputModality::Image];
     })
     .await;
     image_generation.assert_visible_contains(&["image_generation"]);
 
-    let extension_flag_without_imagegen_tool = probe(|turn| {
+    let extension_flag_without_imagegen_tool = probe_context(|turn, model| {
         use_chatgpt_auth(turn);
         set_feature(turn, Feature::ImageGeneration, /*enabled*/ true);
         set_feature(turn, Feature::ImageGenExt, /*enabled*/ true);
-        turn.model_info.input_modalities = vec![InputModality::Image];
+        model.model_info.input_modalities = vec![InputModality::Image];
     })
     .await;
     extension_flag_without_imagegen_tool.assert_visible_contains(&["image_generation"]);
     extension_flag_without_imagegen_tool.assert_visible_lacks(&["image_gen"]);
 
-    let live_web_search = probe(|turn| {
+    let live_web_search = probe_context(|turn, model| {
         set_web_search_mode(turn, WebSearchMode::Live);
-        turn.model_info.web_search_tool_type = WebSearchToolType::TextAndImage;
+        model.model_info.web_search_tool_type = WebSearchToolType::TextAndImage;
     })
     .await;
     assert_eq!(
@@ -1617,11 +1638,11 @@ async fn hosted_tools_follow_provider_auth_model_and_config_gates() {
         }
     );
 
-    let code_mode_only = probe(|turn| {
+    let code_mode_only = probe_context(|turn, model| {
         use_chatgpt_auth(turn);
         set_features(turn, &[Feature::CodeModeOnly, Feature::MultiAgentV2]);
         set_web_search_mode(turn, WebSearchMode::Live);
-        turn.model_info.input_modalities = vec![InputModality::Image];
+        model.model_info.input_modalities = vec![InputModality::Image];
     })
     .await;
     assert_eq!(

--- a/codex-rs/core/src/tools/tool_dispatch_trace.rs
+++ b/codex-rs/core/src/tools/tool_dispatch_trace.rs
@@ -75,7 +75,7 @@ fn tool_dispatch_invocation(invocation: &ToolInvocation) -> Option<ToolDispatchI
 
     Some(ToolDispatchInvocation {
         thread_id: invocation.session.thread_id.to_string(),
-        codex_turn_id: invocation.turn.sub_id.clone(),
+        codex_turn_id: invocation.step_context.turn.sub_id.clone(),
         tool_call_id: invocation.call_id.clone(),
         tool_name: invocation.tool_name.name.clone(),
         tool_namespace: invocation.tool_name.namespace.clone(),

--- a/codex-rs/core/src/tools/tool_dispatch_trace_tests.rs
+++ b/codex-rs/core/src/tools/tool_dispatch_trace_tests.rs
@@ -274,7 +274,6 @@ fn test_invocation_with_payload(
     ToolInvocation {
         session,
         step_context,
-        turn,
         cancellation_token: CancellationToken::new(),
         tracker: Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new())),
         call_id: call_id.to_string(),

--- a/codex-rs/core/src/turn_timing.rs
+++ b/codex-rs/core/src/turn_timing.rs
@@ -12,10 +12,15 @@ use codex_protocol::models::ResponseItem;
 use tokio::sync::Mutex;
 
 use crate::ResponseEvent;
+use crate::session::step_model_context::StepModelContext;
 use crate::session::turn_context::TurnContext;
 use crate::stream_events_utils::raw_assistant_output_text_from_item;
 
-pub(crate) async fn record_turn_ttft_metric(turn_context: &TurnContext, event: &ResponseEvent) {
+pub(crate) async fn record_turn_ttft_metric(
+    turn_context: &TurnContext,
+    model: &StepModelContext,
+    event: &ResponseEvent,
+) {
     let Some(duration) = turn_context
         .turn_timing_state
         .record_ttft_for_response_event(event)
@@ -23,10 +28,14 @@ pub(crate) async fn record_turn_ttft_metric(turn_context: &TurnContext, event: &
     else {
         return;
     };
-    turn_context.session_telemetry.record_turn_ttft(duration);
+    model.session_telemetry.record_turn_ttft(duration);
 }
 
-pub(crate) async fn record_turn_ttfm_metric(turn_context: &TurnContext, item: &TurnItem) {
+pub(crate) async fn record_turn_ttfm_metric(
+    turn_context: &TurnContext,
+    model: &StepModelContext,
+    item: &TurnItem,
+) {
     let Some(duration) = turn_context
         .turn_timing_state
         .record_ttfm_for_turn_item(item)
@@ -34,7 +43,7 @@ pub(crate) async fn record_turn_ttfm_metric(turn_context: &TurnContext, item: &T
     else {
         return;
     };
-    turn_context
+    model
         .session_telemetry
         .record_duration(TURN_TTFM_DURATION_METRIC, duration, &[]);
 }

--- a/codex-rs/core/src/unified_exec/async_watcher.rs
+++ b/codex-rs/core/src/unified_exec/async_watcher.rs
@@ -10,7 +10,7 @@ use super::UnifiedExecContext;
 use super::process::UnifiedExecProcess;
 use crate::exec::MAX_EXEC_OUTPUT_DELTAS_PER_CALL;
 use crate::session::session::Session;
-use crate::session::turn_context::TurnContext;
+use crate::session::step_context::StepContext;
 use crate::tools::events::ToolEmitter;
 use crate::tools::events::ToolEventCtx;
 use crate::tools::events::ToolEventFailure;
@@ -47,7 +47,7 @@ pub(crate) fn start_streaming_output(
     let exit_token = process.cancellation_token();
 
     let session_ref = Arc::clone(&context.session);
-    let turn_ref = Arc::clone(&context.turn);
+    let step_context_ref = Arc::clone(&context.step_context);
     let call_id = context.call_id.clone();
 
     tokio::spawn(async move {
@@ -91,7 +91,7 @@ pub(crate) fn start_streaming_output(
                         &transcript,
                         &call_id,
                         &session_ref,
-                        &turn_ref,
+                        &step_context_ref,
                         &mut emitted_deltas,
                         chunk,
                     ).await;
@@ -107,7 +107,7 @@ pub(crate) fn start_streaming_output(
 pub(crate) fn spawn_exit_watcher(
     process: Arc<UnifiedExecProcess>,
     session_ref: Arc<Session>,
-    turn_ref: Arc<TurnContext>,
+    step_context_ref: Arc<StepContext>,
     call_id: String,
     command: Vec<String>,
     cwd: PathUri,
@@ -126,7 +126,7 @@ pub(crate) fn spawn_exit_watcher(
         if let Some(message) = process.failure_message() {
             emit_failed_exec_end_for_unified_exec(
                 session_ref,
-                turn_ref,
+                step_context_ref,
                 call_id,
                 command,
                 cwd,
@@ -141,7 +141,7 @@ pub(crate) fn spawn_exit_watcher(
             let exit_code = process.exit_code().unwrap_or(-1);
             emit_exec_end_for_unified_exec(
                 session_ref,
-                turn_ref,
+                step_context_ref,
                 call_id,
                 command,
                 cwd,
@@ -161,7 +161,7 @@ async fn process_chunk(
     transcript: &Arc<Mutex<HeadTailBuffer>>,
     call_id: &str,
     session_ref: &Arc<Session>,
-    turn_ref: &Arc<TurnContext>,
+    step_context_ref: &Arc<StepContext>,
     emitted_deltas: &mut usize,
     chunk: Vec<u8>,
 ) {
@@ -182,7 +182,10 @@ async fn process_chunk(
             chunk: prefix,
         };
         session_ref
-            .send_event(turn_ref.as_ref(), EventMsg::ExecCommandOutputDelta(event))
+            .send_event(
+                step_context_ref.turn.as_ref(),
+                EventMsg::ExecCommandOutputDelta(event),
+            )
             .await;
         *emitted_deltas += 1;
     }
@@ -194,7 +197,7 @@ async fn process_chunk(
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn emit_exec_end_for_unified_exec(
     session_ref: Arc<Session>,
-    turn_ref: Arc<TurnContext>,
+    step_context_ref: Arc<StepContext>,
     call_id: String,
     command: Vec<String>,
     cwd: PathUri,
@@ -215,7 +218,7 @@ pub(crate) async fn emit_exec_end_for_unified_exec(
     };
     let event_ctx = ToolEventCtx::new(
         session_ref.as_ref(),
-        turn_ref.as_ref(),
+        step_context_ref.as_ref(),
         &call_id,
         /*turn_diff_tracker*/ None,
     );
@@ -239,7 +242,7 @@ pub(crate) async fn emit_exec_end_for_unified_exec(
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn emit_failed_exec_end_for_unified_exec(
     session_ref: Arc<Session>,
-    turn_ref: Arc<TurnContext>,
+    step_context_ref: Arc<StepContext>,
     call_id: String,
     command: Vec<String>,
     cwd: PathUri,
@@ -269,7 +272,7 @@ pub(crate) async fn emit_failed_exec_end_for_unified_exec(
     };
     let event_ctx = ToolEventCtx::new(
         session_ref.as_ref(),
-        turn_ref.as_ref(),
+        step_context_ref.as_ref(),
         &call_id,
         /*turn_diff_tracker*/ None,
     );

--- a/codex-rs/core/src/unified_exec/mod.rs
+++ b/codex-rs/core/src/unified_exec/mod.rs
@@ -38,7 +38,7 @@ use tokio::sync::Mutex;
 
 use crate::sandboxing::SandboxPermissions;
 use crate::session::session::Session;
-use crate::session::turn_context::TurnContext;
+use crate::session::step_context::StepContext;
 use crate::session::turn_context::TurnEnvironment;
 use crate::shell::ShellType;
 use crate::tools::network_approval::DeferredNetworkApproval;
@@ -74,15 +74,15 @@ pub(crate) const MAX_UNIFIED_EXEC_PROCESSES: usize = 64;
 
 pub(crate) struct UnifiedExecContext {
     pub session: Arc<Session>,
-    pub turn: Arc<TurnContext>,
+    pub step_context: Arc<StepContext>,
     pub call_id: String,
 }
 
 impl UnifiedExecContext {
-    pub fn new(session: Arc<Session>, turn: Arc<TurnContext>, call_id: String) -> Self {
+    pub fn new(session: Arc<Session>, step_context: Arc<StepContext>, call_id: String) -> Self {
         Self {
             session,
-            turn,
+            step_context,
             call_id,
         }
     }

--- a/codex-rs/core/src/unified_exec/mod_tests.rs
+++ b/codex-rs/core/src/unified_exec/mod_tests.rs
@@ -5,6 +5,7 @@ use crate::exec::ExecCapturePolicy;
 use crate::exec::ExecExpiration;
 use crate::sandboxing::ExecRequest;
 use crate::session::session::Session;
+use crate::session::step_context::StepContext;
 use crate::session::tests::make_session_and_context;
 use crate::session::turn_context::TurnContext;
 use crate::tools::context::ExecCommandToolOutput;
@@ -121,8 +122,8 @@ async fn exec_command_with_tty(
             )
             .await?,
     );
-    let context =
-        UnifiedExecContext::new(Arc::clone(session), Arc::clone(turn), "call".to_string());
+    let step_context = StepContext::for_test(Arc::clone(turn));
+    let context = UnifiedExecContext::new(Arc::clone(session), step_context, "call".to_string());
     let started_at = Instant::now();
     let process_started_alive = !process.has_exited() && process.exit_code().is_none();
     if process_started_alive {
@@ -192,7 +193,12 @@ async fn exec_command_with_tty(
         chunk_id: generate_chunk_id(),
         wall_time,
         raw_output: collected,
-        truncation_policy: turn.model_info.truncation_policy.into(),
+        truncation_policy: context
+            .step_context
+            .model
+            .model_info
+            .truncation_policy
+            .into(),
         max_output_tokens: None,
         process_id: response_process_id,
         exit_code,

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -331,7 +331,7 @@ async fn emit_failed_initial_exec_end_if_unstored(
 
     emit_failed_exec_end_for_unified_exec(
         Arc::clone(&context.session),
-        Arc::clone(&context.turn),
+        Arc::clone(&context.step_context),
         context.call_id.clone(),
         request.command.clone(),
         cwd,
@@ -435,7 +435,7 @@ impl UnifiedExecProcessManager {
         let transcript = Arc::new(tokio::sync::Mutex::new(HeadTailBuffer::default()));
         let event_ctx = ToolEventCtx::new(
             context.session.as_ref(),
-            context.turn.as_ref(),
+            context.step_context.as_ref(),
             &context.call_id,
             /*turn_diff_tracker*/ None,
         );
@@ -599,7 +599,7 @@ impl UnifiedExecProcessManager {
             let exit = exit_code.unwrap_or(-1);
             emit_exec_end_for_unified_exec(
                 Arc::clone(&context.session),
-                Arc::clone(&context.turn),
+                Arc::clone(&context.step_context),
                 context.call_id.clone(),
                 request.command.clone(),
                 cwd.clone(),
@@ -622,7 +622,12 @@ impl UnifiedExecProcessManager {
             chunk_id,
             wall_time,
             raw_output: collected,
-            truncation_policy: context.turn.model_info.truncation_policy.into(),
+            truncation_policy: context
+                .step_context
+                .model
+                .model_info
+                .truncation_policy
+                .into(),
             max_output_tokens: request.max_output_tokens,
             process_id: response_process_id,
             exit_code,
@@ -897,7 +902,7 @@ impl UnifiedExecProcessManager {
         spawn_exit_watcher(
             Arc::clone(&process),
             Arc::clone(&context.session),
-            Arc::clone(&context.turn),
+            Arc::clone(&context.step_context),
             context.call_id.clone(),
             command.to_vec(),
             cwd,
@@ -1106,7 +1111,12 @@ impl UnifiedExecProcessManager {
         context: &UnifiedExecContext,
     ) -> Result<(UnifiedExecProcess, Option<DeferredNetworkApproval>), UnifiedExecError> {
         let local_policy_env = create_env(
-            &context.turn.config.permissions.shell_environment_policy,
+            &context
+                .step_context
+                .turn
+                .config
+                .permissions
+                .shell_environment_policy,
             /*thread_id*/ None,
         );
         let mut env = local_policy_env.clone();
@@ -1114,12 +1124,22 @@ impl UnifiedExecProcessManager {
             CODEX_THREAD_ID_ENV_VAR.to_string(),
             context.session.thread_id.to_string(),
         );
-        let active_permission_profile = context.turn.config.permissions.active_permission_profile();
+        let active_permission_profile = context
+            .step_context
+            .turn
+            .config
+            .permissions
+            .active_permission_profile();
         inject_permission_profile_env(&mut env, active_permission_profile.as_ref());
         let env = apply_unified_exec_env(env);
         let exec_server_env_config = ExecServerEnvConfig {
             policy: exec_env_policy_from_shell_policy(
-                &context.turn.config.permissions.shell_environment_policy,
+                &context
+                    .step_context
+                    .turn
+                    .config
+                    .permissions
+                    .shell_environment_policy,
             ),
             local_policy_env,
         };
@@ -1131,9 +1151,9 @@ impl UnifiedExecProcessManager {
             .exec_policy
             .create_exec_approval_requirement_for_command(ExecApprovalRequest {
                 command: &request.command,
-                approval_policy: context.turn.approval_policy.value(),
-                permission_profile: context.turn.permission_profile(),
-                windows_sandbox_level: context.turn.windows_sandbox_level,
+                approval_policy: context.step_context.turn.approval_policy.value(),
+                permission_profile: context.step_context.turn.permission_profile(),
+                windows_sandbox_level: context.step_context.turn.windows_sandbox_level,
                 sandbox_permissions: if request.additional_permissions_preapproved {
                     crate::sandboxing::SandboxPermissions::UseDefault
                 } else {
@@ -1153,6 +1173,7 @@ impl UnifiedExecProcessManager {
             env,
             exec_server_env_config: Some(exec_server_env_config),
             explicit_env_overrides: context
+                .step_context
                 .turn
                 .config
                 .permissions
@@ -1170,18 +1191,12 @@ impl UnifiedExecProcessManager {
         };
         let tool_ctx = ToolCtx {
             session: context.session.clone(),
-            turn: context.turn.clone(),
+            step_context: context.step_context.clone(),
             call_id: context.call_id.clone(),
             tool_name: ToolName::plain("exec_command"),
         };
         orchestrator
-            .run(
-                &mut runtime,
-                &req,
-                &tool_ctx,
-                &context.turn,
-                context.turn.approval_policy.value(),
-            )
+            .run(&mut runtime, &req, &tool_ctx)
             .await
             .map(|result| (result.output, result.deferred_network_approval))
             .map_err(|err| match err {

--- a/codex-rs/core/src/unified_exec/process_manager_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_manager_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::session::step_context::StepContext;
 use crate::unified_exec::clamp_yield_time;
 use codex_network_proxy::ManagedNetworkSandboxContext;
 use pretty_assertions::assert_eq;
@@ -259,9 +260,10 @@ async fn late_network_denial_grace_observes_cancellation_after_exit() {
 #[tokio::test]
 async fn failed_initial_end_for_unstored_process_uses_fallback_output() {
     let (session, turn, rx_event) = crate::session::tests::make_session_and_context_with_rx().await;
+    let step_context = StepContext::for_test(Arc::clone(&turn));
     let context = UnifiedExecContext::new(
         Arc::clone(&session),
-        Arc::clone(&turn),
+        step_context,
         "call-unified-denied".to_string(),
     );
     let request = ExecCommandRequest {

--- a/codex-rs/core/src/user_shell_command.rs
+++ b/codex-rs/core/src/user_shell_command.rs
@@ -3,18 +3,15 @@ use codex_protocol::models::ResponseItem;
 
 use crate::context::ContextualUserFragment;
 use crate::context::UserShellCommand;
-use crate::session::turn_context::TurnContext;
+use crate::session::step_model_context::StepModelContext;
 use crate::tools::format_exec_output_str;
 
 fn user_shell_command_fragment(
     command: &str,
     exec_output: &ExecToolCallOutput,
-    turn_context: &TurnContext,
+    model: &StepModelContext,
 ) -> UserShellCommand {
-    let output = format_exec_output_str(
-        exec_output,
-        turn_context.model_info.truncation_policy.into(),
-    );
+    let output = format_exec_output_str(exec_output, model.model_info.truncation_policy.into());
     UserShellCommand::new(command, exec_output.exit_code, exec_output.duration, output)
 }
 
@@ -22,21 +19,17 @@ fn user_shell_command_fragment(
 pub fn format_user_shell_command_record(
     command: &str,
     exec_output: &ExecToolCallOutput,
-    turn_context: &TurnContext,
+    model: &StepModelContext,
 ) -> String {
-    user_shell_command_fragment(command, exec_output, turn_context).render()
+    user_shell_command_fragment(command, exec_output, model).render()
 }
 
 pub fn user_shell_command_record_item(
     command: &str,
     exec_output: &ExecToolCallOutput,
-    turn_context: &TurnContext,
+    model: &StepModelContext,
 ) -> ResponseItem {
-    ContextualUserFragment::into(user_shell_command_fragment(
-        command,
-        exec_output,
-        turn_context,
-    ))
+    ContextualUserFragment::into(user_shell_command_fragment(command, exec_output, model))
 }
 
 #[cfg(test)]

--- a/codex-rs/core/src/user_shell_command_tests.rs
+++ b/codex-rs/core/src/user_shell_command_tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::context::ContextualUserFragment;
 use crate::context::UserShellCommand;
+use crate::session::step_model_context::StepModelContext;
 use crate::session::tests::make_session_and_context;
 use codex_protocol::exec_output::StreamOutput;
 use codex_protocol::models::ContentItem;
@@ -26,7 +27,8 @@ async fn formats_basic_record() {
         timed_out: false,
     };
     let (_, turn_context) = make_session_and_context().await;
-    let item = user_shell_command_record_item("echo hi", &exec_output, &turn_context);
+    let model = StepModelContext::for_test(&turn_context);
+    let item = user_shell_command_record_item("echo hi", &exec_output, &model);
     let ResponseItem::Message { content, .. } = item else {
         panic!("expected message");
     };
@@ -50,7 +52,8 @@ async fn uses_aggregated_output_over_streams() {
         timed_out: false,
     };
     let (_, turn_context) = make_session_and_context().await;
-    let record = format_user_shell_command_record("false", &exec_output, &turn_context);
+    let model = StepModelContext::for_test(&turn_context);
+    let record = format_user_shell_command_record("false", &exec_output, &model);
     assert_eq!(
         record,
         "<user_shell_command>\n<command>\nfalse\n</command>\n<result>\nExit code: 42\nDuration: 0.1200 seconds\nOutput:\ncombined output wins\n</result>\n</user_shell_command>"

--- a/codex-rs/core/tests/suite/model_switching.rs
+++ b/codex-rs/core/tests/suite/model_switching.rs
@@ -3,9 +3,12 @@ use codex_config::types::Personality;
 use codex_features::Feature;
 use codex_login::CodexAuth;
 use codex_models_manager::manager::RefreshStrategy;
+use codex_protocol::config_types::CollaborationMode;
+use codex_protocol::config_types::ModeKind;
 use codex_protocol::config_types::ReasoningSummary;
 use codex_protocol::config_types::SERVICE_TIER_DEFAULT_REQUEST_VALUE;
 use codex_protocol::config_types::ServiceTier;
+use codex_protocol::config_types::Settings;
 use codex_protocol::models::PermissionProfile;
 use codex_protocol::openai_models::ConfigShellToolType;
 use codex_protocol::openai_models::InputModality;
@@ -20,8 +23,12 @@ use codex_protocol::openai_models::default_input_modalities;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::Op;
+use codex_protocol::request_user_input::RequestUserInputAnswer;
+use codex_protocol::request_user_input::RequestUserInputResponse;
 use codex_protocol::user_input::UserInput;
+use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_completed_with_tokens;
+use core_test_support::responses::ev_function_call;
 use core_test_support::responses::ev_image_generation_call;
 use core_test_support::responses::ev_response_created;
 use core_test_support::responses::mount_models_once;
@@ -37,7 +44,10 @@ use core_test_support::test_codex::local_selections;
 use core_test_support::test_codex::test_codex;
 use core_test_support::test_codex::turn_permission_fields;
 use core_test_support::wait_for_event;
+use core_test_support::wait_for_event_match;
 use pretty_assertions::assert_eq;
+use serde_json::json;
+use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 use wiremock::MockServer;
@@ -142,6 +152,156 @@ fn test_model_info(
         effective_context_window_percent: 95,
         experimental_supported_tools: Vec::new(),
     }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn model_settings_update_during_turn_applies_to_next_turn() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let call_id = "step-context-user-input";
+    let request_args = json!({
+        "questions": [{
+            "id": "confirm",
+            "header": "Confirm",
+            "question": "Continue?",
+            "options": [{
+                "label": "Yes (Recommended)",
+                "description": "Continue the turn."
+            }, {
+                "label": "No",
+                "description": "Stop the turn."
+            }]
+        }]
+    })
+    .to_string();
+    let response_mock = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                ev_function_call(call_id, "request_user_input", &request_args),
+                ev_completed("resp-1"),
+            ]),
+            sse_completed("resp-2"),
+            sse_completed("resp-3"),
+        ],
+    )
+    .await;
+
+    let current_model = "gpt-5.3-codex";
+    let current_instructions = "CURRENT_STEP_SETTINGS";
+    let mut builder = test_codex().with_model(current_model);
+    let test = builder.build_with_auto_env(&server).await?;
+    let (sandbox_policy, permission_profile) =
+        turn_permission_fields(PermissionProfile::Disabled, test.cwd_path());
+
+    test.codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "pause this turn".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: codex_protocol::protocol::ThreadSettingsOverrides {
+                environments: Some(local_selections(test.config.cwd.clone())),
+                approval_policy: Some(AskForApproval::Never),
+                sandbox_policy: Some(sandbox_policy),
+                permission_profile,
+                collaboration_mode: Some(CollaborationMode {
+                    mode: ModeKind::Plan,
+                    settings: Settings {
+                        model: current_model.to_string(),
+                        reasoning_effort: Some(ReasoningEffort::Medium),
+                        developer_instructions: Some(current_instructions.to_string()),
+                    },
+                }),
+                ..Default::default()
+            },
+        })
+        .await?;
+
+    let request = wait_for_event_match(&test.codex, |event| match event {
+        EventMsg::RequestUserInput(request) => Some(request.clone()),
+        _ => None,
+    })
+    .await;
+    assert_eq!(request.call_id, call_id);
+
+    let next_model = "gpt-5.4";
+    let next_instructions = "NEXT_STEP_SETTINGS";
+    core_test_support::submit_thread_settings(
+        &test.codex,
+        codex_protocol::protocol::ThreadSettingsOverrides {
+            collaboration_mode: Some(CollaborationMode {
+                mode: ModeKind::Default,
+                settings: Settings {
+                    model: next_model.to_string(),
+                    reasoning_effort: Some(ReasoningEffort::High),
+                    developer_instructions: Some(next_instructions.to_string()),
+                },
+            }),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    let mut answers = HashMap::new();
+    answers.insert(
+        "confirm".to_string(),
+        RequestUserInputAnswer {
+            answers: vec!["yes".to_string()],
+        },
+    );
+    test.codex
+        .submit(Op::UserInputAnswer {
+            id: request.turn_id,
+            response: RequestUserInputResponse { answers },
+        })
+        .await?;
+    wait_for_event(&test.codex, |event| {
+        matches!(event, EventMsg::TurnComplete(_))
+    })
+    .await;
+
+    let current_turn_requests = response_mock.requests();
+    assert_eq!(current_turn_requests.len(), 2);
+    for request in &current_turn_requests {
+        let body = request.body_json();
+        assert_eq!(body["model"].as_str(), Some(current_model));
+        assert_eq!(body["reasoning"]["effort"].as_str(), Some("medium"));
+        assert!(request.body_contains_text(current_instructions));
+        assert!(!request.body_contains_text(next_instructions));
+    }
+
+    test.codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "start the next turn".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: Default::default(),
+        })
+        .await?;
+    wait_for_event(&test.codex, |event| {
+        matches!(event, EventMsg::TurnComplete(_))
+    })
+    .await;
+
+    let requests = response_mock.requests();
+    assert_eq!(requests.len(), 3);
+    let next_request = &requests[2];
+    let body = next_request.body_json();
+    assert_eq!(body["model"].as_str(), Some(next_model));
+    assert_eq!(body["reasoning"]["effort"].as_str(), Some("high"));
+    assert!(next_request.body_contains_text(next_instructions));
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/codex-rs/ext/extension-api/examples/enabled_extensions.rs
+++ b/codex-rs/ext/extension-api/examples/enabled_extensions.rs
@@ -9,6 +9,7 @@ use std::task::Waker;
 
 use codex_extension_api::ExtensionData;
 use codex_extension_api::ExtensionRegistryBuilder;
+use codex_protocol::openai_models::ModelInfo;
 use shared_state_extension::recorded_style_contributions;
 use shared_state_extension::recorded_usage_contributions;
 
@@ -22,22 +23,26 @@ fn main() {
     let session_store = ExtensionData::new("session");
     let first_thread_store = ExtensionData::new("thread-1");
     let second_thread_store = ExtensionData::new("thread-2");
+    let model_info = example_model_info();
 
     // 3. Reusing the same session store shares session state across threads.
     let first_thread_fragments = block_on_ready(contribute_prompt(
         &registry,
         &session_store,
         &first_thread_store,
+        &model_info,
     ));
     block_on_ready(contribute_prompt(
         &registry,
         &session_store,
         &first_thread_store,
+        &model_info,
     ));
     block_on_ready(contribute_prompt(
         &registry,
         &session_store,
         &second_thread_store,
+        &model_info,
     ));
 
     println!("first prompt fragments: {}", first_thread_fragments.len());
@@ -71,16 +76,37 @@ async fn contribute_prompt(
     registry: &codex_extension_api::ExtensionRegistry<()>,
     session_store: &ExtensionData,
     thread_store: &ExtensionData,
+    model_info: &ModelInfo,
 ) -> Vec<codex_extension_api::PromptFragment> {
     let mut fragments = Vec::new();
     for contributor in registry.context_contributors() {
         fragments.extend(
             contributor
-                .contribute_thread_context(session_store, thread_store)
+                .contribute_thread_context(session_store, thread_store, model_info)
                 .await,
         );
     }
     fragments
+}
+
+fn example_model_info() -> ModelInfo {
+    serde_json::from_value(serde_json::json!({
+        "slug": "example-model",
+        "display_name": "Example Model",
+        "supported_reasoning_levels": [],
+        "shell_type": "default",
+        "visibility": "none",
+        "supported_in_api": true,
+        "priority": 0,
+        "service_tiers": [],
+        "base_instructions": "",
+        "supports_reasoning_summaries": false,
+        "support_verbosity": false,
+        "truncation_policy": { "mode": "bytes", "limit": 10_000 },
+        "supports_parallel_tool_calls": false,
+        "experimental_supported_tools": []
+    }))
+    .expect("example model metadata should deserialize")
 }
 
 fn block_on_ready<F>(future: F) -> F::Output

--- a/codex-rs/ext/extension-api/examples/enabled_extensions/shared_state_extension.rs
+++ b/codex-rs/ext/extension-api/examples/enabled_extensions/shared_state_extension.rs
@@ -6,6 +6,7 @@ use codex_extension_api::ContextContributor;
 use codex_extension_api::ExtensionData;
 use codex_extension_api::ExtensionRegistryBuilder;
 use codex_extension_api::PromptFragment;
+use codex_protocol::openai_models::ModelInfo;
 
 /// Installs the tutorial contributors used by the example host.
 pub fn install(registry: &mut ExtensionRegistryBuilder<()>) {
@@ -21,6 +22,7 @@ impl ContextContributor for StyleContributor {
         &'a self,
         session_store: &'a ExtensionData,
         thread_store: &'a ExtensionData,
+        _model_info: &'a ModelInfo,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Vec<PromptFragment>> + Send + 'a>> {
         Box::pin(async move {
             contribution_counts(session_store).record_style();
@@ -41,6 +43,7 @@ impl ContextContributor for UsageContributor {
         &'a self,
         session_store: &'a ExtensionData,
         thread_store: &'a ExtensionData,
+        _model_info: &'a ModelInfo,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Vec<PromptFragment>> + Send + 'a>> {
         Box::pin(async move {
             contribution_counts(session_store).record_usage();

--- a/codex-rs/ext/extension-api/src/contributors.rs
+++ b/codex-rs/ext/extension-api/src/contributors.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use codex_context_fragments::ContextualUserFragment;
 use codex_protocol::items::TurnItem;
+use codex_protocol::openai_models::ModelInfo;
 use codex_protocol::protocol::ReviewDecision;
 use codex_protocol::protocol::TokenUsageInfo;
 use codex_tools::ToolCall;
@@ -78,11 +79,13 @@ pub trait ContextContributor: Send + Sync {
         &'a self,
         session_store: &'a ExtensionData,
         thread_store: &'a ExtensionData,
+        model_info: &'a ModelInfo,
     ) -> ExtensionFuture<'a, Vec<PromptFragment>> {
         Box::pin(async move {
             let _self = self;
             let _session_store = session_store;
             let _thread_store = thread_store;
+            let _model_info = model_info;
             Vec::new()
         })
     }
@@ -204,6 +207,7 @@ pub trait TurnInputContributor: Send + Sync {
     fn contribute<'a>(
         &'a self,
         input: TurnInputContext,
+        model_info: &'a ModelInfo,
         session_store: &'a ExtensionData,
         thread_store: &'a ExtensionData,
         turn_store: &'a ExtensionData,

--- a/codex-rs/ext/extension-api/src/contributors/world_state.rs
+++ b/codex-rs/ext/extension-api/src/contributors/world_state.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use codex_protocol::ThreadId;
 use codex_protocol::capabilities::SelectedCapabilityRoot;
+use codex_protocol::openai_models::ModelInfo;
 use codex_protocol::protocol::TurnEnvironmentSelection;
 use serde_json::Value;
 
@@ -11,6 +12,8 @@ use crate::ExtensionData;
 pub struct WorldStateContributionInput<'a> {
     pub thread_id: ThreadId,
     pub turn_id: &'a str,
+    /// Model selected for this sampling step.
+    pub model_info: &'a ModelInfo,
     pub environments: &'a [TurnEnvironmentSelection],
     /// Selected roots whose stable environments are ready in this sampling step.
     pub ready_selected_capability_roots: &'a [SelectedCapabilityRoot],

--- a/codex-rs/ext/extension-api/src/lib.rs
+++ b/codex-rs/ext/extension-api/src/lib.rs
@@ -13,6 +13,7 @@ pub use capabilities::ResponseItemInjectionFuture;
 pub use capabilities::ResponseItemInjector;
 pub use codex_context_fragments::ContextualUserFragment;
 pub use codex_protocol::models::ResponseItem;
+pub use codex_protocol::openai_models::ModelInfo;
 pub use codex_tools::ConversationHistory;
 pub use codex_tools::ExtensionTurnItem;
 pub use codex_tools::FunctionCallError;

--- a/codex-rs/ext/extension-api/tests/registry.rs
+++ b/codex-rs/ext/extension-api/tests/registry.rs
@@ -27,6 +27,7 @@ use codex_extension_api::TurnLifecycleContributor;
 use codex_extension_api::empty_extension_registry;
 use codex_protocol::items::HookPromptItem;
 use codex_protocol::items::TurnItem;
+use codex_protocol::openai_models::ModelInfo;
 use codex_protocol::protocol::Event;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::ReviewDecision;
@@ -40,6 +41,7 @@ impl ContextContributor for AllContributors {
         &'a self,
         _session_store: &'a ExtensionData,
         _thread_store: &'a ExtensionData,
+        _model_info: &'a ModelInfo,
     ) -> ExtensionFuture<'a, Vec<PromptFragment>> {
         Box::pin(std::future::ready(Vec::new()))
     }
@@ -57,6 +59,7 @@ impl TurnInputContributor for AllContributors {
     fn contribute<'a>(
         &'a self,
         input: TurnInputContext,
+        _model_info: &'a ModelInfo,
         _session_store: &'a ExtensionData,
         _thread_store: &'a ExtensionData,
         _turn_store: &'a ExtensionData,
@@ -153,6 +156,7 @@ impl ContextContributor for NamedContextContributor {
         &'a self,
         _session_store: &'a ExtensionData,
         _thread_store: &'a ExtensionData,
+        _model_info: &'a ModelInfo,
     ) -> ExtensionFuture<'a, Vec<PromptFragment>> {
         Box::pin(std::future::ready(vec![PromptFragment::developer_policy(
             self.0,
@@ -214,12 +218,13 @@ async fn contributors_preserve_registration_order() {
     let session_store = ExtensionData::new("session");
     let thread_store = ExtensionData::new("thread");
     let turn_store = ExtensionData::new("turn");
+    let model_info = test_model_info();
 
     let mut fragments = Vec::new();
     for contributor in registry.context_contributors() {
         fragments.extend(
             contributor
-                .contribute_thread_context(&session_store, &thread_store)
+                .contribute_thread_context(&session_store, &thread_store, &model_info)
                 .await,
         );
     }
@@ -412,4 +417,24 @@ fn warning_event(id: &str, message: &str) -> Event {
             message: message.to_string(),
         }),
     }
+}
+
+fn test_model_info() -> ModelInfo {
+    serde_json::from_value(serde_json::json!({
+        "slug": "test-model",
+        "display_name": "Test Model",
+        "supported_reasoning_levels": [],
+        "shell_type": "default",
+        "visibility": "none",
+        "supported_in_api": true,
+        "priority": 0,
+        "service_tiers": [],
+        "base_instructions": "",
+        "supports_reasoning_summaries": false,
+        "support_verbosity": false,
+        "truncation_policy": { "mode": "bytes", "limit": 10_000 },
+        "supports_parallel_tool_calls": false,
+        "experimental_supported_tools": []
+    }))
+    .expect("test model metadata should deserialize")
 }

--- a/codex-rs/ext/memories/src/extension.rs
+++ b/codex-rs/ext/memories/src/extension.rs
@@ -6,6 +6,7 @@ use codex_extension_api::ContextContributor;
 use codex_extension_api::ExtensionData;
 use codex_extension_api::ExtensionFuture;
 use codex_extension_api::ExtensionRegistryBuilder;
+use codex_extension_api::ModelInfo;
 use codex_extension_api::PromptFragment;
 use codex_extension_api::ThreadLifecycleContributor;
 use codex_extension_api::ThreadStartInput;
@@ -52,6 +53,7 @@ impl ContextContributor for MemoriesExtension {
         &'a self,
         _session_store: &'a ExtensionData,
         thread_store: &'a ExtensionData,
+        _model_info: &'a ModelInfo,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Vec<PromptFragment>> + Send + 'a>> {
         Box::pin(async move {
             let Some(config) = thread_store.get::<MemoriesExtensionConfig>() else {

--- a/codex-rs/ext/memories/src/tests.rs
+++ b/codex-rs/ext/memories/src/tests.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use codex_extension_api::ContextContributor;
 use codex_extension_api::ExtensionData;
 use codex_extension_api::ExtensionRegistryBuilder;
+use codex_extension_api::ModelInfo;
 use codex_extension_api::NoopTurnItemEmitter;
 use codex_extension_api::PromptSlot;
 use codex_extension_api::ToolCall;
@@ -181,7 +182,11 @@ async fn prompt_contribution_uses_memory_summary_when_enabled() {
     });
 
     let fragments = extension
-        .contribute_thread_context(&ExtensionData::new("session"), &thread_store)
+        .contribute_thread_context(
+            &ExtensionData::new("session"),
+            &thread_store,
+            &test_model_info(),
+        )
         .await;
 
     assert_eq!(fragments.len(), 1);
@@ -191,6 +196,26 @@ async fn prompt_contribution_uses_memory_summary_when_enabled() {
             .text()
             .contains("Remember repository-specific implementation preferences.")
     );
+}
+
+fn test_model_info() -> ModelInfo {
+    serde_json::from_value(serde_json::json!({
+        "slug": "test-model",
+        "display_name": "Test Model",
+        "supported_reasoning_levels": [],
+        "shell_type": "default",
+        "visibility": "none",
+        "supported_in_api": true,
+        "priority": 0,
+        "service_tiers": [],
+        "base_instructions": "",
+        "supports_reasoning_summaries": false,
+        "support_verbosity": false,
+        "truncation_policy": { "mode": "bytes", "limit": 10_000 },
+        "supports_parallel_tool_calls": false,
+        "experimental_supported_tools": []
+    }))
+    .expect("test model metadata should deserialize")
 }
 
 #[tokio::test]

--- a/codex-rs/ext/skills/src/extension.rs
+++ b/codex-rs/ext/skills/src/extension.rs
@@ -104,6 +104,7 @@ where
         &'a self,
         session_store: &'a ExtensionData,
         thread_store: &'a ExtensionData,
+        model_info: &'a ModelInfo,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Vec<PromptFragment>> + Send + 'a>> {
         Box::pin(async move {
             let Some(thread_state) = thread_store.get::<SkillsThreadState>() else {
@@ -130,9 +131,7 @@ where
             for warning in &catalog.warnings {
                 self.emit_warning(thread_store.level_id(), warning.clone());
             }
-            let include_usage = thread_store
-                .get::<ModelInfo>()
-                .is_some_and(|model_info| model_info.include_skills_usage_instructions);
+            let include_usage = model_info.include_skills_usage_instructions;
             available_skills_fragment(&catalog, include_usage)
                 .map(|fragment| PromptFragment::developer_capability(fragment.render()))
                 .into_iter()
@@ -166,10 +165,7 @@ where
             input
                 .turn_store
                 .insert(ExecutorSkillsStepState(catalog.clone()));
-            let include_usage = input
-                .thread_store
-                .get::<ModelInfo>()
-                .is_some_and(|model_info| model_info.include_skills_usage_instructions);
+            let include_usage = input.model_info.include_skills_usage_instructions;
             vec![executor_skills_world_state_section(
                 &catalog,
                 config.include_instructions,
@@ -212,6 +208,7 @@ where
     fn contribute<'a>(
         &'a self,
         input: TurnInputContext,
+        model_info: &'a ModelInfo,
         session_store: &'a ExtensionData,
         thread_store: &'a ExtensionData,
         turn_store: &'a ExtensionData,
@@ -248,9 +245,7 @@ where
                     entry.authority.kind != SkillSourceKind::Executor
                         && entry.authority.kind != SkillSourceKind::Orchestrator
                 });
-                let include_usage = thread_store
-                    .get::<ModelInfo>()
-                    .is_some_and(|model_info| model_info.include_skills_usage_instructions);
+                let include_usage = model_info.include_skills_usage_instructions;
                 if let Some(fragment) = available_skills_fragment(&turn_catalog, include_usage) {
                     fragments.push(Box::new(fragment));
                 }

--- a/codex-rs/ext/skills/tests/skills_extension.rs
+++ b/codex-rs/ext/skills/tests/skills_extension.rs
@@ -22,6 +22,7 @@ use codex_extension_api::TurnInputContext;
 use codex_extension_api::WorldStateContributionInput;
 use codex_protocol::capabilities::CapabilityRootLocation;
 use codex_protocol::capabilities::SelectedCapabilityRoot;
+use codex_protocol::openai_models::ModelInfo;
 use codex_protocol::protocol::Event;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::SKILLS_INSTRUCTIONS_CLOSE_TAG;
@@ -70,6 +71,7 @@ async fn installed_extension_uses_host_service_snapshot() -> TestResult {
     )?;
     std::fs::write(&skill_path, DEMO_SKILL_CONTENTS)?;
     let config = default_config();
+    let model_info = test_model_info();
 
     let mut builder = ExtensionRegistryBuilder::new();
     install(&mut builder, skills_extension_config);
@@ -117,6 +119,7 @@ async fn installed_extension_uses_host_service_snapshot() -> TestResult {
                 }],
                 environments: Vec::new(),
             },
+            &model_info,
             &session_store,
             &thread_store,
             &turn_store,
@@ -179,6 +182,7 @@ async fn selected_executor_catalog_follows_step_availability_and_reuses_its_cach
     }];
     let session_source = SessionSource::Cli;
     let config = default_config();
+    let model_info = test_model_info();
     registry.thread_lifecycle_contributors()[0]
         .on_thread_start(ThreadStartInput {
             config: &config,
@@ -191,7 +195,7 @@ async fn selected_executor_catalog_follows_step_availability_and_reuses_its_cach
         .await;
 
     let prompt_fragments = registry.context_contributors()[0]
-        .contribute_thread_context(&session_store, &thread_store)
+        .contribute_thread_context(&session_store, &thread_store, &model_info)
         .await;
     assert!(prompt_fragments.is_empty());
 
@@ -204,6 +208,7 @@ async fn selected_executor_catalog_follows_step_availability_and_reuses_its_cach
         .contribute_world_state(WorldStateContributionInput {
             thread_id: codex_protocol::ThreadId::new(),
             turn_id: "turn-1",
+            model_info: &model_info,
             environments: std::slice::from_ref(&turn_environment),
             ready_selected_capability_roots: &selected_roots,
             session_store: &session_store,
@@ -233,6 +238,7 @@ async fn selected_executor_catalog_follows_step_availability_and_reuses_its_cach
                 }],
                 environments: Vec::new(),
             },
+            &model_info,
             &session_store,
             &thread_store,
             &turn_store,
@@ -256,6 +262,7 @@ async fn selected_executor_catalog_follows_step_availability_and_reuses_its_cach
         .contribute_world_state(WorldStateContributionInput {
             thread_id: codex_protocol::ThreadId::new(),
             turn_id: "turn-2",
+            model_info: &model_info,
             environments: &[],
             ready_selected_capability_roots: &[],
             session_store: &session_store,
@@ -278,6 +285,7 @@ async fn selected_executor_catalog_follows_step_availability_and_reuses_its_cach
         .contribute_world_state(WorldStateContributionInput {
             thread_id: codex_protocol::ThreadId::new(),
             turn_id: "turn-3",
+            model_info: &model_info,
             environments: &[turn_environment],
             ready_selected_capability_roots: &selected_roots,
             session_store: &session_store,
@@ -305,6 +313,7 @@ async fn selected_executor_catalog_follows_step_availability_and_reuses_its_cach
         .contribute_world_state(WorldStateContributionInput {
             thread_id: codex_protocol::ThreadId::new(),
             turn_id: "turn-4",
+            model_info: &model_info,
             environments: &[],
             ready_selected_capability_roots: &selected_roots,
             session_store: &session_store,
@@ -362,6 +371,7 @@ async fn default_context_truncates_catalog_descriptions() -> TestResult {
     let thread_store = ExtensionData::new("thread");
     let session_source = SessionSource::Cli;
     let config = default_config();
+    let model_info = test_model_info();
     registry.thread_lifecycle_contributors()[0]
         .on_thread_start(ThreadStartInput {
             config: &config,
@@ -374,7 +384,7 @@ async fn default_context_truncates_catalog_descriptions() -> TestResult {
         .await;
 
     let fragments = registry.context_contributors()[0]
-        .contribute_thread_context(&session_store, &thread_store)
+        .contribute_thread_context(&session_store, &thread_store, &model_info)
         .await;
     assert_eq!(1, fragments.len());
     let rendered = fragments[0].text();
@@ -484,6 +494,7 @@ async fn orchestrator_catalog_snapshot_caches_failure() -> TestResult {
     let thread_store = ExtensionData::new("thread");
     let session_source = SessionSource::Cli;
     let config = default_config();
+    let model_info = test_model_info();
     registry.thread_lifecycle_contributors()[0]
         .on_thread_start(ThreadStartInput {
             config: &config,
@@ -496,7 +507,7 @@ async fn orchestrator_catalog_snapshot_caches_failure() -> TestResult {
         .await;
 
     let initial_fragments = registry.context_contributors()[0]
-        .contribute_thread_context(&session_store, &thread_store)
+        .contribute_thread_context(&session_store, &thread_store, &model_info)
         .await;
     assert!(initial_fragments.is_empty());
     let EventMsg::Warning(warning) = event_rx.try_recv()?.msg else {
@@ -518,6 +529,7 @@ async fn orchestrator_catalog_snapshot_caches_failure() -> TestResult {
                     }],
                     environments: Vec::new(),
                 },
+                &model_info,
                 &session_store,
                 &thread_store,
                 &ExtensionData::new(turn_id),
@@ -574,6 +586,7 @@ async fn root_qualified_locator_selects_only_the_matching_executor_skill() -> Te
         .collect::<Vec<_>>();
     let session_source = SessionSource::Cli;
     let config = default_config();
+    let model_info = test_model_info();
     registry.thread_lifecycle_contributors()[0]
         .on_thread_start(ThreadStartInput {
             config: &config,
@@ -590,6 +603,7 @@ async fn root_qualified_locator_selects_only_the_matching_executor_skill() -> Te
         .contribute_world_state(WorldStateContributionInput {
             thread_id: codex_protocol::ThreadId::new(),
             turn_id: "turn-1",
+            model_info: &model_info,
             environments: &[TurnEnvironmentSelection {
                 environment_id: "env-1".to_string(),
                 cwd: PathUri::parse("file:///workspace").expect("cwd URI"),
@@ -610,6 +624,7 @@ async fn root_qualified_locator_selects_only_the_matching_executor_skill() -> Te
                 }],
                 environments: Vec::new(),
             },
+            &model_info,
             &session_store,
             &thread_store,
             &turn_store,
@@ -664,6 +679,7 @@ async fn prompt_hidden_skill_can_still_be_invoked() -> TestResult {
     let thread_store = ExtensionData::new("thread");
     let session_source = SessionSource::Cli;
     let config = default_config();
+    let model_info = test_model_info();
     registry.thread_lifecycle_contributors()[0]
         .on_thread_start(ThreadStartInput {
             config: &config,
@@ -685,6 +701,7 @@ async fn prompt_hidden_skill_can_still_be_invoked() -> TestResult {
                 }],
                 environments: Vec::new(),
             },
+            &model_info,
             &session_store,
             &thread_store,
             &ExtensionData::new("turn-1"),
@@ -797,6 +814,26 @@ fn skills_extension_config(config: &TestConfig) -> SkillsExtensionConfig {
         bundled_skills_enabled: config.bundled_skills_enabled,
         orchestrator_skills_enabled: config.orchestrator_skills_enabled,
     }
+}
+
+fn test_model_info() -> ModelInfo {
+    serde_json::from_value(serde_json::json!({
+        "slug": "test-model",
+        "display_name": "Test Model",
+        "supported_reasoning_levels": [],
+        "shell_type": "default",
+        "visibility": "none",
+        "supported_in_api": true,
+        "priority": 0,
+        "service_tiers": [],
+        "base_instructions": "",
+        "supports_reasoning_summaries": false,
+        "support_verbosity": false,
+        "truncation_policy": { "mode": "bytes", "limit": 10_000 },
+        "supports_parallel_tool_calls": false,
+        "experimental_supported_tools": []
+    }))
+    .expect("test model metadata should deserialize")
 }
 
 fn test_codex_home() -> PathBuf {


### PR DESCRIPTION
## Summary

- make StepModelContext the canonical owner of model selection, reasoning settings, collaboration mode, service tier, model telemetry, and model warning state
- carry a frozen StepContextSeed through turn tasks so every sampling step in an active turn shares its turn-start model snapshot, while thread-setting updates apply to the next turn
- migrate sampling, compaction, tools, hooks, extensions, review/guardian flows, telemetry, and rollout serialization off TurnContext model state

The large diff is mechanical fallout from removing the duplicated TurnContext fields; it does not implement live per-step model switching. Persisted TurnContextItem shape and active-turn behavior remain unchanged.

## Validation

- added an integration test that pauses a turn with request_user_input, changes model/effort/collaboration instructions, verifies both requests in the active turn remain frozen, then verifies the next turn receives the new settings
- ran just fmt and static ownership/call-site audits
- intentionally did not build, lint, or test locally; remote CI and Bazel are the source of truth for this PR