### PR TITLE
exec-server: standardize JSON-RPC request spans

### DIFF
--- a/codex-rs/exec-server/src/client.rs
+++ b/codex-rs/exec-server/src/client.rs
@@ -1310,6 +1310,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    #[serial_test::serial(exec_server_tracing)]
     async fn process_start_propagates_caller_trace_context_across_background_task() {
         let (client_stdin, server_reader) = duplex(1 << 20);
         let (mut server_writer, client_stdout) = duplex(1 << 20);
@@ -1360,6 +1361,15 @@ mod tests {
             trace
         });
 
+        let tracer_provider = SdkTracerProvider::builder().build();
+        let tracer = tracer_provider.tracer("exec-server-test");
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_opentelemetry::layer()
+                .with_tracer(tracer)
+                .with_filter(filter_fn(codex_otel::OtelProvider::trace_export_filter)),
+        );
+        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+
         let client = ExecServerClient::connect(
             JsonRpcConnection::from_stdio(
                 client_stdout,
@@ -1371,14 +1381,6 @@ mod tests {
         .await
         .expect("client should connect");
 
-        let tracer_provider = SdkTracerProvider::builder().build();
-        let tracer = tracer_provider.tracer("exec-server-test");
-        let subscriber = tracing_subscriber::registry().with(
-            tracing_opentelemetry::layer()
-                .with_tracer(tracer)
-                .with_filter(filter_fn(codex_otel::OtelProvider::trace_export_filter)),
-        );
-        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
         tracing::callsite::rebuild_interest_cache();
         let parent_span = tracing::info_span!("process-start-parent");
         let expected_trace = codex_otel::span_w3c_trace_context(&parent_span)

--- a/codex-rs/exec-server/src/remote.rs
+++ b/codex-rs/exec-server/src/remote.rs
@@ -711,6 +711,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    #[serial_test::serial(exec_server_tracing)]
     async fn register_environment_posts_with_auth_provider_headers() {
         let provider = SdkTracerProvider::builder().build();
         let tracer = provider.tracer("exec-server-test");

--- a/codex-rs/exec-server/src/rpc.rs
+++ b/codex-rs/exec-server/src/rpc.rs
@@ -363,23 +363,19 @@ impl RpcClient {
         })
     }
 
-    #[tracing::instrument(
-        name = "codex.exec_server.request",
-        level = "info",
-        skip_all,
-        fields(
-            otel.kind = "client",
-            otel.name = method,
-            method,
-        )
-    )]
+    fn allocate_request_id(&self) -> RequestId {
+        RequestId::Integer(self.next_request_id.fetch_add(1, Ordering::SeqCst))
+    }
+
     pub(crate) async fn call<P, T>(&self, method: &str, params: &P) -> Result<T, RpcCallError>
     where
         P: Serialize,
         T: DeserializeOwned,
     {
         let _call_slot = self.acquire_regular_call_slot()?;
-        self.call_inner(method, params, RpcCallTimeout::None).await
+        let request_id = self.allocate_request_id();
+        self.call_inner(request_id, method, params, RpcCallTimeout::None)
+            .await
     }
 
     pub(crate) async fn call_with_timeout<P, T>(
@@ -393,20 +389,16 @@ impl RpcClient {
         T: DeserializeOwned,
     {
         let _call_slot = self.acquire_regular_call_slot()?;
-        self.call_inner(method, params, RpcCallTimeout::After(call_timeout))
-            .await
+        let request_id = self.allocate_request_id();
+        self.call_inner(
+            request_id,
+            method,
+            params,
+            RpcCallTimeout::After(call_timeout),
+        )
+        .await
     }
 
-    #[tracing::instrument(
-        name = "codex.exec_server.request",
-        level = "info",
-        skip_all,
-        fields(
-            otel.kind = "client",
-            otel.name = method,
-            method,
-        )
-    )]
     pub(crate) async fn call_for_cleanup<P, T>(
         &self,
         method: &str,
@@ -426,11 +418,27 @@ impl RpcClient {
                 }
             },
         };
-        self.call_inner(method, params, RpcCallTimeout::None).await
+        let request_id = self.allocate_request_id();
+        self.call_inner(request_id, method, params, RpcCallTimeout::None)
+            .await
     }
 
