### PR TITLE
build: ratchet direct reqwest dependencies

### DIFF
--- a/codex-rs/deny.toml
+++ b/codex-rs/deny.toml
@@ -233,6 +233,39 @@ deny = [
         "tonic",
         "zbus",
     ], reason = "first-party traits must use native async trait methods with explicit Send bounds" },
+    # Migration ratchet: `codex-http-client` is the intended reqwest owner. Remove each temporary
+    # wrapper when that crate's direct reqwest dependency is migrated to the shared abstraction.
+    { crate = "reqwest", wrappers = [
+        # Intended owner.
+        "codex-http-client",
+        # Temporary migration exceptions.
+        "codex-agent-identity",
+        "codex-api",
+        "codex-app-server",
+        "codex-app-server-daemon",
+        "codex-backend-client",
+        "codex-cloud-tasks",
+        "codex-core",
+        "codex-core-plugins",
+        "codex-exec-server",
+        "codex-lmstudio",
+        "codex-login",
+        "codex-ollama",
+        "codex-otel",
+        "codex-protocol",
+        "codex-responses-api-proxy",
+        "codex-rmcp-client",
+        "codex-tui",
+        "core_test_support",
+        # Third-party crates that own their reqwest integration. These are not part of the
+        # first-party migration count above.
+        "oauth2",
+        "opentelemetry-http",
+        "opentelemetry-otlp",
+        "rmcp",
+        "sentry",
+        "webrtc-sys-build",
+    ], reason = "new direct reqwest dependencies must use codex-http-client; temporary wrappers track migration debt" },
 ]
 
 # List of features to allow/deny


### PR DESCRIPTION
## Why

The `codex-http-client` migration now has a shared implementation and several migrated request paths, but nothing prevents a new crate from adding another direct `reqwest` dependency while the remaining call sites are being converted. The dependency graph should both enforce the direction of travel and make the remaining scope visible.

This PR adds that ratchet on top of #31363. It does not claim the migration is complete: the allowlist deliberately records all 18 first-party crates that still depend on `reqwest` directly.

## What changed

- Ban `reqwest` with cargo-deny unless its immediate parent is an explicitly listed wrapper.
- Identify `codex-http-client` as the intended owner.
- Record the 18 current first-party direct dependents as temporary migration exceptions.
- Separately allow six third-party integrations that own their `reqwest` dependency: `oauth2`, `opentelemetry-http`, `opentelemetry-otlp`, `rmcp`, `sentry`, and `webrtc-sys-build`.
- Cover both `reqwest` 0.12 and 0.13 with the same package-level rule.

## Migration rule

A new first-party crate cannot add `reqwest`. When a listed crate finishes migrating, its direct Cargo dependency and its wrapper entry should be removed in the same PR, so the first-party list can only shrink.

## Review guide

The entire change is the new `reqwest` entry in `codex-rs/deny.toml`:

1. `codex-http-client` is the permanent intended wrapper.
2. The next 18 entries are the first-party migration backlog.
3. The final six entries are separately documented third-party parents required by cargo-deny graph semantics.

## Validation

- `cargo deny check bans --hide-inclusion-graph` (`bans ok`; existing duplicate-version warnings remain warnings)




























---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/31431).
* #31837
* #31828
* #31825
* #31821
* #31637
* __->__ #31431