### PR TITLE
Clarify device-code phishing warning

### DIFF
--- a/codex-rs/login/src/device_code_auth.rs
+++ b/codex-rs/login/src/device_code_auth.rs
@@ -145,15 +145,20 @@ async fn poll_for_token(
     }
 }
 
-fn print_device_code_prompt(verification_url: &str, code: &str) {
+fn device_code_prompt(verification_url: &str, code: &str) -> String {
     let version = env!("CARGO_PKG_VERSION");
-    println!(
+    format!(
         "\nWelcome to Codex [v{ANSI_GRAY}{version}{ANSI_RESET}]\n{ANSI_GRAY}OpenAI's command-line coding agent{ANSI_RESET}\n\
 \nFollow these steps to sign in with ChatGPT using device code authorization:\n\
 \n1. Open this link in your browser and sign in to your account\n   {ANSI_BLUE}{verification_url}{ANSI_RESET}\n\
 \n2. Enter this one-time code {ANSI_GRAY}(expires in 15 minutes){ANSI_RESET}\n   {ANSI_BLUE}{code}{ANSI_RESET}\n\
-\n{ANSI_GRAY}Device codes are a common phishing target. Never share this code.{ANSI_RESET}\n",
-    );
+\n{ANSI_GRAY}Only continue if you started this login in Codex. If a website or another person gave you this code, cancel.{ANSI_RESET}\n",
+    )
+}
+
+fn print_device_code_prompt(verification_url: &str, code: &str) {
+    let prompt = device_code_prompt(verification_url, code);
+    println!("{prompt}");
 }
 
 pub async fn request_device_code(opts: &ServerOptions) -> std::io::Result<DeviceCode> {
@@ -230,3 +235,7 @@ pub async fn run_device_code_login(opts: ServerOptions) -> std::io::Result<()> {
     print_device_code_prompt(&device_code.verification_url, &device_code.user_code);
     complete_device_code_login(opts, device_code).await
 }
+
+#[cfg(test)]
+#[path = "device_code_auth_tests.rs"]
+mod tests;

--- a/codex-rs/login/src/device_code_auth.rs
+++ b/codex-rs/login/src/device_code_auth.rs
@@ -152,7 +152,7 @@ fn device_code_prompt(verification_url: &str, code: &str) -> String {
 \nFollow these steps to sign in with ChatGPT using device code authorization:\n\
 \n1. Open this link in your browser and sign in to your account\n   {ANSI_BLUE}{verification_url}{ANSI_RESET}\n\
 \n2. Enter this one-time code {ANSI_GRAY}(expires in 15 minutes){ANSI_RESET}\n   {ANSI_BLUE}{code}{ANSI_RESET}\n\
-\n{ANSI_GRAY}Only continue if you started this login in Codex. If a website or another person gave you this code, cancel.{ANSI_RESET}\n",
+\n{ANSI_GRAY}Continue only if you started this login in Codex. If a website or another person gave you this code, cancel.{ANSI_RESET}\n",
     )
 }
 

--- a/codex-rs/login/src/device_code_auth_tests.rs
+++ b/codex-rs/login/src/device_code_auth_tests.rs
@@ -1,0 +1,10 @@
+use super::*;
+
+#[test]
+fn device_code_prompt_renders_phishing_warning() {
+    let prompt = device_code_prompt("https://example.com/device", "ABCD-EFGH");
+
+    assert!(prompt.contains(
+        "\x1b[90mOnly continue if you started this login in Codex. If a website or another person gave you this code, cancel.\x1b[0m"
+    ));
+}

--- a/codex-rs/login/src/device_code_auth_tests.rs
+++ b/codex-rs/login/src/device_code_auth_tests.rs
@@ -5,6 +5,6 @@ fn device_code_prompt_renders_phishing_warning() {
     let prompt = device_code_prompt("https://example.com/device", "ABCD-EFGH");
 
     assert!(prompt.contains(
-        "\x1b[90mOnly continue if you started this login in Codex. If a website or another person gave you this code, cancel.\x1b[0m"
+        "\x1b[90mContinue only if you started this login in Codex. If a website or another person gave you this code, cancel.\x1b[0m"
     ));
 }

--- a/codex-rs/tui/src/onboarding/auth/headless_chatgpt_login.rs
+++ b/codex-rs/tui/src/onboarding/auth/headless_chatgpt_login.rs
@@ -126,7 +126,7 @@ pub(super) fn render_device_code_login(
         ]));
         lines.push("".into());
         lines.push(
-            "  Device codes are a common phishing target. Never share this code."
+            "  Only continue if you started this login in Codex. If a website or another person gave you this code, cancel."
                 .dim()
                 .into(),
         );

--- a/codex-rs/tui/src/onboarding/auth/headless_chatgpt_login.rs
+++ b/codex-rs/tui/src/onboarding/auth/headless_chatgpt_login.rs
@@ -126,7 +126,7 @@ pub(super) fn render_device_code_login(
         ]));
         lines.push("".into());
         lines.push(
-            "  Only continue if you started this login in Codex. If a website or another person gave you this code, cancel."
+            "  Continue only if you started this login in Codex. If a website or another person gave you this code, cancel."
                 .dim()
                 .into(),
         );


### PR DESCRIPTION
## Why

The existing device-code warning does not help users distinguish a login they initiated from a phishing attempt. The warning should tell users to stop when the code came from a website or another person.

## What changed

- Updated the warning in the direct CLI and TUI device-code login flows with actionable guidance.
- Added focused coverage for the styled direct CLI prompt.