### PR TITLE
[codex] Support SQLite-disabled degraded mode

### DIFF
--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -526,10 +526,7 @@ pub async fn run_main_with_transport_options(
                 return Err(err);
             }
 
-            let message = config_warning_from_error(
-                "Invalid configuration; using defaults with SQLite disabled.",
-                &err,
-            );
+            let message = config_warning_from_error("Invalid configuration; using defaults.", &err);
             config_warnings.push(message);
             let mut config = config_manager.load_default_config().await.map_err(|e| {
                 std::io::Error::new(
@@ -544,6 +541,14 @@ pub async fn run_main_with_transport_options(
             (config, false)
         }
     };
+    if !config.features.enabled(codex_features::Feature::Sqlite) {
+        config_warnings.push(ConfigWarningNotification {
+            summary: "SQLite is disabled. Codex is running in degraded mode; SQLite-dependent features and operations are unavailable.".to_string(),
+            details: None,
+            path: None,
+            range: None,
+        });
+    }
 
     let otel = codex_core::otel_init::build_provider(
         &config,

--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -528,27 +528,17 @@ pub async fn run_main_with_transport_options(
 
             let message = config_warning_from_error("Invalid configuration; using defaults.", &err);
             config_warnings.push(message);
-            let mut config = config_manager.load_default_config().await.map_err(|e| {
-                std::io::Error::new(
-                    ErrorKind::InvalidData,
-                    format!("error loading default config after config error: {e}"),
-                )
-            })?;
-            config
-                .features
-                .disable(codex_features::Feature::Sqlite)
-                .map_err(std::io::Error::other)?;
-            (config, false)
+            (
+                config_manager.load_default_config().await.map_err(|e| {
+                    std::io::Error::new(
+                        ErrorKind::InvalidData,
+                        format!("error loading default config after config error: {e}"),
+                    )
+                })?,
+                false,
+            )
         }
     };
-    if !config.features.enabled(codex_features::Feature::Sqlite) {
-        config_warnings.push(ConfigWarningNotification {
-            summary: "SQLite is disabled. Codex is running in degraded mode; SQLite-dependent features and operations are unavailable.".to_string(),
-            details: None,
-            path: None,
-            range: None,
-        });
-    }
 
     let otel = codex_core::otel_init::build_provider(
         &config,
@@ -1386,12 +1376,9 @@ mod tests {
     use super::loader_overrides_with_test_user_config_file;
     #[cfg(debug_assertions)]
     use codex_config::LoaderOverrides;
-    use codex_core::config::ConfigBuilder;
-    use codex_features::Feature;
     #[cfg(debug_assertions)]
     use codex_utils_absolute_path::AbsolutePathBuf;
     use pretty_assertions::assert_eq;
-    use tempfile::TempDir;
 
     #[test]
     fn log_format_from_env_value_matches_json_values_case_insensitively() {
@@ -1409,26 +1396,6 @@ mod tests {
         assert_eq!(LogFormat::from_env_value(Some("")), LogFormat::Default);
         assert_eq!(LogFormat::from_env_value(Some("text")), LogFormat::Default);
         assert_eq!(LogFormat::from_env_value(Some("jsonl")), LogFormat::Default);
-    }
-
-    #[tokio::test]
-    async fn sqlite_state_db_can_be_explicitly_disabled() -> anyhow::Result<()> {
-        let temp_dir = TempDir::new()?;
-        let mut config = ConfigBuilder::default()
-            .codex_home(temp_dir.path().to_path_buf())
-            .build()
-            .await?;
-        config.features.disable(Feature::Sqlite)?;
-        let occupied_sqlite_home = temp_dir.path().join("sqlite-home");
-        std::fs::write(&occupied_sqlite_home, "occupied")?;
-        config.sqlite_home = occupied_sqlite_home.clone();
-
-        let result = super::init_sqlite_state_db_with_fresh_start_on_corruption(&config).await?;
-
-        assert!(result.state_db.is_none());
-        assert!(result.recovery_notice.is_none());
-        assert_eq!(std::fs::read_to_string(occupied_sqlite_home)?, "occupied");
-        Ok(())
     }
 
     #[cfg(debug_assertions)]

--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -526,17 +526,22 @@ pub async fn run_main_with_transport_options(
                 return Err(err);
             }
 
-            let message = config_warning_from_error("Invalid configuration; using defaults.", &err);
+            let message = config_warning_from_error(
+                "Invalid configuration; using defaults with SQLite disabled.",
+                &err,
+            );
             config_warnings.push(message);
-            (
-                config_manager.load_default_config().await.map_err(|e| {
-                    std::io::Error::new(
-                        ErrorKind::InvalidData,
-                        format!("error loading default config after config error: {e}"),
-                    )
-                })?,
-                false,
-            )
+            let mut config = config_manager.load_default_config().await.map_err(|e| {
+                std::io::Error::new(
+                    ErrorKind::InvalidData,
+                    format!("error loading default config after config error: {e}"),
+                )
+            })?;
+            config
+                .features
+                .disable(codex_features::Feature::Sqlite)
+                .map_err(std::io::Error::other)?;
+            (config, false)
         }
     };
 
@@ -1209,6 +1214,13 @@ struct StateDbInitResult {
 async fn init_sqlite_state_db_with_fresh_start_on_corruption(
     config: &Config,
 ) -> anyhow::Result<StateDbInitResult> {
+    if !config.features.enabled(codex_features::Feature::Sqlite) {
+        return Ok(StateDbInitResult {
+            state_db: None,
+            recovery_notice: None,
+        });
+    }
+
     let mut attempted_backups = HashSet::new();
     let mut recovered_databases = Vec::new();
     loop {
@@ -1369,9 +1381,12 @@ mod tests {
     use super::loader_overrides_with_test_user_config_file;
     #[cfg(debug_assertions)]
     use codex_config::LoaderOverrides;
+    use codex_core::config::ConfigBuilder;
+    use codex_features::Feature;
     #[cfg(debug_assertions)]
     use codex_utils_absolute_path::AbsolutePathBuf;
     use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
 
     #[test]
     fn log_format_from_env_value_matches_json_values_case_insensitively() {
@@ -1389,6 +1404,26 @@ mod tests {
         assert_eq!(LogFormat::from_env_value(Some("")), LogFormat::Default);
         assert_eq!(LogFormat::from_env_value(Some("text")), LogFormat::Default);
         assert_eq!(LogFormat::from_env_value(Some("jsonl")), LogFormat::Default);
+    }
+
+    #[tokio::test]
+    async fn sqlite_state_db_can_be_explicitly_disabled() -> anyhow::Result<()> {
+        let temp_dir = TempDir::new()?;
+        let mut config = ConfigBuilder::default()
+            .codex_home(temp_dir.path().to_path_buf())
+            .build()
+            .await?;
+        config.features.disable(Feature::Sqlite)?;
+        let occupied_sqlite_home = temp_dir.path().join("sqlite-home");
+        std::fs::write(&occupied_sqlite_home, "occupied")?;
+        config.sqlite_home = occupied_sqlite_home.clone();
+
+        let result = super::init_sqlite_state_db_with_fresh_start_on_corruption(&config).await?;
+
+        assert!(result.state_db.is_none());
+        assert!(result.recovery_notice.is_none());
+        assert_eq!(std::fs::read_to_string(occupied_sqlite_home)?, "occupied");
+        Ok(())
     }
 
     #[cfg(debug_assertions)]

--- a/codex-rs/app-server/src/request_processors/external_agent_config_processor.rs
+++ b/codex-rs/app-server/src/request_processors/external_agent_config_processor.rs
@@ -357,10 +357,9 @@ impl ExternalAgentConfigRequestProcessor {
     pub(crate) async fn read_import_histories(
         &self,
     ) -> Result<ExternalAgentConfigImportHistoriesReadResponse, JSONRPCErrorError> {
-        let state_db = self
-            .state_db
-            .as_ref()
-            .ok_or_else(|| internal_error("state database is unavailable"))?;
+        let Some(state_db) = self.state_db.as_ref() else {
+            return Ok(ExternalAgentConfigImportHistoriesReadResponse { data: Vec::new() });
+        };
         let histories = state_db
             .external_agent_config_import_history_records()
             .await

--- a/codex-rs/app-server/src/request_processors/thread_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor.rs
@@ -1614,16 +1614,10 @@ impl ThreadRequestProcessor {
     }
 
     async fn memory_reset_response_inner(&self) -> Result<MemoryResetResponse, JSONRPCErrorError> {
-        if !self.config.features.enabled(Feature::Sqlite) {
-            return Err(invalid_request(
-                "memory reset requires SQLite, which is disabled",
-            ));
-        }
-
         let state_db = self
             .state_db
             .clone()
-            .ok_or_else(|| internal_error("sqlite state db unavailable for memory reset"))?;
+            .ok_or_else(|| invalid_request("SQLite state DB unavailable for memory reset"))?;
 
         state_db
             .memories()
@@ -1649,12 +1643,6 @@ impl ThreadRequestProcessor {
         &self,
         params: ThreadMetadataUpdateParams,
     ) -> Result<ThreadMetadataUpdateResponse, JSONRPCErrorError> {
-        if !self.config.features.enabled(Feature::Sqlite) {
-            return Err(invalid_request(
-                "thread metadata updates require SQLite, which is disabled",
-            ));
-        }
-
         let ThreadMetadataUpdateParams {
             thread_id,
             git_info,
@@ -2000,11 +1988,6 @@ impl ThreadRequestProcessor {
             )),
             (None, None) => None,
         };
-        if relation_filter.is_some() && !self.config.features.enabled(Feature::Sqlite) {
-            return Err(invalid_request(
-                "thread relationship filters require SQLite, which is disabled",
-            ));
-        }
 
         let requested_page_size = limit
             .map(|value| value as usize)

--- a/codex-rs/app-server/src/request_processors/thread_processor.rs
+++ b/codex-rs/app-server/src/request_processors/thread_processor.rs
@@ -1614,6 +1614,12 @@ impl ThreadRequestProcessor {
     }
 
     async fn memory_reset_response_inner(&self) -> Result<MemoryResetResponse, JSONRPCErrorError> {
+        if !self.config.features.enabled(Feature::Sqlite) {
+            return Err(invalid_request(
+                "memory reset requires SQLite, which is disabled",
+            ));
+        }
+
         let state_db = self
             .state_db
             .clone()
@@ -1643,6 +1649,12 @@ impl ThreadRequestProcessor {
         &self,
         params: ThreadMetadataUpdateParams,
     ) -> Result<ThreadMetadataUpdateResponse, JSONRPCErrorError> {
+        if !self.config.features.enabled(Feature::Sqlite) {
+            return Err(invalid_request(
+                "thread metadata updates require SQLite, which is disabled",
+            ));
+        }
+
         let ThreadMetadataUpdateParams {
             thread_id,
             git_info,
@@ -1988,6 +2000,11 @@ impl ThreadRequestProcessor {
             )),
             (None, None) => None,
         };
+        if relation_filter.is_some() && !self.config.features.enabled(Feature::Sqlite) {
+            return Err(invalid_request(
+                "thread relationship filters require SQLite, which is disabled",
+            ));
+        }
 
         let requested_page_size = limit
             .map(|value| value as usize)

--- a/codex-rs/app-server/tests/suite/strict_config.rs
+++ b/codex-rs/app-server/tests/suite/strict_config.rs
@@ -31,3 +31,38 @@ foo = "bar"
 
     Ok(())
 }
+
+#[test]
+fn non_strict_config_fallback_disables_sqlite() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    std::fs::write(
+        codex_home.path().join("config.toml"),
+        r#"
+model = 123
+
+[features]
+sqlite = false
+"#,
+    )?;
+
+    let output = Command::new(codex_utils_cargo_bin::cargo_bin("codex-app-server")?)
+        .env("CODEX_HOME", codex_home.path())
+        .env(codex_state::SQLITE_HOME_ENV, codex_home.path())
+        .env(
+            "CODEX_APP_SERVER_MANAGED_CONFIG_PATH",
+            codex_home.path().join("managed_config.toml"),
+        )
+        .args(["--listen", "off"])
+        .output()?;
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(
+        stderr.contains("no transport configured"),
+        "expected startup to reach transport validation, got: {stderr}"
+    );
+    for db in codex_state::runtime_db_paths(codex_home.path()) {
+        assert!(!db.path.exists(), "{} should not exist", db.label);
+    }
+    Ok(())
+}

--- a/codex-rs/app-server/tests/suite/strict_config.rs
+++ b/codex-rs/app-server/tests/suite/strict_config.rs
@@ -31,38 +31,3 @@ foo = "bar"
 
     Ok(())
 }
-
-#[test]
-fn non_strict_config_fallback_disables_sqlite() -> Result<()> {
-    let codex_home = TempDir::new()?;
-    std::fs::write(
-        codex_home.path().join("config.toml"),
-        r#"
-model = 123
-
-[features]
-sqlite = false
-"#,
-    )?;
-
-    let output = Command::new(codex_utils_cargo_bin::cargo_bin("codex-app-server")?)
-        .env("CODEX_HOME", codex_home.path())
-        .env(codex_state::SQLITE_HOME_ENV, codex_home.path())
-        .env(
-            "CODEX_APP_SERVER_MANAGED_CONFIG_PATH",
-            codex_home.path().join("managed_config.toml"),
-        )
-        .args(["--listen", "off"])
-        .output()?;
-
-    assert!(!output.status.success());
-    let stderr = String::from_utf8(output.stderr)?;
-    assert!(
-        stderr.contains("no transport configured"),
-        "expected startup to reach transport validation, got: {stderr}"
-    );
-    for db in codex_state::runtime_db_paths(codex_home.path()) {
-        assert!(!db.path.exists(), "{} should not exist", db.label);
-    }
-    Ok(())
-}

--- a/codex-rs/app-server/tests/suite/v2/config_rpc.rs
+++ b/codex-rs/app-server/tests/suite/v2/config_rpc.rs
@@ -40,12 +40,46 @@ use tokio::time::timeout;
 // Bazel CI can spend tens of seconds starting app-server subprocesses or
 // processing config RPCs under load.
 const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+const SQLITE_DISABLED_WARNING_SUMMARY: &str = "SQLite is disabled. Codex is running in degraded mode; SQLite-dependent features and operations are unavailable.";
 
 fn write_config(codex_home: &TempDir, contents: &str) -> Result<()> {
     Ok(std::fs::write(
         codex_home.path().join("config.toml"),
         contents,
     )?)
+}
+
+#[tokio::test]
+async fn sqlite_disabled_emits_degraded_mode_warning() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    write_config(&codex_home, "[features]\nsqlite = false\n")?;
+    let mut mcp =
+        TestAppServer::new_with_env(codex_home.path(), &[("CODEX_SQLITE_HOME", None)]).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let warning = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_matching_notification("SQLite disabled config warning", |message| {
+            message.method == "configWarning"
+                && message
+                    .params
+                    .as_ref()
+                    .and_then(|params| params.get("summary"))
+                    .and_then(serde_json::Value::as_str)
+                    == Some(SQLITE_DISABLED_WARNING_SUMMARY)
+        }),
+    )
+    .await??;
+
+    assert_eq!(
+        warning
+            .params
+            .as_ref()
+            .and_then(|params| params.get("summary"))
+            .and_then(serde_json::Value::as_str),
+        Some(SQLITE_DISABLED_WARNING_SUMMARY)
+    );
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/codex-rs/app-server/tests/suite/v2/config_rpc.rs
+++ b/codex-rs/app-server/tests/suite/v2/config_rpc.rs
@@ -40,7 +40,7 @@ use tokio::time::timeout;
 // Bazel CI can spend tens of seconds starting app-server subprocesses or
 // processing config RPCs under load.
 const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
-const SQLITE_DISABLED_WARNING_SUMMARY: &str = "SQLite is disabled. Codex is running in degraded mode; SQLite-dependent features and operations are unavailable.";
+const SQLITE_DISABLED_WARNING_SUMMARY: &str = "SQLite is disabled. Codex is running in degraded mode; SQLite-dependent features and operations are unavailable. Changes to this setting require restarting Codex.";
 
 fn write_config(codex_home: &TempDir, contents: &str) -> Result<()> {
     Ok(std::fs::write(
@@ -53,11 +53,15 @@ fn write_config(codex_home: &TempDir, contents: &str) -> Result<()> {
 async fn sqlite_disabled_emits_degraded_mode_warning() -> Result<()> {
     let codex_home = TempDir::new()?;
     write_config(&codex_home, "[features]\nsqlite = false\n")?;
-    let mut mcp =
-        TestAppServer::new_with_env(codex_home.path(), &[("CODEX_SQLITE_HOME", None)]).await?;
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .without_auto_env()
+        .with_env_overrides(&[("CODEX_SQLITE_HOME", None)])
+        .build()
+        .await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
 
-    let warning = timeout(
+    timeout(
         DEFAULT_READ_TIMEOUT,
         mcp.read_stream_until_matching_notification("SQLite disabled config warning", |message| {
             message.method == "configWarning"
@@ -70,15 +74,6 @@ async fn sqlite_disabled_emits_degraded_mode_warning() -> Result<()> {
         }),
     )
     .await??;
-
-    assert_eq!(
-        warning
-            .params
-            .as_ref()
-            .and_then(|params| params.get("summary"))
-            .and_then(serde_json::Value::as_str),
-        Some(SQLITE_DISABLED_WARNING_SUMMARY)
-    );
     Ok(())
 }
 

--- a/codex-rs/app-server/tests/suite/v2/external_agent_config.rs
+++ b/codex-rs/app-server/tests/suite/v2/external_agent_config.rs
@@ -58,8 +58,12 @@ async fn external_agent_config_import_histories_are_empty_when_sqlite_is_disable
         codex_home.path().join("config.toml"),
         "[features]\nsqlite = false\n",
     )?;
-    let mut mcp =
-        TestAppServer::new_with_env(codex_home.path(), &[("CODEX_SQLITE_HOME", None)]).await?;
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .without_auto_env()
+        .with_env_overrides(&[("CODEX_SQLITE_HOME", None)])
+        .build()
+        .await?;
     timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;
 
     let request_id = mcp
@@ -76,9 +80,6 @@ async fn external_agent_config_import_histories_are_empty_when_sqlite_is_disable
     let response: ExternalAgentConfigImportHistoriesReadResponse = to_response(response)?;
 
     assert!(response.data.is_empty());
-    for db in codex_state::runtime_db_paths(codex_home.path()) {
-        assert!(!db.path.exists(), "{} should not exist", db.label);
-    }
     Ok(())
 }
 

--- a/codex-rs/app-server/tests/suite/v2/external_agent_config.rs
+++ b/codex-rs/app-server/tests/suite/v2/external_agent_config.rs
@@ -52,6 +52,37 @@ fn assert_import_response(response: ExternalAgentConfigImportResponse) -> String
 }
 
 #[tokio::test]
+async fn external_agent_config_import_histories_are_empty_when_sqlite_is_disabled() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    std::fs::write(
+        codex_home.path().join("config.toml"),
+        "[features]\nsqlite = false\n",
+    )?;
+    let mut mcp =
+        TestAppServer::new_with_env(codex_home.path(), &[("CODEX_SQLITE_HOME", None)]).await?;
+    timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;
+
+    let request_id = mcp
+        .send_raw_request(
+            "externalAgentConfig/import/readHistories",
+            /*params*/ None,
+        )
+        .await?;
+    let response: JSONRPCResponse = timeout(
+        DEFAULT_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    let response: ExternalAgentConfigImportHistoriesReadResponse = to_response(response)?;
+
+    assert!(response.data.is_empty());
+    for db in codex_state::runtime_db_paths(codex_home.path()) {
+        assert!(!db.path.exists(), "{} should not exist", db.label);
+    }
+    Ok(())
+}
+
+#[tokio::test]
 async fn external_agent_config_import_sends_completion_notification_for_sync_only_import()
 -> Result<()> {
     let codex_home = TempDir::new()?;

--- a/codex-rs/app-server/tests/suite/v2/memory_reset.rs
+++ b/codex-rs/app-server/tests/suite/v2/memory_reset.rs
@@ -22,7 +22,7 @@ const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs
 #[tokio::test]
 async fn memory_reset_clears_memory_files_and_rows_preserves_threads() -> Result<()> {
     let codex_home = TempDir::new()?;
-    create_config_toml(codex_home.path())?;
+    create_config_toml(codex_home.path(), /*sqlite_enabled*/ true)?;
     let state_db = init_state_db(codex_home.path()).await?;
 
     let memory_root = codex_home.path().join("memories");
@@ -69,6 +69,37 @@ async fn memory_reset_clears_memory_files_and_rows_preserves_threads() -> Result
         "memory root should be empty after reset"
     );
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn memory_reset_reports_sqlite_disabled() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), /*sqlite_enabled*/ false)?;
+    let memory_root = codex_home.path().join("memories");
+    tokio::fs::create_dir_all(&memory_root).await?;
+    tokio::fs::write(memory_root.join("MEMORY.md"), "stale memory\n").await?;
+
+    let mut mcp = TestAppServer::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+    let request_id = mcp
+        .send_raw_request("memory/reset", /*params*/ None)
+        .await?;
+    let error = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+
+    assert_eq!(error.error.code, -32600);
+    assert_eq!(
+        error.error.message,
+        "memory reset requires SQLite, which is disabled"
+    );
+    assert!(memory_root.join("MEMORY.md").is_file());
+    for db in codex_state::runtime_db_paths(codex_home.path()) {
+        assert!(!db.path.exists(), "{} should not exist", db.label);
+    }
     Ok(())
 }
 
@@ -130,11 +161,12 @@ async fn init_state_db(codex_home: &Path) -> Result<Arc<StateRuntime>> {
     Ok(state_db)
 }
 
-fn create_config_toml(codex_home: &Path) -> std::io::Result<()> {
+fn create_config_toml(codex_home: &Path, sqlite_enabled: bool) -> std::io::Result<()> {
     let config_toml = codex_home.join("config.toml");
     std::fs::write(
         config_toml,
-        r#"
+        format!(
+            r#"
 model = "mock-model"
 approval_policy = "never"
 sandbox_mode = "read-only"
@@ -142,7 +174,7 @@ model_provider = "mock_provider"
 suppress_unstable_features_warning = true
 
 [features]
-sqlite = true
+sqlite = {sqlite_enabled}
 
 [model_providers.mock_provider]
 name = "Mock provider for test"
@@ -151,5 +183,6 @@ wire_api = "responses"
 request_max_retries = 0
 stream_max_retries = 0
 "#,
+        ),
     )
 }

--- a/codex-rs/app-server/tests/suite/v2/memory_reset.rs
+++ b/codex-rs/app-server/tests/suite/v2/memory_reset.rs
@@ -80,7 +80,11 @@ async fn memory_reset_reports_sqlite_disabled() -> Result<()> {
     tokio::fs::create_dir_all(&memory_root).await?;
     tokio::fs::write(memory_root.join("MEMORY.md"), "stale memory\n").await?;
 
-    let mut mcp = TestAppServer::new(codex_home.path()).await?;
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .without_auto_env()
+        .build()
+        .await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
     let request_id = mcp
         .send_raw_request("memory/reset", /*params*/ None)
@@ -94,7 +98,7 @@ async fn memory_reset_reports_sqlite_disabled() -> Result<()> {
     assert_eq!(error.error.code, -32600);
     assert_eq!(
         error.error.message,
-        "memory reset requires SQLite, which is disabled"
+        "SQLite state DB unavailable for memory reset"
     );
     assert!(memory_root.join("MEMORY.md").is_file());
     for db in codex_state::runtime_db_paths(codex_home.path()) {

--- a/codex-rs/app-server/tests/suite/v2/thread_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_list.rs
@@ -1244,7 +1244,7 @@ async fn thread_list_relation_filters_report_sqlite_disabled() -> Result<()> {
     assert_eq!(error.error.code, -32600);
     assert_eq!(
         error.error.message,
-        "thread relationship filters require SQLite, which is disabled"
+        "SQLite state DB unavailable for thread relationship filters"
     );
     Ok(())
 }

--- a/codex-rs/app-server/tests/suite/v2/thread_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_list.rs
@@ -1212,6 +1212,44 @@ async fn thread_list_relation_filters_reject_invalid_requests() -> Result<()> {
 }
 
 #[tokio::test]
+async fn thread_list_relation_filters_report_sqlite_disabled() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    std::fs::write(
+        codex_home.path().join("config.toml"),
+        "[features]\nsqlite = false\n",
+    )?;
+    let mut mcp = init_mcp(codex_home.path()).await?;
+    let request_id = mcp
+        .send_thread_list_request(codex_app_server_protocol::ThreadListParams {
+            cursor: None,
+            sort_key: None,
+            sort_direction: None,
+            model_providers: None,
+            source_kinds: None,
+            archived: None,
+            cwd: None,
+            use_state_db_only: false,
+            search_term: None,
+            parent_thread_id: Some(ThreadId::new().to_string()),
+            ancestor_thread_id: None,
+            limit: Some(10),
+        })
+        .await?;
+    let error = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+
+    assert_eq!(error.error.code, -32600);
+    assert_eq!(
+        error.error.message,
+        "thread relationship filters require SQLite, which is disabled"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn thread_list_empty_source_kinds_defaults_to_interactive_only() -> Result<()> {
     let codex_home = TempDir::new()?;
     create_minimal_config(codex_home.path())?;

--- a/codex-rs/app-server/tests/suite/v2/thread_metadata_update.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_metadata_update.rs
@@ -42,7 +42,11 @@ async fn thread_metadata_update_reports_sqlite_disabled() -> Result<()> {
         codex_home.path().join("config.toml"),
         "[features]\nsqlite = false\n",
     )?;
-    let mut mcp = TestAppServer::new(codex_home.path()).await?;
+    let mut mcp = TestAppServer::builder()
+        .with_codex_home(codex_home.path())
+        .without_auto_env()
+        .build()
+        .await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
     let request_id = mcp
         .send_thread_metadata_update_request(ThreadMetadataUpdateParams {
@@ -63,11 +67,8 @@ async fn thread_metadata_update_reports_sqlite_disabled() -> Result<()> {
     assert_eq!(error.error.code, INVALID_REQUEST_ERROR_CODE);
     assert_eq!(
         error.error.message,
-        "thread metadata updates require SQLite, which is disabled"
+        "SQLite state DB unavailable for thread metadata updates"
     );
-    for db in codex_state::runtime_db_paths(codex_home.path()) {
-        assert!(!db.path.exists(), "{} should not exist", db.label);
-    }
     Ok(())
 }
 

--- a/codex-rs/app-server/tests/suite/v2/thread_metadata_update.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_metadata_update.rs
@@ -36,6 +36,42 @@ const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs
 const INVALID_REQUEST_ERROR_CODE: i64 = -32600;
 
 #[tokio::test]
+async fn thread_metadata_update_reports_sqlite_disabled() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    std::fs::write(
+        codex_home.path().join("config.toml"),
+        "[features]\nsqlite = false\n",
+    )?;
+    let mut mcp = TestAppServer::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+    let request_id = mcp
+        .send_thread_metadata_update_request(ThreadMetadataUpdateParams {
+            thread_id: ThreadId::new().to_string(),
+            git_info: Some(ThreadMetadataGitInfoUpdateParams {
+                sha: None,
+                branch: Some(Some("feature/test".to_string())),
+                origin_url: None,
+            }),
+        })
+        .await?;
+    let error = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_error_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+
+    assert_eq!(error.error.code, INVALID_REQUEST_ERROR_CODE);
+    assert_eq!(
+        error.error.message,
+        "thread metadata updates require SQLite, which is disabled"
+    );
+    for db in codex_state::runtime_db_paths(codex_home.path()) {
+        assert!(!db.path.exists(), "{} should not exist", db.label);
+    }
+    Ok(())
+}
+
+#[tokio::test]
 async fn thread_metadata_update_patches_git_branch_and_returns_updated_thread() -> Result<()> {
     let server = create_mock_responses_server_repeating_assistant("Done").await;
     let codex_home = TempDir::new()?;

--- a/codex-rs/cli/src/doctor.rs
+++ b/codex-rs/cli/src/doctor.rs
@@ -2166,13 +2166,11 @@ async fn state_check(config: &Config) -> DoctorCheck {
     path_readiness(&mut details, "log dir", &config.log_dir);
     path_readiness(&mut details, "sqlite home", &config.sqlite_home);
     let mut integrity_failures = Vec::new();
-    for db in codex_state::runtime_db_paths(&config.sqlite_home) {
-        path_readiness(&mut details, db.label, &db.path);
-        if sqlite_enabled {
+    if sqlite_enabled {
+        for db in codex_state::runtime_db_paths(&config.sqlite_home) {
+            path_readiness(&mut details, db.label, &db.path);
             sqlite_integrity_detail(&mut details, &mut integrity_failures, db.label, &db.path)
                 .await;
-        } else {
-            details.push(format!("{} integrity: skipped (SQLite disabled)", db.label));
         }
     }
     rollout_stats_details(&mut details, &config.codex_home);
@@ -3132,12 +3130,6 @@ mod tests {
             "state paths are inspectable; SQLite is disabled"
         );
         assert_eq!(check.remediation, None);
-        assert!(
-            check
-                .details
-                .iter()
-                .any(|detail| detail == "state DB integrity: skipped (SQLite disabled)")
-        );
     }
 
     #[derive(Default)]

--- a/codex-rs/cli/src/doctor.rs
+++ b/codex-rs/cli/src/doctor.rs
@@ -2161,13 +2161,19 @@ fn non_empty_trimmed(value: String) -> Option<String> {
 
 async fn state_check(config: &Config) -> DoctorCheck {
     let mut details = Vec::new();
+    let sqlite_enabled = config.features.enabled(codex_features::Feature::Sqlite);
     path_readiness(&mut details, "CODEX_HOME", &config.codex_home);
     path_readiness(&mut details, "log dir", &config.log_dir);
     path_readiness(&mut details, "sqlite home", &config.sqlite_home);
     let mut integrity_failures = Vec::new();
     for db in codex_state::runtime_db_paths(&config.sqlite_home) {
         path_readiness(&mut details, db.label, &db.path);
-        sqlite_integrity_detail(&mut details, &mut integrity_failures, db.label, &db.path).await;
+        if sqlite_enabled {
+            sqlite_integrity_detail(&mut details, &mut integrity_failures, db.label, &db.path)
+                .await;
+        } else {
+            details.push(format!("{} integrity: skipped (SQLite disabled)", db.label));
+        }
     }
     rollout_stats_details(&mut details, &config.codex_home);
     standalone_release_cache_details(&mut details);
@@ -2177,7 +2183,9 @@ async fn state_check(config: &Config) -> DoctorCheck {
     } else {
         CheckStatus::Fail
     };
-    let summary = if status == CheckStatus::Ok {
+    let summary = if !sqlite_enabled {
+        "state paths are inspectable; SQLite is disabled"
+    } else if status == CheckStatus::Ok {
         "state paths and databases are inspectable"
     } else {
         "state database integrity check failed"
@@ -3097,6 +3105,40 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use super::*;
+
+    #[tokio::test]
+    async fn state_check_skips_inactive_corrupt_sqlite_database() {
+        let codex_home = tempfile::tempdir().expect("create temp dir");
+        let mut config = ConfigBuilder::default()
+            .codex_home(codex_home.path().to_path_buf())
+            .build()
+            .await
+            .expect("config");
+        config
+            .features
+            .disable(codex_features::Feature::Sqlite)
+            .expect("disable sqlite");
+        std::fs::write(
+            codex_state::state_db_path(config.sqlite_home.as_path()),
+            "not a sqlite database",
+        )
+        .expect("write corrupt database");
+
+        let check = state_check(&config).await;
+
+        assert_eq!(check.status, CheckStatus::Ok);
+        assert_eq!(
+            check.summary,
+            "state paths are inspectable; SQLite is disabled"
+        );
+        assert_eq!(check.remediation, None);
+        assert!(
+            check
+                .details
+                .iter()
+                .any(|detail| detail == "state DB integrity: skipped (SQLite disabled)")
+        );
+    }
 
     #[derive(Default)]
     struct RecordingProgress {

--- a/codex-rs/cli/src/doctor/thread_inventory.rs
+++ b/codex-rs/cli/src/doctor/thread_inventory.rs
@@ -82,6 +82,16 @@ impl RolloutScan {
 }
 
 pub(super) async fn thread_inventory_check(config: &Config) -> DoctorCheck {
+    if !config.features.enabled(codex_features::Feature::Sqlite) {
+        return DoctorCheck::new(
+            CHECK_ID,
+            CHECK_CATEGORY,
+            CheckStatus::Ok,
+            "state database is disabled",
+        )
+        .details(vec!["rollout/state DB parity check skipped".to_string()]);
+    }
+
     thread_inventory_check_for_roots(
         config.codex_home.as_path(),
         config.sqlite_home.as_path(),
@@ -677,6 +687,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use codex_core::config::ConfigBuilder;
+    use codex_features::Feature;
     use codex_protocol::ThreadId;
     use codex_protocol::protocol::RolloutItem;
     use codex_protocol::protocol::RolloutLine;
@@ -684,6 +696,26 @@ mod tests {
     use sqlx::sqlite::SqliteConnectOptions;
     use sqlx::sqlite::SqlitePoolOptions;
     use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn thread_inventory_check_skips_intentionally_disabled_database() {
+        let codex_home = TempDir::new().expect("codex home");
+        let mut config = ConfigBuilder::default()
+            .codex_home(codex_home.path().to_path_buf())
+            .build()
+            .await
+            .expect("config");
+        config
+            .features
+            .disable(Feature::Sqlite)
+            .expect("disable sqlite");
+
+        let check = thread_inventory_check(&config).await;
+
+        assert_eq!(check.status, CheckStatus::Ok);
+        assert_eq!(check.summary, "state database is disabled");
+        assert!(check.issues.is_empty());
+    }
 
     #[tokio::test]
     async fn thread_inventory_check_ok_when_rollouts_match_db() {

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -2025,6 +2025,13 @@ async fn run_debug_clear_memories_command(
         .cli_overrides(cli_kv_overrides)
         .build()
         .await?;
+    clear_memories_for_config(&config).await
+}
+
+async fn clear_memories_for_config(config: &codex_core::config::Config) -> anyhow::Result<()> {
+    if !config.features.enabled(codex_features::Feature::Sqlite) {
+        anyhow::bail!("`codex debug clear-memories` requires SQLite, which is disabled");
+    }
 
     let memories_path = memories_db_path(config.sqlite_home.as_path());
     let cleared_memories_db =
@@ -2500,6 +2507,37 @@ mod tests {
     use codex_protocol::ThreadId;
     use codex_tui::TokenUsage;
     use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn clear_memories_rejects_disabled_sqlite_without_mutating_state() -> anyhow::Result<()> {
+        let codex_home = TempDir::new()?;
+        let mut config = ConfigBuilder::default()
+            .codex_home(codex_home.path().to_path_buf())
+            .loader_overrides(LoaderOverrides::without_managed_config_for_tests())
+            .build()
+            .await?;
+        config.sqlite_home = codex_home.path().to_path_buf();
+        config.features.disable(codex_features::Feature::Sqlite)?;
+        let memory_root = codex_home.path().join("memories");
+        let memory_file = memory_root.join("memory_summary.md");
+        std::fs::create_dir_all(&memory_root)?;
+        std::fs::write(&memory_file, "keep me")?;
+
+        let error = clear_memories_for_config(&config)
+            .await
+            .expect_err("disabled SQLite should reject the command");
+
+        assert_eq!(
+            error.to_string(),
+            "`codex debug clear-memories` requires SQLite, which is disabled"
+        );
+        assert_eq!(std::fs::read_to_string(memory_file)?, "keep me");
+        for db in codex_state::runtime_db_paths(config.sqlite_home.as_path()) {
+            assert!(!db.path.exists(), "{} should not exist", db.label);
+        }
+        Ok(())
+    }
 
     #[test]
     fn exec_server_remote_auth_accepts_api_key_auth() {

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -3073,6 +3073,9 @@ impl Config {
             feature_requirements,
             &mut startup_warnings,
         )?;
+        if !features.enabled(Feature::Sqlite) {
+            startup_warnings.push("SQLite is disabled. Codex is running in degraded mode; SQLite-dependent features and operations are unavailable. Changes to this setting require restarting Codex.".to_string());
+        }
         let respect_system_proxy = features.enabled(Feature::RespectSystemProxy);
         let enable_network_proxy = features.enabled(Feature::NetworkProxy);
         let configured_windows_sandbox_mode = resolve_windows_sandbox_mode(&cfg);

--- a/codex-rs/core/src/state_db_bridge.rs
+++ b/codex-rs/core/src/state_db_bridge.rs
@@ -4,5 +4,32 @@ pub use codex_rollout::state_db::StateDbHandle;
 use crate::config::Config;
 
 pub async fn init_state_db(config: &Config) -> Option<StateDbHandle> {
+    if !config.features.enabled(codex_features::Feature::Sqlite) {
+        return None;
+    }
     rollout_state_db::init(config).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ConfigBuilder;
+    use codex_features::Feature;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn sqlite_disabled_skips_state_db_initialization() -> anyhow::Result<()> {
+        let codex_home = TempDir::new()?;
+        let mut config = ConfigBuilder::default()
+            .codex_home(codex_home.path().to_path_buf())
+            .build()
+            .await?;
+        config.features.disable(Feature::Sqlite)?;
+
+        assert!(init_state_db(&config).await.is_none());
+        for db in codex_state::runtime_db_paths(config.sqlite_home.as_path()) {
+            assert!(!db.path.exists(), "{} should not exist", db.label);
+        }
+        Ok(())
+    }
 }

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -549,6 +549,11 @@ impl Features {
     }
 
     pub fn normalize_dependencies(&mut self) {
+        if !self.enabled(Feature::Sqlite) {
+            // Keep every feature that cannot operate without SQLite in this block.
+            self.disable(Feature::Goals);
+            self.disable(Feature::SpawnCsv);
+        }
         if self.enabled(Feature::SpawnCsv) && !self.enabled(Feature::Collab) {
             self.enable(Feature::Collab);
         }
@@ -919,7 +924,7 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::Sqlite,
         key: "sqlite",
-        stage: Stage::Removed,
+        stage: Stage::Stable,
         default_enabled: true,
     },
     FeatureSpec {

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -48,6 +48,20 @@ fn use_legacy_landlock_is_deprecated_and_disabled_by_default() {
 }
 
 #[test]
+fn sqlite_is_stable_enabled_by_default_and_configurable() {
+    assert_eq!(Feature::Sqlite.stage(), Stage::Stable);
+    assert_eq!(Feature::Sqlite.default_enabled(), true);
+
+    let mut features = Features::with_defaults();
+    features.enable(Feature::SpawnCsv);
+    features.apply_map(&BTreeMap::from([("sqlite".to_string(), false)]));
+    features.normalize_dependencies();
+    assert_eq!(features.enabled(Feature::Sqlite), false);
+    assert_eq!(features.enabled(Feature::Goals), false);
+    assert_eq!(features.enabled(Feature::SpawnCsv), false);
+}
+
+#[test]
 fn use_linux_sandbox_bwrap_is_removed_and_disabled_by_default() {
     assert_eq!(Feature::UseLinuxSandboxBwrap.stage(), Stage::Removed);
     assert_eq!(Feature::UseLinuxSandboxBwrap.default_enabled(), false);

--- a/codex-rs/thread-store/src/local/list_threads.rs
+++ b/codex-rs/thread-store/src/local/list_threads.rs
@@ -142,8 +142,8 @@ pub(super) async fn list_rollout_threads(
             params.search_term.as_deref(),
         )
         .await
-        .ok_or_else(|| ThreadStoreError::Internal {
-            message: "state DB unavailable for relationship-filtered thread listing".to_string(),
+        .ok_or_else(|| ThreadStoreError::InvalidRequest {
+            message: "SQLite state DB unavailable for thread relationship filters".to_string(),
         })?;
         return Ok(page.into());
     }

--- a/codex-rs/thread-store/src/local/update_thread_metadata.rs
+++ b/codex-rs/thread-store/src/local/update_thread_metadata.rs
@@ -54,6 +54,13 @@ pub(super) async fn update_thread_metadata(
         .await;
     }
 
+    let require_sqlite_write = sqlite_write_failure_should_block(&patch);
+    if require_sqlite_write && store.state_db().await.is_none() {
+        return Err(ThreadStoreError::InvalidRequest {
+            message: "SQLite state DB unavailable for thread metadata updates".to_string(),
+        });
+    }
+
     let needs_rollout_compat = needs_rollout_compatibility_update(&patch);
     if needs_rollout_compat {
         // These explicit patches still write legacy rollout/name-index state after the
@@ -69,7 +76,6 @@ pub(super) async fn update_thread_metadata(
         .await?;
         reject_paginated_history_mode(thread.history_mode)?;
     }
-    let require_sqlite_write = sqlite_write_failure_should_block(&patch);
     let updated = apply_metadata_update(
         store,
         thread_id,

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -282,6 +282,10 @@ async fn init_state_db_for_app_server_target(
     config: &Config,
     app_server_target: &AppServerTarget,
 ) -> std::io::Result<Option<StateDbHandle>> {
+    if !config.features.enabled(codex_features::Feature::Sqlite) {
+        return Ok(None);
+    }
+
     match app_server_target {
         AppServerTarget::Embedded => state_db::try_init(config).await.map(Some).map_err(|err| {
             let database_path = codex_state::runtime_db_path_for_corruption_error(&err)
@@ -814,6 +818,17 @@ fn app_server_target_for_launch(
     }
 }
 
+fn app_server_target_for_effective_sqlite_setting(
+    target: AppServerTarget,
+    sqlite_enabled: bool,
+) -> AppServerTarget {
+    // An implicitly reused daemon cannot adopt this invocation's effective feature set.
+    match target {
+        AppServerTarget::LocalDaemon { .. } if !sqlite_enabled => AppServerTarget::Embedded,
+        target => target,
+    }
+}
+
 fn loader_overrides_are_default(loader_overrides: &LoaderOverrides) -> bool {
     let loader_overrides_are_default = loader_overrides.user_config_path.is_none()
         && loader_overrides.user_config_profile.is_none()
@@ -1067,6 +1082,10 @@ pub async fn run_main(
         strict_config,
     )
     .await;
+    let app_server_target = app_server_target_for_effective_sqlite_setting(
+        app_server_target,
+        config.features.enabled(codex_features::Feature::Sqlite),
+    );
 
     remove_legacy_tui_log_file(config.codex_home.as_path());
 
@@ -2320,6 +2339,44 @@ mod tests {
     }
 
     #[test]
+    fn sqlite_disabled_does_not_reuse_implicit_local_daemon() -> color_eyre::Result<()> {
+        let local_endpoint = RemoteAppServerEndpoint::UnixSocket {
+            socket_path: AbsolutePathBuf::relative_to_current_dir("local.sock")?,
+        };
+        let local_target = AppServerTarget::LocalDaemon {
+            endpoint: local_endpoint,
+        };
+        assert_eq!(
+            app_server_target_for_effective_sqlite_setting(
+                local_target.clone(),
+                /*sqlite_enabled*/ false,
+            ),
+            AppServerTarget::Embedded
+        );
+        assert_eq!(
+            app_server_target_for_effective_sqlite_setting(
+                local_target.clone(),
+                /*sqlite_enabled*/ true,
+            ),
+            local_target
+        );
+
+        let remote_target = AppServerTarget::Remote {
+            endpoint: RemoteAppServerEndpoint::UnixSocket {
+                socket_path: AbsolutePathBuf::relative_to_current_dir("remote.sock")?,
+            },
+        };
+        assert_eq!(
+            app_server_target_for_effective_sqlite_setting(
+                remote_target.clone(),
+                /*sqlite_enabled*/ false,
+            ),
+            remote_target
+        );
+        Ok(())
+    }
+
+    #[test]
     fn can_reuse_implicit_local_daemon_requires_default_launch_config() -> color_eyre::Result<()> {
         let mut loader_overrides = LoaderOverrides::default();
         let cli_kv_overrides = vec![("web_search".to_string(), toml::Value::String("live".into()))];
@@ -2913,6 +2970,23 @@ mod tests {
                 .contains("failed to initialize state runtime"),
             "startup error should preserve the underlying state db failure"
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn embedded_state_db_can_be_explicitly_disabled() -> color_eyre::Result<()> {
+        let temp_dir = TempDir::new()?;
+        let mut config = build_config(&temp_dir).await?;
+        config.features.disable(codex_features::Feature::Sqlite)?;
+        let occupied_sqlite_home = temp_dir.path().join("sqlite-home");
+        std::fs::write(&occupied_sqlite_home, "occupied")?;
+        config.sqlite_home = occupied_sqlite_home.clone();
+
+        let state_db =
+            init_state_db_for_app_server_target(&config, &AppServerTarget::Embedded).await?;
+
+        assert!(state_db.is_none());
+        assert_eq!(std::fs::read_to_string(occupied_sqlite_home)?, "occupied");
         Ok(())
     }
 

--- a/codex-rs/tui/src/session_archive_commands.rs
+++ b/codex-rs/tui/src/session_archive_commands.rs
@@ -384,6 +384,10 @@ async fn start_app_server_for_archive_command(
         .build()
         .await
         .wrap_err("failed to load configuration")?;
+    let app_server_target = super::app_server_target_for_effective_sqlite_setting(
+        app_server_target,
+        config.features.enabled(codex_features::Feature::Sqlite),
+    );
     let state_db = super::init_state_db_for_app_server_target(&config, &app_server_target)
         .await
         .wrap_err("failed to initialize state database")?;


### PR DESCRIPTION
## Summary

- Restore `[features] sqlite = false` as a supported escape hatch for environments where the local state database cannot be used safely, such as a Codex home on NFS.
- Treat SQLite selection as startup behavior. Changing `features.sqlite` requires restarting Codex; live toggling is not supported.
- Skip state-database initialization, recovery, and doctor integrity/parity checks when SQLite is disabled, and avoid reusing an implicit local daemon that cannot inherit the invocation's effective feature set.
- Disable SQLite-dependent features (`goals` and `spawn_csv`) and return explicit degraded-mode responses for database-only operations. Import-history reads return an empty list when no state DB exists.
- Keep backend-support checks at the store boundary rather than duplicating feature checks in request processors.
- Emit a startup configuration warning when SQLite is disabled, including the restart requirement.

## Root cause and impact

The `sqlite` feature was marked as removed, so `sqlite = false` was no longer an effective opt-out even though newer startup and request paths initialize and depend on the state DB. Users whose Codex state lives on filesystems with unreliable SQLite locking could therefore no longer prevent Codex from opening the database.

This change makes the flag stable and configurable again while preserving the existing default of `true`. It does **not** make SQLite safe over NFS; it provides an intentional degraded mode. In that mode, SQLite-dependent features and operations are unavailable. Explicit remote app-server targets are unchanged; only implicit local-daemon reuse falls back to the embedded server.

The database runtime is initialized once per process. Changes to `features.sqlite` take effect after restarting Codex; changing it in a running process is unsupported.

## Test plan

- Added feature-normalization coverage for SQLite-dependent features.
- Added core, TUI, CLI, and app-server coverage verifying disabled mode does not create or mutate runtime databases.
- Added API coverage for memory reset, thread metadata updates, relationship filters, and import-history reads when the state DB is unavailable.
- Added initialization coverage for the SQLite-disabled degraded-mode and restart warning.
- Verified existing enabled-mode memory clearing and request behavior still work.
- Rebased onto current `origin/main` and ran:
  - `RUST_MIN_STACK=16777216 cargo check -p codex-features -p codex-core -p codex-thread-store -p codex-app-server -p codex-tui -p codex-exec --tests`
  - `cargo check -p codex-core -p codex-cli -p codex-app-server --tests`
  - `cargo test -p codex-features sqlite_is_stable_enabled_by_default_and_configurable`
  - `cargo test -p codex-core --lib rebuild_preserving_session_layers`
  - `cargo test -p codex-cli state_check_skips_inactive_corrupt_sqlite_database`
  - `cargo test -p codex-app-server --test all sqlite_disabled`
  - `cargo test -p codex-app-server --test all external_agent_config_import_histories_are_empty_when_sqlite_is_disabled`
  - `cargo test -p codex-tui sqlite`
  - `cargo test -p codex-tui embedded_state_db_can_be_explicitly_disabled`
  - `cargo fmt --all -- --check`
  - `git diff --check`
