### PR TITLE
Stabilize encrypted MAv2 spawn request test

### DIFF
--- a/codex-rs/core/tests/suite/subagent_notifications.rs
+++ b/codex-rs/core/tests/suite/subagent_notifications.rs
@@ -1120,10 +1120,22 @@ async fn encrypted_multi_agent_v2_spawn_sends_agent_message_to_child() -> Result
 
     test.submit_turn(TURN_1_PROMPT).await?;
 
-    let child_request = wait_for_requests(&child_request_log)
-        .await?
-        .pop()
-        .expect("child request");
+    // The response mock records candidate requests before its request matcher runs, so wait for
+    // the child request instead of assuming the latest recorded request is already it.
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let child_request = loop {
+        if let Some(request) = child_request_log
+            .requests()
+            .into_iter()
+            .find(|request| !request.inputs_of_type("agent_message").is_empty())
+        {
+            break request;
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("timed out waiting for child agent message request");
+        }
+        sleep(Duration::from_millis(10)).await;
+    };
     assert_eq!(
         strip_metadata_from_json(Value::Array(child_request.inputs_of_type("agent_message"))),
         Value::Array(vec![json!({


### PR DESCRIPTION
## Why

The encrypted MAv2 spawn test often reads the parent follow-up request before the child has sent its first request. The response mock records candidate requests before applying its specific matcher, so the test can see an empty `agent_message` list even though delivery happens a moment later.

## What changed

Wait for the recorded child request that contains `agent_message`, using the same short bounded polling pattern already used in this test module. The exact encrypted payload and communication-log assertions stay unchanged.

This is test-only: it does not add product delays, loosen the assertion, or change multi-agent behavior. No follow-up is expected.