### PR TITLE
Trace major app-server lifecycle surfaces

### DIFF
--- a/codex-rs/app-server/src/extensions.rs
+++ b/codex-rs/app-server/src/extensions.rs
@@ -23,6 +23,7 @@ use codex_protocol::protocol::Event;
 use codex_protocol::protocol::EventMsg;
 use codex_rollout::state_db::StateDbHandle;
 use codex_thread_store::ThreadStore;
+use tracing::Instrument;
 
 use crate::outgoing_message::OutgoingMessageSender;
 use crate::thread_state::ThreadListenerCommand;
@@ -134,7 +135,11 @@ impl ExtensionEventSink for AppServerExtensionEventSink {
                     );
                 }
                 let outgoing = Arc::clone(&self.outgoing);
-                tokio::spawn(async move {
+                let notification_span = tracing::debug_span!(
+                    "app_server.extension_notification",
+                    codex.thread.id = %thread_id,
+                );
+                let notification_task = async move {
                     outgoing
                         .send_server_notification(ServerNotification::ThreadGoalUpdated(
                             ThreadGoalUpdatedNotification {
@@ -144,7 +149,8 @@ impl ExtensionEventSink for AppServerExtensionEventSink {
                             },
                         ))
                         .await;
-                });
+                };
+                tokio::spawn(notification_task.instrument(notification_span));
             }
             msg => {
                 tracing::debug!(event_id = %event.id, ?msg, "dropping unsupported extension event");

--- a/codex-rs/app-server/src/fs_watch.rs
+++ b/codex-rs/app-server/src/fs_watch.rs
@@ -22,6 +22,7 @@ use tokio::sync::Mutex as AsyncMutex;
 #[cfg(test)]
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
+use tracing::Instrument;
 use tracing::warn;
 
 const FS_CHANGED_NOTIFICATION_DEBOUNCE: Duration = Duration::from_millis(200);
@@ -108,7 +109,13 @@ impl FsWatchManager {
         }
 
         let task_watch_id = watch_id.clone();
-        tokio::spawn(async move {
+        let watch_span = tracing::info_span!(
+            parent: None,
+            "app_server.fs_watch",
+            app_server.connection_id = %connection_id,
+        );
+        crate::app_server_tracing::link_to_current_span(&watch_span);
+        let watch_task = async move {
             let mut rx = DebouncedWatchReceiver::new(rx, FS_CHANGED_NOTIFICATION_DEBOUNCE);
             tokio::pin!(terminate_rx);
             loop {
@@ -138,7 +145,8 @@ impl FsWatchManager {
                         .await;
                 }
             }
-        });
+        };
+        tokio::spawn(watch_task.instrument(watch_span));
 
         Ok(FsWatchResponse { path: params.path })
     }

--- a/codex-rs/app-server/src/fuzzy_file_search.rs
+++ b/codex-rs/app-server/src/fuzzy_file_search.rs
@@ -11,6 +11,8 @@ use codex_app_server_protocol::FuzzyFileSearchSessionCompletedNotification;
 use codex_app_server_protocol::FuzzyFileSearchSessionUpdatedNotification;
 use codex_app_server_protocol::ServerNotification;
 use codex_file_search as file_search;
+use tracing::Instrument;
+use tracing::Span;
 use tracing::warn;
 
 use crate::app_server_tracing::spawn_blocking_in_current_span;
@@ -132,28 +134,36 @@ pub(crate) fn start_fuzzy_file_search_session(
     let search_dirs: Vec<PathBuf> = roots.iter().map(PathBuf::from).collect();
     let canceled = Arc::new(AtomicBool::new(false));
 
+    let session_span = tracing::info_span!(
+        parent: None,
+        "app_server.fuzzy_file_search_session",
+    );
+    crate::app_server_tracing::link_to_current_span(&session_span);
     let shared = Arc::new(SessionShared {
         session_id,
         latest_query: Mutex::new(String::new()),
         outgoing,
         runtime: tokio::runtime::Handle::current(),
         canceled: canceled.clone(),
+        span: session_span.clone(),
     });
 
     let reporter = Arc::new(SessionReporterImpl {
         shared: shared.clone(),
     });
-    let session = file_search::create_session(
-        search_dirs,
-        file_search::FileSearchOptions {
-            limit,
-            threads,
-            compute_indices: true,
-            ..Default::default()
-        },
-        reporter,
-        Some(canceled),
-    )?;
+    let session = session_span.in_scope(|| {
+        file_search::create_session(
+            search_dirs,
+            file_search::FileSearchOptions {
+                limit,
+                threads,
+                compute_indices: true,
+                ..Default::default()
+            },
+            reporter,
+            Some(canceled),
+        )
+    })?;
 
     Ok(FuzzyFileSearchSession { session, shared })
 }
