### PR TITLE
trace remote shell starts across core and exec server

### DIFF
--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -405,6 +405,17 @@ impl UnifiedExecProcessManager {
         }
     }
 
+    #[tracing::instrument(
+        name = "codex.core.unified_exec.exec_command",
+        level = "info",
+        skip_all,
+        fields(
+            otel.name = "codex.core.unified_exec.exec_command",
+            otel.kind = "internal",
+            codex.crate = "codex_core",
+            codex.boundary = "exec_command",
+        )
+    )]
     pub(crate) async fn exec_command(
         &self,
         request: ExecCommandRequest,

--- a/codex-rs/exec-server/src/client.rs
+++ b/codex-rs/exec-server/src/client.rs
@@ -645,6 +645,17 @@ impl ExecServerClient {
         self.call(FS_COPY_METHOD, &params).await
     }
 
+    #[tracing::instrument(
+        name = "codex.exec_server.client.process.start",
+        level = "info",
+        skip_all,
+        fields(
+            otel.name = "codex.exec_server.client.process.start",
+            otel.kind = "internal",
+            codex.crate = "codex_exec_server",
+            codex.boundary = "client_process_start",
+        )
+    )]
     pub(crate) async fn start_process(
         &self,
         params: ExecParams,


### PR DESCRIPTION
## why

remote exec-server process work runs outside the local Codex process, so server-only tracing cannot show whether the local client path participated. add stable client-side boundaries so a normal remote shell command appears as one OTEL waterfall across core and the outbound exec-server `process/start` call.

## what

- instrument the async lifetime of unified exec commands as `codex.core.unified_exec.exec_command`
- instrument `ExecServerClient::start_process` as `codex.exec_server.client.process.start`
- attach fixed low-cardinality `codex.crate` and `codex.boundary` fields while `skip_all` keeps commands and RPC payloads out of spans
- retain the existing W3C trace propagation to the remote exec server

## validation

- `cargo check --tests -p codex-exec-server -p codex-core`
- `just test -p codex-exec-server`