### PR TITLE
path-uri: add host absolute path helper

### DIFF
--- a/codex-rs/utils/path-uri/src/api_path_string.rs
+++ b/codex-rs/utils/path-uri/src/api_path_string.rs
@@ -83,6 +83,10 @@ impl LegacyAppPathString {
 
     /// Parses this API string as an absolute path native to the current host.
     ///
+    /// Use this for legacy app or wire path text that must be validated as
+    /// native to the current host. Constructing [`AbsolutePathBuf`] directly
+    /// can misclassify foreign-platform spelling as a local path.
+    ///
     /// Host-specific path namespaces are normalized. Relative and
     /// foreign-platform paths are rejected.
     pub fn to_host_abs_path(&self) -> Result<AbsolutePathBuf, LegacyAppPathStringError> {

--- a/codex-rs/utils/path-uri/src/api_path_string.rs
+++ b/codex-rs/utils/path-uri/src/api_path_string.rs
@@ -30,7 +30,7 @@ use ts_rs::TS;
 /// `String` and is instead encouraged to convert through [`PathUri`] or
 /// [`AbsolutePathBuf`]. Relative path text remains valid until an operation
 /// such as [`Self::to_path_uri`] requires an absolute path.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, TS)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, TS)]
 #[serde(transparent)]
 #[ts(type = "string")]
 pub struct LegacyAppPathString(String);
@@ -74,6 +74,28 @@ impl LegacyAppPathString {
         convention: PathConvention,
     ) -> Result<PathUri, LegacyAppPathStringError> {
         PathUri::from_absolute_native_path(&self.0, convention).ok_or_else(|| {
+            LegacyAppPathStringError::InvalidNativePath {
+                path: self.0.clone(),
+                convention: Some(convention),
+            }
+        })
+    }
+
+    /// Parses this API string as an absolute path native to the current host.
+    ///
+    /// Host-specific path namespaces are normalized before the path is converted
+    /// to a URI. Relative and foreign-platform paths are rejected.
+    pub fn to_host_path_uri(&self) -> Result<PathUri, LegacyAppPathStringError> {
+        self.to_path_uri(PathConvention::native())
+    }
+
+    /// Parses this API string as an absolute path native to the current host.
+    ///
+    /// Host-specific path namespaces are normalized. Relative and
+    /// foreign-platform paths are rejected.
+    pub fn to_host_abs_path(&self) -> Result<AbsolutePathBuf, LegacyAppPathStringError> {
+        let convention = PathConvention::native();
+        self.to_path_uri(convention)?.to_abs_path().map_err(|_| {
             LegacyAppPathStringError::InvalidNativePath {
                 path: self.0.clone(),
                 convention: Some(convention),

--- a/codex-rs/utils/path-uri/src/api_path_string.rs
+++ b/codex-rs/utils/path-uri/src/api_path_string.rs
@@ -83,9 +83,10 @@ impl LegacyAppPathString {
 
     /// Parses this API string as an absolute path native to the current host.
     ///
-    /// Use this for legacy app or wire path text that must be validated as
-    /// native to the current host. Constructing [`AbsolutePathBuf`] directly
-    /// can misclassify foreign-platform spelling as a local path.
+    /// Use this when legacy app or wire path text denotes a file on the
+    /// coordinator host and a host-only filesystem API needs an
+    /// [`AbsolutePathBuf`]. Constructing [`AbsolutePathBuf`] directly can
+    /// misclassify foreign-platform spelling as a local path.
     ///
     /// Host-specific path namespaces are normalized. Relative and
     /// foreign-platform paths are rejected.

--- a/codex-rs/utils/path-uri/src/api_path_string.rs
+++ b/codex-rs/utils/path-uri/src/api_path_string.rs
@@ -30,7 +30,7 @@ use ts_rs::TS;
 /// `String` and is instead encouraged to convert through [`PathUri`] or
 /// [`AbsolutePathBuf`]. Relative path text remains valid until an operation
 /// such as [`Self::to_path_uri`] requires an absolute path.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, TS)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Deserialize, TS)]
 #[serde(transparent)]
 #[ts(type = "string")]
 pub struct LegacyAppPathString(String);
@@ -79,14 +79,6 @@ impl LegacyAppPathString {
                 convention: Some(convention),
             }
         })
-    }
-
-    /// Parses this API string as an absolute path native to the current host.
-    ///
-    /// Host-specific path namespaces are normalized before the path is converted
-    /// to a URI. Relative and foreign-platform paths are rejected.
-    pub fn to_host_path_uri(&self) -> Result<PathUri, LegacyAppPathStringError> {
-        self.to_path_uri(PathConvention::native())
     }
 
     /// Parses this API string as an absolute path native to the current host.

--- a/codex-rs/utils/path-uri/src/lib.rs
+++ b/codex-rs/utils/path-uri/src/lib.rs
@@ -263,22 +263,48 @@ impl PathUri {
         if self.0.host_str() != base.0.host_str() {
             return false;
         }
-
-        let Some(path_segments) = containment_path_segments(
-            &self.0,
-            self.infer_path_convention()
-                .unwrap_or(PathConvention::Posix),
-        ) else {
+        let Some(convention) = self.infer_path_convention() else {
             return false;
         };
-        let Some(base_segments) = containment_path_segments(
-            &base.0,
-            base.infer_path_convention()
-                .unwrap_or(PathConvention::Posix),
-        ) else {
+        if base.infer_path_convention() != Some(convention) {
+            return false;
+        }
+
+        let Some(path_segments) = containment_path_segments(&self.0, convention) else {
+            return false;
+        };
+        let Some(base_segments) = containment_path_segments(&base.0, convention) else {
             return false;
         };
         path_segments.starts_with(&base_segments)
+    }
+
+    /// Returns this path relative to `base` using `/` as the separator.
+    ///
+    /// Both paths are compared lexically in URI space, without consulting the
+    /// host filesystem. `None` is returned when the paths use different native
+    /// conventions or authorities, when this path is outside `base`, or when an
+    /// encoded native separator makes containment ambiguous.
+    pub fn relative_path_from(&self, base: &Self) -> Option<String> {
+        if self == base {
+            return Some(String::new());
+        }
+
+        let convention = self.infer_path_convention()?;
+        if base.infer_path_convention()? != convention || self.0.host_str() != base.0.host_str() {
+            return None;
+        }
+
+        let path_segments = containment_path_segments(&self.0, convention)?;
+        let base_segments = containment_path_segments(&base.0, convention)?;
+        let relative_segments = path_segments.strip_prefix(base_segments.as_slice())?;
+        Some(
+            relative_segments
+                .iter()
+                .map(|segment| decode_uri_path(segment))
+                .collect::<Vec<_>>()
+                .join("/"),
+        )
     }
 
     /// Lexically resolves native absolute or relative path text against this URI.

--- a/codex-rs/utils/path-uri/src/lib.rs
+++ b/codex-rs/utils/path-uri/src/lib.rs
@@ -263,48 +263,21 @@ impl PathUri {
         if self.0.host_str() != base.0.host_str() {
             return false;
         }
-        let Some(convention) = self.infer_path_convention() else {
+        let Some(path_segments) = containment_path_segments(
+            &self.0,
+            self.infer_path_convention()
+                .unwrap_or(PathConvention::Posix),
+        ) else {
             return false;
         };
-        if base.infer_path_convention() != Some(convention) {
-            return false;
-        }
-
-        let Some(path_segments) = containment_path_segments(&self.0, convention) else {
-            return false;
-        };
-        let Some(base_segments) = containment_path_segments(&base.0, convention) else {
+        let Some(base_segments) = containment_path_segments(
+            &base.0,
+            base.infer_path_convention()
+                .unwrap_or(PathConvention::Posix),
+        ) else {
             return false;
         };
         path_segments.starts_with(&base_segments)
-    }
-
-    /// Returns this path relative to `base` using `/` as the separator.
-    ///
-    /// Both paths are compared lexically in URI space, without consulting the
-    /// host filesystem. `None` is returned when the paths use different native
-    /// conventions or authorities, when this path is outside `base`, or when an
-    /// encoded native separator makes containment ambiguous.
-    pub fn relative_path_from(&self, base: &Self) -> Option<String> {
-        if self == base {
-            return Some(String::new());
-        }
-
-        let convention = self.infer_path_convention()?;
-        if base.infer_path_convention()? != convention || self.0.host_str() != base.0.host_str() {
-            return None;
-        }
-
-        let path_segments = containment_path_segments(&self.0, convention)?;
-        let base_segments = containment_path_segments(&base.0, convention)?;
-        let relative_segments = path_segments.strip_prefix(base_segments.as_slice())?;
-        Some(
-            relative_segments
-                .iter()
-                .map(|segment| decode_uri_path(segment))
-                .collect::<Vec<_>>()
-                .join("/"),
-        )
     }
 
     /// Lexically resolves native absolute or relative path text against this URI.


### PR DESCRIPTION
## Why

The larger path-types migration needs a small boundary helper so callers can convert legacy app path strings into host-native absolute paths through the existing URI validation path.

## What

- add `LegacyAppPathString::to_host_abs_path`
- interpret the string with `PathConvention::native()` before converting to `AbsolutePathBuf`

## Validation

- `just test -p codex-utils-path-uri`