### PR TITLE
exec-server: preserve empty workspace roots

### DIFF
--- a/codex-rs/core/src/tools/sandboxing.rs
+++ b/codex-rs/core/src/tools/sandboxing.rs
@@ -511,7 +511,11 @@ impl<'a> SandboxAttempt<'a> {
             exec_request.exec_server_sandbox = Some(FileSystemSandboxContext {
                 permissions: exec_server_permissions.into(),
                 cwd: Some(exec_request.windows_sandbox_policy_cwd.clone()),
-                workspace_roots: Vec::new(),
+                workspace_roots: self
+                    .workspace_roots
+                    .iter()
+                    .map(PathUri::from_abs_path)
+                    .collect(),
                 windows_sandbox_level: self.windows_sandbox_level,
                 windows_sandbox_private_desktop: self.windows_sandbox_private_desktop,
                 use_legacy_landlock: self.use_legacy_landlock,

--- a/codex-rs/core/src/tools/sandboxing_tests.rs
+++ b/codex-rs/core/src/tools/sandboxing_tests.rs
@@ -264,7 +264,7 @@ fn exec_server_env_keeps_command_native_and_carries_sandbox_context() {
         Some(codex_exec_server::FileSystemSandboxContext {
             permissions: exec_server_permissions.clone().into(),
             cwd: Some(cwd_uri.clone()),
-            workspace_roots: Vec::new(),
+            workspace_roots: vec![cwd_uri.clone()],
             windows_sandbox_level: codex_protocol::config_types::WindowsSandboxLevel::Disabled,
             windows_sandbox_private_desktop: false,
             use_legacy_landlock: false,

--- a/codex-rs/core/tests/suite/mod.rs
+++ b/codex-rs/core/tests/suite/mod.rs
@@ -142,3 +142,4 @@ mod websocket_fallback;
 mod window_headers;
 #[cfg(target_os = "windows")]
 mod windows_sandbox;
+mod workspace_roots;

--- a/codex-rs/core/tests/suite/workspace_roots.rs
+++ b/codex-rs/core/tests/suite/workspace_roots.rs
@@ -21,11 +21,10 @@ use core_test_support::responses::ev_response_created;
 use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
-use core_test_support::skip_if_no_remote_env;
+use core_test_support::skip_if_wine_exec;
 use core_test_support::test_codex::TestCodex;
 use core_test_support::test_codex::test_codex;
 use core_test_support::test_target_os;
-use pretty_assertions::assert_eq;
 use serde_json::Value;
 use serde_json::json;
 use wiremock::MockServer;
@@ -78,9 +77,8 @@ fn outside_workspace_path(test: &TestCodex, file_name: &str) -> Result<PathUri> 
 
 fn command_arguments(path: &str) -> Result<String> {
     let (shell, command) = match test_target_os() {
-        TestTargetOs::Linux => ("bash", format!("cat '{path}'")),
+        TestTargetOs::Linux | TestTargetOs::MacOs => ("bash", format!("cat '{path}'")),
         TestTargetOs::Windows => ("powershell", format!("Get-Content -Raw '{path}'")),
-        TestTargetOs::MacOs => unreachable!("remote test targets do not run macOS"),
     };
     Ok(serde_json::to_string(&json!({
         "cmd": command,
@@ -145,10 +143,13 @@ async fn remove_files(test: &TestCodex, paths: &[&PathUri]) -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn remote_workspace_roots_allow_file_read_and_command_run() -> Result<()> {
+async fn workspace_roots_allow_file_read_and_command_run() -> Result<()> {
     const COMMAND_CONTENTS: &str = "workspace root command access";
 
-    skip_if_no_remote_env!(Ok(()));
+    skip_if_wine_exec!(
+        Ok(()),
+        "remote Windows sandboxed process launches are not supported"
+    );
 
     let server = start_mock_server().await;
     let test = workspace_roots_test(&server).await?;
@@ -184,12 +185,12 @@ async fn remote_workspace_roots_allow_file_read_and_command_run() -> Result<()> 
         .and_then(|items| items.first())
         .and_then(|item| item.get("image_url"))
         .and_then(Value::as_str)
-        .context("remote filesystem read should return an image")?;
+        .context("filesystem read should return an image")?;
     assert!(image_url.starts_with("data:image/png;base64,"));
 
     let (command_output, success) = request
         .function_call_output_content_and_success(COMMAND_CALL_ID)
-        .context("remote command result should be present")?;
+        .context("command result should be present")?;
     assert_ne!(success, Some(false));
     assert!(command_output.is_some_and(|output| output.contains(COMMAND_CONTENTS)));
 
@@ -197,10 +198,13 @@ async fn remote_workspace_roots_allow_file_read_and_command_run() -> Result<()> 
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn remote_workspace_roots_deny_file_and_command_reads_outside_roots() -> Result<()> {
+async fn workspace_roots_deny_file_and_command_reads_outside_roots() -> Result<()> {
     const OUTSIDE_CONTENTS: &str = "outside workspace root";
 
-    skip_if_no_remote_env!(Ok(()));
+    skip_if_wine_exec!(
+        Ok(()),
+        "remote Windows sandboxed process launches are not supported"
+    );
 
     let server = start_mock_server().await;
     let test = workspace_roots_test(&server).await?;
@@ -230,21 +234,26 @@ async fn remote_workspace_roots_deny_file_and_command_reads_outside_roots() -> R
     let request = response_mock
         .last_request()
         .context("model should receive both denied tool results")?;
-    let (file_output, file_success) = request
+    let (file_output, _) = request
         .function_call_output_content_and_success(IMAGE_CALL_ID)
-        .context("denied remote file-read result should be present")?;
-    assert_eq!(file_success, Some(false));
+        .context("denied file-read result should be present")?;
     assert!(file_output.is_some_and(|output| {
         output.starts_with(&format!(
             "unable to locate image at `{image_path_display}`:"
         )) || output.starts_with(&format!("unable to read image at `{image_path_display}`:"))
     }));
 
-    let (command_output, command_success) = request
+    let (command_output, _) = request
         .function_call_output_content_and_success(COMMAND_CALL_ID)
-        .context("denied remote command result should be present")?;
-    assert_eq!(command_success, Some(false));
-    assert!(command_output.is_none_or(|output| !output.contains(OUTSIDE_CONTENTS)));
+        .context("denied command result should be present")?;
+    let command_output = command_output.context("denied command output should be present")?;
+    assert!(command_output.contains(&text_path_display));
+    assert!(
+        command_output.contains("Permission denied")
+            || command_output.contains("Operation not permitted")
+            || command_output.contains("No such file or directory")
+    );
+    assert!(!command_output.contains(OUTSIDE_CONTENTS));
 
     remove_files(&test, &[&image_path, &text_path]).await
 }

--- a/codex-rs/core/tests/suite/workspace_roots.rs
+++ b/codex-rs/core/tests/suite/workspace_roots.rs
@@ -11,7 +11,6 @@ use codex_protocol::permissions::FileSystemSandboxEntry;
 use codex_protocol::permissions::FileSystemSandboxPolicy;
 use codex_protocol::permissions::FileSystemSpecialPath;
 use codex_protocol::permissions::NetworkSandboxPolicy;
-use codex_protocol::protocol::EventMsg;
 use codex_utils_path_uri::PathUri;
 use core_test_support::TestTargetOs;
 use core_test_support::responses::ResponseMock;
@@ -26,7 +25,6 @@ use core_test_support::skip_if_no_remote_env;
 use core_test_support::test_codex::TestCodex;
 use core_test_support::test_codex::test_codex;
 use core_test_support::test_target_os;
-use core_test_support::wait_for_event;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 use serde_json::json;
@@ -127,12 +125,7 @@ async fn mount_file_and_command_calls(
 
 async fn submit_workspace_turn(test: &TestCodex, prompt: &str) -> Result<()> {
     test.submit_turn_with_permission_profile(prompt, workspace_roots_read_profile())
-        .await?;
-    wait_for_event(&test.codex, |event| {
-        matches!(event, EventMsg::TurnComplete(_))
-    })
-    .await;
-    Ok(())
+        .await
 }
 
 async fn remove_files(test: &TestCodex, paths: &[&PathUri]) -> Result<()> {

--- a/codex-rs/core/tests/suite/workspace_roots.rs
+++ b/codex-rs/core/tests/suite/workspace_roots.rs
@@ -34,43 +34,24 @@ const COMMAND_CALL_ID: &str = "workspace-root-command";
 const PNG_BASE64: &str =
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
 
-fn workspace_roots_read_profile() -> Result<PermissionProfile> {
-    let entries = vec![
-        FileSystemSandboxEntry {
-            path: FileSystemPath::Special {
-                value: FileSystemSpecialPath::Minimal,
-            },
-            access: FileSystemAccessMode::Read,
-        },
-        FileSystemSandboxEntry {
-            path: FileSystemPath::Special {
-                value: FileSystemSpecialPath::project_roots(/*subpath*/ None),
-            },
-            access: FileSystemAccessMode::Read,
-        },
-    ];
-    #[cfg(target_os = "linux")]
-    let entries = {
-        let mut entries = entries;
-        if !core_test_support::is_remote_test_environment() {
-            // Bubblewrap re-execs the test binary after applying the filesystem policy.
-            // Bazel places that binary outside the platform paths covered by `:minimal`.
-            entries.push(FileSystemSandboxEntry {
-                path: FileSystemPath::Path {
-                    path: codex_utils_absolute_path::AbsolutePathBuf::from_absolute_path(
-                        std::env::current_exe()?,
-                    )?,
+fn workspace_roots_read_profile() -> PermissionProfile {
+    PermissionProfile::from_runtime_permissions(
+        &FileSystemSandboxPolicy::restricted(vec![
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Special {
+                    value: FileSystemSpecialPath::Minimal,
                 },
                 access: FileSystemAccessMode::Read,
-            });
-        }
-        entries
-    };
-
-    Ok(PermissionProfile::from_runtime_permissions(
-        &FileSystemSandboxPolicy::restricted(entries),
+            },
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Special {
+                    value: FileSystemSpecialPath::project_roots(/*subpath*/ None),
+                },
+                access: FileSystemAccessMode::Read,
+            },
+        ]),
         NetworkSandboxPolicy::Restricted,
-    ))
+    )
 }
 
 async fn workspace_roots_test(server: &MockServer) -> Result<TestCodex> {
@@ -141,7 +122,7 @@ async fn mount_file_and_command_calls(
 }
 
 async fn submit_workspace_turn(test: &TestCodex, prompt: &str) -> Result<()> {
-    test.submit_turn_with_permission_profile(prompt, workspace_roots_read_profile()?)
+    test.submit_turn_with_permission_profile(prompt, workspace_roots_read_profile())
         .await
 }
 

--- a/codex-rs/core/tests/suite/workspace_roots.rs
+++ b/codex-rs/core/tests/suite/workspace_roots.rs
@@ -34,24 +34,39 @@ const COMMAND_CALL_ID: &str = "workspace-root-command";
 const PNG_BASE64: &str =
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
 
-fn workspace_roots_read_profile() -> PermissionProfile {
-    PermissionProfile::from_runtime_permissions(
-        &FileSystemSandboxPolicy::restricted(vec![
-            FileSystemSandboxEntry {
-                path: FileSystemPath::Special {
-                    value: FileSystemSpecialPath::Minimal,
-                },
-                access: FileSystemAccessMode::Read,
+fn workspace_roots_read_profile() -> Result<PermissionProfile> {
+    let mut entries = vec![
+        FileSystemSandboxEntry {
+            path: FileSystemPath::Special {
+                value: FileSystemSpecialPath::Minimal,
             },
-            FileSystemSandboxEntry {
-                path: FileSystemPath::Special {
-                    value: FileSystemSpecialPath::project_roots(/*subpath*/ None),
-                },
-                access: FileSystemAccessMode::Read,
+            access: FileSystemAccessMode::Read,
+        },
+        FileSystemSandboxEntry {
+            path: FileSystemPath::Special {
+                value: FileSystemSpecialPath::project_roots(/*subpath*/ None),
             },
-        ]),
+            access: FileSystemAccessMode::Read,
+        },
+    ];
+    #[cfg(target_os = "linux")]
+    if !core_test_support::is_remote_test_environment() {
+        // Bubblewrap re-execs the test binary after applying the filesystem policy.
+        // Bazel places that binary outside the platform paths covered by `:minimal`.
+        entries.push(FileSystemSandboxEntry {
+            path: FileSystemPath::Path {
+                path: codex_utils_absolute_path::AbsolutePathBuf::from_absolute_path(
+                    std::env::current_exe()?,
+                )?,
+            },
+            access: FileSystemAccessMode::Read,
+        });
+    }
+
+    Ok(PermissionProfile::from_runtime_permissions(
+        &FileSystemSandboxPolicy::restricted(entries),
         NetworkSandboxPolicy::Restricted,
-    )
+    ))
 }
 
 async fn workspace_roots_test(server: &MockServer) -> Result<TestCodex> {
@@ -122,7 +137,7 @@ async fn mount_file_and_command_calls(
 }
 
 async fn submit_workspace_turn(test: &TestCodex, prompt: &str) -> Result<()> {
-    test.submit_turn_with_permission_profile(prompt, workspace_roots_read_profile())
+    test.submit_turn_with_permission_profile(prompt, workspace_roots_read_profile()?)
         .await
 }
 

--- a/codex-rs/core/tests/suite/workspace_roots.rs
+++ b/codex-rs/core/tests/suite/workspace_roots.rs
@@ -1,0 +1,257 @@
+use anyhow::Context;
+use anyhow::Result;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use codex_exec_server::RemoveOptions;
+use codex_features::Feature;
+use codex_protocol::models::PermissionProfile;
+use codex_protocol::permissions::FileSystemAccessMode;
+use codex_protocol::permissions::FileSystemPath;
+use codex_protocol::permissions::FileSystemSandboxEntry;
+use codex_protocol::permissions::FileSystemSandboxPolicy;
+use codex_protocol::permissions::FileSystemSpecialPath;
+use codex_protocol::permissions::NetworkSandboxPolicy;
+use codex_protocol::protocol::EventMsg;
+use codex_utils_path_uri::PathUri;
+use core_test_support::TestTargetOs;
+use core_test_support::responses::ResponseMock;
+use core_test_support::responses::ev_assistant_message;
+use core_test_support::responses::ev_completed;
+use core_test_support::responses::ev_function_call;
+use core_test_support::responses::ev_response_created;
+use core_test_support::responses::mount_sse_sequence;
+use core_test_support::responses::sse;
+use core_test_support::responses::start_mock_server;
+use core_test_support::skip_if_no_remote_env;
+use core_test_support::test_codex::TestCodex;
+use core_test_support::test_codex::test_codex;
+use core_test_support::test_target_os;
+use core_test_support::wait_for_event;
+use pretty_assertions::assert_eq;
+use serde_json::Value;
+use serde_json::json;
+use wiremock::MockServer;
+
+const IMAGE_CALL_ID: &str = "workspace-root-image";
+const COMMAND_CALL_ID: &str = "workspace-root-command";
+const PNG_BASE64: &str =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+
+fn workspace_roots_read_profile() -> PermissionProfile {
+    PermissionProfile::from_runtime_permissions(
+        &FileSystemSandboxPolicy::restricted(vec![
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Special {
+                    value: FileSystemSpecialPath::Minimal,
+                },
+                access: FileSystemAccessMode::Read,
+            },
+            FileSystemSandboxEntry {
+                path: FileSystemPath::Special {
+                    value: FileSystemSpecialPath::project_roots(/*subpath*/ None),
+                },
+                access: FileSystemAccessMode::Read,
+            },
+        ]),
+        NetworkSandboxPolicy::Restricted,
+    )
+}
+
+async fn workspace_roots_test(server: &MockServer) -> Result<TestCodex> {
+    let mut builder = test_codex().with_config(|config| {
+        config.use_experimental_unified_exec_tool = true;
+        config
+            .features
+            .enable(Feature::UnifiedExec)
+            .expect("test config should allow feature update");
+        config.workspace_roots = vec![config.cwd.clone()];
+    });
+    builder.build_with_auto_env(server).await
+}
+
+fn outside_workspace_path(test: &TestCodex, file_name: &str) -> Result<PathUri> {
+    let file_name = format!("codex-workspace-roots-{}-{file_name}", std::process::id());
+    PathUri::from_abs_path(&test.config.cwd)
+        .parent()
+        .context("test workspace should have a parent")?
+        .join(&file_name)
+        .map_err(Into::into)
+}
+
+fn command_arguments(path: &str) -> Result<String> {
+    let (shell, command) = match test_target_os() {
+        TestTargetOs::Linux => ("bash", format!("cat '{path}'")),
+        TestTargetOs::Windows => ("powershell", format!("Get-Content -Raw '{path}'")),
+        TestTargetOs::MacOs => unreachable!("remote test targets do not run macOS"),
+    };
+    Ok(serde_json::to_string(&json!({
+        "cmd": command,
+        "shell": shell,
+        "login": false,
+        "yield_time_ms": 10_000,
+    }))?)
+}
+
+async fn mount_file_and_command_calls(
+    server: &MockServer,
+    image_path: &str,
+    command_path: &str,
+) -> Result<ResponseMock> {
+    let command_arguments = command_arguments(command_path)?;
+    Ok(mount_sse_sequence(
+        server,
+        vec![
+            sse(vec![
+                ev_response_created("resp-1"),
+                ev_function_call(
+                    IMAGE_CALL_ID,
+                    "view_image",
+                    &json!({ "path": image_path }).to_string(),
+                ),
+                ev_completed("resp-1"),
+            ]),
+            sse(vec![
+                ev_response_created("resp-2"),
+                ev_function_call(COMMAND_CALL_ID, "exec_command", &command_arguments),
+                ev_completed("resp-2"),
+            ]),
+            sse(vec![
+                ev_response_created("resp-3"),
+                ev_assistant_message("msg-1", "done"),
+                ev_completed("resp-3"),
+            ]),
+        ],
+    )
+    .await)
+}
+
+async fn submit_workspace_turn(test: &TestCodex, prompt: &str) -> Result<()> {
+    test.submit_turn_with_permission_profile(prompt, workspace_roots_read_profile())
+        .await?;
+    wait_for_event(&test.codex, |event| {
+        matches!(event, EventMsg::TurnComplete(_))
+    })
+    .await;
+    Ok(())
+}
+
+async fn remove_files(test: &TestCodex, paths: &[&PathUri]) -> Result<()> {
+    for path in paths {
+        test.fs()
+            .remove(
+                path,
+                RemoveOptions {
+                    recursive: false,
+                    force: true,
+                },
+                /*sandbox*/ None,
+            )
+            .await?;
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_workspace_roots_allow_file_read_and_command_run() -> Result<()> {
+    const COMMAND_CONTENTS: &str = "workspace root command access";
+
+    skip_if_no_remote_env!(Ok(()));
+
+    let server = start_mock_server().await;
+    let test = workspace_roots_test(&server).await?;
+    let cwd = PathUri::from_abs_path(&test.config.cwd);
+    let image_path = cwd.join("workspace-root.png")?;
+    let text_path = cwd.join("workspace-root.txt")?;
+    test.fs()
+        .write_file(
+            &image_path,
+            BASE64_STANDARD.decode(PNG_BASE64)?,
+            /*sandbox*/ None,
+        )
+        .await?;
+    test.fs()
+        .write_file(
+            &text_path,
+            COMMAND_CONTENTS.as_bytes().to_vec(),
+            /*sandbox*/ None,
+        )
+        .await?;
+
+    let response_mock =
+        mount_file_and_command_calls(&server, "workspace-root.png", "workspace-root.txt").await?;
+    submit_workspace_turn(&test, "read files inside the workspace roots").await?;
+
+    let request = response_mock
+        .last_request()
+        .context("model should receive both workspace-root tool results")?;
+    let image_output = request.function_call_output(IMAGE_CALL_ID);
+    let image_url = image_output
+        .get("output")
+        .and_then(Value::as_array)
+        .and_then(|items| items.first())
+        .and_then(|item| item.get("image_url"))
+        .and_then(Value::as_str)
+        .context("remote filesystem read should return an image")?;
+    assert!(image_url.starts_with("data:image/png;base64,"));
+
+    let (command_output, success) = request
+        .function_call_output_content_and_success(COMMAND_CALL_ID)
+        .context("remote command result should be present")?;
+    assert_ne!(success, Some(false));
+    assert!(command_output.is_some_and(|output| output.contains(COMMAND_CONTENTS)));
+
+    remove_files(&test, &[&image_path, &text_path]).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_workspace_roots_deny_file_and_command_reads_outside_roots() -> Result<()> {
+    const OUTSIDE_CONTENTS: &str = "outside workspace root";
+
+    skip_if_no_remote_env!(Ok(()));
+
+    let server = start_mock_server().await;
+    let test = workspace_roots_test(&server).await?;
+    let image_path = outside_workspace_path(&test, "outside.png")?;
+    let text_path = outside_workspace_path(&test, "outside.txt")?;
+    test.fs()
+        .write_file(
+            &image_path,
+            BASE64_STANDARD.decode(PNG_BASE64)?,
+            /*sandbox*/ None,
+        )
+        .await?;
+    test.fs()
+        .write_file(
+            &text_path,
+            OUTSIDE_CONTENTS.as_bytes().to_vec(),
+            /*sandbox*/ None,
+        )
+        .await?;
+    let image_path_display = image_path.inferred_native_path_string();
+    let text_path_display = text_path.inferred_native_path_string();
+
+    let response_mock =
+        mount_file_and_command_calls(&server, &image_path_display, &text_path_display).await?;
+    submit_workspace_turn(&test, "try to read files outside the workspace roots").await?;
+
+    let request = response_mock
+        .last_request()
+        .context("model should receive both denied tool results")?;
+    let (file_output, file_success) = request
+        .function_call_output_content_and_success(IMAGE_CALL_ID)
+        .context("denied remote file-read result should be present")?;
+    assert_eq!(file_success, Some(false));
+    assert!(file_output.is_some_and(|output| {
+        output.starts_with(&format!(
+            "unable to locate image at `{image_path_display}`:"
+        )) || output.starts_with(&format!("unable to read image at `{image_path_display}`:"))
+    }));
+
+    let (command_output, command_success) = request
+        .function_call_output_content_and_success(COMMAND_CALL_ID)
+        .context("denied remote command result should be present")?;
+    assert_eq!(command_success, Some(false));
+    assert!(command_output.is_none_or(|output| !output.contains(OUTSIDE_CONTENTS)));
+
+    remove_files(&test, &[&image_path, &text_path]).await
+}

--- a/codex-rs/core/tests/suite/workspace_roots.rs
+++ b/codex-rs/core/tests/suite/workspace_roots.rs
@@ -212,7 +212,9 @@ async fn workspace_roots_allow_file_read_and_command_run() -> Result<()> {
         .context("command result should be present")?;
     assert_ne!(success, Some(false));
     assert!(
-        command_output.is_some_and(|output| output.contains(COMMAND_CONTENTS)),
+        command_output
+            .as_deref()
+            .is_some_and(|output| output.contains(COMMAND_CONTENTS)),
         "command should read the workspace-root file, got {command_output:?}"
     );
 

--- a/codex-rs/core/tests/suite/workspace_roots.rs
+++ b/codex-rs/core/tests/suite/workspace_roots.rs
@@ -35,7 +35,7 @@ const PNG_BASE64: &str =
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
 
 fn workspace_roots_read_profile() -> Result<PermissionProfile> {
-    let mut entries = vec![
+    let entries = vec![
         FileSystemSandboxEntry {
             path: FileSystemPath::Special {
                 value: FileSystemSpecialPath::Minimal,
@@ -50,18 +50,22 @@ fn workspace_roots_read_profile() -> Result<PermissionProfile> {
         },
     ];
     #[cfg(target_os = "linux")]
-    if !core_test_support::is_remote_test_environment() {
-        // Bubblewrap re-execs the test binary after applying the filesystem policy.
-        // Bazel places that binary outside the platform paths covered by `:minimal`.
-        entries.push(FileSystemSandboxEntry {
-            path: FileSystemPath::Path {
-                path: codex_utils_absolute_path::AbsolutePathBuf::from_absolute_path(
-                    std::env::current_exe()?,
-                )?,
-            },
-            access: FileSystemAccessMode::Read,
-        });
-    }
+    let entries = {
+        let mut entries = entries;
+        if !core_test_support::is_remote_test_environment() {
+            // Bubblewrap re-execs the test binary after applying the filesystem policy.
+            // Bazel places that binary outside the platform paths covered by `:minimal`.
+            entries.push(FileSystemSandboxEntry {
+                path: FileSystemPath::Path {
+                    path: codex_utils_absolute_path::AbsolutePathBuf::from_absolute_path(
+                        std::env::current_exe()?,
+                    )?,
+                },
+                access: FileSystemAccessMode::Read,
+            });
+        }
+        entries
+    };
 
     Ok(PermissionProfile::from_runtime_permissions(
         &FileSystemSandboxPolicy::restricted(entries),
@@ -207,7 +211,10 @@ async fn workspace_roots_allow_file_read_and_command_run() -> Result<()> {
         .function_call_output_content_and_success(COMMAND_CALL_ID)
         .context("command result should be present")?;
     assert_ne!(success, Some(false));
-    assert!(command_output.is_some_and(|output| output.contains(COMMAND_CONTENTS)));
+    assert!(
+        command_output.is_some_and(|output| output.contains(COMMAND_CONTENTS)),
+        "command should read the workspace-root file, got {command_output:?}"
+    );
 
     remove_files(&test, &[&image_path, &text_path]).await
 }
@@ -262,7 +269,10 @@ async fn workspace_roots_deny_file_and_command_reads_outside_roots() -> Result<(
         .function_call_output_content_and_success(COMMAND_CALL_ID)
         .context("denied command result should be present")?;
     let command_output = command_output.context("denied command output should be present")?;
-    assert!(command_output.contains(&text_path_display));
+    assert!(
+        command_output.contains(&text_path_display),
+        "denied command output should identify {text_path_display}, got {command_output:?}"
+    );
     assert!(
         command_output.contains("Permission denied")
             || command_output.contains("Operation not permitted")

--- a/codex-rs/core/tests/suite/workspace_roots.rs
+++ b/codex-rs/core/tests/suite/workspace_roots.rs
@@ -26,16 +26,14 @@ use core_test_support::skip_if_no_remote_env;
 use core_test_support::test_codex::TestCodex;
 use core_test_support::test_codex::test_codex;
 use core_test_support::test_target_os;
-use core_test_support::wait_for_event_with_timeout;
+use core_test_support::wait_for_event;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 use serde_json::json;
-use tokio::time::Duration;
 use wiremock::MockServer;
 
 const IMAGE_CALL_ID: &str = "workspace-root-image";
 const COMMAND_CALL_ID: &str = "workspace-root-command";
-const TURN_COMPLETE_TIMEOUT: Duration = Duration::from_secs(30);
 const PNG_BASE64: &str =
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
 
@@ -130,11 +128,9 @@ async fn mount_file_and_command_calls(
 async fn submit_workspace_turn(test: &TestCodex, prompt: &str) -> Result<()> {
     test.submit_turn_with_permission_profile(prompt, workspace_roots_read_profile())
         .await?;
-    wait_for_event_with_timeout(
-        &test.codex,
-        |event| matches!(event, EventMsg::TurnComplete(_)),
-        TURN_COMPLETE_TIMEOUT,
-    )
+    wait_for_event(&test.codex, |event| {
+        matches!(event, EventMsg::TurnComplete(_))
+    })
     .await;
     Ok(())
 }

--- a/codex-rs/core/tests/suite/workspace_roots.rs
+++ b/codex-rs/core/tests/suite/workspace_roots.rs
@@ -26,14 +26,16 @@ use core_test_support::skip_if_no_remote_env;
 use core_test_support::test_codex::TestCodex;
 use core_test_support::test_codex::test_codex;
 use core_test_support::test_target_os;
-use core_test_support::wait_for_event;
+use core_test_support::wait_for_event_with_timeout;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 use serde_json::json;
+use tokio::time::Duration;
 use wiremock::MockServer;
 
 const IMAGE_CALL_ID: &str = "workspace-root-image";
 const COMMAND_CALL_ID: &str = "workspace-root-command";
+const TURN_COMPLETE_TIMEOUT: Duration = Duration::from_secs(30);
 const PNG_BASE64: &str =
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
 
@@ -128,9 +130,11 @@ async fn mount_file_and_command_calls(
 async fn submit_workspace_turn(test: &TestCodex, prompt: &str) -> Result<()> {
     test.submit_turn_with_permission_profile(prompt, workspace_roots_read_profile())
         .await?;
-    wait_for_event(&test.codex, |event| {
-        matches!(event, EventMsg::TurnComplete(_))
-    })
+    wait_for_event_with_timeout(
+        &test.codex,
+        |event| matches!(event, EventMsg::TurnComplete(_)),
+        TURN_COMPLETE_TIMEOUT,
+    )
     .await;
     Ok(())
 }

--- a/codex-rs/core/tests/suite/workspace_roots.rs
+++ b/codex-rs/core/tests/suite/workspace_roots.rs
@@ -1,19 +1,13 @@
 use anyhow::Context;
 use anyhow::Result;
-use base64::Engine;
-use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use codex_exec_server::RemoveOptions;
 use codex_features::Feature;
 use codex_protocol::models::PermissionProfile;
-use codex_protocol::permissions::FileSystemAccessMode;
-use codex_protocol::permissions::FileSystemPath;
-use codex_protocol::permissions::FileSystemSandboxEntry;
-use codex_protocol::permissions::FileSystemSandboxPolicy;
-use codex_protocol::permissions::FileSystemSpecialPath;
 use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_utils_path_uri::PathUri;
 use core_test_support::TestTargetOs;
 use core_test_support::responses::ResponseMock;
+use core_test_support::responses::ev_apply_patch_custom_tool_call;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_function_call;
@@ -21,36 +15,22 @@ use core_test_support::responses::ev_response_created;
 use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
-use core_test_support::skip_if_wine_exec;
+use core_test_support::skip_if_target_windows;
 use core_test_support::test_codex::TestCodex;
 use core_test_support::test_codex::test_codex;
 use core_test_support::test_target_os;
-use serde_json::Value;
 use serde_json::json;
 use wiremock::MockServer;
 
-const IMAGE_CALL_ID: &str = "workspace-root-image";
+const PATCH_CALL_ID: &str = "workspace-root-patch";
 const COMMAND_CALL_ID: &str = "workspace-root-command";
-const PNG_BASE64: &str =
-    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
 
-fn workspace_roots_read_profile() -> PermissionProfile {
-    PermissionProfile::from_runtime_permissions(
-        &FileSystemSandboxPolicy::restricted(vec![
-            FileSystemSandboxEntry {
-                path: FileSystemPath::Special {
-                    value: FileSystemSpecialPath::Minimal,
-                },
-                access: FileSystemAccessMode::Read,
-            },
-            FileSystemSandboxEntry {
-                path: FileSystemPath::Special {
-                    value: FileSystemSpecialPath::project_roots(/*subpath*/ None),
-                },
-                access: FileSystemAccessMode::Read,
-            },
-        ]),
+fn workspace_roots_profile() -> PermissionProfile {
+    PermissionProfile::workspace_write_with(
+        &[],
         NetworkSandboxPolicy::Restricted,
+        /*exclude_tmpdir_env_var*/ true,
+        /*exclude_slash_tmp*/ true,
     )
 }
 
@@ -75,35 +55,36 @@ fn outside_workspace_path(test: &TestCodex, file_name: &str) -> Result<PathUri> 
         .map_err(Into::into)
 }
 
-fn command_arguments(path: &str) -> Result<String> {
+fn command_arguments(path: &str, contents: &str) -> Result<String> {
     let (shell, command) = match test_target_os() {
-        TestTargetOs::Linux | TestTargetOs::MacOs => ("bash", format!("cat '{path}'")),
-        TestTargetOs::Windows => ("powershell", format!("Get-Content -Raw '{path}'")),
+        TestTargetOs::Linux | TestTargetOs::MacOs => {
+            ("bash", format!("printf %s '{contents}' > '{path}'"))
+        }
+        TestTargetOs::Windows => (
+            "powershell",
+            format!("Set-Content -NoNewline -Path '{path}' -Value '{contents}'"),
+        ),
     };
     Ok(serde_json::to_string(&json!({
         "cmd": command,
         "shell": shell,
         "login": false,
-        "yield_time_ms": 10_000,
     }))?)
 }
 
-async fn mount_file_and_command_calls(
+async fn mount_patch_and_command_calls(
     server: &MockServer,
-    image_path: &str,
+    patch: &str,
     command_path: &str,
+    command_contents: &str,
 ) -> Result<ResponseMock> {
-    let command_arguments = command_arguments(command_path)?;
+    let command_arguments = command_arguments(command_path, command_contents)?;
     Ok(mount_sse_sequence(
         server,
         vec![
             sse(vec![
                 ev_response_created("resp-1"),
-                ev_function_call(
-                    IMAGE_CALL_ID,
-                    "view_image",
-                    &json!({ "path": image_path }).to_string(),
-                ),
+                ev_apply_patch_custom_tool_call(PATCH_CALL_ID, patch),
                 ev_completed("resp-1"),
             ]),
             sse(vec![
@@ -122,8 +103,14 @@ async fn mount_file_and_command_calls(
 }
 
 async fn submit_workspace_turn(test: &TestCodex, prompt: &str) -> Result<()> {
-    test.submit_turn_with_permission_profile(prompt, workspace_roots_read_profile())
+    test.submit_turn_with_permission_profile(prompt, workspace_roots_profile())
         .await
+}
+
+async fn read_file(test: &TestCodex, path: &PathUri) -> Result<String> {
+    Ok(String::from_utf8(
+        test.fs().read_file(path, /*sandbox*/ None).await?,
+    )?)
 }
 
 async fn remove_files(test: &TestCodex, paths: &[&PathUri]) -> Result<()> {
@@ -143,125 +130,113 @@ async fn remove_files(test: &TestCodex, paths: &[&PathUri]) -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn workspace_roots_allow_file_read_and_command_run() -> Result<()> {
+async fn workspace_roots_allow_file_and_command_writes() -> Result<()> {
+    const PATCH_CONTENTS: &str = "workspace root patch access";
     const COMMAND_CONTENTS: &str = "workspace root command access";
 
-    skip_if_wine_exec!(
+    skip_if_target_windows!(
         Ok(()),
-        "remote Windows sandboxed process launches are not supported"
+        "sandboxed process launch is not supported by the exec-server Windows backend"
     );
 
     let server = start_mock_server().await;
     let test = workspace_roots_test(&server).await?;
     let cwd = PathUri::from_abs_path(&test.config.cwd);
-    let image_path = cwd.join("workspace-root.png")?;
-    let text_path = cwd.join("workspace-root.txt")?;
-    test.fs()
-        .write_file(
-            &image_path,
-            BASE64_STANDARD.decode(PNG_BASE64)?,
-            /*sandbox*/ None,
-        )
-        .await?;
-    test.fs()
-        .write_file(
-            &text_path,
-            COMMAND_CONTENTS.as_bytes().to_vec(),
-            /*sandbox*/ None,
-        )
-        .await?;
+    let patch_path = cwd.join("workspace-root-patch.txt")?;
+    let command_path = cwd.join("workspace-root-command.txt")?;
+    let patch = format!(
+        "*** Begin Patch\n*** Add File: workspace-root-patch.txt\n+{PATCH_CONTENTS}\n*** End Patch\n"
+    );
 
-    let response_mock =
-        mount_file_and_command_calls(&server, "workspace-root.png", "workspace-root.txt").await?;
-    submit_workspace_turn(&test, "read files inside the workspace roots").await?;
+    let response_mock = mount_patch_and_command_calls(
+        &server,
+        &patch,
+        "workspace-root-command.txt",
+        COMMAND_CONTENTS,
+    )
+    .await?;
+    submit_workspace_turn(&test, "write files inside the workspace roots").await?;
 
     let request = response_mock
         .last_request()
         .context("model should receive both workspace-root tool results")?;
-    let image_output = request.function_call_output(IMAGE_CALL_ID);
-    let image_url = image_output
-        .get("output")
-        .and_then(Value::as_array)
-        .and_then(|items| items.first())
-        .and_then(|item| item.get("image_url"))
-        .and_then(Value::as_str)
-        .context("filesystem read should return an image")?;
-    assert!(image_url.starts_with("data:image/png;base64,"));
+    let (_, patch_success) = request
+        .custom_tool_call_output_content_and_success(PATCH_CALL_ID)
+        .context("patch result should be present")?;
+    assert_ne!(patch_success, Some(false));
 
-    let (command_output, success) = request
+    let (_, command_success) = request
         .function_call_output_content_and_success(COMMAND_CALL_ID)
         .context("command result should be present")?;
-    assert_ne!(success, Some(false));
-    assert!(
-        command_output
-            .as_deref()
-            .is_some_and(|output| output.contains(COMMAND_CONTENTS)),
-        "command should read the workspace-root file, got {command_output:?}"
+    assert_ne!(command_success, Some(false));
+    assert_eq!(
+        read_file(&test, &patch_path).await?,
+        format!("{PATCH_CONTENTS}\n")
     );
+    assert_eq!(read_file(&test, &command_path).await?, COMMAND_CONTENTS);
 
-    remove_files(&test, &[&image_path, &text_path]).await
+    remove_files(&test, &[&patch_path, &command_path]).await
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn workspace_roots_deny_file_and_command_reads_outside_roots() -> Result<()> {
-    const OUTSIDE_CONTENTS: &str = "outside workspace root";
+async fn workspace_roots_deny_file_and_command_writes_outside_roots() -> Result<()> {
+    const PATCH_CONTENTS: &str = "outside workspace root patch";
+    const COMMAND_CONTENTS: &str = "outside workspace root command";
 
-    skip_if_wine_exec!(
+    skip_if_target_windows!(
         Ok(()),
-        "remote Windows sandboxed process launches are not supported"
+        "sandboxed process launch is not supported by the exec-server Windows backend"
     );
 
     let server = start_mock_server().await;
     let test = workspace_roots_test(&server).await?;
-    let image_path = outside_workspace_path(&test, "outside.png")?;
-    let text_path = outside_workspace_path(&test, "outside.txt")?;
-    test.fs()
-        .write_file(
-            &image_path,
-            BASE64_STANDARD.decode(PNG_BASE64)?,
-            /*sandbox*/ None,
-        )
-        .await?;
-    test.fs()
-        .write_file(
-            &text_path,
-            OUTSIDE_CONTENTS.as_bytes().to_vec(),
-            /*sandbox*/ None,
-        )
-        .await?;
-    let image_path_display = image_path.inferred_native_path_string();
-    let text_path_display = text_path.inferred_native_path_string();
+    let patch_path = outside_workspace_path(&test, "outside-patch.txt")?;
+    let command_path = outside_workspace_path(&test, "outside-command.txt")?;
+    let patch_path_display = patch_path.inferred_native_path_string();
+    let command_path_display = command_path.inferred_native_path_string();
+    let patch = format!(
+        "*** Begin Patch\n*** Add File: {patch_path_display}\n+{PATCH_CONTENTS}\n*** End Patch\n"
+    );
 
     let response_mock =
-        mount_file_and_command_calls(&server, &image_path_display, &text_path_display).await?;
-    submit_workspace_turn(&test, "try to read files outside the workspace roots").await?;
+        mount_patch_and_command_calls(&server, &patch, &command_path_display, COMMAND_CONTENTS)
+            .await?;
+    submit_workspace_turn(&test, "try to write files outside the workspace roots").await?;
 
     let request = response_mock
         .last_request()
         .context("model should receive both denied tool results")?;
-    let (file_output, _) = request
-        .function_call_output_content_and_success(IMAGE_CALL_ID)
-        .context("denied file-read result should be present")?;
-    assert!(file_output.is_some_and(|output| {
-        output.starts_with(&format!(
-            "unable to locate image at `{image_path_display}`:"
-        )) || output.starts_with(&format!("unable to read image at `{image_path_display}`:"))
-    }));
+    let (patch_output, patch_success) = request
+        .custom_tool_call_output_content_and_success(PATCH_CALL_ID)
+        .context("denied patch result should be present")?;
+    assert_ne!(patch_success, Some(true));
+    assert!(
+        patch_output
+            .as_deref()
+            .is_some_and(|output| output.contains("outside of the project")),
+        "patch should be denied outside the workspace roots, got {patch_output:?}"
+    );
 
     let (command_output, _) = request
         .function_call_output_content_and_success(COMMAND_CALL_ID)
         .context("denied command result should be present")?;
     let command_output = command_output.context("denied command output should be present")?;
     assert!(
-        command_output.contains(&text_path_display),
-        "denied command output should identify {text_path_display}, got {command_output:?}"
+        command_output.contains(&command_path_display),
+        "denied command output should identify {command_path_display}, got {command_output:?}"
     );
     assert!(
-        command_output.contains("Permission denied")
-            || command_output.contains("Operation not permitted")
-            || command_output.contains("No such file or directory")
+        test.fs()
+            .read_file(&patch_path, /*sandbox*/ None)
+            .await
+            .is_err()
     );
-    assert!(!command_output.contains(OUTSIDE_CONTENTS));
+    assert!(
+        test.fs()
+            .read_file(&command_path, /*sandbox*/ None)
+            .await
+            .is_err()
+    );
 
-    remove_files(&test, &[&image_path, &text_path]).await
+    Ok(())
 }

--- a/codex-rs/exec-server/src/fs_sandbox.rs
+++ b/codex-rs/exec-server/src/fs_sandbox.rs
@@ -72,11 +72,7 @@ impl FileSystemSandboxRunner {
             .iter()
             .map(native_workspace_root)
             .collect::<Result<Vec<_>, _>>()?;
-        let workspace_roots = if native_workspace_roots.is_empty() {
-            std::slice::from_ref(&cwd.native)
-        } else {
-            native_workspace_roots.as_slice()
-        };
+        let workspace_roots = native_workspace_roots.as_slice();
         let native_permissions: PermissionProfile =
             sandbox.permissions.clone().try_into().map_err(|err| {
                 invalid_request(format!("invalid sandbox permission path URI: {err}"))

--- a/codex-rs/exec-server/src/process_sandbox.rs
+++ b/codex-rs/exec-server/src/process_sandbox.rs
@@ -56,11 +56,7 @@ pub(crate) fn prepare_exec_request(
         .iter()
         .map(|root| native_path(root, "sandbox workspace root"))
         .collect::<Result<Vec<_>, _>>()?;
-    let workspace_roots = if native_workspace_roots.is_empty() {
-        std::slice::from_ref(&native_sandbox_policy_cwd)
-    } else {
-        native_workspace_roots.as_slice()
-    };
+    let workspace_roots = native_workspace_roots.as_slice();
     let permissions = permissions.materialize_project_roots_with_workspace_roots(workspace_roots);
     let managed_mitm_ca_trust_bundle_path = params.managed_network.as_ref().and_then(|_| {
         CUSTOM_CA_ENV_KEYS.iter().find_map(|key| {

--- a/codex-rs/exec-server/tests/exec_process.rs
+++ b/codex-rs/exec-server/tests/exec_process.rs
@@ -13,26 +13,26 @@ use codex_exec_server::ExecOutputStream;
 use codex_exec_server::ExecParams;
 use codex_exec_server::ExecProcess;
 use codex_exec_server::ExecProcessEvent;
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 use codex_exec_server::FileSystemSandboxContext;
 use codex_exec_server::ProcessId;
 use codex_exec_server::ProcessSignal;
 use codex_exec_server::ReadResponse;
 use codex_exec_server::StartedExecProcess;
 use codex_exec_server::WriteStatus;
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 use codex_protocol::models::PermissionProfile;
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 use codex_protocol::permissions::FileSystemAccessMode;
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 use codex_protocol::permissions::FileSystemPath;
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 use codex_protocol::permissions::FileSystemSandboxEntry;
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 use codex_protocol::permissions::FileSystemSandboxPolicy;
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 use codex_protocol::permissions::FileSystemSpecialPath;
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 use codex_protocol::permissions::NetworkSandboxPolicy;
 use codex_utils_path_uri::PathUri;
 use pretty_assertions::assert_eq;
@@ -237,6 +237,51 @@ async fn remote_tty_process_uses_configured_sandbox_helper_with_hostile_path() -
         output,
         ("allowed".to_string(), String::new(), Some(0), true)
     );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_process_preserves_empty_workspace_roots() -> Result<()> {
+    let context = create_process_context(/*use_remote*/ true).await?;
+    let tmp = TempDir::new()?;
+    let file = tmp.path().join("excluded.txt");
+    std::fs::write(&file, b"excluded")?;
+    let cwd = PathUri::from_host_native_path(tmp.path())?;
+    let policy = FileSystemSandboxPolicy::restricted(vec![FileSystemSandboxEntry {
+        path: FileSystemPath::Special {
+            value: FileSystemSpecialPath::project_roots(/*subpath*/ None),
+        },
+        access: FileSystemAccessMode::Read,
+    }]);
+    let mut sandbox = FileSystemSandboxContext::from_permission_profile_with_cwd(
+        PermissionProfile::from_runtime_permissions(&policy, NetworkSandboxPolicy::Restricted),
+        cwd.clone(),
+    );
+    sandbox.workspace_roots.clear();
+
+    let session = context
+        .backend
+        .start(ExecParams {
+            process_id: ProcessId::from("proc-empty-workspace-roots"),
+            argv: vec!["/bin/cat".to_string(), file.to_string_lossy().into_owned()],
+            cwd,
+            env_policy: None,
+            env: HashMap::new(),
+            tty: false,
+            pipe_stdin: false,
+            arg0: None,
+            sandbox: Some(sandbox),
+            enforce_managed_network: false,
+            managed_network: None,
+        })
+        .await?;
+    let (stdout, _stderr, exit_code, closed) =
+        collect_process_output_from_events(session.process).await?;
+
+    assert!(!stdout.contains("excluded"), "unexpected stdout: {stdout}");
+    assert_ne!(exit_code, Some(0));
+    assert!(closed);
     Ok(())
 }
 

--- a/codex-rs/exec-server/tests/file_system_unix.rs
+++ b/codex-rs/exec-server/tests/file_system_unix.rs
@@ -263,6 +263,35 @@ async fn remote_read_file_materializes_environment_workspace_roots() -> Result<(
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_read_file_preserves_empty_workspace_roots() -> Result<()> {
+    let context = create_file_system_context(FileSystemImplementation::Remote).await?;
+    let file_system = context.file_system;
+    let tmp = TempDir::new()?;
+    let file = tmp.path().join("excluded.txt");
+    std::fs::write(&file, b"excluded")?;
+
+    let policy = FileSystemSandboxPolicy::restricted(vec![FileSystemSandboxEntry {
+        path: FileSystemPath::Special {
+            value: FileSystemSpecialPath::project_roots(/*subpath*/ None),
+        },
+        access: FileSystemAccessMode::Read,
+    }]);
+    let mut sandbox = FileSystemSandboxContext::from_permission_profile_with_cwd(
+        PermissionProfile::from_runtime_permissions(&policy, NetworkSandboxPolicy::Restricted),
+        PathUri::from_host_native_path(tmp.path())?,
+    );
+    sandbox.workspace_roots.clear();
+
+    let error = file_system
+        .read_file(&PathUri::from_host_native_path(&file)?, Some(&sandbox))
+        .await
+        .expect_err("empty workspace roots should not grant cwd access");
+    assert_sandbox_denied(&error);
+
+    Ok(())
+}
+
 #[test_case(FileSystemImplementation::Local ; "local")]
 #[test_case(FileSystemImplementation::Remote ; "remote")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/codex-rs/file-system/src/lib.rs
+++ b/codex-rs/file-system/src/lib.rs
@@ -171,10 +171,11 @@ impl FileSystemSandboxContext {
         permissions: PermissionProfile<AbsolutePathBuf>,
         cwd: Option<PathUri>,
     ) -> Self {
+        let workspace_roots = cwd.iter().cloned().collect();
         Self {
             permissions: permissions.into(),
             cwd,
-            workspace_roots: Vec::new(),
+            workspace_roots,
             windows_sandbox_level: WindowsSandboxLevel::Disabled,
             windows_sandbox_private_desktop: false,
             use_legacy_landlock: false,


### PR DESCRIPTION
Depends on #31892.

## Why

Exec-server sandbox contexts carry the concrete roots that define symbolic `:workspace_roots` authority. Both process and filesystem sandboxing treated an empty root list as if it were missing and rebound it to the sandbox cwd. A caller that intentionally selected no workspace roots could therefore still access cwd files.

## What changed

- Stop substituting sandbox cwd when process or filesystem workspace roots are empty.
- Keep the existing `from_permission_profile_with_cwd` convenience behavior by carrying cwd as an explicit workspace root.
- Add remote exec-server integration coverage proving both `fs/readFile` and a sandboxed process cannot read a cwd file after workspace roots are explicitly cleared.

## Testing

- `just test -p codex-exec-server --test file_system_unix remote_read_file_preserves_empty_workspace_roots`
- `just test -p codex-exec-server --test exec_process remote_process_preserves_empty_workspace_roots`
