### PR TITLE
Stabilize shared rollout budget test

### DIFF
--- a/codex-rs/core/tests/suite/rollout_budget.rs
+++ b/codex-rs/core/tests/suite/rollout_budget.rs
@@ -195,9 +195,21 @@ async fn subagent_usage_draws_from_the_shared_budget() -> Result<()> {
     .await;
     test.submit_turn(FOLLOW_UP_PROMPT).await?;
 
-    let request = follow_up.single_request();
+    let requests = follow_up
+        .requests()
+        .into_iter()
+        .filter(|request| {
+            request
+                .message_input_texts("user")
+                .iter()
+                .any(|text| text == FOLLOW_UP_PROMPT)
+        })
+        .collect::<Vec<_>>();
+    let [request] = requests.as_slice() else {
+        anyhow::bail!("expected 1 follow-up request, got {}", requests.len());
+    };
     assert_eq!(
-        rollout_budget_texts(&request).last(),
+        rollout_budget_texts(request).last(),
         Some(&rollout_budget_message(/*remaining_tokens*/ 50))
     );
 


### PR DESCRIPTION
## Why

`subagent_usage_draws_from_the_shared_budget` intermittently fails even when the shared-budget behavior is correct. `ResponseMock` records a request before the custom Wiremock predicate is checked, so the follow-up mock can also contain unrelated requests. In a [recent Windows ARM64 run](https://github.com/openai/codex/actions/runs/28916285431), `single_request()` saw all seven requests from the scenario.

## What changed

Select the request containing the follow-up user prompt before making assertions. The test still requires exactly one matching follow-up request and still checks that the root sees 50 tokens remaining after the child uses its share.

This is test-only. Shared-budget behavior and the common response-mock helper are unchanged.
