### PR TITLE
Clear active turn before publishing terminal events

### DIFF
--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -9892,6 +9892,42 @@ async fn task_finish_emits_thread_idle_lifecycle_after_active_turn_clears() {
 }
 
 #[tokio::test]
+async fn task_finish_clears_active_turn_before_publishing_turn_complete() {
+    let (session, mut turn_context, rx) = make_session_and_context_with_rx().await;
+    let turn_context_mut =
+        Arc::get_mut(&mut turn_context).expect("turn context should not be shared");
+    turn_context_mut.multi_agent_version = MultiAgentVersion::V2;
+    turn_context_mut.session_source = SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
+        parent_thread_id: ThreadId::new(),
+        depth: 1,
+        agent_path: Some(AgentPath::try_from("/root/worker").expect("agent path should parse")),
+        agent_nickname: Some("worker".to_string()),
+        agent_role: None,
+    });
+
+    // Hold the first post-publication lock so the assertion observes the state exactly when the
+    // terminal event becomes visible, rather than after the rest of completion happens to run.
+    let terminal_error = Arc::clone(&turn_context.terminal_error);
+    let terminal_error_guard = terminal_error.lock().await;
+    session
+        .spawn_task(Arc::clone(&turn_context), Vec::new(), CompletingTask)
+        .await;
+
+    loop {
+        let event = timeout(StdDuration::from_secs(2), rx.recv())
+            .await
+            .expect("turn complete event")
+            .expect("event channel open");
+        if matches!(event.msg, EventMsg::TurnComplete(_)) {
+            break;
+        }
+    }
+
+    assert!(session.active_turn.lock().await.is_none());
+    drop(terminal_error_guard);
+}
+
+#[tokio::test]
 async fn thread_idle_lifecycle_waits_for_trigger_turn_mailbox_work() {
     struct ThreadIdleRecorder {
         calls: Arc<std::sync::atomic::AtomicUsize>,

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -774,13 +774,6 @@ impl Session {
                 time_to_first_token_ms,
             })
         };
-        self.send_event(turn_context.as_ref(), event).await;
-        self.services
-            .guardian_rejection_circuit_breaker
-            .lock()
-            .await
-            .clear_turn(&turn_context.sub_id);
-
         let cleared_active_turn = {
             let mut active = self.active_turn.lock().await;
             if let Some(active_turn) = active.as_ref()
@@ -793,6 +786,13 @@ impl Session {
                 false
             }
         };
+        self.send_event(turn_context.as_ref(), event).await;
+        self.services
+            .guardian_rejection_circuit_breaker
+            .lock()
+            .await
+            .clear_turn(&turn_context.sub_id);
+
         if cleared_active_turn {
             self.emit_thread_idle_lifecycle_if_idle().await;
         }


### PR DESCRIPTION
## Why

`TurnComplete` was published before the completed task cleared its active-turn slot. A client that immediately submitted `ThreadRollback` could therefore be told that a turn was still in progress. This race made `thread_rollback_after_generated_image_drops_entire_image_turn_history` fail intermittently in remote Linux CI.

## What changed

- Clear the completed active-turn slot before publishing `TurnComplete` or `TurnAborted`.
- Keep the existing ordering where the terminal event is published before the thread-idle lifecycle runs.
- Add a focused regression test that pauses the first post-publication step and verifies the active turn is already clear.

## Behavior

Once a terminal event is visible, follow-up thread operations can rely on the completed turn no longer being active. There are no API shape changes and no known follow-up work.
