### PR TITLE
Add unified exec plugin lifecycle adapter

### DIFF
--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -9,6 +9,7 @@ use crate::exec::ExecCapturePolicy;
 use crate::exec::ExecExpiration;
 use crate::guardian::GuardianNetworkAccessTrigger;
 use crate::plugin_script_lifecycle::PluginScriptExecution;
+use crate::plugin_script_lifecycle::PluginScriptTerminalOutcome;
 use crate::sandboxing::ExecOptions;
 use crate::sandboxing::ExecServerEnvConfig;
 use crate::sandboxing::SandboxPermissions;
@@ -114,7 +115,7 @@ pub struct UnifiedExecRuntime<'a> {
 trait PluginScriptLifecycle: Send + Sync {
     fn mark_started(&self);
     fn mark_cancelled(&self);
-    fn finish(&self, exit_code: Option<i32>, failed: bool);
+    fn finish(&self, outcome: PluginScriptTerminalOutcome);
 }
 
 impl PluginScriptLifecycle for PluginScriptExecution {
@@ -126,8 +127,8 @@ impl PluginScriptLifecycle for PluginScriptExecution {
         self.mark_interrupted();
     }
 
-    fn finish(&self, exit_code: Option<i32>, failed: bool) {
-        self.finish(exit_code, failed);
+    fn finish(&self, outcome: PluginScriptTerminalOutcome) {
+        self.finish(outcome);
     }
 }
 
@@ -165,14 +166,21 @@ impl SpawnLifecycle for PluginScriptSpawnLifecycle {
 
     fn finish(&self, exit_code: Option<i32>, failed: bool) {
         self.inner.finish(exit_code, failed);
-        self.plugin_script.finish(exit_code, failed);
+        let outcome = if failed {
+            PluginScriptTerminalOutcome::Failed { exit_code }
+        } else if let Some(exit_code) = exit_code {
+            PluginScriptTerminalOutcome::Exited { exit_code }
+        } else {
+            PluginScriptTerminalOutcome::Failed { exit_code: None }
+        };
+        self.plugin_script.finish(outcome);
     }
 }
 
 impl Drop for PluginScriptSpawnLifecycle {
     fn drop(&mut self) {
         self.plugin_script
-            .finish(/*exit_code*/ None, /*failed*/ true);
+            .finish(PluginScriptTerminalOutcome::Failed { exit_code: None });
     }
 }
 
@@ -850,7 +858,7 @@ mod tests {
             self.events.lock().unwrap().push("plugin_cancelled");
         }
 
-        fn finish(&self, _exit_code: Option<i32>, _failed: bool) {
+        fn finish(&self, _outcome: PluginScriptTerminalOutcome) {
             if !self
                 .terminal_emitted
                 .swap(true, std::sync::atomic::Ordering::AcqRel)

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -8,6 +8,7 @@ use crate::command_canonicalization::canonicalize_command_for_approval;
 use crate::exec::ExecCapturePolicy;
 use crate::exec::ExecExpiration;
 use crate::guardian::GuardianNetworkAccessTrigger;
+use crate::plugin_script_lifecycle::PluginScriptExecution;
 use crate::sandboxing::ExecOptions;
 use crate::sandboxing::ExecServerEnvConfig;
 use crate::sandboxing::SandboxPermissions;
@@ -37,6 +38,8 @@ use crate::tools::sandboxing::managed_network_for_sandbox_permissions;
 use crate::tools::sandboxing::sandbox_permissions_preserving_denied_reads;
 use crate::tools::sandboxing::with_cached_approval;
 use crate::unified_exec::NoopSpawnLifecycle;
+use crate::unified_exec::SpawnLifecycle;
+use crate::unified_exec::SpawnLifecycleHandle;
 use crate::unified_exec::UnifiedExecError;
 use crate::unified_exec::UnifiedExecProcess;
 use crate::unified_exec::UnifiedExecProcessManager;
@@ -54,6 +57,7 @@ use codex_utils_path_uri::PathUri;
 use futures::future::BoxFuture;
 use std::collections::HashMap;
 use std::io;
+use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tracing::error;
 
@@ -98,6 +102,124 @@ pub struct UnifiedExecApprovalKey {
 pub struct UnifiedExecRuntime<'a> {
     manager: &'a UnifiedExecProcessManager,
     shell_mode: UnifiedExecShellMode,
+}
+
+/// Lifecycle callback surface that lets unified exec mirror its generic spawn
+/// lifecycle into a resolved plugin-script execution.
+///
+/// Implementations must preserve the caller-provided callback order: unified
+/// exec invokes the generic `SpawnLifecycle` first, then forwards the matching
+/// plugin callback. Terminal callbacks may be repeated by cleanup paths, so
+/// implementations must keep cancellation and finish handling idempotent.
+trait PluginScriptLifecycle: Send + Sync {
+    fn mark_started(&self);
+    fn mark_cancelled(&self);
+    fn finish(&self, exit_code: Option<i32>, failed: bool);
+}
+
+impl PluginScriptLifecycle for PluginScriptExecution {
+    fn mark_started(&self) {
+        self.mark_started();
+    }
+
+    fn mark_cancelled(&self) {
+        self.mark_interrupted();
+    }
+
+    fn finish(&self, exit_code: Option<i32>, failed: bool) {
+        self.finish(exit_code, failed);
+    }
+}
+
+/// Adds plugin attribution without replacing unified exec's generic spawn work.
+struct PluginScriptSpawnLifecycle {
+    inner: SpawnLifecycleHandle,
+    plugin_script: Arc<dyn PluginScriptLifecycle>,
+}
+
+impl std::fmt::Debug for PluginScriptSpawnLifecycle {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PluginScriptSpawnLifecycle")
+            .field("inner", &self.inner)
+            .field("plugin_script", &"tracked")
+            .finish()
+    }
+}
+
+impl SpawnLifecycle for PluginScriptSpawnLifecycle {
+    #[cfg(unix)]
+    fn inherited_fds(&self) -> Vec<i32> {
+        self.inner.inherited_fds()
+    }
+
+    fn after_spawn(&mut self) {
+        self.inner.after_spawn();
+        self.plugin_script.mark_started();
+    }
+
+    fn mark_cancelled(&self) {
+        self.inner.mark_cancelled();
+        self.plugin_script.mark_cancelled();
+    }
+
+    fn finish(&self, exit_code: Option<i32>, failed: bool) {
+        self.inner.finish(exit_code, failed);
+        self.plugin_script.finish(exit_code, failed);
+    }
+}
+
+impl Drop for PluginScriptSpawnLifecycle {
+    fn drop(&mut self) {
+        self.plugin_script
+            .finish(/*exit_code*/ None, /*failed*/ true);
+    }
+}
+
+fn wrap_plugin_script_lifecycle(
+    inner: SpawnLifecycleHandle,
+    plugin_script: Option<Arc<dyn PluginScriptLifecycle>>,
+) -> SpawnLifecycleHandle {
+    match plugin_script {
+        Some(plugin_script) => Box::new(PluginScriptSpawnLifecycle {
+            inner,
+            plugin_script,
+        }),
+        None => inner,
+    }
+}
+
+fn wrap_spawn_lifecycle(
+    inner: SpawnLifecycleHandle,
+    plugin_script: Option<&Arc<PluginScriptExecution>>,
+) -> SpawnLifecycleHandle {
+    wrap_plugin_script_lifecycle(
+        inner,
+        plugin_script
+            .map(|plugin_script| Arc::clone(plugin_script) as Arc<dyn PluginScriptLifecycle>),
+    )
+}
+
+fn should_track_plugin_script(req: &UnifiedExecRequest) -> bool {
+    !req.turn_environment.environment.is_remote()
+}
+
+fn resolve_plugin_script_execution(
+    req: &UnifiedExecRequest,
+    ctx: &ToolCtx,
+) -> Option<Arc<PluginScriptExecution>> {
+    let cwd = req.cwd.to_abs_path().ok()?;
+    should_track_plugin_script(req)
+        .then(|| {
+            PluginScriptExecution::resolve(
+                ctx.session.as_ref(),
+                ctx.turn.as_ref(),
+                &req.hook_command,
+                &cwd,
+                req.shell_type,
+            )
+        })
+        .flatten()
 }
 
 fn unified_exec_options(
@@ -340,6 +462,9 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
             }
             None => (env, None),
         };
+        // Resolve before snapshot, sandbox, PowerShell, or exec-server rewriting:
+        // only the original local request has safe plugin roots and cwd.
+        let plugin_script = resolve_plugin_script_execution(req, ctx);
         let explicit_env_overrides = req.explicit_env_overrides.clone();
         #[cfg(unix)]
         let mut env = env;
@@ -433,7 +558,7 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
                             req.process_id,
                             &prepared.exec_request,
                             req.tty,
-                            prepared.spawn_lifecycle,
+                            wrap_spawn_lifecycle(prepared.spawn_lifecycle, plugin_script.as_ref()),
                             req.turn_environment.environment.as_ref(),
                         )
                         .await
