### PR TITLE
core: add tool-free thread mode

### DIFF
--- a/codex-rs/app-server/src/mcp_refresh.rs
+++ b/codex-rs/app-server/src/mcp_refresh.rs
@@ -1,6 +1,7 @@
 use crate::config_manager::ConfigManager;
 use codex_core::CodexThread;
 use codex_core::ThreadManager;
+use codex_features::Feature;
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::McpServerRefreshConfig;
 use codex_protocol::protocol::Op;
@@ -21,6 +22,9 @@ pub(crate) async fn queue_strict_refresh(
             .get_thread(thread_id)
             .await
             .map_err(|err| io::Error::other(format!("failed to load thread {thread_id}: {err}")))?;
+        if thread.enabled(Feature::ToolFree) {
+            continue;
+        }
         let config = build_refresh_config(thread.as_ref(), config_manager).await?;
         refreshes.push((thread_id, thread, config));
     }
@@ -42,6 +46,9 @@ pub(crate) async fn queue_best_effort_refresh(
                 continue;
             }
         };
+        if thread.enabled(Feature::ToolFree) {
+            continue;
+        }
         let config = match build_refresh_config(thread.as_ref(), config_manager).await {
             Ok(config) => config,
             Err(err) => {

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -674,6 +674,9 @@
             "tool_call_mcp_elicitation": {
               "type": "boolean"
             },
+            "tool_free": {
+              "type": "boolean"
+            },
             "tool_search": {
               "type": "boolean"
             },
@@ -5044,6 +5047,9 @@
           "$ref": "#/definitions/FeatureToml_for_TokenBudgetConfigToml"
         },
         "tool_call_mcp_elicitation": {
+          "type": "boolean"
+        },
+        "tool_free": {
           "type": "boolean"
         },
         "tool_search": {

--- a/codex-rs/core/src/session/mcp.rs
+++ b/codex-rs/core/src/session/mcp.rs
@@ -334,7 +334,11 @@ impl Session {
         } = mcp_projection;
         let mcp_config = Arc::new(mcp_config);
         let tool_plugin_provenance = codex_mcp::tool_plugin_provenance(&mcp_config);
-        let mcp_servers = effective_mcp_servers(&mcp_config, auth.as_ref());
+        let mcp_servers = if self.enabled(Feature::ToolFree) {
+            HashMap::new()
+        } else {
+            effective_mcp_servers(&mcp_config, auth.as_ref())
+        };
         let environment_manager = self.services.turn_environments.environment_manager();
         // TODO(anp): Migrate MCP runtime cwd plumbing to PathUri so foreign environment cwd
         // values can be used without falling back to the legacy host cwd.

--- a/codex-rs/core/src/session/session.rs
+++ b/codex-rs/core/src/session/session.rs
@@ -694,7 +694,11 @@ impl Session {
                 )
                 .await;
             let mcp_config = &mcp_projection.config;
-            let mcp_servers = codex_mcp::effective_mcp_servers(mcp_config, auth.as_ref());
+            let mcp_servers = if config_for_mcp.features.enabled(Feature::ToolFree) {
+                HashMap::new()
+            } else {
+                codex_mcp::effective_mcp_servers(mcp_config, auth.as_ref())
+            };
             let tool_plugin_provenance = codex_mcp::tool_plugin_provenance(mcp_config);
             let auth_statuses = compute_auth_statuses(
                 mcp_servers.iter(),

--- a/codex-rs/core/src/session/turn.rs
+++ b/codex-rs/core/src/session/turn.rs
@@ -515,6 +515,9 @@ async fn build_skills_and_plugins(
     cancellation_token: &CancellationToken,
 ) -> Option<(Vec<ResponseItem>, HashSet<String>)> {
     let turn_context = step_context.turn.as_ref();
+    if turn_context.config.features.enabled(Feature::ToolFree) {
+        return Some((Vec::new(), HashSet::new()));
+    }
     // Guardian input embeds the parent transcript as untrusted evidence. Do not interpret skill or
     // plugin mentions from that generated prompt as requests to inject additional instructions.
     if crate::guardian::is_guardian_reviewer_source(&turn_context.session_source) {
@@ -1220,6 +1223,19 @@ pub(crate) async fn built_tools(
     cancellation_token: &CancellationToken,
 ) -> CodexResult<Arc<ToolRouter>> {
     let turn_context = step_context.turn.as_ref();
+    if turn_context.config.features.enabled(Feature::ToolFree) {
+        return Ok(Arc::new(ToolRouter::from_context(
+            step_context,
+            ToolRouterParams {
+                mcp_tools: None,
+                deferred_mcp_tools: None,
+                tool_suggest_candidates: None,
+                extension_tool_executors: Vec::new(),
+                dynamic_tools: &[],
+            },
+            &sess.services.tool_search_handler_cache,
+        )));
+    }
     let mcp_connection_manager = step_context.mcp.manager();
     let has_mcp_servers = mcp_connection_manager.has_servers();
     let all_mcp_tools = step_context

--- a/codex-rs/core/src/tools/spec_plan.rs
+++ b/codex-rs/core/src/tools/spec_plan.rs
@@ -173,6 +173,9 @@ fn build_tool_specs_and_registry(
     tool_search_handler_cache: &ToolSearchHandlerCache,
 ) -> (Vec<ToolSpec>, ToolRegistry) {
     let turn_context = step_context.turn.as_ref();
+    if turn_context.config.features.enabled(Feature::ToolFree) {
+        return build_model_visible_specs_and_registry(turn_context, PlannedTools::default());
+    }
     let ToolRouterParams {
         mcp_tools,
         deferred_mcp_tools,

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -164,6 +164,8 @@ pub enum Feature {
     ToolSearchAlwaysDeferMcpTools,
     /// Expose MCP model-visible namespaces without the legacy `mcp__` prefix.
     NonPrefixedMcpToolNames,
+    /// Disable tool registration and MCP server startup.
+    ToolFree,
     /// Enable discoverable tool suggestions for apps.
     ToolSuggest,
     /// Enable plugins.
@@ -1085,6 +1087,12 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::NonPrefixedMcpToolNames,
         key: "non_prefixed_mcp_tool_names",
+        stage: Stage::UnderDevelopment,
+        default_enabled: false,
+    },
+    FeatureSpec {
+        id: Feature::ToolFree,
+        key: "tool_free",
         stage: Stage::UnderDevelopment,
         default_enabled: false,
     },


### PR DESCRIPTION
## Summary

- Add an opt-in `tool_free` feature for lightweight helper threads.
- Prevent MCP startup and refresh work for tool-free sessions.
- Skip skill, plugin, and tool enumeration, then enforce an empty tool router.

## Why

Helper turns such as thread-title generation should not start unrelated MCP servers or expose tools they cannot use. A slow server can otherwise consume the helper's full timeout.

## Validation

- `codex-features`: 55 tests passed.
- MCP refresh/runtime: 2 focused tests passed.
- Tool planning: 28 tests passed.
- `cargo check -p codex-app-server` passed.
- Scoped Clippy and formatting passed.
- Runtime control: the normal path started the configured MCP server and sent 11 tools; `tool_free` started no MCP server and sent zero tools.

`argument-comment-lint` is currently blocked because its pinned Rust 1.92 nightly cannot compile SQLx 0.9, which requires Rust 1.94.
