### PR TITLE
ci: smoke Bazel e2e benchmarks

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -76,12 +76,6 @@ jobs:
         shell: bash
         run: ./scripts/check-module-bazel-lock.sh
 
-      - name: Bazel end-to-end benchmark smoke test
-        if: matrix.os == 'ubuntu-24.04' && matrix.target == 'x86_64-unknown-linux-gnu'
-        env:
-          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
-        run: just bench-e2e-smoke
-
       - name: bazel test //...
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
@@ -124,6 +118,65 @@ jobs:
 
       # Save the job-scoped Bazel repository cache after cache misses. Keep the
       # upload non-fatal so cache service issues never fail the job itself.
+      - name: Save bazel repository cache
+        if: always() && !cancelled() && steps.prepare_bazel.outputs.repository-cache-hit != 'true'
+        continue-on-error: true
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ${{ steps.prepare_bazel.outputs.repository-cache-path }}
+          key: ${{ steps.prepare_bazel.outputs.repository-cache-key }}
+
+      - name: Check for a clean worktree
+        if: always() && !cancelled()
+        uses: ./.github/actions/check-clean-worktree
+
+  e2e-benchmark-smoke:
+    # Bazel-backed macrobenchmarks pay a cold build cost that would consume
+    # most of the ordinary Bazel test job's 30-minute budget.
+    timeout-minutes: 45
+    runs-on: ubuntu-24.04
+    name: Bazel end-to-end benchmark smoke
+    environment:
+      name: bazel
+      deployment: false
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Prepare Bazel CI
+        id: prepare_bazel
+        uses: ./.github/actions/prepare-bazel-ci
+        with:
+          target: x86_64-unknown-linux-gnu
+          cache-scope: bazel-e2e-benchmark-smoke
+
+      - name: Bazel end-to-end benchmark smoke test
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          ./.github/scripts/run-bazel-ci.sh -- \
+            test \
+            --compilation_mode=fastbuild \
+            --@rules_rust//rust/settings:extra_rustc_flag=-Cdebug-assertions=no \
+            --@rules_rust//rust/settings:extra_exec_rustc_flag=-Cdebug-assertions=no \
+            --cache_test_results=no \
+            --test_output=streamed \
+            --test_arg=--test \
+            -- \
+            //codex-rs:e2e-benchmarks
+
+      - name: Upload Bazel execution logs
+        if: always() && !cancelled()
+        continue-on-error: true
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: bazel-execution-logs-e2e-benchmark-smoke
+          path: ${{ runner.temp }}/bazel-execution-logs
+          if-no-files-found: ignore
+
       - name: Save bazel repository cache
         if: always() && !cancelled() && steps.prepare_bazel.outputs.repository-cache-hit != 'true'
         continue-on-error: true

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -131,9 +131,6 @@ jobs:
         uses: ./.github/actions/check-clean-worktree
 
   e2e-benchmark-smoke:
-    # Bazel-backed macrobenchmarks pay a cold build cost that would consume
-    # most of the ordinary Bazel test job's 30-minute budget.
-    timeout-minutes: 45
     runs-on: ubuntu-24.04
     name: Bazel end-to-end benchmark smoke
     environment:

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -76,6 +76,12 @@ jobs:
         shell: bash
         run: ./scripts/check-module-bazel-lock.sh
 
+      - name: Bazel end-to-end benchmark smoke test
+        if: matrix.os == 'ubuntu-24.04' && matrix.target == 'x86_64-unknown-linux-gnu'
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: just bench-e2e-smoke
+
       - name: bazel test //...
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}


### PR DESCRIPTION
## Why

The Bazel-backed macrobenchmark path should stay runnable in CI as the suite grows.

## What

- run the explicit CI-only `run-bazel-ci.sh -- test ...` smoke invocation in the existing Linux GNU Bazel job
- keep the smoke run before the broad Bazel test invocation

## Validation

- `just bench-e2e-smoke`

## Stack

1. [#31295 bench: add codex help e2e macrobenchmark](https://github.com/openai/codex/pull/31295)
2. [#31428 bench: add e2e benchmark entrypoints](https://github.com/openai/codex/pull/31428)
3. [#31429 ci: smoke Bazel e2e benchmarks](https://github.com/openai/codex/pull/31429)
