### PR TITLE
[3/5] Retain the active step context

### DIFF
--- a/codex-rs/core/src/guardian/review_session.rs
+++ b/codex-rs/core/src/guardian/review_session.rs
@@ -44,6 +44,7 @@ use crate::context::ContextualUserFragment;
 use crate::context::GuardianFollowupReviewReminder;
 use crate::session::Codex;
 use crate::session::session::Session;
+use crate::session::step_context::StepContext;
 use crate::session::turn_context::TurnContext;
 use codex_config::types::McpServerConfig;
 use codex_features::Feature;
@@ -295,10 +296,11 @@ impl GuardianReviewSessionManager {
     pub(crate) fn initialize(
         &self,
         parent_session: Arc<Session>,
-        parent_turn: Arc<TurnContext>,
+        step_context: Arc<StepContext>,
     ) -> BoxFuture<'_, anyhow::Result<()>> {
         // Boxing breaks the Session::new -> Guardian -> Session::new future recursion.
         Box::pin(async move {
+            let parent_turn = Arc::clone(&step_context.turn);
             let spawn_config = guardian_review_session_config(&parent_session, &parent_turn)
                 .await?
                 .spawn_config;

--- a/codex-rs/core/src/session/input_queue.rs
+++ b/codex-rs/core/src/session/input_queue.rs
@@ -111,7 +111,7 @@ impl InputQueue {
             active_turn
                 .task
                 .as_ref()
-                .is_some_and(|task| task.turn_context.sub_id == sub_id)
+                .is_some_and(|task| task.step_context.turn.sub_id == sub_id)
                 .then(|| Arc::clone(&active_turn.turn_state))
         })
     }

--- a/codex-rs/core/src/session/mcp.rs
+++ b/codex-rs/core/src/session/mcp.rs
@@ -597,11 +597,12 @@ async fn review_guardian_mcp_elicitation(
     session: Arc<Session>,
     request: ElicitationReviewRequest,
 ) -> anyhow::Result<Option<ElicitationResponse>> {
-    let Some((turn_context, _cancellation_token)) =
-        session.active_turn_context_and_cancellation_token().await
+    let Some((step_context, _cancellation_token)) =
+        session.active_step_context_and_cancellation_token().await
     else {
         return Ok(None);
     };
+    let turn_context = Arc::clone(&step_context.turn);
 
     let approvals_reviewer = crate::connectors::mcp_approvals_reviewer(
         turn_context.config.as_ref(),

--- a/codex-rs/core/src/session/mod.rs
+++ b/codex-rs/core/src/session/mod.rs
@@ -2041,8 +2041,8 @@ impl Session {
         active
             .as_ref()
             .and_then(|turn| turn.task.as_ref())
-            .filter(|task| task.turn_context.sub_id == sub_id)
-            .map(|task| Arc::clone(&task.turn_context))
+            .filter(|task| task.step_context.turn.sub_id == sub_id)
+            .map(|task| Arc::clone(&task.step_context.turn))
     }
 
     async fn active_turn_context_and_cancellation_token(
@@ -2051,7 +2051,18 @@ impl Session {
         let active = self.active_turn.lock().await;
         let task = active.as_ref()?.task.as_ref()?;
         Some((
-            Arc::clone(&task.turn_context),
+            Arc::clone(&task.step_context.turn),
+            task.cancellation_token.child_token(),
+        ))
+    }
+
+    async fn active_step_context_and_cancellation_token(
+        &self,
+    ) -> Option<(Arc<StepContext>, CancellationToken)> {
+        let active = self.active_turn.lock().await;
+        let task = active.as_ref()?.task.as_ref()?;
+        Some((
+            Arc::clone(&task.step_context),
             task.cancellation_token.child_token(),
         ))
     }
@@ -3856,7 +3867,7 @@ impl Session {
         let Some(active_task) = active_turn.task.as_ref() else {
             return Err(SteerInputError::NoActiveTurn(input));
         };
-        let active_turn_id = &active_task.turn_context.sub_id;
+        let active_turn_id = &active_task.step_context.turn.sub_id;
 
         if let Some(expected_turn_id) = expected_turn_id
             && expected_turn_id != active_turn_id
@@ -3892,7 +3903,8 @@ impl Session {
 
         if let Some(responsesapi_client_metadata) = responsesapi_client_metadata {
             active_task
-                .turn_context
+                .step_context
+                .turn
                 .turn_metadata_state
                 .set_responsesapi_client_metadata(responsesapi_client_metadata);
         }

--- a/codex-rs/core/src/session/step_context.rs
+++ b/codex-rs/core/src/session/step_context.rs
@@ -77,12 +77,21 @@ impl StepContext {
                 &selected_capability_roots,
             )
             .await;
-        Arc::new(Self::new(
+        let step_context = Arc::new(Self::new(
             Arc::clone(&self.turn),
             environments,
             selected_capability_roots,
             mcp,
             loaded_agents_md,
-        ))
+        ));
+
+        let mut active = session.active_turn.lock().await;
+        if let Some(task) = active.as_mut().and_then(|turn| turn.task.as_mut())
+            && task.step_context.turn.sub_id == step_context.turn.sub_id
+        {
+            task.step_context = Arc::clone(&step_context);
+        }
+
+        step_context
     }
 }

--- a/codex-rs/core/src/session_startup_prewarm.rs
+++ b/codex-rs/core/src/session_startup_prewarm.rs
@@ -251,13 +251,17 @@ async fn schedule_startup_prewarm_inner(
         prewarm_started_at.elapsed(),
         /*status*/ None,
     );
+    let step_context = session
+        .capture_step_context(Arc::clone(&startup_turn_context))
+        .refresh_env(&session)
+        .await;
     if routes_approval_to_guardian(&startup_turn_context) {
         let guardian_session = Arc::clone(&session);
-        let guardian_parent_turn = Arc::clone(&startup_turn_context);
+        let guardian_step_context = Arc::clone(&step_context);
         drop(tokio::spawn(async move {
             if let Err(err) = guardian_session
                 .guardian_review_session
-                .initialize(Arc::clone(&guardian_session), guardian_parent_turn)
+                .initialize(Arc::clone(&guardian_session), guardian_step_context)
                 .await
             {
                 warn!("failed to initialize guardian review session: {err:#}");
@@ -267,10 +271,6 @@ async fn schedule_startup_prewarm_inner(
     let startup_cancellation_token = CancellationToken::new();
     let built_tools_started_at = Instant::now();
     // Startup prewarm runs before run_turn and needs its own tool-building snapshot.
-    let step_context = session
-        .capture_step_context(Arc::clone(&startup_turn_context))
-        .refresh_env(&session)
-        .await;
     let startup_router = built_tools(
         session.as_ref(),
         step_context.as_ref(),

--- a/codex-rs/core/src/state/turn.rs
+++ b/codex-rs/core/src/state/turn.rs
@@ -20,7 +20,7 @@ use tokio::sync::oneshot;
 
 use crate::agent::control::AgentExecutionGuard;
 use crate::session::TurnInputQueue;
-use crate::session::turn_context::TurnContext;
+use crate::session::step_context::StepContext;
 use crate::tasks::AnySessionTask;
 use codex_protocol::models::AdditionalPermissionProfile;
 use codex_protocol::protocol::ReviewDecision;
@@ -75,7 +75,7 @@ pub(crate) struct RunningTask {
     pub(crate) task: Arc<dyn AnySessionTask>,
     pub(crate) cancellation_token: CancellationToken,
     pub(crate) handle: AbortOnDropHandle<()>,
-    pub(crate) turn_context: Arc<TurnContext>,
+    pub(crate) step_context: Arc<StepContext>,
     pub(crate) turn_extension_data: Arc<ExtensionData>,
     pub(crate) _agent_execution_guard: Option<AgentExecutionGuard>,
     // Timer recorded when the task drops to capture the full turn duration.

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -364,6 +364,7 @@ impl Session {
         self.emit_turn_start_lifecycle(turn_context.as_ref(), &token_usage_at_turn_start)
             .await;
 
+        let step_context = self.capture_step_context(Arc::clone(&turn_context));
         let turn_extension_data = Arc::clone(&turn_context.extension_data);
         let mut active = self.active_turn.lock().await;
         let turn = active.get_or_insert_with(ActiveTurn::default);
@@ -442,7 +443,7 @@ impl Session {
             kind: task_kind,
             task,
             cancellation_token,
-            turn_context: Arc::clone(&turn_context),
+            step_context,
             turn_extension_data,
             _agent_execution_guard: agent_execution_guard,
             _timer: timer,
@@ -496,7 +497,9 @@ impl Session {
         if let Some(mut active_turn) = self.take_active_turn().await {
             let task = active_turn.task.take();
             aborted_turn = task.is_some();
-            turn_context = task.as_ref().map(|task| Arc::clone(&task.turn_context));
+            turn_context = task
+                .as_ref()
+                .map(|task| Arc::clone(&task.step_context.turn));
             if let Some(task) = task {
                 self.handle_task_abort(task, reason.clone()).await;
             }
@@ -529,7 +532,7 @@ impl Session {
             if active
                 .as_ref()
                 .and_then(|active_turn| active_turn.task.as_ref())
-                .is_some_and(|task| task.turn_context.sub_id == turn_id)
+                .is_some_and(|task| task.step_context.turn.sub_id == turn_id)
             {
                 active.take()
             } else {
@@ -541,7 +544,9 @@ impl Session {
         };
 
         let task = active_turn.task.take();
-        let turn_context = task.as_ref().map(|task| Arc::clone(&task.turn_context));
+        let turn_context = task
+            .as_ref()
+            .map(|task| Arc::clone(&task.step_context.turn));
         if let Some(task) = task {
             self.handle_task_abort(task, reason.clone()).await;
         }
@@ -827,14 +832,15 @@ impl Session {
     }
 
     async fn handle_task_abort(self: &Arc<Self>, task: RunningTask, reason: TurnAbortReason) {
-        let sub_id = task.turn_context.sub_id.clone();
+        let sub_id = task.step_context.turn.sub_id.clone();
         if task.cancellation_token.is_cancelled() {
             return;
         }
 
         trace!(task_kind = ?task.kind, sub_id, "aborting running task");
         task.cancellation_token.cancel();
-        task.turn_context
+        task.step_context
+            .turn
             .turn_metadata_state
             .cancel_git_enrichment_task();
         let session_task = task.task;
@@ -854,19 +860,19 @@ impl Session {
             Arc::clone(&task.turn_extension_data),
         ));
         session_task
-            .abort(session_ctx, Arc::clone(&task.turn_context))
+            .abort(session_ctx, Arc::clone(&task.step_context.turn))
             .await;
 
         if reason == TurnAbortReason::Interrupted
             && let Some(marker) = interrupted_turn_history_marker(
                 InterruptedTurnHistoryMarker::from_config_and_version(
-                    task.turn_context.config.as_ref(),
-                    task.turn_context.multi_agent_version,
+                    task.step_context.turn.config.as_ref(),
+                    task.step_context.turn.multi_agent_version,
                 ),
             )
         {
             self.record_conversation_items(
-                task.turn_context.as_ref(),
+                task.step_context.turn.as_ref(),
                 std::slice::from_ref(&marker),
             )
             .await;
@@ -878,28 +884,30 @@ impl Session {
         }
 
         let (completed_at, duration_ms) = task
-            .turn_context
+            .step_context
+            .turn
             .turn_timing_state
             .completed_at_and_duration_ms()
             .await;
         self.services
             .analytics_events_client
             .track_turn_profile(TurnProfileFact {
-                turn_id: task.turn_context.sub_id.clone(),
-                profile: task.turn_context.turn_timing_state.complete_profile(),
+                turn_id: task.step_context.turn.sub_id.clone(),
+                profile: task.step_context.turn.turn_timing_state.complete_profile(),
             });
         let event = EventMsg::TurnAborted(TurnAbortedEvent {
-            turn_id: Some(task.turn_context.sub_id.clone()),
+            turn_id: Some(task.step_context.turn.sub_id.clone()),
             reason,
             completed_at,
             duration_ms,
         });
-        self.send_event(task.turn_context.as_ref(), event).await;
+        self.send_event(task.step_context.turn.as_ref(), event)
+            .await;
         self.services
             .guardian_rejection_circuit_breaker
             .lock()
             .await
-            .clear_turn(&task.turn_context.sub_id);
+            .clear_turn(&task.step_context.turn.sub_id);
         // Regular items were flushed before this terminal event was appended; buffering
         // thread writers may not flush it without another explicit barrier.
         if let Err(err) = self.flush_rollout().await {

--- a/codex-rs/core/src/tools/network_approval.rs
+++ b/codex-rs/core/src/tools/network_approval.rs
@@ -482,7 +482,7 @@ impl NetworkApprovalService {
         active_turn
             .as_ref()
             .and_then(|turn| turn.task.as_ref())
-            .map(|task| Arc::clone(&task.turn_context))
+            .map(|task| Arc::clone(&task.step_context.turn))
     }
 
     fn format_network_target(protocol: &str, host: &str, port: u16) -> String {


### PR DESCRIPTION
## Why

An MCP elicitation can arrive outside the sampling call stack, where only the active task is available. Guardian review needs the current request-scoped `StepContext` at that boundary. The preceding source-level capture split lets every installed task retain a lightweight step without refreshing environments or starting MCP before the task is visible.

Startup guardian initialization has the same handoff need: it should receive the prewarm step that will build the advertised tools.

## What changed

- Capture a lightweight step with `capture_step_context` before installing `RunningTask`, retain it non-optionally, and read the task turn through `step_context.turn`.
- Publish each later refreshed sampling or pre-compaction step from `refresh_env` under the active-turn lock, with a turn-ID check after the asynchronous refresh.
- Use the active step for asynchronous MCP elicitation lookup, while keeping downstream guardian APIs turn-based in this stage.
- Capture and refresh the startup prewarm step before guardian initialization and hand that exact step to initialization.

Stacked on #31912. This is PR 3 of 5 and does not move reasoning effort.

## Validation

- `cargo check -p codex-core --tests --message-format short`
- `just test -p codex-core --lib` (2,007 passed, 3 skipped at the stack head)
