### PR TITLE
Track plugin script lifecycle in shell runtime

### DIFF
--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -12,6 +12,7 @@ use crate::command_canonicalization::canonicalize_command_for_approval;
 use crate::exec::ExecCapturePolicy;
 use crate::guardian::GuardianNetworkAccessTrigger;
 use crate::plugin_script_lifecycle::PluginScriptExecution;
+use crate::plugin_script_lifecycle::PluginScriptTerminalOutcome;
 use crate::sandboxing::ExecOptions;
 use crate::sandboxing::SandboxPermissions;
 use crate::sandboxing::execute_exec_request_with_after_spawn;
@@ -105,14 +106,22 @@ fn finish_plugin_script(
             execution.mark_interrupted();
         }
         match &result {
-            Ok(out) => execution.finish(Some(out.exit_code), out.timed_out),
-            Err(ToolError::Codex(CodexErr::Sandbox(SandboxErr::Timeout { output }))) => {
-                execution.finish(Some(output.exit_code), /*failed*/ true)
-            }
+            Ok(out) if out.timed_out => execution.finish(PluginScriptTerminalOutcome::Failed {
+                exit_code: Some(out.exit_code),
+            }),
+            Ok(out) => execution.finish(PluginScriptTerminalOutcome::Exited {
+                exit_code: out.exit_code,
+            }),
+            Err(ToolError::Codex(CodexErr::Sandbox(SandboxErr::Timeout { output }))) => execution
+                .finish(PluginScriptTerminalOutcome::Failed {
+                    exit_code: Some(output.exit_code),
+                }),
             Err(ToolError::Codex(CodexErr::Sandbox(SandboxErr::Denied { output, .. }))) => {
-                execution.finish(Some(output.exit_code), /*failed*/ true)
+                execution.finish(PluginScriptTerminalOutcome::Failed {
+                    exit_code: Some(output.exit_code),
+                })
             }
-            Err(_) => execution.finish(/*exit_code*/ None, /*failed*/ true),
+            Err(_) => execution.finish(PluginScriptTerminalOutcome::Failed { exit_code: None }),
         }
     }
     result

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -11,9 +11,10 @@ pub(crate) mod zsh_fork_backend;
 use crate::command_canonicalization::canonicalize_command_for_approval;
 use crate::exec::ExecCapturePolicy;
 use crate::guardian::GuardianNetworkAccessTrigger;
+use crate::plugin_script_lifecycle::PluginScriptExecution;
 use crate::sandboxing::ExecOptions;
 use crate::sandboxing::SandboxPermissions;
-use crate::sandboxing::execute_env;
+use crate::sandboxing::execute_exec_request_with_after_spawn;
 use crate::session::turn_context::TurnEnvironment;
 use crate::shell::ShellType;
 use crate::tools::flat_tool_name;
@@ -40,6 +41,8 @@ use crate::tools::sandboxing::managed_network_for_sandbox_permissions;
 use crate::tools::sandboxing::sandbox_permissions_preserving_denied_reads;
 use crate::tools::sandboxing::with_cached_approval;
 use codex_network_proxy::NetworkProxy;
+use codex_protocol::error::CodexErr;
+use codex_protocol::error::SandboxErr;
 use codex_protocol::exec_output::ExecToolCallOutput;
 use codex_protocol::models::AdditionalPermissionProfile;
 use codex_protocol::protocol::ReviewDecision;
@@ -48,6 +51,7 @@ use codex_shell_command::powershell::prefix_powershell_script_with_utf8;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use futures::future::BoxFuture;
 use std::collections::HashMap;
