### PR TITLE
skills: make code-review more adversarial

### DIFF
--- a/.codex/skills/code-review/SKILL.md
+++ b/.codex/skills/code-review/SKILL.md
@@ -3,7 +3,7 @@ name: code-review
 description: Run a final code review on a pull request
 ---
 
-Use subagents to review code using all code-review-* skills other than this orchestrator. One subagent per skill. Pass full skill path to subagents. Use xhigh reasoning.
+Use subagents to review code using all code-review-* skills other than this orchestrator. One subagent per skill. Pass full skill path to subagents. Use xhigh reasoning. Don't fork any turns -- blank slate for each subagent.
 
 You must return every single issue from every subagent. You can return an unlimited number of findings.
 Use raw Markdown to report findings.


### PR DESCRIPTION
## Why

Agents seem to be better code reviewers when they don't share context with the agent who implemented a change. I don't remember where I first encountered the idea that agents are more critical reviewers when operating with disjoint context from the implementing agent, but https://myers.io/2026/04/15/LLMs-and-the-Adversarial-loop/ is a pretty decent explanation. Based on [this abstract](https://openreview.net/forum?id=fOHvpLs6zp) the approach also seems to be getting research attention.

Anecdotally I find Codex's code reviews a bit more incisive when it doesn't have any history of the development. Seems like encoding this pattern in our skills might improve what we see when using `$code-review` locally.

## What

Prompt Codex to always spawn its code review subagents without any forked turns so they won't be influenced by the previous context of the thread.
