### PR TITLE
Expand agent core ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,8 @@
 # Core crate ownership.
+/codex-rs/arg0/ @openai/codex-core-agent-team
+/codex-rs/codex-mcp/ @openai/codex-core-agent-team
 /codex-rs/core/ @openai/codex-core-agent-team
+/codex-rs/exec-server/ @openai/codex-core-agent-team
 /codex-rs/exec-server-protocol/ @openai/codex-core-agent-team
 /codex-rs/ext/extension-api/ @openai/codex-core-agent-team
 /codex-rs/prompts/ @openai/codex-core-agent-team


### PR DESCRIPTION
The agent core team owns the core agent implementation and should review changes to its adjacent runtime crates. Those crates were not covered by the existing CODEOWNERS rules.

This adds `@openai/codex-core-agent-team` ownership for:

- `codex-rs/arg0`
- `codex-rs/codex-mcp`
- `codex-rs/exec-server`

## Validation

- `git diff --check`

No runtime tests are applicable because this only changes CODEOWNERS metadata.