@@ -164,6 +174,7 @@ struct SessionShared {
     outgoing: Arc<OutgoingMessageSender>,
     runtime: tokio::runtime::Handle,
     canceled: Arc<AtomicBool>,
+    span: Span,
 }
 
 struct SessionReporterImpl {
@@ -198,9 +209,12 @@ impl SessionReporterImpl {
             },
         );
         let outgoing = self.shared.outgoing.clone();
-        self.shared.runtime.spawn(async move {
+        let task = async move {
             outgoing.send_server_notification(notification).await;
-        });
+        };
+        self.shared
+            .runtime
+            .spawn(task.instrument(self.shared.span.clone()));
     }
 
     fn send_complete(&self) {
@@ -209,12 +223,15 @@ impl SessionReporterImpl {
         }
         let session_id = self.shared.session_id.clone();
         let outgoing = self.shared.outgoing.clone();
-        self.shared.runtime.spawn(async move {
+        let task = async move {
             let notification = ServerNotification::FuzzyFileSearchSessionCompleted(
                 FuzzyFileSearchSessionCompletedNotification { session_id },
             );
             outgoing.send_server_notification(notification).await;
-        });
+        };
+        self.shared
+            .runtime
+            .spawn(task.instrument(self.shared.span.clone()));
     }
 }
 

