### PR TITLE
Bound exec-server JSON-RPC heap expansion

### DIFF
--- a/codex-rs/exec-server-protocol/src/rpc.rs
+++ b/codex-rs/exec-server-protocol/src/rpc.rs
@@ -7,9 +7,23 @@ use std::fmt;
 
 use codex_protocol::protocol::W3cTraceContext;
 use serde::Deserialize;
+use serde::Deserializer;
 use serde::Serialize;
+use serde::de;
+use serde::de::DeserializeSeed;
+use serde::de::MapAccess;
+use serde::de::SeqAccess;
+use serde::de::Visitor;
+use serde_json::Map;
+use serde_json::Number;
+use serde_json::Value;
 
 pub const JSONRPC_VERSION: &str = "2.0";
+
+// A maximum-size fs/walk response has at most 50,000 entries and needs roughly
+// 150,000 JSON values. Keep ample headroom for legitimate protocol messages
+// while preventing compact arrays from expanding into millions of heap values.
+const MAX_JSONRPC_VALUE_NODES: usize = 256 * 1024;
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, Ord, Deserialize, Serialize, Hash, Eq)]
 #[serde(untagged)]
@@ -30,13 +44,153 @@ impl fmt::Display for RequestId {
 pub type Result = serde_json::Value;
 
 /// Any valid exec-server JSON-RPC object that can be decoded from or encoded onto the wire.
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum JSONRPCMessage {
     Request(JSONRPCRequest),
     Notification(JSONRPCNotification),
     Response(JSONRPCResponse),
     Error(JSONRPCError),
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum JSONRPCMessageRepr {
+    Request(JSONRPCRequest),
+    Notification(JSONRPCNotification),
+    Response(JSONRPCResponse),
+    Error(JSONRPCError),
+}
+
+impl From<JSONRPCMessageRepr> for JSONRPCMessage {
+    fn from(value: JSONRPCMessageRepr) -> Self {
+        match value {
+            JSONRPCMessageRepr::Request(request) => Self::Request(request),
+            JSONRPCMessageRepr::Notification(notification) => Self::Notification(notification),
+            JSONRPCMessageRepr::Response(response) => Self::Response(response),
+            JSONRPCMessageRepr::Error(error) => Self::Error(error),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for JSONRPCMessage {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let mut remaining = MAX_JSONRPC_VALUE_NODES;
+        let value = BoundedValueSeed {
+            remaining: &mut remaining,
+        }
+        .deserialize(deserializer)?;
+        JSONRPCMessageRepr::deserialize(value)
+            .map(Self::from)
+            .map_err(de::Error::custom)
+    }
+}
+
+struct BoundedValueSeed<'a> {
+    remaining: &'a mut usize,
+}
+
+impl<'de> DeserializeSeed<'de> for BoundedValueSeed<'_> {
+    type Value = Value;
+
+    fn deserialize<D>(self, deserializer: D) -> std::result::Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let Some(remaining) = self.remaining.checked_sub(1) else {
+            return Err(de::Error::custom(format!(
+                "JSON-RPC message exceeds the limit of {MAX_JSONRPC_VALUE_NODES} JSON values"
+            )));
+        };
+        *self.remaining = remaining;
+        deserializer.deserialize_any(BoundedValueVisitor {
+            remaining: self.remaining,
+        })
+    }
+}
+
+struct BoundedValueVisitor<'a> {
+    remaining: &'a mut usize,
+}
+
+impl<'de> Visitor<'de> for BoundedValueVisitor<'_> {
+    type Value = Value;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a JSON value within the exec-server complexity limit")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> std::result::Result<Self::Value, E> {
+        Ok(Value::Bool(value))
+    }
+
+    fn visit_i64<E>(self, value: i64) -> std::result::Result<Self::Value, E> {
+        Ok(Value::Number(value.into()))
+    }
+
+    fn visit_u64<E>(self, value: u64) -> std::result::Result<Self::Value, E> {
+        Ok(Value::Number(value.into()))
+    }
+
+    fn visit_f64<E>(self, value: f64) -> std::result::Result<Self::Value, E> {
+        Ok(Number::from_f64(value).map_or(Value::Null, Value::Number))
+    }
+
+    fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E> {
+        Ok(Value::String(value.to_string()))
+    }
+
+    fn visit_string<E>(self, value: String) -> std::result::Result<Self::Value, E> {
+        Ok(Value::String(value))
+    }
+
+    fn visit_none<E>(self) -> std::result::Result<Self::Value, E> {
+        Ok(Value::Null)
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> std::result::Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        BoundedValueSeed {
+            remaining: self.remaining,
+        }
+        .deserialize(deserializer)
+    }
+
+    fn visit_unit<E>(self) -> std::result::Result<Self::Value, E> {
+        Ok(Value::Null)
+    }
+
+    fn visit_seq<A>(self, mut sequence: A) -> std::result::Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::new();
+        while let Some(value) = sequence.next_element_seed(BoundedValueSeed {
+            remaining: &mut *self.remaining,
+        })? {
+            values.push(value);
+        }
+        Ok(Value::Array(values))
+    }
+
+    fn visit_map<A>(self, mut object: A) -> std::result::Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut values = Map::new();
+        while let Some(key) = object.next_key::<String>()? {
+            let value = object.next_value_seed(BoundedValueSeed {
+                remaining: &mut *self.remaining,
+            })?;
+            values.insert(key, value);
+        }
+        Ok(Value::Object(values))
+    }
 }
 
 /// A request that expects a response.
