### PR TITLE
[core-plugins] increase plugin share archive limit

### DIFF
--- a/codex-rs/core-plugins/src/remote/share.rs
+++ b/codex-rs/core-plugins/src/remote/share.rs
@@ -16,7 +16,7 @@ use tracing::warn;
 mod checkout;
 mod local_paths;
 
-const REMOTE_PLUGIN_SHARE_MAX_ARCHIVE_BYTES: usize = 50 * 1024 * 1024;
+const REMOTE_PLUGIN_SHARE_MAX_ARCHIVE_BYTES: usize = 100 * 1024 * 1024;
 
 pub use checkout::checkout_remote_plugin_share;
 


### PR DESCRIPTION
## Summary

- raise the client-side compressed archive limit for shared Codex plugins from 50 MiB to 100 MiB
- align the Codex share packer with the backend's existing 100 MiB workspace-plugin upload limit

## Why

Codex currently rejects generated plugin archives above 50 MiB before requesting an upload URL, even though the receiving API accepts archives up to 100 MiB. This removes that client/server mismatch.

## Validation

- `just fmt`
- `just test -p codex-core-plugins` (in progress; initial dependency/build warm-up)
