### PR TITLE
Filter routine Hyper logs from SQLite

### DIFF
--- a/codex-rs/state/src/log_db.rs
+++ b/codex-rs/state/src/log_db.rs
@@ -53,6 +53,7 @@ const LOG_FLUSH_INTERVAL: Duration = Duration::from_secs(2);
 pub fn default_filter() -> Targets {
     Targets::new()
         .with_default(LevelFilter::TRACE)
+        .with_target("hyper_util", LevelFilter::WARN)
         .with_target("log", LevelFilter::OFF)
         .with_target("codex_otel.log_only", LevelFilter::OFF)
         .with_target("codex_otel.trace_safe", LevelFilter::OFF)


### PR DESCRIPTION
## Why

The SQLite feedback log currently persists Hyper's TRACE, DEBUG, and INFO connection-pool bookkeeping. Healthy connects, checkouts, reuse, and timer activity generated thousands of small rows during active sessions without adding useful feedback context.

## What changed

- Set the `hyper_util` target prefix to WARN for the SQLite feedback-log layer.
- Continue persisting Hyper warnings and errors.
- Leave other tracing and OpenTelemetry subscribers unchanged.

This removes routine dependency chatter while preserving actionable failures.

Related to #28224.