+    #[tracing::instrument(
+        name = "codex.exec_server.request",
+        level = "info",
+        skip_all,
+        fields(
+            otel.kind = "client",
+            otel.name = method,
+            rpc.system = "jsonrpc",
+            rpc.method = method,
+            rpc.request_id = %request_id,
+            method,
+        )
+    )]
     async fn call_inner<P, T>(
         &self,
+        request_id: RequestId,
         method: &str,
         params: &P,
         call_timeout: RpcCallTimeout,
@@ -439,7 +447,6 @@ impl RpcClient {
         P: Serialize,
         T: DeserializeOwned,
     {
-        let request_id = RequestId::Integer(self.next_request_id.fetch_add(1, Ordering::SeqCst));
         let (response_tx, response_rx) = oneshot::channel();
         {
             let mut pending = self.pending.lock().await;
@@ -967,6 +974,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    #[serial_test::serial(exec_server_tracing)]
     async fn rpc_client_propagates_current_trace_context() {
         let span_exporter = InMemorySpanExporter::default();
         let tracer_provider = SdkTracerProvider::builder()

--- a/codex-rs/exec-server/src/rpc.rs
+++ b/codex-rs/exec-server/src/rpc.rs
@@ -367,6 +367,19 @@ impl RpcClient {
         RequestId::Integer(self.next_request_id.fetch_add(1, Ordering::SeqCst))
     }
 
+    #[tracing::instrument(
+        name = "codex.exec_server.request",
+        level = "info",
+        skip_all,
+        fields(
+            otel.kind = "client",
+            otel.name = method,
+            rpc.system = "jsonrpc",
+            rpc.method = method,
+            rpc.request_id = tracing::field::Empty,
+            method,
+        )
+    )]
     pub(crate) async fn call<P, T>(&self, method: &str, params: &P) -> Result<T, RpcCallError>
     where
         P: Serialize,
@@ -374,10 +387,24 @@ impl RpcClient {
     {
         let _call_slot = self.acquire_regular_call_slot()?;
         let request_id = self.allocate_request_id();
+        tracing::Span::current().record("rpc.request_id", tracing::field::display(&request_id));
         self.call_inner(request_id, method, params, RpcCallTimeout::None)
             .await
     }
 
+    #[tracing::instrument(
+        name = "codex.exec_server.request",
+        level = "info",
+        skip_all,
+        fields(
+            otel.kind = "client",
+            otel.name = method,
+            rpc.system = "jsonrpc",
+            rpc.method = method,
+            rpc.request_id = tracing::field::Empty,
+            method,
+        )
+    )]
     pub(crate) async fn call_with_timeout<P, T>(
         &self,
         method: &str,
@@ -390,6 +417,7 @@ impl RpcClient {
     {
         let _call_slot = self.acquire_regular_call_slot()?;
         let request_id = self.allocate_request_id();
+        tracing::Span::current().record("rpc.request_id", tracing::field::display(&request_id));
         self.call_inner(
             request_id,
             method,
@@ -399,6 +427,19 @@ impl RpcClient {
         .await
     }
 
+    #[tracing::instrument(
+        name = "codex.exec_server.request",
+        level = "info",
+        skip_all,
+        fields(
+            otel.kind = "client",
+            otel.name = method,
+            rpc.system = "jsonrpc",
+            rpc.method = method,
+            rpc.request_id = tracing::field::Empty,
+            method,
+        )
+    )]
     pub(crate) async fn call_for_cleanup<P, T>(
         &self,
         method: &str,
@@ -419,23 +460,11 @@ impl RpcClient {
             },
         };
         let request_id = self.allocate_request_id();
+        tracing::Span::current().record("rpc.request_id", tracing::field::display(&request_id));
         self.call_inner(request_id, method, params, RpcCallTimeout::None)
             .await
     }
 
-    #[tracing::instrument(
-        name = "codex.exec_server.request",
-        level = "info",
-        skip_all,
-        fields(
-            otel.kind = "client",
-            otel.name = method,
-            rpc.system = "jsonrpc",
-            rpc.method = method,
-            rpc.request_id = %request_id,
-            method,
-        )
-    )]
     async fn call_inner<P, T>(
         &self,
         request_id: RequestId,
@@ -971,6 +1000,98 @@ mod tests {
                 Err(RpcCallError::Closed)
             ));
         }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    #[serial_test::serial(exec_server_tracing)]
