### PR TITLE
bench: add e2e benchmark entrypoints

### DIFF
--- a/codex-rs/BUILD.bazel
+++ b/codex-rs/BUILD.bazel
@@ -15,3 +15,12 @@ filegroup(
     ),
     visibility = ["//visibility:public"],
 )
+
+test_suite(
+    name = "e2e-benchmarks",
+    tags = ["manual"],
+    tests = [
+        "//codex-rs/cli:codex-help-bench",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/justfile
+++ b/justfile
@@ -99,6 +99,19 @@ bench *args:
 bench-smoke:
     just bench -- --test
 
+# Run Bazel-backed end-to-end macrobenchmarks with optimized binaries.
+bench-e2e:
+    # Keep measured binaries comparable to production-style optimized builds.
+    bazel test --compilation_mode=opt --cache_test_results=no --test_output=streamed //codex-rs:e2e-benchmarks
+
+# Run Bazel-backed end-to-end macrobenchmarks once per case with release-like
+# Rust cfg paths but fastbuild codegen.
+bench-e2e-smoke:
+    # Avoid optimizer cost because smoke runs only check that benchmarks work.
+    # Compile target Rust code through the same release-only cfg paths as opt.
+    # Compile exec-platform Rust tools through those release-only cfg paths too.
+    bazel test --compilation_mode=fastbuild --@rules_rust//rust/settings:extra_rustc_flag=-Cdebug-assertions=no --@rules_rust//rust/settings:extra_exec_rustc_flag=-Cdebug-assertions=no --cache_test_results=no --test_output=streamed --test_arg=--test //codex-rs:e2e-benchmarks
+
 # Build and run Codex from source using Bazel.
 # On Unix, use `[no-cd]` and `--run_under="cd $PWD &&"` to ensure Bazel runs
 # the command in the current working directory.


### PR DESCRIPTION
## Why

Bazel-backed macrobenchmarks need stable local entrypoints that can grow without changing every caller.

## What

- add a top-level `e2e-benchmarks` Bazel suite, initially containing the `codex --help` benchmark
- add cross-platform `just bench-e2e` for direct optimized Bazel measurements
- add cross-platform `just bench-e2e-smoke` for one direct fastbuild iteration through release-only Rust cfg paths

## Validation

- `just --dry-run bench-e2e`
- `just --dry-run bench-e2e-smoke`
- `just bench-e2e-smoke`

## Stack

1. [#31295 bench: add codex help e2e macrobenchmark](https://github.com/openai/codex/pull/31295)
2. [#31428 bench: add e2e benchmark entrypoints](https://github.com/openai/codex/pull/31428)
3. [#31429 ci: smoke Bazel e2e benchmarks](https://github.com/openai/codex/pull/31429)
