### PR TITLE
Bound unified exec output collection

### DIFF
--- a/codex-rs/core/src/unified_exec/async_watcher.rs
+++ b/codex-rs/core/src/unified_exec/async_watcher.rs
@@ -326,7 +326,7 @@ async fn resolve_aggregated_output(
         return fallback;
     }
 
-    String::from_utf8_lossy(&guard.to_bytes()).to_string()
+    String::from_utf8_lossy(&guard.to_bytes_with_omission_marker()).to_string()
 }
 
 #[cfg(test)]

--- a/codex-rs/core/src/unified_exec/head_tail_buffer.rs
+++ b/codex-rs/core/src/unified_exec/head_tail_buffer.rs
@@ -10,10 +10,8 @@ pub(crate) struct HeadTailBuffer {
     max_bytes: usize,
     head_budget: usize,
     tail_budget: usize,
-    head: VecDeque<Vec<u8>>,
-    tail: VecDeque<Vec<u8>>,
-    head_bytes: usize,
-    tail_bytes: usize,
+    head: Vec<u8>,
+    tail: VecDeque<u8>,
     omitted_bytes: usize,
 }
 
@@ -35,10 +33,8 @@ impl HeadTailBuffer {
             max_bytes,
             head_budget,
             tail_budget,
-            head: VecDeque::new(),
+            head: Vec::new(),
             tail: VecDeque::new(),
-            head_bytes: 0,
-            tail_bytes: 0,
             omitted_bytes: 0,
         }
     }