+use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 #[derive(Clone, Debug)]
@@ -88,6 +92,30 @@ pub(crate) enum ShellRuntimeBackend {
 
 pub struct ShellRuntime {
     backend: ShellRuntimeBackend,
+    plugin_script: Option<Option<Arc<PluginScriptExecution>>>,
+}
+
+fn finish_plugin_script(
+    result: Result<ExecToolCallOutput, ToolError>,
+    plugin_script: Option<&Arc<PluginScriptExecution>>,
+    cancellation_token: &CancellationToken,
+) -> Result<ExecToolCallOutput, ToolError> {
+    if let Some(execution) = plugin_script {
+        if cancellation_token.is_cancelled() {
+            execution.mark_interrupted();
+        }
+        match &result {
+            Ok(out) => execution.finish(Some(out.exit_code), out.timed_out),
+            Err(ToolError::Codex(CodexErr::Sandbox(SandboxErr::Timeout { output }))) => {
+                execution.finish(Some(output.exit_code), /*failed*/ true)
+            }
+            Err(ToolError::Codex(CodexErr::Sandbox(SandboxErr::Denied { output, .. }))) => {
+                execution.finish(Some(output.exit_code), /*failed*/ true)
+            }
+            Err(_) => execution.finish(/*exit_code*/ None, /*failed*/ true),
+        }
+    }
+    result
 }
 
 #[derive(serde::Serialize, Clone, Debug, Eq, PartialEq, Hash)]
@@ -101,7 +129,10 @@ pub(crate) struct ApprovalKey {
 
 impl ShellRuntime {
     pub(crate) fn for_shell_command(backend: ShellRuntimeBackend) -> Self {
-        Self { backend }
+        Self {
+            backend,
+            plugin_script: None,
+        }
     }
 
     fn stdout_stream(ctx: &ToolCtx) -> Option<crate::exec::StdoutStream> {
@@ -110,6 +141,24 @@ impl ShellRuntime {
             call_id: ctx.call_id.clone(),
             tx_event: ctx.session.get_tx_event(),
         })
+    }
+    fn finish_plugin_script_attempt(
+        &mut self,
+        result: Result<ExecToolCallOutput, ToolError>,
+        plugin_script: Option<&Arc<PluginScriptExecution>>,
+        cancellation_token: &CancellationToken,
+    ) -> Result<ExecToolCallOutput, ToolError> {
+        let denied = matches!(
+            &result,
+            Err(ToolError::Codex(CodexErr::Sandbox(
+                SandboxErr::Denied { .. }
+            )))
+        );
+        let result = finish_plugin_script(result, plugin_script, cancellation_token);
+        if denied {
+            self.plugin_script = None;
+        }
+        result
     }
 }
 
@@ -251,6 +300,18 @@ impl ToolRuntime<ShellRequest, ExecToolCallOutput> for ShellRuntime {
             .as_ref()
             .unwrap_or(session_shell.as_ref());
         let shell_snapshot_location = req.turn_environment.shell_snapshot(&req.cwd);
+        let plugin_script = self
+            .plugin_script
+            .get_or_insert_with(|| {
+                PluginScriptExecution::resolve(
+                    ctx.session.as_ref(),
+                    ctx.turn.as_ref(),
+                    &req.hook_command,
+                    &req.cwd,
+                    req.shell_type.unwrap_or(session_shell.shell_type),
+                )
+            })
+            .clone();
         let (file_system_sandbox_policy, _) = attempt.permissions.to_runtime_permissions();
         let sandbox_permissions = sandbox_permissions_preserving_denied_reads(
             req.sandbox_permissions,
@@ -298,9 +359,30 @@ impl ToolRuntime<ShellRequest, ExecToolCallOutput> for ShellRuntime {
         };
 
         if self.backend == ShellRuntimeBackend::ShellCommandZshFork {
-            match zsh_fork_backend::maybe_run_shell_command(req, attempt, ctx, &command).await? {
-                Some(out) => return Ok(out),
-                None => {
+            match zsh_fork_backend::maybe_run_shell_command(
+                req,
+                attempt,
+                ctx,
+                &command,
+                plugin_script.clone(),
+            )
+            .await
+            {
+                Ok(Some(out)) => {
+                    return self.finish_plugin_script_attempt(
+                        Ok(out),
+                        plugin_script.as_ref(),
+                        &req.cancellation_token,
+                    );
+                }
+                Err(err) => {
+                    return self.finish_plugin_script_attempt(
+                        Err(err),
+                        plugin_script.as_ref(),
+                        &req.cancellation_token,
+                    );
+                }
+                Ok(None) => {
                     tracing::warn!(
                         "ZshFork backend specified, but conditions for using it were not met, falling back to normal execution",
                     );
@@ -327,10 +409,15 @@ impl ToolRuntime<ShellRequest, ExecToolCallOutput> for ShellRuntime {
                 Some(&req.turn_environment.environment_id),
             )
             .map_err(ToolError::Codex)?;
-        let out = execute_env(env, Self::stdout_stream(ctx))
-            .await
-            .map_err(ToolError::Codex)?;
-        Ok(out)
+        let after_spawn = plugin_script.as_ref().map(|plugin_script| {
+            let plugin_script = Arc::clone(plugin_script);
+            Box::new(move || plugin_script.mark_started()) as Box<dyn FnOnce() + Send>
+        });
+        let result =
+            execute_exec_request_with_after_spawn(env, Self::stdout_stream(ctx), after_spawn)
+                .await
+                .map_err(ToolError::Codex);
+        self.finish_plugin_script_attempt(result, plugin_script.as_ref(), &req.cancellation_token)
     }
 }
 

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation.rs
@@ -108,6 +108,7 @@ pub(super) async fn try_run_zsh_fork(
     attempt: &SandboxAttempt<'_>,
     ctx: &ToolCtx,
     command: &[String],
+    plugin_script: Option<Arc<crate::plugin_script_lifecycle::PluginScriptExecution>>,
 ) -> Result<Option<ExecToolCallOutput>, ToolError> {
     let Some(shell_zsh_path) = ctx.session.services.shell_zsh_path.as_ref() else {
         tracing::warn!("ZshFork backend specified, but shell_zsh_path is not configured.");
@@ -202,6 +203,7 @@ pub(super) async fn try_run_zsh_fork(
         windows_sandbox_workspace_roots,
         codex_linux_sandbox_exe: ctx.turn.config.codex_linux_sandbox_exe.clone(),
         use_legacy_landlock: ctx.turn.config.features.use_legacy_landlock(),
+        plugin_script,
     };
     let main_execve_wrapper_exe = ctx
         .session
@@ -225,6 +227,7 @@ pub(super) async fn try_run_zsh_fork(
     // escalation server.
     let stopwatch = Stopwatch::new(effective_timeout);
     let mut cancel_token = stopwatch.cancellation_token();
+    cancel_token = cancel_when_either(cancel_token, req.cancellation_token.clone());
     if let Some(cancellation) = attempt.network_denial_cancellation_token.clone() {
         cancel_token = cancel_when_either(cancel_token, cancellation);
     }
@@ -259,7 +262,7 @@ pub(super) async fn try_run_zsh_fork(
         .await
         .map_err(|err| ToolError::Rejected(err.to_string()))?;
 
-    map_exec_result(attempt.sandbox, exec_result).map(Some)
+    map_exec_result(attempt.sandbox, exec_result, &req.cancellation_token).map(Some)
 }
 
 pub(crate) async fn prepare_unified_exec_zsh_fork(
@@ -315,6 +318,7 @@ pub(crate) async fn prepare_unified_exec_zsh_fork(
         windows_sandbox_workspace_roots: exec_request.windows_sandbox_workspace_roots.clone(),
         codex_linux_sandbox_exe: ctx.turn.config.codex_linux_sandbox_exe.clone(),
         use_legacy_landlock: ctx.turn.config.features.use_legacy_landlock(),
+        plugin_script: None,
     };
     let escalation_policy = CoreShellActionProvider {
         policy: Arc::clone(&exec_policy),
@@ -824,6 +828,7 @@ struct CoreShellCommandExecutor {
     windows_sandbox_workspace_roots: Vec<AbsolutePathBuf>,
     codex_linux_sandbox_exe: Option<PathBuf>,
     use_legacy_landlock: bool,
+    plugin_script: Option<Arc<crate::plugin_script_lifecycle::PluginScriptExecution>>,
 }
 
 struct PrepareSandboxedExecParams<'a> {
@@ -881,6 +886,18 @@ impl CoreShellCommandExecutor {
             }
         }
 
+        let after_spawn = match (after_spawn, self.plugin_script.clone()) {
+            (Some(after_spawn), Some(plugin_script)) => Some(Box::new(move || {
+                after_spawn();
+                plugin_script.mark_started();
+            })
+                as Box<dyn FnOnce() + Send>),
+            (Some(after_spawn), None) => Some(after_spawn),
+            (None, Some(plugin_script)) => {
+                Some(Box::new(move || plugin_script.mark_started()) as Box<dyn FnOnce() + Send>)
+            }
+            (None, None) => None,
+        };
         let result = crate::sandboxing::execute_exec_request_with_after_spawn(
             crate::sandboxing::ExecRequest {
                 command: self.command.clone(),
@@ -1097,6 +1114,7 @@ fn extract_shell_script(command: &[String]) -> Result<ParsedShellCommand, ToolEr
 fn map_exec_result(
     sandbox: SandboxType,
     result: ExecResult,
+    user_cancellation_token: &CancellationToken,
 ) -> Result<ExecToolCallOutput, ToolError> {
     let output = ExecToolCallOutput {
         exit_code: result.exit_code,
@@ -1106,6 +1124,10 @@ fn map_exec_result(
         duration: result.duration,
         timed_out: result.timed_out,
     };
+
+    if user_cancellation_token.is_cancelled() {
+        return Err(ToolError::Rejected("rejected by user".to_string()));
+    }
 
     if result.timed_out {
         return Err(ToolError::Codex(CodexErr::Sandbox(SandboxErr::Timeout {

--- a/codex-rs/core/src/tools/runtimes/shell/unix_escalation_tests.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/unix_escalation_tests.rs
@@ -46,6 +46,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
 
 fn host_absolute_path(segments: &[&str]) -> String {
     let mut path = if cfg!(windows) {
@@ -274,12 +275,38 @@ fn map_exec_result_preserves_stdout_and_stderr() {
             duration: Duration::from_millis(1),
             timed_out: false,
         },
+        &CancellationToken::new(),
     )
     .unwrap();
 
     assert_eq!(out.stdout.text, "out");
     assert_eq!(out.stderr.text, "err");
     assert_eq!(out.aggregated_output.text, "outerr");
+}
+
+#[test]
+fn map_exec_result_maps_user_cancelled_exit_to_rejected_by_user() {
+    let user_cancellation_token = CancellationToken::new();
+    user_cancellation_token.cancel();
+
+    let result = map_exec_result(
+        SandboxType::None,
+        ExecResult {
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: String::new(),
+            output: String::new(),
+            duration: Duration::from_millis(1),
+            timed_out: false,
+        },
+        &user_cancellation_token,
+    );
+
+    assert!(matches!(
+        result,
+        Err(crate::tools::sandboxing::ToolError::Rejected(message))
+            if message == "rejected by user"
+    ));
 }
 
 #[test]
@@ -373,6 +400,7 @@ async fn unsandboxed_intercepted_exec_strips_managed_network_env() -> anyhow::Re
         windows_sandbox_workspace_roots: vec![workdir.clone()],
         codex_linux_sandbox_exe: None,
         use_legacy_landlock: false,
+        plugin_script: None,
     };
     let mut env = HashMap::new();
     env.insert(PROXY_ACTIVE_ENV_KEY.to_string(), "1".to_string());

--- a/codex-rs/core/src/tools/runtimes/shell/zsh_fork_backend.rs
+++ b/codex-rs/core/src/tools/runtimes/shell/zsh_fork_backend.rs
@@ -1,4 +1,5 @@
 use super::ShellRequest;
+use crate::plugin_script_lifecycle::PluginScriptExecution;
 use crate::sandboxing::ExecRequest;
 use crate::tools::runtimes::unified_exec::UnifiedExecRequest;
 use crate::tools::sandboxing::SandboxAttempt;
@@ -7,6 +8,7 @@ use crate::tools::sandboxing::ToolError;
 use crate::unified_exec::SpawnLifecycleHandle;
 use codex_protocol::exec_output::ExecToolCallOutput;
 use codex_tools::ZshForkConfig;
+use std::sync::Arc;
 
 pub(crate) struct PreparedUnifiedExecSpawn {
     pub(crate) exec_request: ExecRequest,
@@ -23,8 +25,9 @@ pub(crate) async fn maybe_run_shell_command(
     attempt: &SandboxAttempt<'_>,
     ctx: &ToolCtx,
     command: &[String],
+    plugin_script: Option<Arc<PluginScriptExecution>>,
 ) -> Result<Option<ExecToolCallOutput>, ToolError> {
-    imp::maybe_run_shell_command(req, attempt, ctx, command).await
+    imp::maybe_run_shell_command(req, attempt, ctx, command, plugin_script).await
 }
 
 /// Prepares unified exec to launch through the zsh-fork backend when the
@@ -76,8 +79,9 @@ mod imp {
         attempt: &SandboxAttempt<'_>,
         ctx: &ToolCtx,
         command: &[String],
+        plugin_script: Option<Arc<PluginScriptExecution>>,
     ) -> Result<Option<ExecToolCallOutput>, ToolError> {
-        unix_escalation::try_run_zsh_fork(req, attempt, ctx, command).await
+        unix_escalation::try_run_zsh_fork(req, attempt, ctx, command, plugin_script).await
     }
 
     pub(super) async fn maybe_prepare_unified_exec(
@@ -118,8 +122,9 @@ mod imp {
         attempt: &SandboxAttempt<'_>,
         ctx: &ToolCtx,
         command: &[String],
+        plugin_script: Option<Arc<PluginScriptExecution>>,
     ) -> Result<Option<ExecToolCallOutput>, ToolError> {
-        let _ = (req, attempt, ctx, command);
+        let _ = (req, attempt, ctx, command, plugin_script);
         Ok(None)
     }
 


### PR DESCRIPTION
## What

- Add plugin script lifecycle tracking to classic shell and zsh-fork execution.
- Emit `started` only after spawn and translate user cancellation to `interrupted`.
- Map terminal shell results through explicit lifecycle outcomes.

## Why

Phase 1 lifecycle metrics need trusted plugin scripts executed through shell runtimes to emit best-effort lifecycle events without changing command behavior.

Enhancement design: [Codex Plugin Metrics](https://app.notion.com/p/openai/Codex-Plugin-Metrics-3898e50b62b0801bb0cdff4e40580268?source=copy_link)

Stacked on #31855.

## How

- Resolve and cache plugin script attribution before shell rewriting and sandbox execution.
- Attach post-spawn callbacks to classic shell and zsh-fork paths.
- Finish lifecycle state from normal exits, timeouts, sandbox denials, and user cancellation.
- Reset attribution after sandbox denial so retries get a new execution ID.

## I tested this

- `just fmt` — passed
- `just fix -p codex-core-plugins -p codex-plugin -p codex-analytics -p codex-core -p codex-features -p codex-app-server -p codex-windows-sandbox` — passed (stack-wide scoped lint gate)
- `just argument-comment-lint` — passed
- `just test -p codex-core shell::unix_escalation` — passed (21/21)
- Stack-level E2E coverage is in #31857: `just test -p codex-app-server plugin_script_lifecycle` — passed (4/4)
- `just test` — attempted; the local workspace build stopped before tests because the runner lacks system `libcap` for unrelated `codex-bwrap`. Exact-head CI provides the full Linux/macOS/Windows matrix.