### PR TITLE
package code mode host as a managed resource

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -352,13 +352,13 @@ jobs:
             rm -rf "$bundle_root"
             mkdir -p "$bundle_root/codex-resources"
             cp "$dest/codex-${{ matrix.target }}" "$bundle_root/codex"
-            cp "$dest/codex-code-mode-host-${{ matrix.target }}" "$bundle_root/codex-resources/codex-code-mode-host"
+            cp "$dest/codex-code-mode-host-${{ matrix.target }}" "$bundle_root/codex-code-mode-host"
             cp "$dest/bwrap-${{ matrix.target }}" "$bundle_root/codex-resources/bwrap"
             chmod 0755 \
               "$bundle_root/codex" \
-              "$bundle_root/codex-resources/codex-code-mode-host" \
+              "$bundle_root/codex-code-mode-host" \
               "$bundle_root/codex-resources/bwrap"
-            tar -C "$bundle_root" -cf - codex codex-resources/codex-code-mode-host codex-resources/bwrap |
+            tar -C "$bundle_root" -cf - codex codex-code-mode-host codex-resources/bwrap |
               zstd -T0 -19 -o "$dest/codex-${{ matrix.target }}-bundle.tar.zst"
           fi
 

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -352,11 +352,13 @@ jobs:
             rm -rf "$bundle_root"
             mkdir -p "$bundle_root/codex-resources"
             cp "$dest/codex-${{ matrix.target }}" "$bundle_root/codex"
+            cp "$dest/codex-code-mode-host-${{ matrix.target }}" "$bundle_root/codex-resources/codex-code-mode-host"
             cp "$dest/bwrap-${{ matrix.target }}" "$bundle_root/codex-resources/bwrap"
             chmod 0755 \
               "$bundle_root/codex" \
+              "$bundle_root/codex-resources/codex-code-mode-host" \
               "$bundle_root/codex-resources/bwrap"
-            tar -C "$bundle_root" -cf - codex codex-resources/bwrap |
+            tar -C "$bundle_root" -cf - codex codex-resources/codex-code-mode-host codex-resources/bwrap |
               zstd -T0 -19 -o "$dest/codex-${{ matrix.target }}-bundle.tar.zst"
           fi
 

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -352,13 +352,11 @@ jobs:
             rm -rf "$bundle_root"
             mkdir -p "$bundle_root/codex-resources"
             cp "$dest/codex-${{ matrix.target }}" "$bundle_root/codex"
-            cp "$dest/codex-code-mode-host-${{ matrix.target }}" "$bundle_root/codex-code-mode-host"
             cp "$dest/bwrap-${{ matrix.target }}" "$bundle_root/codex-resources/bwrap"
             chmod 0755 \
               "$bundle_root/codex" \
-              "$bundle_root/codex-code-mode-host" \
               "$bundle_root/codex-resources/bwrap"
-            tar -C "$bundle_root" -cf - codex codex-code-mode-host codex-resources/bwrap |
+            tar -C "$bundle_root" -cf - codex codex-resources/bwrap |
               zstd -T0 -19 -o "$dest/codex-${{ matrix.target }}-bundle.tar.zst"
           fi
 

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -352,13 +352,13 @@ jobs:
             rm -rf "$bundle_root"
             mkdir -p "$bundle_root/codex-resources"
             cp "$dest/codex-${{ matrix.target }}" "$bundle_root/codex"
-            cp "$dest/codex-code-mode-host-${{ matrix.target }}" "$bundle_root/codex-code-mode-host"
+            cp "$dest/codex-code-mode-host-${{ matrix.target }}" "$bundle_root/codex-resources/codex-code-mode-host"
             cp "$dest/bwrap-${{ matrix.target }}" "$bundle_root/codex-resources/bwrap"
             chmod 0755 \
               "$bundle_root/codex" \
-              "$bundle_root/codex-code-mode-host" \
+              "$bundle_root/codex-resources/codex-code-mode-host" \
               "$bundle_root/codex-resources/bwrap"
-            tar -C "$bundle_root" -cf - codex codex-code-mode-host codex-resources/bwrap |
+            tar -C "$bundle_root" -cf - codex codex-resources/codex-code-mode-host codex-resources/bwrap |
               zstd -T0 -19 -o "$dest/codex-${{ matrix.target }}-bundle.tar.zst"
           fi
 
@@ -1054,7 +1054,7 @@ jobs:
           mkdir -p "$package_dir"
           tar -xzf "${packaged_dir}/${package_stem}-${target}.tar.gz" -C "$package_dir"
           verify_signed_binary "${package_dir}/bin/${package_entrypoint}" "$package_entrypoint"
-          verify_signed_binary "${package_dir}/bin/codex-code-mode-host" "codex-code-mode-host"
+          verify_signed_binary "${package_dir}/codex-resources/codex-code-mode-host" "codex-code-mode-host"
 
           if [[ "${{ matrix.verify_dmg }}" != "true" ]]; then
             exit 0

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2491,6 +2491,7 @@ name = "codex-code-mode"
 version = "0.0.0"
 dependencies = [
  "codex-code-mode-protocol",
+ "codex-install-context",
  "codex-protocol",
  "deno_core_icudata",
  "futures",

--- a/codex-rs/cli/src/doctor.rs
+++ b/codex-rs/cli/src/doctor.rs
@@ -936,6 +936,14 @@ fn describe_install_context(context: &InstallContext) -> String {
                 }
             }
         }
+        InstallMethod::DirectBundle {
+            bundle_dir,
+            resources_dir,
+        } => format!(
+            "direct bundle (root {}, resources {})",
+            bundle_dir.display(),
+            resources_dir.display()
+        ),
         InstallMethod::Npm => {
             describe_method_with_package_layout("npm", context.package_layout.as_ref())
         }

--- a/codex-rs/cli/src/doctor/runtime.rs
+++ b/codex-rs/cli/src/doctor/runtime.rs
@@ -119,6 +119,7 @@ pub(super) fn search_check() -> DoctorCheck {
 fn install_method_name(context: &InstallContext) -> &'static str {
     match &context.method {
         InstallMethod::Standalone { .. } => "standalone",
+        InstallMethod::DirectBundle { .. } => "direct bundle",
         InstallMethod::Npm => "npm",
         InstallMethod::Bun => "bun",
         InstallMethod::Pnpm => "pnpm",

--- a/codex-rs/cli/src/doctor/updates.rs
+++ b/codex-rs/cli/src/doctor/updates.rs
@@ -136,6 +136,7 @@ fn update_action_label(context: &InstallContext) -> &'static str {
         InstallMethod::Pnpm => "pnpm add -g @openai/codex",
         InstallMethod::Brew => "brew upgrade --cask codex",
         InstallMethod::Standalone { .. } => "standalone installer",
+        InstallMethod::DirectBundle { .. } => "manual direct bundle",
         InstallMethod::Other => "manual or unknown",
     }
 }
@@ -147,6 +148,7 @@ fn fetch_latest_version(context: &InstallContext) -> Result<String, String> {
         | InstallMethod::Bun
         | InstallMethod::Pnpm
         | InstallMethod::Standalone { .. }
+        | InstallMethod::DirectBundle { .. }
         | InstallMethod::Other => fetch_latest_github_release_version(),
     }
 }

--- a/codex-rs/code-mode/Cargo.toml
+++ b/codex-rs/code-mode/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 
 [dependencies]
 codex-code-mode-protocol = { workspace = true }
+codex-install-context = { workspace = true }
 codex-protocol = { workspace = true }
 deno_core_icudata = { workspace = true }
 futures = { workspace = true }

--- a/codex-rs/code-mode/src/remote_session.rs
+++ b/codex-rs/code-mode/src/remote_session.rs
@@ -1,5 +1,3 @@
-use std::ffi::OsString;
-use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
@@ -18,6 +16,7 @@ use codex_code_mode_protocol::StartedCell;
 use codex_code_mode_protocol::WaitOutcome;
 use codex_code_mode_protocol::WaitRequest;
 use codex_code_mode_protocol::host::SessionId;
+use codex_install_context::InstallContext;
 use tokio::sync::Semaphore;
 use tokio::sync::watch;
 
@@ -28,8 +27,6 @@ use self::connection::SessionCleanup;
 use crate::NoopCodeModeSessionDelegate;
 
 mod connection;
-
-const CODE_MODE_HOST_PATH_ENV: &str = "CODEX_CODE_MODE_HOST_PATH";
 
 type ShutdownResultReceiver = watch::Receiver<Option<Result<(), String>>>;
 
