### PR TITLE
Stop persisting RMCP service traces

### DIFF
--- a/codex-rs/state/src/log_db.rs
+++ b/codex-rs/state/src/log_db.rs
@@ -56,6 +56,7 @@ pub fn default_filter() -> Targets {
         .with_target("log", LevelFilter::OFF)
         .with_target("codex_otel.log_only", LevelFilter::OFF)
         .with_target("codex_otel.trace_safe", LevelFilter::OFF)
+        .with_target("rmcp::service", LevelFilter::INFO)
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Why

The SQLite feedback log enables TRACE by default. `rmcp::service` renders complete MCP service events at TRACE, including large tool catalogs and other protocol payloads. In a busy local sample, this was the largest retained source and individual rows reached about 2 MiB.

These rows can quickly consume the per-thread retention budget, displace smaller diagnostics, and add unnecessary SQLite insert-and-prune work.

## What changed

- Persist `rmcp::service` at INFO and above in the SQLite feedback log.
- Keep service initialization, shutdown, warnings, and errors available for feedback.
- Leave other tracing and OpenTelemetry subscribers unchanged.

This is intentionally target-specific. Broader persistent-log policy changes can remain separate.

Related to #28224.
