### PR TITLE
core: add pre-rollover auto-compaction fallback

### DIFF
--- a/codex-rs/app-server/src/extensions.rs
+++ b/codex-rs/app-server/src/extensions.rs
@@ -115,7 +115,7 @@ struct AutoCompactFallbackPrompt(Option<String>);
 impl AutoCompactFallbackPromptExtension {
     fn store(thread_store: &ExtensionData, config: &Config) {
         thread_store.insert(AutoCompactFallbackPrompt(
-            config.auto_compact_fallback_prompt.clone(),
+            config.auto_compact_fallback.prompt.clone(),
         ));
     }
 }

--- a/codex-rs/app-server/src/extensions.rs
+++ b/codex-rs/app-server/src/extensions.rs
@@ -12,9 +12,16 @@ use codex_core::config::Config;
 use codex_exec_server::EnvironmentManager;
 use codex_extension_api::AgentSpawnFuture;
 use codex_extension_api::AgentSpawner;
+use codex_extension_api::AutoCompactFallbackContributionInput;
+use codex_extension_api::ConfigContributor;
+use codex_extension_api::ContextContributor;
+use codex_extension_api::ExtensionData;
 use codex_extension_api::ExtensionEventSink;
+use codex_extension_api::ExtensionFuture;
 use codex_extension_api::ExtensionRegistry;
 use codex_extension_api::ExtensionRegistryBuilder;
+use codex_extension_api::ThreadLifecycleContributor;
+use codex_extension_api::ThreadStartInput;
 use codex_goal_extension::GoalService;
 use codex_login::AuthManager;
 use codex_protocol::ThreadId;
@@ -60,6 +67,10 @@ where
         thread_store: _thread_store,
     } = dependencies;
     let mut builder = ExtensionRegistryBuilder::<Config>::with_event_sink(event_sink);
+    let auto_compact_fallback_prompt = Arc::new(AutoCompactFallbackPromptExtension);
+    builder.thread_lifecycle_contributor(auto_compact_fallback_prompt.clone());
+    builder.config_contributor(auto_compact_fallback_prompt.clone());
+    builder.prompt_contributor(auto_compact_fallback_prompt);
     if let Some(state_db) = state_db {
         codex_goal_extension::install_with_backend(
             &mut builder,
@@ -94,6 +105,56 @@ where
         },
     );
     Arc::new(builder.build())
+}
+
+struct AutoCompactFallbackPromptExtension;
+
+#[derive(Clone)]
+struct AutoCompactFallbackPrompt(Option<String>);
+
+impl AutoCompactFallbackPromptExtension {
+    fn store(thread_store: &ExtensionData, config: &Config) {
+        thread_store.insert(AutoCompactFallbackPrompt(
+            config.auto_compact_fallback_prompt.clone(),
+        ));
+    }
+}
+
+impl ThreadLifecycleContributor<Config> for AutoCompactFallbackPromptExtension {
+    fn on_thread_start<'a>(
+        &'a self,
+        input: ThreadStartInput<'a, Config>,
+    ) -> ExtensionFuture<'a, ()> {
+        Box::pin(async move {
+            Self::store(input.thread_store, input.config);
+        })
+    }
+}
+
+impl ConfigContributor<Config> for AutoCompactFallbackPromptExtension {
+    fn on_config_changed(
+        &self,
+        _session_store: &ExtensionData,
+        thread_store: &ExtensionData,
+        _previous_config: &Config,
+        new_config: &Config,
+    ) {
+        Self::store(thread_store, new_config);
+    }
+}
+
+impl ContextContributor for AutoCompactFallbackPromptExtension {
+    fn contribute_auto_compact_fallback_prompt<'a>(
+        &'a self,
+        input: AutoCompactFallbackContributionInput<'a>,
+    ) -> ExtensionFuture<'a, Option<String>> {
+        Box::pin(async move {
+            input
+                .thread_store
+                .get::<AutoCompactFallbackPrompt>()
+                .and_then(|prompt| prompt.0.clone())
+        })
+    }
 }
 
 pub(crate) fn app_server_extension_event_sink(

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "256"]
+
 use clap::Args;
 use clap::CommandFactory;
 use clap::Parser;

