### PR TITLE
feat: change amazon Bedrock GPT-5.6 display names

### DIFF
--- a/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
+++ b/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
@@ -19,11 +19,13 @@ pub(crate) fn static_model_catalog() -> ModelsResponse {
             gpt_5_bedrock_model(
                 GPT_5_5_OPENAI_MODEL_ID,
                 AMAZON_BEDROCK_GPT_5_5_MODEL_ID,
+                "GPT-5.5",
                 /*priority*/ 0,
             ),
             gpt_5_bedrock_model(
                 GPT_5_4_OPENAI_MODEL_ID,
                 AMAZON_BEDROCK_GPT_5_4_MODEL_ID,
+                "GPT-5.4",
                 /*priority*/ 1,
             ),
             gpt_5_6_bedrock_model(
@@ -55,9 +57,15 @@ pub(crate) fn with_default_only_service_tier(mut catalog: ModelsResponse) -> Mod
     catalog
 }
 
-fn gpt_5_bedrock_model(openai_slug: &str, bedrock_slug: &str, priority: i32) -> ModelInfo {
+fn gpt_5_bedrock_model(
+    openai_slug: &str,
+    bedrock_slug: &str,
+    display_name: &str,
+    priority: i32,
+) -> ModelInfo {
     let mut model = bundled_openai_model(openai_slug);
     model.slug = bedrock_slug.to_string();
+    model.display_name = display_name.to_string();
     model.priority = priority;
     model.context_window = Some(GPT_5_BEDROCK_CONTEXT_WINDOW);
     model.max_context_window = Some(GPT_5_BEDROCK_CONTEXT_WINDOW);
@@ -67,8 +75,12 @@ fn gpt_5_bedrock_model(openai_slug: &str, bedrock_slug: &str, priority: i32) -> 
 }
 
 fn gpt_5_6_bedrock_model(bedrock_slug: &str, display_name: &str, priority: i32) -> ModelInfo {
-    let mut model = gpt_5_bedrock_model(GPT_5_5_OPENAI_MODEL_ID, bedrock_slug, priority);
-    model.display_name = display_name.to_string();
+    let mut model = gpt_5_bedrock_model(
+        GPT_5_5_OPENAI_MODEL_ID,
+        bedrock_slug,
+        display_name,
+        priority,
+    );
     model
         .supported_reasoning_levels
         .push(ReasoningEffortPreset {

--- a/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
+++ b/codex-rs/model-provider/src/amazon_bedrock/catalog.rs
@@ -28,17 +28,17 @@ pub(crate) fn static_model_catalog() -> ModelsResponse {
             ),
             gpt_5_6_bedrock_model(
                 AMAZON_BEDROCK_GPT_5_6_SOL_MODEL_ID,
-                "Sol",
+                "GPT-5.6 Sol",
                 /*priority*/ 2,
             ),
             gpt_5_6_bedrock_model(
                 AMAZON_BEDROCK_GPT_5_6_TERRA_MODEL_ID,
-                "Terra",
+                "GPT-5.6 Terra",
                 /*priority*/ 3,
             ),
             gpt_5_6_bedrock_model(
                 AMAZON_BEDROCK_GPT_5_6_LUNA_MODEL_ID,
-                "Luna",
+                "GPT-5.6 Luna",
                 /*priority*/ 4,
             ),
         ],
@@ -148,9 +148,9 @@ mod tests {
             .expect("Bedrock catalog should include GPT-5.5");
 
         for (slug, display_name, priority) in [
-            (AMAZON_BEDROCK_GPT_5_6_SOL_MODEL_ID, "Sol", 2),
-            (AMAZON_BEDROCK_GPT_5_6_TERRA_MODEL_ID, "Terra", 3),
-            (AMAZON_BEDROCK_GPT_5_6_LUNA_MODEL_ID, "Luna", 4),
+            (AMAZON_BEDROCK_GPT_5_6_SOL_MODEL_ID, "GPT-5.6 Sol", 2),
+            (AMAZON_BEDROCK_GPT_5_6_TERRA_MODEL_ID, "GPT-5.6 Terra", 3),
+            (AMAZON_BEDROCK_GPT_5_6_LUNA_MODEL_ID, "GPT-5.6 Luna", 4),
         ] {
             let mut expected = gpt_5_5.clone();
             expected.slug = slug.to_string();

--- a/codex-rs/model-provider/src/provider.rs
+++ b/codex-rs/model-provider/src/provider.rs
@@ -663,7 +663,7 @@ mod tests {
             models,
             vec![
                 ("openai.gpt-5.5", "GPT-5.5"),
-                ("openai.gpt-5.4", "gpt-5.4"),
+                ("openai.gpt-5.4", "GPT-5.4"),
                 ("openai.gpt-5.6-sol", "GPT-5.6 Sol"),
                 ("openai.gpt-5.6-terra", "GPT-5.6 Terra"),
                 ("openai.gpt-5.6-luna", "GPT-5.6 Luna"),

--- a/codex-rs/model-provider/src/provider.rs
+++ b/codex-rs/model-provider/src/provider.rs
@@ -653,20 +653,20 @@ mod tests {
             provider.models_manager(test_codex_home(), /*config_model_catalog*/ None);
 
         let catalog = manager.raw_model_catalog(RefreshStrategy::Online).await;
-        let model_ids = catalog
+        let models = catalog
             .models
             .iter()
-            .map(|model| model.slug.as_str())
+            .map(|model| (model.slug.as_str(), model.display_name.as_str()))
             .collect::<Vec<_>>();
 
         assert_eq!(
-            model_ids,
+            models,
             vec![
-                "openai.gpt-5.5",
-                "openai.gpt-5.4",
-                "openai.gpt-5.6-sol",
-                "openai.gpt-5.6-terra",
-                "openai.gpt-5.6-luna",
+                ("openai.gpt-5.5", "GPT-5.5"),
+                ("openai.gpt-5.4", "gpt-5.4"),
+                ("openai.gpt-5.6-sol", "GPT-5.6 Sol"),
+                ("openai.gpt-5.6-terra", "GPT-5.6 Terra"),
+                ("openai.gpt-5.6-luna", "GPT-5.6 Luna"),
             ]
         );
 


### PR DESCRIPTION
## Why

Amazon Bedrock's GPT-5.6 variants currently appear as only `Sol`, `Terra`, and `Luna`. Those labels omit the model family and version, making them ambiguous in model lists and inconsistent with the naming of other GPT models.

## What changed

- Rename the three Bedrock model display names to `GPT-5.6 Sol`, `GPT-5.6 Terra`, and `GPT-5.6 Luna`.
- Strengthen the Bedrock model-manager test to verify both model IDs and their propagated display names.

Model IDs, ordering, priorities, reasoning support, and default selection are unchanged.
