### PR TITLE
exec-server: centralize client RPC spans

### DIFF
--- a/codex-rs/exec-server/src/client.rs
+++ b/codex-rs/exec-server/src/client.rs
@@ -1310,6 +1310,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    #[serial_test::serial(exec_server_tracing)]
     async fn process_start_propagates_caller_trace_context_across_background_task() {
         let (client_stdin, server_reader) = duplex(1 << 20);
         let (mut server_writer, client_stdout) = duplex(1 << 20);

--- a/codex-rs/exec-server/src/remote.rs
+++ b/codex-rs/exec-server/src/remote.rs
@@ -711,6 +711,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    #[serial_test::serial(exec_server_tracing)]
     async fn register_environment_posts_with_auth_provider_headers() {
         let provider = SdkTracerProvider::builder().build();
         let tracer = provider.tracer("exec-server-test");

--- a/codex-rs/exec-server/src/rpc.rs
+++ b/codex-rs/exec-server/src/rpc.rs
@@ -974,6 +974,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    #[serial_test::serial(exec_server_tracing)]
     async fn rpc_client_propagates_current_trace_context() {
         let span_exporter = InMemorySpanExporter::default();
         let tracer_provider = SdkTracerProvider::builder()

--- a/codex-rs/exec-server/src/rpc.rs
+++ b/codex-rs/exec-server/src/rpc.rs
@@ -363,6 +363,10 @@ impl RpcClient {
         })
     }
 
+    fn allocate_request_id(&self) -> RequestId {
+        RequestId::Integer(self.next_request_id.fetch_add(1, Ordering::SeqCst))
+    }
+
     #[tracing::instrument(
         name = "codex.exec_server.request",
         level = "info",
@@ -370,6 +374,9 @@ impl RpcClient {
         fields(
             otel.kind = "client",
             otel.name = method,
+            rpc.system = "jsonrpc",
+            rpc.method = method,
+            rpc.request_id = tracing::field::Empty,
             method,
         )
     )]
@@ -379,7 +386,10 @@ impl RpcClient {
         T: DeserializeOwned,
     {
         let _call_slot = self.acquire_regular_call_slot()?;
-        self.call_inner(method, params, RpcCallTimeout::None).await
+        let request_id = self.allocate_request_id();
+        tracing::Span::current().record("rpc.request_id", tracing::field::display(&request_id));
+        self.call_inner(request_id, method, params, RpcCallTimeout::None)
+            .await
     }
 
     pub(crate) async fn call_with_timeout<P, T>(
@@ -393,8 +403,14 @@ impl RpcClient {
         T: DeserializeOwned,
     {
         let _call_slot = self.acquire_regular_call_slot()?;
-        self.call_inner(method, params, RpcCallTimeout::After(call_timeout))
-            .await
+        let request_id = self.allocate_request_id();
+        self.call_inner(
+            request_id,
+            method,
+            params,
+            RpcCallTimeout::After(call_timeout),
+        )
+        .await
     }
 
     #[tracing::instrument(
@@ -404,6 +420,9 @@ impl RpcClient {
         fields(
             otel.kind = "client",
             otel.name = method,
+            rpc.system = "jsonrpc",
+            rpc.method = method,
+            rpc.request_id = tracing::field::Empty,
             method,
         )
     )]
@@ -426,11 +445,15 @@ impl RpcClient {
                 }
             },
         };
-        self.call_inner(method, params, RpcCallTimeout::None).await
+        let request_id = self.allocate_request_id();
+        tracing::Span::current().record("rpc.request_id", tracing::field::display(&request_id));
+        self.call_inner(request_id, method, params, RpcCallTimeout::None)
+            .await
     }
 
     async fn call_inner<P, T>(
         &self,
+        request_id: RequestId,
         method: &str,
         params: &P,
         call_timeout: RpcCallTimeout,
@@ -439,7 +462,6 @@ impl RpcClient {
         P: Serialize,
         T: DeserializeOwned,
     {
-        let request_id = RequestId::Integer(self.next_request_id.fetch_add(1, Ordering::SeqCst));
         let (response_tx, response_rx) = oneshot::channel();
         {
             let mut pending = self.pending.lock().await;

--- a/codex-rs/exec-server/src/rpc.rs
+++ b/codex-rs/exec-server/src/rpc.rs
@@ -367,19 +367,6 @@ impl RpcClient {
         RequestId::Integer(self.next_request_id.fetch_add(1, Ordering::SeqCst))
     }
 
-    #[tracing::instrument(
-        name = "codex.exec_server.request",
-        level = "info",
-        skip_all,
-        fields(
-            otel.kind = "client",
-            otel.name = method,
-            rpc.system = "jsonrpc",
-            rpc.method = method,
-            rpc.request_id = tracing::field::Empty,
-            method,
-        )
-    )]
     pub(crate) async fn call<P, T>(&self, method: &str, params: &P) -> Result<T, RpcCallError>
     where
         P: Serialize,
@@ -387,7 +374,6 @@ impl RpcClient {
     {
         let _call_slot = self.acquire_regular_call_slot()?;
         let request_id = self.allocate_request_id();
-        tracing::Span::current().record("rpc.request_id", tracing::field::display(&request_id));
         self.call_inner(request_id, method, params, RpcCallTimeout::None)
             .await
     }
@@ -413,19 +399,6 @@ impl RpcClient {
         .await
     }
 
-    #[tracing::instrument(
-        name = "codex.exec_server.request",
-        level = "info",
-        skip_all,
-        fields(
-            otel.kind = "client",
-            otel.name = method,
-            rpc.system = "jsonrpc",
-            rpc.method = method,
-            rpc.request_id = tracing::field::Empty,
-            method,
-        )
-    )]
     pub(crate) async fn call_for_cleanup<P, T>(
         &self,
         method: &str,
@@ -446,11 +419,23 @@ impl RpcClient {
             },
         };
         let request_id = self.allocate_request_id();
-        tracing::Span::current().record("rpc.request_id", tracing::field::display(&request_id));
         self.call_inner(request_id, method, params, RpcCallTimeout::None)
             .await
     }
 
