### PR TITLE
[codex] emit remote plugin IDs for skill invocations

### DIFF
--- a/codex-rs/analytics/src/analytics_client_tests.rs
+++ b/codex-rs/analytics/src/analytics_client_tests.rs
@@ -3438,6 +3438,7 @@ async fn reducer_ingests_skill_invoked_fact() {
                     skill_scope: codex_protocol::protocol::SkillScope::User,
                     skill_path,
                     plugin_id: None,
+                    remote_plugin_id: None,
                     invocation_type: InvocationType::Explicit,
                 }],
             })),
@@ -3456,6 +3457,7 @@ async fn reducer_ingests_skill_invoked_fact() {
                 "product_client_id": TEST_PRODUCT_CLIENT_ID,
                 "skill_scope": "user",
                 "plugin_id": null,
+                "remote_plugin_id": null,
                 "repo_url": null,
                 "thread_id": "thread-1",
                 "turn_id": "turn-1",
@@ -3467,7 +3469,7 @@ async fn reducer_ingests_skill_invoked_fact() {
 }
 
 #[tokio::test]
-async fn reducer_includes_plugin_id_for_plugin_skill_invocations() {
+async fn reducer_includes_plugin_ids_for_plugin_skill_invocations() {
     let mut reducer = AnalyticsReducer::default();
     let mut events = Vec::new();
     let tracking = test_tracking_context("thread-1", "turn-1");
@@ -3483,6 +3485,7 @@ async fn reducer_includes_plugin_id_for_plugin_skill_invocations() {
                     skill_scope: codex_protocol::protocol::SkillScope::User,
                     skill_path,
                     plugin_id: Some("sample@test".to_string()),
+                    remote_plugin_id: Some("plugins~Plugin_sample".to_string()),
                     invocation_type: InvocationType::Explicit,
                 }],
             })),
@@ -3494,6 +3497,10 @@ async fn reducer_includes_plugin_id_for_plugin_skill_invocations() {
     assert_eq!(
         payload[0]["event_params"]["plugin_id"],
         json!("sample@test")
+    );
+    assert_eq!(
+        payload[0]["event_params"]["remote_plugin_id"],
+        json!("plugins~Plugin_sample")
     );
 }
 

--- a/codex-rs/analytics/src/client_tests.rs
+++ b/codex-rs/analytics/src/client_tests.rs
@@ -76,6 +76,7 @@ fn sample_regular_track_event(thread_id: &str) -> TrackEventRequest {
             product_client_id: None,
             skill_scope: None,
             plugin_id: None,
+            remote_plugin_id: None,
             repo_url: None,
             thread_id: Some(thread_id.to_string()),
             turn_id: Some("turn-1".to_string()),

--- a/codex-rs/analytics/src/events.rs
+++ b/codex-rs/analytics/src/events.rs
@@ -130,6 +130,7 @@ pub(crate) struct SkillInvocationEventParams {
     pub(crate) product_client_id: Option<String>,
     pub(crate) skill_scope: Option<String>,
     pub(crate) plugin_id: Option<String>,
+    pub(crate) remote_plugin_id: Option<String>,
     pub(crate) repo_url: Option<String>,
     pub(crate) thread_id: Option<String>,
     pub(crate) turn_id: Option<String>,

--- a/codex-rs/analytics/src/facts.rs
+++ b/codex-rs/analytics/src/facts.rs
@@ -325,6 +325,7 @@ pub struct SkillInvocation {
     pub skill_scope: SkillScope,
     pub skill_path: PathBuf,
     pub plugin_id: Option<String>,
+    pub remote_plugin_id: Option<String>,
     pub invocation_type: InvocationType,
 }
 

--- a/codex-rs/analytics/src/reducer.rs
+++ b/codex-rs/analytics/src/reducer.rs
@@ -758,6 +758,7 @@ impl AnalyticsReducer {
                         repo_url,
                         skill_scope: Some(skill_scope.to_string()),
                         plugin_id: invocation.plugin_id,
+                        remote_plugin_id: invocation.remote_plugin_id,
                     },
                 },
             ));