--- a/codex-rs/config/src/config_toml.rs
+++ b/codex-rs/config/src/config_toml.rs
@@ -243,10 +243,6 @@ pub struct ConfigToml {
     /// Compact prompt used for history compaction.
     pub compact_prompt: Option<String>,
 
-    /// Developer message contributed by the app-server extension for the single
-    /// fallback turn before an automatic compaction rollover.
-    pub auto_compact_fallback_prompt: Option<String>,
-
     /// When set, restricts ChatGPT login to one or more workspace identifiers.
     #[serde(default)]
     pub forced_chatgpt_workspace_id: Option<ForcedChatgptWorkspaceIds>,

--- a/codex-rs/config/src/config_toml.rs
+++ b/codex-rs/config/src/config_toml.rs
@@ -243,6 +243,10 @@ pub struct ConfigToml {
     /// Compact prompt used for history compaction.
     pub compact_prompt: Option<String>,
 
+    /// Developer message contributed by the app-server extension for the single
+    /// best-effort turn before an automatic compaction rollover.
+    pub auto_compact_fallback_prompt: Option<String>,
+
     /// When set, restricts ChatGPT login to one or more workspace identifiers.
     #[serde(default)]
     pub forced_chatgpt_workspace_id: Option<ForcedChatgptWorkspaceIds>,

--- a/codex-rs/config/src/config_toml.rs
+++ b/codex-rs/config/src/config_toml.rs
@@ -244,7 +244,7 @@ pub struct ConfigToml {
     pub compact_prompt: Option<String>,
 
     /// Developer message contributed by the app-server extension for the single
-    /// best-effort turn before an automatic compaction rollover.
+    /// fallback turn before an automatic compaction rollover.
     pub auto_compact_fallback_prompt: Option<String>,
 
     /// When set, restricts ChatGPT login to one or more workspace identifiers.

--- a/codex-rs/config/src/schema.rs
+++ b/codex-rs/config/src/schema.rs
@@ -53,6 +53,15 @@ pub fn features_schema(schema_gen: &mut SchemaGenerator) -> Schema {
             );
             continue;
         }
+        if feature.id == codex_features::Feature::AutoCompactFallback {
+            validation.properties.insert(
+                feature.key.to_string(),
+                schema_gen.subschema_for::<codex_features::FeatureToml<
+                    codex_features::AutoCompactFallbackConfigToml,
+                >>(),
+            );
+            continue;
+        }
         if feature.id == codex_features::Feature::RolloutBudget {
             validation.properties.insert(
                 feature.key.to_string(),

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -4669,7 +4669,7 @@
       "description": "Machine-local realtime audio device preferences used by realtime voice."
     },
     "auto_compact_fallback_prompt": {
-      "description": "Developer message contributed by the app-server extension for the single best-effort turn before an automatic compaction rollover.",
+      "description": "Developer message contributed by the app-server extension for the single fallback turn before an automatic compaction rollover.",
       "type": "string"
     },
     "auto_review": {

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -315,6 +315,19 @@
         }
       ]
     },
+    "AutoCompactFallbackConfigToml": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "prompt": {
+          "description": "Developer message contributed for the single fallback turn before an automatic compaction rollover.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "AutoCompactTokenLimitScope": {
       "description": "Selects which part of the active context is charged against `model_auto_compact_token_limit`.",
       "oneOf": [
@@ -435,7 +448,7 @@
               "type": "boolean"
             },
             "auto_compact_fallback": {
-              "type": "boolean"
+              "$ref": "#/definitions/FeatureToml_for_AutoCompactFallbackConfigToml"
             },
             "browser_use": {
               "type": "boolean"
@@ -945,6 +958,16 @@
         }
       },
       "type": "object"
+    },
+    "FeatureToml_for_AutoCompactFallbackConfigToml": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/AutoCompactFallbackConfigToml"
+        }
+      ]
     },
     "FeatureToml_for_CodeModeConfigToml": {
       "anyOf": [
@@ -4668,10 +4691,6 @@
       "default": null,
       "description": "Machine-local realtime audio device preferences used by realtime voice."
     },
-    "auto_compact_fallback_prompt": {
-      "description": "Developer message contributed by the app-server extension for the single fallback turn before an automatic compaction rollover.",
-      "type": "string"
-    },
     "auto_review": {
       "allOf": [
         {
@@ -4814,7 +4833,7 @@
           "type": "boolean"
         },
         "auto_compact_fallback": {
-          "type": "boolean"
+          "$ref": "#/definitions/FeatureToml_for_AutoCompactFallbackConfigToml"
         },
         "browser_use": {
           "type": "boolean"

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -434,6 +434,9 @@
             "auth_elicitation": {
               "type": "boolean"
             },
+            "auto_compact_fallback": {
+              "type": "boolean"
+            },
             "browser_use": {
               "type": "boolean"
             },
@@ -4665,6 +4668,10 @@
       "default": null,
       "description": "Machine-local realtime audio device preferences used by realtime voice."
     },
+    "auto_compact_fallback_prompt": {
+      "description": "Developer message contributed by the app-server extension for the single best-effort turn before an automatic compaction rollover.",
+      "type": "string"
+    },
     "auto_review": {
       "allOf": [
         {
@@ -4804,6 +4811,9 @@
           ]
         },
         "auth_elicitation": {
+          "type": "boolean"
+        },
+        "auto_compact_fallback": {
           "type": "boolean"
         },
         "browser_use": {

--- a/codex-rs/core/src/auto_compact_fallback.rs
+++ b/codex-rs/core/src/auto_compact_fallback.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use codex_extension_api::AutoCompactFallbackContributionInput;
 use codex_features::Feature;
 use codex_mcp::McpConnectionManager;
+use codex_protocol::error::Result as CodexResult;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
-use tracing::warn;
 
 use crate::client::ModelClientSession;
 use crate::context_manager::updates::build_developer_update_item;
@@ -16,8 +16,8 @@ use crate::session::turn::SamplingRequestOptions;
 use crate::session::turn::run_sampling_request;
 use crate::turn_diff_tracker::TurnDiffTracker;
 
-/// Runs the optional, extension-configured best-effort turn immediately before an automatic
-/// compaction rollover. The response is sampled exactly once; tool follow-up inference is ignored.
+/// Runs the optional, extension-configured turn immediately before an automatic compaction
+/// rollover. Tool follow-up inference is ignored.
 ///
 /// The returned step refreshes request-scoped world state after any fallback tool side effects while
 /// retaining the model that successfully performed compaction.
@@ -25,14 +25,14 @@ pub(crate) async fn run_auto_compact_fallback(
     sess: &Arc<Session>,
     step_context: &Arc<StepContext>,
     client_session: &mut ModelClientSession,
-) -> Option<Arc<StepContext>> {
+) -> CodexResult<Option<Arc<StepContext>>> {
     let turn_context = &step_context.turn;
     if !turn_context
         .config
         .features
         .enabled(Feature::AutoCompactFallback)
     {
-        return None;
+        return Ok(None);
     }
 
     let mut prompt_sections = Vec::new();
@@ -54,7 +54,7 @@ pub(crate) async fn run_auto_compact_fallback(
     }
 
     let Some(developer_message) = build_developer_update_item(prompt_sections) else {
-        return None;
+        return Ok(None);
     };
     sess.record_conversation_items(turn_context, std::slice::from_ref(&developer_message))
         .await;
@@ -79,7 +79,7 @@ pub(crate) async fn run_auto_compact_fallback(
         .unwrap_or_else(CancellationToken::new);
 
     let _elicitation_guard = McpElicitationAutoDenyGuard::new(restricted_step.mcp.manager_arc());
-    if let Err(err) = run_sampling_request(
+    run_sampling_request(
         Arc::clone(sess),
         restricted_step,
         Arc::clone(&restricted_turn.extension_data),
@@ -90,12 +90,11 @@ pub(crate) async fn run_auto_compact_fallback(
         SamplingRequestOptions::auto_compact_fallback(),
         cancellation_token,
     )
-    .await
-    {
-        warn!(error = %err, "auto-compaction fallback turn failed; continuing rollover");
-    }
+    .await?;
 
-    Some(sess.capture_step_context(Arc::clone(turn_context)).await)
+    Ok(Some(
+        sess.capture_step_context(Arc::clone(turn_context)).await,
+    ))
 }
 
 struct McpElicitationAutoDenyGuard {

--- a/codex-rs/core/src/auto_compact_fallback.rs
+++ b/codex-rs/core/src/auto_compact_fallback.rs
@@ -1,0 +1,118 @@
+use std::sync::Arc;
+
+use codex_extension_api::AutoCompactFallbackContributionInput;
+use codex_features::Feature;
+use codex_mcp::McpConnectionManager;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+use tracing::warn;
+
+use crate::client::ModelClientSession;
+use crate::context_manager::updates::build_developer_update_item;
+use crate::responses_metadata::CodexResponsesRequestKind;
+use crate::session::session::Session;
+use crate::session::step_context::StepContext;
+use crate::session::turn::SamplingRequestOptions;
+use crate::session::turn::run_sampling_request;
+use crate::turn_diff_tracker::TurnDiffTracker;
+
+/// Runs the optional, extension-configured best-effort turn immediately before an automatic
+/// compaction rollover. The response is sampled exactly once; tool follow-up inference is ignored.
+///
+/// The returned step refreshes request-scoped world state after any fallback tool side effects while
+/// retaining the model that successfully performed compaction.
+pub(crate) async fn run_auto_compact_fallback(
+    sess: &Arc<Session>,
+    step_context: &Arc<StepContext>,
+    client_session: &mut ModelClientSession,
+) -> Option<Arc<StepContext>> {
+    let turn_context = &step_context.turn;
+    if !turn_context
+        .config
+        .features
+        .enabled(Feature::AutoCompactFallback)
+    {
+        return None;
+    }
+
+    let mut prompt_sections = Vec::new();
+    for contributor in sess.services.extensions.context_contributors() {
+        if let Some(section) = contributor
+            .contribute_auto_compact_fallback_prompt(AutoCompactFallbackContributionInput {
+                thread_id: sess.thread_id(),
+                turn_id: turn_context.sub_id.as_str(),
+                session_store: &sess.services.session_extension_data,
+                thread_store: &sess.services.thread_extension_data,
+                turn_store: turn_context.extension_data.as_ref(),
+                model_context_window: turn_context.model_context_window(),
+            })
+            .await
+            && !section.trim().is_empty()
+        {
+            prompt_sections.push(section);
+        }
+    }
+
+    let Some(developer_message) = build_developer_update_item(prompt_sections) else {
+        return None;
+    };
+    sess.record_conversation_items(turn_context, std::slice::from_ref(&developer_message))
+        .await;
+
+    let restricted_turn = Arc::new(turn_context.with_approvals_disabled());
+    let restricted_step = Arc::new(step_context.with_turn(Arc::clone(&restricted_turn)));
+    let window_id = sess.current_window_id().await;
+    let responses_metadata = restricted_turn.turn_metadata_state.to_responses_metadata(
+        sess.installation_id.clone(),
+        window_id,
+        CodexResponsesRequestKind::Turn,
+    );
+    let input = sess
+        .clone_history()
+        .await
+        .for_prompt(&restricted_turn.model_info.input_modalities);
+    let turn_diff_tracker = Arc::new(Mutex::new(TurnDiffTracker::new()));
+    let cancellation_token = sess
+        .active_turn_context_and_cancellation_token()
+        .await
+        .map(|(_, token)| token)
+        .unwrap_or_else(CancellationToken::new);
+
+    let _elicitation_guard = McpElicitationAutoDenyGuard::new(restricted_step.mcp.manager_arc());
+    if let Err(err) = run_sampling_request(
+        Arc::clone(sess),
+        restricted_step,
+        Arc::clone(&restricted_turn.extension_data),
+        turn_diff_tracker,
+        client_session,
+        &responses_metadata,
+        input,
+        SamplingRequestOptions::auto_compact_fallback(),
+        cancellation_token,
+    )
+    .await
+    {
+        warn!(error = %err, "auto-compaction fallback turn failed; continuing rollover");
+    }
+
+    Some(sess.capture_step_context(Arc::clone(turn_context)).await)
+}
+
+struct McpElicitationAutoDenyGuard {
+    manager: Arc<McpConnectionManager>,
+    previous: bool,
+}
+
+impl McpElicitationAutoDenyGuard {
+    fn new(manager: Arc<McpConnectionManager>) -> Self {
+        let previous = manager.elicitations_auto_deny();
+        manager.set_elicitations_auto_deny(true);
+        Self { manager, previous }
+    }
+}
+
+impl Drop for McpElicitationAutoDenyGuard {
+    fn drop(&mut self) {
+        self.manager.set_elicitations_auto_deny(self.previous);
+    }
+}

--- a/codex-rs/core/src/auto_compact_fallback.rs
+++ b/codex-rs/core/src/auto_compact_fallback.rs
@@ -65,7 +65,7 @@ pub(crate) async fn run_auto_compact_fallback(
     let responses_metadata = restricted_turn.turn_metadata_state.to_responses_metadata(
         sess.installation_id.clone(),
         window_id,
-        CodexResponsesRequestKind::Turn,
+        CodexResponsesRequestKind::AutoCompactFallback,
     );
     let input = sess
         .clone_history()

--- a/codex-rs/core/src/auto_compact_fallback.rs
+++ b/codex-rs/core/src/auto_compact_fallback.rs
@@ -17,7 +17,8 @@ use crate::session::turn::run_sampling_request;
 use crate::turn_diff_tracker::TurnDiffTracker;
 
 /// Runs the optional, extension-configured turn immediately before an automatic compaction
-/// rollover. Tool follow-up inference is ignored.
+/// rollover. Non-tool responses may continue sampling, but the first response containing a tool
+/// call is terminal for the fallback after its tool output is recorded.
 ///
 /// The returned step refreshes request-scoped world state after any fallback tool side effects while
 /// retaining the model that successfully performed compaction.
@@ -67,10 +68,6 @@ pub(crate) async fn run_auto_compact_fallback(
         window_id,
         CodexResponsesRequestKind::AutoCompactFallback,
     );
-    let input = sess
-        .clone_history()
-        .await
-        .for_prompt(&restricted_turn.model_info.input_modalities);
     let turn_diff_tracker = Arc::new(Mutex::new(TurnDiffTracker::new()));
     let cancellation_token = sess
         .active_turn_context_and_cancellation_token()
@@ -79,18 +76,28 @@ pub(crate) async fn run_auto_compact_fallback(
         .unwrap_or_else(CancellationToken::new);
 
     let _elicitation_guard = McpElicitationAutoDenyGuard::new(restricted_step.mcp.manager_arc());
-    run_sampling_request(
-        Arc::clone(sess),
-        restricted_step,
-        Arc::clone(&restricted_turn.extension_data),
-        turn_diff_tracker,
-        client_session,
-        &responses_metadata,
-        input,
-        SamplingRequestOptions::auto_compact_fallback(),
-        cancellation_token,
-    )
-    .await?;
+    loop {
+        let input = sess
+            .clone_history()
+            .await
+            .for_prompt(&restricted_turn.model_info.input_modalities);
+        let (result, _) = run_sampling_request(
+            Arc::clone(sess),
+            Arc::clone(&restricted_step),
+            Arc::clone(&restricted_turn.extension_data),
+            Arc::clone(&turn_diff_tracker),
+            client_session,
+            &responses_metadata,
+            input,
+            SamplingRequestOptions::auto_compact_fallback(),
+            cancellation_token.child_token(),
+        )
+        .await?;
+
+        if result.tool_call_emitted || !result.needs_follow_up {
+            break;
+        }
+    }
 
     Ok(Some(
         sess.capture_step_context(Arc::clone(turn_context)).await,

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use crate::Prompt;
+use crate::auto_compact_fallback::run_auto_compact_fallback;
 use crate::client::ModelClientSession;
 use crate::client_common::ResponseEvent;
 use crate::context::world_state::WorldState;
@@ -15,6 +16,7 @@ use crate::responses_metadata::CompactionTurnMetadata;
 #[cfg(test)]
 use crate::session::PreviousTurnSettings;
 use crate::session::session::Session;
+use crate::session::step_context::StepContext;
 use crate::session::turn::get_last_assistant_message_from_turn;
 use crate::session::turn_context::TurnContext;
 use crate::util::backoff;
@@ -90,11 +92,13 @@ pub(crate) fn should_use_remote_compact_task(provider: &ModelProviderInfo) -> bo
 
 pub(crate) async fn run_inline_auto_compact_task(
     sess: Arc<Session>,
-    turn_context: Arc<TurnContext>,
+    step_context: Arc<StepContext>,
+    client_session: &mut ModelClientSession,
     initial_context_injection: InitialContextInjection,
     reason: CompactionReason,
     phase: CompactionPhase,
 ) -> CodexResult<()> {
+    let turn_context = Arc::clone(&step_context.turn);
     let prompt = turn_context
         .config
         .compact_prompt
@@ -115,6 +119,8 @@ pub(crate) async fn run_inline_auto_compact_task(
         CompactionTrigger::Auto,
         reason,
         phase,
+        Some(&step_context),
+        Some(client_session),
     )
     .await?;
     Ok(())
@@ -141,6 +147,8 @@ pub(crate) async fn run_compact_task(
         CompactionTrigger::Manual,
         CompactionReason::UserRequested,
         CompactionPhase::StandaloneTurn,
+        None,
+        None,
     )
     .await?;
     Ok(())
@@ -154,6 +162,8 @@ async fn run_compact_task_inner(
     trigger: CompactionTrigger,
     reason: CompactionReason,
     phase: CompactionPhase,
+    auto_step_context: Option<&Arc<StepContext>>,
+    fallback_client_session: Option<&mut ModelClientSession>,
 ) -> CodexResult<()> {
     let compaction_metadata =
         CompactionTurnMetadata::new(trigger, reason, CompactionImplementation::Responses, phase);
@@ -188,6 +198,8 @@ async fn run_compact_task_inner(
         input,
         initial_context_injection,
         compaction_metadata,
+        auto_step_context,
+        fallback_client_session,
     )
     .await;
     let status = compaction_status_from_result(&result);
@@ -223,6 +235,8 @@ async fn run_compact_task_inner_impl(
     input: Vec<UserInput>,
     initial_context_injection: InitialContextInjection,
     compaction_metadata: CompactionTurnMetadata,
+    auto_step_context: Option<&Arc<StepContext>>,
+    fallback_client_session: Option<&mut ModelClientSession>,
 ) -> CodexResult<String> {
     let compaction_item = TurnItem::ContextCompaction(ContextCompactionItem::new());
     sess.emit_turn_item_started(&turn_context, &compaction_item)
@@ -331,7 +345,24 @@ async fn run_compact_task_inner_impl(
         // belongs to this compaction turn.
         summary_item.set_turn_id_if_missing(&turn_context.sub_id);
     }
-    let (window_number, window_ids) = sess.advance_auto_compact_window().await;
+
+    let fallback_step_context = match (auto_step_context, fallback_client_session) {
+        (Some(step_context), Some(client_session)) => {
+            run_auto_compact_fallback(&sess, step_context, client_session).await
+        }
+        _ => None,
+    };
+    let initial_context_injection = match fallback_step_context.as_ref() {
+        Some(step_context) => match initial_context_injection {
+            InitialContextInjection::BeforeLastUserMessage(_) => {
+                InitialContextInjection::BeforeLastUserMessage(Arc::new(
+                    sess.build_world_state_for_step(step_context).await,
+                ))
+            }
+            InitialContextInjection::DoNotInject => InitialContextInjection::DoNotInject,
+        },
+        None => initial_context_injection,
+    };
 
     let (initial_context, world_state_baseline) = build_compaction_initial_context(
         sess.as_ref(),
@@ -343,6 +374,7 @@ async fn run_compact_task_inner_impl(
         new_history =
             insert_initial_context_before_last_real_user_or_summary(new_history, initial_context);
     }
+    let (window_number, window_ids) = sess.advance_auto_compact_window().await;
     let reference_context_item = match initial_context_injection {
         InitialContextInjection::DoNotInject => None,
         InitialContextInjection::BeforeLastUserMessage(_) => {

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -348,7 +348,7 @@ async fn run_compact_task_inner_impl(
 
     let fallback_step_context = match (auto_step_context, fallback_client_session) {
         (Some(step_context), Some(client_session)) => {
-            run_auto_compact_fallback(&sess, step_context, client_session).await
+            run_auto_compact_fallback(&sess, step_context, client_session).await?
         }
         _ => None,
     };

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -267,7 +267,7 @@ async fn run_remote_compact_task_inner_impl(
     } = attempt;
     let fallback_step_context = match (compaction_metadata.trigger(), fallback_client_session) {
         (CompactionTrigger::Auto, Some(client_session)) => {
-            run_auto_compact_fallback(sess, &compaction_step_context, client_session).await
+            run_auto_compact_fallback(sess, &compaction_step_context, client_session).await?
         }
         _ => None,
     };

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -1,6 +1,8 @@
 use std::sync::Arc;
 use std::sync::OnceLock;
 
+use crate::auto_compact_fallback::run_auto_compact_fallback;
+use crate::client::ModelClientSession;
 use crate::compact::CompactionAnalyticsAttempt;
 use crate::compact::CompactionAnalyticsDetails;
 use crate::compact::InitialContextInjection;
@@ -47,11 +49,12 @@ pub(crate) async fn run_inline_remote_auto_compact_task(
     sess: Arc<Session>,
     step_context: Arc<StepContext>,
     fallback_step_context: Option<Arc<StepContext>>,
-    turn_state: Arc<OnceLock<String>>,
+    client_session: &mut ModelClientSession,
     initial_context_injection: InitialContextInjection,
     reason: CompactionReason,
     phase: CompactionPhase,
 ) -> CodexResult<()> {
+    let turn_state = client_session.turn_state();
     let compaction_metadata = CompactionTurnMetadata::new(
         CompactionTrigger::Auto,
         reason,
@@ -63,6 +66,7 @@ pub(crate) async fn run_inline_remote_auto_compact_task(
         &step_context,
         fallback_step_context.as_ref(),
         Some(turn_state),
+        Some(client_session),
         initial_context_injection,
         compaction_metadata,
     )
@@ -96,6 +100,7 @@ pub(crate) async fn run_remote_compact_task(
         &step_context,
         /*fallback_step_context*/ None,
         /*turn_state*/ None,
+        /*fallback_client_session*/ None,
         InitialContextInjection::DoNotInject,
         compaction_metadata,
     )
@@ -108,6 +113,7 @@ async fn run_remote_compact_task_inner(
     step_context: &Arc<StepContext>,
     fallback_step_context: Option<&Arc<StepContext>>,
     turn_state: Option<Arc<OnceLock<String>>>,
+    fallback_client_session: Option<&mut ModelClientSession>,
     initial_context_injection: InitialContextInjection,
     compaction_metadata: CompactionTurnMetadata,
 ) -> CodexResult<()> {
@@ -150,6 +156,7 @@ async fn run_remote_compact_task_inner(
         step_context,
         fallback_step_context,
         turn_state,
+        fallback_client_session,
         initial_context_injection,
         compaction_metadata,
         &mut analytics_details,
@@ -185,6 +192,7 @@ async fn run_remote_compact_task_inner_impl(
     step_context: &Arc<StepContext>,
     fallback_step_context: Option<&Arc<StepContext>>,
     turn_state: Option<Arc<OnceLock<String>>>,
+    fallback_client_session: Option<&mut ModelClientSession>,
     initial_context_injection: InitialContextInjection,
     compaction_metadata: CompactionTurnMetadata,
     analytics_details: &mut CompactionAnalyticsDetails,
@@ -212,8 +220,8 @@ async fn run_remote_compact_task_inner_impl(
         analytics_details,
     )
     .await;
-    let (attempt, compaction_turn_context) = match attempt {
-        Ok(attempt) => (attempt, turn_context),
+    let (attempt, compaction_step_context) = match attempt {
+        Ok(attempt) => (attempt, Arc::clone(step_context)),
         Err(error) => {
             let Some(fallback_step_context) = fallback_step_context else {
                 return Err(error);
@@ -247,16 +255,33 @@ async fn run_remote_compact_task_inner_impl(
                 fallback_result.as_ref().err(),
             );
             match fallback_result {
-                Ok(attempt) => (attempt, fallback_turn_context),
+                Ok(attempt) => (attempt, Arc::clone(fallback_step_context)),
                 Err(_) => return Err(error),
             }
         }
     };
+    let compaction_turn_context = &compaction_step_context.turn;
     let RemoteCompactAttempt {
         new_history,
         trace_input_history,
     } = attempt;
-    let (new_window_number, new_window_ids) = sess.advance_auto_compact_window().await;
+    let fallback_step_context = match (compaction_metadata.trigger(), fallback_client_session) {
+        (CompactionTrigger::Auto, Some(client_session)) => {
+            run_auto_compact_fallback(sess, &compaction_step_context, client_session).await
+        }
+        _ => None,
+    };
+    let initial_context_injection = match fallback_step_context.as_ref() {
+        Some(step_context) => match initial_context_injection {
+            InitialContextInjection::BeforeLastUserMessage(_) => {
+                InitialContextInjection::BeforeLastUserMessage(Arc::new(
+                    sess.build_world_state_for_step(step_context).await,
+                ))
+            }
+            InitialContextInjection::DoNotInject => InitialContextInjection::DoNotInject,
+        },
+        None => initial_context_injection,
+    };
     let (new_history, world_state_baseline) = process_compacted_history(
         sess.as_ref(),
         compaction_turn_context.as_ref(),
@@ -264,6 +289,7 @@ async fn run_remote_compact_task_inner_impl(
         &initial_context_injection,
     )
     .await;
+    let (new_window_number, new_window_ids) = sess.advance_auto_compact_window().await;
 
     let reference_context_item = match initial_context_injection {
         InitialContextInjection::DoNotInject => None,

--- a/codex-rs/core/src/compact_remote_v2.rs
+++ b/codex-rs/core/src/compact_remote_v2.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::Prompt;
 use crate::ResponseStream;
+use crate::auto_compact_fallback::run_auto_compact_fallback;
 use crate::client::ModelClientSession;
 use crate::client_common::ResponseEvent;
 use crate::compact::CompactionAnalyticsAttempt;
@@ -224,8 +225,8 @@ async fn run_remote_compact_task_inner_impl(
         analytics_details,
     )
     .await;
-    let (attempt, compaction_turn_context) = match attempt {
-        Ok(attempt) => (attempt, turn_context),
+    let (attempt, compaction_step_context) = match attempt {
+        Ok(attempt) => (attempt, Arc::clone(step_context)),
         Err(error) => {
             let Some(fallback_step_context) = fallback_step_context else {
                 return Err(error);
@@ -244,7 +245,7 @@ async fn run_remote_compact_task_inner_impl(
             let fallback_result = run_remote_compact_v2_attempt(
                 sess,
                 fallback_step_context,
-                client_session,
+                client_session.as_deref_mut(),
                 &fallback_compaction_trace,
                 compaction_metadata,
                 analytics_details,
@@ -259,11 +260,12 @@ async fn run_remote_compact_task_inner_impl(
                 fallback_result.as_ref().err(),
             );
             match fallback_result {
-                Ok(attempt) => (attempt, fallback_turn_context),
+                Ok(attempt) => (attempt, Arc::clone(fallback_step_context)),
                 Err(_) => return Err(error),
             }
         }
     };
+    let compaction_turn_context = &compaction_step_context.turn;
     let RemoteCompactV2Attempt {
         trace_input_history,
         prompt_input,
@@ -280,7 +282,24 @@ async fn run_remote_compact_task_inner_impl(
     let (compacted_history, retained_images) =
         build_v2_compacted_history(&prompt_input, compaction_output);
     analytics_details.retained_image_count = Some(retained_images);
-    let (new_window_number, new_window_ids) = sess.advance_auto_compact_window().await;
+    let fallback_step_context = match (compaction_metadata.trigger(), client_session.as_deref_mut())
+    {
+        (CompactionTrigger::Auto, Some(client_session)) => {
+            run_auto_compact_fallback(sess, &compaction_step_context, client_session).await
+        }
+        _ => None,
+    };
+    let initial_context_injection = match fallback_step_context.as_ref() {
+        Some(step_context) => match initial_context_injection {
+            InitialContextInjection::BeforeLastUserMessage(_) => {
+                InitialContextInjection::BeforeLastUserMessage(Arc::new(
+                    sess.build_world_state_for_step(step_context).await,
+                ))
+            }
+            InitialContextInjection::DoNotInject => InitialContextInjection::DoNotInject,
+        },
+        None => initial_context_injection,
+    };
     let (new_history, world_state_baseline) = process_compacted_history(
         sess.as_ref(),
         compaction_turn_context.as_ref(),
@@ -288,6 +307,7 @@ async fn run_remote_compact_task_inner_impl(
         &initial_context_injection,
     )
     .await;
+    let (new_window_number, new_window_ids) = sess.advance_auto_compact_window().await;
 
     let reference_context_item = match initial_context_injection {
         InitialContextInjection::DoNotInject => None,

--- a/codex-rs/core/src/compact_remote_v2.rs
+++ b/codex-rs/core/src/compact_remote_v2.rs
@@ -285,7 +285,7 @@ async fn run_remote_compact_task_inner_impl(
     let fallback_step_context = match (compaction_metadata.trigger(), client_session.as_deref_mut())
     {
         (CompactionTrigger::Auto, Some(client_session)) => {
-            run_auto_compact_fallback(sess, &compaction_step_context, client_session).await
+            run_auto_compact_fallback(sess, &compaction_step_context, client_session).await?
         }
         _ => None,
     };

--- a/codex-rs/core/src/compact_token_budget.rs
+++ b/codex-rs/core/src/compact_token_budget.rs
@@ -19,6 +19,11 @@ use codex_protocol::items::TurnItem;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::TurnStartedEvent;
 
+pub(crate) enum AutoCompactFallbackPolicy {
+    Run,
+    Skip,
+}
+
 /// Runs token-budget manual compaction as a normal compaction lifecycle.
 ///
 /// Token-budget compaction skips model/server summarization and installs a fresh context window
@@ -61,6 +66,7 @@ pub(crate) async fn run_inline_auto_compact_task(
     step_context: Arc<StepContext>,
     client_session: &mut ModelClientSession,
     initial_context_injection: InitialContextInjection,
+    fallback_policy: AutoCompactFallbackPolicy,
 ) -> CodexResult<()> {
     let turn_context = &step_context.turn;
     let world_state = match initial_context_injection {
@@ -69,13 +75,17 @@ pub(crate) async fn run_inline_auto_compact_task(
             Arc::new(sess.build_world_state_for_step(&step_context).await)
         }
     };
+    let (auto_step_context, fallback_client_session) = match fallback_policy {
+        AutoCompactFallbackPolicy::Run => (Some(&step_context), Some(client_session)),
+        AutoCompactFallbackPolicy::Skip => (None, None),
+    };
     run_compact_task_inner(
         &sess,
         turn_context,
         world_state,
         CompactionTrigger::Auto,
-        Some(&step_context),
-        Some(client_session),
+        auto_step_context,
+        fallback_client_session,
     )
     .await
 }

--- a/codex-rs/core/src/compact_token_budget.rs
+++ b/codex-rs/core/src/compact_token_budget.rs
@@ -99,7 +99,7 @@ async fn run_compact_task_inner(
         .await;
     if let (Some(step_context), Some(client_session)) = (auto_step_context, fallback_client_session)
         && let Some(refreshed_step_context) =
-            run_auto_compact_fallback(sess, step_context, client_session).await
+            run_auto_compact_fallback(sess, step_context, client_session).await?
     {
         world_state = Arc::new(
             sess.build_world_state_for_step(&refreshed_step_context)

--- a/codex-rs/core/src/compact_token_budget.rs
+++ b/codex-rs/core/src/compact_token_budget.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use crate::auto_compact_fallback::run_auto_compact_fallback;
+use crate::client::ModelClientSession;
 use crate::compact::InitialContextInjection;
 use crate::context::world_state::WorldState;
 use crate::hook_runtime::PostCompactHookOutcome;
@@ -38,7 +40,15 @@ pub(crate) async fn run_manual_compact_task(
     // Manual compaction runs outside run_turn, so it captures its own current step.
     let step_context = sess.capture_step_context(Arc::clone(&turn_context)).await;
     let world_state = Arc::new(sess.build_world_state_for_step(&step_context).await);
-    run_compact_task_inner(&sess, &turn_context, world_state, CompactionTrigger::Manual).await
+    run_compact_task_inner(
+        &sess,
+        &turn_context,
+        world_state,
+        CompactionTrigger::Manual,
+        None,
+        None,
+    )
+    .await
 }
 
 /// Runs token-budget inline auto-compaction as a normal compaction lifecycle.
@@ -49,6 +59,7 @@ pub(crate) async fn run_manual_compact_task(
 pub(crate) async fn run_inline_auto_compact_task(
     sess: Arc<Session>,
     step_context: Arc<StepContext>,
+    client_session: &mut ModelClientSession,
     initial_context_injection: InitialContextInjection,
 ) -> CodexResult<()> {
     let turn_context = &step_context.turn;
@@ -58,14 +69,24 @@ pub(crate) async fn run_inline_auto_compact_task(
             Arc::new(sess.build_world_state_for_step(&step_context).await)
         }
     };
-    run_compact_task_inner(&sess, turn_context, world_state, CompactionTrigger::Auto).await
+    run_compact_task_inner(
+        &sess,
+        turn_context,
+        world_state,
+        CompactionTrigger::Auto,
+        Some(&step_context),
+        Some(client_session),
+    )
+    .await
 }
 
 async fn run_compact_task_inner(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
-    world_state: Arc<WorldState>,
+    mut world_state: Arc<WorldState>,
     trigger: CompactionTrigger,
+    auto_step_context: Option<&Arc<StepContext>>,
+    fallback_client_session: Option<&mut ModelClientSession>,
 ) -> CodexResult<()> {
     let pre_compact_outcome = run_pre_compact_hooks(sess, turn_context, trigger).await;
     match pre_compact_outcome {
@@ -76,6 +97,15 @@ async fn run_compact_task_inner(
     let compaction_item = TurnItem::ContextCompaction(ContextCompactionItem::new());
     sess.emit_turn_item_started(turn_context, &compaction_item)
         .await;
+    if let (Some(step_context), Some(client_session)) = (auto_step_context, fallback_client_session)
+        && let Some(refreshed_step_context) =
+            run_auto_compact_fallback(sess, step_context, client_session).await
+    {
+        world_state = Arc::new(
+            sess.build_world_state_for_step(&refreshed_step_context)
+                .await,
+        );
+    }
     sess.start_new_context_window(turn_context.as_ref(), world_state)
         .await;
     sess.emit_turn_item_completed(turn_context, compaction_item)

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -7095,6 +7095,29 @@ async fn loads_compact_prompt_from_file() -> std::io::Result<()> {
 }
 
 #[tokio::test]
+async fn loads_auto_compact_fallback_prompt() -> std::io::Result<()> {
+    let codex_home = TempDir::new()?;
+    let cfg = ConfigToml {
+        auto_compact_fallback_prompt: Some("  write notes immediately  ".to_string()),
+        ..Default::default()
+    };
+
+    let config = Config::load_from_base_config_with_overrides(
+        cfg,
+        ConfigOverrides::default(),
+        codex_home.abs(),
+    )
+    .await?;
+
+    assert_eq!(
+        config.auto_compact_fallback_prompt.as_deref(),
+        Some("write notes immediately")
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn load_config_uses_requirements_guardian_policy_config() -> std::io::Result<()> {
     let codex_home = TempDir::new()?;
     let config_layer_stack = ConfigLayerStack::new(

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -7095,10 +7095,18 @@ async fn loads_compact_prompt_from_file() -> std::io::Result<()> {
 }
 
 #[tokio::test]
-async fn loads_auto_compact_fallback_prompt() -> std::io::Result<()> {
+async fn loads_auto_compact_fallback_settings() -> std::io::Result<()> {
     let codex_home = TempDir::new()?;
+    let features = toml::from_str(
+        r#"
+[auto_compact_fallback]
+enabled = true
+prompt = "  write notes immediately  "
+"#,
+    )
+    .expect("auto compact fallback feature config should deserialize");
     let cfg = ConfigToml {
-        auto_compact_fallback_prompt: Some("  write notes immediately  ".to_string()),
+        features: Some(features),
         ..Default::default()
     };
 
@@ -7110,9 +7118,42 @@ async fn loads_auto_compact_fallback_prompt() -> std::io::Result<()> {
     .await?;
 
     assert_eq!(
-        config.auto_compact_fallback_prompt.as_deref(),
+        config.auto_compact_fallback.prompt.as_deref(),
         Some("write notes immediately")
     );
+    assert!(config.features.enabled(Feature::AutoCompactFallback));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn prompt_only_auto_compact_fallback_settings_do_not_enable_feature() -> std::io::Result<()> {
+    let codex_home = TempDir::new()?;
+    let features = toml::from_str(
+        r#"
+[auto_compact_fallback]
+prompt = "  write notes immediately  "
+"#,
+    )
+    .expect("auto compact fallback feature config should deserialize");
+    let cfg = ConfigToml {
+        features: Some(features),
+        ..Default::default()
+    };
+
+    let config = Config::load_from_base_config_with_overrides(
+        cfg,
+        ConfigOverrides::default(),
+        codex_home.abs(),
+    )
+    .await?;
+
+    assert_eq!(
+        config.auto_compact_fallback.prompt.as_deref(),
+        Some("write notes immediately")
+    );
+    assert!(!config.features.enabled(Feature::AutoCompactFallback));
+
     Ok(())
 }
 

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -7113,7 +7113,6 @@ async fn loads_auto_compact_fallback_prompt() -> std::io::Result<()> {
         config.auto_compact_fallback_prompt.as_deref(),
         Some("write notes immediately")
     );
-
     Ok(())
 }
 

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -56,6 +56,7 @@ use codex_core_plugins::PluginLoadOutcome;
 use codex_core_plugins::PluginsConfigInput;
 use codex_exec_server::ExecutorFileSystem;
 use codex_exec_server::LOCAL_FS;
+use codex_features::AutoCompactFallbackConfigToml;
 use codex_features::CodeModeConfigToml;
 use codex_features::CurrentTimeReminderConfigToml;
 use codex_features::CurrentTimeReminderDeliveryMode;
@@ -711,8 +712,8 @@ pub struct Config {
     /// Compact prompt override.
     pub compact_prompt: Option<String>,
 
-    /// Developer message contributed for the optional pre-rollover fallback turn.
-    pub auto_compact_fallback_prompt: Option<String>,
+    /// Settings for the optional pre-rollover fallback turn.
+    pub auto_compact_fallback: AutoCompactFallbackConfig,
 
     /// Optional external notifier command. When set, Codex will spawn this
     /// program after each completed *turn* (i.e. when the agent finishes
@@ -1101,6 +1102,11 @@ pub struct TokenBudgetConfig {
     pub reminder_threshold_tokens: Option<i64>,
     pub reminder_message_template: String,
     pub guidance_message: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct AutoCompactFallbackConfig {
+    pub prompt: Option<String>,
 }
 
 impl Default for TokenBudgetConfig {
@@ -2615,6 +2621,17 @@ fn resolve_token_budget_config(
     }))
 }
 
+fn resolve_auto_compact_fallback_config(config_toml: &ConfigToml) -> AutoCompactFallbackConfig {
+    let configured = auto_compact_fallback_toml_config(config_toml.features.as_ref());
+    let prompt = configured
+        .and_then(|config| config.prompt.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+
+    AutoCompactFallbackConfig { prompt }
+}
+
 fn resolve_rollout_budget_config(
     config_toml: &ConfigToml,
     features: &ManagedFeatures,
@@ -2753,6 +2770,15 @@ fn multi_agent_v2_toml_config(features: Option<&FeaturesToml>) -> Option<&MultiA
 
 fn token_budget_toml_config(features: Option<&FeaturesToml>) -> Option<&TokenBudgetConfigToml> {
     match features?.token_budget.as_ref()? {
+        FeatureToml::Enabled(_) => None,
+        FeatureToml::Config(config) => Some(config),
+    }
+}
+
+fn auto_compact_fallback_toml_config(
+    features: Option<&FeaturesToml>,
+) -> Option<&AutoCompactFallbackConfigToml> {
+    match features?.auto_compact_fallback.as_ref()? {
         FeatureToml::Enabled(_) => None,
         FeatureToml::Config(config) => Some(config),
     }
@@ -3414,6 +3440,7 @@ impl Config {
         let code_mode = resolve_code_mode_config(&cfg);
         let multi_agent_v2 = resolve_multi_agent_v2_config(&cfg);
         let token_budget = resolve_token_budget_config(&cfg, &features)?;
+        let auto_compact_fallback = resolve_auto_compact_fallback_config(&cfg);
         let rollout_budget = resolve_rollout_budget_config(&cfg, &features)?;
         let current_time_reminder = resolve_current_time_reminder_config(&cfg, &features)?;
         let terminal_resize_reflow = resolve_terminal_resize_reflow_config(&cfg);
@@ -3595,14 +3622,6 @@ impl Config {
         });
 
         let compact_prompt = compact_prompt.or(cfg.compact_prompt).and_then(|value| {
-            let trimmed = value.trim();
-            if trimmed.is_empty() {
-                None
-            } else {
-                Some(trimmed.to_string())
-            }
-        });
-        let auto_compact_fallback_prompt = cfg.auto_compact_fallback_prompt.and_then(|value| {
             let trimmed = value.trim();
             if trimmed.is_empty() {
                 None
@@ -3825,7 +3844,7 @@ impl Config {
             personality,
             developer_instructions,
             compact_prompt,
-            auto_compact_fallback_prompt,
+            auto_compact_fallback,
             include_permissions_instructions,
             include_apps_instructions,
             include_collaboration_mode_instructions,

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -3610,7 +3610,6 @@ impl Config {
                 Some(trimmed.to_string())
             }
         });
-
         // Load base instructions override from a file if specified. If the
         // path is relative, resolve it against the effective cwd so the
         // behaviour matches other path-like config values.

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -711,6 +711,9 @@ pub struct Config {
     /// Compact prompt override.
     pub compact_prompt: Option<String>,
 
+    /// Developer message contributed for the optional pre-rollover fallback turn.
+    pub auto_compact_fallback_prompt: Option<String>,
+
     /// Optional external notifier command. When set, Codex will spawn this
     /// program after each completed *turn* (i.e. when the agent finishes
     /// processing a user submission). The value must be the full command
@@ -3599,6 +3602,14 @@ impl Config {
                 Some(trimmed.to_string())
             }
         });
+        let auto_compact_fallback_prompt = cfg.auto_compact_fallback_prompt.and_then(|value| {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        });
 
         // Load base instructions override from a file if specified. If the
         // path is relative, resolve it against the effective cwd so the
@@ -3815,6 +3826,7 @@ impl Config {
             personality,
             developer_instructions,
             compact_prompt,
+            auto_compact_fallback_prompt,
             include_permissions_instructions,
             include_apps_instructions,
             include_collaboration_mode_instructions,

--- a/codex-rs/core/src/context/token_budget_context.rs
+++ b/codex-rs/core/src/context/token_budget_context.rs
@@ -63,6 +63,11 @@ impl ContextualUserFragment for TokenBudgetContext {
         }
         format!("\n{}\n", lines.join("\n"))
     }
+
+    fn render(&self) -> String {
+        let body = self.body();
+        format!("\n\n{CONTEXT_WINDOW_OPEN_TAG}{body}{CONTEXT_WINDOW_CLOSE_TAG}\n\n")
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -96,6 +101,13 @@ impl ContextualUserFragment for ContextWindowGuidance {
 
     fn body(&self) -> String {
         format!("\n{}\n", self.message)
+    }
+
+    fn render(&self) -> String {
+        let body = self.body();
+        format!(
+            "\n\n{CONTEXT_WINDOW_GUIDANCE_OPEN_TAG}{body}{CONTEXT_WINDOW_GUIDANCE_CLOSE_TAG}\n\n"
+        )
     }
 }
 

--- a/codex-rs/core/src/guardian/review.rs
+++ b/codex-rs/core/src/guardian/review.rs
@@ -174,10 +174,12 @@ pub(crate) fn routes_approval_to_guardian_with_reviewer(
     turn: &TurnContext,
     approvals_reviewer: ApprovalsReviewer,
 ) -> bool {
-    matches!(
-        turn.approval_policy.value(),
-        AskForApproval::OnRequest | AskForApproval::Granular(_)
-    ) && approvals_reviewer == ApprovalsReviewer::AutoReview
+    !turn.approvals_disabled
+        && matches!(
+            turn.approval_policy.value(),
+            AskForApproval::OnRequest | AskForApproval::Granular(_)
+        )
+        && approvals_reviewer == ApprovalsReviewer::AutoReview
 }
 
 pub(crate) fn is_guardian_reviewer_source(

--- a/codex-rs/core/src/hook_runtime.rs
+++ b/codex-rs/core/src/hook_runtime.rs
@@ -228,6 +228,12 @@ pub(crate) async fn run_permission_request_hooks(
     run_id_suffix: &str,
     payload: PermissionRequestPayload,
 ) -> Option<PermissionRequestDecision> {
+    if turn_context.approvals_disabled {
+        return Some(PermissionRequestDecision::Deny {
+            message: "approval requests are disabled during auto-compaction fallback".to_string(),
+        });
+    }
+
     let request = PermissionRequestRequest {
         session_id: sess.session_id().into(),
         turn_id: turn_context.sub_id.clone(),

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -34,6 +34,7 @@ pub use session::turn_context::TurnContext;
 mod agent;
 mod agent_communication;
 mod attestation;
+mod auto_compact_fallback;
 mod codex_delegate;
 mod command_canonicalization;
 pub mod config;

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -1,5 +1,6 @@
 //! Root of the `codex-core` library.
 
+#![recursion_limit = "256"]
 // Prevent accidental direct writes to stdout/stderr in library code. All
 // user-visible output must go through the appropriate abstraction (e.g.,
 // the TUI or the tracing stack).

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -1227,6 +1227,12 @@ async fn maybe_request_mcp_tool_approval(
         return None;
     }
 
+    if turn_context.approvals_disabled {
+        return Some(McpToolApprovalDecision::Decline {
+            message: Some("approval requests are disabled during auto-compaction fallback".into()),
+        });
+    }
+
     let session_approval_key = session_mcp_tool_approval_key(invocation, metadata, approval_mode);
     let persistent_approval_key = if manager.is_selected_plugin_mcp_server(&invocation.server) {
         None

--- a/codex-rs/core/src/responses_metadata.rs
+++ b/codex-rs/core/src/responses_metadata.rs
@@ -114,6 +114,7 @@ impl CompactionTurnMetadata {
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum CodexResponsesRequestKind {
     Turn,
+    AutoCompactFallback,
     Prewarm,
     Compaction(CompactionTurnMetadata),
     Memory,
@@ -123,6 +124,7 @@ impl CodexResponsesRequestKind {
     fn metadata(self) -> (&'static str, Option<CompactionTurnMetadata>) {
         match self {
             CodexResponsesRequestKind::Turn => ("turn", None),
+            CodexResponsesRequestKind::AutoCompactFallback => ("auto_compact_fallback", None),
             CodexResponsesRequestKind::Prewarm => ("prewarm", None),
             CodexResponsesRequestKind::Compaction(metadata) => ("compaction", Some(metadata)),
             CodexResponsesRequestKind::Memory => ("memory", None),

--- a/codex-rs/core/src/session/mcp.rs
+++ b/codex-rs/core/src/session/mcp.rs
@@ -211,6 +211,17 @@ impl Session {
         request_id: RequestId,
         request: ElicitationRequest,
     ) -> McpServerElicitationOutcome {
+        if turn_context.approvals_disabled {
+            return McpServerElicitationOutcome {
+                response: Some(ElicitationResponse {
+                    action: codex_rmcp_client::ElicitationAction::Decline,
+                    content: None,
+                    meta: None,
+                }),
+                sent: false,
+            };
+        }
+
         if self
             .services
             .latest_mcp_runtime()

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -2022,7 +2022,7 @@ impl Session {
             .map(|task| Arc::clone(&task.turn_context))
     }
 
-    async fn active_turn_context_and_cancellation_token(
+    pub(crate) async fn active_turn_context_and_cancellation_token(
         &self,
     ) -> Option<(Arc<TurnContext>, CancellationToken)> {
         let active = self.active_turn.lock().await;
@@ -2158,6 +2158,10 @@ impl Session {
         additional_permissions: Option<AdditionalPermissionProfile>,
         available_decisions: Option<Vec<ReviewDecision>>,
     ) -> ReviewDecision {
+        if turn_context.approvals_disabled {
+            return ReviewDecision::Denied;
+        }
+
         //  command-level approvals use `call_id`.
         // `approval_id` is only present for subcommand callbacks (execve intercept)
         let effective_approval_id = approval_id.clone().unwrap_or_else(|| call_id.clone());
@@ -2230,6 +2234,12 @@ impl Session {
         reason: Option<String>,
         grant_root: Option<PathBuf>,
     ) -> oneshot::Receiver<ReviewDecision> {
+        if turn_context.approvals_disabled {
+            let (tx_approve, rx_approve) = oneshot::channel();
+            let _ = tx_approve.send(ReviewDecision::Denied);
+            return rx_approve;
+        }
+
         // Add the tx_approve callback to the map before sending the request.
         let (tx_approve, rx_approve) = oneshot::channel();
         let approval_id = call_id.clone();
@@ -2475,6 +2485,10 @@ impl Session {
         call_id: String,
         args: RequestUserInputArgs,
     ) -> Option<RequestUserInputResponse> {
+        if turn_context.approvals_disabled {
+            return None;
+        }
+
         let sub_id = turn_context.sub_id.clone();
         let (tx_response, rx_response) = oneshot::channel();
         let event_id = sub_id.clone();

--- a/codex-rs/core/src/session/review.rs
+++ b/codex-rs/core/src/session/review.rs
@@ -130,6 +130,7 @@ pub(super) async fn spawn_review_thread(
         multi_agent_version: MultiAgentVersion::Disabled,
         personality: parent_turn_context.personality,
         approval_policy: parent_turn_context.approval_policy.clone(),
+        approvals_disabled: false,
         permission_profile: parent_turn_context.permission_profile(),
         network: parent_turn_context.network.clone(),
         windows_sandbox_level: parent_turn_context.windows_sandbox_level,

--- a/codex-rs/core/src/session/step_context.rs
+++ b/codex-rs/core/src/session/step_context.rs
@@ -35,4 +35,14 @@ impl StepContext {
             loaded_agents_md,
         }
     }
+
+    pub(crate) fn with_turn(&self, turn: Arc<TurnContext>) -> Self {
+        Self {
+            turn,
+            environments: self.environments.clone(),
+            selected_capability_roots: self.selected_capability_roots.clone(),
+            mcp: Arc::clone(&self.mcp),
+            loaded_agents_md: self.loaded_agents_md.clone(),
+        }
+    }
 }

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -15,6 +15,7 @@ use crate::compact::run_inline_auto_compact_task;
 use crate::compact::should_use_remote_compact_task;
 use crate::compact_remote::run_inline_remote_auto_compact_task;
 use crate::compact_remote_v2::run_inline_remote_auto_compact_task as run_inline_remote_auto_compact_task_v2;
+use crate::compact_token_budget::AutoCompactFallbackPolicy;
 use crate::connectors;
 use crate::context::ContextualUserFragment;
 use crate::feedback_tags;
@@ -344,15 +345,24 @@ pub(crate) async fn run_turn(
                 .await;
 
                 // as long as compaction works well in getting us way below the token limit, we shouldn't worry about being in an infinite loop.
-                if needs_follow_up
-                    && (sess.take_new_context_window_request().await || token_limit_reached)
-                {
+                let new_context_window_requested = if needs_follow_up {
+                    sess.take_new_context_window_request().await
+                } else {
+                    false
+                };
+                if needs_follow_up && (new_context_window_requested || token_limit_reached) {
+                    let fallback_policy = if new_context_window_requested {
+                        AutoCompactFallbackPolicy::Skip
+                    } else {
+                        AutoCompactFallbackPolicy::Run
+                    };
                     if let Err(err) = run_auto_compact(
                         &sess,
                         Arc::clone(&step_context),
                         /*fallback_step_context*/ None,
                         &mut client_session,
                         InitialContextInjection::BeforeLastUserMessage(Arc::clone(&world_state)),
+                        fallback_policy,
                         CompactionReason::ContextLimit,
                         CompactionPhase::MidTurn,
                     )
@@ -815,6 +825,7 @@ async fn run_pre_sampling_compact(
             /*fallback_step_context*/ None,
             client_session,
             InitialContextInjection::DoNotInject,
+            AutoCompactFallbackPolicy::Run,
             CompactionReason::ContextLimit,
             CompactionPhase::PreTurn,
         )
@@ -892,6 +903,7 @@ async fn maybe_run_previous_model_inline_compact(
             fallback_step_context,
             client_session,
             InitialContextInjection::DoNotInject,
+            AutoCompactFallbackPolicy::Run,
             CompactionReason::CompHashChanged,
             CompactionPhase::PreTurn,
         )
@@ -939,6 +951,7 @@ async fn maybe_run_previous_model_inline_compact(
             fallback_step_context,
             client_session,
             InitialContextInjection::DoNotInject,
+            AutoCompactFallbackPolicy::Run,
             CompactionReason::ModelDownshift,
             CompactionPhase::PreTurn,
         )
@@ -958,6 +971,7 @@ async fn run_auto_compact(
     fallback_step_context: Option<Arc<StepContext>>,
     client_session: &mut ModelClientSession,
     initial_context_injection: InitialContextInjection,
+    fallback_policy: AutoCompactFallbackPolicy,
     reason: CompactionReason,
     phase: CompactionPhase,
 ) -> CodexResult<()> {
@@ -970,6 +984,7 @@ async fn run_auto_compact(
             step_context,
             client_session,
             initial_context_injection,
+            fallback_policy,
         )
         .await?;
         return Ok(());

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -289,6 +289,7 @@ pub(crate) async fn run_turn(
                 &mut client_session,
                 &responses_metadata,
                 sampling_request_input,
+                SamplingRequestOptions::default(),
                 cancellation_token.child_token(),
             )
             .await
@@ -967,6 +968,7 @@ async fn run_auto_compact(
         crate::compact_token_budget::run_inline_auto_compact_task(
             Arc::clone(sess),
             step_context,
+            client_session,
             initial_context_injection,
         )
         .await?;
@@ -1005,7 +1007,7 @@ async fn run_auto_compact(
             Arc::clone(sess),
             step_context,
             fallback_step_context,
-            client_session.turn_state(),
+            client_session,
             initial_context_injection,
             reason,
             phase,
@@ -1019,7 +1021,8 @@ async fn run_auto_compact(
         );
         run_inline_auto_compact_task(
             Arc::clone(sess),
-            Arc::clone(turn_context),
+            step_context,
+            client_session,
             initial_context_injection,
             reason,
             phase,
@@ -1109,7 +1112,7 @@ pub(crate) fn build_prompt(
         cwd = %step_context.turn.cwd.display()
     )
 )]
-async fn run_sampling_request(
+pub(crate) async fn run_sampling_request(
     sess: Arc<Session>,
     step_context: Arc<StepContext>,
     turn_store: Arc<codex_extension_api::ExtensionData>,
@@ -1117,6 +1120,7 @@ async fn run_sampling_request(
     client_session: &mut ModelClientSession,
     responses_metadata: &CodexResponsesMetadata,
     input: Vec<ResponseItem>,
+    options: SamplingRequestOptions,
     cancellation_token: CancellationToken,
 ) -> CodexResult<(SamplingRequestResult, Vec<ResponseItem>)> {
     let turn_context = Arc::clone(&step_context.turn);
@@ -1130,11 +1134,15 @@ async fn run_sampling_request(
         Arc::clone(&step_context),
         Arc::clone(&turn_diff_tracker),
     );
+    let tool_runtime = if options.auto_compact_fallback {
+        tool_runtime.with_auto_compact_fallback_policy()
+    } else {
+        tool_runtime
+    };
     let _code_mode_worker = sess.services.code_mode_service.start_turn_worker(
         &sess,
         Arc::clone(&step_context),
-        Arc::clone(&router),
-        Arc::clone(&turn_diff_tracker),
+        tool_runtime.for_code_mode_nested_dispatch(),
     );
     let max_retries = turn_context.provider.info().stream_max_retries();
     let mut retries = 0;
@@ -1148,12 +1156,27 @@ async fn run_sampling_request(
                 .await
                 .for_prompt(&turn_context.model_info.input_modalities)
         };
-        let prompt = build_prompt(
+        let mut prompt = build_prompt(
             prompt_input,
             router.as_ref(),
             turn_context.as_ref(),
             base_instructions.clone(),
         );
+        if let Some(parallel_tool_calls) = options.parallel_tool_calls {
+            prompt.parallel_tool_calls = parallel_tool_calls;
+        }
+        if options.auto_compact_fallback {
+            // Hosted tools execute server-side before core can enforce the one-call budget. Keep
+            // the fallback surface to client-dispatched tools whose admission we control.
+            prompt.tools.retain(|tool| match tool {
+                codex_tools::ToolSpec::Function(_)
+                | codex_tools::ToolSpec::Namespace(_)
+                | codex_tools::ToolSpec::Freeform(_) => true,
+                codex_tools::ToolSpec::ToolSearch { execution, .. } => execution == "client",
+                codex_tools::ToolSpec::ImageGeneration { .. }
+                | codex_tools::ToolSpec::WebSearch { .. } => false,
+            });
+        }
         let err = match try_run_sampling_request(
             tool_runtime.clone(),
             Arc::clone(&sess),
@@ -1350,9 +1373,24 @@ pub(crate) async fn built_tools(
 }
 
 #[derive(Debug)]
-struct SamplingRequestResult {
+pub(crate) struct SamplingRequestResult {
     needs_follow_up: bool,
     last_agent_message: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct SamplingRequestOptions {
+    pub(crate) parallel_tool_calls: Option<bool>,
+    pub(crate) auto_compact_fallback: bool,
+}
+
+impl SamplingRequestOptions {
+    pub(crate) fn auto_compact_fallback() -> Self {
+        Self {
+            parallel_tool_calls: Some(false),
+            auto_compact_fallback: true,
+        }
+    }
 }
 
 /// Ephemeral per-response state for streaming a single proposed plan.

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -301,6 +301,7 @@ pub(crate) async fn run_turn(
                 let SamplingRequestResult {
                     needs_follow_up: model_needs_follow_up,
                     last_agent_message: sampling_request_last_agent_message,
+                    tool_call_emitted: _,
                 } = sampling_request_output;
                 can_drain_pending_input = true;
                 let (has_pending_input, token_status, estimated_token_count) = async {
@@ -1398,8 +1399,9 @@ pub(crate) async fn built_tools(
 
 #[derive(Debug)]
 pub(crate) struct SamplingRequestResult {
-    needs_follow_up: bool,
+    pub(crate) needs_follow_up: bool,
     last_agent_message: Option<String>,
+    pub(crate) tool_call_emitted: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -2036,6 +2038,7 @@ async fn try_run_sampling_request(
     let mut in_flight: FuturesOrdered<BoxFuture<'static, CodexResult<ResponseInputItem>>> =
         FuturesOrdered::new();
     let mut needs_follow_up = false;
+    let mut tool_call_emitted = false;
     let mut last_agent_message: Option<String> = None;
     let mut active_item: Option<TurnItem> = None;
     let mut active_tool_argument_diff_consumer: Option<(
@@ -2181,11 +2184,13 @@ async fn try_run_sampling_request(
                     last_agent_message = Some(agent_message);
                 }
                 needs_follow_up |= output_result.needs_follow_up;
+                tool_call_emitted |= output_result.tool_call_emitted;
                 // todo: remove before stabilizing multi-agent v2
                 if preempt_for_mailbox_mail && sess.input_queue.has_pending_mailbox_items().await {
                     break Ok(SamplingRequestResult {
                         needs_follow_up: true,
                         last_agent_message,
+                        tool_call_emitted,
                     });
                 }
             }
@@ -2345,6 +2350,7 @@ async fn try_run_sampling_request(
                 break Ok(SamplingRequestResult {
                     needs_follow_up,
                     last_agent_message,
+                    tool_call_emitted,
                 });
             }
             ResponseEvent::OutputTextDelta(delta) => {

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -1144,7 +1144,16 @@ pub(crate) async fn run_sampling_request(
         Arc::clone(&step_context),
         tool_runtime.for_code_mode_nested_dispatch(),
     );
-    let max_retries = turn_context.provider.info().stream_max_retries();
+    let max_retries = options.max_stream_retries.map_or_else(
+        || turn_context.provider.info().stream_max_retries(),
+        |max_stream_retries| {
+            turn_context
+                .provider
+                .info()
+                .stream_max_retries()
+                .min(max_stream_retries)
+        },
+    );
     let mut retries = 0;
     let mut initial_input = Some(input);
     let mut original_input = None;
@@ -1381,6 +1390,7 @@ pub(crate) struct SamplingRequestResult {
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct SamplingRequestOptions {
     pub(crate) parallel_tool_calls: Option<bool>,
+    pub(crate) max_stream_retries: Option<u64>,
     pub(crate) auto_compact_fallback: bool,
 }
 
@@ -1388,6 +1398,8 @@ impl SamplingRequestOptions {
     pub(crate) fn auto_compact_fallback() -> Self {
         Self {
             parallel_tool_calls: Some(false),
+            // Match remote compaction V2: retry a transient stream failure at most twice.
+            max_stream_retries: Some(2),
             auto_compact_fallback: true,
         }
     }

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -127,6 +127,7 @@ pub struct TurnContext {
     pub(crate) multi_agent_version: MultiAgentVersion,
     pub(crate) personality: Option<Personality>,
     pub(crate) approval_policy: Constrained<AskForApproval>,
+    pub(crate) approvals_disabled: bool,
     pub(crate) permission_profile: PermissionProfile,
     pub(crate) network: Option<NetworkProxy>,
     pub(crate) windows_sandbox_level: WindowsSandboxLevel,
@@ -149,6 +150,57 @@ enum TurnMultiAgentRuntime {
 }
 
 impl TurnContext {
+    pub(crate) fn with_approvals_disabled(&self) -> Self {
+        let approval_policy = Constrained::allow_any(AskForApproval::Never);
+        let mut config = (*self.config).clone();
+        config.permissions.approval_policy = approval_policy.clone();
+        Self {
+            sub_id: self.sub_id.clone(),
+            trace_id: self.trace_id.clone(),
+            realtime_active: self.realtime_active,
+            config: Arc::new(config),
+            auth_manager: self.auth_manager.clone(),
+            model_info: self.model_info.clone(),
+            session_telemetry: self.session_telemetry.clone(),
+            provider: self.provider.clone(),
+            reasoning_effort: self.reasoning_effort.clone(),
+            reasoning_summary: self.reasoning_summary,
+            session_source: self.session_source.clone(),
+            parent_thread_id: self.parent_thread_id,
+            originator: self.originator.clone(),
+            environments: self.environments.clone(),
+            #[allow(deprecated)]
+            cwd: self.cwd.clone(),
+            current_date: self.current_date.clone(),
+            timezone: self.timezone.clone(),
+            app_server_client_name: self.app_server_client_name.clone(),
+            developer_instructions: self.developer_instructions.clone(),
+            collaboration_mode: self.collaboration_mode.clone(),
+            multi_agent_version: self.multi_agent_version,
+            personality: self.personality,
+            approval_policy,
+            approvals_disabled: true,
+            permission_profile: self.permission_profile.clone(),
+            network: self.network.clone(),
+            windows_sandbox_level: self.windows_sandbox_level,
+            available_models: self.available_models.clone(),
+            unified_exec_shell_mode: self.unified_exec_shell_mode.clone(),
+            final_output_json_schema: self.final_output_json_schema.clone(),
+            dynamic_tools: self.dynamic_tools.clone(),
+            turn_metadata_state: Arc::clone(&self.turn_metadata_state),
+            extension_data: Arc::clone(&self.extension_data),
+            turn_skills: self.turn_skills.clone(),
+            turn_timing_state: Arc::clone(&self.turn_timing_state),
+            terminal_error: Arc::clone(&self.terminal_error),
+            server_model_warning_emitted: AtomicBool::new(
+                self.server_model_warning_emitted.load(Ordering::Relaxed),
+            ),
+            model_verification_emitted: AtomicBool::new(
+                self.model_verification_emitted.load(Ordering::Relaxed),
+            ),
+        }
+    }
+
     pub(crate) fn permission_profile(&self) -> PermissionProfile {
         self.permission_profile.clone()
     }
@@ -275,6 +327,7 @@ impl TurnContext {
             multi_agent_version: self.multi_agent_version,
             personality: self.personality,
             approval_policy: self.approval_policy.clone(),
+            approvals_disabled: self.approvals_disabled,
             permission_profile: self.permission_profile.clone(),
             network: self.network.clone(),
             windows_sandbox_level: self.windows_sandbox_level,
@@ -553,6 +606,7 @@ impl Session {
             multi_agent_version,
             personality: session_configuration.personality,
             approval_policy: session_configuration.approval_policy.clone(),
+            approvals_disabled: false,
             permission_profile: session_configuration.permission_profile(),
             network,
             windows_sandbox_level: session_configuration.windows_sandbox_level,

--- a/codex-rs/core/src/stream_events_utils.rs
+++ b/codex-rs/core/src/stream_events_utils.rs
@@ -310,6 +310,7 @@ pub(crate) type InFlightFuture<'f> =
 pub(crate) struct OutputItemResult {
     pub last_agent_message: Option<String>,
     pub needs_follow_up: bool,
+    pub tool_call_emitted: bool,
     pub tool_future: Option<InFlightFuture<'static>>,
 }
 
@@ -409,8 +410,10 @@ pub(crate) async fn handle_output_item_done(
 ) -> Result<OutputItemResult> {
     let mut output = OutputItemResult::default();
     let plan_mode = ctx.turn_context.collaboration_mode.mode == ModeKind::Plan;
+    let tool_call = ToolRouter::build_tool_call(item.clone());
+    output.tool_call_emitted = !matches!(&tool_call, Ok(None));
 
-    match ToolRouter::build_tool_call(item.clone()) {
+    match tool_call {
         // The model emitted a tool call; log it, persist the item immediately, and queue the tool execution.
         Ok(Some(call)) => {
             ctx.sess

--- a/codex-rs/core/src/tools/code_mode/delegate.rs
+++ b/codex-rs/core/src/tools/code_mode/delegate.rs
@@ -17,9 +17,6 @@ use tokio_util::sync::CancellationToken;
 use super::ExecContext;
 use super::PUBLIC_TOOL_NAME;
 use super::call_nested_tool;
-use crate::session::step_context::StepContext;
-use crate::tools::ToolRouter;
-use crate::tools::context::SharedTurnDiffTracker;
 use crate::tools::parallel::ToolCallRuntime;
 
 pub(super) struct CodeModeDispatchBroker {
@@ -49,12 +46,8 @@ impl CodeModeDispatchBroker {
     pub(super) fn start_turn_worker(
         &self,
         exec: ExecContext,
-        router: Arc<ToolRouter>,
-        step_context: Arc<StepContext>,
-        tracker: SharedTurnDiffTracker,
+        tool_runtime: ToolCallRuntime,
     ) -> CodeModeDispatchWorker {
-        let tool_runtime =
-            ToolCallRuntime::new(router, Arc::clone(&exec.session), step_context, tracker);
         let host = Arc::new(CoreTurnHost { exec, tool_runtime });
         let dispatch_rx = self.dispatch_rx.clone();
         let dispatch_gates = Arc::clone(&self.dispatch_gates);

--- a/codex-rs/core/src/tools/code_mode/mod.rs
+++ b/codex-rs/core/src/tools/code_mode/mod.rs
@@ -27,9 +27,7 @@ use crate::original_image_detail::sanitize_original_image_detail as sanitize_ima
 use crate::session::session::Session;
 use crate::session::step_context::StepContext;
 use crate::session::turn_context::TurnContext;
-use crate::tools::ToolRouter;
 use crate::tools::context::FunctionToolOutput;
-use crate::tools::context::SharedTurnDiffTracker;
 use crate::tools::context::ToolPayload;
 use crate::tools::effective_tool_mode;
 use crate::tools::parallel::ToolCallRuntime;
@@ -135,8 +133,7 @@ impl CodeModeService {
         &self,
         session: &Arc<Session>,
         step_context: Arc<StepContext>,
-        router: Arc<ToolRouter>,
-        tracker: SharedTurnDiffTracker,
+        tool_runtime: ToolCallRuntime,
     ) -> Option<CodeModeDispatchWorker> {
         let turn = &step_context.turn;
         let tool_mode = effective_tool_mode(turn);
@@ -148,10 +145,7 @@ impl CodeModeService {
             session: Arc::clone(session),
             turn: Arc::clone(turn),
         };
-        Some(
-            self.dispatch_broker
-                .start_turn_worker(exec, router, step_context, tracker),
-        )
+        Some(self.dispatch_broker.start_turn_worker(exec, tool_runtime))
     }
 
     async fn session(&self) -> Result<Arc<dyn CodeModeSession>, String> {

--- a/codex-rs/core/src/tools/orchestrator.rs
+++ b/codex-rs/core/src/tools/orchestrator.rs
@@ -72,7 +72,7 @@ impl ToolOrchestrator {
         let network_approval = match begin_network_approval(
             &tool_ctx.session,
             &tool_ctx.turn.sub_id,
-            managed_network_active,
+            managed_network_active && !tool_ctx.turn.approvals_disabled,
             attempt.sandbox,
             tool.network_approval_spec(req, tool_ctx),
         )
@@ -154,8 +154,10 @@ impl ToolOrchestrator {
         let otel = turn_ctx.session_telemetry.clone();
         let otel_tn = flat_tool_name(&tool_ctx.tool_name).into_owned();
         let otel_ci = &tool_ctx.call_id;
-        let strict_auto_review = tool_ctx.session.strict_auto_review_enabled_for_turn().await;
-        let use_guardian = routes_approval_to_guardian(turn_ctx) || strict_auto_review;
+        let strict_auto_review = !turn_ctx.approvals_disabled
+            && tool_ctx.session.strict_auto_review_enabled_for_turn().await;
+        let use_guardian = !turn_ctx.approvals_disabled
+            && (routes_approval_to_guardian(turn_ctx) || strict_auto_review);
 
         // 1) Approval
         let mut already_approved = false;
@@ -166,6 +168,11 @@ impl ToolOrchestrator {
             default_exec_approval_requirement(approval_policy, &file_system_sandbox_policy)
         });
         match &requirement {
+            ExecApprovalRequirement::NeedsApproval { .. } if turn_ctx.approvals_disabled => {
+                return Err(ToolError::Rejected(
+                    "approvals are disabled during auto-compaction fallback".to_string(),
+                ));
+            }
             ExecApprovalRequirement::Skip { .. } => {
                 if strict_auto_review {
                     let guardian_review_id = Some(new_guardian_review_id());
@@ -400,6 +407,11 @@ impl ToolOrchestrator {
                     && tool.should_bypass_approval(approval_policy, already_approved)
                     && network_approval_context.is_none();
                 if !bypass_retry_approval {
+                    if turn_ctx.approvals_disabled {
+                        return Err(ToolError::Rejected(
+                            "approvals are disabled during auto-compaction fallback".to_string(),
+                        ));
+                    }
                     let guardian_review_id = use_guardian.then(new_guardian_review_id);
                     let approval_ctx = ApprovalCtx {
                         session: &tool_ctx.session,

--- a/codex-rs/core/src/tools/parallel.rs
+++ b/codex-rs/core/src/tools/parallel.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::time::Instant;
 
@@ -26,6 +27,8 @@ use crate::tools::registry::ToolArgumentDiffConsumer;
 use crate::tools::router::ToolCall;
 use crate::tools::router::ToolCallSource;
 use crate::tools::router::ToolRouter;
+use codex_protocol::dynamic_tools::DynamicToolNamespaceTool;
+use codex_protocol::dynamic_tools::DynamicToolSpec;
 use codex_protocol::error::CodexErr;
 use codex_protocol::models::ResponseInputItem;
 
@@ -46,6 +49,11 @@ pub(crate) struct ToolCallRuntime {
     step_context: Arc<StepContext>,
     tracker: SharedTurnDiffTracker,
     parallel_execution: Arc<RwLock<()>>,
+    max_tool_calls: Option<usize>,
+    tool_calls_started: Arc<AtomicUsize>,
+    max_nested_tool_calls: Option<usize>,
+    nested_tool_calls_started: Arc<AtomicUsize>,
+    deny_interactive_tools: bool,
 }
 
 impl ToolCallRuntime {
@@ -61,6 +69,36 @@ impl ToolCallRuntime {
             step_context,
             tracker,
             parallel_execution: Arc::new(RwLock::new(())),
+            max_tool_calls: None,
+            tool_calls_started: Arc::new(AtomicUsize::new(0)),
+            max_nested_tool_calls: None,
+            nested_tool_calls_started: Arc::new(AtomicUsize::new(0)),
+            deny_interactive_tools: false,
+        }
+    }
+
+    pub(crate) fn with_auto_compact_fallback_policy(mut self) -> Self {
+        self.max_tool_calls = Some(1);
+        self.max_nested_tool_calls = Some(1);
+        self.deny_interactive_tools = true;
+        self
+    }
+
+    /// Code-mode nested dispatch must share fallback admission counters with the outer model
+    /// response, but it needs an independent execution gate so a nested call does not deadlock
+    /// behind the top-level `exec` call that is waiting for it.
+    pub(crate) fn for_code_mode_nested_dispatch(&self) -> Self {
+        Self {
+            router: Arc::clone(&self.router),
+            session: Arc::clone(&self.session),
+            step_context: Arc::clone(&self.step_context),
+            tracker: Arc::clone(&self.tracker),
+            parallel_execution: Arc::new(RwLock::new(())),
+            max_tool_calls: self.max_tool_calls,
+            tool_calls_started: Arc::clone(&self.tool_calls_started),
+            max_nested_tool_calls: self.max_nested_tool_calls,
+            nested_tool_calls_started: Arc::clone(&self.nested_tool_calls_started),
+            deny_interactive_tools: self.deny_interactive_tools,
         }
     }
 
@@ -78,10 +116,11 @@ impl ToolCallRuntime {
         cancellation_token: CancellationToken,
     ) -> impl std::future::Future<Output = Result<ResponseInputItem, CodexErr>> {
         let error_call = call.clone();
-        let future =
-            self.handle_tool_call_with_source(call, ToolCallSource::Direct, cancellation_token);
         async move {
-            match future.await {
+            match self
+                .handle_tool_call_with_source(call, ToolCallSource::Direct, cancellation_token)
+                .await
+            {
                 Ok(response) => Ok(response.into_response()),
                 Err(FunctionCallError::Fatal(message)) => Err(CodexErr::Fatal(message)),
                 Err(other) => Ok(Self::failure_response(error_call, other)),
@@ -92,6 +131,78 @@ impl ToolCallRuntime {
 
     #[instrument(level = "trace", skip_all)]
     pub(crate) fn handle_tool_call_with_source(
+        self,
+        call: ToolCall,
+        source: ToolCallSource,
+        cancellation_token: CancellationToken,
+    ) -> impl std::future::Future<Output = Result<AnyToolResult, FunctionCallError>> {
+        let limit_exceeded = match &source {
+            ToolCallSource::Direct => self.max_tool_calls.is_some_and(|max_tool_calls| {
+                self.tool_calls_started.fetch_add(1, Ordering::AcqRel) >= max_tool_calls
+            }),
+            ToolCallSource::CodeMode { .. } => {
+                self.max_nested_tool_calls
+                    .is_some_and(|max_nested_tool_calls| {
+                        self.nested_tool_calls_started
+                            .fetch_add(1, Ordering::AcqRel)
+                            >= max_nested_tool_calls
+                    })
+            }
+        };
+        let interactive_tool_denied = self.deny_interactive_tools
+            && (self.is_dynamic_tool(&call.tool_name)
+                || (call.tool_name.namespace.is_none()
+                    && matches!(
+                        call.tool_name.name.as_str(),
+                        "request_permissions" | "request_plugin_install" | "request_user_input"
+                    )));
+        let rejection = if limit_exceeded {
+            Some(FunctionCallError::RespondToModel(
+                "only one tool call is allowed at this level during auto-compaction fallback"
+                    .to_string(),
+            ))
+        } else if interactive_tool_denied {
+            Some(FunctionCallError::RespondToModel(format!(
+                "{} is unavailable during auto-compaction fallback",
+                call.tool_name
+            )))
+        } else {
+            None
+        };
+        let future = rejection
+            .is_none()
+            .then(|| self.handle_tool_call_with_source_unchecked(call, source, cancellation_token));
+        async move {
+            if let Some(rejection) = rejection {
+                return Err(rejection);
+            }
+            future
+                .expect("tool future should exist without a rejection")
+                .await
+        }
+        .in_current_span()
+    }
+
+    fn is_dynamic_tool(&self, tool_name: &codex_tools::ToolName) -> bool {
+        self.step_context
+            .turn
+            .dynamic_tools
+            .iter()
+            .any(|spec| match spec {
+                DynamicToolSpec::Function(tool) => {
+                    tool_name.namespace.is_none() && tool_name.name == tool.name
+                }
+                DynamicToolSpec::Namespace(namespace) => {
+                    tool_name.namespace.as_deref() == Some(namespace.name.as_str())
+                        && namespace.tools.iter().any(|tool| {
+                            let DynamicToolNamespaceTool::Function(tool) = tool;
+                            tool_name.name == tool.name
+                        })
+                }
+            })
+    }
+
+    fn handle_tool_call_with_source_unchecked(
         self,
         call: ToolCall,
         source: ToolCallSource,
@@ -539,6 +650,266 @@ mod tests {
     }
 
     impl CoreToolRuntime for ImmediateHandler {}
+
+    struct CountingHandler {
+        tool_name: codex_tools::ToolName,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl ToolExecutor<ToolInvocation> for CountingHandler {
+        fn tool_name(&self) -> codex_tools::ToolName {
+            self.tool_name.clone()
+        }
+
+        fn spec(&self) -> codex_tools::ToolSpec {
+            codex_tools::ToolSpec::Function(codex_tools::ResponsesApiTool {
+                name: self.tool_name.name.clone(),
+                description: "Counting test tool.".to_string(),
+                strict: false,
+                defer_loading: None,
+                parameters: codex_tools::JsonSchema::default(),
+                output_schema: None,
+            })
+        }
+
+        fn handle(&self, _invocation: ToolInvocation) -> codex_tools::ToolExecutorFuture<'_> {
+            self.calls.fetch_add(1, Ordering::AcqRel);
+            Box::pin(async {
+                Ok(
+                    Box::new(FunctionToolOutput::from_text("ok".to_string(), Some(true)))
+                        as Box<dyn crate::tools::context::ToolOutput>,
+                )
+            })
+        }
+    }
+
+    impl CoreToolRuntime for CountingHandler {}
+
+    #[tokio::test]
+    async fn auto_compact_fallback_executes_only_the_first_tool_call() -> anyhow::Result<()> {
+        let (session, turn_context) = crate::session::tests::make_session_and_context().await;
+        let session = Arc::new(session);
+        let turn_context = Arc::new(turn_context);
+        let tool_name = codex_tools::ToolName::plain("test_tool");
+        let calls = Arc::new(AtomicUsize::new(0));
+        let handler = Arc::new(CountingHandler {
+            tool_name: tool_name.clone(),
+            calls: Arc::clone(&calls),
+        }) as Arc<dyn CoreToolRuntime>;
+        let step_context = StepContext::for_test(Arc::clone(&turn_context));
+        let router = Arc::new(ToolRouter::from_parts(
+            ToolRegistry::from_tools([handler]),
+            Vec::new(),
+        ));
+        let tracker = Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new()));
+        let runtime = ToolCallRuntime::new(router, session, step_context, tracker)
+            .with_auto_compact_fallback_policy();
+        let make_call = |call_id: &str| ToolCall {
+            tool_name: tool_name.clone(),
+            call_id: call_id.to_string(),
+            payload: ToolPayload::Function {
+                arguments: "{}".to_string(),
+            },
+        };
+
+        let first = runtime
+            .clone()
+            .handle_tool_call(make_call("call-1"), CancellationToken::new())
+            .await?;
+        let second = runtime
+            .handle_tool_call(make_call("call-2"), CancellationToken::new())
+            .await?;
+
+        assert_eq!(calls.load(Ordering::Acquire), 1);
+        let ResponseInputItem::FunctionCallOutput { output, .. } = first else {
+            anyhow::bail!("first tool call should return function output");
+        };
+        assert_eq!(output.success, Some(true));
+        assert_eq!(output.body, FunctionCallOutputBody::Text("ok".to_string()));
+        let ResponseInputItem::FunctionCallOutput { output, .. } = second else {
+            anyhow::bail!("second tool call should return function output");
+        };
+        assert_eq!(output.success, Some(false));
+        let FunctionCallOutputBody::Text(message) = output.body else {
+            anyhow::bail!("rejected tool output should be text");
+        };
+        assert!(message.contains("only one tool call is allowed"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn auto_compact_fallback_has_separate_one_call_limits_for_code_mode() -> anyhow::Result<()>
+    {
+        let (session, turn_context) = crate::session::tests::make_session_and_context().await;
+        let session = Arc::new(session);
+        let turn_context = Arc::new(turn_context);
+        let tool_name = codex_tools::ToolName::plain("test_tool");
+        let calls = Arc::new(AtomicUsize::new(0));
+        let handler = Arc::new(CountingHandler {
+            tool_name: tool_name.clone(),
+            calls: Arc::clone(&calls),
+        }) as Arc<dyn CoreToolRuntime>;
+        let step_context = StepContext::for_test(Arc::clone(&turn_context));
+        let router = Arc::new(ToolRouter::from_parts(
+            ToolRegistry::from_tools([handler]),
+            Vec::new(),
+        ));
+        let tracker = Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new()));
+        let runtime = ToolCallRuntime::new(router, session, step_context, tracker)
+            .with_auto_compact_fallback_policy();
+        let make_call = |call_id: &str| ToolCall {
+            tool_name: tool_name.clone(),
+            call_id: call_id.to_string(),
+            payload: ToolPayload::Function {
+                arguments: "{}".to_string(),
+            },
+        };
+
+        runtime
+            .clone()
+            .handle_tool_call(make_call("direct-1"), CancellationToken::new())
+            .await?;
+        let nested_runtime = runtime.for_code_mode_nested_dispatch();
+        nested_runtime
+            .clone()
+            .handle_tool_call_with_source(
+                make_call("nested-1"),
+                ToolCallSource::CodeMode {
+                    cell_id: "cell-1".to_string(),
+                    runtime_tool_call_id: "runtime-call-1".to_string(),
+                },
+                CancellationToken::new(),
+            )
+            .await?;
+        let second_direct = runtime
+            .handle_tool_call_with_source(
+                make_call("direct-2"),
+                ToolCallSource::Direct,
+                CancellationToken::new(),
+            )
+            .await;
+        let second_nested = nested_runtime
+            .handle_tool_call_with_source(
+                make_call("nested-2"),
+                ToolCallSource::CodeMode {
+                    cell_id: "cell-1".to_string(),
+                    runtime_tool_call_id: "runtime-call-2".to_string(),
+                },
+                CancellationToken::new(),
+            )
+            .await;
+
+        assert_eq!(calls.load(Ordering::Acquire), 2);
+        let Err(FunctionCallError::RespondToModel(message)) = second_direct else {
+            anyhow::bail!("second direct tool call should be rejected");
+        };
+        assert!(message.contains("only one tool call is allowed"));
+        let Err(FunctionCallError::RespondToModel(message)) = second_nested else {
+            anyhow::bail!("second nested tool call should be rejected");
+        };
+        assert!(message.contains("only one tool call is allowed"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn auto_compact_fallback_rejects_request_user_input_before_dispatch() -> anyhow::Result<()>
+    {
+        let (session, turn_context) = crate::session::tests::make_session_and_context().await;
+        let session = Arc::new(session);
+        let turn_context = Arc::new(turn_context);
+        let tool_name = codex_tools::ToolName::plain("request_user_input");
+        let calls = Arc::new(AtomicUsize::new(0));
+        let handler = Arc::new(CountingHandler {
+            tool_name: tool_name.clone(),
+            calls: Arc::clone(&calls),
+        }) as Arc<dyn CoreToolRuntime>;
+        let step_context = StepContext::for_test(Arc::clone(&turn_context));
+        let router = Arc::new(ToolRouter::from_parts(
+            ToolRegistry::from_tools([handler]),
+            Vec::new(),
+        ));
+        let tracker = Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new()));
+        let runtime = ToolCallRuntime::new(router, session, step_context, tracker)
+            .with_auto_compact_fallback_policy();
+        let call = ToolCall {
+            tool_name,
+            call_id: "call-1".to_string(),
+            payload: ToolPayload::Function {
+                arguments: "{}".to_string(),
+            },
+        };
+
+        let response = runtime
+            .handle_tool_call(call, CancellationToken::new())
+            .await?;
+
+        assert_eq!(calls.load(Ordering::Acquire), 0);
+        let ResponseInputItem::FunctionCallOutput { output, .. } = response else {
+            anyhow::bail!("rejected tool call should return function output");
+        };
+        assert_eq!(output.success, Some(false));
+        let FunctionCallOutputBody::Text(message) = output.body else {
+            anyhow::bail!("rejected tool output should be text");
+        };
+        assert!(message.contains("unavailable during auto-compaction fallback"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn auto_compact_fallback_rejects_dynamic_tool_before_dispatch() -> anyhow::Result<()> {
+        let tool_name = codex_tools::ToolName::plain("dynamic_tool");
+        let dynamic_tools = vec![DynamicToolSpec::Function(
+            codex_protocol::dynamic_tools::DynamicToolFunctionSpec {
+                name: tool_name.name.clone(),
+                description: "Dynamic test tool.".to_string(),
+                input_schema: serde_json::json!({"type": "object"}),
+                defer_loading: false,
+            },
+        )];
+        let (session, mut turn_context) = crate::session::tests::make_session_and_context().await;
+        turn_context.dynamic_tools = dynamic_tools;
+        let session = Arc::new(session);
+        let turn_context = Arc::new(turn_context);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let handler = Arc::new(CountingHandler {
+            tool_name: tool_name.clone(),
+            calls: Arc::clone(&calls),
+        }) as Arc<dyn CoreToolRuntime>;
+        let step_context = StepContext::for_test(Arc::clone(&turn_context));
+        let router = Arc::new(ToolRouter::from_parts(
+            ToolRegistry::from_tools([handler]),
+            Vec::new(),
+        ));
+        let tracker = Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new()));
+        let runtime = ToolCallRuntime::new(router, session, step_context, tracker)
+            .with_auto_compact_fallback_policy();
+        let call = ToolCall {
+            tool_name,
+            call_id: "call-1".to_string(),
+            payload: ToolPayload::Function {
+                arguments: "{}".to_string(),
+            },
+        };
+
+        let response = runtime
+            .handle_tool_call(call, CancellationToken::new())
+            .await?;
+
+        assert_eq!(calls.load(Ordering::Acquire), 0);
+        let ResponseInputItem::FunctionCallOutput { output, .. } = response else {
+            anyhow::bail!("rejected tool call should return function output");
+        };
+        assert_eq!(output.success, Some(false));
+        let FunctionCallOutputBody::Text(message) = output.body else {
+            anyhow::bail!("rejected tool output should be text");
+        };
+        assert!(message.contains("unavailable during auto-compaction fallback"));
+
+        Ok(())
+    }
 
     struct CancellationCleanupHandler {
         tool_name: codex_tools::ToolName,

--- a/codex-rs/core/src/turn_metadata_tests.rs
+++ b/codex-rs/core/src/turn_metadata_tests.rs
@@ -736,6 +736,18 @@ fn turn_metadata_state_overlays_compaction_only_on_compaction_requests() {
     assert_eq!(regular_json["request_kind"].as_str(), Some("turn"));
     assert_eq!(regular_json[WINDOW_ID_KEY].as_str(), Some("thread-a:3"));
     assert!(regular_json.get("compaction").is_none());
+
+    let fallback_header = test_responses_metadata_json(
+        &state,
+        "thread-a:3",
+        CodexResponsesRequestKind::AutoCompactFallback,
+    );
+    let fallback_json: Value = serde_json::from_str(&fallback_header).expect("json");
+    assert_eq!(
+        fallback_json["request_kind"].as_str(),
+        Some("auto_compact_fallback")
+    );
+    assert!(fallback_json.get("compaction").is_none());
 }
 
 #[tokio::test]

--- a/codex-rs/core/tests/suite/compact.rs
+++ b/codex-rs/core/tests/suite/compact.rs
@@ -2071,7 +2071,7 @@ async fn auto_compact_fallback_runs_one_tool_once_before_rollover() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn auto_compact_fallback_sampling_failure_still_rolls_over() {
+async fn auto_compact_fallback_retries_then_fails_without_rollover() {
     skip_if_no_network!();
 
     let server = start_mock_server().await;
@@ -2087,20 +2087,26 @@ async fn auto_compact_fallback_sampling_failure_still_rolls_over() {
                 ev_completed_with_tokens("compact-response", /*total_tokens*/ 10),
             ]),
             sse_failed(
-                "fallback-failed",
+                "fallback-failed-1",
                 "internal_error",
-                "fallback sampling failed",
+                "fallback sampling failed once",
             ),
-            sse(vec![
-                ev_assistant_message("next-message", FINAL_REPLY),
-                ev_completed_with_tokens("next-response", /*total_tokens*/ 10),
-            ]),
+            sse_failed(
+                "fallback-failed-2",
+                "internal_error",
+                "fallback sampling failed twice",
+            ),
+            sse_failed(
+                "fallback-failed-3",
+                "internal_error",
+                "fallback sampling failed three times",
+            ),
         ],
     )
     .await;
     let (extensions, prompt_calls, tool_calls) = auto_compact_fallback_test_extensions();
     let mut model_provider = non_openai_model_provider(&server);
-    model_provider.stream_max_retries = Some(0);
+    model_provider.stream_max_retries = Some(10);
     let mut builder = test_codex()
         .with_extensions(extensions)
         .with_config(move |config| {
@@ -2118,26 +2124,25 @@ async fn auto_compact_fallback_sampling_failure_still_rolls_over() {
     test.submit_turn("fill the first context window")
         .await
         .expect("submit first turn");
-    test.submit_turn("continue despite fallback failure")
+    test.submit_turn("fail after fallback retries")
         .await
         .expect("submit second turn");
 
     let requests = request_log.requests();
     assert_eq!(
         requests.len(),
-        4,
-        "failed fallback sample should not prevent post-rollover sampling"
+        5,
+        "expected initial, compact, and three fallback attempts without post-rollover sampling"
     );
     assert!(requests[1].body_contains_text(SUMMARIZATION_PROMPT));
-    assert!(
-        requests[2]
-            .message_input_texts("developer")
-            .iter()
-            .any(|text| text == AUTO_COMPACT_FALLBACK_PROMPT)
-    );
-    let post_rollover_body = requests[3].body_json().to_string();
-    assert!(post_rollover_body.contains("continue despite fallback failure"));
-    assert!(post_rollover_body.contains(AUTO_SUMMARY_TEXT));
+    for fallback_request in &requests[2..] {
+        assert!(
+            fallback_request
+                .message_input_texts("developer")
+                .iter()
+                .any(|text| text == AUTO_COMPACT_FALLBACK_PROMPT)
+        );
+    }
     assert_eq!(prompt_calls.load(Ordering::SeqCst), 1);
     assert_eq!(tool_calls.load(Ordering::SeqCst), 0);
 }

--- a/codex-rs/core/tests/suite/compact.rs
+++ b/codex-rs/core/tests/suite/compact.rs
@@ -1961,10 +1961,13 @@ async fn auto_compact_fallback_is_gated_by_feature_flag() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn auto_compact_fallback_runs_one_tool_once_before_rollover() {
+async fn auto_compact_fallback_allows_reasoning_before_one_tool_call() {
     skip_if_no_network!();
 
     let server = start_mock_server().await;
+    let mut fallback_reasoning_completed =
+        ev_completed_with_tokens("fallback-reasoning-response", /*total_tokens*/ 10);
+    fallback_reasoning_completed["response"]["end_turn"] = json!(false);
     let request_log = mount_sse_sequence(
         &server,
         vec![
@@ -1975,6 +1978,14 @@ async fn auto_compact_fallback_runs_one_tool_once_before_rollover() {
             sse(vec![
                 ev_assistant_message("compact-message", AUTO_SUMMARY_TEXT),
                 ev_completed_with_tokens("compact-response", /*total_tokens*/ 10),
+            ]),
+            sse(vec![
+                ev_reasoning_item(
+                    "fallback-reasoning",
+                    &["I should record fallback state before rollover."],
+                    &[],
+                ),
+                fallback_reasoning_completed,
             ]),
             // Deliberately violate `parallel_tool_calls: false`: the fallback
             // runtime must still execute no more than one tool call.
@@ -2024,8 +2035,8 @@ async fn auto_compact_fallback_runs_one_tool_once_before_rollover() {
     let requests = request_log.requests();
     assert_eq!(
         requests.len(),
-        4,
-        "expected initial, compact, one fallback sample, and post-rollover requests"
+        5,
+        "expected initial, compact, reasoning fallback, tool fallback, and post-rollover requests"
     );
     assert!(
         requests[1].body_contains_text(SUMMARIZATION_PROMPT),
@@ -2045,6 +2056,16 @@ async fn auto_compact_fallback_runs_one_tool_once_before_rollover() {
         Some(&Value::Bool(false)),
         "fallback sampling must disable parallel tool calls"
     );
+    let tool_fallback_request = &requests[3];
+    assert!(
+        tool_fallback_request.body_contains_text("I should record fallback state before rollover."),
+        "the tool-call fallback request should include the preceding reasoning item"
+    );
+    assert_eq!(
+        tool_fallback_request.body_json().get("parallel_tool_calls"),
+        Some(&Value::Bool(false)),
+        "every fallback sampling request must disable parallel tool calls"
+    );
     assert_eq!(prompt_calls.load(Ordering::SeqCst), 1);
     assert_eq!(
         tool_calls.load(Ordering::SeqCst),
@@ -2052,7 +2073,7 @@ async fn auto_compact_fallback_runs_one_tool_once_before_rollover() {
         "fallback runtime should execute at most one tool call"
     );
 
-    let post_rollover_request = &requests[3];
+    let post_rollover_request = &requests[4];
     let post_rollover_body = post_rollover_request.body_json().to_string();
     assert!(
         post_rollover_body.contains("continue after compaction"),
@@ -2064,6 +2085,7 @@ async fn auto_compact_fallback_runs_one_tool_once_before_rollover() {
     );
     assert!(
         !post_rollover_body.contains(AUTO_COMPACT_FALLBACK_PROMPT)
+            && !post_rollover_body.contains("I should record fallback state before rollover.")
             && !post_rollover_body.contains("fallback-call-1")
             && !post_rollover_body.contains("fallback-call-2"),
         "fallback-only prompt and tool artifacts should stay in the old window"

--- a/codex-rs/core/tests/suite/compact.rs
+++ b/codex-rs/core/tests/suite/compact.rs
@@ -3,6 +3,20 @@ use anyhow::anyhow;
 use codex_core::compact::SUMMARIZATION_PROMPT;
 use codex_core::compact::SUMMARY_PREFIX;
 use codex_core::config::Config;
+use codex_extension_api::AutoCompactFallbackContributionInput;
+use codex_extension_api::ContextContributor;
+use codex_extension_api::ExtensionData;
+use codex_extension_api::ExtensionRegistry;
+use codex_extension_api::ExtensionRegistryBuilder;
+use codex_extension_api::JsonToolOutput;
+use codex_extension_api::ResponsesApiTool;
+use codex_extension_api::ToolCall as ExtensionToolCall;
+use codex_extension_api::ToolContributor;
+use codex_extension_api::ToolExecutor;
+use codex_extension_api::ToolExecutorFuture;
+use codex_extension_api::ToolName;
+use codex_extension_api::ToolOutput;
+use codex_extension_api::ToolSpec;
 use codex_features::Feature;
 use codex_login::CodexAuth;
 use codex_model_provider_info::ModelProviderInfo;
@@ -63,6 +77,8 @@ use serde_json::json;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use tempfile::TempDir;
 use wiremock::MockServer;
 // --- Test helpers -----------------------------------------------------------
@@ -90,6 +106,9 @@ const GLOBAL_AGENTS_OVERRIDE_FILENAME: &str = "AGENTS.override.md";
 const NEW_GLOBAL_INSTRUCTIONS: &str = "new global instructions";
 const OLD_GLOBAL_INSTRUCTIONS: &str = "old global instructions";
 const REMOTE_V2_SUMMARY: &str = "global-instructions-remote-v2-summary";
+const AUTO_COMPACT_FALLBACK_PROMPT: &str =
+    "Persist the important state once before the context window rolls over.";
+const AUTO_COMPACT_FALLBACK_TOOL_NAME: &str = "record_fallback_state";
 
 pub(super) const COMPACT_WARNING_MESSAGE: &str = "Heads up: Long threads and multiple compactions can cause the model to be less accurate. Start a new thread when possible to keep threads small and targeted.";
 
@@ -99,6 +118,86 @@ fn ev_shell_command_call(call_id: &str, command: &str) -> serde_json::Value {
         "shell_command",
         &json!({ "command": command }).to_string(),
     )
+}
+
+struct AutoCompactFallbackTestExtension {
+    prompt_calls: Arc<AtomicUsize>,
+    tool_calls: Arc<AtomicUsize>,
+}
+
+impl ContextContributor for AutoCompactFallbackTestExtension {
+    fn contribute_auto_compact_fallback_prompt<'a>(
+        &'a self,
+        _input: AutoCompactFallbackContributionInput<'a>,
+    ) -> codex_extension_api::ExtensionFuture<'a, Option<String>> {
+        self.prompt_calls.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async { Some(AUTO_COMPACT_FALLBACK_PROMPT.to_string()) })
+    }
+}
+
+impl ToolContributor for AutoCompactFallbackTestExtension {
+    fn tools(
+        &self,
+        _session_store: &ExtensionData,
+        _thread_store: &ExtensionData,
+    ) -> Vec<Arc<dyn ToolExecutor<ExtensionToolCall>>> {
+        vec![Arc::new(AutoCompactFallbackTestTool {
+            calls: Arc::clone(&self.tool_calls),
+        })]
+    }
+}
+
+struct AutoCompactFallbackTestTool {
+    calls: Arc<AtomicUsize>,
+}
+
+impl ToolExecutor<ExtensionToolCall> for AutoCompactFallbackTestTool {
+    fn tool_name(&self) -> ToolName {
+        ToolName::plain(AUTO_COMPACT_FALLBACK_TOOL_NAME)
+    }
+
+    fn spec(&self) -> ToolSpec {
+        ToolSpec::Function(ResponsesApiTool {
+            name: AUTO_COMPACT_FALLBACK_TOOL_NAME.to_string(),
+            description: "Records fallback state for the auto-compaction test.".to_string(),
+            strict: true,
+            parameters: codex_extension_api::parse_tool_input_schema(&json!({
+                "type": "object",
+                "properties": {
+                    "state": { "type": "string" }
+                },
+                "required": ["state"],
+                "additionalProperties": false
+            }))
+            .expect("fallback test tool schema should parse"),
+            output_schema: None,
+            defer_loading: None,
+        })
+    }
+
+    fn handle(&self, _call: ExtensionToolCall) -> ToolExecutorFuture<'_> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async {
+            Ok(Box::new(JsonToolOutput::new(json!({ "recorded": true }))) as Box<dyn ToolOutput>)
+        })
+    }
+}
+
+fn auto_compact_fallback_test_extensions() -> (
+    Arc<ExtensionRegistry<Config>>,
+    Arc<AtomicUsize>,
+    Arc<AtomicUsize>,
+) {
+    let prompt_calls = Arc::new(AtomicUsize::new(0));
+    let tool_calls = Arc::new(AtomicUsize::new(0));
+    let extension = Arc::new(AutoCompactFallbackTestExtension {
+        prompt_calls: Arc::clone(&prompt_calls),
+        tool_calls: Arc::clone(&tool_calls),
+    });
+    let mut builder = ExtensionRegistryBuilder::<Config>::new();
+    builder.prompt_contributor(extension.clone());
+    builder.tool_contributor(extension);
+    (Arc::new(builder.build()), prompt_calls, tool_calls)
 }
 
 fn disabled_permission_user_turn(text: impl Into<String>, cwd: PathBuf, model: String) -> Op {
@@ -1799,6 +1898,248 @@ async fn auto_compact_runs_after_token_limit_hit() {
             .any(|text| text.contains(prefixed_auto_summary)),
         "auto compact follow-up request should include the summary message"
     );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn auto_compact_fallback_is_gated_by_feature_flag() {
+    skip_if_no_network!();
+
+    let server = start_mock_server().await;
+    let request_log = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_assistant_message("initial-message", FIRST_REPLY),
+                ev_completed_with_tokens("initial-response", /*total_tokens*/ 95),
+            ]),
+            sse(vec![
+                ev_assistant_message("compact-message", AUTO_SUMMARY_TEXT),
+                ev_completed_with_tokens("compact-response", /*total_tokens*/ 10),
+            ]),
+            sse(vec![
+                ev_assistant_message("next-message", FINAL_REPLY),
+                ev_completed_with_tokens("next-response", /*total_tokens*/ 10),
+            ]),
+        ],
+    )
+    .await;
+    let (extensions, prompt_calls, tool_calls) = auto_compact_fallback_test_extensions();
+    let model_provider = non_openai_model_provider(&server);
+    let mut builder = test_codex()
+        .with_extensions(extensions)
+        .with_config(move |config| {
+            config.model_provider = model_provider;
+            set_test_compact_prompt(config);
+            config.model_context_window = Some(100);
+            config.model_auto_compact_token_limit = Some(90);
+            config
+                .features
+                .disable(Feature::AutoCompactFallback)
+                .expect("auto compact fallback feature should be known");
+        });
+    let test = builder.build(&server).await.expect("build codex");
+
+    test.submit_turn("fill the first context window")
+        .await
+        .expect("submit first turn");
+    test.submit_turn("continue after compaction")
+        .await
+        .expect("submit second turn");
+
+    let requests = request_log.requests();
+    assert_eq!(
+        requests.len(),
+        3,
+        "feature-off auto compaction should not add a fallback request"
+    );
+    assert!(
+        requests[1].body_contains_text(SUMMARIZATION_PROMPT),
+        "second request should be local auto compaction"
+    );
+    assert_eq!(prompt_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(tool_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn auto_compact_fallback_runs_one_tool_once_before_rollover() {
+    skip_if_no_network!();
+
+    let server = start_mock_server().await;
+    let request_log = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_assistant_message("initial-message", FIRST_REPLY),
+                ev_completed_with_tokens("initial-response", /*total_tokens*/ 95),
+            ]),
+            sse(vec![
+                ev_assistant_message("compact-message", AUTO_SUMMARY_TEXT),
+                ev_completed_with_tokens("compact-response", /*total_tokens*/ 10),
+            ]),
+            // Deliberately violate `parallel_tool_calls: false`: the fallback
+            // runtime must still execute no more than one tool call.
+            sse(vec![
+                ev_function_call(
+                    "fallback-call-1",
+                    AUTO_COMPACT_FALLBACK_TOOL_NAME,
+                    &json!({ "state": "first" }).to_string(),
+                ),
+                ev_function_call(
+                    "fallback-call-2",
+                    AUTO_COMPACT_FALLBACK_TOOL_NAME,
+                    &json!({ "state": "second" }).to_string(),
+                ),
+                ev_completed_with_tokens("fallback-response", /*total_tokens*/ 10),
+            ]),
+            sse(vec![
+                ev_assistant_message("next-message", FINAL_REPLY),
+                ev_completed_with_tokens("next-response", /*total_tokens*/ 10),
+            ]),
+        ],
+    )
+    .await;
+    let (extensions, prompt_calls, tool_calls) = auto_compact_fallback_test_extensions();
+    let model_provider = non_openai_model_provider(&server);
+    let mut builder = test_codex()
+        .with_extensions(extensions)
+        .with_config(move |config| {
+            config.model_provider = model_provider;
+            set_test_compact_prompt(config);
+            config.model_context_window = Some(100);
+            config.model_auto_compact_token_limit = Some(90);
+            config
+                .features
+                .enable(Feature::AutoCompactFallback)
+                .expect("auto compact fallback feature should be known");
+        });
+    let test = builder.build(&server).await.expect("build codex");
+
+    test.submit_turn("fill the first context window")
+        .await
+        .expect("submit first turn");
+    test.submit_turn("continue after compaction")
+        .await
+        .expect("submit second turn");
+
+    let requests = request_log.requests();
+    assert_eq!(
+        requests.len(),
+        4,
+        "expected initial, compact, one fallback sample, and post-rollover requests"
+    );
+    assert!(
+        requests[1].body_contains_text(SUMMARIZATION_PROMPT),
+        "fallback must run only after local auto compaction completes"
+    );
+
+    let fallback_request = &requests[2];
+    assert!(
+        fallback_request
+            .message_input_texts("developer")
+            .iter()
+            .any(|text| text == AUTO_COMPACT_FALLBACK_PROMPT),
+        "fallback request should contain the contributor prompt as a developer message"
+    );
+    assert_eq!(
+        fallback_request.body_json().get("parallel_tool_calls"),
+        Some(&Value::Bool(false)),
+        "fallback sampling must disable parallel tool calls"
+    );
+    assert_eq!(prompt_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        tool_calls.load(Ordering::SeqCst),
+        1,
+        "fallback runtime should execute at most one tool call"
+    );
+
+    let post_rollover_request = &requests[3];
+    let post_rollover_body = post_rollover_request.body_json().to_string();
+    assert!(
+        post_rollover_body.contains("continue after compaction"),
+        "post-rollover request should retain the pending user turn"
+    );
+    assert!(
+        post_rollover_body.contains(AUTO_SUMMARY_TEXT),
+        "post-rollover request should contain the compacted summary"
+    );
+    assert!(
+        !post_rollover_body.contains(AUTO_COMPACT_FALLBACK_PROMPT)
+            && !post_rollover_body.contains("fallback-call-1")
+            && !post_rollover_body.contains("fallback-call-2"),
+        "fallback-only prompt and tool artifacts should stay in the old window"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn auto_compact_fallback_sampling_failure_still_rolls_over() {
+    skip_if_no_network!();
+
+    let server = start_mock_server().await;
+    let request_log = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_assistant_message("initial-message", FIRST_REPLY),
+                ev_completed_with_tokens("initial-response", /*total_tokens*/ 95),
+            ]),
+            sse(vec![
+                ev_assistant_message("compact-message", AUTO_SUMMARY_TEXT),
+                ev_completed_with_tokens("compact-response", /*total_tokens*/ 10),
+            ]),
+            sse_failed(
+                "fallback-failed",
+                "internal_error",
+                "fallback sampling failed",
+            ),
+            sse(vec![
+                ev_assistant_message("next-message", FINAL_REPLY),
+                ev_completed_with_tokens("next-response", /*total_tokens*/ 10),
+            ]),
+        ],
+    )
+    .await;
+    let (extensions, prompt_calls, tool_calls) = auto_compact_fallback_test_extensions();
+    let mut model_provider = non_openai_model_provider(&server);
+    model_provider.stream_max_retries = Some(0);
+    let mut builder = test_codex()
+        .with_extensions(extensions)
+        .with_config(move |config| {
+            config.model_provider = model_provider;
+            set_test_compact_prompt(config);
+            config.model_context_window = Some(100);
+            config.model_auto_compact_token_limit = Some(90);
+            config
+                .features
+                .enable(Feature::AutoCompactFallback)
+                .expect("auto compact fallback feature should be known");
+        });
+    let test = builder.build(&server).await.expect("build codex");
+
+    test.submit_turn("fill the first context window")
+        .await
+        .expect("submit first turn");
+    test.submit_turn("continue despite fallback failure")
+        .await
+        .expect("submit second turn");
+
+    let requests = request_log.requests();
+    assert_eq!(
+        requests.len(),
+        4,
+        "failed fallback sample should not prevent post-rollover sampling"
+    );
+    assert!(requests[1].body_contains_text(SUMMARIZATION_PROMPT));
+    assert!(
+        requests[2]
+            .message_input_texts("developer")
+            .iter()
+            .any(|text| text == AUTO_COMPACT_FALLBACK_PROMPT)
+    );
+    let post_rollover_body = requests[3].body_json().to_string();
+    assert!(post_rollover_body.contains("continue despite fallback failure"));
+    assert!(post_rollover_body.contains(AUTO_SUMMARY_TEXT));
+    assert_eq!(prompt_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(tool_calls.load(Ordering::SeqCst), 0);
 }
 
 // Windows CI only: bump to 4 workers to prevent SSE/event starvation and test timeouts.

--- a/codex-rs/core/tests/suite/snapshots/all__suite__token_budget__token_budget_new_context_window_tool_full_context.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__token_budget__token_budget_new_context_window_tool_full_context.snap
@@ -1,6 +1,6 @@
 ---
 source: core/tests/suite/token_budget.rs
-assertion_line: 545
+assertion_line: 1239
 expression: snapshot
 ---
 Scenario: New context window tool installs fresh full context before the next follow-up request.
@@ -9,7 +9,7 @@ Scenario: New context window tool installs fresh full context before the next fo
 00:message/developer[3]:
     [01] <PERMISSIONS_INSTRUCTIONS>
     [02] <SKILLS_INSTRUCTIONS>
-    [03] <context_window>\nThread id: <THREAD_ID>\nFirst context window id: <FIRST_WINDOW_ID>\nCurrent context window id: <WINDOW_ID>\nPrevious context window id: <FIRST_WINDOW_ID>\n</context_window>
+    [03] \n\n<context_window>\nThread id: <THREAD_ID>\nFirst context window id: <FIRST_WINDOW_ID>\nCurrent context window id: <WINDOW_ID>\nPrevious context window id: <FIRST_WINDOW_ID>\n</context_window>\n\n
 01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 02:function_call/update_plan
 03:function_call_output:Plan updated

--- a/codex-rs/core/tests/suite/token_budget.rs
+++ b/codex-rs/core/tests/suite/token_budget.rs
@@ -41,6 +41,7 @@ use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_completed_with_tokens;
 use core_test_support::responses::ev_function_call;
+use core_test_support::responses::ev_reasoning_item;
 use core_test_support::responses::ev_response_created;
 use core_test_support::responses::mount_compact_json_once;
 use core_test_support::responses::mount_sse_sequence;
@@ -954,13 +955,16 @@ async fn token_budget_mid_turn_auto_compaction_resets_before_active_follow_up() 
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn token_budget_auto_compact_fallback_runs_in_old_window_before_reset() -> Result<()> {
+async fn token_budget_auto_compact_fallback_allows_reasoning_before_one_tool_call() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
     let trigger_call_id = "token-budget-trigger-call";
     let first_fallback_call_id = "token-budget-fallback-call-1";
     let second_fallback_call_id = "token-budget-fallback-call-2";
+    let mut fallback_reasoning_completed =
+        ev_completed_with_tokens("fallback-reasoning", /*total_tokens*/ 10);
+    fallback_reasoning_completed["response"]["end_turn"] = json!(false);
     let responses = mount_sse_sequence(
         &server,
         vec![
@@ -968,6 +972,14 @@ async fn token_budget_auto_compact_fallback_runs_in_old_window_before_reset() ->
                 ev_response_created("resp-1"),
                 ev_function_call(trigger_call_id, "get_context_remaining", "{}"),
                 ev_completed_with_tokens("resp-1", /*total_tokens*/ 9_500),
+            ]),
+            sse(vec![
+                ev_reasoning_item(
+                    "fallback-reasoning-item",
+                    &["I should persist token-budget fallback state."],
+                    &[],
+                ),
+                fallback_reasoning_completed,
             ]),
             // Deliberately return two calls even though the request disables parallel tool calls.
             // The fallback runtime must execute only the first one.
@@ -1021,8 +1033,8 @@ async fn token_budget_auto_compact_fallback_runs_in_old_window_before_reset() ->
     let requests = responses.requests();
     assert_eq!(
         requests.len(),
-        3,
-        "expected initial, fallback, and post-rollover sampling requests"
+        4,
+        "expected initial, reasoning fallback, tool fallback, and post-rollover sampling requests"
     );
 
     let thread_id = test.session_configured.thread_id;
@@ -1048,13 +1060,27 @@ async fn token_budget_auto_compact_fallback_runs_in_old_window_before_reset() ->
         fallback_request.body_json().get("parallel_tool_calls"),
         Some(&Value::Bool(false))
     );
+    let tool_fallback_request = &requests[2];
+    assert_eq!(
+        token_budget_contexts(tool_fallback_request),
+        initial_context,
+        "tool fallback sampling should remain in the old context window"
+    );
+    assert!(
+        tool_fallback_request.body_contains_text("I should persist token-budget fallback state."),
+        "the tool-call request should include the preceding reasoning item"
+    );
+    assert_eq!(
+        tool_fallback_request.body_json().get("parallel_tool_calls"),
+        Some(&Value::Bool(false))
+    );
     assert_eq!(
         tool_calls.load(Ordering::SeqCst),
         1,
         "only one extension tool call may execute during fallback"
     );
 
-    let post_rollover_request = &requests[2];
+    let post_rollover_request = &requests[3];
     let post_rollover_context = token_budget_contexts(post_rollover_request);
     assert_eq!(post_rollover_context.len(), 1);
     let (new_first_window_id, previous_window_id, new_window_id) =
@@ -1064,6 +1090,7 @@ async fn token_budget_auto_compact_fallback_runs_in_old_window_before_reset() ->
     assert_ne!(new_window_id, old_window_id);
     for fallback_artifact in [
         TOKEN_BUDGET_FALLBACK_PROMPT,
+        "I should persist token-budget fallback state.",
         first_fallback_call_id,
         second_fallback_call_id,
         "first-fallback-state",

--- a/codex-rs/core/tests/suite/token_budget.rs
+++ b/codex-rs/core/tests/suite/token_budget.rs
@@ -1,7 +1,22 @@
 use anyhow::Result;
 use codex_config::types::McpServerConfig;
 use codex_config::types::McpServerTransportConfig;
+use codex_core::config::Config;
 use codex_core::config::TokenBudgetConfig;
+use codex_extension_api::AutoCompactFallbackContributionInput;
+use codex_extension_api::ContextContributor;
+use codex_extension_api::ExtensionData;
+use codex_extension_api::ExtensionRegistry;
+use codex_extension_api::ExtensionRegistryBuilder;
+use codex_extension_api::JsonToolOutput;
+use codex_extension_api::ResponsesApiTool;
+use codex_extension_api::ToolCall as ExtensionToolCall;
+use codex_extension_api::ToolContributor;
+use codex_extension_api::ToolExecutor;
+use codex_extension_api::ToolExecutorFuture;
+use codex_extension_api::ToolName;
+use codex_extension_api::ToolOutput;
+use codex_extension_api::ToolSpec;
 use codex_features::Feature;
 use codex_model_provider_info::built_in_model_providers;
 use codex_protocol::config_types::AutoCompactTokenLimitScope;
@@ -43,9 +58,89 @@ use serde_json::Value;
 use serde_json::json;
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 const CONFIGURED_CONTEXT_WINDOW: i64 = 128_000;
+const TOKEN_BUDGET_FALLBACK_PROMPT: &str =
+    "Persist token-budget state once before this context window rolls over.";
+const TOKEN_BUDGET_FALLBACK_TOOL_NAME: &str = "record_token_budget_fallback_state";
+
+struct TokenBudgetAutoCompactFallbackExtension {
+    tool_calls: Arc<AtomicUsize>,
+}
+
+impl ContextContributor for TokenBudgetAutoCompactFallbackExtension {
+    fn contribute_auto_compact_fallback_prompt<'a>(
+        &'a self,
+        _input: AutoCompactFallbackContributionInput<'a>,
+    ) -> codex_extension_api::ExtensionFuture<'a, Option<String>> {
+        Box::pin(async { Some(TOKEN_BUDGET_FALLBACK_PROMPT.to_string()) })
+    }
+}
+
+impl ToolContributor for TokenBudgetAutoCompactFallbackExtension {
+    fn tools(
+        &self,
+        _session_store: &ExtensionData,
+        _thread_store: &ExtensionData,
+    ) -> Vec<Arc<dyn ToolExecutor<ExtensionToolCall>>> {
+        vec![Arc::new(TokenBudgetAutoCompactFallbackTool {
+            calls: Arc::clone(&self.tool_calls),
+        })]
+    }
+}
+
+struct TokenBudgetAutoCompactFallbackTool {
+    calls: Arc<AtomicUsize>,
+}
+
+impl ToolExecutor<ExtensionToolCall> for TokenBudgetAutoCompactFallbackTool {
+    fn tool_name(&self) -> ToolName {
+        ToolName::plain(TOKEN_BUDGET_FALLBACK_TOOL_NAME)
+    }
+
+    fn spec(&self) -> ToolSpec {
+        ToolSpec::Function(ResponsesApiTool {
+            name: TOKEN_BUDGET_FALLBACK_TOOL_NAME.to_string(),
+            description: "Records fallback state for the token-budget integration test."
+                .to_string(),
+            strict: true,
+            parameters: codex_extension_api::parse_tool_input_schema(&json!({
+                "type": "object",
+                "properties": {
+                    "state": { "type": "string" }
+                },
+                "required": ["state"],
+                "additionalProperties": false
+            }))
+            .expect("token-budget fallback tool schema should parse"),
+            output_schema: None,
+            defer_loading: None,
+        })
+    }
+
+    fn handle(&self, _call: ExtensionToolCall) -> ToolExecutorFuture<'_> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async {
+            Ok(Box::new(JsonToolOutput::new(json!({ "recorded": true }))) as Box<dyn ToolOutput>)
+        })
+    }
+}
+
+fn token_budget_auto_compact_fallback_extensions()
+-> (Arc<ExtensionRegistry<Config>>, Arc<AtomicUsize>) {
+    let tool_calls = Arc::new(AtomicUsize::new(0));
+    let extension = Arc::new(TokenBudgetAutoCompactFallbackExtension {
+        tool_calls: Arc::clone(&tool_calls),
+    });
+    let mut builder = ExtensionRegistryBuilder::<Config>::new();
+    builder.prompt_contributor(extension.clone());
+    builder.tool_contributor(extension);
+    (Arc::new(builder.build()), tool_calls)
+}
 
 fn token_budget_contexts(request: &ResponsesRequest) -> Vec<String> {
     let context_window_prefix = format!("{CONTEXT_WINDOW_OPEN_TAG}\nThread id: ");
@@ -854,6 +949,131 @@ async fn token_budget_mid_turn_auto_compaction_resets_before_active_follow_up() 
         follow_up_window_id, initial_window_id,
         "mid-turn token-budget auto-compaction should reset the context window"
     );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn token_budget_auto_compact_fallback_runs_in_old_window_before_reset() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let trigger_call_id = "token-budget-trigger-call";
+    let first_fallback_call_id = "token-budget-fallback-call-1";
+    let second_fallback_call_id = "token-budget-fallback-call-2";
+    let responses = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                ev_function_call(trigger_call_id, "get_context_remaining", "{}"),
+                ev_completed_with_tokens("resp-1", /*total_tokens*/ 9_500),
+            ]),
+            // Deliberately return two calls even though the request disables parallel tool calls.
+            // The fallback runtime must execute only the first one.
+            sse(vec![
+                ev_response_created("fallback-resp"),
+                ev_function_call(
+                    first_fallback_call_id,
+                    TOKEN_BUDGET_FALLBACK_TOOL_NAME,
+                    &json!({ "state": "first-fallback-state" }).to_string(),
+                ),
+                ev_function_call(
+                    second_fallback_call_id,
+                    TOKEN_BUDGET_FALLBACK_TOOL_NAME,
+                    &json!({ "state": "second-fallback-state" }).to_string(),
+                ),
+                ev_completed_with_tokens("fallback-resp", /*total_tokens*/ 10),
+            ]),
+            sse(vec![
+                ev_response_created("resp-3"),
+                ev_assistant_message("msg-3", "done in the new window"),
+                ev_completed("resp-3"),
+            ]),
+        ],
+    )
+    .await;
+    let (extensions, tool_calls) = token_budget_auto_compact_fallback_extensions();
+    let mut model_provider = built_in_model_providers(/*openai_base_url*/ None)["openai"].clone();
+    model_provider.name = "OpenAI (test)".into();
+    model_provider.base_url = Some(format!("{}/v1", server.uri()));
+    model_provider.supports_websockets = false;
+    let test = test_codex()
+        .with_extensions(extensions)
+        .with_config(move |config| {
+            config.model_provider = model_provider;
+            config.model_context_window = Some(10_000);
+            config
+                .features
+                .enable(Feature::TokenBudget)
+                .expect("test config should allow token budget");
+            config
+                .features
+                .enable(Feature::AutoCompactFallback)
+                .expect("auto compact fallback feature should be known");
+        })
+        .build(&server)
+        .await?;
+
+    test.submit_turn("trigger token-budget fallback compaction")
+        .await?;
+
+    let requests = responses.requests();
+    assert_eq!(
+        requests.len(),
+        3,
+        "expected initial, fallback, and post-rollover sampling requests"
+    );
+
+    let thread_id = test.session_configured.thread_id;
+    let initial_context = token_budget_contexts(&requests[0]);
+    assert_eq!(initial_context.len(), 1);
+    let (first_window_id, _, old_window_id) =
+        token_budget_window_ids(&initial_context[0], thread_id);
+
+    let fallback_request = &requests[1];
+    assert_eq!(
+        token_budget_contexts(fallback_request),
+        initial_context,
+        "fallback sampling should still use the old context window"
+    );
+    assert!(
+        fallback_request
+            .message_input_texts("developer")
+            .iter()
+            .any(|text| text == TOKEN_BUDGET_FALLBACK_PROMPT),
+        "fallback request should include the extension-provided developer message"
+    );
+    assert_eq!(
+        fallback_request.body_json().get("parallel_tool_calls"),
+        Some(&Value::Bool(false))
+    );
+    assert_eq!(
+        tool_calls.load(Ordering::SeqCst),
+        1,
+        "only one extension tool call may execute during fallback"
+    );
+
+    let post_rollover_request = &requests[2];
+    let post_rollover_context = token_budget_contexts(post_rollover_request);
+    assert_eq!(post_rollover_context.len(), 1);
+    let (new_first_window_id, previous_window_id, new_window_id) =
+        token_budget_window_ids(&post_rollover_context[0], thread_id);
+    assert_eq!(new_first_window_id, first_window_id);
+    assert_eq!(previous_window_id.as_deref(), Some(old_window_id.as_str()));
+    assert_ne!(new_window_id, old_window_id);
+    for fallback_artifact in [
+        TOKEN_BUDGET_FALLBACK_PROMPT,
+        first_fallback_call_id,
+        second_fallback_call_id,
+        "first-fallback-state",
+        "second-fallback-state",
+    ] {
+        assert!(
+            !post_rollover_request.body_contains_text(fallback_artifact),
+            "new-window sampling should exclude fallback artifact: {fallback_artifact}"
+        );
+    }
 
     Ok(())
 }

--- a/codex-rs/core/tests/suite/token_budget.rs
+++ b/codex-rs/core/tests/suite/token_budget.rs
@@ -1079,7 +1079,7 @@ async fn token_budget_auto_compact_fallback_runs_in_old_window_before_reset() ->
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn new_context_tool_starts_new_window_before_follow_up() -> Result<()> {
+async fn new_context_tool_skips_fallback_and_starts_new_window_before_follow_up() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
@@ -1097,7 +1097,9 @@ async fn new_context_tool_starts_new_window_before_follow_up() -> Result<()> {
             sse(vec![
                 ev_response_created("resp-1"),
                 ev_function_call(call_id, "new_context", "{}"),
-                ev_completed("resp-1"),
+                // Explicit rollover takes precedence even when this response also crosses the
+                // automatic compaction threshold.
+                ev_completed_with_tokens("resp-1", /*total_tokens*/ 9_500),
             ]),
             sse(vec![
                 ev_response_created("resp-2"),
@@ -1112,13 +1114,19 @@ async fn new_context_tool_starts_new_window_before_follow_up() -> Result<()> {
         ],
     )
     .await;
+    let (extensions, fallback_tool_calls) = token_budget_auto_compact_fallback_extensions();
     let test = test_codex()
+        .with_extensions(extensions)
         .with_config(|config| {
-            config.model_context_window = Some(CONFIGURED_CONTEXT_WINDOW);
+            config.model_context_window = Some(10_000);
             config
                 .features
                 .enable(Feature::TokenBudget)
                 .expect("test config should allow token budget");
+            config
+                .features
+                .enable(Feature::AutoCompactFallback)
+                .expect("auto compact fallback feature should be known");
         })
         .build(&server)
         .await?;
@@ -1133,12 +1141,32 @@ async fn new_context_tool_starts_new_window_before_follow_up() -> Result<()> {
             .any(|name| name == "new_context"),
         "new_context should be exposed when token budget is enabled"
     );
+    assert_eq!(
+        fallback_tool_calls.load(Ordering::SeqCst),
+        0,
+        "explicit new_context should skip fallback tool execution"
+    );
+    assert!(
+        !requests[1].body_contains_text(TOKEN_BUDGET_FALLBACK_PROMPT),
+        "the first new-window request should not include the fallback prompt"
+    );
+    let first_new_window_metadata: Value = serde_json::from_str(
+        &requests[1]
+            .header("x-codex-turn-metadata")
+            .expect("the first new-window request should include turn metadata"),
+    )
+    .expect("turn metadata should be valid json");
+    assert_eq!(
+        first_new_window_metadata["request_kind"].as_str(),
+        Some("turn"),
+        "explicit new_context should continue directly with a normal turn"
+    );
     let thread_id = test.session_configured.thread_id;
     let initial_token_budget = token_budget_contexts(&requests[0]);
     assert_eq!(initial_token_budget.len(), 1);
     let (initial_first_window_id, _, initial_window_id) =
         token_budget_window_ids(&initial_token_budget[0], thread_id);
-    let new_window_token_budget = token_budget_contexts(&requests[2]);
+    let new_window_token_budget = token_budget_contexts(&requests[1]);
     assert_eq!(new_window_token_budget.len(), 1);
     let (new_first_window_id, new_previous_window_id, new_window_id) =
         token_budget_window_ids(&new_window_token_budget[0], thread_id);
@@ -1149,7 +1177,7 @@ async fn new_context_tool_starts_new_window_before_follow_up() -> Result<()> {
     );
     assert_ne!(new_window_id, initial_window_id);
     assert!(
-        !requests[2].body_contains_text("request new context window"),
+        !requests[1].body_contains_text("request new context window"),
         "new_context should drop the prior window history before continuing the turn"
     );
     assert_eq!(

--- a/codex-rs/core/tests/suite/token_budget.rs
+++ b/codex-rs/core/tests/suite/token_budget.rs
@@ -148,7 +148,7 @@ fn token_budget_contexts(request: &ResponsesRequest) -> Vec<String> {
     request
         .message_input_texts("developer")
         .into_iter()
-        .filter(|text| text.starts_with(&context_window_prefix))
+        .filter(|text| text.trim_start().starts_with(&context_window_prefix))
         .collect()
 }
 
@@ -156,6 +156,7 @@ fn token_budget_window_ids(
     text: &str,
     thread_id: codex_protocol::ThreadId,
 ) -> (String, Option<String>, String) {
+    let text = text.trim();
     let captures = assert_regex_match(
         &format!(
             r"^{CONTEXT_WINDOW_OPEN_TAG}\nThread id: {thread_id}\nFirst context window id: ([0-9a-f-]{{36}})\nCurrent context window id: ([0-9a-f-]{{36}})(?:\nPrevious context window id: ([0-9a-f-]{{36}}))?\n{CONTEXT_WINDOW_CLOSE_TAG}$"
@@ -343,12 +344,27 @@ async fn token_budget_guidance_follows_context_window() -> Result<()> {
     let developer_texts = response.single_request().message_input_texts("developer");
     let context_window_index = developer_texts
         .iter()
-        .position(|text| text.starts_with(CONTEXT_WINDOW_OPEN_TAG))
+        .position(|text| text.trim_start().starts_with(CONTEXT_WINDOW_OPEN_TAG))
         .expect("context-window metadata should be present");
+    let developer_text = developer_texts.concat();
+    assert!(
+        developer_text.contains(&format!("\n\n{CONTEXT_WINDOW_OPEN_TAG}")),
+        "context-window metadata should follow a blank line"
+    );
+    assert!(
+        developer_text.contains(&format!(
+            "{CONTEXT_WINDOW_CLOSE_TAG}\n\n\n\n{CONTEXT_WINDOW_GUIDANCE_OPEN_TAG}"
+        )),
+        "context-window guidance should be padded from context-window metadata"
+    );
+    assert!(
+        developer_text.contains(&format!("{CONTEXT_WINDOW_GUIDANCE_CLOSE_TAG}\n\n")),
+        "context-window guidance should end with a blank line"
+    );
     assert_eq!(
         developer_texts.get(context_window_index + 1),
         Some(&format!(
-            "{CONTEXT_WINDOW_GUIDANCE_OPEN_TAG}\n{guidance_message}\n{CONTEXT_WINDOW_GUIDANCE_CLOSE_TAG}"
+            "\n\n{CONTEXT_WINDOW_GUIDANCE_OPEN_TAG}\n{guidance_message}\n{CONTEXT_WINDOW_GUIDANCE_CLOSE_TAG}\n\n"
         ))
     );
 
@@ -423,7 +439,7 @@ async fn token_budget_context_injects_plain_thread_hint_text() -> Result<()> {
         &format!(
             r"^{CONTEXT_WINDOW_OPEN_TAG}\nThread id: {thread_id}\nFirst context window id: ([0-9a-f-]{{36}})\nCurrent context window id: ([0-9a-f-]{{36}})\nmanual history hint for thread {thread_id}\nunstructured notes/thread_hint fixture result\n{CONTEXT_WINDOW_CLOSE_TAG}$"
         ),
-        &token_budgets[0],
+        token_budgets[0].trim(),
     );
     assert_eq!(
         captures.get(1).expect("first window id capture").as_str(),

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -2,6 +2,7 @@
 //   stdout is the final message (if any).
 // - In --json mode, stdout must be valid JSONL, one event per line.
 // For both modes, any other output must be written to stderr.
+#![recursion_limit = "256"]
 #![deny(clippy::print_stdout)]
 
 mod cli;

--- a/codex-rs/ext/extension-api/src/contributors.rs
+++ b/codex-rs/ext/extension-api/src/contributors.rs
@@ -111,7 +111,7 @@ pub trait ContextContributor: Send + Sync {
     }
 
     /// Returns an optional developer-message fragment for the single
-    /// best-effort turn run before an automatic compaction rollover.
+    /// fallback turn run before an automatic compaction rollover.
     ///
     /// The host combines non-empty contributions in registration order into
     /// one developer message. Implementations should keep the contribution

--- a/codex-rs/ext/extension-api/src/contributors.rs
+++ b/codex-rs/ext/extension-api/src/contributors.rs
@@ -20,6 +20,7 @@ mod turn_input;
 mod turn_lifecycle;
 mod world_state;
 
+pub use context::AutoCompactFallbackContributionInput;
 pub use context::TurnContextContributionInput;
 pub use mcp::McpServerContribution;
 pub use mcp::McpServerContributionContext;
@@ -106,6 +107,23 @@ pub trait ContextContributor: Send + Sync {
             let _self = self;
             let _input = input;
             Vec::new()
+        })
+    }
+
+    /// Returns an optional developer-message fragment for the single
+    /// best-effort turn run before an automatic compaction rollover.
+    ///
+    /// The host combines non-empty contributions in registration order into
+    /// one developer message. Implementations should keep the contribution
+    /// bounded and return `None` when they do not need the fallback turn.
+    fn contribute_auto_compact_fallback_prompt<'a>(
+        &'a self,
+        input: AutoCompactFallbackContributionInput<'a>,
+    ) -> ExtensionFuture<'a, Option<String>> {
+        Box::pin(async move {
+            let _self = self;
+            let _input = input;
+            None
         })
     }
 }

--- a/codex-rs/ext/extension-api/src/contributors/context.rs
+++ b/codex-rs/ext/extension-api/src/contributors/context.rs
@@ -2,6 +2,24 @@ use codex_protocol::ThreadId;
 
 use crate::ExtensionData;
 
+/// Host context available while extensions contribute the prompt for the
+/// best-effort turn immediately before an automatic compaction rollover.
+#[derive(Clone, Copy)]
+pub struct AutoCompactFallbackContributionInput<'a> {
+    /// Stable host-owned thread identifier.
+    pub thread_id: ThreadId,
+    /// Stable host-owned turn identifier.
+    pub turn_id: &'a str,
+    /// Store scoped to the host session runtime.
+    pub session_store: &'a ExtensionData,
+    /// Store scoped to this thread runtime.
+    pub thread_store: &'a ExtensionData,
+    /// Store scoped to this turn.
+    pub turn_store: &'a ExtensionData,
+    /// Effective model context window for this turn, when known.
+    pub model_context_window: Option<i64>,
+}
+
 /// Host context available while extensions contribute turn-scoped context fragments.
 #[derive(Clone, Copy)]
 pub struct TurnContextContributionInput<'a> {

--- a/codex-rs/ext/extension-api/src/contributors/context.rs
+++ b/codex-rs/ext/extension-api/src/contributors/context.rs
@@ -3,7 +3,7 @@ use codex_protocol::ThreadId;
 use crate::ExtensionData;
 
 /// Host context available while extensions contribute the prompt for the
-/// best-effort turn immediately before an automatic compaction rollover.
+/// fallback turn immediately before an automatic compaction rollover.
 #[derive(Clone, Copy)]
 pub struct AutoCompactFallbackContributionInput<'a> {
     /// Stable host-owned thread identifier.

--- a/codex-rs/ext/extension-api/src/lib.rs
+++ b/codex-rs/ext/extension-api/src/lib.rs
@@ -32,6 +32,7 @@ pub use codex_tools::TurnItemEmitter;
 pub use codex_tools::parse_tool_input_schema;
 pub use codex_tools::parse_tool_input_schema_without_compaction;
 pub use contributors::ApprovalReviewContributor;
+pub use contributors::AutoCompactFallbackContributionInput;
 pub use contributors::ConfigContributor;
 pub use contributors::ContextContributor;
 pub use contributors::ExtensionFuture;

--- a/codex-rs/ext/extension-api/tests/registry.rs
+++ b/codex-rs/ext/extension-api/tests/registry.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 
 use codex_extension_api::ApprovalReviewContributor;
+use codex_extension_api::AutoCompactFallbackContributionInput;
 use codex_extension_api::ConfigContributor;
 use codex_extension_api::ContextContributor;
 use codex_extension_api::ContextualUserFragment;
@@ -172,6 +173,70 @@ impl ContextContributor for NamedTurnContextContributor {
             self.0,
         )]))
     }
+}
+
+struct DefaultAutoCompactFallbackContributor;
+
+impl ContextContributor for DefaultAutoCompactFallbackContributor {}
+
+struct CustomAutoCompactFallbackContributor;
+
+impl ContextContributor for CustomAutoCompactFallbackContributor {
+    fn contribute_auto_compact_fallback_prompt<'a>(
+        &'a self,
+        input: AutoCompactFallbackContributionInput<'a>,
+    ) -> ExtensionFuture<'a, Option<String>> {
+        Box::pin(async move {
+            Some(format!(
+                "thread={} turn={} session_store={} thread_store={} turn_store={} context_window={:?}",
+                input.thread_id,
+                input.turn_id,
+                input.session_store.level_id(),
+                input.thread_store.level_id(),
+                input.turn_store.level_id(),
+                input.model_context_window,
+            ))
+        })
+    }
+}
+
+#[tokio::test]
+async fn auto_compact_fallback_prompt_supports_default_and_custom_contributors() {
+    let mut builder = ExtensionRegistryBuilder::<()>::new();
+    builder.prompt_contributor(Arc::new(DefaultAutoCompactFallbackContributor));
+    builder.prompt_contributor(Arc::new(CustomAutoCompactFallbackContributor));
+    let registry = builder.build();
+    let thread_id = codex_protocol::ThreadId::default();
+    let session_store = ExtensionData::new("session");
+    let thread_store = ExtensionData::new("thread");
+    let turn_store = ExtensionData::new("turn");
+    let input = AutoCompactFallbackContributionInput {
+        thread_id,
+        turn_id: turn_store.level_id(),
+        session_store: &session_store,
+        thread_store: &thread_store,
+        turn_store: &turn_store,
+        model_context_window: Some(123),
+    };
+
+    let mut contributions = Vec::new();
+    for contributor in registry.context_contributors() {
+        contributions.push(
+            contributor
+                .contribute_auto_compact_fallback_prompt(input)
+                .await,
+        );
+    }
+
+    assert_eq!(
+        contributions,
+        vec![
+            None,
+            Some(format!(
+                "thread={thread_id} turn=turn session_store=session thread_store=thread turn_store=turn context_window=Some(123)"
+            )),
+        ]
+    );
 }
 
 struct RecordingTurnItemContributor {

--- a/codex-rs/features/src/feature_configs.rs
+++ b/codex-rs/features/src/feature_configs.rs
@@ -106,6 +106,27 @@ impl FeatureConfig for TokenBudgetConfigToml {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct AutoCompactFallbackConfigToml {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+    /// Developer message contributed for the single fallback turn before an
+    /// automatic compaction rollover.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+}
+
+impl FeatureConfig for AutoCompactFallbackConfigToml {
+    fn enabled(&self) -> Option<bool> {
+        self.enabled
+    }
+
+    fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = Some(enabled);
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct RolloutBudgetConfigToml {

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -16,6 +16,7 @@ use toml::Table;
 
 mod feature_configs;
 mod legacy;
+pub use feature_configs::AutoCompactFallbackConfigToml;
 pub use feature_configs::CodeModeConfigToml;
 pub use feature_configs::CurrentTimeReminderConfigToml;
 pub use feature_configs::CurrentTimeReminderDeliveryMode;
@@ -644,6 +645,8 @@ pub struct FeaturesToml {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub token_budget: Option<FeatureToml<TokenBudgetConfigToml>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_compact_fallback: Option<FeatureToml<AutoCompactFallbackConfigToml>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rollout_budget: Option<FeatureToml<RolloutBudgetConfigToml>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub current_time_reminder: Option<FeatureToml<CurrentTimeReminderConfigToml>>,
@@ -682,6 +685,13 @@ impl FeaturesToml {
         if let Some(enabled) = self.token_budget.as_ref().and_then(FeatureToml::enabled) {
             entries.insert(Feature::TokenBudget.key().to_string(), enabled);
         }
+        if let Some(enabled) = self
+            .auto_compact_fallback
+            .as_ref()
+            .and_then(FeatureToml::enabled)
+        {
+            entries.insert(Feature::AutoCompactFallback.key().to_string(), enabled);
+        }
         if let Some(enabled) = self.rollout_budget.as_ref().and_then(FeatureToml::enabled) {
             entries.insert(Feature::RolloutBudget.key().to_string(), enabled);
         }
@@ -704,6 +714,7 @@ impl FeaturesToml {
             code_mode,
             multi_agent_v2,
             token_budget,
+            auto_compact_fallback,
             rollout_budget,
             current_time_reminder,
             removed_apps_mcp_path_override: _,
@@ -721,6 +732,8 @@ impl FeaturesToml {
                 materialize_resolved_feature_enabled(multi_agent_v2, enabled);
             } else if spec.id == Feature::TokenBudget {
                 materialize_resolved_feature_enabled(token_budget, enabled);
+            } else if spec.id == Feature::AutoCompactFallback {
+                materialize_resolved_feature_enabled(auto_compact_fallback, enabled);
             } else if spec.id == Feature::RolloutBudget {
                 materialize_resolved_feature_enabled(rollout_budget, enabled);
             } else if spec.id == Feature::CurrentTimeReminder {

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -220,6 +220,8 @@ pub enum Feature {
     Goals,
     /// Add current context-window metadata to model-visible context.
     TokenBudget,
+    /// Run one extension-configured fallback turn before automatic compaction rolls over.
+    AutoCompactFallback,
     /// Track and report a shared token budget across a session's agent threads.
     RolloutBudget,
     /// Add current-time reminders to model-visible context.
@@ -1243,6 +1245,12 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::TokenBudget,
         key: "token_budget",
+        stage: Stage::UnderDevelopment,
+        default_enabled: false,
+    },
+    FeatureSpec {
+        id: Feature::AutoCompactFallback,
+        key: "auto_compact_fallback",
         stage: Stage::UnderDevelopment,
         default_enabled: false,
     },

--- a/codex-rs/features/src/tests.rs
+++ b/codex-rs/features/src/tests.rs
@@ -643,10 +643,50 @@ non_code_mode_only = true
 }
 
 #[test]
+fn auto_compact_fallback_feature_config_deserializes_boolean_toggle() {
+    let features: FeaturesToml =
+        toml::from_str("auto_compact_fallback = true").expect("features table should deserialize");
+
+    assert_eq!(
+        features.entries(),
+        BTreeMap::from([("auto_compact_fallback".to_string(), true)])
+    );
+    assert_eq!(
+        features.auto_compact_fallback,
+        Some(FeatureToml::Enabled(true))
+    );
+}
+
+#[test]
+fn auto_compact_fallback_feature_config_deserializes_table() {
+    let features: FeaturesToml = toml::from_str(
+        r#"
+[auto_compact_fallback]
+enabled = true
+prompt = "Persist the important state."
+"#,
+    )
+    .expect("features table should deserialize");
+
+    assert_eq!(
+        features.entries(),
+        BTreeMap::from([("auto_compact_fallback".to_string(), true)])
+    );
+    assert_eq!(
+        features.auto_compact_fallback,
+        Some(FeatureToml::Config(crate::AutoCompactFallbackConfigToml {
+            enabled: Some(true),
+            prompt: Some("Persist the important state.".to_string()),
+        }))
+    );
+}
+
+#[test]
 fn materialize_resolved_enabled_writes_all_features_and_preserves_custom_config() {
     let mut features = Features::with_defaults();
     features.enable(Feature::CodeMode);
     features.enable(Feature::MultiAgentV2);
+    features.enable(Feature::AutoCompactFallback);
     features.enable(Feature::NetworkProxy);
     features.enable(Feature::RespectSystemProxy);
 
@@ -655,6 +695,10 @@ fn materialize_resolved_enabled_writes_all_features_and_preserves_custom_config(
             enabled: Some(false),
             min_wait_timeout_ms: Some(2500),
             ..Default::default()
+        })),
+        auto_compact_fallback: Some(FeatureToml::Config(crate::AutoCompactFallbackConfigToml {
+            enabled: Some(false),
+            prompt: Some("Persist the important state.".to_string()),
         })),
         network_proxy: Some(FeatureToml::Config(crate::NetworkProxyConfigToml {
             enabled: Some(false),
@@ -682,6 +726,13 @@ fn materialize_resolved_enabled_writes_all_features_and_preserves_custom_config(
             enabled: Some(true),
             min_wait_timeout_ms: Some(2500),
             ..Default::default()
+        }))
+    );
+    assert_eq!(
+        features_toml.auto_compact_fallback,
+        Some(FeatureToml::Config(crate::AutoCompactFallbackConfigToml {
+            enabled: Some(true),
+            prompt: Some("Persist the important state.".to_string()),
         }))
     );
     assert_eq!(

--- a/codex-rs/mcp-server/src/lib.rs
+++ b/codex-rs/mcp-server/src/lib.rs
@@ -1,4 +1,5 @@
 //! Prototype MCP server.
+#![recursion_limit = "256"]
 #![deny(clippy::print_stdout, clippy::print_stderr)]
 
 use std::io::ErrorKind;

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -1,6 +1,7 @@
 // Forbid accidental stdout/stderr writes in the *library* portion of the TUI.
 // The standalone `codex-tui` binary prints a short help message before the
 // alternate‑screen mode starts; that file opts‑out locally via `allow`.
+#![recursion_limit = "256"]
 #![deny(clippy::print_stdout, clippy::print_stderr)]
 #![deny(clippy::disallowed_methods)]
 use crate::legacy_core::config::Config;


### PR DESCRIPTION
## Summary

- add an under-development structured `auto_compact_fallback` feature with `enabled` and `prompt` settings
- let extensions contribute the developer prompt for the fallback request
- run one restricted sampling request immediately before an automatic compaction rollover is installed
- apply the fallback consistently to local, remote v1/v2, and token-budget compaction paths
- execute at most one direct tool call, refresh request-scoped world state after any side effects, and ignore tool follow-up inference
- use ordinary model/provider sampling bounds and token accounting; there is no fallback-specific output-token cap

## Configuration

```toml
[features.auto_compact_fallback]
enabled = true
prompt = "Save a concise checkpoint before rollover."
```

The feature is disabled by default. A prompt-only table does not enable it, and the legacy boolean feature-toggle form remains accepted. The structured table deliberately contains only `enabled` and `prompt`.

## Behavior

After automatic compaction preparation succeeds, Codex records the contributed developer prompt in the old context and performs one fallback sampling request before installing the compacted history or fresh token-budget window.

The request disables parallel tool calls and approvals, auto-denies MCP elicitations, filters out server-hosted tools, rejects interactive or dynamic tools, and admits at most one direct tool call (plus one nested code-mode dispatch when applicable). Tool follow-up inference is not run. The fallback artifacts stay in the old context, while tool side effects are reflected through refreshed world state before rollover.

Fallback sampling uses the normal provider request and accounting path without `max_output_tokens` plumbing. Retryable stream failures are retried at most twice (three attempts total). A non-retryable sampling error or exhausted retries propagates, so Codex does not install the compacted history or advance the context window.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p codex-features -p codex-core -p codex-app-server -p codex-config`
- `cargo test -p codex-features auto_compact_fallback` (2 passed)
- `cargo test -p codex-core --lib auto_compact_fallback` (6 passed)
- `cargo test -p codex-core --lib config_schema_matches_fixture` (1 passed)
- `RUST_MIN_STACK=16777216 cargo test -p codex-core --test all auto_compact_fallback -- --test-threads=1` (4 passed)
- `git diff --check f1affbac5e..HEAD`
