### PR TITLE
core: use unique IDs for review history messages

### DIFF
--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -217,8 +217,6 @@ pub(crate) async fn exit_review_mode(
     review_output: Option<ReviewOutputEvent>,
     ctx: Arc<TurnContext>,
 ) {
-    const REVIEW_USER_MESSAGE_ID: &str = "review_rollout_user";
-    const REVIEW_ASSISTANT_MESSAGE_ID: &str = "review_rollout_assistant";
     let (user_message, assistant_message) = if let Some(out) = review_output.clone() {
         let mut findings_str = String::new();
         let text = out.overall_explanation.trim();
@@ -244,7 +242,7 @@ pub(crate) async fn exit_review_mode(
         .record_conversation_items(
             &ctx,
             &[ResponseItem::Message {
-                id: Some(REVIEW_USER_MESSAGE_ID.to_string()),
+                id: Some(uuid::Uuid::now_v7().to_string()),
                 role: "user".to_string(),
                 content: vec![ContentItem::InputText { text: user_message }],
                 phase: None,
@@ -263,7 +261,7 @@ pub(crate) async fn exit_review_mode(
         .record_response_item_and_emit_turn_item(
             ctx.as_ref(),
             ResponseItem::Message {
-                id: Some(REVIEW_ASSISTANT_MESSAGE_ID.to_string()),
+                id: Some(uuid::Uuid::now_v7().to_string()),
                 role: "assistant".to_string(),
                 content: vec![ContentItem::OutputText {
                     text: assistant_message,


### PR DESCRIPTION
## Description

This PR gives each user and assistant history message synthesized by `/review` a unique ID.

## Why

`/review` currently reuses `review_rollout_user` and `review_rollout_assistant` every time it runs. These are separate response items and should not share identity across review turns.

## What changed

- Generate a fresh UUIDv7 for each synthesized review history message.