### PR TITLE
Allow plugin installs for backend dependency IDs

### DIFF
--- a/codex-rs/core/src/tools/handlers/request_plugin_install.rs
+++ b/codex-rs/core/src/tools/handlers/request_plugin_install.rs
@@ -5,11 +5,18 @@ use codex_analytics::PluginInstallRequestSource;
 use codex_analytics::PluginInstallRequested;
 use codex_analytics::PluginInstallRequestedPlugin;
 use codex_analytics::build_track_events_context;
+use codex_app_server_protocol::PluginAvailability;
+use codex_app_server_protocol::PluginInstallPolicy;
 use codex_config::types::ToolSuggestDisabledTool;
 use codex_core_plugins::remote::REMOTE_GLOBAL_MARKETPLACE_NAME;
+use codex_core_plugins::remote::RemotePluginDetail;
+use codex_core_plugins::remote::RemotePluginServiceConfig;
+use codex_core_plugins::remote::fetch_remote_plugin_detail;
+use codex_core_plugins::remote::is_valid_remote_plugin_id;
 use codex_mcp::CODEX_APPS_MCP_SERVER_NAME;
 use codex_rmcp_client::ElicitationAction;
 use codex_rmcp_client::ElicitationResponse;
+use codex_tools::DiscoverablePluginInfo;
 use codex_tools::DiscoverableTool;
 use codex_tools::DiscoverableToolAction;
 use codex_tools::DiscoverableToolType;
@@ -147,36 +154,45 @@ impl RequestPluginInstallHandler {
             turn.app_server_client_name.as_deref(),
         );
 
