### PR TITLE
protocol: genericize permission path models

### DIFF
--- a/codex-rs/core/src/session/tests/guardian_tests.rs
+++ b/codex-rs/core/src/session/tests/guardian_tests.rs
@@ -348,7 +348,7 @@ async fn guardian_allows_shell_command_additional_permissions_requests_past_poli
                     "workdir": workdir,
                     "timeout_ms": expiration_ms,
                     "sandbox_permissions": SandboxPermissions::WithAdditionalPermissions,
-                    "additional_permissions": PermissionProfile {
+                    "additional_permissions": PermissionProfile::<codex_utils_absolute_path::AbsolutePathBuf> {
                         network: Some(NetworkPermissions {
                             enabled: Some(true),
                         }),

--- a/codex-rs/core/tests/suite/extension_sandbox.rs
+++ b/codex-rs/core/tests/suite/extension_sandbox.rs
@@ -197,7 +197,7 @@ async fn extension_tool_uses_granted_turn_permissions_without_local_persistence(
     let image_dir = tempfile::tempdir()?;
     let image_path = image_dir.path().canonicalize()?.join("granted.png");
     std::fs::write(&image_path, TINY_PNG_BYTES)?;
-    let requested_permissions = RequestPermissionProfile {
+    let requested_permissions = RequestPermissionProfile::<AbsolutePathBuf> {
         file_system: Some(FileSystemPermissions::from_read_write_roots(
             Some(vec![image_dir.path().canonicalize()?.try_into()?]),
             Some(Vec::new()),

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -143,6 +143,30 @@ impl<PathType> FileSystemPermissions<PathType> {
         })
     }
 
+    /// Maps explicit filesystem paths while preserving glob and special-path entries.
+    pub fn map_paths<OutputPath>(
+        self,
+        mut map: impl FnMut(PathType) -> OutputPath,
+    ) -> FileSystemPermissions<OutputPath> {
+        FileSystemPermissions {
+            entries: self
+                .entries
+                .into_iter()
+                .map(|entry| FileSystemSandboxEntry {
+                    path: match entry.path {
+                        FileSystemPath::Path { path } => FileSystemPath::Path { path: map(path) },
+                        FileSystemPath::GlobPattern { pattern } => {
+                            FileSystemPath::GlobPattern { pattern }
+                        }
+                        FileSystemPath::Special { value } => FileSystemPath::Special { value },
+                    },
+                    access: entry.access,
+                })
+                .collect(),
+            glob_scan_max_depth: self.glob_scan_max_depth,
+        }
+    }
+
     pub fn legacy_read_write_roots(&self) -> Option<LegacyReadWriteRoots<PathType>>
     where
         PathType: Clone,
@@ -263,15 +287,60 @@ impl NetworkPermissions {
 
 /// Partial permission overlay used for per-command requests and approved
 /// session/turn grants.
-#[derive(Debug, Clone, Default, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, TS)]
-pub struct AdditionalPermissionProfile {
+#[derive(Debug, Clone, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, TS)]
+#[serde(bound(
+    serialize = "PathType: Clone + Serialize",
+    deserialize = "PathType: Deserialize<'de>"
+))]
+pub struct AdditionalPermissionProfile<PathType = AbsolutePathBuf> {
     pub network: Option<NetworkPermissions>,
-    pub file_system: Option<FileSystemPermissions>,
+    pub file_system: Option<FileSystemPermissions<PathType>>,
 }
 
-impl AdditionalPermissionProfile {
+impl<PathType> AdditionalPermissionProfile<PathType> {
     pub fn is_empty(&self) -> bool {
         self.network.is_none() && self.file_system.is_none()
+    }
+
+    /// Maps explicit filesystem paths while preserving the rest of the overlay.
+    pub fn map_paths<OutputPath>(
+        self,
+        map: impl FnMut(PathType) -> OutputPath,
+    ) -> AdditionalPermissionProfile<OutputPath> {
+        AdditionalPermissionProfile {
+            network: self.network,
+            file_system: self
+                .file_system
+                .map(|file_system| file_system.map_paths(map)),
+        }
+    }
+}
+
+impl<PathType> Default for AdditionalPermissionProfile<PathType> {
+    fn default() -> Self {
+        Self {
+            network: None,
+            file_system: None,
+        }
+    }
+}
+
+impl From<AdditionalPermissionProfile<AbsolutePathBuf>> for AdditionalPermissionProfile<PathUri> {
+    fn from(value: AdditionalPermissionProfile<AbsolutePathBuf>) -> Self {
+        value.map_paths(|path| PathUri::from_abs_path(&path))
+    }
+}
+
+impl TryFrom<AdditionalPermissionProfile<PathUri>>
+    for AdditionalPermissionProfile<AbsolutePathBuf>
+{
+    type Error = io::Error;
+
+    fn try_from(value: AdditionalPermissionProfile<PathUri>) -> Result<Self, Self::Error> {
+        Ok(Self {
+            network: value.network,
+            file_system: value.file_system.map(TryInto::try_into).transpose()?,
+        })
     }
 }
 

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -2479,12 +2479,15 @@ mod tests {
 
     #[test]
     fn additional_permission_profile_is_empty_when_all_fields_are_none() {
-        assert_eq!(AdditionalPermissionProfile::default().is_empty(), true);
+        assert_eq!(
+            AdditionalPermissionProfile::<AbsolutePathBuf>::default().is_empty(),
+            true
+        );
     }
 
     #[test]
     fn additional_permission_profile_is_not_empty_when_field_is_present_but_nested_empty() {
-        let permission_profile = AdditionalPermissionProfile {
+        let permission_profile = AdditionalPermissionProfile::<AbsolutePathBuf> {
             network: Some(NetworkPermissions { enabled: None }),
             file_system: None,
         };

--- a/codex-rs/protocol/src/request_permissions.rs
+++ b/codex-rs/protocol/src/request_permissions.rs
@@ -15,21 +15,47 @@ pub enum PermissionGrantScope {
     Session,
 }
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
 #[serde(deny_unknown_fields)]
-pub struct RequestPermissionProfile {
+#[serde(bound(
+    serialize = "PathType: Clone + Serialize",
+    deserialize = "PathType: Deserialize<'de>"
+))]
+pub struct RequestPermissionProfile<PathType = AbsolutePathBuf> {
     pub network: Option<NetworkPermissions>,
-    pub file_system: Option<FileSystemPermissions>,
+    pub file_system: Option<FileSystemPermissions<PathType>>,
 }
 
-impl RequestPermissionProfile {
+impl<PathType> RequestPermissionProfile<PathType> {
     pub fn is_empty(&self) -> bool {
         self.network.is_none() && self.file_system.is_none()
     }
+
+    /// Maps explicit filesystem paths while preserving the rest of the request.
+    pub fn map_paths<OutputPath>(
+        self,
+        map: impl FnMut(PathType) -> OutputPath,
+    ) -> RequestPermissionProfile<OutputPath> {
+        RequestPermissionProfile {
+            network: self.network,
+            file_system: self
+                .file_system
+                .map(|file_system| file_system.map_paths(map)),
+        }
+    }
 }
 
-impl From<RequestPermissionProfile> for AdditionalPermissionProfile {
-    fn from(value: RequestPermissionProfile) -> Self {
+impl<PathType> Default for RequestPermissionProfile<PathType> {
+    fn default() -> Self {
+        Self {
+            network: None,
+            file_system: None,
+        }
+    }
+}
+
+impl<PathType> From<RequestPermissionProfile<PathType>> for AdditionalPermissionProfile<PathType> {
+    fn from(value: RequestPermissionProfile<PathType>) -> Self {
         Self {
             network: value.network,
             file_system: value.file_system,
@@ -37,8 +63,8 @@ impl From<RequestPermissionProfile> for AdditionalPermissionProfile {
     }
 }
 
-impl From<AdditionalPermissionProfile> for RequestPermissionProfile {
-    fn from(value: AdditionalPermissionProfile) -> Self {
+impl<PathType> From<AdditionalPermissionProfile<PathType>> for RequestPermissionProfile<PathType> {
+    fn from(value: AdditionalPermissionProfile<PathType>) -> Self {
         Self {
             network: value.network,
             file_system: value.file_system,
@@ -47,7 +73,11 @@ impl From<AdditionalPermissionProfile> for RequestPermissionProfile {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
-pub struct RequestPermissionsArgs {
+#[serde(bound(
+    serialize = "PathType: Clone + Serialize",
+    deserialize = "PathType: Deserialize<'de>"
+))]
+pub struct RequestPermissionsArgs<PathType = AbsolutePathBuf> {
     #[serde(
         default,
         rename = "environment_id",
@@ -58,17 +88,34 @@ pub struct RequestPermissionsArgs {
     pub environment_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
-    pub permissions: RequestPermissionProfile,
+    pub permissions: RequestPermissionProfile<PathType>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
-pub struct RequestPermissionsResponse {
-    pub permissions: RequestPermissionProfile,
+#[serde(bound(
+    serialize = "PathType: Clone + Serialize",
+    deserialize = "PathType: Deserialize<'de>"
+))]
+pub struct RequestPermissionsResponse<PathType = AbsolutePathBuf> {
+    pub permissions: RequestPermissionProfile<PathType>,
     #[serde(default)]
     pub scope: PermissionGrantScope,
     /// Review every subsequent command in this turn before normal sandboxed execution.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub strict_auto_review: bool,
+}
+
+impl<PathType> RequestPermissionsResponse<PathType> {
+    pub fn map_paths<OutputPath>(
+        self,
+        map: impl FnMut(PathType) -> OutputPath,
+    ) -> RequestPermissionsResponse<OutputPath> {
+        RequestPermissionsResponse {
+            permissions: self.permissions.map_paths(map),
+            scope: self.scope,
+            strict_auto_review: self.strict_auto_review,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]


### PR DESCRIPTION
## Why

Permission models cross multiple layers that need different path representations. Making the models generic lets later migrations use `PathUri` internally while compatibility boundaries keep legacy path strings.

## What

- Genericize `AdditionalPermissionProfile` and `RequestPermissionProfile` over their path type.
- Genericize request-permission args and responses.
- Add mapping and conversion helpers for translating path-bearing permission data between layers.
- Add explicit path types to existing test fixtures where generic inference has no surrounding context.

## Validation

- `just test -p codex-protocol`
- `just test -p codex-core guardian_allows_shell_command_additional_permissions_requests_past_policy`
- `just test -p codex-core extension_tool_uses_granted_turn_permissions_without_local_persistence`

Stacked on #31955.