--- a/codex-rs/app-server/src/in_process.rs
+++ b/codex-rs/app-server/src/in_process.rs
@@ -350,6 +350,7 @@ impl InProcessClientHandle {
 /// This function sends `initialize` followed by `initialized` before returning
 /// the handle, so callers receive a ready-to-use runtime. If initialize fails,
 /// the runtime is shut down and an `InvalidData` error is returned.
+#[tracing::instrument(name = "app_server.in_process.start", skip_all)]
 pub async fn start(mut args: InProcessStartArgs) -> IoResult<InProcessClientHandle> {
     if let Ok(Some(err)) = check_execpolicy_for_warnings(&args.config.config_layer_stack).await {
         let (path, range) = crate::exec_policy_warning_location(&err);

--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -1153,6 +1153,9 @@ pub async fn run_main_with_transport_options(
                 }
             };
 
+            processor.clear_runtime_references();
+            processor.cancel_active_login().await;
+            processor.clear_all_thread_listeners().await;
             if !shutdown_state.forced() {
                 futures::future::join_all(
                     connections
@@ -1166,6 +1169,7 @@ pub async fn run_main_with_transport_options(
             } else {
                 connection_cleanup_tasks.abort();
             }
+            processor.cancel_pending_server_requests().await;
             info!(
                 exit_reason,
                 remaining_connection_count = connections.len(),

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -692,6 +692,19 @@ impl MessageProcessor {
         self.thread_processor.shutdown_threads().await;
     }
 
+    pub(crate) async fn cancel_pending_server_requests(&self) {
+        self.outgoing
+            .cancel_all_requests(Some(crate::error_code::internal_error(
+                "app-server is shutting down",
+            )))
+            .await;
+    }
+
+    #[tracing::instrument(
+        name = "app_server.connection_cleanup",
+        skip_all,
+        fields(app_server.connection_id = %connection_id)
+    )]
     pub(crate) async fn connection_closed(
         &self,
         connection_id: ConnectionId,

--- a/codex-rs/app-server/src/outgoing_message.rs
+++ b/codex-rs/app-server/src/outgoing_message.rs
@@ -42,10 +42,10 @@ pub(crate) type ClientRequestResult = std::result::Result<Result, JSONRPCErrorEr
 enum RpcResult {
     Success,
     Error,
-    Cancelled,
-    SendFailed,
     Disconnected,
     Replaced,
+    Cancelled,
+    SendFailed,
 }
 
 impl RpcResult {
@@ -53,10 +53,10 @@ impl RpcResult {
         match self {
             Self::Success => "success",
             Self::Error => "error",
-            Self::Cancelled => "cancelled",
-            Self::SendFailed => "send_failed",
             Self::Disconnected => "disconnected",
             Self::Replaced => "replaced",
+            Self::Cancelled => "cancelled",
+            Self::SendFailed => "send_failed",
         }
     }
 }

--- a/codex-rs/app-server/src/request_processors/process_exec_processor.rs
+++ b/codex-rs/app-server/src/request_processors/process_exec_processor.rs
@@ -35,6 +35,7 @@ use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
 
 use crate::error_code::internal_error;
 use crate::error_code::invalid_params;
@@ -328,12 +329,21 @@ impl ProcessExecManager {
             }
         };
 
+        let run_span = tracing::info_span!(
+            parent: None,
+            "app_server.process_spawn.run",
+            rpc.method = "process/spawn",
+            rpc.request_id = %request_id.request_id,
+            app_server.connection_id = %request_id.connection_id,
+            process.outcome = tracing::field::Empty,
+        );
+        crate::app_server_tracing::link_to_current_span(&run_span);
         outgoing
             .send_response(request_id.clone(), ProcessSpawnResponse {})
             .await;
 
         let sessions = Arc::clone(&self.sessions);
-        tokio::spawn(async move {
+        let run_task = async move {
             run_process(RunProcessParams {
                 outgoing,
                 request_id,
@@ -347,7 +357,8 @@ impl ProcessExecManager {
             })
             .await;
             sessions.lock().await.remove(&process_key);
-        });
+        };
+        tokio::spawn(run_task.instrument(run_span));
 
         Ok(())
     }
@@ -572,10 +583,18 @@ async fn run_process(params: RunProcessParams) {
     };
 
     // Give stdout/stderr readers a bounded grace period to drain after process exit.
-    let timeout_handle = tokio::spawn(async move {
+    let timeout_task = async move {
         tokio::time::sleep(Duration::from_millis(IO_DRAIN_TIMEOUT_MS)).await;
         let _ = stdio_timeout_tx.send(true);
-    });
+    };
+    let timeout_handle = tokio::spawn(timeout_task.in_current_span());
+
+    let outcome = match expiration_outcome {
+        Some(ExecExpirationOutcome::TimedOut) => "timed_out",
+        Some(ExecExpirationOutcome::Cancelled) => "cancelled",
+        None => "exited",
+    };
+    tracing::Span::current().record("process.outcome", outcome);
 
     let stdout = stdout_handle.await.unwrap_or_default();
     let stderr = stderr_handle.await.unwrap_or_default();
@@ -609,7 +628,7 @@ fn collect_spawn_process_output(
         stream_output,
         output_bytes_cap,
     } = params;
-    tokio::spawn(async move {
+    let output_task = async move {
         let mut buffer: Vec<u8> = Vec::new();
         let mut observed_num_bytes = 0usize;
         let mut cap_reached = false;
@@ -660,7 +679,8 @@ fn collect_spawn_process_output(
             text: bytes_to_string_smart(&buffer),
             cap_reached,
         }
-    })
+    };
+    tokio::spawn(output_task.in_current_span())
 }
 
 async fn handle_process_write(

--- a/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
+++ b/codex-rs/app-server/src/request_processors/thread_lifecycle.rs
@@ -274,7 +274,13 @@ pub(super) async fn ensure_listener_task_running(
         ..
     } = listener_task_context;
     let outgoing_for_task = Arc::clone(&outgoing);
-    tokio::spawn(async move {
+    let listener_span = tracing::info_span!(
+        parent: None,
+        "app_server.thread_listener",
+        codex.thread.id = %conversation_id,
+    );
+    crate::app_server_tracing::link_to_current_span(&listener_span);
+    let listener_task = async move {
         loop {
             tokio::select! {
                 biased;
@@ -382,7 +388,8 @@ pub(super) async fn ensure_listener_task_running(
             thread_state_manager.unregister_listener_command_tx(conversation_id);
             thread_state.clear_listener();
         }
-    });
+    };
+    tokio::spawn(listener_task.instrument(listener_span));
     Ok(())
 }
 
@@ -412,17 +419,41 @@ pub(super) async fn unload_thread_without_subscribers(
         .await;
     thread_state_manager.remove_thread_state(thread_id).await;
 
-    tokio::spawn(async move {
-        match wait_for_thread_shutdown(&thread).await {
-            ThreadShutdownResult::Complete => {
-                if thread_manager.remove_thread(&thread_id).await.is_none() {
-                    info!("thread {thread_id} was already removed before teardown finalized");
-                    thread_watch_manager
-                        .remove_thread(&thread_id.to_string())
-                        .await;
-                    pending_thread_unloads.lock().await.remove(&thread_id);
-                    return;
-                }
+    tokio::spawn(complete_thread_unload(
+        thread_manager,
+        outgoing,
+        pending_thread_unloads,
+        thread_watch_manager,
+        thread_id,
+        thread,
+    ));
+}
+
+#[tracing::instrument(
+    name = "app_server.thread_unload",
+    skip_all,
+    fields(
+        codex.thread.id = %thread_id,
+        thread_unload.outcome = tracing::field::Empty,
+    )
+)]
+async fn complete_thread_unload(
+    thread_manager: Arc<ThreadManager>,
+    outgoing: Arc<OutgoingMessageSender>,
+    pending_thread_unloads: Arc<Mutex<HashSet<ThreadId>>>,
+    thread_watch_manager: ThreadWatchManager,
+    thread_id: ThreadId,
+    thread: Arc<CodexThread>,
+) {
+    let outcome = match wait_for_thread_shutdown(&thread).await {
+        ThreadShutdownResult::Complete => {
+            if thread_manager.remove_thread(&thread_id).await.is_none() {
+                info!("thread {thread_id} was already removed before teardown finalized");
+                thread_watch_manager
+                    .remove_thread(&thread_id.to_string())
+                    .await;
+                "already_removed"
+            } else {
                 thread_watch_manager
                     .remove_thread(&thread_id.to_string())
                     .await;
@@ -432,18 +463,20 @@ pub(super) async fn unload_thread_without_subscribers(
                 outgoing
                     .send_server_notification(ServerNotification::ThreadClosed(notification))
                     .await;
-                pending_thread_unloads.lock().await.remove(&thread_id);
-            }
-            ThreadShutdownResult::SubmitFailed => {
-                pending_thread_unloads.lock().await.remove(&thread_id);
-                warn!("failed to submit Shutdown to thread {thread_id}");
-            }
-            ThreadShutdownResult::TimedOut => {
-                pending_thread_unloads.lock().await.remove(&thread_id);
-                warn!("thread {thread_id} shutdown timed out; leaving thread loaded");
+                "complete"
             }
         }
-    });
+        ThreadShutdownResult::SubmitFailed => {
+            warn!("failed to submit Shutdown to thread {thread_id}");
+            "submit_failed"
+        }
+        ThreadShutdownResult::TimedOut => {
+            warn!("thread {thread_id} shutdown timed out; leaving thread loaded");
+            "timed_out"
+        }
+    };
+    pending_thread_unloads.lock().await.remove(&thread_id);
+    tracing::Span::current().record("thread_unload.outcome", outcome);
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/codex-rs/app-server/src/thread_status.rs
+++ b/codex-rs/app-server/src/thread_status.rs
@@ -15,6 +15,7 @@ use tokio::sync::Mutex;
 #[cfg(test)]
 use tokio::sync::mpsc;
 use tokio::sync::watch;
+use tracing::Instrument;
 
 #[derive(Clone)]
 pub(crate) struct ThreadWatchManager {
@@ -50,11 +51,16 @@ impl Drop for ThreadWatchActiveGuard {
         let manager = self.manager.clone();
         let thread_id = self.thread_id.clone();
         let guard_type = self.guard_type;
-        self.handle.spawn(async move {
+        let release_span = tracing::debug_span!(
+            "app_server.thread_watch_guard_release",
+            codex.thread.id = thread_id.as_str(),
+        );
+        let release_task = async move {
             manager
                 .note_active_guard_released(thread_id, guard_type)
                 .await;
-        });
+        };
+        self.handle.spawn(release_task.instrument(release_span));
     }
 }
 


### PR DESCRIPTION
## intent

complete the app-server tracing audit by covering long-lived work that outlives the rpc which started it, without holding request spans open.

## implementation

add linked root spans for filesystem watchers, fuzzy-search sessions, process exec, thread lifecycle and status, in-process startup, and shutdown cleanup.

## stack

1. [#31721](https://github.com/openai/codex/pull/31721) — rpc outcomes → `main`
2. [#31725](https://github.com/openai/codex/pull/31725) — server requests → layer 1
3. [#31726](https://github.com/openai/codex/pull/31726) — request task context → layer 2
4. [#31723](https://github.com/openai/codex/pull/31723) — detached work → layer 3
5. [#31724](https://github.com/openai/codex/pull/31724) — major surfaces → layer 4

## validation

- `just test -p codex-app-server --lib` (259 passed)
- focused lifecycle, process, shutdown, and thread integration tests (22 passed)
- focused fuzzy-search session integration tests (12 passed)