### PR TITLE
Add dormant plugin script lifecycle state

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -578,6 +578,9 @@
             "plugin_hooks": {
               "type": "boolean"
             },
+            "plugin_script_lifecycle": {
+              "type": "boolean"
+            },
             "plugin_sharing": {
               "type": "boolean"
             },
@@ -4948,6 +4951,9 @@
           "type": "boolean"
         },
         "plugin_hooks": {
+          "type": "boolean"
+        },
+        "plugin_script_lifecycle": {
           "type": "boolean"
         },
         "plugin_sharing": {

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -75,6 +75,7 @@ pub use mention_syntax::TOOL_MENTION_SIGIL;
 pub use utils::path_utils;
 pub mod personality_migration;
 #[allow(dead_code)]
+mod plugin_script_lifecycle;
 mod plugin_script_resolver;
 pub(crate) mod plugins;
 #[doc(hidden)]

--- a/codex-rs/core/src/plugin_script_lifecycle.rs
+++ b/codex-rs/core/src/plugin_script_lifecycle.rs
@@ -34,10 +34,18 @@ pub(crate) struct PluginScriptExecution {
     emitted: std::sync::Mutex<Vec<CodexPluginScriptLifecycleEvent>>,
 }
 
+/// Terminal process result used to classify one plugin script execution.
+pub(crate) enum PluginScriptTerminalOutcome {
+    Exited { exit_code: i32 },
+    Failed { exit_code: Option<i32> },
+}
+
 #[derive(Clone)]
 struct PluginScriptEvent {
+    session_id: String,
     thread_id: String,
     turn_id: String,
+    product_client_id: String,
     plugin_id: String,
     execution_id: String,
     script_path: String,
@@ -66,8 +74,10 @@ impl PluginScriptExecution {
         Some(Arc::new(Self::new(
             session.services.analytics_events_client.clone(),
             PluginScriptEvent {
+                session_id: session.session_id().to_string(),
                 thread_id: session.thread_id.to_string(),
                 turn_id: turn.sub_id.clone(),
+                product_client_id: turn.originator.clone(),
                 plugin_id: resolved.plugin_id,
                 execution_id: Uuid::new_v4().to_string(),
                 script_path: resolved.script_path,
@@ -91,7 +101,7 @@ impl PluginScriptExecution {
         self.interrupted.store(true, Ordering::Release);
     }
 
-    pub(crate) fn finish(&self, exit_code: Option<i32>, failed: bool) {
+    pub(crate) fn finish(&self, outcome: PluginScriptTerminalOutcome) {
         let Some(started_at) = self.started_at.get() else {
             return;
         };
@@ -99,12 +109,21 @@ impl PluginScriptExecution {
             return;
         }
 
+        let (exit_code, terminal_status) = match outcome {
+            PluginScriptTerminalOutcome::Exited { exit_code: 0 } => {
+                (Some(0), PluginScriptLifecycleStatus::Completed)
+            }
+            PluginScriptTerminalOutcome::Exited { exit_code } => {
+                (Some(exit_code), PluginScriptLifecycleStatus::Failed)
+            }
+            PluginScriptTerminalOutcome::Failed { exit_code } => {
+                (exit_code, PluginScriptLifecycleStatus::Failed)
+            }
+        };
         let status = if self.interrupted.load(Ordering::Acquire) {
             PluginScriptLifecycleStatus::Interrupted
-        } else if !failed && exit_code == Some(0) {
-            PluginScriptLifecycleStatus::Completed
         } else {
-            PluginScriptLifecycleStatus::Failed
+            terminal_status
         };
         let duration_ms = u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX);
         self.emit(self.event(status, Some(duration_ms), exit_code));
@@ -129,8 +148,10 @@ impl PluginScriptExecution {
         exit_code: Option<i32>,
     ) -> CodexPluginScriptLifecycleEvent {
         CodexPluginScriptLifecycleEvent {
+            session_id: self.event.session_id.clone(),
             thread_id: self.event.thread_id.clone(),
             turn_id: self.event.turn_id.clone(),
+            product_client_id: self.event.product_client_id.clone(),
             plugin_id: self.event.plugin_id.clone(),
             execution_id: self.event.execution_id.clone(),
             script_path: self.event.script_path.clone(),

--- a/codex-rs/core/src/plugin_script_lifecycle.rs
+++ b/codex-rs/core/src/plugin_script_lifecycle.rs
@@ -1,0 +1,161 @@
+use std::sync::Arc;
+use std::sync::OnceLock;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::time::Instant;
+
+use chrono::SecondsFormat;
+use chrono::Utc;
+use codex_analytics::AnalyticsEventsClient;
+use codex_analytics::CodexPluginScriptLifecycleEvent;
+use codex_analytics::PluginScriptLifecycleStatus;
+use codex_analytics::PluginScriptSkill;
+use codex_features::Feature;
+use codex_utils_absolute_path::AbsolutePathBuf;
+use uuid::Uuid;
+
+use crate::plugin_script_resolver::resolve_plugin_script;
+use crate::session::session::Session;
+use crate::session::turn_context::TurnContext;
+use crate::shell::ShellType;
+
+/// Tracks one resolved plugin-script invocation through executor lifecycle events.
+///
+/// Resolution is dormant until an executor adapter calls these methods. The
+/// started fact is built only after successful process spawn so terminal
+/// duration measures actual process lifetime rather than attribution time.
+pub(crate) struct PluginScriptExecution {
+    analytics: AnalyticsEventsClient,
+    event: PluginScriptEvent,
+    started_at: OnceLock<Instant>,
+    terminal_emitted: AtomicBool,
+    interrupted: AtomicBool,
+    #[cfg(test)]
+    emitted: std::sync::Mutex<Vec<CodexPluginScriptLifecycleEvent>>,
+}
+
+#[derive(Clone)]
+struct PluginScriptEvent {
+    thread_id: String,
+    turn_id: String,
+    plugin_id: String,
+    execution_id: String,
+    script_path: String,
+    skill: Option<PluginScriptSkill>,
+}
+
+impl PluginScriptExecution {
+    pub(crate) fn resolve(
+        session: &Session,
+        turn: &TurnContext,
+        command: &str,
+        cwd: &AbsolutePathBuf,
+        shell_type: ShellType,
+    ) -> Option<Arc<Self>> {
+        if !turn.config.features.enabled(Feature::PluginScriptLifecycle) {
+            return None;
+        }
+
+        let resolved = resolve_plugin_script(
+            &turn.first_party_plugin_roots,
+            turn.turn_skills.snapshot.outcome(),
+            command,
+            cwd,
+            shell_type,
+        )?;
+        Some(Arc::new(Self::new(
+            session.services.analytics_events_client.clone(),
+            PluginScriptEvent {
+                thread_id: session.thread_id.to_string(),
+                turn_id: turn.sub_id.clone(),
+                plugin_id: resolved.plugin_id,
+                execution_id: Uuid::new_v4().to_string(),
+                script_path: resolved.script_path,
+                skill: resolved.skill,
+            },
+        )))
+    }
+
+    pub(crate) fn mark_started(&self) {
+        if self.started_at.set(Instant::now()).is_err() {
+            return;
+        }
+        self.emit(self.event(
+            PluginScriptLifecycleStatus::Started,
+            /*duration_ms*/ None,
+            /*exit_code*/ None,
+        ));
+    }
+
+    pub(crate) fn mark_interrupted(&self) {
+        self.interrupted.store(true, Ordering::Release);
+    }
+
+    pub(crate) fn finish(&self, exit_code: Option<i32>, failed: bool) {
+        let Some(started_at) = self.started_at.get() else {
+            return;
+        };
+        if self.terminal_emitted.swap(true, Ordering::AcqRel) {
+            return;
+        }
+
+        let status = if self.interrupted.load(Ordering::Acquire) {
+            PluginScriptLifecycleStatus::Interrupted
+        } else if !failed && exit_code == Some(0) {
+            PluginScriptLifecycleStatus::Completed
+        } else {
+            PluginScriptLifecycleStatus::Failed
+        };
+        let duration_ms = u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX);
+        self.emit(self.event(status, Some(duration_ms), exit_code));
+    }
+
+    fn new(analytics: AnalyticsEventsClient, event: PluginScriptEvent) -> Self {
+        Self {
+            analytics,
+            event,
+            started_at: OnceLock::new(),
+            terminal_emitted: AtomicBool::new(false),
+            interrupted: AtomicBool::new(false),
+            #[cfg(test)]
+            emitted: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    fn event(
+        &self,
+        status: PluginScriptLifecycleStatus,
+        duration_ms: Option<u64>,
+        exit_code: Option<i32>,
+    ) -> CodexPluginScriptLifecycleEvent {
+        CodexPluginScriptLifecycleEvent {
+            thread_id: self.event.thread_id.clone(),
+            turn_id: self.event.turn_id.clone(),
+            plugin_id: self.event.plugin_id.clone(),
+            execution_id: self.event.execution_id.clone(),
+            script_path: self.event.script_path.clone(),
+            timestamp: lifecycle_timestamp(),
+            status,
+            duration_ms,
+            exit_code,
+            skill: self.event.skill.clone(),
+        }
+    }
+
+    fn emit(&self, event: CodexPluginScriptLifecycleEvent) {
+        #[cfg(test)]
+        self.emitted
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(event.clone());
+        self.analytics.track_plugin_script_lifecycle(event);
+    }
+}
+
+fn lifecycle_timestamp() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Millis, true)
+}
+
+#[cfg(test)]
+#[path = "plugin_script_lifecycle_tests.rs"]
+mod tests;

--- a/codex-rs/core/src/plugin_script_lifecycle_tests.rs
+++ b/codex-rs/core/src/plugin_script_lifecycle_tests.rs
@@ -1,0 +1,131 @@
+use std::thread;
+use std::time::Duration;
+use std::time::Instant;
+
+use codex_analytics::AnalyticsEventsClient;
+use codex_analytics::CodexPluginScriptLifecycleEvent;
+use codex_analytics::PluginScriptLifecycleStatus;
+use pretty_assertions::assert_eq;
+
+use super::*;
+
+fn execution() -> PluginScriptExecution {
+    PluginScriptExecution::new(
+        AnalyticsEventsClient::disabled(),
+        PluginScriptEvent {
+            thread_id: "thread".to_string(),
+            turn_id: "turn".to_string(),
+            plugin_id: "plugin".to_string(),
+            execution_id: "execution".to_string(),
+            script_path: "scripts/run.py".to_string(),
+            skill: None,
+        },
+    )
+}
+
+fn emitted(execution: &PluginScriptExecution) -> Vec<CodexPluginScriptLifecycleEvent> {
+    execution
+        .emitted
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .clone()
+}
+
+fn statuses(execution: &PluginScriptExecution) -> Vec<&'static str> {
+    emitted(execution)
+        .into_iter()
+        .map(|event| match event.status {
+            PluginScriptLifecycleStatus::Started => "started",
+            PluginScriptLifecycleStatus::Completed => "completed",
+            PluginScriptLifecycleStatus::Failed => "failed",
+            PluginScriptLifecycleStatus::Interrupted => "interrupted",
+        })
+        .collect()
+}
+
+#[test]
+fn finish_before_start_emits_no_transition() {
+    let execution = execution();
+
+    execution.finish(Some(0), /*failed*/ false);
+
+    assert_eq!(statuses(&execution), Vec::<&str>::new());
+}
+
+#[test]
+fn start_is_idempotent() {
+    let execution = execution();
+
+    execution.mark_started();
+    execution.mark_started();
+
+    assert_eq!(statuses(&execution), vec!["started"]);
+}
+
+#[test]
+fn exit_zero_completes() {
+    let execution = execution();
+
+    execution.mark_started();
+    execution.finish(Some(0), /*failed*/ false);
+
+    assert_eq!(statuses(&execution), vec!["started", "completed"]);
+}
+
+#[test]
+fn nonzero_exit_and_executor_error_fail() {
+    for (exit_code, failed) in [(Some(9), false), (None, true)] {
+        let execution = execution();
+        execution.mark_started();
+        execution.finish(exit_code, failed);
+
+        assert_eq!(statuses(&execution), vec!["started", "failed"]);
+    }
+}
+
+#[test]
+fn cancellation_wins_over_terminal_classification() {
+    let execution = execution();
+
+    execution.mark_started();
+    execution.mark_interrupted();
+    execution.finish(Some(0), /*failed*/ false);
+
+    assert_eq!(statuses(&execution), vec!["started", "interrupted"]);
+}
+
+#[test]
+fn terminal_transition_is_idempotent() {
+    let execution = execution();
+
+    execution.mark_started();
+    execution.finish(Some(0), /*failed*/ false);
+    execution.finish(Some(9), /*failed*/ true);
+
+    assert_eq!(statuses(&execution), vec!["started", "completed"]);
+}
+
+#[test]
+fn duration_begins_at_actual_start() {
+    let execution = execution();
+    let before_pre_start_delay = Instant::now();
+
+    thread::sleep(Duration::from_millis(25));
+    execution.mark_started();
+    execution.finish(Some(0), /*failed*/ false);
+
+    let duration_ms = emitted(&execution)[1].duration_ms.expect("duration");
+    let total_elapsed_ms = before_pre_start_delay.elapsed().as_millis();
+    assert!(u128::from(duration_ms) < total_elapsed_ms);
+}
+
+#[test]
+fn start_and_terminal_facts_retain_one_execution_id() {
+    let execution = execution();
+
+    execution.mark_started();
+    execution.finish(Some(0), /*failed*/ false);
+    let events = emitted(&execution);
+
+    assert_eq!(events[0].execution_id, events[1].execution_id);
+}

--- a/codex-rs/core/src/plugin_script_lifecycle_tests.rs
+++ b/codex-rs/core/src/plugin_script_lifecycle_tests.rs
@@ -13,8 +13,10 @@ fn execution() -> PluginScriptExecution {
     PluginScriptExecution::new(
         AnalyticsEventsClient::disabled(),
         PluginScriptEvent {
+            session_id: "session".to_string(),
             thread_id: "thread".to_string(),
             turn_id: "turn".to_string(),
+            product_client_id: "codex-test".to_string(),
             plugin_id: "plugin".to_string(),
             execution_id: "execution".to_string(),
             script_path: "scripts/run.py".to_string(),
@@ -47,7 +49,7 @@ fn statuses(execution: &PluginScriptExecution) -> Vec<&'static str> {
 fn finish_before_start_emits_no_transition() {
     let execution = execution();
 
-    execution.finish(Some(0), /*failed*/ false);
+    execution.finish(PluginScriptTerminalOutcome::Exited { exit_code: 0 });
 
     assert_eq!(statuses(&execution), Vec::<&str>::new());
 }
@@ -67,17 +69,20 @@ fn exit_zero_completes() {
     let execution = execution();
 
     execution.mark_started();
-    execution.finish(Some(0), /*failed*/ false);
+    execution.finish(PluginScriptTerminalOutcome::Exited { exit_code: 0 });
 
     assert_eq!(statuses(&execution), vec!["started", "completed"]);
 }
 
 #[test]
-fn nonzero_exit_and_executor_error_fail() {
-    for (exit_code, failed) in [(Some(9), false), (None, true)] {
+fn nonzero_exit_and_failed_outcome_fail() {
+    for outcome in [
+        PluginScriptTerminalOutcome::Exited { exit_code: 9 },
+        PluginScriptTerminalOutcome::Failed { exit_code: None },
+    ] {
         let execution = execution();
         execution.mark_started();
-        execution.finish(exit_code, failed);
+        execution.finish(outcome);
 
         assert_eq!(statuses(&execution), vec!["started", "failed"]);
     }
@@ -89,7 +94,7 @@ fn cancellation_wins_over_terminal_classification() {
 
     execution.mark_started();
     execution.mark_interrupted();
-    execution.finish(Some(0), /*failed*/ false);
+    execution.finish(PluginScriptTerminalOutcome::Exited { exit_code: 0 });
 
     assert_eq!(statuses(&execution), vec!["started", "interrupted"]);
 }
@@ -99,8 +104,8 @@ fn terminal_transition_is_idempotent() {
     let execution = execution();
 
     execution.mark_started();
-    execution.finish(Some(0), /*failed*/ false);
-    execution.finish(Some(9), /*failed*/ true);
+    execution.finish(PluginScriptTerminalOutcome::Exited { exit_code: 0 });
+    execution.finish(PluginScriptTerminalOutcome::Failed { exit_code: Some(9) });
 
     assert_eq!(statuses(&execution), vec!["started", "completed"]);
 }
@@ -112,7 +117,7 @@ fn duration_begins_at_actual_start() {
 
     thread::sleep(Duration::from_millis(25));
     execution.mark_started();
-    execution.finish(Some(0), /*failed*/ false);
+    execution.finish(PluginScriptTerminalOutcome::Exited { exit_code: 0 });
 
     let duration_ms = emitted(&execution)[1].duration_ms.expect("duration");
     let total_elapsed_ms = before_pre_start_delay.elapsed().as_millis();
@@ -120,12 +125,16 @@ fn duration_begins_at_actual_start() {
 }
 
 #[test]
-fn start_and_terminal_facts_retain_one_execution_id() {
+fn start_and_terminal_facts_retain_execution_and_session_identity() {
     let execution = execution();
 
     execution.mark_started();
-    execution.finish(Some(0), /*failed*/ false);
+    execution.finish(PluginScriptTerminalOutcome::Exited { exit_code: 0 });
     let events = emitted(&execution);
 
     assert_eq!(events[0].execution_id, events[1].execution_id);
+    assert_eq!(events[0].session_id, "session");
+    assert_eq!(events[1].session_id, "session");
+    assert_eq!(events[0].product_client_id, "codex-test");
+    assert_eq!(events[1].product_client_id, "codex-test");
 }

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -168,6 +168,8 @@ pub enum Feature {
     ToolSuggest,
     /// Enable plugins.
     Plugins,
+    /// Emit lifecycle analytics for scripts executed from first-party plugins.
+    PluginScriptLifecycle,
     /// Removed compatibility flag for plugin-bundled lifecycle hooks.
     PluginHooks,
     /// Allow the in-app browser pane in desktop apps.
@@ -1105,6 +1107,12 @@ pub const FEATURES: &[FeatureSpec] = &[
         key: "plugins",
         stage: Stage::Stable,
         default_enabled: true,
+    },
+    FeatureSpec {
+        id: Feature::PluginScriptLifecycle,
+        key: "plugin_script_lifecycle",
+        stage: Stage::UnderDevelopment,
+        default_enabled: false,
     },
     FeatureSpec {
         id: Feature::PluginHooks,


### PR DESCRIPTION
## What

- Add a dormant `PluginScriptExecution` state object for one attributed plugin-script invocation.
- Add the default-off `plugin_script_lifecycle` feature flag and generated config schema entries.
- Emit one `started` fact and one terminal `completed`, `failed`, or `interrupted` fact.
- Use an explicit terminal-outcome type and carry session/client identity for direct-session analytics fallback.

## Why

Phase 1 needs one best-effort lifecycle state machine with a stable execution ID before shell and unified-exec adapters wire it into actual process execution. Explicit outcomes avoid ambiguous exit-code/bool call sites.

Enhancement design: [Codex Plugin Metrics](https://app.notion.com/p/openai/Codex-Plugin-Metrics-3898e50b62b0801bb0cdff4e40580268?source=copy_link)

Stacked on #31854.

## How

- Resolve an attributed first-party plugin script only when the feature is enabled.
- Generate one UUID per execution and start timing only after successful spawn.
- Make start and terminal transitions idempotent.
- Classify explicit process outcomes as completed or failed, with interruption overriding terminal classification.
- Preserve session ID and product client ID on both lifecycle facts.
- Keep the state dormant until later runtime-adapter PRs opt in.

## I tested this

- `just fmt` — passed
- `just write-config-schema` — passed with no generated drift
- `just fix -p codex-core-plugins -p codex-plugin -p codex-analytics -p codex-core -p codex-features -p codex-app-server -p codex-windows-sandbox` — passed (stack-wide scoped lint gate)
- `just argument-comment-lint` — passed
- `just test -p codex-core plugin_script_lifecycle` — passed (8/8)
- `just test` — attempted; the local workspace build stopped before tests because the runner lacks system `libcap` for unrelated `codex-bwrap`. Exact-head CI provides the full Linux/macOS/Windows matrix.