@@ -66,7 +63,7 @@ impl ProcessOwnedCodeModeSessionProvider {
 
 impl Default for ProcessOwnedCodeModeSessionProvider {
     fn default() -> Self {
-        Self::with_host_program(default_host_program())
+        Self::with_host_program(InstallContext::current().code_mode_host_program())
     }
 }
 
@@ -195,7 +192,9 @@ impl ProcessOwnedCodeModeSession {
     pub fn new() -> Self {
         Self::with_process_host(
             Arc::new(NoopCodeModeSessionDelegate),
-            Arc::new(OwnedProcessHost::new(default_host_program())),
+            Arc::new(OwnedProcessHost::new(
+                InstallContext::current().code_mode_host_program(),
+            )),
         )
     }
 
@@ -492,33 +491,6 @@ impl CodeModeSession for ProcessOwnedCodeModeSession {
     fn shutdown<'a>(&'a self) -> CodeModeSessionResultFuture<'a, ()> {
         Box::pin(ProcessOwnedCodeModeSession::shutdown(self))
     }
-}
-
-fn default_host_program() -> PathBuf {
-    resolve_host_program(
-        std::env::var_os(CODE_MODE_HOST_PATH_ENV),
-        std::env::current_exe(),
-    )
-}
-
-fn resolve_host_program(
-    override_path: Option<OsString>,
-    current_exe: io::Result<PathBuf>,
-) -> PathBuf {
-    if let Some(path) = override_path {
-        return PathBuf::from(path);
-    }
-    let executable_name = if cfg!(windows) {
-        "codex-code-mode-host.exe"
-    } else {
-        "codex-code-mode-host"
-    };
-    if let Ok(current_exe) = current_exe
-        && let Some(parent) = current_exe.parent()
-    {
-        return parent.join(executable_name);
-    }
-    PathBuf::from(executable_name)
 }
 
 #[cfg(test)]

--- a/codex-rs/code-mode/src/remote_session.rs
+++ b/codex-rs/code-mode/src/remote_session.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
@@ -63,7 +64,7 @@ impl ProcessOwnedCodeModeSessionProvider {
 
 impl Default for ProcessOwnedCodeModeSessionProvider {
     fn default() -> Self {
-        Self::with_host_program(InstallContext::current().code_mode_host_program())
+        Self::with_host_program(default_host_program())
     }
 }
 
@@ -192,9 +193,7 @@ impl ProcessOwnedCodeModeSession {
     pub fn new() -> Self {
         Self::with_process_host(
             Arc::new(NoopCodeModeSessionDelegate),
-            Arc::new(OwnedProcessHost::new(
-                InstallContext::current().code_mode_host_program(),
-            )),
+            Arc::new(OwnedProcessHost::new(default_host_program())),
         )
     }
 
@@ -491,6 +490,26 @@ impl CodeModeSession for ProcessOwnedCodeModeSession {
     fn shutdown<'a>(&'a self) -> CodeModeSessionResultFuture<'a, ()> {
         Box::pin(ProcessOwnedCodeModeSession::shutdown(self))
     }
+}
+
+fn default_host_program() -> PathBuf {
+    InstallContext::current()
+        .code_mode_host_program()
+        .unwrap_or_else(|| resolve_host_program(std::env::current_exe()))
+}
+
+fn resolve_host_program(current_exe: io::Result<PathBuf>) -> PathBuf {
+    let executable_name = if cfg!(windows) {
+        "codex-code-mode-host.exe"
+    } else {
+        "codex-code-mode-host"
+    };
+    if let Ok(current_exe) = current_exe
+        && let Some(parent) = current_exe.parent()
+    {
+        return parent.join(executable_name);
+    }
+    PathBuf::from(executable_name)
 }
 
 #[cfg(test)]

--- a/codex-rs/code-mode/src/remote_session.rs
+++ b/codex-rs/code-mode/src/remote_session.rs
@@ -1,4 +1,3 @@
-use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
@@ -25,8 +24,6 @@ use self::connection::Connection;
 use self::connection::ConnectionError;
 use self::connection::RemoteSession;
 use self::connection::SessionCleanup;
-use crate::NoopCodeModeSessionDelegate;
-
 mod connection;
 
 type ShutdownResultReceiver = watch::Receiver<Option<Result<(), String>>>;
@@ -50,6 +47,12 @@ impl ProcessOwnedCodeModeSessionProvider {
         }
     }
 
