### PR TITLE
Move permissions guidance into World State

### DIFF
--- a/codex-rs/core/src/context/world_state/mod.rs
+++ b/codex-rs/core/src/context/world_state/mod.rs
@@ -1,6 +1,7 @@
 mod agents_md;
 mod apps_instructions;
 mod environment;
+mod permissions;
 mod plugins_instructions;
 
 use crate::context::ContextualUserFragment;
@@ -20,6 +21,7 @@ use std::fmt;
 pub(crate) use agents_md::AgentsMdState;
 pub(crate) use apps_instructions::AppsInstructionsState;
 pub(crate) use environment::EnvironmentsState;
+pub(crate) use permissions::PermissionsState;
 pub(crate) use plugins_instructions::PluginsInstructionsState;
 
 trait ErasedWorldStateSection: Send + Sync {

--- a/codex-rs/core/src/context/world_state/permissions.rs
+++ b/codex-rs/core/src/context/world_state/permissions.rs
@@ -1,0 +1,118 @@
+use super::PreviousSectionState;
+use super::WorldStateSection;
+use crate::context::ApprovalPromptContext;
+use crate::context::ContextualUserFragment;
+use crate::context::PermissionsInstructions;
+use crate::session::turn_context::TurnContext;
+use codex_execpolicy::Policy;
+use codex_features::Feature;
+use serde::Deserialize;
+use serde::Serialize;
+use sha1::Digest;
+
+/// The permissions guidance currently visible to the model.
+#[derive(Clone, Debug)]
+pub(crate) struct PermissionsState {
+    instructions: Option<PermissionsInstructions>,
+    snapshot: PermissionsSnapshot,
+}
+
+/// Persisted inputs that determine when permissions guidance must be rendered again.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+pub(crate) struct PermissionsSnapshot {
+    enabled: bool,
+    model_slug: Option<String>,
+    instructions_fingerprint: Option<String>,
+}
+
+impl PermissionsState {
+    pub(crate) fn from_turn_context(turn_context: &TurnContext, exec_policy: &Policy) -> Self {
+        if !turn_context.config.include_permissions_instructions {
+            return Self::disabled();
+        }
+
+        let approval_messages = turn_context
+            .model_info
+            .model_messages
+            .as_ref()
+            .and_then(|messages| messages.approvals.as_ref());
+        let instructions = PermissionsInstructions::from_permission_profile(
+            &turn_context.permission_profile,
+            turn_context.approval_policy.value(),
+            ApprovalPromptContext::new(turn_context.config.approvals_reviewer, approval_messages),
+            exec_policy,
+            #[allow(deprecated)]
+            &turn_context.cwd,
+            turn_context
+                .config
+                .features
+                .enabled(Feature::ExecPermissionApprovals),
+            turn_context
+                .config
+                .features
+                .enabled(Feature::RequestPermissionsTool),
+        );
+        Self::enabled(instructions, turn_context.model_info.slug.as_str())
+    }
+
+    pub(crate) fn enabled(instructions: PermissionsInstructions, model_slug: &str) -> Self {
+        let instructions_fingerprint = Some(format!(
+            "sha1:{:x}",
+            sha1::Sha1::digest(instructions.body().as_bytes())
+        ));
+
+        Self {
+            instructions: Some(instructions),
+            snapshot: PermissionsSnapshot {
+                enabled: true,
+                model_slug: Some(model_slug.to_string()),
+                instructions_fingerprint,
+            },
+        }
+    }
+
+    pub(crate) fn disabled() -> Self {
+        Self {
+            instructions: None,
+            snapshot: PermissionsSnapshot::default(),
+        }
+    }
+}
+
+impl WorldStateSection for PermissionsState {
+    const ID: &'static str = "permissions";
+    type Snapshot = PermissionsSnapshot;
+
+    fn snapshot(&self) -> Self::Snapshot {
+        self.snapshot.clone()
+    }
+
+    fn matches_legacy_fragment(role: &str, text: &str) -> bool {
+        role == "developer" && PermissionsInstructions::matches_text(text)
+    }
+
+    fn has_retained_fragment_matcher() -> bool {
+        true
+    }
+
+    fn matches_retained_fragment(role: &str, text: &str) -> bool {
+        Self::matches_legacy_fragment(role, text)
+    }
+
+    fn render_diff(
+        &self,
+        previous: PreviousSectionState<'_, Self::Snapshot>,
+    ) -> Option<Box<dyn ContextualUserFragment>> {
+        if matches!(previous, PreviousSectionState::Known(previous) if previous == &self.snapshot) {
+            return None;
+        }
+
+        self.instructions
+            .clone()
+            .map(|instructions| Box::new(instructions) as Box<dyn ContextualUserFragment>)
+    }
+}
+
+#[cfg(test)]
+#[path = "permissions_tests.rs"]
+mod tests;

