### PR TITLE
Stabilize remote compaction parity against dynamic skill catalogs

### DIFF
--- a/codex-rs/core/tests/suite/compact_remote_parity.rs
+++ b/codex-rs/core/tests/suite/compact_remote_parity.rs
@@ -941,6 +941,19 @@ fn normalize_string(value: &str) -> String {
     normalize_tmp_prefix_before_marker(&mut text, "/skills/");
     normalize_tmp_prefix_before_marker(&mut text, "\\skills\\");
 
+    let skills_open_tag = "<skills_instructions>";
+    let skills_close_tag = "</skills_instructions>";
+    let mut search_start = 0;
+    while let Some(relative_start) = text[search_start..].find(skills_open_tag) {
+        let body_start = search_start + relative_start + skills_open_tag.len();
+        let Some(relative_end) = text[body_start..].find(skills_close_tag) else {
+            break;
+        };
+        let body_end = body_start + relative_end;
+        text.replace_range(body_start..body_end, "\n...\n");
+        search_start = body_start + "\n...\n".len() + skills_close_tag.len();
+    }
+
     let mut search_start = 0;
     let wall_time_prefix = "Wall time: ";
     let wall_time_suffix = " seconds";
@@ -962,6 +975,19 @@ fn normalize_string(value: &str) -> String {
         }
     }
     text
+}
+
+#[test]
+fn normalize_string_rewrites_dynamic_skill_instructions() {
+    let text = normalize_string(
+        "before\n<skills_instructions>\n## Skills\n- demo: Dynamic description\n\
+         </skills_instructions>\nafter",
+    );
+
+    assert_eq!(
+        text,
+        "before\n<skills_instructions>\n...\n</skills_instructions>\nafter"
+    );
 }
 
 fn is_uuid_like(value: &str) -> bool {


### PR DESCRIPTION
## Why

The remote compaction parity test compares legacy and v2 sessions created with separate temporary homes. Those sessions can discover different model-visible skill catalogs, so the request comparison can fail even when the compaction and service-tier behavior matches.

This is the most frequent retry-saved full-CI failure in the recent JUnit history.

## What changed

Normalize only the contents of `<skills_instructions>` before comparing the captured requests. The opening and closing tags remain in the comparison, so the test still catches a missing or misplaced skills block.

The service-tier, compacted input, follow-up request, and replacement-history assertions are unchanged. A focused normalizer test covers the new behavior.

## Scope

This is test-only. It does not change runtime compaction or skill behavior. Exact skill-catalog rendering remains covered by the dedicated skills tests.