@@ -79,3 +233,7 @@ pub struct JSONRPCErrorError {
     pub data: Option<serde_json::Value>,
     pub message: String,
 }
+
+#[cfg(test)]
+#[path = "rpc_tests.rs"]
+mod tests;

--- a/codex-rs/exec-server-protocol/src/rpc.rs
+++ b/codex-rs/exec-server-protocol/src/rpc.rs
@@ -184,6 +184,11 @@ impl<'de> Visitor<'de> for BoundedValueVisitor<'_> {
     {
         let mut values = Map::new();
         while let Some(key) = object.next_key::<String>()? {
+            if values.contains_key(&key) {
+                return Err(de::Error::custom(format!(
+                    "duplicate JSON object key `{key}`"
+                )));
+            }
             let value = object.next_value_seed(BoundedValueSeed {
                 remaining: &mut *self.remaining,
             })?;

--- a/codex-rs/exec-server-protocol/src/rpc_tests.rs
+++ b/codex-rs/exec-server-protocol/src/rpc_tests.rs
@@ -61,6 +61,19 @@ fn accepts_large_scalar_payload() -> serde_json::Result<()> {
 }
 
 #[test]
+fn rejects_duplicate_object_keys() {
+    let error = serde_json::from_str::<JSONRPCMessage>(r#"{"method":"safe","method":"dangerous"}"#)
+        .expect_err("duplicate JSON object keys should be rejected");
+
+    assert!(
+        error
+            .to_string()
+            .contains("duplicate JSON object key `method`"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
 fn rejects_compact_array_heap_amplification() {
     const REPRO_VALUE_COUNT: usize = 2_097_137;
     const REPRO_MESSAGE_BYTES: usize = 4_194_303;

--- a/codex-rs/exec-server-protocol/src/rpc_tests.rs
+++ b/codex-rs/exec-server-protocol/src/rpc_tests.rs
@@ -1,0 +1,86 @@
+use pretty_assertions::assert_eq;
+use serde_json::json;
+
+use super::JSONRPCError;
+use super::JSONRPCErrorError;
+use super::JSONRPCMessage;
+use super::JSONRPCNotification;
+use super::JSONRPCRequest;
+use super::JSONRPCResponse;
+use super::MAX_JSONRPC_VALUE_NODES;
+use super::RequestId;
+
+#[test]
+fn round_trips_every_jsonrpc_message_variant() -> serde_json::Result<()> {
+    let messages = [
+        JSONRPCMessage::Request(JSONRPCRequest {
+            id: RequestId::Integer(1),
+            method: "request".to_string(),
+            params: Some(json!({"items": [1, 2, 3]})),
+            trace: None,
+        }),
+        JSONRPCMessage::Notification(JSONRPCNotification {
+            method: "notification".to_string(),
+            params: Some(json!({"enabled": true})),
+        }),
+        JSONRPCMessage::Response(JSONRPCResponse {
+            id: RequestId::String("response".to_string()),
+            result: json!({"value": "ok"}),
+        }),
+        JSONRPCMessage::Error(JSONRPCError {
+            error: JSONRPCErrorError {
+                code: -32603,
+                data: Some(json!({"retryable": false})),
+                message: "failed".to_string(),
+            },
+            id: RequestId::Integer(2),
+        }),
+    ];
+
+    for expected in messages {
+        let encoded = serde_json::to_string(&expected)?;
+        let actual = serde_json::from_str::<JSONRPCMessage>(&encoded)?;
+        assert_eq!(actual, expected);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn accepts_large_scalar_payload() -> serde_json::Result<()> {
+    let expected = JSONRPCMessage::Notification(JSONRPCNotification {
+        method: "large".to_string(),
+        params: Some(json!({"data": "x".repeat(MAX_JSONRPC_VALUE_NODES + 1)})),
+    });
+
+    let encoded = serde_json::to_string(&expected)?;
+    let actual = serde_json::from_str::<JSONRPCMessage>(&encoded)?;
+
+    assert_eq!(actual, expected);
+    Ok(())
+}
+
+#[test]
+fn rejects_compact_array_heap_amplification() {
+    const REPRO_VALUE_COUNT: usize = 2_097_137;
+    const REPRO_MESSAGE_BYTES: usize = 4_194_303;
+
+    let mut encoded = String::with_capacity(REPRO_MESSAGE_BYTES);
+    encoded.push_str(r#"{"method":"probe","params":["#);
+    for index in 0..REPRO_VALUE_COUNT {
+        if index != 0 {
+            encoded.push(',');
+        }
+        encoded.push('0');
+    }
+    encoded.push_str("]}");
+    assert_eq!(encoded.len(), REPRO_MESSAGE_BYTES);
+
+    let error = serde_json::from_str::<JSONRPCMessage>(&encoded)
+        .expect_err("amplification payload should exceed the JSON value limit");
+    let expected_error = format!("exceeds the limit of {MAX_JSONRPC_VALUE_NODES} JSON values");
+    assert!(
+        error.to_string().contains(&expected_error),
+        "unexpected error: {error}"
+    );
+}

--- a/codex-rs/exec-server/src/rpc.rs
+++ b/codex-rs/exec-server/src/rpc.rs
@@ -607,10 +607,11 @@ where
     P: DeserializeOwned,
 {
     let params = params.unwrap_or(Value::Null);
-    match serde_json::from_value(params.clone()) {
+    let retry_as_null = matches!(&params, Value::Object(map) if map.is_empty());
+    match serde_json::from_value(params) {
         Ok(params) => Ok(params),
         Err(err) => {
-            if matches!(params, Value::Object(ref map) if map.is_empty()) {
+            if retry_as_null {
                 serde_json::from_value(Value::Null).map_err(|_| err)
             } else {
                 Err(err)

--- a/codex-rs/exec-server/src/server/file_system_handler.rs
+++ b/codex-rs/exec-server/src/server/file_system_handler.rs
@@ -11,6 +11,7 @@ use crate::ExecutorFileSystem;
 use crate::RemoveOptions;
 use crate::file_read::FileReadHandleManager;
 use crate::local_file_system::LocalFileSystem;
+use crate::protocol::FS_READ_DIRECTORY_METHOD;
 use crate::protocol::FS_WRITE_FILE_METHOD;
 use crate::protocol::FsCanonicalizeParams;
 use crate::protocol::FsCanonicalizeResponse;
@@ -42,6 +43,9 @@ use crate::rpc::invalid_request;
 use crate::rpc::not_found;
 
 const MAX_FILE_READ_HANDLE_ID_BYTES: usize = 32;
+// Each read-directory entry needs four JSON values. Keep same-version
+// producers comfortably below the shared 256K-value decoder budget.
+const MAX_READ_DIRECTORY_ENTRIES: usize = 50_000;
 
 #[derive(Clone)]
 pub(crate) struct FileSystemHandler {
@@ -189,7 +193,14 @@ impl FileSystemHandler {
             .file_system
             .read_directory(&params.path, params.sandbox.as_ref())
             .await
-            .map_err(map_fs_error)?
+            .map_err(map_fs_error)?;
+        let entry_count = entries.len();
+        if entry_count > MAX_READ_DIRECTORY_ENTRIES {
+            return Err(internal_error(format!(
+                "{FS_READ_DIRECTORY_METHOD} returned {entry_count} entries; limit is {MAX_READ_DIRECTORY_ENTRIES}"
+            )));
+        }
+        let entries = entries
             .into_iter()
             .map(|entry| FsReadDirectoryEntry {
                 file_name: entry.file_name,


### PR DESCRIPTION
## Why

The exec-server transports cap serialized messages, but the shared JSON-RPC decoder could turn a small, valid message into a much larger heap allocation before method routing.

In a focused macOS parse using the production protocol type, the concrete reproduction was a notification whose `params` was a flat array of zeroes:

| Measurement | Result |
| --- | ---: |
| Serialized message | 4,194,303 bytes |
| Array elements | 2,097,137 |
| RSS before parsing | 12,992 KiB |
| RSS after parsing | 246,048 KiB |
| RSS increase | 233,056 KiB / 56.9x |

Each `0` costs about two bytes on the wire, but becomes a full `serde_json::Value` in memory. The untagged JSON-RPC envelope also needs an intermediate representation while it selects request, notification, response, or error. Method lookup happens later, so an unknown method does not protect the process. At the 64 MiB serialized ceiling, the same shape can require several GiB and terminate the orchestrator.

## What changed

- Decode every `JSONRPCMessage` through a shared, budgeted JSON-value visitor.
- Stop decoding after 262,144 JSON values, before a compact array can grow into millions of heap objects.
- Apply the same limit automatically to stdio, WebSocket, relay, and Noise because they all deserialize the shared protocol type.
- Reject duplicate JSON object keys instead of changing typed envelope fields to last-wins behavior.
- Limit same-version `fs/readDirectory` producers to 50,000 entries, keeping their responses below the shared decoder budget.
- Preserve the existing untagged envelope selection after the bounded tree is built, so valid request, notification, response, and error messages keep the same wire shape.
- Move request params into typed decoding instead of cloning the full JSON tree first.
- Add the exact 4,194,303-byte reproduction and duplicate-key case as regression tests.

## Why 262,144 values

The largest configured `fs/walk` response can contain 50,000 entries, which is roughly 150,000 JSON values before the small fixed envelope. A maximum same-version `fs/readDirectory` response contains about 200,004 values. A 262,144-value ceiling leaves headroom for both while putting the reproduction about 8x over budget.

This is a structural limit, not a byte limit. A large scalar string counts as one value, so base64 file payloads remain governed by the transport's serialized-message ceiling rather than this guard. The tests explicitly cover a scalar larger than 262,144 bytes.

## Behavior and scope

Messages over the value budget or with duplicate object keys follow the existing malformed-message path. A same-version server returns a JSON-RPC error instead of producing an `fs/readDirectory` response with more than 50,000 entries. Serialization and the JSON-RPC wire schema do not change; this intentionally assumes the client and exec-server move together and adds no version negotiation.

This complements #31782: that PR bounds raw stdio framing at 64 MiB; this PR bounds the heap expansion that can happen inside an accepted frame. Existing Noise and WebSocket byte ceilings are unchanged.

This PR intentionally does not add method-specific limits beyond the producer guard above or a byte-weighted budget spanning every queued and in-flight RPC owner. That would require carrying ownership permits through notifications, pending responses, and typed decoding. It is a separate hardening layer; this change closes the demonstrated single-message structural amplification without introducing that machinery.
