### PR TITLE
exec-server: trace RPC notifications

### DIFF
--- a/codex-rs/exec-server/src/rpc.rs
+++ b/codex-rs/exec-server/src/rpc.rs
@@ -233,8 +233,13 @@ where
             .map(|(&method, route)| (method, route))
     }
 
-    pub(crate) fn notification_route(&self, method: &str) -> Option<&NotificationRoute<S>> {
-        self.notification_routes.get(method)
+    pub(crate) fn notification_route(
+        &self,
+        method: &str,
+    ) -> Option<(&'static str, &NotificationRoute<S>)> {
+        self.notification_routes
+            .get_key_value(method)
+            .map(|(&method, route)| (method, route))
     }
 }
 

--- a/codex-rs/exec-server/src/server/processor.rs
+++ b/codex-rs/exec-server/src/server/processor.rs
@@ -185,41 +185,50 @@ async fn run_connection(
                     }
                 }
                 codex_exec_server_protocol::JSONRPCMessage::Notification(notification) => {
-                    let method = notification.method.as_str();
+                    let method = notification.method.clone();
                     let notification_span = tracing::info_span!(
                         "codex.exec_server.notification",
                         otel.kind = "server",
                         otel.name = tracing::field::Empty,
                         rpc.system = "jsonrpc",
-                        rpc.method = method,
+                        rpc.method = method.as_str(),
                         rpc.transport = transport.metric_tag(),
-                        method,
+                        method = method.as_str(),
                         result = tracing::field::Empty,
                     );
-                    let Some((method, route)) = router.notification_route(method) else {
-                        notification_span.record("otel.name", "unknown");
-                        notification_span.record("result", "error");
-                        warn!(
-                            "closing exec-server connection after unexpected notification: {}",
-                            notification.method
-                        );
-                        break;
-                    };
-                    notification_span.record("otel.name", method);
-                    let result = tokio::select! {
-                        result = route(Arc::clone(&handler), notification).instrument(notification_span.clone()) => result,
-                        _ = disconnected_rx.changed() => {
-                            notification_span.record("result", "disconnected");
-                            debug!(
-                                "exec-server transport disconnected while handling notification"
+                    let continue_connection = async {
+                        let Some((method, route)) = router.notification_route(method.as_str())
+                        else {
+                            tracing::Span::current().record("otel.name", "unknown");
+                            tracing::Span::current().record("result", "error");
+                            warn!(
+                                "closing exec-server connection after unexpected notification: {}",
+                                notification.method
                             );
-                            break;
+                            return false;
+                        };
+                        tracing::Span::current().record("otel.name", method);
+                        let result = tokio::select! {
+                            result = route(Arc::clone(&handler), notification) => result,
+                            _ = disconnected_rx.changed() => {
+                                tracing::Span::current().record("result", "disconnected");
+                                debug!(
+                                    "exec-server transport disconnected while handling notification"
+                                );
+                                return false;
+                            }
+                        };
+                        tracing::Span::current()
+                            .record("result", if result.is_ok() { "success" } else { "error" });
+                        if let Err(err) = result {
+                            warn!("closing exec-server connection after protocol error: {err}");
+                            return false;
                         }
-                    };
-                    notification_span
-                        .record("result", if result.is_ok() { "success" } else { "error" });
-                    if let Err(err) = result {
-                        warn!("closing exec-server connection after protocol error: {err}");
+                        true
+                    }
+                    .instrument(notification_span)
+                    .await;
+                    if !continue_connection {
                         break;
                     }
                 }

--- a/codex-rs/exec-server/src/server/processor.rs
+++ b/codex-rs/exec-server/src/server/processor.rs
@@ -185,23 +185,39 @@ async fn run_connection(
                     }
                 }
                 codex_exec_server_protocol::JSONRPCMessage::Notification(notification) => {
-                    let Some(route) = router.notification_route(notification.method.as_str())
-                    else {
+                    let method = notification.method.as_str();
+                    let notification_span = tracing::info_span!(
+                        "codex.exec_server.notification",
+                        otel.kind = "server",
+                        otel.name = tracing::field::Empty,
+                        rpc.system = "jsonrpc",
+                        rpc.method = method,
+                        rpc.transport = transport.metric_tag(),
+                        method,
+                        result = tracing::field::Empty,
+                    );
+                    let Some((method, route)) = router.notification_route(method) else {
+                        notification_span.record("otel.name", "unknown");
+                        notification_span.record("result", "error");
                         warn!(
                             "closing exec-server connection after unexpected notification: {}",
                             notification.method
                         );
                         break;
                     };
+                    notification_span.record("otel.name", method);
                     let result = tokio::select! {
-                        result = route(Arc::clone(&handler), notification) => result,
+                        result = route(Arc::clone(&handler), notification).instrument(notification_span.clone()) => result,
                         _ = disconnected_rx.changed() => {
+                            notification_span.record("result", "disconnected");
                             debug!(
                                 "exec-server transport disconnected while handling notification"
                             );
                             break;
                         }
                     };
+                    notification_span
+                        .record("result", if result.is_ok() { "success" } else { "error" });
                     if let Err(err) = result {
                         warn!("closing exec-server connection after protocol error: {err}");
                         break;


### PR DESCRIPTION
## Why

`initialized` is the only registered inbound exec-server RPC endpoint that bypasses request tracing, leaving handshake handling absent from server traces.

## What

- Return the canonical notification route name.
- Wrap notification dispatch in a bounded `codex.exec_server.notification` server span.
- Record success, error, and disconnect outcomes without changing request metrics or the wire protocol.

## Manual validation

- `just test -p codex-exec-server` (307 passed, 2 skipped)

## Stack

1. https://github.com/openai/codex/pull/31687 (#31687, 1/5)
2. https://github.com/openai/codex/pull/31690 (#31690, this PR, 2/5)
3. https://github.com/openai/codex/pull/31707 (#31707, 3/5)
4. https://github.com/openai/codex/pull/31729 (#31729, 4/5)
5. https://github.com/openai/codex/pull/31730 (#31730, 5/5)