### PR TITLE
test(app-server): use native rollout fixture paths

### DIFF
--- a/codex-rs/app-server/tests/common/rollout.rs
+++ b/codex-rs/app-server/tests/common/rollout.rs
@@ -9,6 +9,7 @@ use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::TokenCountEvent;
 use codex_protocol::protocol::TokenUsage;
 use codex_protocol::protocol::TokenUsageInfo;
+use core_test_support::test_path_buf;
 use serde_json::json;
 use std::fs;
 use std::fs::FileTimes;
@@ -189,7 +190,7 @@ fn create_fake_rollout_with_source_and_parent_thread_id(
         forked_from_id: None,
         parent_thread_id,
         timestamp: meta_rfc3339.to_string(),
-        cwd: PathBuf::from("/"),
+        cwd: test_path_buf("/"),
         originator: "codex".to_string(),
         cli_version: "0.0.0".to_string(),
         source,
@@ -279,7 +280,7 @@ pub fn create_fake_rollout_with_text_elements(
         forked_from_id: None,
         parent_thread_id: None,
         timestamp: meta_rfc3339.to_string(),
-        cwd: PathBuf::from("/"),
+        cwd: test_path_buf("/"),
         originator: "codex".to_string(),
         cli_version: "0.0.0".to_string(),
         source: SessionSource::Cli,

--- a/codex-rs/app-server/tests/suite/conversation_summary.rs
+++ b/codex-rs/app-server/tests/suite/conversation_summary.rs
@@ -29,6 +29,7 @@ use codex_thread_store::InMemoryThreadStore;
 use codex_thread_store::ThreadPersistenceMetadata;
 use codex_thread_store::ThreadStore;
 use codex_utils_absolute_path::AbsolutePathBuf;
+use core_test_support::test_path_buf;
 use pretty_assertions::assert_eq;
 use std::path::Path;
 use std::path::PathBuf;
@@ -53,7 +54,7 @@ fn expected_summary(conversation_id: ThreadId, path: PathBuf) -> ConversationSum
         timestamp: Some(CREATED_AT_RFC3339.to_string()),
         updated_at: Some(UPDATED_AT_RFC3339.to_string()),
         model_provider: MODEL_PROVIDER.to_string(),
-        cwd: PathBuf::from("/"),
+        cwd: test_path_buf("/"),
         cli_version: "0.0.0".to_string(),
         source: SessionSource::Cli,
         git_info: None,


### PR DESCRIPTION
## Why

Windows CI now places temporary and build files on the `D:` Dev Drive. Fake rollout metadata still stored `/` as its working directory, but `/` is drive-relative on Windows. When the migrated auto-environment tests resumed or listed those rollouts, the fixture resolved to `D:\` while the established test expectation remained `C:\`, causing unrelated PRs to fail the Windows app-server shard.

This follows the interaction between #31357, which moved CI build paths to the Dev Drive, and #31614, which migrated these app-server tests to automatic environments.

## What

- Construct fake rollout working directories with `test_path_buf("/")`, producing a fully qualified native path on Windows while preserving `/` on Unix.
- Use the same native test-path helper for the legacy conversation-summary expectation.

## How to Test

Automated tests were intentionally not run locally at request; the app-server suite was stopped during compilation. `just fmt` completed successfully.

To verify the regression on a Windows runner:

1. Configure `TEMP` and `TMP` on a non-`C:` drive, as CI does with the Dev Drive.
2. Run `just test -p codex-app-server`.
3. Confirm the existing thread list, read, and resume tests no longer report `D:\` actual versus `C:\` expected paths.

This is a test-fixture-only change, so there is no product smoke path.