### PR TITLE
[TPP-502] fix(imagegen): avoid duplicate markdown image links

### DIFF
--- a/codex-rs/core/src/context/image_generation_instructions.rs
+++ b/codex-rs/core/src/context/image_generation_instructions.rs
@@ -18,7 +18,7 @@ fn image_generation_hint(
     image_output_path: impl Display,
 ) -> String {
     format!(
-        "Generated images are saved to {image_output_dir} as {image_output_path} by default.\nThe generated image is already displayed to the user. Do not embed or link it, or an unchanged copy of it, in Markdown.\nIf you need to use the generated image at another path for further work, copy it and leave the original in place unless the user explicitly asks you to delete it."
+        "Generated images are saved to {image_output_dir} as {image_output_path} by default.\nAlready displayed; do not repeat it or an unchanged copy in final Markdown unless asked.\nFor another path, copy it and keep the original unless asked to delete it."
     )
 }
 

--- a/codex-rs/core/src/context/image_generation_instructions.rs
+++ b/codex-rs/core/src/context/image_generation_instructions.rs
@@ -18,7 +18,7 @@ fn image_generation_hint(
     image_output_path: impl Display,
 ) -> String {
     format!(
-        "Generated images are saved to {image_output_dir} as {image_output_path} by default.\nIf you need to use a generated image at another path, copy it and leave the original in place unless the user explicitly asks you to delete it."
+        "Generated images are saved to {image_output_dir} as {image_output_path} by default.\nThe generated image is already displayed to the user. Do not embed or link it, or an unchanged copy of it, in Markdown.\nIf you need to use the generated image at another path for further work, copy it and leave the original in place unless the user explicitly asks you to delete it."
     )
 }
 

--- a/codex-rs/core/tests/suite/model_switching.rs
+++ b/codex-rs/core/tests/suite/model_switching.rs
@@ -703,8 +703,11 @@ async fn generated_image_is_replayed_for_image_capable_models() -> Result<()> {
         second_request
             .message_input_texts("developer")
             .iter()
-            .any(|text| text.contains("Generated images are saved to")),
-        "second request should include the saved-path note in model-visible history"
+            .any(|text| {
+                text.contains("Generated images are saved to")
+                    && text.contains("do not repeat it or an unchanged copy")
+            }),
+        "second request should include the saved-path and render-once note in model-visible history"
     );
     let _ = std::fs::remove_file(&saved_path);
 
@@ -827,8 +830,11 @@ async fn model_change_from_generated_image_to_text_preserves_prior_generated_ima
         second_request
             .message_input_texts("developer")
             .iter()
-            .any(|text| text.contains("Generated images are saved to")),
-        "second request should include the saved-path note in model-visible history"
+            .any(|text| {
+                text.contains("Generated images are saved to")
+                    && text.contains("do not repeat it or an unchanged copy")
+            }),
+        "second request should include the saved-path and render-once note in model-visible history"
     );
     let _ = std::fs::remove_file(&saved_path);
 

--- a/codex-rs/ext/image-generation/src/tests.rs
+++ b/codex-rs/ext/image-generation/src/tests.rs
@@ -224,9 +224,12 @@ async fn recent_image_fallback_requires_requested_count() {
 fn generated_output_returns_image_input_and_output_hint() {
     let output_hint =
         extension_image_generation_output_hint("/tmp", "/tmp/call-1.png").expect("hint should fit");
+    let expected_output_hint = "Generated images are saved to /tmp as /tmp/call-1.png by default.
+The generated image is already displayed to the user. Do not embed or link it, or an unchanged copy of it, in Markdown.
+If you need to use the generated image at another path for further work, copy it and leave the original in place unless the user explicitly asks you to delete it.";
     let output = GeneratedImageOutput {
         result: RESULT.to_string(),
-        output_hint: Some(output_hint.clone()),
+        output_hint: Some(output_hint),
     };
 
     let ResponseInputItem::FunctionCallOutput {
@@ -246,7 +249,9 @@ fn generated_output_returns_image_input_and_output_hint() {
                 image_url: format!("data:image/png;base64,{RESULT}"),
                 detail: Some(DEFAULT_IMAGE_DETAIL),
             },
-            FunctionCallOutputContentItem::InputText { text: output_hint },
+            FunctionCallOutputContentItem::InputText {
+                text: expected_output_hint.to_string(),
+            },
         ]
     );
 }

--- a/codex-rs/ext/image-generation/src/tests.rs
+++ b/codex-rs/ext/image-generation/src/tests.rs
@@ -225,8 +225,8 @@ fn generated_output_returns_image_input_and_output_hint() {
     let output_hint =
         extension_image_generation_output_hint("/tmp", "/tmp/call-1.png").expect("hint should fit");
     let expected_output_hint = "Generated images are saved to /tmp as /tmp/call-1.png by default.
-The generated image is already displayed to the user. Do not embed or link it, or an unchanged copy of it, in Markdown.
-If you need to use the generated image at another path for further work, copy it and leave the original in place unless the user explicitly asks you to delete it.";
+Already displayed; do not repeat it or an unchanged copy in final Markdown unless asked.
+For another path, copy it and keep the original unless asked to delete it.";
     let output = GeneratedImageOutput {
         result: RESULT.to_string(),
         output_hint: Some(output_hint),


### PR DESCRIPTION
## Summary

<img width="762" height="510" alt="Screenshot 2026-07-14 at 1 19 14 PM" src="https://github.com/user-attachments/assets/b975ad9c-fe6c-489e-a90f-aee13aa1b64e" />


- Tell the model that generated images are already displayed to the user.
- Prevent Markdown links or embeds for the generated image and unchanged copies.
- Preserve the existing saved-path guidance for follow-up image work.

## Root cause

The shared image-generation output hint exposed the saved image path without explaining that the client had already rendered the generated-image item. The model could then repeat the same image as a Markdown image or file link.

## Validation

- `just test -p codex-image-generation-extension`
- `git diff --check`
- `cargo fmt --manifest-path codex-rs/Cargo.toml --all`

Attempted `just test -p codex-core handle_output_item_done_records_image_save_history_message`; local linking of the large `codex-core` test binary failed before the test ran.