+    async fn rpc_client_emits_spans_for_admission_failures() {
+        let span_exporter = InMemorySpanExporter::default();
+        let tracer_provider = SdkTracerProvider::builder()
+            .with_simple_exporter(span_exporter.clone())
+            .build();
+        let tracer = tracer_provider.tracer("exec-server-test");
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_opentelemetry::layer()
+                .with_tracer(tracer)
+                .with_filter(filter_fn(codex_otel::OtelProvider::trace_export_filter)),
+        );
+        let _subscriber_guard = tracing::subscriber::set_default(subscriber);
+        tracing::callsite::rebuild_interest_cache();
+
+        let (outgoing_tx, _outgoing_rx) = tokio::sync::mpsc::channel(/*buffer*/ 1);
+        let (_incoming_tx, incoming_rx) = tokio::sync::mpsc::channel(/*buffer*/ 1);
+        let (_disconnected_tx, disconnected_rx) = tokio::sync::watch::channel(/*init*/ false);
+        let connection = JsonRpcConnection {
+            outgoing_tx,
+            incoming_rx,
+            disconnected_rx,
+            task_handles: Vec::new(),
+            transport: JsonRpcTransport::Plain,
+        };
+        let (client, _events_rx) = RpcClient::new(connection);
+        let _regular_call_slots = (0..MAX_IN_FLIGHT_REGULAR_CALLS)
+            .map(|_| {
+                client
+                    .shared_call_slots
+                    .try_acquire()
+                    .expect("regular call slot")
+            })
+            .collect::<Vec<_>>();
+        let _cleanup_call_slot = client
+            .cleanup_call_slots
+            .try_acquire()
+            .expect("cleanup call slot");
+        let params = serde_json::json!({});
+
+        assert!(matches!(
+            client
+                .call::<_, serde_json::Value>("overflow", &params)
+                .await,
+            Err(RpcCallError::PendingRequestLimitExceeded { limit })
+                if limit == MAX_IN_FLIGHT_REGULAR_CALLS
+        ));
+        assert!(matches!(
+            client
+                .call_for_cleanup::<_, serde_json::Value>("cleanup-overflow", &params)
+                .await,
+            Err(RpcCallError::Closed)
+        ));
+
+        tracer_provider.force_flush().expect("flush traces");
+        let spans = span_exporter.get_finished_spans().expect("span export");
+        let mut rpc_spans = spans
+            .iter()
+            .filter(|span| matches!(span.name.as_ref(), "overflow" | "cleanup-overflow"))
+            .filter_map(|span| {
+                let rpc_system = span.attributes.iter().find_map(|attribute| {
+                    (attribute.key.as_str() == "rpc.system").then_some(&attribute.value)
+                })?;
+                let rpc_method = span.attributes.iter().find_map(|attribute| {
+                    (attribute.key.as_str() == "rpc.method").then_some(&attribute.value)
+                })?;
+                Some((
+                    span.name.to_string(),
+                    rpc_system.to_string(),
+                    rpc_method.to_string(),
+                ))
+            })
+            .collect::<Vec<_>>();
+        rpc_spans.sort();
+        assert_eq!(
+            rpc_spans,
+            vec![
+                (
+                    "cleanup-overflow".to_string(),
+                    "jsonrpc".to_string(),
+                    "cleanup-overflow".to_string(),
+                ),
+                (
+                    "overflow".to_string(),
+                    "jsonrpc".to_string(),
+                    "overflow".to_string(),
+                ),
+            ]
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/codex-rs/exec-server/src/server.rs
+++ b/codex-rs/exec-server/src/server.rs
@@ -47,6 +47,7 @@ mod tests {
     use crate::ExecServerTelemetry;
 
     #[tokio::test]
+    #[serial_test::serial(exec_server_tracing)]
     async fn telemetry_entrypoint_emits_root_span() {
         let exporter = InMemorySpanExporter::default();
         let provider = SdkTracerProvider::builder()

--- a/codex-rs/exec-server/src/server/processor.rs
+++ b/codex-rs/exec-server/src/server/processor.rs
@@ -129,7 +129,7 @@ async fn run_connection(
                 codex_exec_server_protocol::JSONRPCMessage::Request(request) => {
                     let request_started_at = Instant::now();
                     if let Some((method, route)) = router.request_route(request.method.as_str()) {
-                        let request_span = request_span(method, &request);
+                        let request_span = request_span(method, &request, transport);
                         let message = tokio::select! {
                             message = route(Arc::clone(&handler), request).instrument(request_span.clone()) => message,
                             _ = disconnected_rx.changed() => {
@@ -160,7 +160,7 @@ async fn run_connection(
                         drop(request_span);
                     } else {
                         let method = "unknown";
-                        let request_span = request_span(method, &request);
+                        let request_span = request_span(method, &request, transport);
                         if outgoing_tx
                             .send(RpcServerOutboundMessage::Error {
                                 request_id: request.id,
@@ -244,12 +244,17 @@ async fn run_connection(
 fn request_span(
     span_name: &str,
     request: &codex_exec_server_protocol::JSONRPCRequest,
+    transport: ConnectionTransport,
 ) -> tracing::Span {
     let method = request.method.as_str();
     let span = tracing::info_span!(
         "codex.exec_server.request",
         otel.kind = "server",
         otel.name = span_name,
+        rpc.system = "jsonrpc",
+        rpc.method = method,
+        rpc.transport = transport.metric_tag(),
+        rpc.request_id = %request.id,
         method,
         result = tracing::field::Empty,
     );
@@ -324,6 +329,7 @@ mod tests {
     use crate::server::session_registry::SessionRegistry;
 
     #[test]
+    #[serial_test::serial(exec_server_tracing)]
     fn request_span_uses_bounded_name_wire_method_and_inbound_trace_parent() {
         let span_exporter = InMemorySpanExporter::default();
         let tracer_provider = SdkTracerProvider::builder()
@@ -351,7 +357,11 @@ mod tests {
                 params: None,
                 trace: Some(trace),
             };
-            let request_span = request_span("unknown", &request);
+            let request_span = request_span(
+                "unknown",
+                &request,
+                crate::telemetry::ConnectionTransport::Stdio,
+            );
             request_span.in_scope(|| {});
             drop(request_span);
         });

--- a/codex-rs/exec-server/src/telemetry.rs
+++ b/codex-rs/exec-server/src/telemetry.rs
@@ -52,7 +52,7 @@ pub(crate) enum ConnectionTransport {
 }
 
 impl ConnectionTransport {
-    fn metric_tag(self) -> &'static str {
+    pub(crate) fn metric_tag(self) -> &'static str {
         match self {
             Self::Relay => "relay",
             Self::Stdio => "stdio",

--- a/codex-rs/exec-server/src/trace_context_tests.rs
+++ b/codex-rs/exec-server/src/trace_context_tests.rs
@@ -5,6 +5,7 @@ use tracing_subscriber::prelude::*;
 use super::current_trace_context_headers;
 
 #[test]
+#[serial_test::serial(exec_server_tracing)]
 fn creates_traceparent_header_from_current_span() {
     let provider = SdkTracerProvider::builder().build();
     let tracer = provider.tracer("exec-server-test");


### PR DESCRIPTION
## Why

app-server OTEL spans for RPC methods include a standard set of fields; exec-server should match, and every client request path should share the same telemetry shape, including timed calls and admission failures.

## What

- Add `rpc.system`, `rpc.method`, and `rpc.request_id` to client and server request spans.
- Record the bounded connection transport on server spans.
- Instrument the regular, timed, and cleanup client request entry points so early admission failures retain request telemetry without duplicate nesting.
- Record client request IDs after admission, when an outbound JSON-RPC request is allocated.
- Serialize the exec-server tracing tests that rebuild process-global callsite interest.
- Preserve the existing span names and wire protocol.

## Validation

- `just test -p codex-exec-server` (307 passed, 2 skipped)
- Added regression coverage for regular pending-limit and cleanup-overflow request spans.

## Stack

1. **[#31687](https://github.com/openai/codex/pull/31687) (this PR, 1/5)**
2. [#31690](https://github.com/openai/codex/pull/31690) (2/5)
3. [#31707](https://github.com/openai/codex/pull/31707) (3/5)
4. [#31729](https://github.com/openai/codex/pull/31729) (4/5)
5. [#31730](https://github.com/openai/codex/pull/31730) (5/5)
