### PR TITLE
backend-client: add workspace attribution settings transport

### DIFF
--- a/codex-rs/backend-client/src/client.rs
+++ b/codex-rs/backend-client/src/client.rs
@@ -1,5 +1,6 @@
 use crate::types::AccountsCheckResponse;
 use crate::types::CodeTaskDetailsResponse;
+use crate::types::CodexUserSettingsResponse;
 use crate::types::CodexWorkspaceMessagesResponse;
 use crate::types::ConfigBundleResponse;
 use crate::types::PaginatedListTaskListItem;
@@ -432,6 +433,24 @@ impl Client {
             .map_err(RequestError::from)
     }
 
+    /// Fetch authenticated Codex user settings from the active backend route.
+    ///
+    /// Uses `GET /api/codex/settings/user` for Codex API hosts and
+    /// `GET /wham/settings/user` for ChatGPT `backend-api` hosts.
+    pub async fn get_user_settings(
+        &self,
+    ) -> std::result::Result<CodexUserSettingsResponse, RequestError> {
+        let url = self.user_settings_url();
+        let req = self
+            .http
+            .get(&url)
+            .headers(self.headers())
+            .header(CACHE_CONTROL, HeaderValue::from_static("no-store"));
+        let (body, ct) = self.exec_request_detailed(req, "GET", &url).await?;
+        self.decode_json::<CodexUserSettingsResponse>(&url, &ct, &body)
+            .map_err(RequestError::from)
+    }
+
     pub async fn list_workspace_messages(
         &self,
     ) -> std::result::Result<CodexWorkspaceMessagesResponse, RequestError> {
@@ -590,6 +609,13 @@ impl Client {
         match self.path_style {
             PathStyle::CodexApi => format!("{}/api/codex/workspace-messages", self.base_url),
             PathStyle::ChatGptApi => format!("{}/wham/workspace-messages", self.base_url),
+        }
+    }
+
+    fn user_settings_url(&self) -> String {
+        match self.path_style {
+            PathStyle::CodexApi => format!("{}/api/codex/settings/user", self.base_url),
+            PathStyle::ChatGptApi => format!("{}/wham/settings/user", self.base_url),
         }
     }
 
@@ -971,6 +997,55 @@ mod tests {
         assert_eq!(
             chatgpt_client.workspace_messages_url(),
             "https://chatgpt.com/backend-api/wham/workspace-messages"
+        );
+    }
+
+    #[test]
+    fn user_settings_uses_expected_paths() {
+        let codex_client = test_client("https://example.test", PathStyle::CodexApi);
+        assert_eq!(
+            codex_client.user_settings_url(),
+            "https://example.test/api/codex/settings/user"
+        );
+
+        let chatgpt_client = test_client("https://chatgpt.com/backend-api", PathStyle::ChatGptApi);
+        assert_eq!(
+            chatgpt_client.user_settings_url(),
+            "https://chatgpt.com/backend-api/wham/settings/user"
+        );
+    }
+
+    #[test]
+    fn user_settings_missing_attribution_policy_defaults_to_disabled() {
+        assert_eq!(
+            serde_json::from_value::<CodexUserSettingsResponse>(serde_json::json!({})).unwrap(),
+            CodexUserSettingsResponse {
+                commit_attribution_enabled: false,
+            }
+        );
+    }
+
+    #[test]
+    fn authenticated_user_settings_client_uses_active_workspace_headers() {
+        let auth = CodexAuth::from_external_chatgpt_tokens(
+            "e30.e30.c2ln",
+            "workspace-123",
+            Some("enterprise"),
+        )
+        .unwrap();
+        let client = Client::from_auth("https://chatgpt.com/backend-api", &auth).unwrap();
+        let headers = client.headers();
+
+        assert_eq!(
+            [
+                headers
+                    .get("authorization")
+                    .and_then(|value| value.to_str().ok()),
+                headers
+                    .get("chatgpt-account-id")
+                    .and_then(|value| value.to_str().ok()),
+            ],
+            [Some("Bearer e30.e30.c2ln"), Some("workspace-123")]
         );
     }
 

--- a/codex-rs/backend-client/src/lib.rs
+++ b/codex-rs/backend-client/src/lib.rs
@@ -8,6 +8,7 @@ pub use types::AccountEntry;
 pub use types::AccountsCheckResponse;
 pub use types::CodeTaskDetailsResponse;
 pub use types::CodeTaskDetailsResponseExt;
+pub use types::CodexUserSettingsResponse;
 pub use types::CodexWorkspaceMessage;
 pub use types::CodexWorkspaceMessageType;
 pub use types::CodexWorkspaceMessagesResponse;

--- a/codex-rs/backend-client/src/types.rs
+++ b/codex-rs/backend-client/src/types.rs
@@ -60,6 +60,16 @@ pub struct CodexWorkspaceMessagesResponse {
     pub messages: Vec<CodexWorkspaceMessage>,
 }
 
+/// Authenticated Codex user settings used by CLI runtime policy.
+#[derive(Clone, Copy, Debug, Default, Deserialize, PartialEq, Eq)]
+pub struct CodexUserSettingsResponse {
+    /// Server-computed effective commit-attribution policy.
+    ///
+    /// Older backend responses omit this field, which safely defaults to disabled.
+    #[serde(default)]
+    pub commit_attribution_enabled: bool,
+}
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct CodexWorkspaceMessage {
     pub message_id: String,


### PR DESCRIPTION
## Summary

- add a typed authenticated `GET settings/user` call to `codex-backend-client`
- route correctly through `/api/codex/settings/user` or ChatGPT's `/wham/settings/user`
- reuse the existing auth provider so the active `ChatGPT-Account-ID` and FedRAMP routing follow the current CLI account
- default an omitted `commit_attribution_enabled` field to `false` for safe compatibility with pre-BIZG-546 servers
- request fresh settings with `Cache-Control: no-store`

## Why

BIZG-549 requires Codex CLI sessions to consume the effective workspace attribution policy computed by BIZG-546. The CLI should not read `/accounts/{id}/settings`, infer eligibility from local plan claims, or add an enterprise policy to TOML. The existing backend client is the narrow shared transport that already owns Codex API versus `/wham` routing and authenticated workspace headers.

## Scope and dependencies

This draft is an independently mergeable foundation directly on `main`; it is not stacked on BIZG-548 and contains no prompt-attribution logic.

BIZG-548 is not yet present on `main`, so the remaining CLI integration is deliberately not duplicated here. After BIZG-546 and BIZG-548 are available, the follow-up in this PR can fetch these settings from the current auth snapshot at thread bootstrap, treat timeout/fetch/decode failures as disabled without blocking startup, and pass only the resolved gate into the shared contributor. End-to-end enabled/disabled, personal/ineligible, offline, workspace-switch, app-server, and MCP-host coverage depends on that consumer seam.

Ticket: [BIZG-549](https://linear.app/openai/issue/BIZG-549/ensure-workspace-attribution-policy-works-in-codex-cli)

## Validation

- `just fmt`
- `just test -p codex-backend-client` — 19 passed
- `just fix -p codex-backend-client`
- structured autoreview against the uncommitted `origin/main` diff — clean, no accepted/actionable findings
