### PR TITLE
Add turn-start MCP and connector availability analytics

### DIFF
--- a/codex-rs/analytics/src/analytics_client_tests.rs
+++ b/codex-rs/analytics/src/analytics_client_tests.rs
@@ -78,6 +78,9 @@ use crate::facts::TurnCodexErrorFact;
 use crate::facts::TurnProfile;
 use crate::facts::TurnProfileFact;
 use crate::facts::TurnResolvedConfigFact;
+use crate::facts::TurnStartAvailability;
+use crate::facts::TurnStartAvailabilityFact;
+use crate::facts::TurnStartConnectorIdentity;
 use crate::facts::TurnStatus;
 use crate::facts::TurnSteerRequestError;
 use crate::facts::TurnTokenUsageFact;
@@ -425,6 +428,119 @@ fn sample_turn_resolved_config(thread_id: &str, turn_id: &str) -> TurnResolvedCo
         workspace_kind: None,
         is_first_turn: true,
     }
+}
+
+fn sample_turn_start_availability() -> TurnStartAvailability {
+    TurnStartAvailability::new(
+        ["zeta_mcp", "alpha_mcp", "alpha_mcp"].map(str::to_string),
+        [
+            ("drive".to_string(), "Google Drive".to_string()),
+            ("calendar".to_string(), "Google Calendar".to_string()),
+        ],
+    )
+}
+
+fn sample_turn_start_availability_fact(turn_id: &str) -> AnalyticsFact {
+    AnalyticsFact::Custom(CustomAnalyticsFact::TurnStartAvailability(Box::new(
+        TurnStartAvailabilityFact {
+            turn_id: turn_id.to_string(),
+            availability: sample_turn_start_availability(),
+        },
+    )))
+}
+
+#[test]
+fn turn_start_availability_is_deterministic_and_bounded() {
+    let item_count = crate::facts::TURN_START_AVAILABILITY_MAX_ITEMS + 2;
+    let mut mcp_server_names = (0..item_count)
+        .rev()
+        .map(|index| format!("server_{index:03}"))
+        .collect::<Vec<_>>();
+    mcp_server_names.push("server_001".to_string());
+    let mut connectors = (0..item_count)
+        .rev()
+        .map(|index| {
+            (
+                format!("connector_{index:03}"),
+                format!("Connector {index:03}"),
+            )
+        })
+        .collect::<Vec<_>>();
+    connectors.push(("connector_001".to_string(), "Alpha".to_string()));
+
+    let availability = TurnStartAvailability::new(mcp_server_names, connectors);
+
+    assert_eq!(
+        availability.available_mcp_server_names.len(),
+        crate::facts::TURN_START_AVAILABILITY_MAX_ITEMS
+    );
+    assert_eq!(
+        availability
+            .available_mcp_server_names
+            .first()
+            .map(String::as_str),
+        Some("server_000")
+    );
+    assert_eq!(
+        availability
+            .available_mcp_server_names
+            .last()
+            .map(String::as_str),
+        Some("server_099")
+    );
+    assert!(availability.available_mcp_server_names_truncated);
+    assert_eq!(
+        availability.available_connectors.len(),
+        crate::facts::TURN_START_AVAILABILITY_MAX_ITEMS
+    );
+    assert_eq!(availability.available_connectors[1].connector_name, "Alpha");
+    assert_eq!(
+        availability
+            .available_connectors
+            .last()
+            .map(|connector| connector.connector_id.as_str()),
+        Some("connector_099")
+    );
+    assert!(availability.available_connectors_truncated);
+}
+
+#[test]
+fn turn_start_availability_drops_whole_identities_to_enforce_byte_budget() {
+    let oversized =
+        "x".repeat(crate::facts::TURN_START_AVAILABILITY_MAX_SERIALIZED_BYTES_PER_FIELD);
+    let availability = TurnStartAvailability::new(
+        [oversized.clone(), "small_server".to_string()],
+        [
+            (oversized, "Oversized".to_string()),
+            ("small_connector".to_string(), "Small Connector".to_string()),
+        ],
+    );
+
+    assert_eq!(
+        availability.available_mcp_server_names,
+        ["small_server".to_string()]
+    );
+    assert!(availability.available_mcp_server_names_truncated);
+    assert_eq!(
+        availability.available_connectors,
+        [TurnStartConnectorIdentity {
+            connector_id: "small_connector".to_string(),
+            connector_name: "Small Connector".to_string(),
+        }]
+    );
+    assert!(availability.available_connectors_truncated);
+    assert!(
+        serde_json::to_vec(&availability.available_mcp_server_names)
+            .expect("MCP server names should serialize")
+            .len()
+            <= crate::facts::TURN_START_AVAILABILITY_MAX_SERIALIZED_BYTES_PER_FIELD
+    );
+    assert!(
+        serde_json::to_vec(&availability.available_connectors)
+            .expect("connectors should serialize")
+            .len()
+            <= crate::facts::TURN_START_AVAILABILITY_MAX_SERIALIZED_BYTES_PER_FIELD
+    );
 }
 
 fn sample_turn_profile() -> TurnProfile {
@@ -3869,6 +3985,12 @@ async fn reducer_ingests_external_agent_config_import_failure_fact() {
 
 #[test]
 fn turn_event_serializes_expected_shape() {
+    let TurnStartAvailability {
+        available_mcp_server_names,
+        available_mcp_server_names_truncated,
+        available_connectors,
+        available_connectors_truncated,
+    } = sample_turn_start_availability();
     let event = TrackEventRequest::TurnEvent(Box::new(CodexTurnEventRequest {
         event_type: "codex_turn_event",
         event_params: crate::events::CodexTurnEventParams {
@@ -3897,6 +4019,10 @@ fn turn_event_serializes_expected_shape() {
             workspace_kind: Some("projectless".to_string()),
             num_input_images: 2,
             is_first_turn: true,
+            turn_start_available_mcp_server_names: available_mcp_server_names,
+            turn_start_available_mcp_server_names_truncated: available_mcp_server_names_truncated,
+            turn_start_available_connectors: available_connectors,
+            turn_start_available_connectors_truncated: available_connectors_truncated,
             status: Some(TurnStatus::Completed),
             turn_error: None,
             codex_error_kind: None,
@@ -3969,6 +4095,19 @@ fn turn_event_serializes_expected_shape() {
                 "workspace_kind": "projectless",
                 "num_input_images": 2,
                 "is_first_turn": true,
+                "turn_start_available_mcp_server_names": ["alpha_mcp", "zeta_mcp"],
+                "turn_start_available_mcp_server_names_truncated": false,
+                "turn_start_available_connectors": [
+                    {
+                        "connector_id": "calendar",
+                        "connector_name": "Google Calendar"
+                    },
+                    {
+                        "connector_id": "drive",
+                        "connector_name": "Google Drive"
+                    }
+                ],
+                "turn_start_available_connectors_truncated": false,
                 "status": "completed",
                 "turn_error": null,
                 "codex_error_kind": null,
@@ -4254,6 +4393,9 @@ async fn turn_lifecycle_emits_turn_event() {
     )
     .await;
     reducer
+        .ingest(sample_turn_start_availability_fact("turn-2"), &mut out)
+        .await;
+    reducer
         .ingest(
             AnalyticsFact::Notification(Box::new(sample_turn_completed_notification(
                 "thread-2",
@@ -4297,6 +4439,31 @@ async fn turn_lifecycle_emits_turn_event() {
     assert_eq!(payload["event_params"]["ephemeral"], json!(false));
     assert_eq!(payload["event_params"]["workspace_kind"], json!(null));
     assert_eq!(payload["event_params"]["num_input_images"], json!(1));
+    assert_eq!(
+        payload["event_params"]["turn_start_available_mcp_server_names"],
+        json!(["alpha_mcp", "zeta_mcp"])
+    );
+    assert_eq!(
+        payload["event_params"]["turn_start_available_mcp_server_names_truncated"],
+        json!(false)
+    );
+    assert_eq!(
+        payload["event_params"]["turn_start_available_connectors"],
+        json!([
+            {
+                "connector_id": "calendar",
+                "connector_name": "Google Calendar",
+            },
+            {
+                "connector_id": "drive",
+                "connector_name": "Google Drive",
+            },
+        ])
+    );
+    assert_eq!(
+        payload["event_params"]["turn_start_available_connectors_truncated"],
+        json!(false)
+    );
     assert_eq!(payload["event_params"]["status"], json!("completed"));
     assert_eq!(payload["event_params"]["steer_count"], json!(0));
     assert_eq!(payload["event_params"]["total_tool_call_count"], json!(0));

--- a/codex-rs/analytics/src/client.rs
+++ b/codex-rs/analytics/src/client.rs
@@ -27,6 +27,7 @@ use crate::facts::TrackEventsContext;
 use crate::facts::TurnCodexErrorFact;
 use crate::facts::TurnProfileFact;
 use crate::facts::TurnResolvedConfigFact;
+use crate::facts::TurnStartAvailabilityFact;
 use crate::facts::TurnTokenUsageFact;
 use crate::reducer::AnalyticsReducer;
 use codex_app_server_protocol::ClientRequest;
@@ -340,6 +341,12 @@ impl AnalyticsEventsClient {
     pub fn track_turn_resolved_config(&self, fact: TurnResolvedConfigFact) {
         self.record_fact(AnalyticsFact::Custom(
             CustomAnalyticsFact::TurnResolvedConfig(Box::new(fact)),
+        ));
+    }
+
+    pub fn track_turn_start_availability(&self, fact: TurnStartAvailabilityFact) {
+        self.record_fact(AnalyticsFact::Custom(
+            CustomAnalyticsFact::TurnStartAvailability(Box::new(fact)),
         ));
     }
 

--- a/codex-rs/analytics/src/events.rs
+++ b/codex-rs/analytics/src/events.rs
@@ -19,6 +19,7 @@ use crate::facts::PluginState;
 use crate::facts::SubAgentThreadStartedInput;
 use crate::facts::ThreadInitializationMode;
 use crate::facts::TrackEventsContext;
+use crate::facts::TurnStartConnectorIdentity;
 use crate::facts::TurnStatus;
 use crate::facts::TurnSteerRejectionReason;
 use crate::facts::TurnSteerResult;
@@ -875,6 +876,10 @@ pub(crate) struct CodexTurnEventParams {
     pub(crate) workspace_kind: Option<String>,
     pub(crate) num_input_images: usize,
     pub(crate) is_first_turn: bool,
+    pub(crate) turn_start_available_mcp_server_names: Vec<String>,
+    pub(crate) turn_start_available_mcp_server_names_truncated: bool,
+    pub(crate) turn_start_available_connectors: Vec<TurnStartConnectorIdentity>,
+    pub(crate) turn_start_available_connectors_truncated: bool,
     pub(crate) status: Option<TurnStatus>,
     pub(crate) turn_error: Option<CodexErrorInfo>,
     pub(crate) codex_error_kind: Option<CodexErrKind>,

--- a/codex-rs/analytics/src/facts.rs
+++ b/codex-rs/analytics/src/facts.rs
@@ -28,7 +28,12 @@ use codex_protocol::protocol::SubAgentSource;
 use codex_protocol::protocol::TokenUsage;
 use codex_protocol::request_permissions::RequestPermissionsResponse;
 use serde::Serialize;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::path::PathBuf;
+
+pub(crate) const TURN_START_AVAILABILITY_MAX_ITEMS: usize = 100;
+pub(crate) const TURN_START_AVAILABILITY_MAX_SERIALIZED_BYTES_PER_FIELD: usize = 16 * 1024;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct AcceptedLineFingerprint {
@@ -87,6 +92,111 @@ pub struct TurnResolvedConfigFact {
     pub personality: Option<Personality>,
     pub workspace_kind: Option<String>,
     pub is_first_turn: bool,
+}
+
+/// MCP and connector identities in the post-policy exposure frozen at turn start.
+///
+/// Each identity list is sorted, deduplicated, and capped at 100 items and 16 KiB when serialized.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct TurnStartAvailability {
+    pub(crate) available_mcp_server_names: Vec<String>,
+    pub(crate) available_mcp_server_names_truncated: bool,
+    pub(crate) available_connectors: Vec<TurnStartConnectorIdentity>,
+    pub(crate) available_connectors_truncated: bool,
+}
+
+impl TurnStartAvailability {
+    /// Builds a bounded snapshot without retaining tool schemas or connector metadata.
+    pub fn new(
+        mcp_server_names: impl IntoIterator<Item = String>,
+        connectors: impl IntoIterator<Item = (String, String)>,
+    ) -> Self {
+        let mcp_server_names = mcp_server_names.into_iter().collect::<BTreeSet<_>>();
+        let (available_mcp_server_names, available_mcp_server_names_truncated) =
+            collect_bounded_serializable(mcp_server_names, String::len);
+
+        let mut connectors_by_id = BTreeMap::new();
+        for (connector_id, connector_name) in connectors {
+            connectors_by_id
+                .entry(connector_id)
+                .and_modify(|existing_name: &mut String| {
+                    if connector_name < *existing_name {
+                        existing_name.clone_from(&connector_name);
+                    }
+                })
+                .or_insert(connector_name);
+        }
+        let (available_connectors, available_connectors_truncated) = collect_bounded_serializable(
+            connectors_by_id
+                .into_iter()
+                .map(
+                    |(connector_id, connector_name)| TurnStartConnectorIdentity {
+                        connector_id,
+                        connector_name,
+                    },
+                ),
+            |connector| {
+                connector
+                    .connector_id
+                    .len()
+                    .saturating_add(connector.connector_name.len())
+            },
+        );
+
+        Self {
+            available_mcp_server_names,
+            available_mcp_server_names_truncated,
+            available_connectors,
+            available_connectors_truncated,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub(crate) struct TurnStartConnectorIdentity {
+    pub(crate) connector_id: String,
+    pub(crate) connector_name: String,
+}
+
+fn collect_bounded_serializable<T: Serialize>(
+    items: impl IntoIterator<Item = T>,
+    raw_string_bytes: impl Fn(&T) -> usize,
+) -> (Vec<T>, bool) {
+    let mut collected = Vec::new();
+    let mut truncated = false;
+    let mut serialized_bytes = 2_usize;
+    for item in items {
+        if collected.len() == TURN_START_AVAILABILITY_MAX_ITEMS {
+            truncated = true;
+            break;
+        }
+        if raw_string_bytes(&item) > TURN_START_AVAILABILITY_MAX_SERIALIZED_BYTES_PER_FIELD {
+            truncated = true;
+            continue;
+        }
+        let Ok(serialized) = serde_json::to_vec(&item) else {
+            truncated = true;
+            continue;
+        };
+        let separator_bytes = usize::from(!collected.is_empty());
+        let next_serialized_bytes = serialized_bytes
+            .saturating_add(separator_bytes)
+            .saturating_add(serialized.len());
+        if next_serialized_bytes > TURN_START_AVAILABILITY_MAX_SERIALIZED_BYTES_PER_FIELD {
+            truncated = true;
+            continue;
+        }
+        serialized_bytes = next_serialized_bytes;
+        collected.push(item);
+    }
+    (collected, truncated)
+}
+
+/// Associates a frozen availability snapshot with the turn reducer state.
+#[derive(Clone)]
+pub struct TurnStartAvailabilityFact {
+    pub turn_id: String,
+    pub availability: TurnStartAvailability,
 }
 
 #[derive(Clone, Copy, Debug, Serialize)]
@@ -501,6 +611,7 @@ pub(crate) enum CustomAnalyticsFact {
     Goal(Box<CodexGoalEvent>),
     GuardianReview(Box<GuardianReviewEventParams>),
     TurnResolvedConfig(Box<TurnResolvedConfigFact>),
+    TurnStartAvailability(Box<TurnStartAvailabilityFact>),
     TurnTokenUsage(Box<TurnTokenUsageFact>),
     TurnProfile(Box<TurnProfileFact>),
     TurnCodexError(Box<TurnCodexErrorFact>),

--- a/codex-rs/analytics/src/lib.rs
+++ b/codex-rs/analytics/src/lib.rs
@@ -53,6 +53,8 @@ pub use facts::TurnCodexErrorFact;
 pub use facts::TurnProfile;
 pub use facts::TurnProfileFact;
 pub use facts::TurnResolvedConfigFact;
+pub use facts::TurnStartAvailability;
+pub use facts::TurnStartAvailabilityFact;
 pub use facts::TurnStatus;
 pub use facts::TurnSteerRejectionReason;
 pub use facts::TurnSteerRequestError;

--- a/codex-rs/analytics/src/reducer.rs
+++ b/codex-rs/analytics/src/reducer.rs
@@ -90,6 +90,8 @@ use crate::facts::TurnCodexErrorFact;
 use crate::facts::TurnProfile;
 use crate::facts::TurnProfileFact;
 use crate::facts::TurnResolvedConfigFact;
+use crate::facts::TurnStartAvailability;
+use crate::facts::TurnStartAvailabilityFact;
 use crate::facts::TurnStatus;
 use crate::facts::TurnSteerRejectionReason;
 use crate::facts::TurnSteerResult;
@@ -363,6 +365,7 @@ struct TurnState {
     thread_id: Option<String>,
     num_input_images: Option<usize>,
     resolved_config: Option<TurnResolvedConfigFact>,
+    turn_start_availability: Option<TurnStartAvailability>,
     started_at: Option<u64>,
     token_usage: Option<TokenUsage>,
     profile: Option<TurnProfile>,
@@ -511,6 +514,9 @@ impl AnalyticsReducer {
                 }
                 CustomAnalyticsFact::TurnResolvedConfig(input) => {
                     self.ingest_turn_resolved_config(*input, out).await;
+                }
+                CustomAnalyticsFact::TurnStartAvailability(input) => {
+                    self.ingest_turn_start_availability(*input, out).await;
                 }
                 CustomAnalyticsFact::TurnTokenUsage(input) => {
                     self.ingest_turn_token_usage(*input, out).await;
@@ -677,6 +683,19 @@ impl AnalyticsReducer {
         turn_state.thread_id = Some(thread_id);
         turn_state.num_input_images = Some(num_input_images);
         turn_state.resolved_config = Some(input);
+        self.maybe_emit_turn_event(&turn_id, out).await;
+    }
+
+    async fn ingest_turn_start_availability(
+        &mut self,
+        input: TurnStartAvailabilityFact,
+        out: &mut Vec<TrackEventRequest>,
+    ) {
+        let turn_id = input.turn_id;
+        self.turns
+            .entry(turn_id.clone())
+            .or_default()
+            .turn_start_availability = Some(input.availability);
         self.maybe_emit_turn_event(&turn_id, out).await;
     }
 
@@ -2596,6 +2615,10 @@ fn codex_turn_event_params(
     else {
         unreachable!("turn event params require a fully populated turn state");
     };
+    let turn_start_availability = turn_state
+        .turn_start_availability
+        .clone()
+        .unwrap_or_default();
     let started_at = turn_state.started_at;
     let TurnResolvedConfigFact {
         turn_id: _resolved_turn_id,
@@ -2619,6 +2642,12 @@ fn codex_turn_event_params(
         workspace_kind,
         is_first_turn,
     } = resolved_config;
+    let TurnStartAvailability {
+        available_mcp_server_names: turn_start_available_mcp_server_names,
+        available_mcp_server_names_truncated: turn_start_available_mcp_server_names_truncated,
+        available_connectors: turn_start_available_connectors,
+        available_connectors_truncated: turn_start_available_connectors_truncated,
+    } = turn_start_availability;
     let TurnProfile {
         before_first_sampling_ms,
         sampling_ms,
@@ -2661,6 +2690,10 @@ fn codex_turn_event_params(
         workspace_kind,
         num_input_images,
         is_first_turn,
+        turn_start_available_mcp_server_names,
+        turn_start_available_mcp_server_names_truncated,
+        turn_start_available_connectors,
+        turn_start_available_connectors_truncated,
         status: completed.status,
         turn_error: completed.turn_error,
         codex_error_kind: codex_error.map(|error| error.kind),

--- a/codex-rs/app-server/tests/suite/v2/mcp_server_status.rs
+++ b/codex-rs/app-server/tests/suite/v2/mcp_server_status.rs
@@ -450,7 +450,7 @@ url = "{underscore_server_url}/mcp"
     Ok(())
 }
 
-async fn start_mcp_server(tool_name: &str) -> Result<(String, JoinHandle<()>)> {
+pub(super) async fn start_mcp_server(tool_name: &str) -> Result<(String, JoinHandle<()>)> {
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
     let tool_name = Arc::new(tool_name.to_string());

--- a/codex-rs/app-server/tests/suite/v2/turn_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start.rs
@@ -92,6 +92,7 @@ use wiremock::ResponseTemplate;
 
 use super::analytics::mount_analytics_capture;
 use super::analytics::wait_for_analytics_event;
+use super::mcp_server_status::start_mcp_server;
 
 #[cfg(windows)]
 const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(25);
@@ -854,6 +855,7 @@ async fn turn_start_tracks_thread_originator_in_analytics() -> Result<()> {
         ],
     )
     .await;
+    let (generic_mcp_url, generic_mcp_handle) = start_mcp_server("analytics_lookup").await?;
 
     let codex_home = TempDir::new()?;
     write_mock_responses_config_toml_with_chatgpt_base_url(
@@ -864,7 +866,16 @@ async fn turn_start_tracks_thread_originator_in_analytics() -> Result<()> {
     let config_path = codex_home.path().join("config.toml");
     let config = std::fs::read_to_string(&config_path)?
         .replace("stream_max_retries = 0", "stream_max_retries = 1");
-    std::fs::write(config_path, config)?;
+    std::fs::write(
+        config_path,
+        format!(
+            r#"{config}
+
+[mcp_servers.analytics_generic]
+url = "{generic_mcp_url}/mcp"
+"#
+        ),
+    )?;
     mount_analytics_capture(&server, codex_home.path()).await?;
 
     let mut mcp = TestAppServer::new_without_managed_config(codex_home.path()).await?;
@@ -946,6 +957,15 @@ async fn turn_start_tracks_thread_originator_in_analytics() -> Result<()> {
     assert_eq!(event["event_params"]["output_tokens"], 0);
     assert_eq!(event["event_params"]["reasoning_output_tokens"], 0);
     assert_eq!(event["event_params"]["total_tokens"], 0);
+    assert_eq!(
+        event["event_params"]["turn_start_available_mcp_server_names"],
+        json!(["analytics_generic"])
+    );
+    assert_eq!(
+        event["event_params"]["turn_start_available_connectors"],
+        json!([])
+    );
+    assert_eq!(event["event_params"]["mcp_tool_call_count"], 0);
     let params = &event["event_params"];
     let timings_are_numbers = [
         "before_first_sampling_ms",
@@ -972,6 +992,13 @@ async fn turn_start_tracks_thread_originator_in_analytics() -> Result<()> {
             "responseRequestCount": 2,
         })
     );
+    assert!(
+        response_mock.requests()[0]
+            .tool_by_name("mcp__analytics_generic", "analytics_lookup")
+            .is_some()
+    );
+    generic_mcp_handle.abort();
+    let _ = generic_mcp_handle.await;
 
     Ok(())
 }

--- a/codex-rs/core/src/mcp_tool_exposure.rs
+++ b/codex-rs/core/src/mcp_tool_exposure.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use codex_analytics::TurnStartAvailability;
 use codex_connectors::AppToolPolicyEvaluator;
 use codex_connectors::AppToolPolicyInput;
 use codex_mcp::CODEX_APPS_MCP_SERVER_NAME;
@@ -93,6 +94,33 @@ fn filter_codex_apps_mcp_tools(
         })
         .cloned()
         .collect()
+}
+
+/// Projects the post-policy direct and deferred tool exposure into analytics identities.
+pub(crate) fn turn_start_availability(exposure: &McpToolExposure) -> TurnStartAvailability {
+    let exposed_tools = || {
+        exposure
+            .direct_tools
+            .iter()
+            .chain(exposure.deferred_tools.iter().flatten())
+    };
+    TurnStartAvailability::new(
+        exposed_tools()
+            .filter(|tool| tool.server_name != CODEX_APPS_MCP_SERVER_NAME)
+            .map(|tool| tool.server_name.clone()),
+        exposed_tools()
+            .filter(|tool| tool.server_name == CODEX_APPS_MCP_SERVER_NAME)
+            .filter_map(|tool| {
+                let connector_id = tool.connector_id.as_ref()?;
+                let connector_name = tool
+                    .connector_name
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|name| !name.is_empty())
+                    .unwrap_or(connector_id);
+                Some((connector_id.clone(), connector_name.to_string()))
+            }),
+    )
 }
 
 #[cfg(test)]

--- a/codex-rs/core/src/mcp_tool_exposure_test.rs
+++ b/codex-rs/core/src/mcp_tool_exposure_test.rs
@@ -295,4 +295,17 @@ async fn defers_apps_and_non_app_mcp_tools() {
         "mcp__codex_apps__calendar",
         "_create_event"
     )));
+    assert_eq!(
+        serde_json::to_value(turn_start_availability(&exposure))
+            .expect("availability should serialize"),
+        serde_json::json!({
+            "available_mcp_server_names": ["rmcp"],
+            "available_mcp_server_names_truncated": false,
+            "available_connectors": [{
+                "connector_id": "calendar",
+                "connector_name": "Calendar",
+            }],
+            "available_connectors_truncated": false,
+        })
+    );
 }

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -29,6 +29,7 @@ use crate::injection::app_id_from_path;
 use crate::injection::tool_kind_for_path;
 use crate::mcp_skill_dependencies::maybe_prompt_and_install_mcp_dependencies;
 use crate::mcp_tool_exposure::build_mcp_tool_exposure;
+use crate::mcp_tool_exposure::turn_start_availability;
 use crate::mentions::build_connector_slug_counts;
 use crate::mentions::build_skill_name_counts;
 use crate::mentions::collect_explicit_app_ids;
@@ -72,6 +73,8 @@ use codex_analytics::CompactionPhase;
 use codex_analytics::CompactionReason;
 use codex_analytics::InvocationType;
 use codex_analytics::TurnResolvedConfigFact;
+use codex_analytics::TurnStartAvailability;
+use codex_analytics::TurnStartAvailabilityFact;
 use codex_analytics::build_track_events_context;
 use codex_async_utils::OrCancelExt;
 use codex_core_plugins::RecommendedPluginCandidatesInput;
@@ -208,6 +211,7 @@ pub(crate) async fn run_turn(
 
     let mut last_agent_message: Option<String> = None;
     let mut stop_hook_active = false;
+    let mut turn_start_availability_tracked = false;
     // Although from the perspective of codex.rs, TurnDiffTracker has the lifecycle of a Task which contains
     // many turns, from the perspective of the user, it is a single turn.
     let turn_diff_tracker = Arc::new(tokio::sync::Mutex::new(
@@ -281,15 +285,34 @@ pub(crate) async fn run_turn(
                 window_id,
                 CodexResponsesRequestKind::Turn,
             );
+            let sampling_cancellation_token = cancellation_token.child_token();
+            let (router, availability) = built_tools_with_turn_start_availability(
+                sess.as_ref(),
+                step_context.as_ref(),
+                &sampling_cancellation_token,
+            )
+            .await?;
+            if !turn_start_availability_tracked {
+                // The first step context was captured before turn-scoped dependency installation,
+                // so this is the frozen post-policy exposure for turn-start analytics.
+                sess.services
+                    .analytics_events_client
+                    .track_turn_start_availability(TurnStartAvailabilityFact {
+                        turn_id: turn_context.sub_id.clone(),
+                        availability,
+                    });
+                turn_start_availability_tracked = true;
+            }
             run_sampling_request(
                 Arc::clone(&sess),
                 Arc::clone(&step_context),
+                router,
                 Arc::clone(&turn_extension_data),
                 Arc::clone(&turn_diff_tracker),
                 &mut client_session,
                 &responses_metadata,
                 sampling_request_input,
-                cancellation_token.child_token(),
+                sampling_cancellation_token,
             )
             .await
         }
@@ -1059,6 +1082,16 @@ pub(crate) fn build_prompt(
     }
 }
 
+pub(crate) async fn built_tools(
+    sess: &Session,
+    step_context: &StepContext,
+    cancellation_token: &CancellationToken,
+) -> CodexResult<Arc<ToolRouter>> {
+    let (router, _) =
+        built_tools_with_turn_start_availability(sess, step_context, cancellation_token).await?;
+    Ok(router)
+}
+
 #[allow(clippy::too_many_arguments)]
 #[allow(deprecated)]
 #[instrument(level = "trace",
@@ -1072,6 +1105,7 @@ pub(crate) fn build_prompt(
 async fn run_sampling_request(
     sess: Arc<Session>,
     step_context: Arc<StepContext>,
+    router: Arc<ToolRouter>,
     turn_store: Arc<codex_extension_api::ExtensionData>,
     turn_diff_tracker: SharedTurnDiffTracker,
     client_session: &mut ModelClientSession,
@@ -1080,7 +1114,6 @@ async fn run_sampling_request(
     cancellation_token: CancellationToken,
 ) -> CodexResult<(SamplingRequestResult, Vec<ResponseItem>)> {
     let turn_context = Arc::clone(&step_context.turn);
-    let router = built_tools(sess.as_ref(), step_context.as_ref(), &cancellation_token).await?;
 
     let base_instructions = sess.get_base_instructions().await;
 
@@ -1166,7 +1199,7 @@ async fn run_sampling_request(
     }
 }
 
-#[instrument(level = "trace",
+#[instrument(name = "built_tools", level = "trace",
     skip_all,
     fields(
         turn_id = %step_context.turn.sub_id,
@@ -1174,11 +1207,11 @@ async fn run_sampling_request(
         apps_enabled = step_context.turn.apps_enabled()
     )
 )]
-pub(crate) async fn built_tools(
+async fn built_tools_with_turn_start_availability(
     sess: &Session,
     step_context: &StepContext,
     cancellation_token: &CancellationToken,
-) -> CodexResult<Arc<ToolRouter>> {
+) -> CodexResult<(Arc<ToolRouter>, TurnStartAvailability)> {
     let turn_context = step_context.turn.as_ref();
     let mcp_connection_manager = step_context.mcp.manager();
     let has_mcp_servers = mcp_connection_manager.has_servers();
@@ -1294,19 +1327,23 @@ pub(crate) async fn built_tools(
         &turn_context.config,
         search_tool_enabled(turn_context),
     );
+    let turn_start_availability = turn_start_availability(&mcp_tool_exposure);
     let mcp_tools = has_mcp_servers.then_some(mcp_tool_exposure.direct_tools);
     let deferred_mcp_tools = mcp_tool_exposure.deferred_tools;
-    Ok(Arc::new(ToolRouter::from_context(
-        step_context,
-        ToolRouterParams {
-            mcp_tools,
-            deferred_mcp_tools,
-            tool_suggest_candidates,
-            extension_tool_executors: extension_tool_executors(sess),
-            dynamic_tools: turn_context.dynamic_tools.as_slice(),
-        },
-        &sess.services.tool_search_handler_cache,
-    )))
+    Ok((
+        Arc::new(ToolRouter::from_context(
+            step_context,
+            ToolRouterParams {
+                mcp_tools,
+                deferred_mcp_tools,
+                tool_suggest_candidates,
+                extension_tool_executors: extension_tool_executors(sess),
+                dynamic_tools: turn_context.dynamic_tools.as_slice(),
+            },
+            &sess.services.tool_search_handler_cache,
+        )),
+        turn_start_availability,
+    ))
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary

- extend `codex_turn_event` with the generic MCP server names and connector identities exposed at turn start
- derive the snapshot from the first frozen, post-policy direct/deferred MCP exposure
- sort, deduplicate, and cap both fields while excluding schemas, descriptions, URLs, and full tool metadata
- add analytics serialization/reducer coverage plus focused core and app-server turn tests

## Why

The connector-runtime RFC calls for distinguishing inventory availability from actual usage. Turn analytics currently reports MCP tool-call counts, so a zero cannot tell us whether no MCP/connector tools were available or whether available tools simply were not called.

RFC: https://app.notion.com/p/3818e50b62b081d28e88f9c3342d4d10

## Payload

`codex_turn_event` now includes:

- `turn_start_available_mcp_server_names`
- `turn_start_available_mcp_server_names_truncated`
- `turn_start_available_connectors` as `{ connector_id, connector_name }`
- `turn_start_available_connectors_truncated`

Each identity list is stably ordered, deduplicated, capped at 100 items and 16 KiB of serialized JSON, and accompanied by a truncation flag. The `codex_apps` MCP server is represented through connector identities rather than as a generic server name.

The snapshot represents post-policy exposure: model visibility, connector accessibility, app policy, and direct/deferred search gating have been applied. It intentionally precedes final router schema validation, tool-name collision resolution, and code-mode exclusions.

## Validation

- `just test -p codex-analytics` — 86 passed
- `just test -p codex-core defers_apps_and_non_app_mcp_tools`
- `just test -p codex-app-server --test all turn_start_tracks_thread_originator_in_analytics`
- `just fix -p codex-analytics`
- `just fix -p codex-core`
- `just fix -p codex-app-server`
- `just fmt`
- release app-server test-target compilation

## Draft status

Draft pending final cleanup around cumulative byte-budget test coverage and a few small reducer/test simplifications identified in the final review.