--- a/codex-rs/core/src/context/world_state/permissions_tests.rs
+++ b/codex-rs/core/src/context/world_state/permissions_tests.rs
@@ -1,0 +1,242 @@
+use super::*;
+use crate::context::ApprovalPromptContext;
+use codex_execpolicy::Decision;
+use codex_execpolicy::Policy;
+use codex_protocol::config_types::ApprovalsReviewer;
+use codex_protocol::models::PermissionProfile;
+use codex_protocol::models::ResponseItem;
+use codex_protocol::openai_models::ApprovalMessages;
+use codex_protocol::protocol::AskForApproval;
+use pretty_assertions::assert_eq;
+use std::path::Path;
+
+fn permissions_state(
+    model_slug: &str,
+    approval_policy: AskForApproval,
+    reviewer: ApprovalsReviewer,
+    on_request: Option<&str>,
+    on_request_auto_review: Option<&str>,
+) -> PermissionsState {
+    let messages = ApprovalMessages {
+        on_request: on_request.map(str::to_string),
+        on_request_auto_review: on_request_auto_review.map(str::to_string),
+    };
+    let permission_profile = PermissionProfile::Disabled;
+    let instructions = PermissionsInstructions::from_permission_profile(
+        &permission_profile,
+        approval_policy,
+        ApprovalPromptContext::new(reviewer, Some(&messages)),
+        &Policy::empty(),
+        Path::new("."),
+        /*exec_permission_approvals_enabled*/ false,
+        /*request_permissions_tool_enabled*/ false,
+    );
+    PermissionsState::enabled(instructions, model_slug)
+}
+
+fn render(
+    state: &PermissionsState,
+    previous: PreviousSectionState<'_, PermissionsSnapshot>,
+) -> Vec<String> {
+    state
+        .render_diff(previous)
+        .into_iter()
+        .map(|fragment| fragment.render())
+        .collect()
+}
+
+#[test]
+fn renders_when_reviewer_or_catalog_message_changes() {
+    let user = permissions_state(
+        "model-a",
+        AskForApproval::OnRequest,
+        ApprovalsReviewer::User,
+        Some("user approvals v1"),
+        Some("auto approvals"),
+    );
+    let same_snapshot = user.snapshot();
+    let auto = permissions_state(
+        "model-a",
+        AskForApproval::OnRequest,
+        ApprovalsReviewer::AutoReview,
+        Some("user approvals v1"),
+        Some("auto approvals"),
+    );
+    let updated_catalog = permissions_state(
+        "model-a",
+        AskForApproval::OnRequest,
+        ApprovalsReviewer::User,
+        Some("user approvals v2"),
+        Some("auto approvals"),
+    );
+
+    assert_eq!(render(&user, PreviousSectionState::Absent).len(), 1);
+    assert_eq!(
+        render(&user, PreviousSectionState::Known(&same_snapshot)),
+        Vec::<String>::new()
+    );
+    assert!(
+        render(&auto, PreviousSectionState::Known(&same_snapshot))[0].contains("auto approvals")
+    );
+    assert!(
+        render(
+            &updated_catalog,
+            PreviousSectionState::Known(&same_snapshot)
+        )[0]
+        .contains("user approvals v2")
+    );
+    assert_eq!(
+        render(&PermissionsState::disabled(), PreviousSectionState::Absent),
+        Vec::<String>::new()
+    );
+}
+
+#[test]
+fn missing_and_empty_catalog_messages_have_distinct_snapshots() {
+    let missing = permissions_state(
+        "model-a",
+        AskForApproval::OnRequest,
+        ApprovalsReviewer::User,
+        None,
+        None,
+    );
+    let empty = permissions_state(
+        "model-a",
+        AskForApproval::OnRequest,
+        ApprovalsReviewer::User,
+        Some(""),
+        None,
+    );
+
+    assert_ne!(missing.snapshot(), empty.snapshot());
+}
+
+#[test]
+fn model_changes_render_even_when_catalog_messages_match() {
+    let model_a = permissions_state(
+        "model-a",
+        AskForApproval::OnRequest,
+        ApprovalsReviewer::User,
+        Some("shared approvals"),
+        None,
+    );
+    let model_b = permissions_state(
+        "model-b",
+        AskForApproval::OnRequest,
+        ApprovalsReviewer::User,
+        Some("shared approvals"),
+        None,
+    );
+    let expected = render(&model_b, PreviousSectionState::Absent);
+
+    assert_eq!(
+        render(&model_b, PreviousSectionState::Known(&model_a.snapshot())),
+        expected
+    );
+}
+
+#[test]
+fn reviewer_changes_are_ignored_when_approval_policy_is_never() {
+    let user = permissions_state(
+        "model-a",
+        AskForApproval::Never,
+        ApprovalsReviewer::User,
+        None,
+        None,
+    );
+    let auto = permissions_state(
+        "model-a",
+        AskForApproval::Never,
+        ApprovalsReviewer::AutoReview,
+        None,
+        None,
+    );
+
+    assert_eq!(user.snapshot(), auto.snapshot());
+    assert!(render(&auto, PreviousSectionState::Known(&user.snapshot())).is_empty());
+}
+
+#[test]
+fn approved_prefix_changes_rendered_permissions_snapshot() {
+    let permission_profile = PermissionProfile::Disabled;
+    let make_state = |exec_policy: &Policy| {
+        let instructions = PermissionsInstructions::from_permission_profile(
+            &permission_profile,
+            AskForApproval::OnRequest,
+            ApprovalPromptContext::new(ApprovalsReviewer::User, /*messages*/ None),
+            exec_policy,
+            Path::new("."),
+            /*exec_permission_approvals_enabled*/ false,
+            /*request_permissions_tool_enabled*/ false,
+        );
+        PermissionsState::enabled(instructions, "model-a")
+    };
+    let before = make_state(&Policy::empty());
+    let mut policy_with_prefix = Policy::empty();
+    policy_with_prefix
+        .add_prefix_rule(&["git".to_string(), "pull".to_string()], Decision::Allow)
+        .expect("add prefix rule");
+    let after = make_state(&policy_with_prefix);
+
+    assert_ne!(before.snapshot(), after.snapshot());
+    assert!(
+        render(&after, PreviousSectionState::Known(&before.snapshot()))[0]
+            .contains(r#"["git", "pull"]"#)
+    );
+}
+
+#[test]
+fn legacy_permissions_are_reinjected_to_establish_a_snapshot() {
+    let state = permissions_state(
+        "model-a",
+        AskForApproval::OnRequest,
+        ApprovalsReviewer::User,
+        Some("user approvals"),
+        Some("auto approvals"),
+    );
+    let legacy: ResponseItem = ContextualUserFragment::into(
+        state
+            .instructions
+            .clone()
+            .expect("enabled state should have instructions"),
+    );
+    let mut world_state = super::super::WorldState::default();
+    world_state.add_section(state);
+
+    assert_eq!(
+        world_state
+            .render_history_diff(/*previous*/ None, &[legacy])
+            .len(),
+        1
+    );
+}
+
+#[test]
+fn persisted_permissions_are_restored_only_when_missing_from_history() {
+    let state = permissions_state(
+        "model-a",
+        AskForApproval::OnRequest,
+        ApprovalsReviewer::User,
+        Some("user approvals"),
+        Some("auto approvals"),
+    );
+    let retained: ResponseItem = ContextualUserFragment::into(
+        state
+            .instructions
+            .clone()
+            .expect("enabled state should have instructions"),
+    );
+    let mut world_state = super::super::WorldState::default();
+    world_state.add_section(state);
+    let snapshot = world_state.snapshot();
+
+    assert_eq!(
+        world_state.render_history_diff(Some(&snapshot), &[]).len(),
+        1
+    );
+    assert!(
+        world_state
+            .render_history_diff(Some(&snapshot), &[retained])
+            .is_empty()
+    );
+}

--- a/codex-rs/core/src/context/world_state/permissions_tests.rs
+++ b/codex-rs/core/src/context/world_state/permissions_tests.rs
@@ -97,15 +97,15 @@ fn missing_and_empty_catalog_messages_have_distinct_snapshots() {
         "model-a",
         AskForApproval::OnRequest,
         ApprovalsReviewer::User,
-        None,
-        None,
+        /*on_request*/ None,
+        /*on_request_auto_review*/ None,
     );
     let empty = permissions_state(
         "model-a",
         AskForApproval::OnRequest,
         ApprovalsReviewer::User,
         Some(""),
-        None,
+        /*on_request_auto_review*/ None,
     );
 
     assert_ne!(missing.snapshot(), empty.snapshot());
@@ -118,14 +118,14 @@ fn model_changes_render_even_when_catalog_messages_match() {
         AskForApproval::OnRequest,
         ApprovalsReviewer::User,
         Some("shared approvals"),
-        None,
+        /*on_request_auto_review*/ None,
     );
     let model_b = permissions_state(
         "model-b",
         AskForApproval::OnRequest,
         ApprovalsReviewer::User,
         Some("shared approvals"),
-        None,
+        /*on_request_auto_review*/ None,
     );
     let expected = render(&model_b, PreviousSectionState::Absent);
 
@@ -141,15 +141,15 @@ fn reviewer_changes_are_ignored_when_approval_policy_is_never() {
         "model-a",
         AskForApproval::Never,
         ApprovalsReviewer::User,
-        None,
-        None,
+        /*on_request*/ None,
+        /*on_request_auto_review*/ None,
     );
     let auto = permissions_state(
         "model-a",
         AskForApproval::Never,
         ApprovalsReviewer::AutoReview,
-        None,
-        None,
+        /*on_request*/ None,
+        /*on_request_auto_review*/ None,
     );
 
     assert_eq!(user.snapshot(), auto.snapshot());

--- a/codex-rs/core/src/context_manager/updates.rs
+++ b/codex-rs/core/src/context_manager/updates.rs
@@ -1,65 +1,19 @@
-use crate::context::ApprovalPromptContext;
 use crate::context::CollaborationModeInstructions;
 use crate::context::ContextualUserFragment;
 use crate::context::ModelSwitchInstructions;
 use crate::context::MultiAgentModeInstructions;
-use crate::context::PermissionsInstructions;
 use crate::context::PersonalitySpecInstructions;
 use crate::context::RealtimeEndInstructions;
 use crate::context::RealtimeStartInstructions;
 use crate::context::RealtimeStartWithInstructions;
 use crate::session::PreviousTurnSettings;
 use crate::session::turn_context::TurnContext;
-use codex_execpolicy::Policy;
-use codex_features::Feature;
 use codex_protocol::config_types::MultiAgentMode;
 use codex_protocol::config_types::Personality;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::openai_models::ModelInfo;
 use codex_protocol::protocol::TurnContextItem;
-
-fn build_permissions_update_item(
-    previous: Option<&TurnContextItem>,
-    next: &TurnContext,
-    exec_policy: &Policy,
-) -> Option<String> {
-    if !next.config.include_permissions_instructions {
-        return None;
-    }
-
-    let prev = previous?;
-    if prev.permission_profile() == next.permission_profile()
-        && prev.approval_policy == next.approval_policy.value()
-        && prev.model == next.model_info.slug
-    {
-        return None;
-    }
-
-    Some(
-        PermissionsInstructions::from_permission_profile(
-            &next.permission_profile,
-            next.approval_policy.value(),
-            ApprovalPromptContext::new(
-                next.config.approvals_reviewer,
-                next.model_info
-                    .model_messages
-                    .as_ref()
-                    .and_then(|messages| messages.approvals.as_ref()),
-            ),
-            exec_policy,
-            #[allow(deprecated)]
-            &next.cwd,
-            next.config
-                .features
-                .enabled(Feature::ExecPermissionApprovals),
-            next.config
-                .features
-                .enabled(Feature::RequestPermissionsTool),
-        )
-        .render(),
-    )
-}
 
 fn build_collaboration_mode_update_item(
     previous: Option<&TurnContextItem>,
@@ -241,7 +195,6 @@ pub(crate) fn build_settings_update_items(
     previous: Option<&TurnContextItem>,
     previous_turn_settings: Option<&PreviousTurnSettings>,
     next: &TurnContext,
-    exec_policy: &Policy,
     personality_feature_enabled: bool,
 ) -> Vec<ResponseItem> {
     // TODO(ccunningham): build_settings_update_items still does not cover every
@@ -252,7 +205,6 @@ pub(crate) fn build_settings_update_items(
         // Keep model-switch instructions first so model-specific guidance is read before
         // any other context diffs on this turn.
         build_model_instructions_update_item(previous_turn_settings, next),
-        build_permissions_update_item(previous, next, exec_policy),
         build_collaboration_mode_update_item(previous, next),
         build_multi_agent_mode_update_item(previous, next),
         build_realtime_update_item(previous, previous_turn_settings, next),

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -21,14 +21,12 @@ use crate::build_available_skills;
 use crate::compact;
 use crate::config::ManagedFeatures;
 use crate::config::resolve_tool_suggest_config_from_layer_stack;
-use crate::context::ApprovalPromptContext;
 use crate::context::ApprovedCommandPrefixSaved;
 use crate::context::AvailableSkillsInstructions;
 use crate::context::CollaborationModeInstructions;
 use crate::context::ContextualUserFragment;
 use crate::context::MultiAgentModeInstructions;
 use crate::context::NetworkRuleSaved;
-use crate::context::PermissionsInstructions;
 use crate::context::PersonalitySpecInstructions;
 use crate::context::RecommendedPluginsInstructions;
 use crate::context::world_state::WorldState;
@@ -1733,18 +1731,16 @@ impl Session {
     ) -> Vec<ResponseItem> {
         // TODO: Make context updates a pure diff of persisted previous/current TurnContextItem
         // state so replay/backtracking is deterministic. Runtime inputs that affect model-visible
-        // context (exec policy, feature gates, previous-turn bridge) should be persisted
-        // state or explicit non-state replay events.
+        // context (feature gates, previous-turn bridge) should be persisted state or explicit
+        // non-state replay events.
         let previous_turn_settings = {
             let state = self.state.lock().await;
             state.previous_turn_settings()
         };
-        let exec_policy = self.services.exec_policy.current();
         crate::context_manager::updates::build_settings_update_items(
             reference_context_item,
             previous_turn_settings.as_ref(),
             current_context,
-            exec_policy.as_ref(),
             self.features.enabled(Feature::Personality),
         )
     }
@@ -3201,34 +3197,6 @@ impl Session {
             )
         {
             developer_sections.push(model_switch_message);
-        }
-        if turn_context.config.include_permissions_instructions {
-            developer_sections.push(
-                PermissionsInstructions::from_permission_profile(
-                    &turn_context.permission_profile,
-                    turn_context.approval_policy.value(),
-                    ApprovalPromptContext::new(
-                        turn_context.config.approvals_reviewer,
-                        turn_context
-                            .model_info
-                            .model_messages
-                            .as_ref()
-                            .and_then(|messages| messages.approvals.as_ref()),
-                    ),
-                    self.services.exec_policy.current().as_ref(),
-                    #[allow(deprecated)]
-                    &turn_context.cwd,
-                    turn_context
-                        .config
-                        .features
-                        .enabled(Feature::ExecPermissionApprovals),
-                    turn_context
-                        .config
-                        .features
-                        .enabled(Feature::RequestPermissionsTool),
-                )
-                .render(),
-            );
         }
         let separate_guardian_developer_message =
             crate::guardian::is_guardian_reviewer_source(&session_source);

--- a/codex-rs/core/src/session/rollout_reconstruction_tests.rs
+++ b/codex-rs/core/src/session/rollout_reconstruction_tests.rs
@@ -137,12 +137,19 @@ async fn record_initial_history_restores_world_state_baseline() {
     let (session, turn_context) = make_session_and_context().await;
     let turn_context = Arc::new(turn_context);
     let world_state = build_world_state_from_turn_context(&session, &turn_context).await;
-    let rollout_items = completed_user_turn_rollout(
-        turn_context.to_turn_context_item(),
-        vec![RolloutItem::WorldState(WorldStateItem::full(
-            world_state.snapshot().into_value(),
-        ))],
-    );
+    let initial_context = session
+        .build_initial_context_with_world_state(turn_context.as_ref(), &world_state)
+        .await;
+    let mut persisted_items = initial_context
+        .iter()
+        .cloned()
+        .map(RolloutItem::ResponseItem)
+        .collect::<Vec<_>>();
+    persisted_items.push(RolloutItem::WorldState(WorldStateItem::full(
+        world_state.snapshot().into_value(),
+    )));
+    let rollout_items =
+        completed_user_turn_rollout(turn_context.to_turn_context_item(), persisted_items);
 
     session
         .record_initial_history(InitialHistory::Resumed(ResumedHistory {
@@ -156,7 +163,7 @@ async fn record_initial_history_restores_world_state_baseline() {
         .record_context_updates_and_set_reference_context_item(&step_context)
         .await;
 
-    assert_eq!(session.clone_history().await.raw_items(), &[]);
+    assert_eq!(session.clone_history().await.raw_items(), &initial_context);
 }
 
 #[tokio::test]

--- a/codex-rs/core/src/session/snapshots/codex_core__codex_tests__fork_startup_context_then_first_turn_diff.snap
+++ b/codex-rs/core/src/session/snapshots/codex_core__codex_tests__fork_startup_context_then_first_turn_diff.snap
@@ -8,7 +8,6 @@ Scenario: First request after fork when startup preserves the parent baseline, t
 00:message/developer:<PERMISSIONS_INSTRUCTIONS>
 01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 02:message/user:fork seed
-03:message/developer[2]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <collaboration_mode>Fork turn collaboration instructions.</collaboration_mode>
-04:message/user:after fork
+03:message/developer:<collaboration_mode>Fork turn collaboration instructions.</collaboration_mode>
+04:message/developer:<PERMISSIONS_INSTRUCTIONS>
+05:message/user:after fork

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -9045,6 +9045,13 @@ async fn record_context_updates_and_set_reference_context_item_persists_baseline
     let previous_context_item = turn_context.to_turn_context_item();
     let previous_context = Arc::new(turn_context);
     let world_state = build_world_state_from_turn_context(&session, &previous_context).await;
+    let initial_context = session
+        .build_initial_context_with_world_state(previous_context.as_ref(), &world_state)
+        .await;
+    session
+        .record_conversation_items(previous_context.as_ref(), &initial_context)
+        .await;
+    let expected_history = session.clone_history().await.raw_items().to_vec();
     let mut turn_context = Arc::try_unwrap(previous_context)
         .unwrap_or_else(|_| panic!("previous turn context should have no remaining references"));
     turn_context.sub_id = format!("{}-next", turn_context.sub_id);
@@ -9070,7 +9077,7 @@ async fn record_context_updates_and_set_reference_context_item_persists_baseline
 
     assert_eq!(
         session.clone_history().await.raw_items().to_vec(),
-        Vec::new()
+        expected_history
     );
     assert_eq!(
         serde_json::to_value(session.reference_context_item().await)

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -346,6 +346,8 @@ pub(crate) async fn run_turn(
                 if needs_follow_up
                     && (sess.take_new_context_window_request().await || token_limit_reached)
                 {
+                    // TODO(sayan): Decide whether restoring newly approved command prefixes after
+                    // same-turn compaction with deferred executors disabled is worth supporting.
                     if let Err(err) = run_auto_compact(
                         &sess,
                         Arc::clone(&step_context),

--- a/codex-rs/core/src/session/world_state.rs
+++ b/codex-rs/core/src/session/world_state.rs
@@ -4,6 +4,7 @@ use crate::connectors;
 use crate::context::world_state::AgentsMdState;
 use crate::context::world_state::AppsInstructionsState;
 use crate::context::world_state::EnvironmentsState;
+use crate::context::world_state::PermissionsState;
 use crate::context::world_state::PluginsInstructionsState;
 use crate::context::world_state::WorldState;
 use codex_extension_api::WorldStateContributionInput;
@@ -29,6 +30,11 @@ impl Session {
         };
 
         let mut world_state = WorldState::default();
+        let exec_policy = self.services.exec_policy.current();
+        world_state.add_section(PermissionsState::from_turn_context(
+            turn_context,
+            exec_policy.as_ref(),
+        ));
         world_state.add_section(AgentsMdState::new(step_context.loaded_agents_md.as_deref()));
         if turn_context.config.include_environment_context {
             world_state.add_section(

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -1649,12 +1649,9 @@ async fn includes_user_instructions_message_in_request() {
             .contains("be nice")
     );
     assert_message_role(&request_body["input"][0], "developer");
-    let permissions_text = request_body["input"][0]["content"][0]["text"]
-        .as_str()
-        .expect("invalid permissions message content");
     assert!(
-        permissions_text.contains("`sandbox_mode`"),
-        "expected permissions message to mention sandbox_mode, got {permissions_text:?}"
+        message_input_text_contains(&request, "developer", "`sandbox_mode`"),
+        "expected a permissions message to mention sandbox_mode"
     );
 
     assert_message_role(&request_body["input"][1], "user");
@@ -2881,10 +2878,6 @@ async fn includes_developer_instructions_message_in_request() {
     let request = resp_mock.single_request();
     let request_body = request.body_json();
 
-    let permissions_text = request_body["input"][0]["content"][0]["text"]
-        .as_str()
-        .expect("invalid permissions message content");
-
     assert!(
         !request_body["instructions"]
             .as_str()
@@ -2893,8 +2886,8 @@ async fn includes_developer_instructions_message_in_request() {
     );
     assert_message_role(&request_body["input"][0], "developer");
     assert!(
-        permissions_text.contains("`sandbox_mode`"),
-        "expected permissions message to mention sandbox_mode, got {permissions_text:?}"
+        message_input_text_contains(&request, "developer", "`sandbox_mode`"),
+        "expected a permissions message to mention sandbox_mode"
     );
 
     let developer_messages: Vec<&serde_json::Value> = request_body["input"]

--- a/codex-rs/core/tests/suite/compact.rs
+++ b/codex-rs/core/tests/suite/compact.rs
@@ -1222,18 +1222,19 @@ async fn multiple_auto_compact_per_task_runs_after_token_limit_hit() {
                     return None;
                 }
 
-                let text = value
-                    .get("content")
-                    .and_then(|content| content.as_array())
-                    .and_then(|content| content.first())
-                    .and_then(|item| item.get("text"))
-                    .and_then(|text| text.as_str());
+                let content = value.get("content").and_then(|content| content.as_array());
 
                 // Ignore cached prefix messages (project docs + permissions) since they are not
                 // relevant to compaction behavior and can change as bundled prompts evolve.
                 let role = value.get("role").and_then(|role| role.as_str());
                 if role == Some("developer")
-                    && text.is_some_and(|text| text.contains("`sandbox_mode`"))
+                    && content.is_some_and(|content| {
+                        content.iter().any(|item| {
+                            item.get("text")
+                                .and_then(|text| text.as_str())
+                                .is_some_and(|text| text.contains("<permissions instructions>"))
+                        })
+                    })
                 {
                     return None;
                 }

--- a/codex-rs/core/tests/suite/permissions_messages.rs
+++ b/codex-rs/core/tests/suite/permissions_messages.rs
@@ -6,10 +6,13 @@ use codex_core::context::ApprovalPromptContext;
 use codex_core::context::ContextualUserFragment;
 use codex_core::context::PermissionsInstructions;
 use codex_core::load_exec_policy;
+use codex_login::CodexAuth;
 use codex_models_manager::model_info::model_info_from_slug;
+use codex_protocol::config_types::ApprovalsReviewer;
 use codex_protocol::models::PermissionProfile;
 use codex_protocol::openai_models::ApprovalMessages;
 use codex_protocol::openai_models::ModelMessages;
+use codex_protocol::openai_models::ModelVisibility;
 use codex_protocol::openai_models::ModelsResponse;
 use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_protocol::protocol::AskForApproval;
@@ -17,11 +20,13 @@ use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::Op;
 use codex_protocol::user_input::UserInput;
 use codex_utils_absolute_path::AbsolutePathBuf;
+use core_test_support::responses;
 use core_test_support::responses::ResponsesRequest;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_response_created;
 use core_test_support::responses::mount_sse_once;
 use core_test_support::responses::sse;
+use core_test_support::responses::sse_response;
 use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::test_codex;
@@ -29,6 +34,7 @@ use core_test_support::wait_for_event;
 use pretty_assertions::assert_eq;
 use std::collections::HashSet;
 use tempfile::TempDir;
+use wiremock::MockServer;
 
 fn permissions_texts(request: &ResponsesRequest) -> Vec<String> {
     request
@@ -44,6 +50,8 @@ fn model_with_approval_messages(
     on_request_auto_review: &str,
 ) -> codex_protocol::openai_models::ModelInfo {
     let mut model = model_info_from_slug(slug);
+    model.visibility = ModelVisibility::List;
+    model.used_fallback_model_metadata = false;
     model.model_messages = Some(ModelMessages {
         instructions_template: None,
         instructions_variables: None,
@@ -157,6 +165,132 @@ async fn model_change_appends_new_catalog_approval_message() -> Result<()> {
         permissions
             .last()
             .is_some_and(|text| text.contains("model B approvals"))
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reviewer_change_appends_matching_catalog_approval_message() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let _req1 = mount_sse_once(
+        &server,
+        sse(vec![ev_response_created("resp-1"), ev_completed("resp-1")]),
+    )
+    .await;
+    let req2 = mount_sse_once(
+        &server,
+        sse(vec![ev_response_created("resp-2"), ev_completed("resp-2")]),
+    )
+    .await;
+    let model_slug = "catalog-approvals-reviewer-model";
+    let model = model_with_approval_messages(
+        model_slug,
+        "catalog user approval instructions",
+        "catalog auto-review approval instructions",
+    );
+    let mut builder = test_codex()
+        .with_model(model_slug)
+        .with_config(move |config| {
+            config.permissions.approval_policy = Constrained::allow_any(AskForApproval::OnRequest);
+            config.approvals_reviewer = ApprovalsReviewer::User;
+            config.model_catalog = Some(ModelsResponse {
+                models: vec![model],
+            });
+        });
+    let test = builder.build(&server).await?;
+    submit_text_turn(&test, "first").await?;
+
+    core_test_support::submit_thread_settings(
+        &test.codex,
+        codex_protocol::protocol::ThreadSettingsOverrides {
+            approvals_reviewer: Some(ApprovalsReviewer::AutoReview),
+            ..Default::default()
+        },
+    )
+    .await?;
+    submit_text_turn(&test, "second").await?;
+
+    let permissions = permissions_texts(&req2.single_request());
+    assert_eq!(permissions.len(), 2);
+    assert!(
+        permissions
+            .last()
+            .is_some_and(|text| text.contains("catalog auto-review approval instructions"))
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn same_model_catalog_message_change_appends_new_permissions() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    const ETAG_1: &str = "\"permissions-models-etag-1\"";
+    const ETAG_2: &str = "\"permissions-models-etag-2\"";
+
+    let server = MockServer::start().await;
+    let model_slug = "catalog-approvals-refresh-model";
+    let first_model = model_with_approval_messages(
+        model_slug,
+        "catalog user approvals v1",
+        "catalog auto approvals",
+    );
+    let second_model = model_with_approval_messages(
+        model_slug,
+        "catalog user approvals v2",
+        "catalog auto approvals",
+    );
+    let _spawn_models_mock = responses::mount_models_once_with_etag(
+        &server,
+        ModelsResponse {
+            models: vec![first_model],
+        },
+        ETAG_1,
+    )
+    .await;
+    let refresh_models_mock = responses::mount_models_once_with_etag(
+        &server,
+        ModelsResponse {
+            models: vec![second_model],
+        },
+        ETAG_2,
+    )
+    .await;
+    let mut builder = test_codex()
+        .with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing())
+        .with_model(model_slug)
+        .with_config(|config| {
+            config.permissions.approval_policy = Constrained::allow_any(AskForApproval::OnRequest);
+            config.model_provider.request_max_retries = Some(0);
+        });
+    let test = builder.build(&server).await?;
+
+    let _req1 = responses::mount_response_once(
+        &server,
+        sse_response(sse(vec![
+            ev_response_created("resp-1"),
+            ev_completed("resp-1"),
+        ]))
+        .insert_header("X-Models-Etag", ETAG_2),
+    )
+    .await;
+    submit_text_turn(&test, "first").await?;
+    assert_eq!(refresh_models_mock.requests().len(), 1);
+
+    let req2 = mount_sse_once(
+        &server,
+        sse(vec![ev_response_created("resp-2"), ev_completed("resp-2")]),
+    )
+    .await;
+    submit_text_turn(&test, "second").await?;
+
+    let permissions = permissions_texts(&req2.single_request());
+    assert_eq!(permissions.len(), 2);
+    assert!(
+        permissions
+            .last()
+            .is_some_and(|text| text.contains("catalog user approvals v2"))
     );
     Ok(())
 }

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -62,6 +62,20 @@ fn assert_eq_without_metadata(left: serde_json::Value, right: serde_json::Value)
     );
 }
 
+fn assert_permissions_message(message: &serde_json::Value) {
+    assert_eq!(message["role"].as_str(), Some("developer"));
+    assert!(
+        message["content"]
+            .as_array()
+            .is_some_and(|content| content.iter().any(|item| {
+                item["text"]
+                    .as_str()
+                    .is_some_and(|text| text.contains("<permissions instructions>"))
+            })),
+        "expected permissions update: {message:?}"
+    );
+}
+
 fn assert_default_env_context(text: &str, cwd: &str) {
     assert_env_context_fragment(text);
     assert!(
@@ -660,16 +674,10 @@ async fn override_before_first_turn_emits_environment_context() -> anyhow::Resul
 
     let permissions_texts: Vec<&str> = input
         .iter()
-        .filter_map(|msg| {
-            let role = msg["role"].as_str()?;
-            if role != "developer" {
-                return None;
-            }
-            msg["content"]
-                .as_array()
-                .and_then(|content| content.first())
-                .and_then(|item| item["text"].as_str())
-        })
+        .filter(|msg| msg["role"].as_str() == Some("developer"))
+        .filter_map(|msg| msg["content"].as_array())
+        .flatten()
+        .filter_map(|item| item["text"].as_str())
         .collect();
     assert!(
         permissions_texts.iter().any(|text| {
@@ -812,7 +820,9 @@ async fn per_turn_overrides_keep_cached_prefix_and_key_constant() -> anyhow::Res
         }),
         "expected model switch section after model override: {expected_settings_update_msg:?}"
     );
-    let expected_env_msg_2 = body2["input"][body1_input.len() + 1].clone();
+    let expected_permissions_update_msg = body2["input"][body1_input.len() + 1].clone();
+    assert_permissions_message(&expected_permissions_update_msg);
+    let expected_env_msg_2 = body2["input"][body1_input.len() + 2].clone();
     assert_eq!(expected_env_msg_2["role"].as_str(), Some("user"));
     let env_text = expected_env_msg_2["content"][0]["text"]
         .as_str()
@@ -821,6 +831,7 @@ async fn per_turn_overrides_keep_cached_prefix_and_key_constant() -> anyhow::Res
     assert_default_env_context(env_text, &expected_cwd);
     let mut expected_body2 = body1_input.to_vec();
     expected_body2.push(expected_settings_update_msg);
+    expected_body2.push(expected_permissions_update_msg);
     expected_body2.push(expected_env_msg_2);
     expected_body2.push(expected_user_message_2);
     assert_eq_without_metadata(
@@ -1112,7 +1123,9 @@ async fn send_user_turn_with_changes_sends_environment_context() -> anyhow::Resu
         }),
         "expected model switch section after model override: {expected_settings_update_msg:?}"
     );
-    let expected_env_update_msg = body2["input"][body1_input.len() + 1].clone();
+    let expected_permissions_update_msg = body2["input"][body1_input.len() + 1].clone();
+    assert_permissions_message(&expected_permissions_update_msg);
+    let expected_env_update_msg = body2["input"][body1_input.len() + 2].clone();
     assert_eq!(expected_env_update_msg["role"].as_str(), Some("user"));
     let expected_env_update_text = expected_env_update_msg["content"][0]["text"]
         .as_str()
@@ -1130,6 +1143,7 @@ async fn send_user_turn_with_changes_sends_environment_context() -> anyhow::Resu
         expected_contextual_user_msg_1,
         expected_user_message_1,
         expected_settings_update_msg,
+        expected_permissions_update_msg,
         expected_env_update_msg,
         expected_user_message_2,
     ]);

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact__pre_turn_compaction_strips_incoming_model_switch_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact__pre_turn_compaction_strips_incoming_model_switch_shapes.snap
@@ -21,7 +21,7 @@ Scenario: Pre-turn compaction during model switch (without pre-sampling model-sw
 01:message/user:<COMPACTION_SUMMARY>\nPRETURN_SWITCH_SUMMARY
 02:message/developer[3]:
     [01] <model_switch>\nThe user was previously using a different model....
-    [02] <PERMISSIONS_INSTRUCTIONS>
-    [03] <personality_spec> The user has requested a new communication st...
+    [02] <personality_spec> The user has requested a new communication st...
+    [03] <PERMISSIONS_INSTRUCTIONS>
 03:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 04:message/user:AFTER_SWITCH_USER

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_compact_resume_restates_realtime_end_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_compact_resume_restates_realtime_end_shapes.snap
@@ -6,8 +6,8 @@ Scenario: After remote manual /compact and resume, the first resumed turn rebuil
 
 ## Remote Compaction Request
 00:message/developer[2]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <realtime_conversation>\nRealtime conversation started.\n\nYou a...
+    [01] <realtime_conversation>\nRealtime conversation started.\n\nYou a...
+    [02] <PERMISSIONS_INSTRUCTIONS>
 01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 02:message/user:USER_ONE
 03:message/assistant:REMOTE_FIRST_REPLY
@@ -15,7 +15,7 @@ Scenario: After remote manual /compact and resume, the first resumed turn rebuil
 ## Remote Post-Resume History Layout
 00:compaction:encrypted=true
 01:message/developer[2]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <realtime_conversation>\nRealtime conversation ended.\n\nSubsequ...
+    [01] <realtime_conversation>\nRealtime conversation ended.\n\nSubsequ...
+    [02] <PERMISSIONS_INSTRUCTIONS>
 02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 03:message/user:USER_TWO

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_manual_compact_restates_realtime_start_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_manual_compact_restates_realtime_start_shapes.snap
@@ -6,8 +6,8 @@ Scenario: Remote manual /compact while realtime remains active: the next regular
 
 ## Remote Compaction Request
 00:message/developer[2]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <realtime_conversation>\nRealtime conversation started.\n\nYou a...
+    [01] <realtime_conversation>\nRealtime conversation started.\n\nYou a...
+    [02] <PERMISSIONS_INSTRUCTIONS>
 01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 02:message/user:USER_ONE
 03:message/assistant:REMOTE_FIRST_REPLY
@@ -15,7 +15,7 @@ Scenario: Remote manual /compact while realtime remains active: the next regular
 ## Remote Post-Compaction History Layout
 00:compaction:encrypted=true
 01:message/developer[2]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <realtime_conversation>\nRealtime conversation started.\n\nYou a...
+    [01] <realtime_conversation>\nRealtime conversation started.\n\nYou a...
+    [02] <PERMISSIONS_INSTRUCTIONS>
 02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 03:message/user:USER_TWO

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_does_not_restate_realtime_end_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_does_not_restate_realtime_end_shapes.snap
@@ -6,8 +6,8 @@ Scenario: Remote mid-turn continuation compaction after realtime was closed befo
 
 ## Second Turn Initial Request
 00:message/developer[2]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <realtime_conversation>\nRealtime conversation started.\n\nYou a...
+    [01] <realtime_conversation>\nRealtime conversation started.\n\nYou a...
+    [02] <PERMISSIONS_INSTRUCTIONS>
 01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 02:message/user:SETUP_USER
 03:message/assistant:REMOTE_SETUP_REPLY
@@ -16,8 +16,8 @@ Scenario: Remote mid-turn continuation compaction after realtime was closed befo
 
 ## Remote Compaction Request
 00:message/developer[2]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <realtime_conversation>\nRealtime conversation started.\n\nYou a...
+    [01] <realtime_conversation>\nRealtime conversation started.\n\nYou a...
+    [02] <PERMISSIONS_INSTRUCTIONS>
 01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 02:message/user:SETUP_USER
 03:message/assistant:REMOTE_SETUP_REPLY

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_restates_realtime_end_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_restates_realtime_end_shapes.snap
@@ -6,8 +6,8 @@ Scenario: Remote pre-turn auto-compaction after realtime was closed between turn
 
 ## Remote Compaction Request
 00:message/developer[2]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <realtime_conversation>\nRealtime conversation started.\n\nYou a...
+    [01] <realtime_conversation>\nRealtime conversation started.\n\nYou a...
+    [02] <PERMISSIONS_INSTRUCTIONS>
 01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 02:message/user:USER_ONE
 03:message/assistant:REMOTE_FIRST_REPLY
@@ -15,7 +15,7 @@ Scenario: Remote pre-turn auto-compaction after realtime was closed between turn
 ## Remote Post-Compaction History Layout
 00:compaction:encrypted=true
 01:message/developer[2]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <realtime_conversation>\nRealtime conversation ended.\n\nSubsequ...
+    [01] <realtime_conversation>\nRealtime conversation ended.\n\nSubsequ...
+    [02] <PERMISSIONS_INSTRUCTIONS>
 02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 03:message/user:USER_TWO

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_restates_realtime_start_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_restates_realtime_start_shapes.snap
@@ -6,8 +6,8 @@ Scenario: Remote pre-turn auto-compaction while realtime remains active: compact
 
 ## Remote Compaction Request
 00:message/developer[2]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <realtime_conversation>\nRealtime conversation started.\n\nYou a...
+    [01] <realtime_conversation>\nRealtime conversation started.\n\nYou a...
+    [02] <PERMISSIONS_INSTRUCTIONS>
 01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 02:message/user:USER_ONE
 03:message/assistant:REMOTE_FIRST_REPLY
@@ -15,7 +15,7 @@ Scenario: Remote pre-turn auto-compaction while realtime remains active: compact
 ## Remote Post-Compaction History Layout
 00:compaction:encrypted=true
 01:message/developer[2]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <realtime_conversation>\nRealtime conversation started.\n\nYou a...
+    [01] <realtime_conversation>\nRealtime conversation started.\n\nYou a...
+    [02] <PERMISSIONS_INSTRUCTIONS>
 02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 03:message/user:USER_TWO

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_strips_incoming_model_switch_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_strips_incoming_model_switch_shapes.snap
@@ -20,7 +20,7 @@ Scenario: Remote pre-turn compaction during model switch currently excludes inco
 01:compaction:encrypted=true
 02:message/developer[3]:
     [01] <model_switch>\nThe user was previously using a different model....
-    [02] <PERMISSIONS_INSTRUCTIONS>
-    [03] <personality_spec> The user has requested a new communication st...
+    [02] <personality_spec> The user has requested a new communication st...
+    [03] <PERMISSIONS_INSTRUCTIONS>
 03:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 04:message/user:AFTER_SWITCH_USER

--- a/codex-rs/core/tests/suite/snapshots/all__suite__model_visible_layout__model_visible_layout_cwd_change_does_not_refresh_agents.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__model_visible_layout__model_visible_layout_cwd_change_does_not_refresh_agents.snap
@@ -6,15 +6,15 @@ Scenario: Second turn changes cwd to a directory with different AGENTS.md; curre
 
 ## First Request (agents_one)
 00:message/developer[2]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <SKILLS_INSTRUCTIONS>
+    [01] <SKILLS_INSTRUCTIONS>
+    [02] <PERMISSIONS_INSTRUCTIONS>
 01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 02:message/user:first turn in agents_one
 
 ## Second Request (agents_two cwd)
 00:message/developer[2]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <SKILLS_INSTRUCTIONS>
+    [01] <SKILLS_INSTRUCTIONS>
+    [02] <PERMISSIONS_INSTRUCTIONS>
 01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 02:message/user:first turn in agents_one
 03:message/assistant:turn one complete

--- a/codex-rs/core/tests/suite/snapshots/all__suite__model_visible_layout__model_visible_layout_resume_override_matches_rollout_model.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__model_visible_layout__model_visible_layout_resume_override_matches_rollout_model.snap
@@ -6,15 +6,15 @@ Scenario: First post-resume turn where pre-turn override sets model to rollout m
 
 ## Last Request Before Resume
 00:message/developer[2]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <SKILLS_INSTRUCTIONS>
+    [01] <SKILLS_INSTRUCTIONS>
+    [02] <PERMISSIONS_INSTRUCTIONS>
 01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 02:message/user:seed resume history
 
 ## First Request After Resume + Override
 00:message/developer[2]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <SKILLS_INSTRUCTIONS>
+    [01] <SKILLS_INSTRUCTIONS>
+    [02] <PERMISSIONS_INSTRUCTIONS>
 01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 02:message/user:seed resume history
 03:message/assistant:recorded before resume

--- a/codex-rs/core/tests/suite/snapshots/all__suite__model_visible_layout__model_visible_layout_resume_with_personality_change.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__model_visible_layout__model_visible_layout_resume_with_personality_change.snap
@@ -6,20 +6,19 @@ Scenario: First post-resume turn where resumed config model differs from rollout
 
 ## Last Request Before Resume
 00:message/developer[2]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <SKILLS_INSTRUCTIONS>
+    [01] <SKILLS_INSTRUCTIONS>
+    [02] <PERMISSIONS_INSTRUCTIONS>
 01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 02:message/user:seed resume history
 
 ## First Request After Resume
 00:message/developer[2]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <SKILLS_INSTRUCTIONS>
+    [01] <SKILLS_INSTRUCTIONS>
+    [02] <PERMISSIONS_INSTRUCTIONS>
 01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 02:message/user:seed resume history
 03:message/assistant:recorded before resume
-04:message/developer[2]:
-    [01] <model_switch>\nThe user was previously using a different model. Please continue the conversatio...
-    [02] <PERMISSIONS_INSTRUCTIONS>
-05:message/user:<ENVIRONMENT_CONTEXT:cwd=PRETURN_CONTEXT_DIFF_CWD>
-06:message/user:resume and change personality
+04:message/developer:<model_switch>\nThe user was previously using a different model. Please continue the conversatio...
+05:message/developer:<PERMISSIONS_INSTRUCTIONS>
+06:message/user:<ENVIRONMENT_CONTEXT:cwd=PRETURN_CONTEXT_DIFF_CWD>
+07:message/user:resume and change personality

--- a/codex-rs/core/tests/suite/snapshots/all__suite__model_visible_layout__model_visible_layout_turn_overrides.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__model_visible_layout__model_visible_layout_turn_overrides.snap
@@ -6,20 +6,19 @@ Scenario: Second turn changes cwd, approval policy, and personality while keepin
 
 ## First Request (Baseline)
 00:message/developer[2]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <SKILLS_INSTRUCTIONS>
+    [01] <SKILLS_INSTRUCTIONS>
+    [02] <PERMISSIONS_INSTRUCTIONS>
 01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 02:message/user:first turn
 
 ## Second Request (Turn Overrides)
 00:message/developer[2]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <SKILLS_INSTRUCTIONS>
+    [01] <SKILLS_INSTRUCTIONS>
+    [02] <PERMISSIONS_INSTRUCTIONS>
 01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 02:message/user:first turn
 03:message/assistant:turn one complete
-04:message/developer[2]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <personality_spec> The user has requested a new communication style. Future messages should adhe...
-05:message/user:<ENVIRONMENT_CONTEXT:cwd=PRETURN_CONTEXT_DIFF_CWD>
-06:message/user:second turn with context updates
+04:message/developer:<personality_spec> The user has requested a new communication style. Future messages should adhe...
+05:message/developer:<PERMISSIONS_INSTRUCTIONS>
+06:message/user:<ENVIRONMENT_CONTEXT:cwd=PRETURN_CONTEXT_DIFF_CWD>
+07:message/user:second turn with context updates

--- a/codex-rs/core/tests/suite/snapshots/all__suite__token_budget__token_budget_new_context_window_tool_full_context.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__token_budget__token_budget_new_context_window_tool_full_context.snap
@@ -1,15 +1,14 @@
 ---
 source: core/tests/suite/token_budget.rs
-assertion_line: 545
 expression: snapshot
 ---
 Scenario: New context window tool installs fresh full context before the next follow-up request.
 
 ## Final Follow-Up Request
 00:message/developer[3]:
-    [01] <PERMISSIONS_INSTRUCTIONS>
-    [02] <SKILLS_INSTRUCTIONS>
-    [03] <context_window>\nThread id: <THREAD_ID>\nFirst context window id: <FIRST_WINDOW_ID>\nCurrent context window id: <WINDOW_ID>\nPrevious context window id: <FIRST_WINDOW_ID>\n</context_window>
+    [01] <SKILLS_INSTRUCTIONS>
+    [02] <context_window>\nThread id: <THREAD_ID>\nFirst context window id: <FIRST_WINDOW_ID>\nCurrent context window id: <WINDOW_ID>\nPrevious context window id: <FIRST_WINDOW_ID>\n</context_window>
+    [03] <PERMISSIONS_INSTRUCTIONS>
 01:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 02:function_call/update_plan
 03:function_call_output:Plan updated


### PR DESCRIPTION
## Why

Permissions guidance is model-visible state, but initial context and later turns currently build and compare it through separate paths. That comparison covers only selected `TurnContext` fields, missing changes such as refreshed catalog text and requiring reviewer-specific persistence like #31309.

## What changed

- add a persisted `permissions` World State section keyed by model and a fingerprint of the rendered guidance
- build it from the active permission profile, reviewer, model-catalog messages from #31312, and exec policy
- remove the separate initial-context and turn-update permissions paths
- reconcile legacy, resumed, and forked histories through the existing World State machinery
- update prompt snapshots for the resulting World State ordering

This supersedes #31309 by persisting what the model was actually shown rather than one input to that rendering.

## Known Tradeoffs
- Ordering: permissions move after skills/extensions/context-window guidance
- Cost: every World State build rerenders permissions and performs some synchronous filesystem metadata checks
- Prefix gap: flag-off same-turn compaction may lose newly approved-prefix guidance until the next turn; enforcement remains correct