### PR TITLE
codex-mcp: serialize connector runtime refreshes

### DIFF
--- a/codex-rs/codex-mcp/src/connection_manager.rs
+++ b/codex-rs/codex-mcp/src/connection_manager.rs
@@ -17,6 +17,7 @@ use crate::McpAuthStatusEntry;
 use crate::connector_runtime::CodexAppsToolsCache;
 use crate::connector_runtime::CodexAppsToolsCacheKey;
 use crate::connector_runtime::CodexAppsToolsFetchSource;
+use crate::connector_runtime::ConnectorRuntimeSnapshot;
 use crate::elicitation::ElicitationRequestManager;
 use crate::elicitation::ElicitationRequestRouter;
 use crate::elicitation::ElicitationReviewerHandle;
@@ -24,6 +25,7 @@ use crate::mcp::CODEX_APPS_MCP_SERVER_NAME;
 use crate::mcp::ToolPluginProvenance;
 use crate::rmcp_client::AsyncManagedClient;
 use crate::rmcp_client::CODEX_APPS_REFRESH_DURATION_METRIC;
+use crate::rmcp_client::CodexAppsStartupMode;
 use crate::rmcp_client::DEFAULT_STARTUP_TIMEOUT;
 use crate::rmcp_client::MCP_TOOLS_LIST_DURATION_METRIC;
 use crate::rmcp_client::ManagedClient;
