### PR TITLE
Stabilize the memories feature flag

### DIFF
--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -925,11 +925,7 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::MemoryTool,
         key: "memories",
-        stage: Stage::Experimental {
-            name: "Memories",
-            menu_description: "Allow Codex to create new memories from conversations and bring relevant memories into new conversations.",
-            announcement: "NEW: Codex can now generate and use memories. Try it now with `/memories`",
-        },
+        stage: Stage::Stable,
         default_enabled: false,
     },
     FeatureSpec {


### PR DESCRIPTION
Memories is graduating from the experimental lifecycle, but it should remain opt-in.

This changes the feature stage to stable while keeping `default_enabled` false. It removes memories from the experimental menu and announcement without enabling it by default.

Companion Codex Apps PR: https://github.com/openai/openai/pull/1110434
