### PR TITLE
fix(sandboxing): initialize network proxy config inline

### DIFF
--- a/codex-rs/sandboxing/src/seatbelt_tests.rs
+++ b/codex-rs/sandboxing/src/seatbelt_tests.rs
@@ -657,9 +657,11 @@ async fn create_seatbelt_args_merges_proxy_and_explicit_unix_socket_paths() -> a
     );
     let network_socket = "/tmp/codex-proxy-use";
     let explicit_socket = "/tmp/codex-browser-use";
-    let mut network_config = NetworkProxyConfig::default();
-    network_config.enabled = true;
-    network_config.mode = NetworkMode::Full;
+    let mut network_config = NetworkProxyConfig {
+        enabled: true,
+        mode: NetworkMode::Full,
+        ..Default::default()
+    };
     network_config.set_allow_unix_sockets(vec![network_socket.to_string()]);
     let state = build_config_state(network_config, NetworkProxyConstraints::default())?;
     let network_proxy = NetworkProxy::builder()


### PR DESCRIPTION
## Why

PR #31767 flattened `NetworkProxyConfig`, leaving the [seatbelt test setup](https://github.com/openai/codex/blob/d72d669ca727a26765315ffe03db3dd2594d9b91/codex-rs/sandboxing/src/seatbelt_tests.rs#L660-L662) to assign fields directly after `NetworkProxyConfig::default()`. Rust 1.95 flags that pattern as `clippy::field_reassign_with_default`, and the macOS Bazel Clippy job treats the warning as an error, blocking `main` and PRs based on it.

## What Changed

Initialize `enabled` and `mode` in the `NetworkProxyConfig` struct literal, then apply the Unix socket allowlist through the existing setter. This preserves the test behavior while satisfying Clippy.

## How to Test

This is a test-only initialization change, so there is no manual product flow.

Targeted tests:

- `just test -p codex-sandboxing` (65 passed)
- `just clippy -p codex-sandboxing`

The local argument-comment lint could not complete because Bazel's LLVM repository is missing the `compiler-rt` BUILD package. The touched Rust diff was manually audited and adds no positional literal calls.
