### PR TITLE
feat(state): add thread history fork bases

### DIFF
--- a/codex-rs/state/thread_history_migrations/0002_thread_history_fork_bases.sql
+++ b/codex-rs/state/thread_history_migrations/0002_thread_history_fork_bases.sql
@@ -1,0 +1,14 @@
+CREATE TABLE thread_history_fork_bases (
+    child_thread_id TEXT PRIMARY KEY,
+    parent_thread_id TEXT NOT NULL,
+    parent_start_thread_id TEXT,
+    parent_start_ordinal INTEGER,
+    parent_end_thread_id TEXT NOT NULL,
+    parent_end_ordinal INTEGER NOT NULL,
+    fork_depth INTEGER NOT NULL,
+    inherited_history_view TEXT NOT NULL,
+    boundary_turn_snapshot_json TEXT
+);
+
+CREATE INDEX idx_thread_history_fork_bases_parent
+    ON thread_history_fork_bases(parent_thread_id);


### PR DESCRIPTION
## Description

Adds the SQLite relation for reference-backed paginated thread forks.

This is an additive schema-only change stacked on #30131. It does not create, resolve, or page fork bases yet.

## Why

Paginated forks should reference a frozen parent range instead of copying inherited turns and items into child-owned rows. The canonical descriptor will live in the child rollout; SQLite keeps a rebuildable cache for bounded pagination and lifecycle checks.

## What changed

- Added `thread_history_fork_bases` keyed by child thread.
- Stored the direct logical parent and concrete half-open start/end positions as thread ID plus rollout ordinal.
- Stored derived fork depth and a versioned inherited-history view discriminator.
- Added an optional typed boundary-turn snapshot payload for forks through active turns.
- Added a parent index for descendant and retention checks.
- Left semantic validation to Rust so adding view variants does not require changing SQLite constraints.

## Validation

- `just test -p codex-state`