@@ -468,6 +593,8 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
             error @ ToolError::Codex(_) => error,
         })?;
         let options = unified_exec_options(attempt.network_denial_cancellation_token.clone());
+        let spawn_lifecycle =
+            wrap_spawn_lifecycle(Box::new(NoopSpawnLifecycle), plugin_script.as_ref());
         self.manager
             .open_session_with_exec_env(
                 req.process_id,
@@ -478,7 +605,7 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
                 /*environment_id*/ Some(&req.turn_environment.environment_id),
                 req.exec_server_env_config.clone(),
                 req.tty,
-                Box::new(NoopSpawnLifecycle),
+                spawn_lifecycle,
                 req.turn_environment.environment.as_ref(),
             )
             .await
@@ -681,6 +808,164 @@ mod tests {
             justification: None,
             exec_approval_requirement,
         }
+    }
+
+    #[derive(Debug)]
+    struct RecordingLifecycle {
+        #[cfg(unix)]
+        inherited_fds: Vec<i32>,
+        events: Arc<std::sync::Mutex<Vec<&'static str>>>,
+    }
+
+    impl SpawnLifecycle for RecordingLifecycle {
+        #[cfg(unix)]
+        fn inherited_fds(&self) -> Vec<i32> {
+            self.inherited_fds.clone()
+        }
+
+        fn after_spawn(&mut self) {
+            self.events.lock().unwrap().push("inner_started");
+        }
+
+        fn mark_cancelled(&self) {
+            self.events.lock().unwrap().push("inner_cancelled");
+        }
+
+        fn finish(&self, _exit_code: Option<i32>, _failed: bool) {
+            self.events.lock().unwrap().push("inner_finished");
+        }
+    }
+
+    struct RecordingPluginLifecycle {
+        events: Arc<std::sync::Mutex<Vec<&'static str>>>,
+        terminal_emitted: std::sync::atomic::AtomicBool,
+    }
+
+    impl PluginScriptLifecycle for RecordingPluginLifecycle {
+        fn mark_started(&self) {
+            self.events.lock().unwrap().push("plugin_started");
+        }
+
+        fn mark_cancelled(&self) {
+            self.events.lock().unwrap().push("plugin_cancelled");
+        }
+
+        fn finish(&self, _exit_code: Option<i32>, _failed: bool) {
+            if !self
+                .terminal_emitted
+                .swap(true, std::sync::atomic::Ordering::AcqRel)
+            {
+                self.events.lock().unwrap().push("plugin_finished");
+            }
+        }
+    }
+
+    fn recording_lifecycle() -> (
+        PluginScriptSpawnLifecycle,
+        Arc<std::sync::Mutex<Vec<&'static str>>>,
+    ) {
+        let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let lifecycle = PluginScriptSpawnLifecycle {
+            inner: Box::new(RecordingLifecycle {
+                #[cfg(unix)]
+                inherited_fds: vec![7, 11],
+                events: Arc::clone(&events),
+            }),
+            plugin_script: Arc::new(RecordingPluginLifecycle {
+                events: Arc::clone(&events),
+                terminal_emitted: std::sync::atomic::AtomicBool::new(false),
+            }),
+        };
+        (lifecycle, events)
+    }
+
+    #[test]
+    fn plugin_lifecycle_starts_after_inner() {
+        let (mut lifecycle, events) = recording_lifecycle();
+
+        lifecycle.after_spawn();
+
+        assert_eq!(
+            *events.lock().unwrap(),
+            vec!["inner_started", "plugin_started"]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn plugin_lifecycle_preserves_inherited_fds() {
+        let (lifecycle, _events) = recording_lifecycle();
+
+        assert_eq!(lifecycle.inherited_fds(), vec![7, 11]);
+    }
+
+    #[test]
+    fn plugin_lifecycle_wraps_local_shell_trackers() {
+        for shell_type in [ShellType::PowerShell, ShellType::Cmd, ShellType::Bash] {
+            let events = Arc::new(std::sync::Mutex::new(Vec::new()));
+            let mut lifecycle = wrap_plugin_script_lifecycle(
+                Box::new(RecordingLifecycle {
+                    #[cfg(unix)]
+                    inherited_fds: Vec::new(),
+                    events: Arc::clone(&events),
+                }),
+                Some(Arc::new(RecordingPluginLifecycle {
+                    events: Arc::clone(&events),
+                    terminal_emitted: std::sync::atomic::AtomicBool::new(false),
+                })),
+            );
+
+            lifecycle.after_spawn();
+            lifecycle.finish(Some(0), /*failed*/ false);
+            assert_eq!(
+                *events.lock().unwrap(),
+                vec![
+                    "inner_started",
+                    "plugin_started",
+                    "inner_finished",
+                    "plugin_finished"
+                ],
+                "{shell_type:?} should keep plugin attribution",
+            );
+        }
+    }
+
+    #[test]
+    fn plugin_lifecycle_forwards_cancellation_and_idempotent_terminal_state() {
+        let (lifecycle, events) = recording_lifecycle();
+
+        lifecycle.mark_cancelled();
+        lifecycle.finish(Some(0), /*failed*/ false);
+        lifecycle.finish(Some(9), /*failed*/ true);
+        drop(lifecycle);
+
+        assert_eq!(
+            *events.lock().unwrap(),
+            vec![
+                "inner_cancelled",
+                "plugin_cancelled",
+                "inner_finished",
+                "plugin_finished",
+                "inner_finished",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn remote_unified_exec_requests_do_not_track_plugin_scripts() {
+        let mut request = test_request(
+            SandboxPermissions::UseDefault,
+            ExecApprovalRequirement::Skip {
+                bypass_sandbox: false,
+                proposed_execpolicy_amendment: None,
+            },
+        );
+        request.turn_environment.environment = Arc::new(
+            Environment::create_for_tests(Some("ws://127.0.0.1:1/remote-exec-server".to_string()))
+                .expect("remote environment"),
+        );
+
+        assert!(!should_track_plugin_script(&request));
     }
 
     fn zsh_fork_mode() -> UnifiedExecShellMode {

--- a/codex-rs/core/src/unified_exec/mod.rs
+++ b/codex-rs/core/src/unified_exec/mod.rs
@@ -56,7 +56,6 @@ pub(crate) fn set_deterministic_process_ids_for_tests(enabled: bool) {
 
 pub(crate) use errors::UnifiedExecError;
 pub(crate) use process::NoopSpawnLifecycle;
-#[cfg(unix)]
 pub(crate) use process::SpawnLifecycle;
 pub(crate) use process::SpawnLifecycleHandle;
 pub(crate) use process::UnifiedExecProcess;


### PR DESCRIPTION
## What

- Attach plugin lifecycle tracking to direct and zsh-fork unified exec paths.
- Suppress attribution for remote execution environments.
- Translate generic process callbacks into explicit plugin terminal outcomes at the adapter boundary.

## Why

Phase 1 lifecycle metrics need to cover the default unified-exec path without changing execution behavior.

Enhancement design: [Codex Plugin Metrics](https://app.notion.com/p/openai/Codex-Plugin-Metrics-3898e50b62b0801bb0cdff4e40580268?source=copy_link)

Stacked on #31857.

## How

- Resolve the original local command before sandbox/shell rewriting.
- Wrap the existing spawn lifecycle and forward started, interrupted, and terminal callbacks idempotently.
- Keep the generic lifecycle API unchanged and translate outcomes only in the plugin adapter.

## I tested this

- `just fmt` — passed
- `just fix -p codex-core-plugins -p codex-plugin -p codex-analytics -p codex-core -p codex-features -p codex-app-server -p codex-windows-sandbox` — passed (stack-wide scoped lint gate)
- `just argument-comment-lint` — passed
- `just test -p codex-core plugin_lifecycle` — passed (4/4)
- `just test -p codex-core remote_unified_exec_requests` — passed (1/1)
- `just test -p codex-app-server plugin_script_lifecycle` — passed (4/4)
- `just test` — attempted; the local workspace build stopped before tests because the runner lacks system `libcap` for unrelated `codex-bwrap`. Exact-head CI provides the full Linux/macOS/Windows matrix.