### PR TITLE
Preserve first-party plugin execution context

### DIFF
--- a/codex-rs/core-plugins/src/loader.rs
+++ b/codex-rs/core-plugins/src/loader.rs
@@ -1,3 +1,5 @@
+use crate::OPENAI_API_CURATED_MARKETPLACE_NAME;
+use crate::OPENAI_CURATED_MARKETPLACE_NAME;
 use crate::app_mcp_routing::apply_app_mcp_routing_policy;
 use crate::app_mcp_routing::apps_route_available;
 use crate::is_openai_curated_marketplace_name;
@@ -14,6 +16,9 @@ use crate::marketplace_policy::configured_plugins_from_stack;
 use crate::npm_source::materialize_npm_plugin_source;
 use crate::remote::REMOTE_GLOBAL_MARKETPLACE_NAME;
 use crate::remote::RemoteInstalledPlugin;
+use crate::startup_sync::curated_plugins_api_marketplace_path;
+use crate::startup_sync::curated_plugins_repo_path;
+use crate::startup_sync::read_curated_plugins_sha;
 use crate::store::PluginStore;
 use crate::store::plugin_version_for_source;
 use crate::store::plugin_version_for_source_with_fallback_manifest;
@@ -762,6 +767,7 @@ async fn load_plugin(
         manifest_name: None,
         plugin_namespace: None,
         manifest_description: None,
+        is_first_party: false,
         root,
         enabled: plugin.enabled,
         skill_roots: Vec::new(),
@@ -802,6 +808,7 @@ async fn load_plugin(
         return loaded_plugin;
     };
 
+    loaded_plugin.is_first_party = is_openai_curated_plugin(&loaded_plugin_id, &plugin_root, store);
     let manifest_paths = &manifest.paths;
     loaded_plugin.plugin_namespace = Some(manifest.name.clone());
     match scope {
@@ -844,6 +851,45 @@ async fn load_plugin(
     loaded_plugin.hook_sources = hook_sources;
     loaded_plugin.hook_load_warnings = hook_load_warnings;
     loaded_plugin
+}
+
+fn is_openai_curated_plugin(
+    plugin_id: &PluginId,
+    loaded_root: &AbsolutePathBuf,
+    store: &PluginStore,
+) -> bool {
+    if !is_openai_curated_marketplace_name(&plugin_id.marketplace_name) {
+        return false;
+    }
+
+    let Some(curated_sha) = read_curated_plugins_sha(store.codex_home()) else {
+        return false;
+    };
+    let expected_version = curated_plugin_cache_version(&curated_sha);
+    let expected_root = store.plugin_root(plugin_id, &expected_version);
+    if loaded_root != &expected_root || !expected_root.as_path().is_dir() {
+        return false;
+    }
+
+    let marketplace_path = match plugin_id.marketplace_name.as_str() {
+        OPENAI_CURATED_MARKETPLACE_NAME => {
+            curated_plugins_repo_path(store.codex_home()).join(".agents/plugins/marketplace.json")
+        }
+        OPENAI_API_CURATED_MARKETPLACE_NAME => {
+            curated_plugins_api_marketplace_path(store.codex_home())
+        }
+        _ => return false,
+    };
+    let Ok(marketplace_path) = AbsolutePathBuf::try_from(marketplace_path) else {
+        return false;
+    };
+    load_marketplace(&marketplace_path).is_ok_and(|marketplace| {
+        marketplace.name == plugin_id.marketplace_name
+            && marketplace
+                .plugins
+                .iter()
+                .any(|plugin| plugin.name == plugin_id.plugin_name)
+    })
 }
 
 fn apply_plugin_mcp_server_policy(config: &mut McpServerConfig, policy: &PluginMcpServerConfig) {

--- a/codex-rs/core-plugins/src/loader_tests.rs
+++ b/codex-rs/core-plugins/src/loader_tests.rs
@@ -1,6 +1,13 @@
 use super::*;
+use crate::PluginLoadOutcome;
 use crate::manifest::load_plugin_manifest;
+use crate::startup_sync::curated_plugins_repo_path;
+use crate::test_support::TEST_CURATED_PLUGIN_CACHE_VERSION;
+use crate::test_support::TEST_CURATED_PLUGIN_SHA;
+use crate::test_support::write_curated_plugin_sha_with;
 use crate::test_support::write_file;
+use crate::test_support::write_openai_api_curated_marketplace;
+use crate::test_support::write_openai_curated_marketplace;
 use codex_config::ConfigLayerEntry;
 use codex_config::ConfigLayerSource;
 use codex_config::ConfigRequirements;
@@ -225,6 +232,202 @@ fn curated_plugin_cache_version_preserves_non_git_sha_versions() {
         "export-backup"
     );
     assert_eq!(curated_plugin_cache_version("0123456"), "0123456");
+}
+
+fn curated_plugin_config_layer(temp_dir: &TempDir, plugin_name: &str) -> ConfigLayerStack {
+    curated_plugin_config_layer_for_marketplace(
+        temp_dir,
+        plugin_name,
+        crate::OPENAI_CURATED_MARKETPLACE_NAME,
+    )
+}
+
+fn curated_plugin_config_layer_for_marketplace(
+    temp_dir: &TempDir,
+    plugin_name: &str,
+    marketplace_name: &str,
+) -> ConfigLayerStack {
+    ConfigLayerStack::new(
+        vec![user_layer(
+            user_config_path(temp_dir, "config.toml"),
+            &format!(
+                r#"[plugins."{plugin_name}@{marketplace_name}"]
+enabled = true
+"#,
+            ),
+        )],
+        ConfigRequirements::default(),
+        ConfigRequirementsToml::default(),
+    )
+    .expect("valid curated plugin config")
+}
+
+fn write_curated_cached_plugin(codex_home: &Path, plugin_name: &str, version: &str) {
+    write_curated_cached_plugin_for_marketplace(
+        codex_home,
+        plugin_name,
+        crate::OPENAI_CURATED_MARKETPLACE_NAME,
+        version,
+    );
+}
+
+fn write_curated_cached_plugin_for_marketplace(
+    codex_home: &Path,
+    plugin_name: &str,
+    marketplace_name: &str,
+    version: &str,
+) {
+    let plugin_root = codex_home
+        .join("plugins/cache")
+        .join(marketplace_name)
+        .join(plugin_name)
+        .join(version);
+    write_file(
+        &plugin_root.join(".codex-plugin/plugin.json"),
+        &format!(r#"{{"name":"{plugin_name}"}}"#),
+    );
+    write_file(&plugin_root.join("skills/SKILL.md"), "skill");
+}
+
+#[tokio::test]
+async fn load_api_curated_plugin_uses_matching_synced_marketplace() {
+    let temp_dir = TempDir::new().expect("tempdir");
+    let curated_root = curated_plugins_repo_path(temp_dir.path());
+    write_openai_curated_marketplace(&curated_root, &["standard-only"]);
+    write_openai_api_curated_marketplace(&curated_root, &["api-only"]);
+    write_curated_plugin_sha_with(temp_dir.path(), TEST_CURATED_PLUGIN_SHA);
+    write_curated_cached_plugin_for_marketplace(
+        temp_dir.path(),
+        "api-only",
+        crate::OPENAI_API_CURATED_MARKETPLACE_NAME,
+        TEST_CURATED_PLUGIN_CACHE_VERSION,
+    );
+
+    let outcome = PluginLoadOutcome::from_plugins(
+        load_plugins_from_layer_stack(
+            &curated_plugin_config_layer_for_marketplace(
+                &temp_dir,
+                "api-only",
+                crate::OPENAI_API_CURATED_MARKETPLACE_NAME,
+            ),
+            HashMap::new(),
+            &PluginStore::new(temp_dir.path().to_path_buf()),
+            /*plugin_skill_snapshots*/ None,
+            Some(Product::Codex),
+            /*remote_global_catalog_active*/ false,
+        )
+        .await,
+    );
+    let plugin = outcome.plugins().first().expect("configured plugin");
+
+    assert!(plugin.is_first_party);
+    assert_eq!(
+        outcome.effective_first_party_plugin_roots()[0].plugin_id,
+        "api-only@openai-api-curated"
+    );
+}
+
+async fn load_curated_plugin(temp_dir: &TempDir, plugin_name: &str) -> PluginLoadOutcome {
+    PluginLoadOutcome::from_plugins(
+        load_plugins_from_layer_stack(
+            &curated_plugin_config_layer(temp_dir, plugin_name),
+            HashMap::new(),
+            &PluginStore::new(temp_dir.path().to_path_buf()),
+            /*plugin_skill_snapshots*/ None,
+            Some(Product::Codex),
+            /*remote_global_catalog_active*/ false,
+        )
+        .await,
+    )
+}
+
+#[tokio::test]
+async fn load_curated_plugin_uses_synced_sha_root_when_it_is_only_installed_root() {
+    let temp_dir = TempDir::new().expect("tempdir");
+    let curated_root = curated_plugins_repo_path(temp_dir.path());
+    write_openai_curated_marketplace(&curated_root, &["slack"]);
+    write_curated_plugin_sha_with(temp_dir.path(), TEST_CURATED_PLUGIN_SHA);
+    write_curated_cached_plugin(temp_dir.path(), "slack", TEST_CURATED_PLUGIN_CACHE_VERSION);
+
+    let outcome = load_curated_plugin(&temp_dir, "slack").await;
+    let plugin = outcome.plugins().first().expect("configured plugin");
+    let synced_root = AbsolutePathBuf::try_from(temp_dir.path().join(format!(
+        "plugins/cache/openai-curated/slack/{TEST_CURATED_PLUGIN_CACHE_VERSION}"
+    )))
+    .expect("synced plugin root");
+
+    assert_eq!(plugin.root, synced_root);
+    assert!(plugin.is_first_party);
+    assert_eq!(
+        outcome.effective_first_party_plugin_roots(),
+        vec![codex_plugin::FirstPartyPluginRoot {
+            plugin_id: "slack@openai-curated".to_string(),
+            plugin_root: synced_root,
+        }]
+    );
+}
+
+#[tokio::test]
+async fn load_curated_plugin_without_synced_cache_root_is_not_first_party() {
+    let temp_dir = TempDir::new().expect("tempdir");
+    let curated_root = curated_plugins_repo_path(temp_dir.path());
+    write_openai_curated_marketplace(&curated_root, &["slack"]);
+    write_curated_plugin_sha_with(temp_dir.path(), TEST_CURATED_PLUGIN_SHA);
+    write_curated_cached_plugin(temp_dir.path(), "slack", "local");
+
+    let outcome = load_curated_plugin(&temp_dir, "slack").await;
+
+    assert!(
+        !outcome
+            .plugins()
+            .first()
+            .expect("configured plugin")
+            .is_first_party
+    );
+    assert_eq!(outcome.effective_first_party_plugin_roots(), Vec::new());
+}
+
+#[tokio::test]
+async fn load_curated_plugin_keeps_local_root_priority_over_synced_sha_root() {
+    let temp_dir = TempDir::new().expect("tempdir");
+    let curated_root = curated_plugins_repo_path(temp_dir.path());
+    write_openai_curated_marketplace(&curated_root, &["slack"]);
+    write_curated_plugin_sha_with(temp_dir.path(), TEST_CURATED_PLUGIN_SHA);
+    write_curated_cached_plugin(temp_dir.path(), "slack", "local");
+    write_curated_cached_plugin(temp_dir.path(), "slack", TEST_CURATED_PLUGIN_CACHE_VERSION);
+
+    let outcome = load_curated_plugin(&temp_dir, "slack").await;
+    let plugin = outcome.plugins().first().expect("configured plugin");
+    let local_root = AbsolutePathBuf::try_from(
+        temp_dir
+            .path()
+            .join("plugins/cache/openai-curated/slack/local"),
+    )
+    .expect("local plugin root");
+
+    assert_eq!(plugin.root, local_root);
+    assert!(!plugin.is_first_party);
+    assert_eq!(outcome.effective_first_party_plugin_roots(), Vec::new());
+}
+
+#[tokio::test]
+async fn load_curated_plugin_missing_from_synced_marketplace_is_not_first_party() {
+    let temp_dir = TempDir::new().expect("tempdir");
+    let curated_root = curated_plugins_repo_path(temp_dir.path());
+    write_openai_curated_marketplace(&curated_root, &["github"]);
+    write_curated_plugin_sha_with(temp_dir.path(), TEST_CURATED_PLUGIN_SHA);
+    write_curated_cached_plugin(temp_dir.path(), "slack", TEST_CURATED_PLUGIN_CACHE_VERSION);
+
+    let outcome = load_curated_plugin(&temp_dir, "slack").await;
+
+    assert!(
+        !outcome
+            .plugins()
+            .first()
+            .expect("configured plugin")
+            .is_first_party
+    );
+    assert_eq!(outcome.effective_first_party_plugin_roots(), Vec::new());
 }
 
 fn plugin_id() -> PluginId {

--- a/codex-rs/core-plugins/src/manager.rs
+++ b/codex-rs/core-plugins/src/manager.rs
@@ -1450,14 +1450,8 @@ impl PluginsManager {
             }
             _ => return Ok(()),
         };
-        let expected_path = AbsolutePathBuf::try_from(expected_path)
-            .ok()
-            .and_then(|path| path.canonicalize().ok());
-        let requested_path = marketplace_path.canonicalize().ok();
-        if requested_path
-            .zip(expected_path)
-            .is_none_or(|(requested, expected)| requested != expected)
-        {
+        let expected_path = AbsolutePathBuf::try_from(expected_path).ok();
+        if expected_path.as_ref() != Some(marketplace_path) {
             return Err(PluginStoreError::Invalid(format!(
                 "marketplace '{marketplace_name}' can only be installed from the synced curated marketplace"
             ))

--- a/codex-rs/core-plugins/src/manager.rs
+++ b/codex-rs/core-plugins/src/manager.rs
@@ -1,5 +1,7 @@
 use super::LoadedPlugin;
 use super::PluginLoadOutcome;
+use crate::OPENAI_API_CURATED_MARKETPLACE_NAME;
+use crate::OPENAI_CURATED_MARKETPLACE_NAME;
 use crate::app_mcp_routing::apply_app_mcp_routing_policy;
 use crate::installed_marketplaces::installed_marketplace_roots_from_layer_stack;
 use crate::is_openai_curated_marketplace_name;
@@ -1331,6 +1333,7 @@ impl PluginsManager {
             self.track_plugin_install_resolution_failed(&err);
             return Err(err.into());
         }
+        self.validate_curated_marketplace_install_source(&request.marketplace_path, &resolved)?;
         Ok(resolved)
     }
 
@@ -1431,6 +1434,36 @@ impl PluginsManager {
                 error_type.to_string(),
             );
         }
+    }
+
+    fn validate_curated_marketplace_install_source(
+        &self,
+        marketplace_path: &AbsolutePathBuf,
+        resolved: &ResolvedMarketplacePlugin,
+    ) -> Result<(), PluginInstallError> {
+        let marketplace_name = resolved.plugin_id.marketplace_name.as_str();
+        let expected_path = match marketplace_name {
+            OPENAI_CURATED_MARKETPLACE_NAME => curated_plugins_repo_path(self.codex_home.as_path())
+                .join(".agents/plugins/marketplace.json"),
+            OPENAI_API_CURATED_MARKETPLACE_NAME => {
+                curated_plugins_api_marketplace_path(self.codex_home.as_path())
+            }
+            _ => return Ok(()),
+        };
+        let expected_path = AbsolutePathBuf::try_from(expected_path)
+            .ok()
+            .and_then(|path| path.canonicalize().ok());
+        let requested_path = marketplace_path.canonicalize().ok();
+        if requested_path
+            .zip(expected_path)
+            .is_none_or(|(requested, expected)| requested != expected)
+        {
+            return Err(PluginStoreError::Invalid(format!(
+                "marketplace '{marketplace_name}' can only be installed from the synced curated marketplace"
+            ))
+            .into());
+        }
+        Ok(())
     }
 
     async fn install_resolved_plugin(

--- a/codex-rs/core-plugins/src/manager_tests.rs
+++ b/codex-rs/core-plugins/src/manager_tests.rs
@@ -2818,6 +2818,46 @@ async fn install_plugin_rejects_spoofed_openai_curated_marketplace() {
     );
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn install_plugin_rejects_symlinked_openai_curated_marketplace() {
+    let tmp = tempfile::tempdir().unwrap();
+    let curated_root = curated_plugins_repo_path(tmp.path());
+    write_openai_curated_marketplace(&curated_root, &["slack"]);
+    write_curated_plugin_sha(tmp.path(), TEST_CURATED_PLUGIN_SHA);
+    let spoofed_root = tmp.path().join("spoofed-marketplace");
+    write_curated_plugin(&spoofed_root, "slack");
+    let spoofed_marketplace_path = spoofed_root.join(".agents/plugins/marketplace.json");
+    fs::create_dir_all(spoofed_marketplace_path.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(
+        curated_root.join(".agents/plugins/marketplace.json"),
+        &spoofed_marketplace_path,
+    )
+    .unwrap();
+
+    let err = PluginsManager::new(tmp.path().to_path_buf())
+        .install_plugin(
+            &unrestricted_config_layer_stack(),
+            PluginInstallRequest {
+                plugin_name: "slack".to_string(),
+                marketplace_path: AbsolutePathBuf::try_from(spoofed_marketplace_path).unwrap(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(err.is_invalid_request());
+    assert!(
+        err.to_string()
+            .contains("can only be installed from the synced curated marketplace")
+    );
+    assert!(
+        !tmp.path()
+            .join("plugins/cache/openai-curated/slack")
+            .exists()
+    );
+}
+
 #[tokio::test]
 async fn install_plugin_rejects_spoofed_openai_api_curated_marketplace() {
     let tmp = tempfile::tempdir().unwrap();

--- a/codex-rs/core-plugins/src/manager_tests.rs
+++ b/codex-rs/core-plugins/src/manager_tests.rs
@@ -862,6 +862,7 @@ async fn load_plugins_loads_default_skills_and_mcp_servers() {
             manifest_description: Some(
                 "Plugin that includes the sample MCP server and Skills".to_string(),
             ),
+            is_first_party: false,
             root: AbsolutePathBuf::try_from(plugin_root.clone()).unwrap(),
             enabled: true,
             skill_roots: vec![plugin_root.join("skills").abs()],
@@ -2143,6 +2144,7 @@ async fn load_plugins_preserves_disabled_plugins_without_effective_contributions
             manifest_name: None,
             plugin_namespace: None,
             manifest_description: None,
+            is_first_party: false,
             root: AbsolutePathBuf::try_from(plugin_root).unwrap(),
             enabled: false,
             skill_roots: Vec::new(),
@@ -2318,6 +2320,7 @@ fn capability_index_filters_inactive_and_zero_capability_plugins() {
                 .to_string(),
         ),
         manifest_description: None,
+        is_first_party: false,
         root: AbsolutePathBuf::try_from(codex_home.path().join(dir_name)).unwrap(),
         enabled: true,
         skill_roots: Vec::new(),
@@ -2777,6 +2780,76 @@ async fn install_openai_curated_plugin_uses_short_sha_cache_version() {
             installed_path: AbsolutePathBuf::try_from(installed_path).unwrap(),
             auth_policy: MarketplacePluginAuthPolicy::OnInstall,
         }
+    );
+}
+
+#[tokio::test]
+async fn install_plugin_rejects_spoofed_openai_curated_marketplace() {
+    let tmp = tempfile::tempdir().unwrap();
+    let curated_root = curated_plugins_repo_path(tmp.path());
+    write_openai_curated_marketplace(&curated_root, &["slack"]);
+    write_curated_plugin_sha(tmp.path(), TEST_CURATED_PLUGIN_SHA);
+    let spoofed_root = tmp.path().join("spoofed-marketplace");
+    write_openai_curated_marketplace(&spoofed_root, &["slack"]);
+
+    let err = PluginsManager::new(tmp.path().to_path_buf())
+        .install_plugin(
+            &unrestricted_config_layer_stack(),
+            PluginInstallRequest {
+                plugin_name: "slack".to_string(),
+                marketplace_path: AbsolutePathBuf::try_from(
+                    spoofed_root.join(".agents/plugins/marketplace.json"),
+                )
+                .unwrap(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(err.is_invalid_request());
+    assert!(
+        err.to_string()
+            .contains("can only be installed from the synced curated marketplace")
+    );
+    assert!(
+        !tmp.path()
+            .join("plugins/cache/openai-curated/slack")
+            .exists()
+    );
+}
+
+#[tokio::test]
+async fn install_plugin_rejects_spoofed_openai_api_curated_marketplace() {
+    let tmp = tempfile::tempdir().unwrap();
+    let curated_root = curated_plugins_repo_path(tmp.path());
+    write_openai_api_curated_marketplace(&curated_root, &["api-only"]);
+    write_curated_plugin_sha(tmp.path(), TEST_CURATED_PLUGIN_SHA);
+    let spoofed_root = tmp.path().join("spoofed-marketplace");
+    write_openai_api_curated_marketplace(&spoofed_root, &["api-only"]);
+
+    let err = PluginsManager::new(tmp.path().to_path_buf())
+        .install_plugin(
+            &unrestricted_config_layer_stack(),
+            PluginInstallRequest {
+                plugin_name: "api-only".to_string(),
+                marketplace_path: AbsolutePathBuf::try_from(
+                    spoofed_root.join(".agents/plugins/api_marketplace.json"),
+                )
+                .unwrap(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(err.is_invalid_request());
+    assert!(
+        err.to_string()
+            .contains("can only be installed from the synced curated marketplace")
+    );
+    assert!(
+        !tmp.path()
+            .join("plugins/cache/openai-api-curated/api-only")
+            .exists()
     );
 }
 

--- a/codex-rs/core/src/session/review.rs
+++ b/codex-rs/core/src/session/review.rs
@@ -144,6 +144,7 @@ pub(super) async fn spawn_review_thread(
         turn_metadata_state,
         extension_data,
         turn_skills: TurnSkillsContext::new(parent_turn_context.turn_skills.snapshot.clone()),
+        first_party_plugin_roots: Arc::clone(&parent_turn_context.first_party_plugin_roots),
         turn_timing_state: Arc::new(TurnTimingState::default()),
         terminal_error: Arc::new(Mutex::new(None)),
         server_model_warning_emitted: AtomicBool::new(false),

--- a/codex-rs/core/src/session/tests.rs
+++ b/codex-rs/core/src/session/tests.rs
@@ -5535,6 +5535,7 @@ pub(crate) async fn make_session_and_context() -> (Session, TurnContext) {
         .plugins_manager
         .plugins_for_config(&plugins_input)
         .await;
+    let first_party_plugin_roots = plugin_outcome.effective_first_party_plugin_roots();
     let effective_skill_roots = plugin_outcome.effective_plugin_skill_roots();
     let plugin_skill_snapshots = services
         .plugins_manager
@@ -5566,6 +5567,7 @@ pub(crate) async fn make_session_and_context() -> (Session, TurnContext) {
         session_configuration.cwd().clone(),
         "turn_id".to_string(),
         skills_snapshot,
+        first_party_plugin_roots,
     );
     let session = Session {
         thread_id,
@@ -7666,6 +7668,7 @@ where
         .plugins_manager
         .plugins_for_config(&plugins_input)
         .await;
+    let first_party_plugin_roots = plugin_outcome.effective_first_party_plugin_roots();
     let effective_skill_roots = plugin_outcome.effective_plugin_skill_roots();
     let plugin_skill_snapshots = services
         .plugins_manager
@@ -7697,6 +7700,7 @@ where
         session_configuration.cwd().clone(),
         "turn_id".to_string(),
         skills_snapshot,
+        first_party_plugin_roots,
     ));
     let session = Arc::new(Session {
         thread_id,

--- a/codex-rs/core/src/session/turn_context.rs
+++ b/codex-rs/core/src/session/turn_context.rs
@@ -5,6 +5,7 @@ use codex_core_skills::HostSkillsSnapshot;
 use codex_file_system::FileSystemSandboxContext;
 use codex_model_provider::SharedModelProvider;
 use codex_model_provider::create_model_provider;
+use codex_plugin::FirstPartyPluginRoot;
 use codex_protocol::SessionId;
 use codex_protocol::ThreadId;
 use codex_protocol::models::AdditionalPermissionProfile;
@@ -139,6 +140,7 @@ pub struct TurnContext {
     pub(crate) turn_metadata_state: Arc<TurnMetadataState>,
     pub(crate) extension_data: Arc<codex_extension_api::ExtensionData>,
     pub(crate) turn_skills: TurnSkillsContext,
+    pub(crate) first_party_plugin_roots: Arc<Vec<FirstPartyPluginRoot>>,
     pub(crate) turn_timing_state: Arc<TurnTimingState>,
     pub(crate) terminal_error: Arc<Mutex<Option<String>>>,
     pub(crate) server_model_warning_emitted: AtomicBool,
@@ -296,6 +298,7 @@ impl TurnContext {
             turn_metadata_state: self.turn_metadata_state.clone(),
             extension_data: Arc::clone(&self.extension_data),
             turn_skills: self.turn_skills.clone(),
+            first_party_plugin_roots: Arc::clone(&self.first_party_plugin_roots),
             turn_timing_state: Arc::clone(&self.turn_timing_state),
             terminal_error: Arc::clone(&self.terminal_error),
             server_model_warning_emitted: AtomicBool::new(
@@ -496,6 +499,7 @@ impl Session {
         cwd: AbsolutePathBuf,
         sub_id: String,
         skills_snapshot: HostSkillsSnapshot,
+        first_party_plugin_roots: Vec<FirstPartyPluginRoot>,
     ) -> TurnContext {
         let reasoning_effort = session_configuration.collaboration_mode.reasoning_effort();
         let reasoning_summary = session_configuration
@@ -576,6 +580,7 @@ impl Session {
             turn_metadata_state,
             extension_data,
             turn_skills: TurnSkillsContext::new(skills_snapshot),
+            first_party_plugin_roots: Arc::new(first_party_plugin_roots),
             turn_timing_state: Arc::new(TurnTimingState::default()),
             terminal_error: Arc::new(Mutex::new(None)),
             server_model_warning_emitted: AtomicBool::new(false),
@@ -733,6 +738,7 @@ impl Session {
             .plugins_manager
             .plugins_for_config(&plugins_input)
             .await;
+        let first_party_plugin_roots = plugin_outcome.effective_first_party_plugin_roots();
         let effective_skill_roots = plugin_outcome.effective_plugin_skill_roots();
         let plugin_skill_snapshots = self
             .services
@@ -775,6 +781,7 @@ impl Session {
             cwd,
             sub_id,
             skills_snapshot,
+            first_party_plugin_roots,
         );
         turn_context.realtime_active = self.conversation.running_state().await.is_some();
 

--- a/codex-rs/plugin/src/lib.rs
+++ b/codex-rs/plugin/src/lib.rs
@@ -13,6 +13,7 @@ mod provider;
 use codex_config::HookEventsToml;
 use codex_utils_absolute_path::AbsolutePathBuf;
 pub use load_outcome::EffectiveSkillRoots;
+pub use load_outcome::FirstPartyPluginRoot;
 pub use load_outcome::LoadedPlugin;
 pub use load_outcome::PluginLoadOutcome;
 pub use load_outcome::prompt_safe_plugin_description;

--- a/codex-rs/plugin/src/load_outcome.rs
+++ b/codex-rs/plugin/src/load_outcome.rs
@@ -11,6 +11,11 @@ use crate::PluginHookSource;
 use crate::app_connector_ids_from_declarations;
 
 const MAX_CAPABILITY_SUMMARY_DESCRIPTION_LEN: usize = 1024;
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FirstPartyPluginRoot {
+    pub plugin_id: String,
+    pub plugin_root: AbsolutePathBuf,
+}
 
 /// A plugin that was loaded from disk, including merged MCP server definitions.
 #[derive(Debug, Clone, PartialEq)]
@@ -19,6 +24,7 @@ pub struct LoadedPlugin<M> {
     pub manifest_name: Option<String>,
     pub plugin_namespace: Option<String>,
     pub manifest_description: Option<String>,
+    pub is_first_party: bool,
     pub root: AbsolutePathBuf,
     pub enabled: bool,
     pub skill_roots: Vec<AbsolutePathBuf>,
@@ -146,6 +152,26 @@ impl<M: Clone> PluginLoadOutcome<M> {
         skill_roots
     }
 
+    pub fn effective_first_party_plugin_roots(&self) -> Vec<FirstPartyPluginRoot> {
+        let mut plugin_roots = Vec::new();
+        let mut seen_paths = HashSet::new();
+        for plugin in self
+            .plugins
+            .iter()
+            .filter(|plugin| plugin.is_active() && plugin.is_first_party)
+        {
+            if seen_paths.insert(plugin.root.clone()) {
+                plugin_roots.push(FirstPartyPluginRoot {
+                    plugin_id: plugin.config_name.clone(),
+                    plugin_root: plugin.root.clone(),
+                });
+            }
+        }
+
+        plugin_roots.sort_unstable_by(|a, b| a.plugin_root.cmp(&b.plugin_root));
+        plugin_roots
+    }
+
     pub fn effective_mcp_servers(&self) -> HashMap<String, M> {
         let mut mcp_servers = HashMap::new();
         for plugin in self.plugins.iter().filter(|plugin| plugin.is_active()) {
@@ -230,6 +256,7 @@ mod tests {
                     .to_string(),
             ),
             manifest_description: None,
+            is_first_party: false,
             root: test_path(config_name),
             enabled: true,
             skill_roots,
@@ -258,6 +285,40 @@ mod tests {
                 plugin_id: "zeta@test".to_string(),
                 plugin_namespace: "zeta".to_string(),
                 plugin_root: test_path("zeta@test"),
+            }]
+        );
+    }
+
+    #[test]
+    fn effective_first_party_plugin_roots_only_includes_active_openai_plugins() {
+        let shared_root = test_path("shared-plugin");
+        let mut first_party = loaded_plugin("first@test", Vec::new());
+        first_party.root = shared_root.clone();
+        first_party.is_first_party = true;
+        let mut duplicate = loaded_plugin("duplicate@test", Vec::new());
+        duplicate.root = shared_root.clone();
+        duplicate.is_first_party = true;
+        let third_party = loaded_plugin("third@test", Vec::new());
+        let mut disabled = loaded_plugin("disabled@test", Vec::new());
+        disabled.is_first_party = true;
+        disabled.enabled = false;
+        let mut broken = loaded_plugin("broken@test", Vec::new());
+        broken.is_first_party = true;
+        broken.error = Some("broken".to_string());
+
+        let outcome = PluginLoadOutcome::from_plugins(vec![
+            first_party,
+            duplicate,
+            third_party,
+            disabled,
+            broken,
+        ]);
+
+        assert_eq!(
+            outcome.effective_first_party_plugin_roots(),
+            vec![FirstPartyPluginRoot {
+                plugin_id: "first@test".to_string(),
+                plugin_root: shared_root,
             }]
         );
     }


### PR DESCRIPTION
## What

- Preserve trusted first-party plugin roots in turn and review contexts for later lifecycle attribution.
- Recognize both local curated and API-curated synced catalogs.
- Reject spoofed or symlink-aliased curated marketplace install paths.

## Why

Phase 1 lifecycle metrics must attribute scripts only to installed, trusted first-party plugins. Accepting arbitrary same-named or symlink-aliased marketplace paths could produce false attribution or copy attacker-controlled plugin sources.

This slice is identity/context plumbing only; it does not emit lifecycle events yet.

Enhancement design: [Codex Plugin Metrics](https://app.notion.com/p/openai/Codex-Plugin-Metrics-3898e50b62b0801bb0cdff4e40580268?source=copy_link)

Related backend stack: openai/openai#1111389 → openai/openai#1111392.

## How

- Mark loaded plugins first-party only when their root matches the current synced cache SHA and the plugin appears in the matching curated catalog.
- Carry deduplicated active first-party roots into turn and review contexts.
- Require curated installs to use the exact synced marketplace path before resolving relative plugin sources.

## I tested this

- `just fmt` — passed
- `just fix -p codex-core-plugins -p codex-plugin -p codex-analytics -p codex-core -p codex-features -p codex-app-server -p codex-windows-sandbox` — passed (stack-wide scoped lint gate)
- `just argument-comment-lint` — passed
- `just test -p codex-core-plugins` — passed (321/321)
- `just test -p codex-plugin` — passed (4/4)
- `just test` — attempted; the local workspace build stopped before tests because the runner lacks system `libcap` for unrelated `codex-bwrap`. Exact-head CI provides the full Linux/macOS/Windows matrix.