+    #[tracing::instrument(
+        name = "codex.exec_server.request",
+        level = "info",
+        skip_all,
+        fields(
+            otel.kind = "client",
+            otel.name = method,
+            rpc.system = "jsonrpc",
+            rpc.method = method,
+            rpc.request_id = %request_id,
+            method,
+        )
+    )]
     async fn call_inner<P, T>(
         &self,
         request_id: RequestId,

--- a/codex-rs/exec-server/src/server.rs
+++ b/codex-rs/exec-server/src/server.rs
@@ -47,6 +47,7 @@ mod tests {
     use crate::ExecServerTelemetry;
 
     #[tokio::test]
+    #[serial_test::serial(exec_server_tracing)]
     async fn telemetry_entrypoint_emits_root_span() {
         let exporter = InMemorySpanExporter::default();
         let provider = SdkTracerProvider::builder()

--- a/codex-rs/exec-server/src/server/processor.rs
+++ b/codex-rs/exec-server/src/server/processor.rs
@@ -129,7 +129,7 @@ async fn run_connection(
                 codex_exec_server_protocol::JSONRPCMessage::Request(request) => {
                     let request_started_at = Instant::now();
                     if let Some((method, route)) = router.request_route(request.method.as_str()) {
-                        let request_span = request_span(method, &request);
+                        let request_span = request_span(method, &request, transport);
                         let message = tokio::select! {
                             message = route(Arc::clone(&handler), request).instrument(request_span.clone()) => message,
                             _ = disconnected_rx.changed() => {
@@ -160,7 +160,7 @@ async fn run_connection(
                         drop(request_span);
                     } else {
                         let method = "unknown";
-                        let request_span = request_span(method, &request);
+                        let request_span = request_span(method, &request, transport);
                         if outgoing_tx
                             .send(RpcServerOutboundMessage::Error {
                                 request_id: request.id,
@@ -244,12 +244,17 @@ async fn run_connection(
 fn request_span(
     span_name: &str,
     request: &codex_exec_server_protocol::JSONRPCRequest,
+    transport: ConnectionTransport,
 ) -> tracing::Span {
     let method = request.method.as_str();
     let span = tracing::info_span!(
         "codex.exec_server.request",
         otel.kind = "server",
         otel.name = span_name,
+        rpc.system = "jsonrpc",
+        rpc.method = method,
+        rpc.transport = transport.metric_tag(),
+        rpc.request_id = %request.id,
         method,
         result = tracing::field::Empty,
     );
@@ -351,7 +356,11 @@ mod tests {
                 params: None,
                 trace: Some(trace),
             };
-            let request_span = request_span("unknown", &request);
+            let request_span = request_span(
+                "unknown",
+                &request,
+                crate::telemetry::ConnectionTransport::Stdio,
+            );
             request_span.in_scope(|| {});
             drop(request_span);
         });

--- a/codex-rs/exec-server/src/server/processor.rs
+++ b/codex-rs/exec-server/src/server/processor.rs
@@ -329,6 +329,7 @@ mod tests {
     use crate::server::session_registry::SessionRegistry;
 
     #[test]
+    #[serial_test::serial(exec_server_tracing)]
     fn request_span_uses_bounded_name_wire_method_and_inbound_trace_parent() {
         let span_exporter = InMemorySpanExporter::default();
         let tracer_provider = SdkTracerProvider::builder()

--- a/codex-rs/exec-server/src/telemetry.rs
+++ b/codex-rs/exec-server/src/telemetry.rs
@@ -52,7 +52,7 @@ pub(crate) enum ConnectionTransport {
 }
 
 impl ConnectionTransport {
-    fn metric_tag(self) -> &'static str {
+    pub(crate) fn metric_tag(self) -> &'static str {
         match self {
             Self::Relay => "relay",
             Self::Stdio => "stdio",

--- a/codex-rs/exec-server/src/trace_context_tests.rs
+++ b/codex-rs/exec-server/src/trace_context_tests.rs
@@ -5,6 +5,7 @@ use tracing_subscriber::prelude::*;
 use super::current_trace_context_headers;
 
 #[test]
+#[serial_test::serial(exec_server_tracing)]
 fn creates_traceparent_header_from_current_span() {
     let provider = SdkTracerProvider::builder().build();
     let tracer = provider.tracer("exec-server-test");


### PR DESCRIPTION
## Why

`environment/info` uses the timed client-call path, which bypassed the existing RPC client span and left one admitted request path without the basic trace boundary.

## What

Move the existing client RPC instrumentation from the normal and cleanup wrappers into their shared `call_inner` path. Normal, timed, and cleanup requests now receive exactly one client span; admission failures remain outside because they do not send an RPC request.

Serialize exec-server tracing tests that rebuild tracing's process-global callsite-interest cache so concurrent thread-local subscribers cannot invalidate one another's span callsites.

## Validation

- `just test -p codex-exec-server rpc_client_` (5 passed)
- `just test -p codex-exec-server --lib` (172 passed)
- `just test -p codex-exec-server` on the completed stack (306 passed, 2 skipped)

## Stack

2 of 3:

1. [#31687](https://github.com/openai/codex/pull/31687) — align JSON-RPC span attributes
2. [#31689](https://github.com/openai/codex/pull/31689) — centralize client RPC spans (this PR)
3. [#31690](https://github.com/openai/codex/pull/31690) — trace RPC notifications
