### PR TITLE
chore(protocol): use UUIDv7 for generated item IDs

### DIFF
--- a/codex-rs/protocol/src/items.rs
+++ b/codex-rs/protocol/src/items.rs
@@ -378,11 +378,13 @@ pub struct ContextCompactionItem {
     pub id: String,
 }
 
+fn new_item_id() -> String {
+    uuid::Uuid::now_v7().to_string()
+}
+
 impl ContextCompactionItem {
     pub fn new() -> Self {
-        Self {
-            id: uuid::Uuid::now_v7().to_string(),
-        }
+        Self { id: new_item_id() }
     }
 }
 
@@ -395,7 +397,7 @@ impl Default for ContextCompactionItem {
 impl UserMessageItem {
     pub fn new(content: &[UserInput]) -> Self {
         Self {
-            id: uuid::Uuid::now_v7().to_string(),
+            id: new_item_id(),
             client_id: None,
             content: content.to_vec(),
         }
@@ -497,9 +499,7 @@ fn trim_trailing_default_image_details(
 impl HookPromptItem {
     pub fn from_fragments(id: Option<&String>, fragments: Vec<HookPromptFragment>) -> Self {
         Self {
-            id: id
-                .cloned()
-                .unwrap_or_else(|| uuid::Uuid::now_v7().to_string()),
+            id: id.cloned().unwrap_or_else(new_item_id),
             fragments,
         }
     }
@@ -529,7 +529,7 @@ pub fn build_hook_prompt_message(fragments: &[HookPromptFragment]) -> Option<Res
     }
 
     Some(ResponseItem::Message {
-        id: Some(uuid::Uuid::now_v7().to_string()),
+        id: Some(new_item_id()),
         role: "user".to_string(),
         content,
         phase: None,
@@ -582,7 +582,7 @@ fn serialize_hook_prompt_fragment(text: &str, hook_run_id: &str) -> Option<Strin
 impl AgentMessageItem {
     pub fn new(content: &[AgentMessageContent]) -> Self {
         Self {
-            id: uuid::Uuid::now_v7().to_string(),
+            id: new_item_id(),
             content: content.to_vec(),
             phase: None,
             memory_citation: None,

--- a/codex-rs/protocol/src/items.rs
+++ b/codex-rs/protocol/src/items.rs
@@ -381,7 +381,7 @@ pub struct ContextCompactionItem {
 impl ContextCompactionItem {
     pub fn new() -> Self {
         Self {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: uuid::Uuid::now_v7().to_string(),
         }
     }
 }
@@ -395,7 +395,7 @@ impl Default for ContextCompactionItem {
 impl UserMessageItem {
     pub fn new(content: &[UserInput]) -> Self {
         Self {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: uuid::Uuid::now_v7().to_string(),
             client_id: None,
             content: content.to_vec(),
         }
@@ -499,7 +499,7 @@ impl HookPromptItem {
         Self {
             id: id
                 .cloned()
-                .unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),
+                .unwrap_or_else(|| uuid::Uuid::now_v7().to_string()),
             fragments,
         }
     }
@@ -529,7 +529,7 @@ pub fn build_hook_prompt_message(fragments: &[HookPromptFragment]) -> Option<Res
     }
 
     Some(ResponseItem::Message {
-        id: Some(uuid::Uuid::new_v4().to_string()),
+        id: Some(uuid::Uuid::now_v7().to_string()),
         role: "user".to_string(),
         content,
         phase: None,
@@ -582,7 +582,7 @@ fn serialize_hook_prompt_fragment(text: &str, hook_run_id: &str) -> Option<Strin
 impl AgentMessageItem {
     pub fn new(content: &[AgentMessageContent]) -> Self {
         Self {
-            id: uuid::Uuid::new_v4().to_string(),
+            id: uuid::Uuid::now_v7().to_string(),
             content: content.to_vec(),
             phase: None,
             memory_citation: None,


### PR DESCRIPTION
## Description

Use UUIDv7 for item IDs generated locally in `codex-protocol`.

This covers user messages, agent messages, hook prompts, and context compaction items. These IDs are generated once and carried through item lifecycle, so this only changes the UUID version. It keeps generated item IDs consistent with thread and turn IDs.