+    fn in_process() -> Self {
+        Self {
+            state: StdMutex::new(ProviderState::InProcess),
+        }
+    }
+
     fn process_host(&self) -> Option<Arc<OwnedProcessHost>> {
         match &*self
             .state
@@ -64,7 +67,10 @@ impl ProcessOwnedCodeModeSessionProvider {
 
 impl Default for ProcessOwnedCodeModeSessionProvider {
     fn default() -> Self {
-        Self::with_host_program(default_host_program())
+        match InstallContext::current().code_mode_host_program() {
+            Some(host_program) => Self::with_host_program(host_program),
+            None => Self::in_process(),
+        }
     }
 }
 
@@ -190,13 +196,6 @@ pub struct ProcessOwnedCodeModeSession {
 }
 
 impl ProcessOwnedCodeModeSession {
-    pub fn new() -> Self {
-        Self::with_process_host(
-            Arc::new(NoopCodeModeSessionDelegate),
-            Arc::new(OwnedProcessHost::new(default_host_program())),
-        )
-    }
-
     fn with_process_host(
         delegate: Arc<dyn CodeModeSessionDelegate>,
         process_host: Arc<OwnedProcessHost>,
@@ -465,12 +464,6 @@ impl Drop for ProcessOwnedCodeModeSession {
     }
 }
 
-impl Default for ProcessOwnedCodeModeSession {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl CodeModeSession for ProcessOwnedCodeModeSession {
     fn execute<'a>(
         &'a self,
@@ -490,26 +483,6 @@ impl CodeModeSession for ProcessOwnedCodeModeSession {
     fn shutdown<'a>(&'a self) -> CodeModeSessionResultFuture<'a, ()> {
         Box::pin(ProcessOwnedCodeModeSession::shutdown(self))
     }
-}
-
-fn default_host_program() -> PathBuf {
-    InstallContext::current()
-        .code_mode_host_program()
-        .unwrap_or_else(|| resolve_host_program(std::env::current_exe()))
-}
-
-fn resolve_host_program(current_exe: io::Result<PathBuf>) -> PathBuf {
-    let executable_name = if cfg!(windows) {
-        "codex-code-mode-host.exe"
-    } else {
-        "codex-code-mode-host"
-    };
-    if let Ok(current_exe) = current_exe
-        && let Some(parent) = current_exe.parent()
-    {
-        return parent.join(executable_name);
-    }
-    PathBuf::from(executable_name)
 }
 
 #[cfg(test)]

--- a/codex-rs/code-mode/src/remote_session_tests.rs
+++ b/codex-rs/code-mode/src/remote_session_tests.rs
@@ -1,5 +1,3 @@
-use std::io;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use codex_code_mode_protocol::CodeModeSessionProvider;
@@ -8,14 +6,16 @@ use codex_code_mode_protocol::FunctionCallOutputContentItem;
 use codex_code_mode_protocol::RuntimeResponse;
 use pretty_assertions::assert_eq;
 
+use super::OwnedProcessHost;
 use super::ProcessOwnedCodeModeSession;
 use super::ProcessOwnedCodeModeSessionProvider;
-use super::resolve_host_program;
 use crate::NoopCodeModeSessionDelegate;
 
 #[test]
 fn provider_reuses_its_live_process_host() {
-    let provider = ProcessOwnedCodeModeSessionProvider::default();
+    let provider = ProcessOwnedCodeModeSessionProvider::with_host_program(
+        "codex-code-mode-host-for-test".into(),
+    );
 
     let first = provider.process_host().expect("owned process host");
     let second = provider.process_host().expect("owned process host");
@@ -24,34 +24,10 @@ fn provider_reuses_its_live_process_host() {
 }
 
 #[test]
-fn host_program_is_next_to_the_main_executable_even_when_missing() {
-    let executable_name = if cfg!(windows) {
-        "codex-code-mode-host.exe"
-    } else {
-        "codex-code-mode-host"
-    };
+fn provider_without_host_program_uses_in_process_mode() {
+    let provider = ProcessOwnedCodeModeSessionProvider::in_process();
 
-    assert_eq!(
-        resolve_host_program(Ok(PathBuf::from("/opt/codex/bin/codex"))),
-        PathBuf::from("/opt/codex/bin").join(executable_name)
-    );
-}
-
-#[test]
-fn host_program_falls_back_to_its_name_when_main_executable_is_unknown() {
-    let executable_name = if cfg!(windows) {
-        "codex-code-mode-host.exe"
-    } else {
-        "codex-code-mode-host"
-    };
-
-    assert_eq!(
-        resolve_host_program(Err(io::Error::new(
-            io::ErrorKind::NotFound,
-            "missing executable"
-        ))),
-        PathBuf::from(executable_name)
-    );
+    assert!(provider.process_host().is_none());
 }
 
 #[tokio::test]
@@ -92,7 +68,12 @@ async fn provider_falls_back_to_in_process_session_when_host_is_missing() {
 
 #[tokio::test]
 async fn shutdown_before_open_does_not_spawn_the_host() {
-    let session = ProcessOwnedCodeModeSession::new();
+    let session = ProcessOwnedCodeModeSession::with_process_host(
+        Arc::new(NoopCodeModeSessionDelegate),
+        Arc::new(OwnedProcessHost::new(
+            "codex-code-mode-host-does-not-exist".into(),
+        )),
+    );
 
     session.shutdown().await.expect("shutdown session");
     let error = session

--- a/codex-rs/code-mode/src/remote_session_tests.rs
+++ b/codex-rs/code-mode/src/remote_session_tests.rs
@@ -1,3 +1,5 @@
+use std::io;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use codex_code_mode_protocol::CodeModeSessionProvider;
@@ -8,6 +10,7 @@ use pretty_assertions::assert_eq;
 
 use super::ProcessOwnedCodeModeSession;
 use super::ProcessOwnedCodeModeSessionProvider;
+use super::resolve_host_program;
 use crate::NoopCodeModeSessionDelegate;
 
 #[test]
@@ -18,6 +21,37 @@ fn provider_reuses_its_live_process_host() {
     let second = provider.process_host().expect("owned process host");
 
     assert!(Arc::ptr_eq(&first, &second));
+}
+
+#[test]
+fn host_program_is_next_to_the_main_executable_even_when_missing() {
+    let executable_name = if cfg!(windows) {
+        "codex-code-mode-host.exe"
+    } else {
+        "codex-code-mode-host"
+    };
+
+    assert_eq!(
+        resolve_host_program(Ok(PathBuf::from("/opt/codex/bin/codex"))),
+        PathBuf::from("/opt/codex/bin").join(executable_name)
+    );
+}
+
+#[test]
+fn host_program_falls_back_to_its_name_when_main_executable_is_unknown() {
+    let executable_name = if cfg!(windows) {
+        "codex-code-mode-host.exe"
+    } else {
+        "codex-code-mode-host"
+    };
+
+    assert_eq!(
+        resolve_host_program(Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "missing executable"
+        ))),
+        PathBuf::from(executable_name)
+    );
 }
 
 #[tokio::test]

--- a/codex-rs/code-mode/src/remote_session_tests.rs
+++ b/codex-rs/code-mode/src/remote_session_tests.rs
@@ -1,5 +1,3 @@
-use std::io;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use codex_code_mode_protocol::CodeModeSessionProvider;
@@ -10,7 +8,6 @@ use pretty_assertions::assert_eq;
 
 use super::ProcessOwnedCodeModeSession;
 use super::ProcessOwnedCodeModeSessionProvider;
-use super::resolve_host_program;
 use crate::NoopCodeModeSessionDelegate;
 
 #[test]
@@ -21,54 +18,6 @@ fn provider_reuses_its_live_process_host() {
     let second = provider.process_host().expect("owned process host");
 
     assert!(Arc::ptr_eq(&first, &second));
-}
-
-#[test]
-fn host_program_override_takes_precedence() {
-    assert_eq!(
-        resolve_host_program(
-            Some("custom-code-mode-host".into()),
-            Ok(PathBuf::from("/opt/codex/bin/codex")),
-        ),
-        PathBuf::from("custom-code-mode-host")
-    );
-}
-
-#[test]
-fn host_program_is_next_to_the_main_executable_even_when_missing() {
-    let executable_name = if cfg!(windows) {
-        "codex-code-mode-host.exe"
-    } else {
-        "codex-code-mode-host"
-    };
-
-    assert_eq!(
-        resolve_host_program(
-            /*override_path*/ None,
-            Ok(PathBuf::from("/opt/codex/bin/codex")),
-        ),
-        PathBuf::from("/opt/codex/bin").join(executable_name)
-    );
-}
-
-#[test]
-fn host_program_falls_back_to_its_name_when_main_executable_is_unknown() {
-    let executable_name = if cfg!(windows) {
-        "codex-code-mode-host.exe"
-    } else {
-        "codex-code-mode-host"
-    };
-
-    assert_eq!(
-        resolve_host_program(
-            /*override_path*/ None,
-            Err(io::Error::new(
-                io::ErrorKind::NotFound,
-                "missing executable"
-            )),
-        ),
-        PathBuf::from(executable_name)
-    );
 }
 
 #[tokio::test]

--- a/codex-rs/install-context/src/lib.rs
+++ b/codex-rs/install-context/src/lib.rs
@@ -52,6 +52,12 @@ pub enum InstallMethod {
         /// The platform of the standalone release, either `Unix` or `Windows`.
         platform: StandalonePlatform,
     },
+    /// A directly extracted Linux bundle with `codex` at its root and managed
+    /// resources under `codex-resources/`.
+    DirectBundle {
+        bundle_dir: AbsolutePathBuf,
+        resources_dir: AbsolutePathBuf,
+    },
     /// A Codex binary launched through the npm-managed `codex.js` shim.
     Npm,
     /// A Codex binary launched through the bun-managed `codex.js` shim.
@@ -136,7 +142,8 @@ impl InstallContext {
         if let InstallMethod::Standalone {
             resources_dir: Some(resources_dir),
             ..
-        } = &self.method
+        }
+        | InstallMethod::DirectBundle { resources_dir, .. } = &self.method
         {
             let bundled_rg = resources_dir.join(default_rg_command());
             if bundled_rg.is_file() {
@@ -147,7 +154,7 @@ impl InstallContext {
         default_rg_command()
     }
 
-    /// Returns the code-mode host when it is part of the detected package layout.
+    /// Returns the code-mode host when it is part of the detected installation.
     pub fn code_mode_host_program(&self) -> Option<PathBuf> {
         self.bundled_resource(code_mode_host_executable_name())
             .map(AbsolutePathBuf::into_path_buf)
@@ -166,7 +173,8 @@ impl InstallContext {
         if let InstallMethod::Standalone {
             resources_dir: Some(resources_dir),
             ..
-        } = &self.method
+        }
+        | InstallMethod::DirectBundle { resources_dir, .. } = &self.method
         {
             let resource = resources_dir.join(file_name);
             if resource.is_file() {
@@ -225,12 +233,40 @@ fn install_method_from_exe(
     {
         return standalone_method;
     }
+    if let Some(direct_bundle_method) = direct_bundle_install_method(exe_path, package_layout) {
+        return direct_bundle_method;
+    }
 
     if is_macos && (exe_path.starts_with("/opt/homebrew") || exe_path.starts_with("/usr/local")) {
         InstallMethod::Brew
     } else {
         InstallMethod::Other
     }
+}
+
+fn direct_bundle_install_method(
+    exe_path: &Path,
+    package_layout: Option<&CodexPackageLayout>,
+) -> Option<InstallMethod> {
+    if !cfg!(target_os = "linux") || package_layout.is_some() {
+        return None;
+    }
+
+    let canonical_exe = canonical_absolute_path(exe_path)?;
+    if canonical_exe.file_name() != Some(OsStr::new("codex")) {
+        return None;
+    }
+
+    let bundle_dir = canonical_exe.parent()?;
+    let resources_dir = bundle_dir.join(RESOURCES_DIRNAME);
+    if !resources_dir.is_dir() {
+        return None;
+    }
+
+    Some(InstallMethod::DirectBundle {
+        bundle_dir,
+        resources_dir,
+    })
 }
 
 fn standalone_install_method(
@@ -336,6 +372,49 @@ mod tests {
         };
 
         assert_eq!(context.code_mode_host_program(), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn detects_direct_bundle_and_resolves_resources() -> std::io::Result<()> {
+        let bundle_dir = tempfile::tempdir()?;
+        let resources_dir = bundle_dir.path().join(RESOURCES_DIRNAME);
+        fs::create_dir_all(&resources_dir)?;
+        let exe_path = bundle_dir.path().join("codex");
+        let host_path = resources_dir.join(code_mode_host_executable_name());
+        fs::write(&exe_path, "")?;
+        fs::write(&host_path, "")?;
+        let canonical_bundle_dir =
+            AbsolutePathBuf::from_absolute_path(bundle_dir.path().canonicalize()?)?;
+        let canonical_resources_dir =
+            AbsolutePathBuf::from_absolute_path(resources_dir.canonicalize()?)?;
+
+        let context = InstallContext::from_exe_with_codex_home(
+            /*is_macos*/ false,
+            /*current_exe*/ Some(&exe_path),
+            /*method_override*/ None,
+            /*codex_home*/ None,
+        );
+
+        assert_eq!(
+            context,
+            InstallContext {
+                method: InstallMethod::DirectBundle {
+                    bundle_dir: canonical_bundle_dir,
+                    resources_dir: canonical_resources_dir.clone(),
+                },
+                package_layout: None,
+            }
+        );
+        assert_eq!(
+            context.code_mode_host_program(),
+            Some(
+                canonical_resources_dir
+                    .join(code_mode_host_executable_name())
+                    .into_path_buf()
+            )
+        );
+        Ok(())
     }
 
     #[test]

--- a/codex-rs/install-context/src/lib.rs
+++ b/codex-rs/install-context/src/lib.rs
@@ -1,6 +1,4 @@
 use std::ffi::OsStr;
-use std::ffi::OsString;
-use std::io;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::OnceLock;
@@ -8,7 +6,6 @@ use std::sync::OnceLock;
 use codex_utils_absolute_path::AbsolutePathBuf;
 
 const BIN_DIRNAME: &str = "bin";
-const CODE_MODE_HOST_PATH_ENV: &str = "CODEX_CODE_MODE_HOST_PATH";
 const PACKAGE_METADATA_FILENAME: &str = "codex-package.json";
 const PATH_DIRNAME: &str = "codex-path";
 const RELEASES_DIRNAME: &str = "releases";
@@ -150,35 +147,10 @@ impl InstallContext {
         default_rg_command()
     }
 
-    /// Resolves the code-mode host executable for the current installation.
-    pub fn code_mode_host_program(&self) -> PathBuf {
-        self.resolve_code_mode_host_program(
-            std::env::var_os(CODE_MODE_HOST_PATH_ENV),
-            std::env::current_exe(),
-        )
-    }
-
-    fn resolve_code_mode_host_program(
-        &self,
-        override_path: Option<OsString>,
-        current_exe: io::Result<PathBuf>,
-    ) -> PathBuf {
-        if let Some(path) = override_path {
-            return PathBuf::from(path);
-        }
-
-        let executable_name = code_mode_host_executable_name();
-        if let Some(path) = self.bundled_resource(executable_name) {
-            return path.into_path_buf();
-        }
-
-        if let Ok(current_exe) = current_exe
-            && let Some(parent) = current_exe.parent()
-        {
-            return parent.join(executable_name);
-        }
-
-        PathBuf::from(executable_name)
+    /// Returns the code-mode host when it is part of the detected package layout.
+    pub fn code_mode_host_program(&self) -> Option<PathBuf> {
+        self.bundled_resource(code_mode_host_executable_name())
+            .map(AbsolutePathBuf::into_path_buf)
     }
 
     pub fn bundled_resource(&self, file_name: impl AsRef<Path>) -> Option<AbsolutePathBuf> {
@@ -334,7 +306,7 @@ mod tests {
     const TEST_RESOURCE_NAME: &str = "codex-test-helper";
 
     #[test]
-    fn code_mode_host_program_prefers_override_then_bundled_resource() -> std::io::Result<()> {
+    fn code_mode_host_program_returns_bundled_resource() -> std::io::Result<()> {
         let package_dir = tempfile::tempdir()?;
         let bin_dir = package_dir.path().join(BIN_DIRNAME);
         let resources_dir = package_dir.path().join(RESOURCES_DIRNAME);
@@ -352,53 +324,18 @@ mod tests {
             /*method_override*/ None,
         );
 
-        assert_eq!(
-            context.resolve_code_mode_host_program(
-                Some("custom-code-mode-host".into()),
-                Ok(exe_path.clone()),
-            ),
-            PathBuf::from("custom-code-mode-host")
-        );
-        assert_eq!(
-            context.resolve_code_mode_host_program(/*override_path*/ None, Ok(exe_path),),
-            canonical_host_path
-        );
+        assert_eq!(context.code_mode_host_program(), Some(canonical_host_path));
         Ok(())
     }
 
     #[test]
-    fn code_mode_host_program_uses_adjacent_binary_for_legacy_layout() {
+    fn code_mode_host_program_is_none_without_bundled_resource() {
         let context = InstallContext {
             method: InstallMethod::Other,
             package_layout: None,
         };
 
-        assert_eq!(
-            context.resolve_code_mode_host_program(
-                /*override_path*/ None,
-                Ok(PathBuf::from("/opt/codex/bin/codex")),
-            ),
-            PathBuf::from("/opt/codex/bin").join(code_mode_host_executable_name())
-        );
-    }
-
-    #[test]
-    fn code_mode_host_program_falls_back_to_executable_name() {
-        let context = InstallContext {
-            method: InstallMethod::Other,
-            package_layout: None,
-        };
-
-        assert_eq!(
-            context.resolve_code_mode_host_program(
-                /*override_path*/ None,
-                Err(io::Error::new(
-                    io::ErrorKind::NotFound,
-                    "missing executable"
-                )),
-            ),
-            PathBuf::from(code_mode_host_executable_name())
-        );
+        assert_eq!(context.code_mode_host_program(), None);
     }
 
     #[test]

--- a/codex-rs/install-context/src/lib.rs
+++ b/codex-rs/install-context/src/lib.rs
@@ -353,7 +353,8 @@ mod tests {
         fs::write(&exe_path, "")?;
         let host_path = resources_dir.join(code_mode_host_executable_name());
         fs::write(&host_path, "")?;
-        let canonical_host_path = host_path.canonicalize()?;
+        let canonical_host_path =
+            AbsolutePathBuf::from_absolute_path(host_path.canonicalize()?)?.into_path_buf();
         let context = InstallContext::from_exe(
             /*is_macos*/ false,
             /*current_exe*/ Some(&exe_path),

--- a/codex-rs/install-context/src/lib.rs
+++ b/codex-rs/install-context/src/lib.rs
@@ -1,4 +1,6 @@
 use std::ffi::OsStr;
+use std::ffi::OsString;
+use std::io;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::OnceLock;
@@ -6,6 +8,7 @@ use std::sync::OnceLock;
 use codex_utils_absolute_path::AbsolutePathBuf;
 
 const BIN_DIRNAME: &str = "bin";
+const CODE_MODE_HOST_PATH_ENV: &str = "CODEX_CODE_MODE_HOST_PATH";
 const PACKAGE_METADATA_FILENAME: &str = "codex-package.json";
 const PATH_DIRNAME: &str = "codex-path";
 const RELEASES_DIRNAME: &str = "releases";
@@ -147,6 +150,37 @@ impl InstallContext {
         default_rg_command()
     }
 
+    /// Resolves the code-mode host executable for the current installation.
+    pub fn code_mode_host_program(&self) -> PathBuf {
+        self.resolve_code_mode_host_program(
+            std::env::var_os(CODE_MODE_HOST_PATH_ENV),
+            std::env::current_exe(),
+        )
+    }
+
+    fn resolve_code_mode_host_program(
+        &self,
+        override_path: Option<OsString>,
+        current_exe: io::Result<PathBuf>,
+    ) -> PathBuf {
+        if let Some(path) = override_path {
+            return PathBuf::from(path);
+        }
+
+        let executable_name = code_mode_host_executable_name();
+        if let Some(path) = self.bundled_resource(executable_name) {
+            return path.into_path_buf();
+        }
+
+        if let Ok(current_exe) = current_exe
+            && let Some(parent) = current_exe.parent()
+        {
+            return parent.join(executable_name);
+        }
+
+        PathBuf::from(executable_name)
+    }
+
     pub fn bundled_resource(&self, file_name: impl AsRef<Path>) -> Option<AbsolutePathBuf> {
         if let Some(package_layout) = &self.package_layout
             && let Some(resources_dir) = &package_layout.resources_dir
@@ -279,6 +313,14 @@ fn default_rg_command() -> PathBuf {
     }
 }
 
+fn code_mode_host_executable_name() -> &'static str {
+    if cfg!(windows) {
+        "codex-code-mode-host.exe"
+    } else {
+        "codex-code-mode-host"
+    }
+}
+
 fn zsh_resource_path() -> PathBuf {
     PathBuf::from(ZSH_DIRNAME).join(BIN_DIRNAME).join("zsh")
 }
@@ -290,6 +332,74 @@ mod tests {
     use std::fs;
 
     const TEST_RESOURCE_NAME: &str = "codex-test-helper";
+
+    #[test]
+    fn code_mode_host_program_prefers_override_then_bundled_resource() -> std::io::Result<()> {
+        let package_dir = tempfile::tempdir()?;
+        let bin_dir = package_dir.path().join(BIN_DIRNAME);
+        let resources_dir = package_dir.path().join(RESOURCES_DIRNAME);
+        fs::create_dir_all(&bin_dir)?;
+        fs::create_dir_all(&resources_dir)?;
+        fs::write(package_dir.path().join(PACKAGE_METADATA_FILENAME), "{}")?;
+        let exe_path = bin_dir.join(if cfg!(windows) { "codex.exe" } else { "codex" });
+        fs::write(&exe_path, "")?;
+        let host_path = resources_dir.join(code_mode_host_executable_name());
+        fs::write(&host_path, "")?;
+        let canonical_host_path = host_path.canonicalize()?;
+        let context = InstallContext::from_exe(
+            /*is_macos*/ false,
+            /*current_exe*/ Some(&exe_path),
+            /*method_override*/ None,
+        );
+
+        assert_eq!(
+            context.resolve_code_mode_host_program(
+                Some("custom-code-mode-host".into()),
+                Ok(exe_path.clone()),
+            ),
+            PathBuf::from("custom-code-mode-host")
+        );
+        assert_eq!(
+            context.resolve_code_mode_host_program(/*override_path*/ None, Ok(exe_path),),
+            canonical_host_path
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn code_mode_host_program_uses_adjacent_binary_for_legacy_layout() {
+        let context = InstallContext {
+            method: InstallMethod::Other,
+            package_layout: None,
+        };
+
+        assert_eq!(
+            context.resolve_code_mode_host_program(
+                /*override_path*/ None,
+                Ok(PathBuf::from("/opt/codex/bin/codex")),
+            ),
+            PathBuf::from("/opt/codex/bin").join(code_mode_host_executable_name())
+        );
+    }
+
+    #[test]
+    fn code_mode_host_program_falls_back_to_executable_name() {
+        let context = InstallContext {
+            method: InstallMethod::Other,
+            package_layout: None,
+        };
+
+        assert_eq!(
+            context.resolve_code_mode_host_program(
+                /*override_path*/ None,
+                Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "missing executable"
+                )),
+            ),
+            PathBuf::from(code_mode_host_executable_name())
+        );
+    }
 
     #[test]
     fn detects_standalone_install_from_release_layout() -> std::io::Result<()> {

--- a/codex-rs/linux-sandbox/src/bundled_bwrap.rs
+++ b/codex-rs/linux-sandbox/src/bundled_bwrap.rs
@@ -226,15 +226,20 @@ mod tests {
     }
 
     #[test]
-    fn finds_legacy_standalone_bundled_bwrap_next_to_exe_resources() {
+    fn finds_direct_bundle_bwrap_from_install_context() {
         let temp_dir = tempdir().expect("temp dir");
         let exe = temp_dir.path().join("codex");
         let expected_bwrap = temp_dir.path().join("codex-resources").join("bwrap");
         write_executable(&exe);
         write_executable(&expected_bwrap);
+        let context = InstallContext::from_exe(
+            /*is_macos*/ false,
+            /*current_exe*/ Some(&exe),
+            /*method_override*/ None,
+        );
 
         assert_eq!(
-            find_legacy_for_exe(&exe),
+            find_for_install_context(&context),
             Some(AbsolutePathBuf::from_absolute_path(&expected_bwrap).expect("absolute"))
         );
     }

--- a/codex-rs/tui/src/update_action.rs
+++ b/codex-rs/tui/src/update_action.rs
@@ -34,7 +34,7 @@ impl UpdateAction {
                 StandalonePlatform::Unix => UpdateAction::StandaloneUnix,
                 StandalonePlatform::Windows => UpdateAction::StandaloneWindows,
             }),
-            InstallMethod::Other => None,
+            InstallMethod::DirectBundle { .. } | InstallMethod::Other => None,
         }
     }
 

--- a/scripts/codex_package/README.md
+++ b/scripts/codex_package/README.md
@@ -10,10 +10,10 @@ The builder creates a canonical Codex package directory:
 .
 ├── codex-package.json
 ├── bin
-│   ├── <entrypoint>[.exe]
-│   └── codex-code-mode-host[.exe]
+│   └── <entrypoint>[.exe]
 ├── codex-resources
 │   ├── bwrap                             # Linux only
+│   ├── codex-code-mode-host[.exe]
 │   ├── zsh/bin/zsh                       # supported Unix targets only
 │   ├── codex-command-runner.exe          # Windows only
 │   └── codex-windows-sandbox-setup.exe   # Windows only
@@ -53,7 +53,7 @@ entrypoint should pass `--entrypoint-bin` so the package contains that exact
 binary instead of rebuilding it.
 
 Release jobs should likewise pass `--code-mode-host-bin` so the package contains
-the signed host executable beside the signed entrypoint.
+the signed host executable in `codex-resources`.
 
 Release jobs that already built package resource binaries should also pass the
 corresponding resource flags: `--bwrap-bin` for Linux packages, and

--- a/scripts/codex_package/layout.py
+++ b/scripts/codex_package/layout.py
@@ -53,7 +53,7 @@ def build_package_dir(
     )
     copy_executable(
         inputs.code_mode_host_bin,
-        bin_dir / f"codex-code-mode-host{spec.exe_suffix}",
+        resources_dir / f"codex-code-mode-host{spec.exe_suffix}",
         is_windows=spec.is_windows,
     )
     copy_executable(inputs.rg_bin, path_dir / spec.rg_name, is_windows=spec.is_windows)
@@ -135,7 +135,7 @@ def validate_package_dir(
 
     required_files = [
         Path("bin") / variant.entrypoint_name(spec),
-        Path("bin") / f"codex-code-mode-host{spec.exe_suffix}",
+        Path("codex-resources") / f"codex-code-mode-host{spec.exe_suffix}",
         Path("codex-path") / spec.rg_name,
     ]
     executable_files = list(required_files)

--- a/scripts/codex_package/test_layout.py
+++ b/scripts/codex_package/test_layout.py
@@ -15,36 +15,61 @@ from codex_package.targets import TARGET_SPECS
 
 
 class PackageLayoutTest(unittest.TestCase):
-    def test_app_server_package_places_code_mode_host_beside_entrypoint(self) -> None:
+    def test_app_server_package_places_code_mode_host_in_resources(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
-            root = Path(temp_dir)
-            package_dir = root / "package"
-            package_dir.mkdir()
-            inputs = PackageInputs(
-                entrypoint_bin=touch_executable(root / "codex-app-server"),
-                code_mode_host_bin=touch_executable(root / "codex-code-mode-host"),
-                rg_bin=touch_executable(root / "rg"),
-                zsh_bin=None,
-                bwrap_bin=touch_executable(root / "bwrap"),
-                codex_command_runner_bin=None,
-                codex_windows_sandbox_setup_bin=None,
-            )
+            for target in (
+                "x86_64-unknown-linux-musl",
+                "x86_64-pc-windows-msvc",
+            ):
+                with self.subTest(target=target):
+                    root = Path(temp_dir) / target
+                    root.mkdir()
+                    package_dir = root / "package"
+                    package_dir.mkdir()
+                    spec = TARGET_SPECS[target]
+                    inputs = PackageInputs(
+                        entrypoint_bin=touch_executable(root / "codex-app-server"),
+                        code_mode_host_bin=touch_executable(
+                            root / "codex-code-mode-host"
+                        ),
+                        rg_bin=touch_executable(root / "rg"),
+                        zsh_bin=None,
+                        bwrap_bin=(
+                            touch_executable(root / "bwrap") if spec.is_linux else None
+                        ),
+                        codex_command_runner_bin=(
+                            touch_executable(root / "codex-command-runner.exe")
+                            if spec.is_windows
+                            else None
+                        ),
+                        codex_windows_sandbox_setup_bin=(
+                            touch_executable(root / "codex-windows-sandbox-setup.exe")
+                            if spec.is_windows
+                            else None
+                        ),
+                    )
 
-            build_package_dir(
-                package_dir,
-                "1.2.3",
-                PACKAGE_VARIANTS["codex-app-server"],
-                TARGET_SPECS["x86_64-unknown-linux-musl"],
-                inputs,
-            )
-            validate_package_dir(
-                package_dir,
-                PACKAGE_VARIANTS["codex-app-server"],
-                TARGET_SPECS["x86_64-unknown-linux-musl"],
-                include_zsh=False,
-            )
+                    build_package_dir(
+                        package_dir,
+                        "1.2.3",
+                        PACKAGE_VARIANTS["codex-app-server"],
+                        spec,
+                        inputs,
+                    )
+                    validate_package_dir(
+                        package_dir,
+                        PACKAGE_VARIANTS["codex-app-server"],
+                        spec,
+                        include_zsh=False,
+                    )
 
-            self.assertTrue((package_dir / "bin" / "codex-code-mode-host").is_file())
+                    self.assertTrue(
+                        (
+                            package_dir
+                            / "codex-resources"
+                            / f"codex-code-mode-host{spec.exe_suffix}"
+                        ).is_file()
+                    )
 
 
 def touch_executable(path: Path) -> Path:

--- a/scripts/codex_package/test_layout.py
+++ b/scripts/codex_package/test_layout.py
@@ -17,16 +17,12 @@ from codex_package.targets import TARGET_SPECS
 class PackageLayoutTest(unittest.TestCase):
     def test_app_server_package_places_code_mode_host_in_resources(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
-            for target in (
-                "x86_64-unknown-linux-musl",
-                "x86_64-pc-windows-msvc",
-            ):
+            for target, spec in TARGET_SPECS.items():
                 with self.subTest(target=target):
                     root = Path(temp_dir) / target
                     root.mkdir()
                     package_dir = root / "package"
                     package_dir.mkdir()
-                    spec = TARGET_SPECS[target]
                     inputs = PackageInputs(
                         entrypoint_bin=touch_executable(root / "codex-app-server"),
                         code_mode_host_bin=touch_executable(

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -539,7 +539,6 @@ function Test-PackageContentsAreComplete {
         "codex-package.json",
         "bin\codex.exe",
         "codex-path\rg.exe",
-        "codex-resources\codex-code-mode-host.exe",
         "codex-resources\codex-command-runner.exe",
         "codex-resources\codex-windows-sandbox-setup.exe"
     )
@@ -549,7 +548,17 @@ function Test-PackageContentsAreComplete {
         }
     }
 
-    return $true
+    $hostPaths = @(
+        "codex-resources\codex-code-mode-host.exe",
+        "bin\codex-code-mode-host.exe"
+    )
+    foreach ($name in $hostPaths) {
+        if (Test-Path -LiteralPath (Join-Path $PackageDir $name) -PathType Leaf) {
+            return $true
+        }
+    }
+
+    return $false
 }
 
 function Test-LegacyPlatformNpmContentsAreComplete {

--- a/scripts/install/install.ps1
+++ b/scripts/install/install.ps1
@@ -538,8 +538,8 @@ function Test-PackageContentsAreComplete {
     $expectedFiles = @(
         "codex-package.json",
         "bin\codex.exe",
-        "bin\codex-code-mode-host.exe",
         "codex-path\rg.exe",
+        "codex-resources\codex-code-mode-host.exe",
         "codex-resources\codex-command-runner.exe",
         "codex-resources\codex-windows-sandbox-setup.exe"
     )

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -771,12 +771,11 @@ install_package_release() {
   tar -xzf "$archive_path" -C "$stage_release"
   chmod 0755 \
     "$stage_release/bin/codex" \
-    "$stage_release/bin/codex-code-mode-host" \
+    "$stage_release/codex-resources/codex-code-mode-host" \
     "$stage_release/codex-path/rg"
   if [ -f "$stage_release/codex-resources/bwrap" ]; then
     chmod 0755 "$stage_release/codex-resources/bwrap"
   fi
-  ln -sf "bin/codex" "$stage_release/codex"
 
   if [ -e "$release_dir" ] || [ -L "$release_dir" ]; then
     rm -rf "$release_dir"
@@ -825,8 +824,7 @@ release_dir_is_complete() {
     package)
       [ -f "$release_dir/codex-package.json" ] &&
         [ -x "$release_dir/bin/codex" ] &&
-        [ -x "$release_dir/bin/codex-code-mode-host" ] &&
-        [ -x "$release_dir/codex" ] &&
+        [ -x "$release_dir/codex-resources/codex-code-mode-host" ] &&
         [ -x "$release_dir/codex-path/rg" ] ||
         return 1
       ;;

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -7,7 +7,6 @@ NON_INTERACTIVE="${CODEX_NON_INTERACTIVE:-false}"
 
 BIN_DIR="${CODEX_INSTALL_DIR:-$HOME/.local/bin}"
 BIN_PATH="$BIN_DIR/codex"
-CODE_MODE_HOST_BIN_PATH="$BIN_DIR/codex-code-mode-host"
 CODEX_HOME_DIR="${CODEX_HOME:-$HOME/.codex}"
 STANDALONE_ROOT="$CODEX_HOME_DIR/packages/standalone"
 RELEASES_DIR="$STANDALONE_ROOT/releases"
@@ -877,35 +876,12 @@ update_visible_command() {
   mkdir -p "$BIN_DIR"
   tmp_link="$BIN_DIR/.codex.$$"
   codex_relative_path="$(release_codex_relative_path "$release_dir")"
-  code_mode_host_relative_path="$(package_code_mode_host_relative_path "$release_dir")"
 
   replace_path_with_symlink "$BIN_PATH" "$CURRENT_LINK/$codex_relative_path" "$tmp_link"
-
-  if [ "$os" = "darwin" ] &&
-    [ "$code_mode_host_relative_path" = "bin/codex-code-mode-host" ] &&
-    [ -x "$release_dir/$code_mode_host_relative_path" ]; then
-    replace_path_with_symlink \
-      "$CODE_MODE_HOST_BIN_PATH" \
-      "$CURRENT_LINK/$code_mode_host_relative_path" \
-      "$tmp_link"
-  else
-    existing_code_mode_host_target="$(readlink "$CODE_MODE_HOST_BIN_PATH" 2>/dev/null || true)"
-    case "$existing_code_mode_host_target" in
-      "$CURRENT_LINK/bin/codex-code-mode-host" | \
-        "$CURRENT_LINK/codex-resources/codex-code-mode-host")
-        rm -f "$CODE_MODE_HOST_BIN_PATH"
-        ;;
-    esac
-  fi
 }
 
 verify_visible_command() {
   "$BIN_PATH" --version >/dev/null
-  if [ "$os" = "darwin" ] && [ "$install_layout" = "package" ] &&
-    [ "$(package_code_mode_host_relative_path "$release_dir")" = \
-      "bin/codex-code-mode-host" ]; then
-    [ -x "$CODE_MODE_HOST_BIN_PATH" ]
-  fi
 }
 
 parse_args "$@"

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -881,7 +881,9 @@ update_visible_command() {
 
   replace_path_with_symlink "$BIN_PATH" "$CURRENT_LINK/$codex_relative_path" "$tmp_link"
 
-  if [ "$os" = "darwin" ] && [ -x "$release_dir/$code_mode_host_relative_path" ]; then
+  if [ "$os" = "darwin" ] &&
+    [ "$code_mode_host_relative_path" = "bin/codex-code-mode-host" ] &&
+    [ -x "$release_dir/$code_mode_host_relative_path" ]; then
     replace_path_with_symlink \
       "$CODE_MODE_HOST_BIN_PATH" \
       "$CURRENT_LINK/$code_mode_host_relative_path" \
@@ -899,7 +901,9 @@ update_visible_command() {
 
 verify_visible_command() {
   "$BIN_PATH" --version >/dev/null
-  if [ "$os" = "darwin" ] && [ "$install_layout" = "package" ]; then
+  if [ "$os" = "darwin" ] && [ "$install_layout" = "package" ] &&
+    [ "$(package_code_mode_host_relative_path "$release_dir")" = \
+      "bin/codex-code-mode-host" ]; then
     [ -x "$CODE_MODE_HOST_BIN_PATH" ]
   fi
 }

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -760,6 +760,15 @@ handle_conflicting_install() {
   fi
 }
 
+package_code_mode_host_relative_path() {
+  package_dir="$1"
+  if [ -f "$package_dir/codex-resources/codex-code-mode-host" ]; then
+    printf 'codex-resources/codex-code-mode-host\n'
+  else
+    printf 'bin/codex-code-mode-host\n'
+  fi
+}
+
 install_package_release() {
   release_dir="$1"
   archive_path="$2"
@@ -769,9 +778,10 @@ install_package_release() {
   rm -rf "$stage_release"
   mkdir -p "$stage_release"
   tar -xzf "$archive_path" -C "$stage_release"
+  code_mode_host_relative_path="$(package_code_mode_host_relative_path "$stage_release")"
   chmod 0755 \
     "$stage_release/bin/codex" \
-    "$stage_release/codex-resources/codex-code-mode-host" \
+    "$stage_release/$code_mode_host_relative_path" \
     "$stage_release/codex-path/rg"
   if [ -f "$stage_release/codex-resources/bwrap" ]; then
     chmod 0755 "$stage_release/codex-resources/bwrap"
@@ -824,7 +834,8 @@ release_dir_is_complete() {
     package)
       [ -f "$release_dir/codex-package.json" ] &&
         [ -x "$release_dir/bin/codex" ] &&
-        [ -x "$release_dir/codex-resources/codex-code-mode-host" ] &&
+        { [ -x "$release_dir/codex-resources/codex-code-mode-host" ] ||
+          [ -x "$release_dir/bin/codex-code-mode-host" ]; } &&
         [ -x "$release_dir/codex-path/rg" ] ||
         return 1
       ;;
@@ -866,17 +877,23 @@ update_visible_command() {
   mkdir -p "$BIN_DIR"
   tmp_link="$BIN_DIR/.codex.$$"
   codex_relative_path="$(release_codex_relative_path "$release_dir")"
+  code_mode_host_relative_path="$(package_code_mode_host_relative_path "$release_dir")"
 
   replace_path_with_symlink "$BIN_PATH" "$CURRENT_LINK/$codex_relative_path" "$tmp_link"
 
-  if [ "$os" = "darwin" ] && [ -x "$release_dir/bin/codex-code-mode-host" ]; then
+  if [ "$os" = "darwin" ] && [ -x "$release_dir/$code_mode_host_relative_path" ]; then
     replace_path_with_symlink \
       "$CODE_MODE_HOST_BIN_PATH" \
-      "$CURRENT_LINK/bin/codex-code-mode-host" \
+      "$CURRENT_LINK/$code_mode_host_relative_path" \
       "$tmp_link"
-  elif [ "$(readlink "$CODE_MODE_HOST_BIN_PATH" 2>/dev/null || true)" = \
-    "$CURRENT_LINK/bin/codex-code-mode-host" ]; then
-    rm -f "$CODE_MODE_HOST_BIN_PATH"
+  else
+    existing_code_mode_host_target="$(readlink "$CODE_MODE_HOST_BIN_PATH" 2>/dev/null || true)"
+    case "$existing_code_mode_host_target" in
+      "$CURRENT_LINK/bin/codex-code-mode-host" | \
+        "$CURRENT_LINK/codex-resources/codex-code-mode-host")
+        rm -f "$CODE_MODE_HOST_BIN_PATH"
+        ;;
+    esac
   fi
 }
 

--- a/scripts/install/test_install_sh.py
+++ b/scripts/install/test_install_sh.py
@@ -89,30 +89,38 @@ class InstallShTest(unittest.TestCase):
         self.assertNotIn("codex-package_SHA256SUMS", requests[1])
 
     def test_macos_install_exposes_code_mode_host_beside_codex(self) -> None:
-        with tempfile.TemporaryDirectory() as temp_dir:
-            root = Path(temp_dir)
-            archive_path, checksum_path, metadata_json = create_package_release(root)
+        for host_dir in ("codex-resources", "bin"):
+            with (
+                self.subTest(host_dir=host_dir),
+                tempfile.TemporaryDirectory() as temp_dir,
+            ):
+                root = Path(temp_dir)
+                archive_path, checksum_path, metadata_json = create_package_release(
+                    root, host_dir=host_dir
+                )
 
-            result, _requests = run_installer_in(
-                root,
-                VERSION,
-                metadata_json=metadata_json,
-                archive_path=archive_path,
-                checksum_path=checksum_path,
-                force_macos=True,
-            )
+                result, _requests = run_installer_in(
+                    root,
+                    VERSION,
+                    metadata_json=metadata_json,
+                    archive_path=archive_path,
+                    checksum_path=checksum_path,
+                    force_macos=True,
+                )
 
-            self.assertEqual(result.returncode, 0, result.stderr)
-            install_bin = root / "install-bin"
-            current = root / "codex-home" / "packages" / "standalone" / "current"
-            codex_path = install_bin / "codex"
-            host_path = install_bin / "codex-code-mode-host"
-            self.assertEqual(os.readlink(codex_path), str(current / "bin" / "codex"))
-            self.assertEqual(
-                os.readlink(host_path),
-                str(current / "bin" / "codex-code-mode-host"),
-            )
-            self.assertTrue(os.access(host_path, os.X_OK))
+                self.assertEqual(result.returncode, 0, result.stderr)
+                install_bin = root / "install-bin"
+                current = root / "codex-home" / "packages" / "standalone" / "current"
+                codex_path = install_bin / "codex"
+                host_path = install_bin / "codex-code-mode-host"
+                self.assertEqual(
+                    os.readlink(codex_path), str(current / "bin" / "codex")
+                )
+                self.assertEqual(
+                    os.readlink(host_path),
+                    str(current / host_dir / "codex-code-mode-host"),
+                )
+                self.assertTrue(os.access(host_path, os.X_OK))
 
 
 def run_installer(
@@ -241,9 +249,12 @@ def run_installer_in(
     return result, requests
 
 
-def create_package_release(root: Path) -> tuple[Path, Path, str]:
+def create_package_release(
+    root: Path, *, host_dir: str = "codex-resources"
+) -> tuple[Path, Path, str]:
     package_dir = root / "package"
     (package_dir / "bin").mkdir(parents=True)
+    (package_dir / host_dir).mkdir(exist_ok=True)
     (package_dir / "codex-path").mkdir()
     (package_dir / "codex-package.json").write_text("{}\n", encoding="utf-8")
     write_executable(
@@ -251,7 +262,7 @@ def create_package_release(root: Path) -> tuple[Path, Path, str]:
         f"#!/bin/sh\nprintf 'codex-cli {VERSION}\\n'\n",
     )
     write_executable(
-        package_dir / "bin" / "codex-code-mode-host",
+        package_dir / host_dir / "codex-code-mode-host",
         "#!/bin/sh\nexit 0\n",
     )
     write_executable(package_dir / "codex-path" / "rg", "#!/bin/sh\nexit 0\n")

--- a/scripts/install/test_install_sh.py
+++ b/scripts/install/test_install_sh.py
@@ -88,9 +88,7 @@ class InstallShTest(unittest.TestCase):
         self.assertIn("/codex-npm-", requests[1])
         self.assertNotIn("codex-package_SHA256SUMS", requests[1])
 
-    def test_macos_install_only_exposes_legacy_code_mode_host_beside_codex(
-        self,
-    ) -> None:
+    def test_macos_install_only_exposes_codex(self) -> None:
         for host_dir in ("codex-resources", "bin"):
             with (
                 self.subTest(host_dir=host_dir),
@@ -118,14 +116,7 @@ class InstallShTest(unittest.TestCase):
                 self.assertEqual(
                     os.readlink(codex_path), str(current / "bin" / "codex")
                 )
-                if host_dir == "bin":
-                    self.assertEqual(
-                        os.readlink(host_path),
-                        str(current / host_dir / "codex-code-mode-host"),
-                    )
-                    self.assertTrue(os.access(host_path, os.X_OK))
-                else:
-                    self.assertFalse(host_path.exists())
+                self.assertFalse(host_path.exists())
 
 
 def run_installer(

--- a/scripts/install/test_install_sh.py
+++ b/scripts/install/test_install_sh.py
@@ -88,7 +88,9 @@ class InstallShTest(unittest.TestCase):
         self.assertIn("/codex-npm-", requests[1])
         self.assertNotIn("codex-package_SHA256SUMS", requests[1])
 
-    def test_macos_install_exposes_code_mode_host_beside_codex(self) -> None:
+    def test_macos_install_only_exposes_legacy_code_mode_host_beside_codex(
+        self,
+    ) -> None:
         for host_dir in ("codex-resources", "bin"):
             with (
                 self.subTest(host_dir=host_dir),
@@ -116,11 +118,14 @@ class InstallShTest(unittest.TestCase):
                 self.assertEqual(
                     os.readlink(codex_path), str(current / "bin" / "codex")
                 )
-                self.assertEqual(
-                    os.readlink(host_path),
-                    str(current / host_dir / "codex-code-mode-host"),
-                )
-                self.assertTrue(os.access(host_path, os.X_OK))
+                if host_dir == "bin":
+                    self.assertEqual(
+                        os.readlink(host_path),
+                        str(current / host_dir / "codex-code-mode-host"),
+                    )
+                    self.assertTrue(os.access(host_path, os.X_OK))
+                else:
+                    self.assertFalse(host_path.exists())
 
 
 def run_installer(

--- a/sdk/python/scripts/update_sdk_artifacts.py
+++ b/sdk/python/scripts/update_sdk_artifacts.py
@@ -280,9 +280,9 @@ def _validate_codex_package_layout(package_dir: Path, package_archive: Path) -> 
     package_binary = package_dir / "bin" / runtime_binary_name()
     if not package_binary.is_file():
         missing_entries.append(str(Path("bin") / runtime_binary_name()))
-    code_mode_host = package_dir / "bin" / runtime_code_mode_host_name()
+    code_mode_host = package_dir / "codex-resources" / runtime_code_mode_host_name()
     if not code_mode_host.is_file():
-        missing_entries.append(str(Path("bin") / runtime_code_mode_host_name()))
+        missing_entries.append(str(Path("codex-resources") / runtime_code_mode_host_name()))
     if missing_entries:
         missing = ", ".join(missing_entries)
         raise RuntimeError(f"Missing Codex package layout entries in {package_archive}: {missing}")

--- a/sdk/python/scripts/update_sdk_artifacts.py
+++ b/sdk/python/scripts/update_sdk_artifacts.py
@@ -280,9 +280,12 @@ def _validate_codex_package_layout(package_dir: Path, package_archive: Path) -> 
     package_binary = package_dir / "bin" / runtime_binary_name()
     if not package_binary.is_file():
         missing_entries.append(str(Path("bin") / runtime_binary_name()))
-    code_mode_host = package_dir / "codex-resources" / runtime_code_mode_host_name()
-    if not code_mode_host.is_file():
-        missing_entries.append(str(Path("codex-resources") / runtime_code_mode_host_name()))
+    code_mode_host_paths = (
+        Path("codex-resources") / runtime_code_mode_host_name(),
+        Path("bin") / runtime_code_mode_host_name(),
+    )
+    if not any((package_dir / path).is_file() for path in code_mode_host_paths):
+        missing_entries.append(" or ".join(map(str, code_mode_host_paths)))
     if missing_entries:
         missing = ", ".join(missing_entries)
         raise RuntimeError(f"Missing Codex package layout entries in {package_archive}: {missing}")

--- a/sdk/python/tests/test_artifact_workflow_and_binaries.py
+++ b/sdk/python/tests/test_artifact_workflow_and_binaries.py
@@ -51,13 +51,15 @@ def _load_runtime_setup_module():
     return module
 
 
-def _write_fake_codex_package(package_dir: Path, script) -> Path:
+def _write_fake_codex_package(
+    package_dir: Path, script, *, host_dir: str = "codex-resources"
+) -> Path:
     (package_dir / "bin").mkdir(parents=True)
     (package_dir / "codex-resources").mkdir()
     (package_dir / "codex-path").mkdir()
     (package_dir / "codex-package.json").write_text('{"variant":"codex"}\n')
     (package_dir / "bin" / script.runtime_binary_name()).write_text("fake codex\n")
-    (package_dir / "codex-resources" / script.runtime_code_mode_host_name()).write_text(
+    (package_dir / host_dir / script.runtime_code_mode_host_name()).write_text(
         "fake code mode host\n"
     )
     (package_dir / "codex-resources" / "bwrap").write_text("fake bwrap\n")
@@ -699,6 +701,26 @@ def test_stage_runtime_release_copies_package_layout_and_sets_version(
     }
     assert 'name = "openai-codex-cli-bin"' in (staged / "pyproject.toml").read_text()
     assert 'version = "1.2.3"' in (staged / "pyproject.toml").read_text()
+
+
+def test_stage_runtime_release_accepts_legacy_code_mode_host_location(
+    tmp_path: Path,
+) -> None:
+    script = _load_update_script_module()
+    package_dir = _write_fake_codex_package(tmp_path / "codex-package", script, host_dir="bin")
+    package_archive = tmp_path / "codex-package.tar.gz"
+    _write_package_archive(package_dir, package_archive)
+
+    staged = script.stage_python_runtime_package(
+        tmp_path / "runtime-stage",
+        "1.2.3",
+        package_archive,
+    )
+
+    package_root = script.staged_runtime_package_root(staged)
+    assert (
+        package_root / "bin" / script.runtime_code_mode_host_name()
+    ).read_text() == "fake code mode host\n"
 
 
 def test_normalize_codex_version_accepts_release_tags_and_pep440_versions() -> None:

--- a/sdk/python/tests/test_artifact_workflow_and_binaries.py
+++ b/sdk/python/tests/test_artifact_workflow_and_binaries.py
@@ -57,7 +57,9 @@ def _write_fake_codex_package(package_dir: Path, script) -> Path:
     (package_dir / "codex-path").mkdir()
     (package_dir / "codex-package.json").write_text('{"variant":"codex"}\n')
     (package_dir / "bin" / script.runtime_binary_name()).write_text("fake codex\n")
-    (package_dir / "bin" / script.runtime_code_mode_host_name()).write_text("fake code mode host\n")
+    (package_dir / "codex-resources" / script.runtime_code_mode_host_name()).write_text(
+        "fake code mode host\n"
+    )
     (package_dir / "codex-resources" / "bwrap").write_text("fake bwrap\n")
     (package_dir / "codex-path" / "rg").write_text("fake rg\n")
     return package_dir
@@ -683,7 +685,9 @@ def test_stage_runtime_release_copies_package_layout_and_sets_version(
     assert {
         "metadata": (package_root / "codex-package.json").read_text(),
         "codex": (package_root / "bin" / script.runtime_binary_name()).read_text(),
-        "code_mode_host": (package_root / "bin" / script.runtime_code_mode_host_name()).read_text(),
+        "code_mode_host": (
+            package_root / "codex-resources" / script.runtime_code_mode_host_name()
+        ).read_text(),
         "bwrap": (package_root / "codex-resources" / "bwrap").read_text(),
         "rg": (package_root / "codex-path" / "rg").read_text(),
     } == {


### PR DESCRIPTION
## Why

`codex-code-mode-host` is a managed runtime dependency, not a user-facing entrypoint. Packaging it with entrypoint binaries and resolving it relative to the running executable made its location depend on the install format. That was especially fragile across npm, standalone, and direct Linux bundles.

The host should live with the other managed resources and be resolved through `InstallContext`, which already owns knowledge of the active package layout.

## What changed

- Package `codex-code-mode-host` under `codex-resources/` in canonical archives on every platform, and in the direct Linux release bundle alongside `bwrap`.
- Resolve the host through `InstallContext`. Code mode uses the in-process implementation when the active installation does not provide a managed host; it no longer uses an environment override or searches next to the Codex executable.
- Recognize directly extracted Linux bundles as an explicit install method so both the code-mode host and `bwrap` resolve from their `codex-resources/` directory.
- Update the shell and PowerShell installers, release verification, package construction, and Python SDK artifact plumbing for the resource layout. The shell installer no longer creates a visible host symlink.
- Keep installer validation compatible with packages that placed the host under `bin/`, while all newly produced packages use `codex-resources/`.

## Testing

- Added package-layout coverage for the host resource on Linux, macOS, and Windows targets.
- Added installer and Python SDK artifact tests for the new archive layout.
- Added `InstallContext` coverage for canonical packages, direct Linux bundles, missing resources, and Windows path normalization.
- Updated code-mode provider tests for managed-host and in-process resolution.