-        let tool = discoverable_tools
-            .into_iter()
-            .find(|tool| {
-                tool.id() == requested_tool_id
-                    && match self.presentation {
-                        ToolSuggestPresentation::ListTool => {
-                            Some(tool.tool_type()) == requested_tool_type
-                        }
-                        ToolSuggestPresentation::RecommendationContext => {
-                            matches!(tool, DiscoverableTool::Plugin(_))
-                        }
+        let candidate_not_found = || {
+            let (argument_name, source) = match self.presentation {
+                ToolSuggestPresentation::ListTool => (
+                    "tool_id",
+                    format!(
+                        "the discoverable tools returned by {LIST_AVAILABLE_PLUGINS_TO_INSTALL_TOOL_NAME}"
+                    ),
+                ),
+                ToolSuggestPresentation::RecommendationContext => (
+                    "plugin_id",
+                    "the entries in the <recommended_plugins> list".to_string(),
+                ),
+            };
+            FunctionCallError::RespondToModel(format!(
+                "{argument_name} must match one of {source} or be an exact installable canonical_plugin_id returned by get_plugin_dependencies"
+            ))
+        };
+        let plugin_request = requested_tool_type == Some(DiscoverableToolType::Plugin)
+            || self.presentation == ToolSuggestPresentation::RecommendationContext;
+        let tool = if let Some(tool) = discoverable_tools.into_iter().find(|tool| {
+            tool.id() == requested_tool_id
+                && match self.presentation {
+                    ToolSuggestPresentation::ListTool => {
+                        Some(tool.tool_type()) == requested_tool_type
                     }
-            })
-            .ok_or_else(|| {
-                let (argument_name, source) = match self.presentation {
-                    ToolSuggestPresentation::ListTool => (
-                        "tool_id",
-                        format!(
-                            "the discoverable tools returned by {LIST_AVAILABLE_PLUGINS_TO_INSTALL_TOOL_NAME}"
-                        ),
-                    ),
-                    ToolSuggestPresentation::RecommendationContext => (
-                        "plugin_id",
-                        "the entries in the <recommended_plugins> list".to_string(),
-                    ),
-                };
-                FunctionCallError::RespondToModel(format!(
-                    "{argument_name} must match one of {source}"
-                ))
-            })?;
+                    ToolSuggestPresentation::RecommendationContext => {
+                        matches!(tool, DiscoverableTool::Plugin(_))
+                    }
+                }
+        }) {
+            tool
+        } else if plugin_request {
+            let auth = session.services.auth_manager.auth().await;
+            resolve_backend_plugin_install_tool(turn.as_ref(), auth.as_ref(), &requested_tool_id)
+                .await
+                .ok_or_else(candidate_not_found)?
+        } else {
+            return Err(candidate_not_found());
+        };
         let tool_type = tool.tool_type();
 
         let suggestion_id = format!("request_plugin_install_{call_id}");
@@ -286,6 +302,88 @@ impl RequestPluginInstallHandler {
 }
 
 impl CoreToolRuntime for RequestPluginInstallHandler {}
+
+async fn resolve_backend_plugin_install_tool(
+    turn: &crate::session::turn_context::TurnContext,
+    auth: Option<&codex_login::CodexAuth>,
+    requested_plugin_id: &str,
+) -> Option<DiscoverableTool> {
+    if !turn.config.plugins_config_input().remote_plugin_enabled
+        || !is_valid_remote_plugin_id(requested_plugin_id)
+    {
+        return None;
+    }
+
+    let service_config = RemotePluginServiceConfig {
+        chatgpt_base_url: turn.config.chatgpt_base_url.clone(),
+    };
+    let detail = match fetch_remote_plugin_detail(
+        &service_config,
+        auth,
+        REMOTE_GLOBAL_MARKETPLACE_NAME,
+        requested_plugin_id,
+    )
+    .await
+    {
+        Ok(detail) => detail,
+        Err(err) => {
+            warn!(
+                error = %err,
+                requested_plugin_id,
+                "failed to resolve backend plugin install request"
+            );
+            return None;
+        }
+    };
+
+    discoverable_backend_plugin_install_tool(
+        requested_plugin_id,
+        &turn.config.tool_suggest.disabled_tools,
+        detail,
+    )
+}
+
+fn discoverable_backend_plugin_install_tool(
+    requested_plugin_id: &str,
+    disabled_tools: &[ToolSuggestDisabledTool],
+    detail: RemotePluginDetail,
+) -> Option<DiscoverableTool> {
+    if detail.summary.remote_plugin_id != requested_plugin_id
+        || detail.marketplace_name != REMOTE_GLOBAL_MARKETPLACE_NAME
+        || detail.summary.availability != PluginAvailability::Available
+        || detail.summary.install_policy != PluginInstallPolicy::Available
+        || detail.summary.installed
+        || disabled_tools.contains(&ToolSuggestDisabledTool::plugin(detail.summary.id.as_str()))
+        || disabled_tools.contains(&ToolSuggestDisabledTool::plugin(
+            detail.summary.remote_plugin_id.as_str(),
+        ))
+    {
+        return None;
+    }
+
+    let name = detail
+        .summary
+        .interface
+        .as_ref()
+        .and_then(|interface| interface.display_name.clone())
+        .unwrap_or_else(|| detail.summary.name.clone());
+    let description = detail
+        .summary
+        .interface
+        .as_ref()
+        .and_then(|interface| interface.short_description.clone())
+        .or_else(|| detail.description.clone());
+
+    Some(DiscoverableTool::from(DiscoverablePluginInfo {
+        id: detail.summary.id,
+        remote_plugin_id: Some(detail.summary.remote_plugin_id),
+        name,
+        description,
+        has_skills: !detail.skills.is_empty(),
+        mcp_server_names: detail.mcp_servers,
+        app_connector_ids: detail.app_ids,
+    }))
+}
 
 async fn maybe_persist_disabled_install_request(
     session: &crate::session::session::Session,

--- a/codex-rs/core/src/tools/handlers/request_plugin_install_spec.rs
+++ b/codex-rs/core/src/tools/handlers/request_plugin_install_spec.rs
@@ -28,7 +28,10 @@ pub(crate) fn create_request_plugin_install_tool(
                 ),
                 (
                     "tool_id".to_string(),
-                    JsonSchema::string(Some("Connector or plugin id to suggest.".to_string())),
+                    JsonSchema::string(Some(
+                        "Connector or plugin id to suggest. For a Plugin Management dependency, use the exact canonical_plugin_id."
+                            .to_string(),
+                    )),
                 ),
                 (
                     "suggest_reason".to_string(),
@@ -45,7 +48,7 @@ pub(crate) fn create_request_plugin_install_tool(
                 "suggest_reason".to_string(),
             ],
             format!(
-                "# Request plugin/connector install\n\nUse this tool only after `{LIST_AVAILABLE_PLUGINS_TO_INSTALL_TOOL_NAME}` returns a plugin or connector that exactly matches the user's explicit request.\n\nDo not use it for adjacent capabilities, broad recommendations, or tools that merely seem useful. Pass the returned `tool_type` through directly, and pass the returned `id` as `tool_id`.\n\nIMPORTANT: DO NOT call this tool in parallel with other tools."
+                "# Request plugin/connector install\n\nUse this tool only after `{LIST_AVAILABLE_PLUGINS_TO_INSTALL_TOOL_NAME}` returns a plugin or connector that exactly matches the user's explicit request, or after Plugin Management `get_plugin_dependencies` returns an exact installable `canonical_plugin_id`.\n\nFor a dependency, use this tool only when `canonical_plugin_status=\"enabled\"`, `canonical_plugin_installation_policy=\"available\"`, and `canonical_plugin_installed=false`; pass `tool_type=\"plugin\"`, `action_type=\"install\"`, and the exact `canonical_plugin_id` as `tool_id`. Never invent IDs or use bare or fuzzy plugin names.\n\nDo not use it for adjacent capabilities, broad recommendations, or tools that merely seem useful. Pass list-tool results through directly.\n\nIMPORTANT: DO NOT call this tool in parallel with other tools."
             ),
         ),
         ToolSuggestPresentation::RecommendationContext => (
@@ -53,7 +56,8 @@ pub(crate) fn create_request_plugin_install_tool(
                 (
                     "plugin_id".to_string(),
                     JsonSchema::string(Some(
-                        "Plugin id from the `<recommended_plugins>` list.".to_string(),
+                        "Plugin id from the `<recommended_plugins>` list, or exact canonical_plugin_id returned by Plugin Management `get_plugin_dependencies`."
+                            .to_string(),
                     )),
                 ),
                 (
@@ -65,7 +69,7 @@ pub(crate) fn create_request_plugin_install_tool(
                 ),
             ]),
             vec!["plugin_id".to_string(), "suggest_reason".to_string()],
-            "# Suggest a recommended plugin installation\n\nSuggest installing a plugin from the `<recommended_plugins>` list when it would help with the user's current request. Briefly explain why in `suggest_reason`.".to_string(),
+            "# Suggest a plugin installation\n\nSuggest installing a plugin from the `<recommended_plugins>` list when it would help with the user's current request. You may also use an exact `canonical_plugin_id` returned by Plugin Management `get_plugin_dependencies` when `canonical_plugin_status=\"enabled\"`, `canonical_plugin_installation_policy=\"available\"`, and `canonical_plugin_installed=false`. Never invent IDs or use bare or fuzzy plugin names. Briefly explain why in `suggest_reason`.".to_string(),
         ),
     };
 
@@ -90,8 +94,9 @@ mod tests {
     fn create_request_plugin_install_tool_uses_expected_legacy_wire_shape() {
         let expected_description = concat!(
             "# Request plugin/connector install\n\n",
-            "Use this tool only after `list_available_plugins_to_install` returns a plugin or connector that exactly matches the user's explicit request.\n\n",
-            "Do not use it for adjacent capabilities, broad recommendations, or tools that merely seem useful. Pass the returned `tool_type` through directly, and pass the returned `id` as `tool_id`.\n\n",
+            "Use this tool only after `list_available_plugins_to_install` returns a plugin or connector that exactly matches the user's explicit request, or after Plugin Management `get_plugin_dependencies` returns an exact installable `canonical_plugin_id`.\n\n",
+            "For a dependency, use this tool only when `canonical_plugin_status=\"enabled\"`, `canonical_plugin_installation_policy=\"available\"`, and `canonical_plugin_installed=false`; pass `tool_type=\"plugin\"`, `action_type=\"install\"`, and the exact `canonical_plugin_id` as `tool_id`. Never invent IDs or use bare or fuzzy plugin names.\n\n",
+            "Do not use it for adjacent capabilities, broad recommendations, or tools that merely seem useful. Pass list-tool results through directly.\n\n",
             "IMPORTANT: DO NOT call this tool in parallel with other tools.",
         );
 
@@ -120,7 +125,7 @@ mod tests {
                         (
                             "tool_id".to_string(),
                             JsonSchema::string(Some(
-                                    "Connector or plugin id to suggest."
+                                    "Connector or plugin id to suggest. For a Plugin Management dependency, use the exact canonical_plugin_id."
                                         .to_string(),
                                 ),),
                         ),
@@ -148,7 +153,7 @@ mod tests {
             create_request_plugin_install_tool(ToolSuggestPresentation::RecommendationContext),
             ToolSpec::Function(ResponsesApiTool {
                 name: "request_plugin_install".to_string(),
-                description: "# Suggest a recommended plugin installation\n\nSuggest installing a plugin from the `<recommended_plugins>` list when it would help with the user's current request. Briefly explain why in `suggest_reason`.".to_string(),
+                description: "# Suggest a plugin installation\n\nSuggest installing a plugin from the `<recommended_plugins>` list when it would help with the user's current request. You may also use an exact `canonical_plugin_id` returned by Plugin Management `get_plugin_dependencies` when `canonical_plugin_status=\"enabled\"`, `canonical_plugin_installation_policy=\"available\"`, and `canonical_plugin_installed=false`. Never invent IDs or use bare or fuzzy plugin names. Briefly explain why in `suggest_reason`.".to_string(),
                 strict: false,
                 defer_loading: None,
                 parameters: JsonSchema::object(
@@ -156,7 +161,7 @@ mod tests {
                         (
                             "plugin_id".to_string(),
                             JsonSchema::string(Some(
-                                "Plugin id from the `<recommended_plugins>` list.".to_string(),
+                                "Plugin id from the `<recommended_plugins>` list, or exact canonical_plugin_id returned by Plugin Management `get_plugin_dependencies`.".to_string(),
                             )),
                         ),
                         (

--- a/codex-rs/core/src/tools/handlers/request_plugin_install_tests.rs
+++ b/codex-rs/core/src/tools/handlers/request_plugin_install_tests.rs
@@ -3,6 +3,7 @@ use crate::plugins::test_support::load_plugins_config;
 use crate::plugins::test_support::write_curated_plugin_sha;
 use crate::plugins::test_support::write_openai_curated_marketplace;
 use crate::plugins::test_support::write_plugins_feature_config;
+use codex_app_server_protocol::PluginAuthPolicy;
 use codex_config::CONFIG_TOML_FILE;
 use codex_config::config_toml::ConfigToml;
 use codex_config::types::ToolSuggestConfig;
@@ -11,6 +12,9 @@ use codex_config::types::ToolSuggestDiscoverable;
 use codex_config::types::ToolSuggestDiscoverableType;
 use codex_core_plugins::PluginInstallRequest;
 use codex_core_plugins::PluginsManager;
+use codex_core_plugins::remote::RemotePluginDetail;
+use codex_core_plugins::remote::RemotePluginSkill;
+use codex_core_plugins::remote::RemotePluginSummary;
 use codex_core_plugins::startup_sync::curated_plugins_repo_path;
 use codex_rmcp_client::ElicitationResponse;
 use codex_tools::DiscoverablePluginInfo;
@@ -87,6 +91,66 @@ fn recommended_plugin_install_args_accept_legacy_tool_id() {
     .expect("legacy arguments should deserialize");
 
     assert_eq!(current, legacy);
+}
+
+#[test]
+fn backend_plugin_detail_resolves_to_installable_tool() {
+    assert_eq!(
+        discoverable_backend_plugin_install_tool(BACKEND_PLUGIN_ID, &[], backend_plugin_detail()),
+        Some(DiscoverableTool::Plugin(Box::new(DiscoverablePluginInfo {
+            id: "slack@openai-curated-remote".to_string(),
+            remote_plugin_id: Some(BACKEND_PLUGIN_ID.to_string()),
+            name: "Slack".to_string(),
+            description: Some("Collaborate in Slack.".to_string()),
+            has_skills: true,
+            mcp_server_names: vec!["slack".to_string()],
+            app_connector_ids: vec!["connector_slack".to_string()],
+        })))
+    );
+}
+
+#[test]
+fn backend_plugin_detail_rejects_uninstallable_or_disabled_plugins() {
+    let mut mismatched_id = backend_plugin_detail();
+    mismatched_id.summary.remote_plugin_id = "plugins~Plugin_other".to_string();
+    let mut non_global = backend_plugin_detail();
+    non_global.marketplace_name = "workspace-directory".to_string();
+    let mut disabled_by_admin = backend_plugin_detail();
+    disabled_by_admin.summary.availability = PluginAvailability::DisabledByAdmin;
+    let mut not_available = backend_plugin_detail();
+    not_available.summary.install_policy = PluginInstallPolicy::NotAvailable;
+    let mut installed_by_default = backend_plugin_detail();
+    installed_by_default.summary.install_policy = PluginInstallPolicy::InstalledByDefault;
+    let mut installed = backend_plugin_detail();
+    installed.summary.installed = true;
+
+    for detail in [
+        mismatched_id,
+        non_global,
+        disabled_by_admin,
+        not_available,
+        installed_by_default,
+        installed,
+    ] {
+        assert_eq!(
+            discoverable_backend_plugin_install_tool(BACKEND_PLUGIN_ID, &[], detail),
+            None
+        );
+    }
+
+    for disabled_tool in [
+        ToolSuggestDisabledTool::plugin("slack@openai-curated-remote"),
+        ToolSuggestDisabledTool::plugin(BACKEND_PLUGIN_ID),
+    ] {
+        assert_eq!(
+            discoverable_backend_plugin_install_tool(
+                BACKEND_PLUGIN_ID,
+                &[disabled_tool],
+                backend_plugin_detail(),
+            ),
+            None
+        );
+    }
 }
 
 #[test]
@@ -226,6 +290,46 @@ id = "slack@openai-curated"
             ],
         })
     );
+}
+
+const BACKEND_PLUGIN_ID: &str = "plugins~Plugin_slack";
+
+fn backend_plugin_detail() -> RemotePluginDetail {
+    RemotePluginDetail {
+        marketplace_name: REMOTE_GLOBAL_MARKETPLACE_NAME.to_string(),
+        marketplace_display_name: "OpenAI Curated Remote".to_string(),
+        summary: RemotePluginSummary {
+            id: "slack@openai-curated-remote".to_string(),
+            remote_plugin_id: BACKEND_PLUGIN_ID.to_string(),
+            version: Some("1.0.0".to_string()),
+            local_version: None,
+            name: "Slack".to_string(),
+            share_context: None,
+            installed: false,
+            enabled: false,
+            install_policy: PluginInstallPolicy::Available,
+            install_policy_source: None,
+            auth_policy: PluginAuthPolicy::OnUse,
+            availability: PluginAvailability::Available,
+            interface: None,
+            keywords: Vec::new(),
+        },
+        share_url: None,
+        description: Some("Collaborate in Slack.".to_string()),
+        release_version: Some("1.0.0".to_string()),
+        bundle_download_url: None,
+        app_manifest: None,
+        skills: vec![RemotePluginSkill {
+            name: "slack".to_string(),
+            description: "Work with Slack.".to_string(),
+            short_description: None,
+            interface: None,
+            enabled: true,
+        }],
+        app_ids: vec!["connector_slack".to_string()],
+        app_templates: Vec::new(),
+        mcp_servers: vec!["slack".to_string()],
+    }
 }
 
 fn connector_tool(id: &str, name: &str) -> DiscoverableTool {

--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -772,9 +772,11 @@ fn add_core_utility_tools(context: &CoreToolPlanContext<'_>, planned_tools: &mut
     }
 
     if tool_suggest_enabled(turn_context)
-        && let Some(candidates) = context
-            .tool_suggest_candidates
-            .filter(|candidates| !candidates.tools.is_empty())
+        && let Some(candidates) = context.tool_suggest_candidates.filter(|candidates| {
+            candidates.presentation
+                == crate::tools::router::ToolSuggestPresentation::RecommendationContext
+                || !candidates.tools.is_empty()
+        })
     {
         if candidates.presentation == crate::tools::router::ToolSuggestPresentation::ListTool {
             planned_tools.add(ListAvailablePluginsToInstallHandler::new(

--- a/codex-rs/core/src/tools/spec_plan_tests.rs
+++ b/codex-rs/core/src/tools/spec_plan_tests.rs
@@ -941,31 +941,42 @@ async fn request_plugin_install_requires_all_discovery_features() {
         ]);
     }
 
-    for tool_suggest_candidates in [
-        None,
-        Some(ToolSuggestCandidates {
-            tools: Vec::new(),
-            presentation: ToolSuggestPresentation::RecommendationContext,
-        }),
-    ] {
-        let plan = probe_with(
-            |turn| {
-                set_features(
-                    turn,
-                    &[Feature::ToolSuggest, Feature::Apps, Feature::Plugins],
-                );
-            },
-            ToolPlanInputs {
-                tool_suggest_candidates,
-                ..ToolPlanInputs::default()
-            },
-        )
-        .await;
-        plan.assert_visible_lacks(&[
-            "list_available_plugins_to_install",
-            "request_plugin_install",
-        ]);
-    }
+    let no_candidates = probe_with(
+        |turn| {
+            set_features(
+                turn,
+                &[Feature::ToolSuggest, Feature::Apps, Feature::Plugins],
+            );
+        },
+        ToolPlanInputs {
+            tool_suggest_candidates: None,
+            ..ToolPlanInputs::default()
+        },
+    )
+    .await;
+    no_candidates.assert_visible_lacks(&[
+        "list_available_plugins_to_install",
+        "request_plugin_install",
+    ]);
+
+    let empty_recommendations = probe_with(
+        |turn| {
+            set_features(
+                turn,
+                &[Feature::ToolSuggest, Feature::Apps, Feature::Plugins],
+            );
+        },
+        ToolPlanInputs {
+            tool_suggest_candidates: Some(ToolSuggestCandidates {
+                tools: Vec::new(),
+                presentation: ToolSuggestPresentation::RecommendationContext,
+            }),
+            ..ToolPlanInputs::default()
+        },
+    )
+    .await;
+    empty_recommendations.assert_visible_lacks(&["list_available_plugins_to_install"]);
+    empty_recommendations.assert_visible_contains(&["request_plugin_install"]);
 
     let enabled = probe_with(
         |turn| {

--- a/codex-rs/core/tests/suite/request_plugin_install.rs
+++ b/codex-rs/core/tests/suite/request_plugin_install.rs
@@ -56,6 +56,9 @@ const REMOTE_CALENDAR_PLUGIN_ID: &str = "plugin_calendar";
 const CALENDAR_CONNECTOR_ID: &str = "calendar";
 const CALENDAR_NAMESPACE: &str = "mcp__codex_apps__calendar";
 const CALENDAR_CREATE_EVENT_TOOL: &str = "_create_event";
+const BACKEND_SLACK_PLUGIN_CONFIG_ID: &str = "slack@openai-curated-remote";
+const BACKEND_SLACK_PLUGIN_ID: &str = "plugins~Plugin_slack";
+const SLACK_CONNECTOR_ID: &str = "connector_slack";
 
 fn tool_names(body: &Value) -> Vec<String> {
     body.get("tools")
@@ -221,6 +224,37 @@ async fn mount_remote_calendar_recommendation(server: &wiremock::MockServer) {
         .await;
 }
 
+async fn mount_backend_slack_plugin_detail(server: &wiremock::MockServer) -> MockGuard {
+    Mock::given(method("GET"))
+        .and(path(format!("/ps/plugins/{BACKEND_SLACK_PLUGIN_ID}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": BACKEND_SLACK_PLUGIN_ID,
+            "name": "slack",
+            "scope": "GLOBAL",
+            "installation_policy": "AVAILABLE",
+            "authentication_policy": "ON_USE",
+            "status": "ENABLED",
+            "release": {
+                "version": "1.0.0",
+                "display_name": "Slack",
+                "description": "Collaborate in Slack.",
+                "app_ids": [SLACK_CONNECTOR_ID],
+                "interface": {
+                    "short_description": "Collaborate in Slack."
+                },
+                "skills": [{
+                    "name": "slack",
+                    "description": "Work with Slack.",
+                    "interface": null
+                }],
+                "mcp_servers": [{"key": "slack"}]
+            }
+        })))
+        .expect(1)
+        .mount_as_scoped(server)
+        .await
+}
+
 fn remote_installed_plugins_response(plugins: Vec<Value>) -> ResponseTemplate {
     ResponseTemplate::new(200).set_body_json(json!({
         "plugins": plugins,
@@ -329,8 +363,11 @@ async fn explicit_false_preserves_legacy_workflow() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn endpoint_mode_injects_candidates_hides_list_and_rejects_invented_ids() -> Result<()> {
+async fn endpoint_mode_injects_candidates_hides_list_and_rejects_missing_backend_ids() -> Result<()>
+{
     skip_if_no_network!(Ok(()));
+
+    const MISSING_PLUGIN_ID: &str = "plugins~Plugin_missing";
 
     let server = start_mock_server().await;
     let apps_server = AppsTestServer::mount(&server).await?;
@@ -357,7 +394,13 @@ async fn endpoint_mode_injects_candidates_hides_list_and_rejects_invented_ids() 
         })),
     )
     .await;
-    let call_id = "invented-plugin";
+    Mock::given(method("GET"))
+        .and(path(format!("/ps/plugins/{MISSING_PLUGIN_ID}")))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&server)
+        .await;
+    let call_id = "missing-plugin";
     let mock = mount_sse_sequence(
         &server,
         vec![
@@ -367,7 +410,7 @@ async fn endpoint_mode_injects_candidates_hides_list_and_rejects_invented_ids() 
                     call_id,
                     REQUEST_PLUGIN_INSTALL_TOOL_NAME,
                     &serde_json::to_string(&json!({
-                        "plugin_id": "invented@openai-curated-remote",
+                        "plugin_id": MISSING_PLUGIN_ID,
                         "suggest_reason": "Try this"
                     }))?,
                 ),
@@ -407,6 +450,7 @@ async fn endpoint_mode_injects_candidates_hides_list_and_rejects_invented_ids() 
         .function_call_output_text(call_id)
         .expect("request tool output");
     assert!(output.contains("<recommended_plugins> list"));
+    assert!(output.contains("canonical_plugin_id"));
     Ok(())
 }
 
@@ -416,6 +460,84 @@ async fn endpoint_recommendation_adds_install_identity_only_to_elicitation_metad
     skip_if_no_network!(Ok(()));
 
     run_remote_plugin_install_metadata_case().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn endpoint_mode_resolves_backend_plugin_id_for_install_elicitation() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let apps_server = AppsTestServer::mount(&server).await?;
+    mount_recommendations(
+        &server,
+        ResponseTemplate::new(200).set_body_json(json!({
+            "enabled": true,
+            "plugins": []
+        })),
+    )
+    .await;
+    let _detail = mount_backend_slack_plugin_detail(&server).await;
+    let _installed = mount_empty_remote_installed_plugins(&server).await;
+    let call_id = "install-slack-dependency";
+    let suggest_reason = "Use Slack for this request";
+    let mock = mount_sse_sequence(
+        &server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                ev_function_call(
+                    call_id,
+                    REQUEST_PLUGIN_INSTALL_TOOL_NAME,
+                    &serde_json::to_string(&json!({
+                        "plugin_id": BACKEND_SLACK_PLUGIN_ID,
+                        "suggest_reason": suggest_reason
+                    }))?,
+                ),
+                ev_completed("resp-1"),
+            ]),
+            sse(vec![
+                ev_response_created("resp-2"),
+                ev_assistant_message("msg-1", "done"),
+                ev_completed("resp-2"),
+            ]),
+        ],
+    )
+    .await;
+    let test = build_test(&server, &apps_server).await?;
+
+    let elicitation = start_install_turn(&test, "use Slack").await?;
+    let ElicitationRequest::Form {
+        meta: Some(meta), ..
+    } = &elicitation.request
+    else {
+        panic!("expected form elicitation metadata");
+    };
+    assert_eq!(meta["tool_id"], BACKEND_SLACK_PLUGIN_CONFIG_ID);
+    assert_eq!(meta["tool_name"], "Slack");
+    assert_eq!(meta["remote_plugin_id"], BACKEND_SLACK_PLUGIN_ID);
+    assert_eq!(meta["app_connector_ids"], json!([SLACK_CONNECTOR_ID]));
+
+    resolve_install_elicitation(&test, elicitation, ElicitationAction::Decline).await?;
+
+    let requests = mock.requests();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(
+        serde_json::from_str::<Value>(
+            &requests[1]
+                .function_call_output_text(call_id)
+                .expect("install tool output")
+        )?,
+        json!({
+            "completed": false,
+            "user_confirmed": false,
+            "tool_type": "plugin",
+            "action_type": "install",
+            "tool_id": BACKEND_SLACK_PLUGIN_CONFIG_ID,
+            "tool_name": "Slack",
+            "suggest_reason": suggest_reason
+        })
+    );
+    Ok(())
 }
 
 async fn run_remote_plugin_install_metadata_case() -> Result<()> {
@@ -624,16 +746,16 @@ async fn run_remote_plugin_install_refresh_case(refreshed_tools: RefreshedAppsTo
         "the resumed router should reflect the refreshed Apps tools"
     );
     assert!(
-        !tool_names(&requests[1].body_json())
+        tool_names(&requests[1].body_json())
             .iter()
             .any(|name| name == REQUEST_PLUGIN_INSTALL_TOOL_NAME),
-        "the refreshed installed-plugin cache should filter the cached recommendation"
+        "the request tool should remain available for backend dependency IDs after the cached recommendation is filtered"
     );
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn endpoint_mode_with_no_eligible_candidates_exposes_no_suggestion_tools() -> Result<()> {
+async fn endpoint_mode_with_no_eligible_candidates_still_exposes_request_tool() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
@@ -688,7 +810,7 @@ async fn endpoint_mode_with_no_eligible_candidates_exposes_no_suggestion_tools()
             .any(|name| name == LIST_AVAILABLE_PLUGINS_TO_INSTALL_TOOL_NAME)
     );
     assert!(
-        !tools
+        tools
             .iter()
             .any(|name| name == REQUEST_PLUGIN_INSTALL_TOOL_NAME)
     );


### PR DESCRIPTION
## Summary

- Allow `request_plugin_install` to resolve exact backend plugin IDs when they are not present in `<recommended_plugins>` or `list_available_plugins_to_install`.
- Normalize the backend detail response into the existing Codex plugin identity and reuse the existing install elicitation, metadata, analytics, persistence, and completion flow.
- Keep `request_plugin_install` available in endpoint-recommendation mode even when there are zero static recommendation candidates.

## Motivation

Plugin Management dependency discovery can return canonical backend plugin IDs for related plugins that are valid and installable but are not part of the small per-turn recommendation list. Today `request_plugin_install` rejects those IDs before the user can see the normal install elicitation.

This change keeps the existing recommendation/list path unchanged and adds a narrow fallback: resolve the exact backend ID through the existing `/ps/plugins/{plugin_id}` detail API, then reuse the existing client-compatible Codex config ID such as `slack@openai-curated-remote`.

## Behavior

- The backend detail response is the source of truth for the fallback. The plugin must resolve to the requested backend ID, be global, available, have installation policy `AVAILABLE`, and not already be installed.
- Remote plugins must be enabled, and persisted disabled suggestions are honored for both normalized config IDs and backend IDs.
- The model-facing tool docs allow exact `canonical_plugin_id` values from `get_plugin_dependencies` only when `canonical_plugin_status="enabled"`, `canonical_plugin_installation_policy="available"`, and `canonical_plugin_installed=false`.
- The elicitation continues to emit the normalized config ID plus `remote_plugin_id` and app connector IDs, so Codex desktop and ChatGPT Work mode can reuse their existing install UI.

## Scope

- No Plugin Management changes.
- No new HTTP routes.
- No Codex webview or ChatGPT web changes.
- No expansion of `list_available_plugins_to_install`.

## Validation

- `just test -p codex-core request_plugin_install` — 21 passed.
- `just test -p codex-tools request_plugin_install` — 6 passed.
- `just test -p codex-core endpoint_mode_resolves_backend_plugin_id_for_install_elicitation` — passed with zero recommendation candidates.
- `just test -p codex-core endpoint_mode_injects_candidates_hides_list_and_rejects_missing_backend_ids` — passed.
- `just fix -p codex-core`.
- `just fmt`.
- `git diff --check`.