--- a/codex-rs/core-plugins/src/loader.rs
+++ b/codex-rs/core-plugins/src/loader.rs
@@ -73,6 +73,7 @@ pub struct PluginHookLoadOutcome {
 enum PluginLoadScope<'a> {
     AllCapabilities {
         restriction_product: Option<Product>,
+        remote_plugin_ids_by_plugin_key: &'a HashMap<String, String>,
         skill_config_rules: &'a SkillConfigRules,
         plugin_skill_snapshots: Option<&'a PluginSkillSnapshots>,
     },
@@ -114,6 +115,7 @@ pub(crate) fn log_plugin_load_errors(plugins: &[LoadedPlugin<McpServerConfig>]) 
 pub(crate) async fn load_plugins_from_layer_stack(
     config_layer_stack: &ConfigLayerStack,
     extra_plugins: HashMap<String, PluginConfig>,
+    remote_plugin_ids_by_plugin_key: HashMap<String, String>,
     store: &PluginStore,
     plugin_skill_snapshots: Option<&PluginSkillSnapshots>,
     restriction_product: Option<Product>,
@@ -127,6 +129,7 @@ pub(crate) async fn load_plugins_from_layer_stack(
         remote_global_catalog_active,
         PluginLoadScope::AllCapabilities {
             restriction_product,
+            remote_plugin_ids_by_plugin_key: &remote_plugin_ids_by_plugin_key,
             skill_config_rules: &skill_config_rules,
             plugin_skill_snapshots,
         },
@@ -759,6 +762,7 @@ async fn load_plugin(
         });
     let mut loaded_plugin = LoadedPlugin {
         config_name,
+        remote_plugin_id: None,
         manifest_name: None,
         plugin_namespace: None,
         manifest_description: None,
@@ -791,6 +795,17 @@ async fn load_plugin(
             return loaded_plugin;
         }
     };
+    loaded_plugin.remote_plugin_id = match scope {
+        PluginLoadScope::AllCapabilities {
+            remote_plugin_ids_by_plugin_key,
+            ..
+        } => remote_plugin_id_for_loaded_plugin(
+            &loaded_plugin_id,
+            store,
+            remote_plugin_ids_by_plugin_key,
+        ),
+        PluginLoadScope::HooksOnly => None,
+    };
 
     if !plugin_root.as_path().is_dir() {
         loaded_plugin.error = Some("path does not exist or is not a directory".to_string());
@@ -809,13 +824,15 @@ async fn load_plugin(
             restriction_product,
             skill_config_rules,
             plugin_skill_snapshots,
+            ..
         } => {
             loaded_plugin.manifest_name = Some(manifest.display_name().to_string());
             loaded_plugin.manifest_description = manifest.description.clone();
             loaded_plugin.skill_roots = plugin_skill_roots(&plugin_root, manifest_paths);
-            let resolved_skills = load_plugin_skills(
+            let resolved_skills = load_plugin_skills_with_remote_id(
                 &plugin_root,
                 &loaded_plugin_id,
+                loaded_plugin.remote_plugin_id.as_deref(),
                 &manifest,
                 *restriction_product,
                 skill_config_rules,
@@ -844,6 +861,29 @@ async fn load_plugin(
     loaded_plugin.hook_sources = hook_sources;
     loaded_plugin.hook_load_warnings = hook_load_warnings;
     loaded_plugin
+}
+
+fn remote_plugin_id_for_loaded_plugin(
+    plugin_id: &PluginId,
+    store: &PluginStore,
+    remote_plugin_ids_by_plugin_key: &HashMap<String, String>,
+) -> Option<String> {
+    let plugin_key = plugin_id.as_key();
+    if let Some(remote_plugin_id) = remote_plugin_ids_by_plugin_key.get(&plugin_key) {
+        return Some(remote_plugin_id.clone());
+    }
+
+    match store.remote_plugin_id(plugin_id) {
+        Ok(remote_plugin_id) => remote_plugin_id,
+        Err(err) => {
+            warn!(
+                plugin_id = %plugin_key,
+                error = %err,
+                "failed to read persisted remote plugin identity"
+            );
+            None
+        }
+    }
 }
 
 fn apply_plugin_mcp_server_policy(config: &mut McpServerConfig, policy: &PluginMcpServerConfig) {
@@ -918,9 +958,31 @@ pub async fn load_plugin_skills(
     skill_config_rules: &SkillConfigRules,
     plugin_skill_snapshots: Option<&PluginSkillSnapshots>,
 ) -> ResolvedPluginSkills {
+    load_plugin_skills_with_remote_id(
+        plugin_root,
+        plugin_id,
+        /*remote_plugin_id*/ None,
+        manifest,
+        restriction_product,
+        skill_config_rules,
+        plugin_skill_snapshots,
+    )
+    .await
+}
+
+pub(crate) async fn load_plugin_skills_with_remote_id(
+    plugin_root: &AbsolutePathBuf,
+    plugin_id: &PluginId,
+    remote_plugin_id: Option<&str>,
+    manifest: &PluginManifest,
+    restriction_product: Option<Product>,
+    skill_config_rules: &SkillConfigRules,
+    plugin_skill_snapshots: Option<&PluginSkillSnapshots>,
+) -> ResolvedPluginSkills {
     load_plugin_skill_inventory(
         plugin_root,
         plugin_id,
+        remote_plugin_id,
         manifest,
         restriction_product,
         plugin_skill_snapshots,
@@ -932,6 +994,7 @@ pub async fn load_plugin_skills(
 pub(crate) async fn load_plugin_skill_inventory(
     plugin_root: &AbsolutePathBuf,
     plugin_id: &PluginId,
+    remote_plugin_id: Option<&str>,
     manifest: &PluginManifest,
     restriction_product: Option<Product>,
     plugin_skill_snapshots: Option<&PluginSkillSnapshots>,
@@ -943,6 +1006,7 @@ pub(crate) async fn load_plugin_skill_inventory(
             scope: SkillScope::User,
             file_system: Arc::clone(&LOCAL_FS),
             plugin_id: Some(plugin_id.as_key()),
+            remote_plugin_id: remote_plugin_id.map(str::to_string),
             plugin_namespace: Some(manifest.name.clone()),
             plugin_root: Some(plugin_root.clone()),
         })

--- a/codex-rs/core-plugins/src/loader_tests.rs
+++ b/codex-rs/core-plugins/src/loader_tests.rs
@@ -159,6 +159,7 @@ enabled = true
     let full = load_plugins_from_layer_stack(
         &stack,
         HashMap::new(),
+        HashMap::new(),
         &store,
         /*plugin_skill_snapshots*/ None,
         Some(Product::Codex),

--- a/codex-rs/core-plugins/src/manager.rs
+++ b/codex-rs/core-plugins/src/manager.rs
@@ -10,7 +10,7 @@ use crate::loader::load_plugin_apps_from_manifest;
 use crate::loader::load_plugin_hooks;
 use crate::loader::load_plugin_hooks_from_layer_stack;
 use crate::loader::load_plugin_mcp_servers_from_manifest;
-use crate::loader::load_plugin_skills;
+use crate::loader::load_plugin_skills_with_remote_id;
 use crate::loader::load_plugins_from_layer_stack;
 use crate::loader::log_plugin_load_errors;
 use crate::loader::materialize_marketplace_plugin_source;
@@ -561,6 +561,7 @@ impl PluginsManager {
         let plugins = load_plugins_from_layer_stack(
             &config.config_layer_stack,
             self.remote_installed_plugin_configs(),
+            self.remote_plugin_ids_by_plugin_key(),
             &self.store,
             Some(&plugin_skill_snapshots),
             self.restriction_product,
@@ -646,6 +647,7 @@ impl PluginsManager {
         let plugins = load_plugins_from_layer_stack(
             config_layer_stack,
             self.remote_installed_plugin_configs(),
+            self.remote_plugin_ids_by_plugin_key(),
             &self.store,
             /*plugin_skill_snapshots*/ None,
             self.restriction_product,
@@ -731,6 +733,25 @@ impl PluginsManager {
         };
 
         remote_installed_plugins_to_config(plugins, &self.store)
+    }
+
+    fn remote_plugin_ids_by_plugin_key(&self) -> HashMap<String, String> {
+        let cache = match self.remote_installed_plugins_cache.read() {
+            Ok(cache) => cache,
+            Err(err) => err.into_inner(),
+        };
+        let Some(plugins) = cache.as_ref() else {
+            return HashMap::new();
+        };
+
+        plugins
+            .iter()
+            .filter_map(|plugin| {
+                PluginId::new(plugin.name.clone(), plugin.marketplace_name.clone())
+                    .ok()
+                    .map(|plugin_id| (plugin_id.as_key(), plugin.id.clone()))
+            })
+            .collect()
     }
 
     fn remote_plugin_id_for(&self, plugin_id: &PluginId) -> Option<String> {
@@ -1844,9 +1865,11 @@ impl PluginsManager {
             manifest.interface.clone(),
             marketplace_category,
         );
-        let resolved_skills = load_plugin_skills(
+        let remote_plugin_id = self.remote_plugin_id_for(&plugin_id);
+        let resolved_skills = load_plugin_skills_with_remote_id(
             &source_path,
             &plugin_id,
+            remote_plugin_id.as_deref(),
             &manifest,
             self.restriction_product,
             &codex_core_skills::config_rules::skill_config_rules_from_stack(

--- a/codex-rs/core-plugins/src/manager_tests.rs
+++ b/codex-rs/core-plugins/src/manager_tests.rs
@@ -857,6 +857,7 @@ async fn load_plugins_loads_default_skills_and_mcp_servers() {
         outcome.plugins(),
         vec![LoadedPlugin {
             config_name: "sample@test".to_string(),
+            remote_plugin_id: None,
             manifest_name: Some("sample".to_string()),
             plugin_namespace: Some("sample".to_string()),
             manifest_description: Some(
@@ -2140,6 +2141,7 @@ async fn load_plugins_preserves_disabled_plugins_without_effective_contributions
         outcome.plugins(),
         vec![LoadedPlugin {
             config_name: "sample@test".to_string(),
+            remote_plugin_id: None,
             manifest_name: None,
             plugin_namespace: None,
             manifest_description: None,
@@ -2310,6 +2312,7 @@ fn capability_index_filters_inactive_and_zero_capability_plugins() {
     };
     let plugin = |config_name: &str, dir_name: &str, manifest_name: &str| LoadedPlugin {
         config_name: config_name.to_string(),
+        remote_plugin_id: None,
         manifest_name: Some(manifest_name.to_string()),
         plugin_namespace: Some(
             config_name
@@ -2494,7 +2497,7 @@ async fn plugin_cache_ignores_unrelated_session_overrides() {
 }
 
 #[tokio::test]
-async fn skills_service_reuses_skills_parsed_during_plugin_load() {
+async fn skill_snapshots_preserve_remote_plugin_identity() {
     let codex_home = TempDir::new().unwrap();
     let codex_home_abs = codex_home.path().to_path_buf().abs();
     let plugin_root = codex_home
@@ -2513,8 +2516,15 @@ async fn skills_service_reuses_skills_parsed_during_plugin_load() {
         &plugin_config_toml(/*enabled*/ true, /*plugins_feature_enabled*/ true),
     );
 
+    let plugin_id = PluginId::parse("sample@test").expect("plugin id should parse");
+    PluginStore::new(codex_home.path().to_path_buf())
+        .write_remote_plugin_id(&plugin_id, "plugins~Plugin_stale")
+        .expect("persist stale remote plugin id");
     let config = load_config(codex_home.path(), codex_home.path()).await;
     let manager = PluginsManager::new(codex_home.path().to_path_buf());
+    manager.write_remote_installed_plugins_cache(vec![remote_installed_plugin_in_marketplace(
+        "sample", "test",
+    )]);
     let plugin_outcome = manager.plugins_for_config(&config).await;
     let plugin_skill_snapshots = manager.plugin_skill_snapshots_for_config(&config);
     write_file(&skill_path, "---\nname: search\ndescription: second\n---\n");
@@ -2536,9 +2546,13 @@ async fn skills_service_reuses_skills_parsed_during_plugin_load() {
             .outcome()
             .skills
             .iter()
-            .map(|skill| skill.description.as_str())
+            .map(|skill| (
+                skill.description.as_str(),
+                skill.plugin_id.as_deref(),
+                skill.remote_plugin_id.as_deref(),
+            ))
             .collect::<Vec<_>>(),
-        vec!["first"]
+        vec![("first", Some("sample@test"), Some("plugins~Plugin_sample"),)]
     );
 }
 
@@ -5817,6 +5831,7 @@ async fn load_plugins_ignores_project_config_files() {
 
     let plugins = load_plugins_from_layer_stack(
         &stack,
+        std::collections::HashMap::new(),
         std::collections::HashMap::new(),
         &PluginStore::new(codex_home.path().to_path_buf()),
         /*plugin_skill_snapshots*/ None,

--- a/codex-rs/core-plugins/src/tool_suggest_metadata.rs
+++ b/codex-rs/core-plugins/src/tool_suggest_metadata.rs
@@ -213,6 +213,7 @@ async fn load_plugin_metadata(
     let skill_inventory = load_plugin_skill_inventory(
         plugin_root,
         &plugin_id,
+        /*remote_plugin_id*/ None,
         &manifest,
         restriction_product,
         /*plugin_skill_snapshots*/ None,

--- a/codex-rs/core-skills/src/injection.rs
+++ b/codex-rs/core-skills/src/injection.rs
@@ -90,6 +90,7 @@ pub async fn build_skill_injections(
                     skill_scope: skill.scope,
                     skill_path: skill.path_to_skills_md.to_path_buf(),
                     plugin_id: skill.plugin_id.clone(),
+                    remote_plugin_id: skill.remote_plugin_id.clone(),
                     invocation_type: InvocationType::Explicit,
                 });
                 result.items.push(SkillInjection {

--- a/codex-rs/core-skills/src/injection_tests.rs
+++ b/codex-rs/core-skills/src/injection_tests.rs
@@ -17,6 +17,7 @@ fn make_skill(name: &str, path: &str) -> SkillMetadata {
         path_to_skills_md: test_path_buf(path).abs(),
         scope: codex_protocol::protocol::SkillScope::User,
         plugin_id: None,
+        remote_plugin_id: None,
     }
 }
 

--- a/codex-rs/core-skills/src/invocation_utils_tests.rs
+++ b/codex-rs/core-skills/src/invocation_utils_tests.rs
@@ -22,6 +22,7 @@ fn test_skill_metadata(skill_doc_path: AbsolutePathBuf) -> SkillMetadata {
         path_to_skills_md: skill_doc_path,
         scope: codex_protocol::protocol::SkillScope::User,
         plugin_id: None,
+        remote_plugin_id: None,
     }
 }
 

--- a/codex-rs/core-skills/src/loader.rs
+++ b/codex-rs/core-skills/src/loader.rs
@@ -185,8 +185,15 @@ pub struct SkillRoot {
     pub scope: SkillScope,
     pub file_system: Arc<dyn ExecutorFileSystem>,
     pub plugin_id: Option<String>,
+    pub remote_plugin_id: Option<String>,
     pub plugin_namespace: Option<String>,
     pub plugin_root: Option<AbsolutePathBuf>,
+}
+
+#[derive(Clone, Copy)]
+struct PluginSkillIdentity<'a> {
+    plugin_id: &'a str,
+    remote_plugin_id: Option<&'a str>,
 }
 
 pub async fn load_skills_from_roots<I>(
@@ -213,16 +220,21 @@ pub(crate) async fn load_skill_root(root: SkillRoot) -> SkillRootSnapshot {
         scope,
         file_system,
         plugin_id,
+        remote_plugin_id,
         plugin_namespace,
         plugin_root,
     } = root;
     let root = canonicalize_for_skill_identity(file_system.as_ref(), &path).await;
+    let plugin_identity = plugin_id.as_deref().map(|plugin_id| PluginSkillIdentity {
+        plugin_id,
+        remote_plugin_id: remote_plugin_id.as_deref(),
+    });
     let mut outcome = SkillLoadOutcome::default();
     load_skills_under_root(
         file_system.as_ref(),
         &root,
         scope,
-        plugin_id.as_deref(),
+        plugin_identity,
         plugin_namespace.as_deref(),
         plugin_root.as_ref(),
         &mut outcome,
@@ -270,6 +282,7 @@ async fn skill_roots_with_home_dir(
         scope: SkillScope::User,
         file_system: Arc::clone(&LOCAL_FS),
         plugin_id: Some(root.plugin_id),
+        remote_plugin_id: root.remote_plugin_id,
         plugin_namespace: Some(root.plugin_namespace),
         plugin_root: Some(root.plugin_root),
     }));
@@ -278,6 +291,7 @@ async fn skill_roots_with_home_dir(
         scope: SkillScope::User,
         file_system: Arc::clone(&LOCAL_FS),
         plugin_id: None,
+        remote_plugin_id: None,
         plugin_namespace: None,
         plugin_root: None,
     }));
@@ -309,6 +323,7 @@ fn skill_roots_from_layer_stack_inner(
                         scope: SkillScope::Repo,
                         file_system: Arc::clone(repo_fs),
                         plugin_id: None,
+                        remote_plugin_id: None,
                         plugin_namespace: None,
                         plugin_root: None,
                     });
@@ -322,6 +337,7 @@ fn skill_roots_from_layer_stack_inner(
                     scope: SkillScope::User,
                     file_system: Arc::clone(&LOCAL_FS),
                     plugin_id: None,
+                    remote_plugin_id: None,
                     plugin_namespace: None,
                     plugin_root: None,
                 });
@@ -333,6 +349,7 @@ fn skill_roots_from_layer_stack_inner(
                         scope: SkillScope::User,
                         file_system: Arc::clone(&LOCAL_FS),
                         plugin_id: None,
+                        remote_plugin_id: None,
                         plugin_namespace: None,
                         plugin_root: None,
                     });
@@ -345,6 +362,7 @@ fn skill_roots_from_layer_stack_inner(
                     scope: SkillScope::System,
                     file_system: Arc::clone(&LOCAL_FS),
                     plugin_id: None,
+                    remote_plugin_id: None,
                     plugin_namespace: None,
                     plugin_root: None,
                 });
@@ -357,6 +375,7 @@ fn skill_roots_from_layer_stack_inner(
                     scope: SkillScope::Admin,
                     file_system: Arc::clone(&LOCAL_FS),
                     plugin_id: None,
+                    remote_plugin_id: None,
                     plugin_namespace: None,
                     plugin_root: None,
                 });
@@ -393,6 +412,7 @@ async fn repo_agents_skill_roots(
                 scope: SkillScope::Repo,
                 file_system: Arc::clone(&fs),
                 plugin_id: None,
+                remote_plugin_id: None,
                 plugin_namespace: None,
                 plugin_root: None,
             }),
@@ -667,7 +687,7 @@ async fn load_skills_under_root(
     fs: &dyn ExecutorFileSystem,
     root: &AbsolutePathBuf,
     scope: SkillScope,
-    plugin_id: Option<&str>,
+    plugin_identity: Option<PluginSkillIdentity<'_>>,
     plugin_namespace: Option<&str>,
     plugin_root: Option<&AbsolutePathBuf>,
     outcome: &mut SkillLoadOutcome,
@@ -715,7 +735,7 @@ async fn load_skills_under_root(
             fs,
             &path,
             scope,
-            plugin_id,
+            plugin_identity,
             namespace_resolver.for_skill(&root_uri, &path_uri),
             plugin_root.as_ref(),
         )
@@ -735,7 +755,7 @@ async fn parse_skill_file(
     fs: &dyn ExecutorFileSystem,
     path: &AbsolutePathBuf,
     scope: SkillScope,
-    plugin_id: Option<&str>,
+    plugin_identity: Option<PluginSkillIdentity<'_>>,
     namespace: &ResolvedSkillNamespace,
     plugin_root: Option<&AbsolutePathBuf>,
 ) -> Result<SkillMetadata, SkillParseError> {
@@ -769,7 +789,12 @@ async fn parse_skill_file(
         policy,
         path_to_skills_md: resolved_path,
         scope,
-        plugin_id: plugin_id.map(str::to_string),
+        plugin_id: plugin_identity.map(|identity| identity.plugin_id.to_string()),
+        remote_plugin_id: plugin_identity.and_then(|identity| {
+            identity
+                .remote_plugin_id
+                .map(std::string::ToString::to_string)
+        }),
     })
 }
 

--- a/codex-rs/core-skills/src/loader_tests.rs
+++ b/codex-rs/core-skills/src/loader_tests.rs
@@ -334,6 +334,7 @@ async fn loads_skills_from_home_agents_dir_for_user_scope() -> anyhow::Result<()
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::User,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 
@@ -401,6 +402,7 @@ async fn load_user_skills_root(root: &Path) -> SkillLoadOutcome {
             scope: SkillScope::User,
             file_system: Arc::clone(&LOCAL_FS),
             plugin_id: None,
+            remote_plugin_id: None,
             plugin_namespace: None,
             plugin_root: None,
         }],
@@ -420,6 +422,7 @@ fn expected_user_skill(path: &Path, name: &str, description: &str) -> SkillMetad
         path_to_skills_md: normalized(path),
         scope: SkillScope::User,
         plugin_id: None,
+        remote_plugin_id: None,
     }
 }
 
@@ -507,6 +510,7 @@ async fn loads_skill_dependencies_metadata_from_yaml() {
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::User,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -563,6 +567,7 @@ interface:
             path_to_skills_md: normalized(skill_path.as_path()),
             scope: SkillScope::User,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -717,6 +722,7 @@ async fn accepts_icon_paths_under_assets_dir() {
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::User,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -758,6 +764,7 @@ async fn ignores_invalid_brand_color() {
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::User,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -812,6 +819,7 @@ async fn ignores_default_prompt_over_max_length() {
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::User,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -854,6 +862,7 @@ async fn drops_interface_when_icons_are_invalid() {
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::User,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -887,6 +896,7 @@ interface:
             scope: SkillScope::User,
             file_system: Arc::clone(&LOCAL_FS),
             plugin_id: Some("twilio-developer-kit@test".to_string()),
+            remote_plugin_id: None,
             plugin_namespace: None,
             plugin_root: Some(plugin_root_abs.clone()),
         }],
@@ -919,6 +929,7 @@ interface:
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::User,
             plugin_id: Some("twilio-developer-kit@test".to_string()),
+            remote_plugin_id: None,
         }]
     );
 }
@@ -948,6 +959,7 @@ interface:
             scope: SkillScope::User,
             file_system: Arc::clone(&LOCAL_FS),
             plugin_id: Some("twilio-developer-kit@test".to_string()),
+            remote_plugin_id: None,
             plugin_namespace: None,
             plugin_root: Some(plugin_root.abs()),
         }],
@@ -972,6 +984,7 @@ interface:
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::User,
             plugin_id: Some("twilio-developer-kit@test".to_string()),
+            remote_plugin_id: None,
         }]
     );
 }
@@ -1017,6 +1030,7 @@ async fn loads_skills_via_symlinked_subdir_for_user_scope() {
             path_to_skills_md: normalized(&shared_skill_path),
             scope: SkillScope::User,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -1077,6 +1091,7 @@ async fn does_not_loop_on_symlink_cycle_for_user_scope() {
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::User,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -1098,6 +1113,7 @@ async fn loads_skills_via_symlinked_subdir_for_admin_scope() {
             scope: SkillScope::Admin,
             file_system: Arc::clone(&LOCAL_FS),
             plugin_id: None,
+            remote_plugin_id: None,
             plugin_namespace: None,
             plugin_root: None,
         }],
@@ -1122,6 +1138,7 @@ async fn loads_skills_via_symlinked_subdir_for_admin_scope() {
             path_to_skills_md: normalized(&shared_skill_path),
             scope: SkillScope::Admin,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -1162,6 +1179,7 @@ async fn loads_skills_via_symlinked_subdir_for_repo_scope() {
             path_to_skills_md: normalized(&linked_skill_path),
             scope: SkillScope::Repo,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -1184,6 +1202,7 @@ async fn system_scope_ignores_symlinked_subdir() {
             scope: SkillScope::System,
             file_system: Arc::clone(&LOCAL_FS),
             plugin_id: None,
+            remote_plugin_id: None,
             plugin_namespace: None,
             plugin_root: None,
         }],
@@ -1222,6 +1241,7 @@ async fn respects_max_scan_depth_for_user_scope() {
             scope: SkillScope::User,
             file_system: Arc::clone(&LOCAL_FS),
             plugin_id: None,
+            remote_plugin_id: None,
             plugin_namespace: None,
             plugin_root: None,
         }],
@@ -1246,6 +1266,7 @@ async fn respects_max_scan_depth_for_user_scope() {
             path_to_skills_md: normalized(&within_depth_path),
             scope: SkillScope::User,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -1274,6 +1295,7 @@ async fn loads_valid_skill() {
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::User,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -1307,12 +1329,13 @@ async fn falls_back_to_directory_name_when_skill_name_is_missing() {
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::User,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
 
 #[tokio::test]
-async fn namespaces_plugin_skills_using_provided_namespace() {
+async fn namespaces_plugin_skills_and_preserves_plugin_identity() {
     let root = tempfile::tempdir().expect("tempdir");
     let plugin_root = root.path().join("plugins/sample");
     let skill_path = write_raw_skill_at(
@@ -1333,6 +1356,7 @@ async fn namespaces_plugin_skills_using_provided_namespace() {
             scope: SkillScope::User,
             file_system: Arc::clone(&LOCAL_FS),
             plugin_id: Some("sample@test".to_string()),
+            remote_plugin_id: Some("plugins~Plugin_sample".to_string()),
             plugin_namespace: Some("sample".to_string()),
             plugin_root: Some(plugin_root.abs()),
         }],
@@ -1357,6 +1381,7 @@ async fn namespaces_plugin_skills_using_provided_namespace() {
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::User,
             plugin_id: Some("sample@test".to_string()),
+            remote_plugin_id: Some("plugins~Plugin_sample".to_string()),
         }]
     );
 }
@@ -1622,6 +1647,7 @@ async fn plugin_skill_name_length_limit_allows_max_qualified_name() {
             scope: SkillScope::User,
             file_system: Arc::clone(&LOCAL_FS),
             plugin_id: Some("sample@test".to_string()),
+            remote_plugin_id: None,
             plugin_namespace: Some(plugin_name.clone()),
             plugin_root: Some(plugin_root.abs()),
         }],
@@ -1646,6 +1672,7 @@ async fn plugin_skill_name_length_limit_allows_max_qualified_name() {
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::User,
             plugin_id: Some("sample@test".to_string()),
+            remote_plugin_id: None,
         }]
     );
 }
@@ -1671,6 +1698,7 @@ async fn plugin_skill_name_length_limit_rejects_overlong_qualified_name() {
             scope: SkillScope::User,
             file_system: Arc::clone(&LOCAL_FS),
             plugin_id: Some("sample@test".to_string()),
+            remote_plugin_id: None,
             plugin_namespace: Some(plugin_name.clone()),
             plugin_root: Some(plugin_root.abs()),
         }],
@@ -1715,6 +1743,7 @@ async fn loads_short_description_from_metadata() {
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::User,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -1747,6 +1776,7 @@ async fn loads_unquoted_description_containing_colon_space() {
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::User,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -1779,6 +1809,7 @@ async fn loads_unquoted_short_description_containing_colon_space_and_apostrophe(
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::User,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -1811,6 +1842,7 @@ async fn loads_unrecognized_frontmatter_fields_that_need_quotes() {
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::User,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -1843,6 +1875,7 @@ async fn preserves_block_scalar_body_while_repairing_other_fields() {
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::User,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -1960,6 +1993,7 @@ async fn loads_skills_from_repo_root() {
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::Repo,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -1996,6 +2030,7 @@ async fn loads_skills_from_agents_dir_without_codex_dir() {
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::Repo,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -2050,6 +2085,7 @@ async fn loads_skills_from_all_codex_dirs_under_project_root() {
                 path_to_skills_md: normalized(&nested_skill_path),
                 scope: SkillScope::Repo,
                 plugin_id: None,
+                remote_plugin_id: None,
             },
             SkillMetadata {
                 name: "root-skill".to_string(),
@@ -2061,6 +2097,7 @@ async fn loads_skills_from_all_codex_dirs_under_project_root() {
                 path_to_skills_md: normalized(&root_skill_path),
                 scope: SkillScope::Repo,
                 plugin_id: None,
+                remote_plugin_id: None,
             },
         ]
     );
@@ -2101,6 +2138,7 @@ async fn loads_skills_from_codex_dir_when_not_git_repo() {
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::Repo,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -2118,6 +2156,7 @@ async fn deduplicates_by_path_preferring_first_root() {
                 scope: SkillScope::Repo,
                 file_system: Arc::clone(&LOCAL_FS),
                 plugin_id: None,
+                remote_plugin_id: None,
                 plugin_namespace: None,
                 plugin_root: None,
             },
@@ -2126,6 +2165,7 @@ async fn deduplicates_by_path_preferring_first_root() {
                 scope: SkillScope::User,
                 file_system: Arc::clone(&LOCAL_FS),
                 plugin_id: None,
+                remote_plugin_id: None,
                 plugin_namespace: None,
                 plugin_root: None,
             },
@@ -2151,6 +2191,7 @@ async fn deduplicates_by_path_preferring_first_root() {
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::Repo,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -2193,6 +2234,7 @@ async fn keeps_duplicate_names_from_repo_and_user() {
                 path_to_skills_md: normalized(&repo_skill_path),
                 scope: SkillScope::Repo,
                 plugin_id: None,
+                remote_plugin_id: None,
             },
             SkillMetadata {
                 name: "dupe-skill".to_string(),
@@ -2204,6 +2246,7 @@ async fn keeps_duplicate_names_from_repo_and_user() {
                 path_to_skills_md: normalized(&user_skill_path),
                 scope: SkillScope::User,
                 plugin_id: None,
+                remote_plugin_id: None,
             },
         ]
     );
@@ -2267,6 +2310,7 @@ async fn keeps_duplicate_names_from_nested_codex_dirs() {
                 path_to_skills_md: first_path,
                 scope: SkillScope::Repo,
                 plugin_id: None,
+                remote_plugin_id: None,
             },
             SkillMetadata {
                 name: "dupe-skill".to_string(),
@@ -2278,6 +2322,7 @@ async fn keeps_duplicate_names_from_nested_codex_dirs() {
                 path_to_skills_md: second_path,
                 scope: SkillScope::Repo,
                 plugin_id: None,
+                remote_plugin_id: None,
             },
         ]
     );
@@ -2350,6 +2395,7 @@ async fn loads_skills_when_cwd_is_file_in_repo() {
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::Repo,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }
@@ -2409,6 +2455,7 @@ async fn loads_skills_from_system_cache_when_present() {
             path_to_skills_md: normalized(&skill_path),
             scope: SkillScope::System,
             plugin_id: None,
+            remote_plugin_id: None,
         }]
     );
 }

--- a/codex-rs/core-skills/src/model.rs
+++ b/codex-rs/core-skills/src/model.rs
@@ -23,6 +23,7 @@ pub struct SkillMetadata {
     pub path_to_skills_md: AbsolutePathBuf,
     pub scope: SkillScope,
     pub plugin_id: Option<String>,
+    pub remote_plugin_id: Option<String>,
 }
 
 impl SkillMetadata {

--- a/codex-rs/core-skills/src/render.rs
+++ b/codex-rs/core-skills/src/render.rs
@@ -939,6 +939,7 @@ mod tests {
             path_to_skills_md: test_path_buf(&format!("/tmp/{name}/SKILL.md")).abs(),
             scope,
             plugin_id: None,
+            remote_plugin_id: None,
         }
     }
 

--- a/codex-rs/core-skills/src/root_loader.rs
+++ b/codex-rs/core-skills/src/root_loader.rs
@@ -54,6 +54,7 @@ where
             (Some(plugin_id), Some(plugin_namespace), Some(plugin_root)) => Some(PluginSkillRoot {
                 path: root.path.clone(),
                 plugin_id,
+                remote_plugin_id: root.remote_plugin_id.clone(),
                 plugin_namespace,
                 plugin_root,
             }),

--- a/codex-rs/core-skills/src/service_tests.rs
+++ b/codex-rs/core-skills/src/service_tests.rs
@@ -70,6 +70,7 @@ fn plugin_skill_root_for_skill_path(
     PluginSkillRoot {
         path: skills_root.abs(),
         plugin_id: plugin_id.to_string(),
+        remote_plugin_id: None,
         plugin_namespace: plugin_namespace.to_string(),
         plugin_root: plugin_root.abs(),
     }
@@ -89,6 +90,7 @@ fn test_skill(name: &str, path: PathBuf) -> SkillMetadata {
             .expect("skill path should canonicalize"),
         scope: SkillScope::User,
         plugin_id: None,
+        remote_plugin_id: None,
     }
 }
 

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -8570,6 +8570,7 @@ async fn build_initial_context_trims_skill_metadata_from_context_window_budget()
             path_to_skills_md: test_path_buf("/tmp/admin-skill/SKILL.md").abs(),
             scope: SkillScope::Admin,
             plugin_id: None,
+            remote_plugin_id: None,
         },
         SkillMetadata {
             name: "repo-skill".to_string(),
@@ -8581,6 +8582,7 @@ async fn build_initial_context_trims_skill_metadata_from_context_window_budget()
             path_to_skills_md: test_path_buf("/tmp/repo-skill/SKILL.md").abs(),
             scope: SkillScope::Repo,
             plugin_id: None,
+            remote_plugin_id: None,
         },
     ];
     turn_context.model_info.context_window = Some(100);
@@ -8618,6 +8620,7 @@ fn emit_thread_start_skill_metrics_records_enabled_kept_and_truncated_values() {
         path_to_skills_md: test_path_buf("/tmp/repo-skill/SKILL.md").abs(),
         scope: SkillScope::Repo,
         plugin_id: None,
+        remote_plugin_id: None,
     }];
     let rendered = build_available_skills(
         &outcome,
@@ -8663,6 +8666,7 @@ fn emit_thread_start_skill_metrics_records_description_truncated_chars_without_o
         path_to_skills_md: test_path_buf("/tmp/alpha-skill/SKILL.md").abs(),
         scope: SkillScope::Repo,
         plugin_id: None,
+        remote_plugin_id: None,
     };
     let beta = SkillMetadata {
         name: "beta-skill".to_string(),
@@ -8674,6 +8678,7 @@ fn emit_thread_start_skill_metrics_records_description_truncated_chars_without_o
         path_to_skills_md: test_path_buf("/tmp/beta-skill/SKILL.md").abs(),
         scope: SkillScope::Repo,
         plugin_id: None,
+        remote_plugin_id: None,
     };
     let minimum_skill_line_cost = |skill: &SkillMetadata| {
         let path = skill.path_to_skills_md.to_string_lossy().replace('\\', "/");
@@ -8722,6 +8727,7 @@ async fn build_initial_context_emits_thread_start_skill_warning_on_repeated_buil
             path_to_skills_md: test_path_buf("/tmp/admin-skill/SKILL.md").abs(),
             scope: SkillScope::Admin,
             plugin_id: None,
+            remote_plugin_id: None,
         },
         SkillMetadata {
             name: "repo-skill".to_string(),
@@ -8733,6 +8739,7 @@ async fn build_initial_context_emits_thread_start_skill_warning_on_repeated_buil
             path_to_skills_md: test_path_buf("/tmp/repo-skill/SKILL.md").abs(),
             scope: SkillScope::Repo,
             plugin_id: None,
+            remote_plugin_id: None,
         },
     ];
     turn_context.model_info.context_window = Some(100);

--- a/codex-rs/core/src/skills.rs
+++ b/codex-rs/core/src/skills.rs
@@ -63,6 +63,7 @@ pub(crate) async fn maybe_emit_implicit_skill_invocation(
         skill_scope: candidate.scope,
         skill_path: candidate.path_to_skills_md.to_path_buf(),
         plugin_id: candidate.plugin_id,
+        remote_plugin_id: candidate.remote_plugin_id,
         invocation_type: InvocationType::Implicit,
     };
     let skill_scope = match invocation.skill_scope {

--- a/codex-rs/core/tests/suite/plugins.rs
+++ b/codex-rs/core/tests/suite/plugins.rs
@@ -579,3 +579,82 @@ async fn explicit_plugin_mentions_track_plugin_used_analytics() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicit_plugin_skill_mentions_track_remote_identity() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+    let server = start_mock_server().await;
+    let _resp_mock = mount_sse_once(
+        &server,
+        sse(vec![ev_response_created("resp-1"), ev_completed("resp-1")]),
+    )
+    .await;
+
+    let codex_home = Arc::new(TempDir::new()?);
+    let skill_path = write_plugin_skill_plugin(codex_home.as_ref());
+    std::fs::write(
+        sample_plugin_root(codex_home.as_ref())
+            .parent()
+            .expect("plugin version root should have a parent")
+            .join(".codex-remote-plugin-install.json"),
+        serde_json::json!({
+            "schema_version": 1,
+            "remote_plugin_id": "plugins~Plugin_sample"
+        })
+        .to_string(),
+    )
+    .expect("write remote plugin identity");
+    let skill_path = skill_path
+        .canonicalize()
+        .unwrap_or_else(|_| skill_path.clone());
+    let test_codex = build_analytics_plugin_test_codex(&server, codex_home).await?;
+    let codex = Arc::clone(&test_codex.codex);
+
+    codex
+        .submit(Op::UserInput {
+            items: vec![codex_protocol::user_input::UserInput::Skill {
+                name: "sample:sample-search".to_string(),
+                path: skill_path,
+            }],
+            final_output_json_schema: None,
+            responsesapi_client_metadata: None,
+            additional_context: Default::default(),
+            thread_settings: Default::default(),
+        })
+        .await?;
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let skill_event = loop {
+        let requests = server.received_requests().await.unwrap_or_default();
+        if let Some(event) = requests
+            .into_iter()
+            .filter(|request| request.url.path() == "/codex/analytics-events/events")
+            .find_map(|request| {
+                let payload: serde_json::Value = serde_json::from_slice(&request.body).ok()?;
+                payload["events"].as_array().and_then(|events| {
+                    events
+                        .iter()
+                        .find(|event| event["event_type"] == "skill_invocation")
+                        .cloned()
+                })
+            })
+        {
+            break event;
+        }
+        if Instant::now() >= deadline {
+            panic!("timed out waiting for skill invocation analytics request");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+
+    assert_eq!(skill_event["skill_name"], "sample:sample-search");
+    assert_eq!(skill_event["event_params"]["plugin_id"], "sample@test");
+    assert_eq!(
+        skill_event["event_params"]["remote_plugin_id"],
+        "plugins~Plugin_sample"
+    );
+    assert_eq!(skill_event["event_params"]["invoke_type"], "explicit");
+
+    Ok(())
+}

--- a/codex-rs/ext/skills/tests/executor_file_system_authority.rs
+++ b/codex-rs/ext/skills/tests/executor_file_system_authority.rs
@@ -207,6 +207,7 @@ async fn skill_loading_and_reads_use_the_supplied_executor_file_system() {
                 has_plugin_manifest: false,
             }),
             plugin_id: None,
+            remote_plugin_id: None,
             plugin_namespace: None,
             plugin_root: None,
         }],

--- a/codex-rs/ext/skills/tests/skills_extension.rs
+++ b/codex-rs/ext/skills/tests/skills_extension.rs
@@ -101,6 +101,7 @@ async fn installed_extension_uses_host_service_snapshot() -> TestResult {
         path_to_skills_md: skill_path,
         scope: SkillScope::User,
         plugin_id: None,
+        remote_plugin_id: None,
     });
     let loaded_skills = Arc::new(outcome);
     let skill_prompt_path = skill_path_string.replace('\\', "/");

--- a/codex-rs/plugin/src/load_outcome.rs
+++ b/codex-rs/plugin/src/load_outcome.rs
@@ -16,6 +16,7 @@ const MAX_CAPABILITY_SUMMARY_DESCRIPTION_LEN: usize = 1024;
 #[derive(Debug, Clone, PartialEq)]
 pub struct LoadedPlugin<M> {
     pub config_name: String,
+    pub remote_plugin_id: Option<String>,
     pub manifest_name: Option<String>,
     pub plugin_namespace: Option<String>,
     pub manifest_description: Option<String>,
@@ -135,6 +136,7 @@ impl<M: Clone> PluginLoadOutcome<M> {
                     skill_roots.push(PluginSkillRoot {
                         path: path.clone(),
                         plugin_id: plugin.config_name.clone(),
+                        remote_plugin_id: plugin.remote_plugin_id.clone(),
                         plugin_namespace: plugin_namespace.clone(),
                         plugin_root: plugin.root.clone(),
                     });
@@ -222,6 +224,7 @@ mod tests {
     fn loaded_plugin(config_name: &str, skill_roots: Vec<AbsolutePathBuf>) -> LoadedPlugin<()> {
         LoadedPlugin {
             config_name: config_name.to_string(),
+            remote_plugin_id: None,
             manifest_name: None,
             plugin_namespace: Some(
                 config_name
@@ -246,8 +249,10 @@ mod tests {
     #[test]
     fn effective_plugin_skill_roots_preserves_first_plugin_for_shared_root() {
         let shared_root = test_path("shared-skills");
+        let mut first_plugin = loaded_plugin("zeta@test", vec![shared_root.clone()]);
+        first_plugin.remote_plugin_id = Some("plugins~Plugin_zeta".to_string());
         let outcome = PluginLoadOutcome::from_plugins(vec![
-            loaded_plugin("zeta@test", vec![shared_root.clone()]),
+            first_plugin,
             loaded_plugin("alpha@test", vec![shared_root.clone()]),
         ]);
 
@@ -256,6 +261,7 @@ mod tests {
             vec![PluginSkillRoot {
                 path: shared_root,
                 plugin_id: "zeta@test".to_string(),
+                remote_plugin_id: Some("plugins~Plugin_zeta".to_string()),
                 plugin_namespace: "zeta".to_string(),
                 plugin_root: test_path("zeta@test"),
             }]

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -6337,6 +6337,7 @@ mod tests {
             path_to_skills_md: skill_path.clone(),
             scope: crate::test_support::skill_scope_user(),
             plugin_id: None,
+            remote_plugin_id: None,
         }]));
 
         let ActivePopup::Skill(popup) = &composer.popups.active else {
@@ -6380,6 +6381,7 @@ mod tests {
             path_to_skills_md: skill_path.clone(),
             scope: crate::test_support::skill_scope_repo(),
             plugin_id: None,
+            remote_plugin_id: None,
         }]));
         composer.set_plugin_mentions(Some(vec![PluginCapabilitySummary {
             config_name: "google-calendar@debug".to_string(),
@@ -6496,6 +6498,7 @@ mod tests {
                     path_to_skills_md: test_path_buf("/tmp/repo/google-calendar/SKILL.md").abs(),
                     scope: crate::test_support::skill_scope_repo(),
                     plugin_id: None,
+                    remote_plugin_id: None,
                 }]));
                 composer.set_plugin_mentions(Some(vec![PluginCapabilitySummary {
                 config_name: "google-calendar@debug".to_string(),

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -2639,6 +2639,7 @@ mod tests {
                 path_to_skills_md: test_path_buf("/tmp/test-skill/SKILL.md").abs(),
                 scope: crate::test_support::skill_scope_user(),
                 plugin_id: None,
+                remote_plugin_id: None,
             }]),
         });
 

--- a/codex-rs/tui/src/chatwidget/skills.rs
+++ b/codex-rs/tui/src/chatwidget/skills.rs
@@ -251,6 +251,7 @@ fn protocol_skill_to_core(skill: &ProtocolSkillMetadata) -> Option<SkillMetadata
         path_to_skills_md: skill.path.clone(),
         scope,
         plugin_id: None,
+        remote_plugin_id: None,
     })
 }
 

--- a/codex-rs/tui/src/chatwidget/tests/composer_submission.rs
+++ b/codex-rs/tui/src/chatwidget/tests/composer_submission.rs
@@ -552,6 +552,7 @@ async fn submission_prefers_selected_duplicate_skill_path() {
             path_to_skills_md: repo_skill_path,
             scope: crate::test_support::skill_scope_repo(),
             plugin_id: None,
+            remote_plugin_id: None,
         },
         SkillMetadata {
             name: "figma".to_string(),
@@ -563,6 +564,7 @@ async fn submission_prefers_selected_duplicate_skill_path() {
             path_to_skills_md: user_skill_path.clone(),
             scope: crate::test_support::skill_scope_user(),
             plugin_id: None,
+            remote_plugin_id: None,
         },
     ]));
 

--- a/codex-rs/utils/plugins/src/lib.rs
+++ b/codex-rs/utils/plugins/src/lib.rs
@@ -17,6 +17,7 @@ pub use plugin_namespace::plugin_namespace_for_skill_uri;
 pub struct PluginSkillRoot {
     pub path: AbsolutePathBuf,
     pub plugin_id: String,
+    pub remote_plugin_id: Option<String>,
     pub plugin_namespace: String,
     pub plugin_root: AbsolutePathBuf,
 }


### PR DESCRIPTION
## Summary

- resolve remote plugin identity before plugin skill snapshots are built
- carry local and remote plugin IDs through plugin roots and skill metadata
- emit `remote_plugin_id` for explicit and implicit skill invocation analytics

## Why

Skill invocation analytics previously emitted only the local plugin key, so producer events could not be joined to the backend remote plugin identity. Resolving provenance during plugin loading also keeps cached skill snapshots correctly attributed.

## Impact

Plugin skill invocation events now include `remote_plugin_id` when available. Local and non-plugin skills remain unchanged with no remote ID. This PR is producer-only; backend consumption can follow separately.

## Validation

- `just test -p codex-analytics` — 84 passed
- `just test -p codex-core-plugins` — 311 passed
- `just test -p codex-plugin` — 3 passed
- `just test -p codex-skills-extension` — 9 passed
- `just test -p codex-core explicit_plugin_skill_mentions_track_remote_identity` — passed
- `just fix -p codex-analytics`
- `just fix -p codex-core-skills`
- `just fix -p codex-core-plugins`
- `just fix -p codex-core`
- `just fmt`

Broad codex-core and codex-tui suites compiled but were not fully green because the local filesystem sandbox helper aborts and ambient `/tmp/.codex` and `/tmp/.agents` directories affect unrelated tests.