@@ -47,7 +43,7 @@ impl HeadTailBuffer {
     #[allow(dead_code)]
     /// Total bytes currently retained by the buffer (head + tail).
     pub(crate) fn retained_bytes(&self) -> usize {
-        self.head_bytes.saturating_add(self.tail_bytes)
+        self.head.len().saturating_add(self.tail.len())
     }
 
     // Used for tests.
@@ -63,31 +59,21 @@ impl HeadTailBuffer {
     /// remaining bytes are added to the tail, with older tail bytes being
     /// dropped to preserve the tail budget.
     pub(crate) fn push_chunk(&mut self, chunk: Vec<u8>) {
+        if chunk.is_empty() {
+            return;
+        }
         if self.max_bytes == 0 {
             self.omitted_bytes = self.omitted_bytes.saturating_add(chunk.len());
             return;
         }
 
         // Fill the head budget first, then keep a capped tail.
-        if self.head_bytes < self.head_budget {
-            let remaining_head = self.head_budget.saturating_sub(self.head_bytes);
-            if chunk.len() <= remaining_head {
-                self.head_bytes = self.head_bytes.saturating_add(chunk.len());
-                self.head.push_back(chunk);
-                return;
-            }
-
-            // Split the chunk: part goes to head, remainder goes to tail.
-            let (head_part, tail_part) = chunk.split_at(remaining_head);
-            if !head_part.is_empty() {
-                self.head_bytes = self.head_bytes.saturating_add(head_part.len());
-                self.head.push_back(head_part.to_vec());
-            }
-            self.push_to_tail(tail_part.to_vec());
-            return;
+        let remaining_head = self.head_budget.saturating_sub(self.head.len());
+        let head_len = remaining_head.min(chunk.len());
+        if head_len > 0 {
+            self.head.extend_from_slice(&chunk[..head_len]);
         }
-
-        self.push_to_tail(chunk);
+        self.push_to_tail(&chunk[head_len..]);
     }
 
     /// Snapshot the retained output as a list of chunks.
@@ -95,9 +81,13 @@ impl HeadTailBuffer {
     /// The returned chunks are ordered as: head chunks first, then tail chunks.
     /// Omitted bytes are not represented in the snapshot.
     pub(crate) fn snapshot_chunks(&self) -> Vec<Vec<u8>> {
-        let mut out = Vec::new();
-        out.extend(self.head.iter().cloned());
-        out.extend(self.tail.iter().cloned());
+        let mut out = Vec::with_capacity(2);
+        if !self.head.is_empty() {
+            out.push(self.head.clone());
+        }
+        if !self.tail.is_empty() {
+            out.push(self.tail.iter().copied().collect());
+        }
         out
     }
 
@@ -107,12 +97,8 @@ impl HeadTailBuffer {
     /// Omitted bytes are not represented in the returned value.
     pub(crate) fn to_bytes(&self) -> Vec<u8> {
         let mut out = Vec::with_capacity(self.retained_bytes());
-        for chunk in self.head.iter() {
-            out.extend_from_slice(chunk);
-        }
-        for chunk in self.tail.iter() {
-            out.extend_from_slice(chunk);
-        }
+        out.extend_from_slice(&self.head);
+        out.extend(self.tail.iter().copied());
         out
     }
 
@@ -126,13 +112,9 @@ impl HeadTailBuffer {
         let omitted_bytes = self.omitted_bytes;
         let marker = format!("\n... {omitted_bytes} bytes omitted ...\n");
         let mut out = Vec::with_capacity(self.retained_bytes().saturating_add(marker.len()));
-        for chunk in self.head.iter() {
-            out.extend_from_slice(chunk);
-        }
+        out.extend_from_slice(&self.head);
         out.extend_from_slice(marker.as_bytes());
-        for chunk in self.tail.iter() {
-            out.extend_from_slice(chunk);
-        }
+        out.extend(self.tail.iter().copied());
         out
     }
 
@@ -141,15 +123,21 @@ impl HeadTailBuffer {
     /// The drained chunks are returned in head-then-tail order. Omitted bytes
     /// are discarded along with the retained content.
     pub(crate) fn drain_chunks(&mut self) -> Vec<Vec<u8>> {
-        let mut out: Vec<Vec<u8>> = self.head.drain(..).collect();
-        out.extend(self.tail.drain(..));
-        self.head_bytes = 0;
-        self.tail_bytes = 0;
+        let mut out = Vec::with_capacity(2);
+        if !self.head.is_empty() {
+            out.push(std::mem::take(&mut self.head));
+        }
+        if !self.tail.is_empty() {
+            out.push(self.tail.drain(..).collect());
+        }
         self.omitted_bytes = 0;
         out
     }
 
-    fn push_to_tail(&mut self, chunk: Vec<u8>) {
+    fn push_to_tail(&mut self, chunk: &[u8]) {
+        if chunk.is_empty() {
+            return;
+        }
         if self.tail_budget == 0 {
             self.omitted_bytes = self.omitted_bytes.saturating_add(chunk.len());
             return;
@@ -159,41 +147,26 @@ impl HeadTailBuffer {
             // This single chunk is larger than the whole tail budget. Keep only the last
             // tail_budget bytes and drop everything else.
             let start = chunk.len().saturating_sub(self.tail_budget);
-            let kept = chunk[start..].to_vec();
+            let kept = &chunk[start..];
             let dropped = chunk.len().saturating_sub(kept.len());
             self.omitted_bytes = self
                 .omitted_bytes
-                .saturating_add(self.tail_bytes)
+                .saturating_add(self.tail.len())
                 .saturating_add(dropped);
             self.tail.clear();
-            self.tail_bytes = kept.len();
-            self.tail.push_back(kept);
+            self.tail.extend(kept);
             return;
         }
 
-        self.tail_bytes = self.tail_bytes.saturating_add(chunk.len());
-        self.tail.push_back(chunk);
+        self.tail.extend(chunk);
         self.trim_tail_to_budget();
     }
 
     fn trim_tail_to_budget(&mut self) {
-        let mut excess = self.tail_bytes.saturating_sub(self.tail_budget);
-        while excess > 0 {
-            match self.tail.front_mut() {
-                Some(front) if excess >= front.len() => {
-                    excess -= front.len();
-                    self.tail_bytes = self.tail_bytes.saturating_sub(front.len());
-                    self.omitted_bytes = self.omitted_bytes.saturating_add(front.len());
-                    self.tail.pop_front();
-                }
-                Some(front) => {
-                    front.drain(..excess);
-                    self.tail_bytes = self.tail_bytes.saturating_sub(excess);
-                    self.omitted_bytes = self.omitted_bytes.saturating_add(excess);
-                    break;
-                }
-                None => break,
-            }
+        let excess = self.tail.len().saturating_sub(self.tail_budget);
+        if excess > 0 {
+            drop(self.tail.drain(..excess));
+            self.omitted_bytes = self.omitted_bytes.saturating_add(excess);
         }
     }
 }

--- a/codex-rs/core/src/unified_exec/head_tail_buffer.rs
+++ b/codex-rs/core/src/unified_exec/head_tail_buffer.rs
@@ -116,6 +116,26 @@ impl HeadTailBuffer {
         out
     }
 
+    /// Return the retained output with an explicit marker between the head and
+    /// tail when bytes were omitted.
+    pub(crate) fn to_bytes_with_omission_marker(&self) -> Vec<u8> {
+        if self.omitted_bytes == 0 {
+            return self.to_bytes();
+        }
+
+        let omitted_bytes = self.omitted_bytes;
+        let marker = format!("\n... {omitted_bytes} bytes omitted ...\n");
+        let mut out = Vec::with_capacity(self.retained_bytes().saturating_add(marker.len()));
+        for chunk in self.head.iter() {
+            out.extend_from_slice(chunk);
+        }
+        out.extend_from_slice(marker.as_bytes());
+        for chunk in self.tail.iter() {
+            out.extend_from_slice(chunk);
+        }
+        out
+    }
+
     /// Drain all retained chunks from the buffer and reset its state.
     ///
     /// The drained chunks are returned in head-then-tail order. Omitted bytes

--- a/codex-rs/core/src/unified_exec/head_tail_buffer_tests.rs
+++ b/codex-rs/core/src/unified_exec/head_tail_buffer_tests.rs
@@ -16,6 +16,10 @@ fn keeps_prefix_and_suffix_when_over_budget() {
     let rendered = String::from_utf8_lossy(&buf.to_bytes()).to_string();
     assert!(rendered.starts_with("01234"));
     assert!(rendered.ends_with("89ab"));
+    assert_eq!(
+        String::from_utf8_lossy(&buf.to_bytes_with_omission_marker()),
+        "01234\n... 2 bytes omitted ...\n789ab"
+    );
 }
 
 #[test]

--- a/codex-rs/core/src/unified_exec/head_tail_buffer_tests.rs
+++ b/codex-rs/core/src/unified_exec/head_tail_buffer_tests.rs
@@ -91,3 +91,20 @@ fn fills_head_then_tail_across_multiple_chunks() {
     assert_eq!(buf.to_bytes(), b"012346789a".to_vec());
     assert_eq!(buf.omitted_bytes(), 1);
 }
+
+#[test]
+fn empty_and_tiny_chunks_have_bounded_metadata() {
+    let mut buf = HeadTailBuffer::new(/*max_bytes*/ 10);
+
+    for byte in b"0123456789ab" {
+        buf.push_chunk(Vec::new());
+        buf.push_chunk(vec![*byte]);
+    }
+
+    assert_eq!(
+        buf.snapshot_chunks(),
+        vec![b"01234".to_vec(), b"789ab".to_vec()]
+    );
+    assert_eq!(buf.retained_bytes(), 10);
+    assert_eq!(buf.omitted_bytes(), 2);
+}

--- a/codex-rs/core/src/unified_exec/mod_tests.rs
+++ b/codex-rs/core/src/unified_exec/mod_tests.rs
@@ -327,17 +327,11 @@ fn push_chunk_preserves_prefix_and_suffix() {
 
     assert_eq!(buffer.retained_bytes(), UNIFIED_EXEC_OUTPUT_MAX_BYTES);
     let snapshot = buffer.snapshot_chunks();
-
-    let first = snapshot.first().expect("expected at least one chunk");
-    assert_eq!(first.first(), Some(&b'a'));
-    assert!(snapshot.iter().any(|chunk| chunk.as_slice() == b"b"));
-    assert_eq!(
-        snapshot
-            .last()
-            .expect("expected at least one chunk")
-            .as_slice(),
-        b"c"
-    );
+    let head_bytes = UNIFIED_EXEC_OUTPUT_MAX_BYTES / 2;
+    let tail_bytes = UNIFIED_EXEC_OUTPUT_MAX_BYTES - head_bytes;
+    let mut expected_tail = vec![b'a'; tail_bytes - 2];
+    expected_tail.extend_from_slice(b"bc");
+    assert_eq!(snapshot, vec![vec![b'a'; head_bytes], expected_tail]);
 }
 
 #[test]

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -1285,7 +1285,7 @@ impl UnifiedExecProcessManager {
             }
         }
 
-        collected.to_bytes()
+        collected.to_bytes_with_omission_marker()
     }
 
     async fn extend_deadlines_while_paused(

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -1210,7 +1210,7 @@ impl UnifiedExecProcessManager {
     ) -> Vec<u8> {
         const POST_EXIT_CLOSE_WAIT_CAP: Duration = Duration::from_millis(50);
 
-        let mut collected: Vec<u8> = Vec::with_capacity(4096);
+        let mut collected = HeadTailBuffer::default();
         let mut exit_signal_received = cancellation_token.is_cancelled();
         let mut post_exit_deadline: Option<Instant> = None;
         loop {
@@ -1276,7 +1276,7 @@ impl UnifiedExecProcessManager {
             }
 
             for chunk in drained_chunks {
-                collected.extend_from_slice(&chunk);
+                collected.push_chunk(chunk);
             }
 
             exit_signal_received |= cancellation_token.is_cancelled();
@@ -1285,7 +1285,7 @@ impl UnifiedExecProcessManager {
             }
         }
 
-        collected
+        collected.to_bytes()
     }
 
     async fn extend_deadlines_while_paused(

--- a/codex-rs/core/src/unified_exec/process_manager_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_manager_tests.rs
@@ -278,8 +278,10 @@ async fn output_collection_stays_bounded_across_repeated_drains() {
     let (collected, ()) = tokio::join!(collect, produce);
     let head_bytes = crate::unified_exec::UNIFIED_EXEC_OUTPUT_MAX_BYTES / 2;
     let tail_bytes = crate::unified_exec::UNIFIED_EXEC_OUTPUT_MAX_BYTES - head_bytes;
+    let omitted_bytes = 2 * crate::unified_exec::UNIFIED_EXEC_OUTPUT_MAX_BYTES;
     let mut expected = vec![b'a'; head_bytes];
-    expected.resize(head_bytes + tail_bytes, b'c');
+    expected.extend_from_slice(format!("\n... {omitted_bytes} bytes omitted ...\n").as_bytes());
+    expected.resize(expected.len() + tail_bytes, b'c');
     assert_eq!(collected, expected);
 }
 

--- a/codex-rs/core/src/unified_exec/process_manager_tests.rs
+++ b/codex-rs/core/src/unified_exec/process_manager_tests.rs
@@ -235,6 +235,55 @@ fn initial_exec_yield_time_has_no_platform_floor() {
 }
 
 #[tokio::test]
+async fn output_collection_stays_bounded_across_repeated_drains() {
+    let output_buffer = Arc::new(tokio::sync::Mutex::new(HeadTailBuffer::default()));
+    let output_notify = Arc::new(Notify::new());
+    let output_closed = Arc::new(AtomicBool::new(false));
+    let output_closed_notify = Arc::new(Notify::new());
+    let cancellation_token = CancellationToken::new();
+
+    let collect = UnifiedExecProcessManager::collect_output_until_deadline(
+        &output_buffer,
+        &output_notify,
+        &output_closed,
+        &output_closed_notify,
+        &cancellation_token,
+        /*pause_state*/ None,
+        Instant::now() + Duration::from_secs(5),
+    );
+    let produce = async {
+        for byte in [b'a', b'b', b'c'] {
+            output_buffer.lock().await.push_chunk(
+                vec![byte; crate::unified_exec::UNIFIED_EXEC_OUTPUT_MAX_BYTES],
+            );
+            output_notify.notify_one();
+            tokio::time::timeout(Duration::from_secs(1), async {
+                loop {
+                    if output_buffer.lock().await.retained_bytes() == 0 {
+                        break;
+                    }
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("collector should drain each chunk");
+        }
+
+        output_closed.store(true, Ordering::Release);
+        cancellation_token.cancel();
+        output_closed_notify.notify_waiters();
+        output_notify.notify_waiters();
+    };
+
+    let (collected, ()) = tokio::join!(collect, produce);
+    let head_bytes = crate::unified_exec::UNIFIED_EXEC_OUTPUT_MAX_BYTES / 2;
+    let tail_bytes = crate::unified_exec::UNIFIED_EXEC_OUTPUT_MAX_BYTES - head_bytes;
+    let mut expected = vec![b'a'; head_bytes];
+    expected.resize(head_bytes + tail_bytes, b'c');
+    assert_eq!(collected, expected);
+}
+
+#[tokio::test]
 async fn network_denial_fallback_message_names_sandbox_network_proxy() {
     let message = network_denial_message_for_session(/*session*/ None, /*deferred*/ None).await;
 


### PR DESCRIPTION
## Why

Unified exec stores process output in a 1 MiB head/tail buffer, but each poll drained that buffer into an uncapped `Vec`. An executor that kept producing output during the yield window could therefore make one `exec_command` or `write_stdin` call retain much more than the intended limit.

Simply joining the retained head and tail would also make omitted output look contiguous and complete.

## What changed

- Collect drained output into another `HeadTailBuffer` instead of an uncapped `Vec`.
- Keep draining process output after the limit is reached so the producer does not become blocked.
- Preserve the beginning and end of the output using the existing 1 MiB policy.
- Store retained output in at most two byte containers, dropping empty chunks and coalescing tiny chunks so metadata cannot grow with event count.
- Insert an explicit omitted-byte marker between the retained head and tail whenever output is dropped.
- Add regression coverage for repeated full-buffer drains and adversarial empty and tiny chunks.

## Scope

This only changes call-local unified-exec output collection and the private head/tail buffer it uses. Executor transport framing and process-event queue limits are separate concerns.