@@ -144,6 +146,7 @@ impl McpConnectionManager {
         elicitation_reviewer: Option<ElicitationReviewerHandle>,
         elicitation_lifecycle: Option<crate::ElicitationLifecycle>,
         elicitation_router: ElicitationRequestRouter,
+        codex_apps_startup_mode: CodexAppsStartupMode,
     ) -> Self {
         let mut required_servers = mcp_servers
             .iter()
@@ -223,6 +226,7 @@ impl McpConnectionManager {
                 runtime_auth_provider,
                 client_elicitation_capability.clone(),
                 supports_openai_form_elicitation,
+                codex_apps_startup_mode,
             );
             clients.insert(server_name.clone(), async_managed_client.clone());
             let tx_event = tx_event.clone();
@@ -528,6 +532,78 @@ impl McpConnectionManager {
         normalize_tools_for_model_with_prefix(tools, self.prefix_mcp_tool_names)
     }
 
+    /// Force-refreshes the connector runtime exactly once under the active
+    /// context's shared lock and returns the exact committed snapshot.
+    pub async fn hard_refresh_codex_apps_runtime(&self) -> Result<Arc<ConnectorRuntimeSnapshot>> {
+        let refresh_start = Instant::now();
+        let async_client = self
+            .clients
+            .get(CODEX_APPS_MCP_SERVER_NAME)
+            .ok_or_else(|| anyhow!("unknown MCP server '{CODEX_APPS_MCP_SERVER_NAME}'"))?;
+        let result = async {
+            let cache_context = async_client
+                .codex_apps_tools_cache_context
+                .as_ref()
+                .ok_or_else(|| anyhow!("connector runtime manager is unavailable"))?;
+            let _refresh_guard = cache_context
+                .lock_explicit_refresh()
+                .await
+                .context("connector runtime context changed before refresh")?;
+            let managed_client = self.client_by_name(CODEX_APPS_MCP_SERVER_NAME).await?;
+            let list_start = Instant::now();
+            let fetch_ticket = cache_context.begin_fetch(CodexAppsToolsFetchSource::HardRefresh);
+            let tools = list_tools_for_client_uncached(
+                CODEX_APPS_MCP_SERVER_NAME,
+                /*is_codex_apps_mcp_server*/ true,
+                /*codex_apps_refresh_trigger*/ "explicit",
+                &managed_client.client,
+                managed_client.tool_timeout,
+                managed_client.server_instructions.as_deref(),
+            )
+            .await
+            .with_context(|| {
+                format!("failed to refresh tools for MCP server '{CODEX_APPS_MCP_SERVER_NAME}'")
+            })?;
+            let snapshot = cache_context
+                .publish_runtime_if_newest_accepted(
+                    fetch_ticket,
+                    &managed_client.server_info,
+                    tools,
+                )
+                .context("connector runtime context changed while publishing refresh")?;
+            emit_duration(
+                MCP_TOOLS_LIST_DURATION_METRIC,
+                list_start.elapsed(),
+                &[("cache", "miss")],
+            );
+            Ok(snapshot)
+        }
+        .await;
+        let outcome = if result.is_ok() { "success" } else { "error" };
+        let retained_previous = if result.is_err()
+            && async_client
+                .codex_apps_tools_cache_context
+                .as_ref()
+                .and_then(super::connector_runtime::ConnectorRuntimeContext::current_snapshot)
+                .is_some()
+        {
+            "true"
+        } else {
+            "false"
+        };
+        emit_duration(
+            CODEX_APPS_REFRESH_DURATION_METRIC,
+            refresh_start.elapsed(),
+            &[
+                ("path", "new"),
+                ("trigger", "explicit"),
+                ("outcome", outcome),
+                ("retained_previous_snapshot", retained_previous),
+            ],
+        );
+        result
+    }
+
     /// Force-refresh codex apps tools by bypassing the in-process cache.
     ///
     /// On success, the refreshed tools replace shared cache contents when the
@@ -535,6 +611,19 @@ impl McpConnectionManager {
     /// the caller. On failure, existing shared cache contents remain unchanged.
     pub async fn hard_refresh_codex_apps_tools_cache(&self) -> Result<Vec<ToolInfo>> {
         let refresh_start = Instant::now();
+        let async_client = self
+            .clients
+            .get(CODEX_APPS_MCP_SERVER_NAME)
+            .ok_or_else(|| anyhow!("unknown MCP server '{CODEX_APPS_MCP_SERVER_NAME}'"))?;
+        let _refresh_guard = match async_client.codex_apps_tools_cache_context.as_ref() {
+            Some(cache_context) => Some(
+                cache_context
+                    .lock_explicit_refresh()
+                    .await
+                    .context("connector runtime context changed before refresh")?,
+            ),
+            None => None,
+        };
         let managed_client = self.client_by_name(CODEX_APPS_MCP_SERVER_NAME).await?;
 
         let list_start = Instant::now();
@@ -555,16 +644,21 @@ impl McpConnectionManager {
             format!("failed to refresh tools for MCP server '{CODEX_APPS_MCP_SERVER_NAME}'")
         })?;
 
-        let tools =
-            match (
-                managed_client.codex_apps_tools_cache_context.as_ref(),
-                fetch_ticket,
-            ) {
-                (Some(cache_context), Some(fetch_ticket)) => cache_context
-                    .publish_if_newest_accepted(fetch_ticket, &managed_client.server_info, tools)?,
-                (None, None) => tools,
-                _ => unreachable!("Codex Apps fetch ticket requires cache context"),
-            };
+        let tools = match (
+            managed_client.codex_apps_tools_cache_context.as_ref(),
+            fetch_ticket,
+        ) {
+            (Some(cache_context), Some(fetch_ticket)) => cache_context
+                .publish_runtime_if_newest_accepted(
+                    fetch_ticket,
+                    &managed_client.server_info,
+                    tools,
+                )
+                .map(|snapshot| snapshot.tools().to_vec())
+                .context("connector runtime context changed while publishing refresh")?,
+            (None, None) => tools,
+            _ => unreachable!("Codex Apps fetch ticket requires cache context"),
+        };
         emit_duration(
             MCP_TOOLS_LIST_DURATION_METRIC,
             list_start.elapsed(),

--- a/codex-rs/codex-mcp/src/connection_manager_tests.rs
+++ b/codex-rs/codex-mcp/src/connection_manager_tests.rs
@@ -8,6 +8,7 @@ use crate::elicitation::ElicitationRequestRouter;
 use crate::elicitation::elicitation_is_rejected_by_policy;
 use crate::rmcp_client::AsyncManagedClient;
 use crate::rmcp_client::CODEX_APPS_RECONNECT_INITIAL_BACKOFF;
+use crate::rmcp_client::CodexAppsStartupMode;
 use crate::rmcp_client::CodexAppsStartupReconnect;
 use crate::rmcp_client::ManagedClient;
 use crate::rmcp_client::ManagedClientFuture;
@@ -1911,6 +1912,7 @@ async fn no_local_runtime_fails_local_stdio_but_keeps_local_http_server() {
         /*elicitation_reviewer*/ None,
         /*elicitation_lifecycle*/ None,
         ElicitationRequestRouter::default(),
+        CodexAppsStartupMode::ListTools,
     )
     .await;
 

--- a/codex-rs/codex-mcp/src/connector_runtime.rs
+++ b/codex-rs/codex-mcp/src/connector_runtime.rs
@@ -19,6 +19,7 @@ use codex_login::CodexAuth;
 use codex_protocol::mcp::McpServerInfo;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::sync::OwnedMutexGuard;
 
 use crate::connector_runtime_persistence::load_cached_codex_apps_server_info;
 use crate::connector_runtime_persistence::load_cached_connector_runtime_for_identity;
@@ -200,6 +201,21 @@ impl ConnectorRuntimeContext {
         }
     }
 
+    pub(crate) async fn lock_explicit_refresh(
+        &self,
+    ) -> Result<OwnedMutexGuard<()>, ConnectorRuntimeContextDiscarded> {
+        if !self.is_active() {
+            return Err(ConnectorRuntimeContextDiscarded);
+        }
+        let guard = Arc::clone(&self.entry.explicit_refresh_lock)
+            .lock_owned()
+            .await;
+        if !self.is_active() {
+            return Err(ConnectorRuntimeContextDiscarded);
+        }
+        Ok(guard)
+    }
+
     pub(crate) fn publish_runtime_if_newest_accepted(
         &self,
         ticket: CodexAppsToolsFetchTicket,
@@ -269,6 +285,7 @@ impl ConnectorRuntimeContext {
         Ok(snapshot)
     }
 
+    #[cfg(test)]
     pub(crate) fn publish_if_newest_accepted(
         &self,
         ticket: CodexAppsToolsFetchTicket,
@@ -331,6 +348,7 @@ pub(crate) struct ConnectorRuntimeEntry {
     pub(crate) current_snapshot: ArcSwapOption<ConnectorRuntimeSnapshot>,
     next_fetch_generation: AtomicU64,
     last_accepted_generation: Mutex<u64>,
+    explicit_refresh_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl ConnectorRuntimeEntry {
@@ -341,6 +359,7 @@ impl ConnectorRuntimeEntry {
             current_snapshot: ArcSwapOption::from(current_snapshot),
             next_fetch_generation: AtomicU64::new(0),
             last_accepted_generation: Mutex::new(0),
+            explicit_refresh_lock: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 }

--- a/codex-rs/codex-mcp/src/connector_runtime_tests.rs
+++ b/codex-rs/codex-mcp/src/connector_runtime_tests.rs
@@ -16,6 +16,7 @@ use std::collections::HashSet;
 use std::os::unix::ffi::OsStringExt;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 use tempfile::tempdir;
 
 fn create_test_tool(server_name: &str, tool_name: &str) -> ToolInfo {
@@ -750,4 +751,66 @@ fn live_publish_sets_timestamp_and_stale_publish_preserves_it() {
         .expect("stale publish returns current snapshot");
     assert!(Arc::ptr_eq(&current, &stale));
     assert_eq!(stale.refreshed_at(), current.refreshed_at());
+}
+
+#[tokio::test]
+async fn explicit_refresh_lock_serializes_concurrent_refreshes() {
+    let codex_home = tempdir().expect("tempdir");
+    let context = create_codex_apps_tools_cache_context(
+        codex_home.path().to_path_buf(),
+        Some("account-one"),
+        Some("user-one"),
+    );
+    let first_guard = context
+        .lock_explicit_refresh()
+        .await
+        .expect("acquire first refresh lock");
+    let second_context = context.clone();
+    let (attempting_tx, attempting_rx) = tokio::sync::oneshot::channel();
+    let (acquired_tx, mut acquired_rx) = tokio::sync::oneshot::channel();
+    let second_refresh = tokio::spawn(async move {
+        attempting_tx.send(()).expect("signal lock attempt");
+        let _guard = second_context
+            .lock_explicit_refresh()
+            .await
+            .expect("acquire second refresh lock");
+        acquired_tx.send(()).expect("signal lock acquisition");
+    });
+    attempting_rx.await.expect("second refresh attempted lock");
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(20), &mut acquired_rx)
+            .await
+            .is_err()
+    );
+    drop(first_guard);
+    tokio::time::timeout(Duration::from_secs(1), acquired_rx)
+        .await
+        .expect("second refresh should acquire after first releases")
+        .expect("second refresh acquisition signal");
+    second_refresh.await.expect("second refresh task");
+}
+
+#[tokio::test]
+async fn discarded_context_cannot_acquire_explicit_refresh_lock() {
+    let codex_home = tempdir().expect("tempdir");
+    let manager = ConnectorRuntimeManager::default();
+    let context_a = manager.context(
+        codex_home.path().to_path_buf(),
+        ConnectorRuntimeContextKey {
+            account_id: Some("account-a".to_string()),
+            chatgpt_user_id: Some("user-a".to_string()),
+            is_workspace_account: false,
+        },
+    );
+    let _context_b = manager.context(
+        codex_home.path().to_path_buf(),
+        ConnectorRuntimeContextKey {
+            account_id: Some("account-b".to_string()),
+            chatgpt_user_id: Some("user-b".to_string()),
+            is_workspace_account: false,
+        },
+    );
+
+    assert!(context_a.lock_explicit_refresh().await.is_err());
 }

--- a/codex-rs/codex-mcp/src/lib.rs
+++ b/codex-rs/codex-mcp/src/lib.rs
@@ -9,6 +9,7 @@ pub use resource_client::McpResourceClient;
 pub use resource_client::McpResourceClientCacheKey;
 pub use resource_client::McpResourcePage;
 pub use resource_client::McpResourceReadResult;
+pub use rmcp_client::CodexAppsStartupMode;
 pub use rmcp_client::MCP_SANDBOX_STATE_META_CAPABILITY;
 pub use runtime::McpRuntimeContext;
 pub use runtime::SandboxState;

--- a/codex-rs/codex-mcp/src/mcp/mod.rs
+++ b/codex-rs/codex-mcp/src/mcp/mod.rs
@@ -47,6 +47,7 @@ use crate::ResolvedMcpCatalog;
 use crate::connection_manager::McpConnectionManager;
 use crate::connector_runtime::CodexAppsToolsCache;
 use crate::connector_runtime::codex_apps_tools_cache_key;
+use crate::rmcp_client::CodexAppsStartupMode;
 use crate::runtime::McpRuntimeContext;
 use crate::server::EffectiveMcpServer;
 
@@ -341,6 +342,7 @@ pub async fn read_mcp_resource(
         /*elicitation_reviewer*/ None,
         /*elicitation_lifecycle*/ None,
         crate::elicitation::ElicitationRequestRouter::default(),
+        CodexAppsStartupMode::ListTools,
     )
     .await;
 
@@ -419,6 +421,7 @@ pub async fn collect_mcp_server_status_snapshot_with_detail(
         /*elicitation_reviewer*/ None,
         /*elicitation_lifecycle*/ None,
         crate::elicitation::ElicitationRequestRouter::default(),
+        CodexAppsStartupMode::ListTools,
     )
     .await;
 

--- a/codex-rs/codex-mcp/src/rmcp_client.rs
+++ b/codex-rs/codex-mcp/src/rmcp_client.rs
@@ -264,6 +264,16 @@ fn codex_apps_reconnect_backoff(consecutive_failures: u32) -> Duration {
         .min(CODEX_APPS_RECONNECT_MAX_BACKOFF)
 }
 
+/// Controls whether the host-owned Apps client lists tools during startup.
+///
+/// Explicit connector-runtime refreshes initialize the client first, then run
+/// their one serialized `tools/list` through the runtime manager.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodexAppsStartupMode {
+    ListTools,
+    InitializeOnly,
+}
+
 #[derive(Clone)]
 struct ManagedClientStartup {
     server_name: String,
@@ -277,6 +287,7 @@ struct ManagedClientStartup {
     runtime_auth_provider: Option<SharedAuthProvider>,
     client_elicitation_capability: ElicitationCapability,
     supports_openai_form_elicitation: bool,
+    codex_apps_startup_mode: CodexAppsStartupMode,
     cancel_token: CancellationToken,
     startup_complete: Arc<AtomicBool>,
 }
@@ -295,6 +306,7 @@ impl ManagedClientStartup {
             runtime_auth_provider,
             client_elicitation_capability,
             supports_openai_form_elicitation,
+            codex_apps_startup_mode,
             cancel_token,
             startup_complete,
         } = self.clone();
@@ -305,7 +317,9 @@ impl ManagedClientStartup {
             .unwrap_or_default();
         let cancel_token_for_fut = cancel_token;
         async move {
-            let refresh_start = is_codex_apps_mcp_server.then(Instant::now);
+            let refresh_start = (is_codex_apps_mcp_server
+                && codex_apps_startup_mode == CodexAppsStartupMode::ListTools)
+                .then(Instant::now);
             let outcome = match async {
                 if let Err(error) = validate_mcp_server_name(&server_name) {
                     return Err(error.into());
@@ -341,6 +355,7 @@ impl ManagedClientStartup {
                         codex_apps_tools_cache_context,
                         client_elicitation_capability,
                         supports_openai_form_elicitation,
+                        codex_apps_startup_mode,
                     },
                 )
                 .await
@@ -403,6 +418,7 @@ impl AsyncManagedClient {
         runtime_auth_provider: Option<SharedAuthProvider>,
         client_elicitation_capability: ElicitationCapability,
         supports_openai_form_elicitation: bool,
+        codex_apps_startup_mode: CodexAppsStartupMode,
     ) -> Self {
         let is_codex_apps_mcp_server = server_name == CODEX_APPS_MCP_SERVER_NAME;
         let reconnect_server_name = server_name.clone();
@@ -431,6 +447,7 @@ impl AsyncManagedClient {
             runtime_auth_provider,
             client_elicitation_capability,
             supports_openai_form_elicitation,
+            codex_apps_startup_mode,
             cancel_token: cancel_token.clone(),
             startup_complete: Arc::clone(&startup_complete),
         });
@@ -600,26 +617,33 @@ pub(crate) async fn list_tools_for_client_uncached(
     server_instructions: Option<&str>,
 ) -> Result<Vec<ToolInfo>> {
     let fetch_start = Instant::now();
-    let resp = client
-        .list_tools_with_connector_ids(/*params*/ None, timeout)
-        .await?;
-    let tools = resp
-        .tools
-        .into_iter()
-        .map(|tool| {
-            tool_info_from_listed_tool(
-                server_name,
-                is_codex_apps_mcp_server,
-                server_instructions,
-                tool,
-            )
-        })
-        .collect();
+    let result = async {
+        let resp = client
+            .list_tools_with_connector_ids(/*params*/ None, timeout)
+            .await?;
+        Ok(resp
+            .tools
+            .into_iter()
+            .map(|tool| {
+                tool_info_from_listed_tool(
+                    server_name,
+                    is_codex_apps_mcp_server,
+                    server_instructions,
+                    tool,
+                )
+            })
+            .collect())
+    }
+    .await;
     if is_codex_apps_mcp_server {
+        let outcome = if result.is_ok() { "success" } else { "error" };
         emit_duration(
             MCP_TOOLS_FETCH_UNCACHED_DURATION_METRIC,
             fetch_start.elapsed(),
-            &[("trigger", codex_apps_refresh_trigger)],
+            &[
+                ("trigger", codex_apps_refresh_trigger),
+                ("outcome", outcome),
+            ],
         );
     } else {
         emit_duration(
@@ -628,7 +652,7 @@ pub(crate) async fn list_tools_for_client_uncached(
             &[],
         );
     }
-    Ok(tools)
+    result
 }
 
 /// Presents declared Codex Apps file parameters to the model as local-path inputs and adds plugin
@@ -845,6 +869,7 @@ async fn start_server_task(
         codex_apps_tools_cache_context,
         client_elicitation_capability,
         supports_openai_form_elicitation,
+        codex_apps_startup_mode,
     } = params;
     let params = mcp_initialize_request_params(
         client_elicitation_capability,
@@ -864,35 +889,44 @@ async fn start_server_task(
         .as_ref()
         .and_then(|exp| exp.get(MCP_SANDBOX_STATE_META_CAPABILITY))
         .is_some();
-    let list_start = Instant::now();
-    let fetch_ticket = codex_apps_tools_cache_context
-        .as_ref()
-        .map(|cache_context| cache_context.begin_fetch(CodexAppsToolsFetchSource::Startup));
-    let tools = list_tools_for_client_uncached(
-        &server_name,
-        is_codex_apps_mcp_server,
-        /*codex_apps_refresh_trigger*/ "initial",
-        &client,
-        startup_timeout,
-        initialize_result.instructions.as_deref(),
-    )
-    .await
-    .map_err(StartupOutcomeError::from)?;
     let server_info = mcp_server_info_from_implementation(initialize_result.server_info);
-    let tools = match (codex_apps_tools_cache_context.as_ref(), fetch_ticket) {
-        (Some(cache_context), Some(fetch_ticket)) => cache_context
-            .publish_if_newest_accepted(fetch_ticket, &server_info, tools)
-            .map_err(|error| StartupOutcomeError::from(anyhow!(error)))?,
-        (None, None) => tools,
-        _ => unreachable!("Codex Apps fetch ticket requires cache context"),
+    let tools = if is_codex_apps_mcp_server
+        && codex_apps_startup_mode == CodexAppsStartupMode::InitializeOnly
+    {
+        Vec::new()
+    } else {
+        let list_start = Instant::now();
+        let fetch_ticket = codex_apps_tools_cache_context
+            .as_ref()
+            .map(|cache_context| cache_context.begin_fetch(CodexAppsToolsFetchSource::Startup));
+        let tools = list_tools_for_client_uncached(
+            &server_name,
+            is_codex_apps_mcp_server,
+            /*codex_apps_refresh_trigger*/ "initial",
+            &client,
+            startup_timeout,
+            initialize_result.instructions.as_deref(),
+        )
+        .await
+        .map_err(StartupOutcomeError::from)?;
+        let tools = match (codex_apps_tools_cache_context.as_ref(), fetch_ticket) {
+            (Some(cache_context), Some(fetch_ticket)) => cache_context
+                .publish_runtime_if_newest_accepted(fetch_ticket, &server_info, tools)
+                .map(|snapshot| snapshot.tools().to_vec())
+                .map_err(anyhow::Error::from)
+                .map_err(StartupOutcomeError::from)?,
+            (None, None) => tools,
+            _ => unreachable!("Codex Apps fetch ticket requires cache context"),
+        };
+        if is_codex_apps_mcp_server {
+            emit_duration(
+                MCP_TOOLS_LIST_DURATION_METRIC,
+                list_start.elapsed(),
+                &[("cache", "miss")],
+            );
+        }
+        tools
     };
-    if is_codex_apps_mcp_server {
-        emit_duration(
-            MCP_TOOLS_LIST_DURATION_METRIC,
-            list_start.elapsed(),
-            &[("cache", "miss")],
-        );
-    }
     let tools = filter_tools(tools, &tool_filter);
 
     let managed = ManagedClient {
@@ -954,6 +988,7 @@ struct StartServerTaskParams {
     codex_apps_tools_cache_context: Option<CodexAppsToolsCacheContext>,
     client_elicitation_capability: ElicitationCapability,
     supports_openai_form_elicitation: bool,
+    codex_apps_startup_mode: CodexAppsStartupMode,
 }
 
 #[instrument(level = "trace", skip_all, fields(server_name = %server_name))]

--- a/codex-rs/core/src/connectors.rs
+++ b/codex-rs/core/src/connectors.rs
@@ -32,6 +32,8 @@ use codex_features::Feature;
 use codex_login::AuthManager;
 use codex_login::CodexAuth;
 use codex_mcp::CODEX_APPS_MCP_SERVER_NAME;
+use codex_mcp::CodexAppsStartupMode;
+use codex_mcp::ConnectorRuntimeSnapshot;
 use codex_mcp::MCP_TOOL_CODEX_APPS_META_KEY;
 use codex_mcp::McpConnectionManager;
 use codex_mcp::McpRuntimeContext;
@@ -39,6 +41,7 @@ use codex_mcp::ToolInfo;
 use codex_mcp::ToolPluginProvenance;
 use codex_mcp::codex_apps_tools_cache_key;
 use codex_mcp::compute_auth_statuses;
+use codex_mcp::connector_runtime_context_key;
 use codex_mcp::effective_mcp_servers;
 use codex_mcp::tool_plugin_provenance;
 
@@ -272,6 +275,7 @@ pub async fn list_accessible_connectors_from_mcp_tools_with_mcp_manager(
         /*elicitation_reviewer*/ None,
         /*elicitation_lifecycle*/ None,
         codex_mcp::ElicitationRequestRouter::default(),
+        codex_mcp::CodexAppsStartupMode::ListTools,
     )
     .await;
 
@@ -341,6 +345,81 @@ pub async fn list_accessible_connectors_from_mcp_tools_with_mcp_manager(
         connectors: accessible_connectors,
         codex_apps_ready,
     })
+}
+
+/// Returns the committed runtime snapshot for the active account/workspace without refreshing it.
+pub fn connector_runtime_snapshot(
+    config: &Config,
+    auth: Option<&CodexAuth>,
+    mcp_manager: &McpManager,
+) -> Option<Arc<ConnectorRuntimeSnapshot>> {
+    mcp_manager.connector_runtime_manager().current_snapshot(
+        config.codex_home.to_path_buf(),
+        connector_runtime_context_key(auth),
+    )
+}
+
+/// Performs one strict, uncached hosted-connector refresh and returns the exact committed snapshot.
+///
+/// The temporary connection manager contains only the host-owned Codex Apps server and skips its
+/// normal startup `tools/list`, leaving `hard_refresh_codex_apps_runtime` as the single network
+/// listing. Snapshot serialization and publication remain owned by `ConnectorRuntimeManager`.
+pub async fn refresh_connector_runtime_snapshot(
+    config: &Config,
+    auth: Option<&CodexAuth>,
+    environment_manager: Arc<EnvironmentManager>,
+    mcp_manager: &McpManager,
+) -> anyhow::Result<Arc<ConnectorRuntimeSnapshot>> {
+    let mcp_config = mcp_manager.runtime_config(config).await;
+    let tool_plugin_provenance = tool_plugin_provenance(&mcp_config);
+    let mut mcp_servers = effective_mcp_servers(&mcp_config, auth);
+    mcp_servers.retain(|name, _| name == CODEX_APPS_MCP_SERVER_NAME);
+    anyhow::ensure!(
+        !mcp_servers.is_empty(),
+        "host-owned MCP server '{CODEX_APPS_MCP_SERVER_NAME}' is not enabled"
+    );
+
+    let runtime_context = McpRuntimeContext::new(environment_manager, config.cwd.to_path_buf());
+    let auth_status_entries = compute_auth_statuses(
+        mcp_servers.iter(),
+        mcp_config.mcp_oauth_credentials_store_mode,
+        mcp_config.auth_keyring_backend_kind,
+        auth,
+        &runtime_context,
+    )
+    .await;
+    let (tx_event, rx_event) = unbounded();
+    drop(rx_event);
+    let cancellation_token = CancellationToken::new();
+    let connection_manager = McpConnectionManager::new(
+        &mcp_servers,
+        mcp_config.mcp_oauth_credentials_store_mode,
+        mcp_config.auth_keyring_backend_kind,
+        auth_status_entries,
+        &config.permissions.approval_policy,
+        INITIAL_SUBMIT_ID.to_owned(),
+        tx_event,
+        cancellation_token.clone(),
+        config.permissions.permission_profile().clone(),
+        runtime_context,
+        mcp_config.codex_home.clone(),
+        mcp_manager.codex_apps_tools_cache(),
+        connector_runtime_context_key(auth),
+        mcp_config.prefix_mcp_tool_names,
+        mcp_config.client_elicitation_capability,
+        /*supports_openai_form_elicitation*/ false,
+        tool_plugin_provenance,
+        auth,
+        /*elicitation_reviewer*/ None,
+        /*elicitation_lifecycle*/ None,
+        codex_mcp::ElicitationRequestRouter::default(),
+        CodexAppsStartupMode::InitializeOnly,
+    )
+    .await;
+    let snapshot = connection_manager.hard_refresh_codex_apps_runtime().await;
+    cancellation_token.cancel();
+    connection_manager.shutdown().await;
+    snapshot
 }
 
 fn accessible_connectors_cache_key(

--- a/codex-rs/core/src/mcp.rs
+++ b/codex-rs/core/src/mcp.rs
@@ -14,6 +14,7 @@ use codex_extension_api::McpServerContributionContext;
 use codex_login::CodexAuth;
 use codex_mcp::CODEX_APPS_MCP_SERVER_NAME;
 use codex_mcp::CodexAppsToolsCache;
+use codex_mcp::ConnectorRuntimeManager;
 use codex_mcp::EffectiveMcpServer;
 use codex_mcp::McpConfig;
 use codex_mcp::McpPluginAttribution;
@@ -49,7 +50,7 @@ enum OrderedMcpOverlay {
 pub struct McpManager {
     plugins_manager: Arc<PluginsManager>,
     extensions: Arc<ExtensionRegistry<Config>>,
-    codex_apps_tools_cache: CodexAppsToolsCache,
+    connector_runtime_manager: ConnectorRuntimeManager,
 }
 
 impl McpManager {
@@ -68,12 +69,20 @@ impl McpManager {
         Self {
             plugins_manager,
             extensions,
-            codex_apps_tools_cache: CodexAppsToolsCache::default(),
+            connector_runtime_manager: ConnectorRuntimeManager::default(),
         }
     }
 
+    pub fn connector_runtime_manager(&self) -> ConnectorRuntimeManager {
+        self.connector_runtime_manager.clone()
+    }
+
+    /// Returns the legacy name for the connector-owned runtime manager.
+    ///
+    /// `CodexAppsToolsCache` remains an alias during migration so old MCP construction paths keep
+    /// sharing the same account/workspace-scoped runtime state.
     pub fn codex_apps_tools_cache(&self) -> CodexAppsToolsCache {
-        self.codex_apps_tools_cache.clone()
+        self.connector_runtime_manager.clone()
     }
 
     /// Returns the MCP config after applying compatibility built-ins and

--- a/codex-rs/core/src/mcp_tool_call_tests.rs
+++ b/codex-rs/core/src/mcp_tool_call_tests.rs
@@ -1465,6 +1465,7 @@ async fn host_owned_codex_apps_manager(
         /*elicitation_reviewer*/ None,
         /*elicitation_lifecycle*/ None,
         codex_mcp::ElicitationRequestRouter::default(),
+        codex_mcp::CodexAppsStartupMode::ListTools,
     )
     .await;
     Arc::new(manager)

--- a/codex-rs/core/src/session/mcp.rs
+++ b/codex-rs/core/src/session/mcp.rs
@@ -385,6 +385,7 @@ impl Session {
             elicitation_reviewer,
             Some(self.mcp_elicitation_lifecycle()),
             current_runtime.manager().elicitation_router(),
+            codex_mcp::CodexAppsStartupMode::ListTools,
         )
         .await;
         refreshed_manager

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -1221,6 +1221,7 @@ impl Session {
                 Some(sess.mcp_elicitation_reviewer()),
                 Some(sess.mcp_elicitation_lifecycle()),
                 codex_mcp::ElicitationRequestRouter::default(),
+                codex_mcp::CodexAppsStartupMode::ListTools,
             )
             .instrument(info_span!(
                 "session_init.mcp_manager_init",


### PR DESCRIPTION
## What

- Add one async explicit-refresh lock per active connector runtime context.
- Add `McpConnectionManager::hard_refresh_codex_apps_runtime`, which performs exactly one uncached Apps `tools/list` under that shared lock and returns the exact committed `Arc<ConnectorRuntimeSnapshot>`.
- Start the host-owned Apps MCP client in initialize-only mode for the new strict path so startup cannot issue a second competing list request.
- Keep legacy `hard_refresh_codex_apps_tools` / `app/list` behavior intact while routing its refresh through the same lock.
- Retain the previously committed snapshot when fetch or publication fails.
- Record the uncached list outcome/trigger and expose the committed snapshot to core for later consumers.

## Why

This is stack PR 2 of 4, based on #31471. It creates the single refresh seam needed by request-stable runtime consumption and `app/installed` without changing app-server APIs yet.

## Invariants

- Concurrent explicit reloads serialize per account/workspace context.
- A strict reload performs one network `tools/list`, then atomically publishes and returns that same committed state.
- Generic tool filtering, exposure, approval, elicitation, and execution remain owned by `McpConnectionManager`.
- The legacy `app/list` compatibility path remains available and retains its existing response behavior.

## Checks

- `just test -p codex-mcp` (114 passed)
- `just fmt`

The broader `codex-core` suite was also compiled and exercised while developing this slice; its connector/MCP tests passed, with only the checkout's known sandbox/CLI-fixture failures in the full crate run.
