### PR TITLE
Summarize streamed response item logs

### DIFF
--- a/codex-rs/core/src/stream_events_utils.rs
+++ b/codex-rs/core/src/stream_events_utils.rs
@@ -425,7 +425,26 @@ pub(crate) async fn handle_non_tool_response_item(
     item: &ResponseItem,
     plan_mode: bool,
 ) -> Option<TurnItem> {
-    debug!(?item, "Output item");
+    let item_type = match item {
+        ResponseItem::AdditionalTools { .. } => "additional_tools",
+        ResponseItem::Message { .. } => "message",
+        ResponseItem::AgentMessage { .. } => "agent_message",
+        ResponseItem::Reasoning { .. } => "reasoning",
+        ResponseItem::LocalShellCall { .. } => "local_shell_call",
+        ResponseItem::FunctionCall { .. } => "function_call",
+        ResponseItem::ToolSearchCall { .. } => "tool_search_call",
+        ResponseItem::FunctionCallOutput { .. } => "function_call_output",
+        ResponseItem::CustomToolCall { .. } => "custom_tool_call",
+        ResponseItem::CustomToolCallOutput { .. } => "custom_tool_call_output",
+        ResponseItem::ToolSearchOutput { .. } => "tool_search_output",
+        ResponseItem::WebSearchCall { .. } => "web_search_call",
+        ResponseItem::ImageGenerationCall { .. } => "image_generation_call",
+        ResponseItem::Compaction { .. } => "compaction",
+        ResponseItem::CompactionTrigger { .. } => "compaction_trigger",
+        ResponseItem::ContextCompaction { .. } => "context_compaction",
+        ResponseItem::Other => "other",
+    };
+    debug!(item_type, item_id = item.id(), "Output item");
 
     match item {
         ResponseItem::Message { .. }


### PR DESCRIPTION
## Why

`handle_non_tool_response_item` logged the complete decoded `ResponseItem` at DEBUG. Those values can contain assistant text, reasoning content, and tool payloads that are already stored in the durable rollout, making the SQLite copy both redundant and potentially large or sensitive.

## What changed

- Replace the complete item dump with bounded `item_type` and `item_id` fields.
- Keep an event-flow breadcrumb for debugging without duplicating item content.
- Leave rollout persistence and tool-call telemetry unchanged.

The item-type match is exhaustive so new response item variants must choose an explicit log label.

Related to #28224.
