### PR TITLE
[codex] keep CCA models cache in memory

### DIFF
--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -89,6 +89,7 @@ use tracing::instrument;
 use tracing::warn;
 
 const THREAD_CREATED_CHANNEL_CAPACITY: usize = 1024;
+const CODEX_CLOUD_AGENT_SESSION_SOURCE: &str = "codex-cloud-agent";
 /// Test-only override for enabling thread-manager behaviors used by integration
 /// tests.
 ///
@@ -333,11 +334,23 @@ impl ThreadManager {
             config.bundled_skills_enabled(),
             restriction_product,
         ));
+        let models_manager = if matches!(
+            &session_source,
+            SessionSource::Custom(source) if source == CODEX_CLOUD_AGENT_SESSION_SOURCE
+        ) {
+            create_model_provider(
+                config.model_provider.clone(),
+                Some(Arc::clone(&auth_manager)),
+            )
+            .models_manager_without_disk_cache(config.model_catalog.clone())
+        } else {
+            build_models_manager(config, Arc::clone(&auth_manager))
+        };
         Self {
             state: Arc::new(ThreadManagerState {
                 threads: Arc::new(RwLock::new(HashMap::new())),
                 thread_created_tx,
-                models_manager: build_models_manager(config, auth_manager.clone()),
+                models_manager,
                 environment_manager,
                 skills_service,
                 plugins_manager,

--- a/codex-rs/core/src/thread_manager_tests.rs
+++ b/codex-rs/core/src/thread_manager_tests.rs
@@ -1369,6 +1369,51 @@ async fn new_uses_active_provider_for_model_refresh() {
     assert_eq!(models_mock.requests().len(), 1);
 }
 
+#[tokio::test]
+async fn cloud_agent_uses_memory_only_models_cache() {
+    let server = MockServer::start().await;
+    let models_mock = mount_models_once(&server, ModelsResponse { models: vec![] }).await;
+
+    let temp_dir = tempdir().expect("tempdir");
+    let mut config = test_config().await;
+    config.codex_home = temp_dir.path().join("codex-home").abs();
+    config.cwd = config.codex_home.abs();
+    std::fs::create_dir_all(&config.codex_home).expect("create codex home");
+    config.model_catalog = None;
+    config.model_provider.base_url = Some(server.uri());
+
+    let auth_manager =
+        AuthManager::from_auth_for_testing(CodexAuth::create_dummy_chatgpt_auth_for_testing());
+    let manager = ThreadManager::new(
+        &config,
+        auth_manager,
+        SessionSource::Custom(CODEX_CLOUD_AGENT_SESSION_SOURCE.to_string()),
+        Arc::new(codex_exec_server::EnvironmentManager::default_for_tests()),
+        empty_extension_registry(),
+        Arc::new(crate::test_support::EmptyUserInstructionsProvider),
+        /*analytics_events_client*/ None,
+        thread_store_from_config(&config, /*state_db*/ None),
+        /*agent_graph_store*/ None,
+        TEST_INSTALLATION_ID.to_string(),
+        /*attestation_provider*/ None,
+        /*external_time_provider*/ None,
+    );
+
+    let http_client_factory = crate::test_support::default_http_client_factory();
+    let _ = manager
+        .list_models(
+            RefreshStrategy::OnlineIfUncached,
+            http_client_factory.clone(),
+        )
+        .await;
+    let _ = manager
+        .list_models(RefreshStrategy::OnlineIfUncached, http_client_factory)
+        .await;
+
+    assert_eq!(models_mock.requests().len(), 1);
+    assert!(!config.codex_home.join("models_cache.json").exists());
+}
+
 #[test]
 fn interrupted_fork_snapshot_appends_interrupt_boundary() {
     let committed_history =

--- a/codex-rs/model-provider/src/amazon_bedrock/mod.rs
+++ b/codex-rs/model-provider/src/amazon_bedrock/mod.rs
@@ -172,6 +172,16 @@ impl ModelProvider for AmazonBedrockModelProvider {
             config_model_catalog.map_or_else(static_model_catalog, with_default_only_service_tier),
         ))
     }
+
+    fn models_manager_without_disk_cache(
+        &self,
+        config_model_catalog: Option<ModelsResponse>,
+    ) -> SharedModelsManager {
+        Arc::new(StaticModelsManager::new(
+            /*auth_manager*/ None,
+            config_model_catalog.map_or_else(static_model_catalog, with_default_only_service_tier),
+        ))
+    }
 }
 
 #[cfg(test)]

--- a/codex-rs/model-provider/src/provider.rs
+++ b/codex-rs/model-provider/src/provider.rs
@@ -199,6 +199,20 @@ pub trait ModelProvider: fmt::Debug + Send + Sync {
         codex_home: PathBuf,
         config_model_catalog: Option<ModelsResponse>,
     ) -> SharedModelsManager;
+
+    /// Creates a model manager without host filesystem persistence.
+    ///
+    /// Providers that fetch model catalogs should override this method. The default uses an
+    /// authoritative in-memory catalog so hosted callers cannot accidentally write to disk.
+    fn models_manager_without_disk_cache(
+        &self,
+        config_model_catalog: Option<ModelsResponse>,
+    ) -> SharedModelsManager {
+        let model_catalog = config_model_catalog
+            .or_else(|| codex_models_manager::bundled_models_response().ok())
+            .unwrap_or_default();
+        Arc::new(StaticModelsManager::new(self.auth_manager(), model_catalog))
+    }
 }
 
 pub type ModelProviderFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
@@ -328,6 +342,28 @@ impl ModelProvider for ConfiguredModelProvider {
                 ));
                 Arc::new(OpenAiModelsManager::new(
                     codex_home,
+                    endpoint,
+                    self.auth_manager.clone(),
+                ))
+            }
+        }
+    }
+
+    fn models_manager_without_disk_cache(
+        &self,
+        config_model_catalog: Option<ModelsResponse>,
+    ) -> SharedModelsManager {
+        match config_model_catalog {
+            Some(model_catalog) => Arc::new(StaticModelsManager::new(
+                self.auth_manager.clone(),
+                model_catalog,
+            )),
+            None => {
+                let endpoint = Arc::new(OpenAiModelsEndpoint::new(
+                    self.info.clone(),
+                    self.auth_manager.clone(),
+                ));
+                Arc::new(OpenAiModelsManager::new_without_disk_cache(
                     endpoint,
                     self.auth_manager.clone(),
                 ))
@@ -657,6 +693,8 @@ mod tests {
         );
         let manager =
             provider.models_manager(test_codex_home(), /*config_model_catalog*/ None);
+        let memory_manager =
+            provider.models_manager_without_disk_cache(/*config_model_catalog*/ None);
 
         let catalog = manager
             .raw_model_catalog(
@@ -664,6 +702,13 @@ mod tests {
                 HttpClientFactory::new(OutboundProxyPolicy::ReqwestDefault),
             )
             .await;
+        let memory_catalog = memory_manager
+            .raw_model_catalog(
+                RefreshStrategy::Online,
+                HttpClientFactory::new(OutboundProxyPolicy::ReqwestDefault),
+            )
+            .await;
+        assert_eq!(memory_catalog, catalog);
         let models = catalog
             .models
             .iter()

--- a/codex-rs/models-manager/src/cache.rs
+++ b/codex-rs/models-manager/src/cache.rs
@@ -8,13 +8,15 @@ use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::time::Duration;
 use tokio::fs;
+use tokio::sync::RwLock;
 use tracing::error;
 use tracing::info;
 
-/// Manages loading and saving of models cache to disk.
+/// Manages loading and saving model cache state in memory or on disk.
 #[derive(Debug)]
 pub(crate) struct ModelsCacheManager {
-    cache_path: PathBuf,
+    cache_path: Option<PathBuf>,
+    memory_cache: RwLock<Option<ModelsCache>>,
     cache_ttl: Duration,
 }
 
@@ -22,7 +24,17 @@ impl ModelsCacheManager {
     /// Create a new cache manager with the given path and TTL.
     pub(crate) fn new(cache_path: PathBuf, cache_ttl: Duration) -> Self {
         Self {
-            cache_path,
+            cache_path: Some(cache_path),
+            memory_cache: RwLock::new(None),
+            cache_ttl,
+        }
+    }
+
+    /// Create a cache manager that retains model state in memory only.
+    pub(crate) fn without_disk_cache(cache_ttl: Duration) -> Self {
+        Self {
+            cache_path: None,
+            memory_cache: RwLock::new(None),
             cache_ttl,
         }
     }
@@ -30,8 +42,8 @@ impl ModelsCacheManager {
     /// Attempt to load a fresh cache entry. Returns `None` if the cache doesn't exist or is stale.
     pub(crate) async fn load_fresh(&self, expected_version: &str) -> Option<ModelsCache> {
         info!(
-                cache_path = %self.cache_path.display(),
-                expected_version,
+            cache_path = ?self.cache_path.as_ref(),
+            expected_version,
             "models cache: attempting load_fresh"
         );
         let cache = match self.load().await {
@@ -42,14 +54,14 @@ impl ModelsCacheManager {
             }
         };
         info!(
-            cache_path = %self.cache_path.display(),
+            cache_path = ?self.cache_path.as_ref(),
             cached_version = ?cache.client_version,
             fetched_at = %cache.fetched_at,
-            "models cache: loaded cache file"
+            "models cache: loaded cache entry"
         );
         if cache.client_version.as_deref() != Some(expected_version) {
             info!(
-                cache_path = %self.cache_path.display(),
+                cache_path = ?self.cache_path.as_ref(),
                 expected_version,
                 cached_version = ?cache.client_version,
                 "models cache: cache version mismatch"
@@ -58,7 +70,7 @@ impl ModelsCacheManager {
         }
         if !cache.is_fresh(self.cache_ttl) {
             info!(
-                cache_path = %self.cache_path.display(),
+                cache_path = ?self.cache_path.as_ref(),
                 cache_ttl_secs = self.cache_ttl.as_secs(),
                 fetched_at = %cache.fetched_at,
                 "models cache: cache is stale"
@@ -66,14 +78,14 @@ impl ModelsCacheManager {
             return None;
         }
         info!(
-            cache_path = %self.cache_path.display(),
+            cache_path = ?self.cache_path.as_ref(),
             cache_ttl_secs = self.cache_ttl.as_secs(),
             "models cache: cache hit"
         );
         Some(cache)
     }
 
-    /// Persist the cache to disk, creating parent directories as needed.
+    /// Persist the cache to its configured storage, creating disk directories as needed.
     pub(crate) async fn persist_cache(
         &self,
         models: &[ModelInfo],
@@ -102,7 +114,10 @@ impl ModelsCacheManager {
     }
 
     async fn load(&self) -> io::Result<Option<ModelsCache>> {
-        match fs::read(&self.cache_path).await {
+        let Some(cache_path) = self.cache_path.as_ref() else {
+            return Ok(self.memory_cache.read().await.clone());
+        };
+        match fs::read(cache_path).await {
             Ok(contents) => {
                 let cache = serde_json::from_slice(&contents)
                     .map_err(|err| io::Error::new(ErrorKind::InvalidData, err.to_string()))?;
@@ -114,12 +129,16 @@ impl ModelsCacheManager {
     }
 
     async fn save_internal(&self, cache: &ModelsCache) -> io::Result<()> {
-        if let Some(parent) = self.cache_path.parent() {
+        let Some(cache_path) = self.cache_path.as_ref() else {
+            *self.memory_cache.write().await = Some(cache.clone());
+            return Ok(());
+        };
+        if let Some(parent) = cache_path.parent() {
             fs::create_dir_all(parent).await?;
         }
         let json = serde_json::to_vec_pretty(cache)
             .map_err(|err| io::Error::new(ErrorKind::InvalidData, err.to_string()))?;
-        fs::write(&self.cache_path, json).await
+        fs::write(cache_path, json).await
     }
 
     #[cfg(test)]
@@ -157,7 +176,7 @@ impl ModelsCacheManager {
     }
 }
 
-/// Serialized snapshot of models and metadata cached on disk.
+/// Snapshot of models and metadata retained in memory or serialized to disk.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct ModelsCache {
     pub(crate) fetched_at: DateTime<Utc>,

--- a/codex-rs/models-manager/src/cache.rs
+++ b/codex-rs/models-manager/src/cache.rs
@@ -7,23 +7,17 @@ use std::io;
 use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::time::Duration;
-use std::time::Instant;
 use tokio::fs;
 use tokio::sync::RwLock;
 use tracing::error;
 use tracing::info;
 
-/// Tracks in-process freshness or loads and saves model cache snapshots on disk.
+/// Manages loading and saving model cache state in memory or on disk.
 #[derive(Debug)]
 pub(crate) struct ModelsCacheManager {
     cache_path: Option<PathBuf>,
-    memory_cache_fetched_at: RwLock<Option<Instant>>,
+    memory_cache: RwLock<Option<ModelsCache>>,
     cache_ttl: Duration,
-}
-
-pub(crate) enum ModelsCacheHit {
-    InMemory,
-    Persisted(ModelsCache),
 }
 
 impl ModelsCacheManager {
@@ -31,7 +25,7 @@ impl ModelsCacheManager {
     pub(crate) fn new(cache_path: PathBuf, cache_ttl: Duration) -> Self {
         Self {
             cache_path: Some(cache_path),
-            memory_cache_fetched_at: RwLock::new(None),
+            memory_cache: RwLock::new(None),
             cache_ttl,
         }
     }
@@ -40,31 +34,18 @@ impl ModelsCacheManager {
     pub(crate) fn without_disk_cache(cache_ttl: Duration) -> Self {
         Self {
             cache_path: None,
-            memory_cache_fetched_at: RwLock::new(None),
+            memory_cache: RwLock::new(None),
             cache_ttl,
         }
     }
 
     /// Attempt to load a fresh cache entry. Returns `None` if the cache doesn't exist or is stale.
-    pub(crate) async fn load_fresh(&self, expected_version: &str) -> Option<ModelsCacheHit> {
+    pub(crate) async fn load_fresh(&self, expected_version: &str) -> Option<ModelsCache> {
         info!(
             cache_path = ?self.cache_path.as_ref(),
             expected_version,
             "models cache: attempting load_fresh"
         );
-        if self.cache_path.is_none() {
-            // An in-memory entry cannot outlive this process or its fixed client version. The
-            // model manager already owns the corresponding models and ETag.
-            let fetched_at = *self.memory_cache_fetched_at.read().await;
-            let is_fresh = fetched_at.is_some_and(|fetched_at| {
-                !self.cache_ttl.is_zero() && fetched_at.elapsed() <= self.cache_ttl
-            });
-            info!(
-                cache_ttl_secs = self.cache_ttl.as_secs(),
-                is_fresh, "models cache: checked in-memory freshness"
-            );
-            return is_fresh.then_some(ModelsCacheHit::InMemory);
-        }
         let cache = match self.load().await {
             Ok(cache) => cache?,
             Err(err) => {
@@ -101,20 +82,16 @@ impl ModelsCacheManager {
             cache_ttl_secs = self.cache_ttl.as_secs(),
             "models cache: cache hit"
         );
-        Some(ModelsCacheHit::Persisted(cache))
+        Some(cache)
     }
 
-    /// Record fresh cache state, serializing it when disk persistence is configured.
+    /// Persist the cache to its configured storage, creating disk directories as needed.
     pub(crate) async fn persist_cache(
         &self,
         models: &[ModelInfo],
         etag: Option<String>,
         client_version: String,
     ) {
-        if self.cache_path.is_none() {
-            *self.memory_cache_fetched_at.write().await = Some(Instant::now());
-            return;
-        }
         let cache = ModelsCache {
             fetched_at: Utc::now(),
             etag,
@@ -128,14 +105,6 @@ impl ModelsCacheManager {
 
     /// Renew the cache TTL by updating the fetched_at timestamp to now.
     pub(crate) async fn renew_cache_ttl(&self) -> io::Result<()> {
-        if self.cache_path.is_none() {
-            let mut fetched_at = self.memory_cache_fetched_at.write().await;
-            if fetched_at.is_none() {
-                return Err(io::Error::new(ErrorKind::NotFound, "cache not found"));
-            }
-            *fetched_at = Some(Instant::now());
-            return Ok(());
-        }
         let mut cache = match self.load().await? {
             Some(cache) => cache,
             None => return Err(io::Error::new(ErrorKind::NotFound, "cache not found")),
@@ -146,7 +115,7 @@ impl ModelsCacheManager {
 
     async fn load(&self) -> io::Result<Option<ModelsCache>> {
         let Some(cache_path) = self.cache_path.as_ref() else {
-            return Ok(None);
+            return Ok(self.memory_cache.read().await.clone());
         };
         match fs::read(cache_path).await {
             Ok(contents) => {
@@ -161,10 +130,8 @@ impl ModelsCacheManager {
 
     async fn save_internal(&self, cache: &ModelsCache) -> io::Result<()> {
         let Some(cache_path) = self.cache_path.as_ref() else {
-            return Err(io::Error::new(
-                ErrorKind::Unsupported,
-                "memory-only cache does not serialize model data",
-            ));
+            *self.memory_cache.write().await = Some(cache.clone());
+            return Ok(());
         };
         if let Some(parent) = cache_path.parent() {
             fs::create_dir_all(parent).await?;
@@ -209,7 +176,7 @@ impl ModelsCacheManager {
     }
 }
 
-/// Serialized snapshot of models and metadata cached on disk.
+/// Snapshot of models and metadata retained in memory or serialized to disk.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct ModelsCache {
     pub(crate) fetched_at: DateTime<Utc>,

--- a/codex-rs/models-manager/src/cache.rs
+++ b/codex-rs/models-manager/src/cache.rs
@@ -7,17 +7,23 @@ use std::io;
 use std::io::ErrorKind;
 use std::path::PathBuf;
 use std::time::Duration;
+use std::time::Instant;
 use tokio::fs;
 use tokio::sync::RwLock;
 use tracing::error;
 use tracing::info;
 
-/// Manages loading and saving model cache state in memory or on disk.
+/// Tracks in-process freshness or loads and saves model cache snapshots on disk.
 #[derive(Debug)]
 pub(crate) struct ModelsCacheManager {
     cache_path: Option<PathBuf>,
-    memory_cache: RwLock<Option<ModelsCache>>,
+    memory_cache_fetched_at: RwLock<Option<Instant>>,
     cache_ttl: Duration,
+}
+
+pub(crate) enum ModelsCacheHit {
+    InMemory,
+    Persisted(ModelsCache),
 }
 
 impl ModelsCacheManager {
@@ -25,7 +31,7 @@ impl ModelsCacheManager {
     pub(crate) fn new(cache_path: PathBuf, cache_ttl: Duration) -> Self {
         Self {
             cache_path: Some(cache_path),
-            memory_cache: RwLock::new(None),
+            memory_cache_fetched_at: RwLock::new(None),
             cache_ttl,
         }
     }
@@ -34,18 +40,31 @@ impl ModelsCacheManager {
     pub(crate) fn without_disk_cache(cache_ttl: Duration) -> Self {
         Self {
             cache_path: None,
-            memory_cache: RwLock::new(None),
+            memory_cache_fetched_at: RwLock::new(None),
             cache_ttl,
         }
     }
 
     /// Attempt to load a fresh cache entry. Returns `None` if the cache doesn't exist or is stale.
-    pub(crate) async fn load_fresh(&self, expected_version: &str) -> Option<ModelsCache> {
+    pub(crate) async fn load_fresh(&self, expected_version: &str) -> Option<ModelsCacheHit> {
         info!(
             cache_path = ?self.cache_path.as_ref(),
             expected_version,
             "models cache: attempting load_fresh"
         );
+        if self.cache_path.is_none() {
+            // An in-memory entry cannot outlive this process or its fixed client version. The
+            // model manager already owns the corresponding models and ETag.
+            let fetched_at = *self.memory_cache_fetched_at.read().await;
+            let is_fresh = fetched_at.is_some_and(|fetched_at| {
+                !self.cache_ttl.is_zero() && fetched_at.elapsed() <= self.cache_ttl
+            });
+            info!(
+                cache_ttl_secs = self.cache_ttl.as_secs(),
+                is_fresh, "models cache: checked in-memory freshness"
+            );
+            return is_fresh.then_some(ModelsCacheHit::InMemory);
+        }
         let cache = match self.load().await {
             Ok(cache) => cache?,
             Err(err) => {
@@ -82,16 +101,20 @@ impl ModelsCacheManager {
             cache_ttl_secs = self.cache_ttl.as_secs(),
             "models cache: cache hit"
         );
-        Some(cache)
+        Some(ModelsCacheHit::Persisted(cache))
     }
 
-    /// Persist the cache to its configured storage, creating disk directories as needed.
+    /// Record fresh cache state, serializing it when disk persistence is configured.
     pub(crate) async fn persist_cache(
         &self,
         models: &[ModelInfo],
         etag: Option<String>,
         client_version: String,
     ) {
+        if self.cache_path.is_none() {
+            *self.memory_cache_fetched_at.write().await = Some(Instant::now());
+            return;
+        }
         let cache = ModelsCache {
             fetched_at: Utc::now(),
             etag,
@@ -105,6 +128,14 @@ impl ModelsCacheManager {
 
     /// Renew the cache TTL by updating the fetched_at timestamp to now.
     pub(crate) async fn renew_cache_ttl(&self) -> io::Result<()> {
+        if self.cache_path.is_none() {
+            let mut fetched_at = self.memory_cache_fetched_at.write().await;
+            if fetched_at.is_none() {
+                return Err(io::Error::new(ErrorKind::NotFound, "cache not found"));
+            }
+            *fetched_at = Some(Instant::now());
+            return Ok(());
+        }
         let mut cache = match self.load().await? {
             Some(cache) => cache,
             None => return Err(io::Error::new(ErrorKind::NotFound, "cache not found")),
@@ -115,7 +146,7 @@ impl ModelsCacheManager {
 
     async fn load(&self) -> io::Result<Option<ModelsCache>> {
         let Some(cache_path) = self.cache_path.as_ref() else {
-            return Ok(self.memory_cache.read().await.clone());
+            return Ok(None);
         };
         match fs::read(cache_path).await {
             Ok(contents) => {
@@ -130,8 +161,10 @@ impl ModelsCacheManager {
 
     async fn save_internal(&self, cache: &ModelsCache) -> io::Result<()> {
         let Some(cache_path) = self.cache_path.as_ref() else {
-            *self.memory_cache.write().await = Some(cache.clone());
-            return Ok(());
+            return Err(io::Error::new(
+                ErrorKind::Unsupported,
+                "memory-only cache does not serialize model data",
+            ));
         };
         if let Some(parent) = cache_path.parent() {
             fs::create_dir_all(parent).await?;
@@ -176,7 +209,7 @@ impl ModelsCacheManager {
     }
 }
 
-/// Snapshot of models and metadata retained in memory or serialized to disk.
+/// Serialized snapshot of models and metadata cached on disk.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct ModelsCache {
     pub(crate) fetched_at: DateTime<Utc>,

--- a/codex-rs/models-manager/src/manager.rs
+++ b/codex-rs/models-manager/src/manager.rs
@@ -1,3 +1,4 @@
+use super::cache::ModelsCacheHit;
 use super::cache::ModelsCacheManager;
 use crate::collaboration_mode_presets::builtin_collaboration_mode_presets;
 use crate::config::ModelsManagerConfig;
@@ -6,6 +7,7 @@ use codex_http_client::HttpClientFactory;
 use codex_login::AuthManager;
 use codex_protocol::auth::AuthMode;
 use codex_protocol::config_types::CollaborationModeMask;
+use codex_protocol::error::CodexErr;
 use codex_protocol::error::Result as CoreResult;
 use codex_protocol::openai_models::ModelInfo;
 use codex_protocol::openai_models::ModelPreset;
@@ -18,6 +20,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
+use tokio::sync::Semaphore;
 use tokio::sync::TryLockError;
 use tracing::Instrument as _;
 use tracing::error;
@@ -215,6 +218,7 @@ pub type SharedModelsManager = Arc<dyn ModelsManager>;
 pub struct OpenAiModelsManager {
     remote_models: RwLock<Vec<ModelInfo>>,
     etag: RwLock<Option<String>>,
+    refresh_permit: Semaphore,
     cache_manager: ModelsCacheManager,
     endpoint_client: SharedModelsEndpointClient,
     auth_manager: Option<Arc<AuthManager>>,
@@ -263,6 +267,7 @@ impl OpenAiModelsManager {
         Self {
             remote_models: RwLock::new(remote_models),
             etag: RwLock::new(None),
+            refresh_permit: Semaphore::new(1),
             cache_manager,
             endpoint_client,
             auth_manager,
@@ -375,7 +380,7 @@ impl OpenAiModelsManager {
             RefreshStrategy::Offline => {
                 // Only try to load from cache, never fetch
                 self.try_load_cache().await;
-                Ok(())
+                return Ok(());
             }
             RefreshStrategy::OnlineIfUncached => {
                 // Try cache first, fall back to online if unavailable
@@ -383,14 +388,24 @@ impl OpenAiModelsManager {
                     info!("models cache: using cached models for OnlineIfUncached");
                     return Ok(());
                 }
-                info!("models cache: cache miss, fetching remote models");
-                self.fetch_and_update_models(http_client_factory).await
             }
-            RefreshStrategy::Online => {
-                // Always fetch from network
-                self.fetch_and_update_models(http_client_factory).await
-            }
+            RefreshStrategy::Online => {}
         }
+
+        // Serialize network refreshes so models, ETag, and freshness come from one response.
+        let _refresh_permit = self
+            .refresh_permit
+            .acquire()
+            .await
+            .map_err(|_| CodexErr::InternalServerError)?;
+        if matches!(refresh_strategy, RefreshStrategy::OnlineIfUncached)
+            && self.try_load_cache().await
+        {
+            info!("models cache: another refresh populated the cache");
+            return Ok(());
+        }
+        info!("models cache: fetching remote models");
+        self.fetch_and_update_models(http_client_factory).await
     }
 
     async fn fetch_and_update_models(
@@ -464,6 +479,10 @@ impl OpenAiModelsManager {
                 info!("models cache: no usable cache entry");
                 return false;
             }
+        };
+        let ModelsCacheHit::Persisted(cache) = cache else {
+            info!("models cache: using current in-memory models");
+            return true;
         };
         let models = cache.models.clone();
         *self.etag.write().await = cache.etag.clone();

--- a/codex-rs/models-manager/src/manager.rs
+++ b/codex-rs/models-manager/src/manager.rs
@@ -1,4 +1,3 @@
-use super::cache::ModelsCacheHit;
 use super::cache::ModelsCacheManager;
 use crate::collaboration_mode_presets::builtin_collaboration_mode_presets;
 use crate::config::ModelsManagerConfig;
@@ -7,7 +6,6 @@ use codex_http_client::HttpClientFactory;
 use codex_login::AuthManager;
 use codex_protocol::auth::AuthMode;
 use codex_protocol::config_types::CollaborationModeMask;
-use codex_protocol::error::CodexErr;
 use codex_protocol::error::Result as CoreResult;
 use codex_protocol::openai_models::ModelInfo;
 use codex_protocol::openai_models::ModelPreset;
@@ -20,7 +18,6 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
-use tokio::sync::Semaphore;
 use tokio::sync::TryLockError;
 use tracing::Instrument as _;
 use tracing::error;
@@ -218,7 +215,6 @@ pub type SharedModelsManager = Arc<dyn ModelsManager>;
 pub struct OpenAiModelsManager {
     remote_models: RwLock<Vec<ModelInfo>>,
     etag: RwLock<Option<String>>,
-    refresh_permit: Semaphore,
     cache_manager: ModelsCacheManager,
     endpoint_client: SharedModelsEndpointClient,
     auth_manager: Option<Arc<AuthManager>>,
@@ -267,7 +263,6 @@ impl OpenAiModelsManager {
         Self {
             remote_models: RwLock::new(remote_models),
             etag: RwLock::new(None),
-            refresh_permit: Semaphore::new(1),
             cache_manager,
             endpoint_client,
             auth_manager,
@@ -380,7 +375,7 @@ impl OpenAiModelsManager {
             RefreshStrategy::Offline => {
                 // Only try to load from cache, never fetch
                 self.try_load_cache().await;
-                return Ok(());
+                Ok(())
             }
             RefreshStrategy::OnlineIfUncached => {
                 // Try cache first, fall back to online if unavailable
@@ -388,24 +383,14 @@ impl OpenAiModelsManager {
                     info!("models cache: using cached models for OnlineIfUncached");
                     return Ok(());
                 }
+                info!("models cache: cache miss, fetching remote models");
+                self.fetch_and_update_models(http_client_factory).await
             }
-            RefreshStrategy::Online => {}
+            RefreshStrategy::Online => {
+                // Always fetch from network
+                self.fetch_and_update_models(http_client_factory).await
+            }
         }
-
-        // Serialize network refreshes so models, ETag, and freshness come from one response.
-        let _refresh_permit = self
-            .refresh_permit
-            .acquire()
-            .await
-            .map_err(|_| CodexErr::InternalServerError)?;
-        if matches!(refresh_strategy, RefreshStrategy::OnlineIfUncached)
-            && self.try_load_cache().await
-        {
-            info!("models cache: another refresh populated the cache");
-            return Ok(());
-        }
-        info!("models cache: fetching remote models");
-        self.fetch_and_update_models(http_client_factory).await
     }
 
     async fn fetch_and_update_models(
@@ -479,10 +464,6 @@ impl OpenAiModelsManager {
                 info!("models cache: no usable cache entry");
                 return false;
             }
-        };
-        let ModelsCacheHit::Persisted(cache) = cache else {
-            info!("models cache: using current in-memory models");
-            return true;
         };
         let models = cache.models.clone();
         *self.etag.write().await = cache.etag.clone();

--- a/codex-rs/models-manager/src/manager.rs
+++ b/codex-rs/models-manager/src/manager.rs
@@ -235,7 +235,30 @@ impl OpenAiModelsManager {
         auth_manager: Option<Arc<AuthManager>>,
     ) -> Self {
         let cache_path = codex_home.join(MODEL_CACHE_FILE);
-        let cache_manager = ModelsCacheManager::new(cache_path, DEFAULT_MODEL_CACHE_TTL);
+        Self::new_with_cache_manager(
+            ModelsCacheManager::new(cache_path, DEFAULT_MODEL_CACHE_TTL),
+            endpoint_client,
+            auth_manager,
+        )
+    }
+
+    /// Construct an OpenAI-compatible model manager with memory-only catalog state.
+    pub fn new_without_disk_cache(
+        endpoint_client: Arc<dyn ModelsEndpointClient>,
+        auth_manager: Option<Arc<AuthManager>>,
+    ) -> Self {
+        Self::new_with_cache_manager(
+            ModelsCacheManager::without_disk_cache(DEFAULT_MODEL_CACHE_TTL),
+            endpoint_client,
+            auth_manager,
+        )
+    }
+
+    fn new_with_cache_manager(
+        cache_manager: ModelsCacheManager,
+        endpoint_client: Arc<dyn ModelsEndpointClient>,
+        auth_manager: Option<Arc<AuthManager>>,
+    ) -> Self {
         let remote_models = load_remote_models_from_file().unwrap_or_default();
         Self {
             remote_models: RwLock::new(remote_models),

--- a/codex-rs/models-manager/src/manager_tests.rs
+++ b/codex-rs/models-manager/src/manager_tests.rs
@@ -21,6 +21,7 @@ use std::sync::Mutex;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use tempfile::tempdir;
+use tokio::sync::Notify;
 
 #[path = "model_info_overrides_tests.rs"]
 mod model_info_overrides_tests;
@@ -82,6 +83,13 @@ struct TestModelsEndpoint {
     responses: Mutex<VecDeque<Vec<ModelInfo>>>,
     fetch_count: AtomicUsize,
     observed_proxy_policy: Mutex<Option<OutboundProxyPolicy>>,
+    first_fetch_gate: Option<Arc<FirstFetchGate>>,
+}
+
+#[derive(Debug)]
+struct FirstFetchGate {
+    started: Notify,
+    release: Notify,
 }
 
 impl TestModelsEndpoint {
@@ -92,6 +100,7 @@ impl TestModelsEndpoint {
             responses: Mutex::new(responses.into()),
             fetch_count: AtomicUsize::new(0),
             observed_proxy_policy: Mutex::new(None),
+            first_fetch_gate: None,
         })
     }
 
@@ -102,7 +111,26 @@ impl TestModelsEndpoint {
             responses: Mutex::new(responses.into()),
             fetch_count: AtomicUsize::new(0),
             observed_proxy_policy: Mutex::new(None),
+            first_fetch_gate: None,
         })
+    }
+
+    fn with_blocked_first_fetch(
+        responses: Vec<Vec<ModelInfo>>,
+    ) -> (Arc<Self>, Arc<FirstFetchGate>) {
+        let gate = Arc::new(FirstFetchGate {
+            started: Notify::new(),
+            release: Notify::new(),
+        });
+        let endpoint = Arc::new(Self {
+            has_command_auth: false,
+            uses_codex_backend: true,
+            responses: Mutex::new(responses.into()),
+            fetch_count: AtomicUsize::new(0),
+            observed_proxy_policy: Mutex::new(None),
+            first_fetch_gate: Some(Arc::clone(&gate)),
+        });
+        (endpoint, gate)
     }
 
     fn fetch_count(&self) -> usize {
@@ -117,7 +145,13 @@ impl TestModelsEndpoint {
     }
 
     async fn list_models(&self) -> CoreResult<(Vec<ModelInfo>, Option<String>)> {
-        self.fetch_count.fetch_add(1, Ordering::SeqCst);
+        let fetch_index = self.fetch_count.fetch_add(1, Ordering::SeqCst);
+        if fetch_index == 0
+            && let Some(gate) = self.first_fetch_gate.as_ref()
+        {
+            gate.started.notify_one();
+            gate.release.notified().await;
+        }
         let models = self
             .responses
             .lock()
@@ -237,6 +271,96 @@ async fn manager_without_disk_cache_fetches_and_retains_models_in_memory() {
     assert_eq!(catalog.models, remote_models);
     assert_eq!(cached_catalog, catalog);
     assert_eq!(manager.get_remote_models().await, remote_models);
+    assert_eq!(endpoint.fetch_count(), 1);
+}
+
+#[tokio::test]
+async fn manager_without_disk_cache_refetches_when_stale() {
+    let remote_models = vec![remote_model("remote", "Remote", /*priority*/ 0)];
+    let endpoint = TestModelsEndpoint::new(vec![remote_models.clone(), remote_models]);
+    let mut manager = OpenAiModelsManager::new_without_disk_cache(
+        endpoint.clone(),
+        Some(AuthManager::from_auth_for_testing(
+            CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+        )),
+    );
+    manager.cache_manager.set_ttl(Duration::ZERO);
+
+    for _ in 0..2 {
+        let _ = manager
+            .raw_model_catalog(
+                RefreshStrategy::OnlineIfUncached,
+                DEFAULT_HTTP_CLIENT_FACTORY,
+            )
+            .await;
+    }
+
+    assert_eq!(endpoint.fetch_count(), 2);
+}
+
+#[tokio::test]
+async fn manager_without_disk_cache_online_always_refetches() {
+    let remote_models = vec![remote_model("remote", "Remote", /*priority*/ 0)];
+    let endpoint = TestModelsEndpoint::new(vec![remote_models.clone(), remote_models]);
+    let manager = OpenAiModelsManager::new_without_disk_cache(
+        endpoint.clone(),
+        Some(AuthManager::from_auth_for_testing(
+            CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+        )),
+    );
+
+    for _ in 0..2 {
+        let _ = manager
+            .raw_model_catalog(RefreshStrategy::Online, DEFAULT_HTTP_CLIENT_FACTORY)
+            .await;
+    }
+
+    assert_eq!(endpoint.fetch_count(), 2);
+}
+
+#[tokio::test]
+async fn concurrent_memory_cache_misses_share_one_fetch() {
+    let remote_models = vec![remote_model("remote", "Remote", /*priority*/ 0)];
+    let (endpoint, gate) =
+        TestModelsEndpoint::with_blocked_first_fetch(vec![remote_models.clone(), remote_models]);
+    let manager = Arc::new(OpenAiModelsManager::new_without_disk_cache(
+        endpoint.clone(),
+        Some(AuthManager::from_auth_for_testing(
+            CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+        )),
+    ));
+
+    let first_refresh = tokio::spawn({
+        let manager = Arc::clone(&manager);
+        async move {
+            manager
+                .raw_model_catalog(
+                    RefreshStrategy::OnlineIfUncached,
+                    DEFAULT_HTTP_CLIENT_FACTORY,
+                )
+                .await
+        }
+    });
+    gate.started.notified().await;
+    let second_refresh = tokio::spawn({
+        let manager = Arc::clone(&manager);
+        async move {
+            manager
+                .raw_model_catalog(
+                    RefreshStrategy::OnlineIfUncached,
+                    DEFAULT_HTTP_CLIENT_FACTORY,
+                )
+                .await
+        }
+    });
+    tokio::task::yield_now().await;
+    gate.release.notify_one();
+
+    let (first_catalog, second_catalog) = tokio::join!(first_refresh, second_refresh);
+    assert_eq!(
+        first_catalog.expect("first refresh should complete"),
+        second_catalog.expect("second refresh should complete")
+    );
     assert_eq!(endpoint.fetch_count(), 1);
 }
 
@@ -676,6 +800,7 @@ async fn refresh_available_models_keeps_merging_for_api_auth() {
         responses: Mutex::new(vec![remote_models.clone()].into()),
         fetch_count: AtomicUsize::new(0),
         observed_proxy_policy: Mutex::new(None),
+        first_fetch_gate: None,
     });
     let manager = openai_manager_for_tests_with_auth(
         codex_home.path().to_path_buf(),

--- a/codex-rs/models-manager/src/manager_tests.rs
+++ b/codex-rs/models-manager/src/manager_tests.rs
@@ -21,7 +21,6 @@ use std::sync::Mutex;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use tempfile::tempdir;
-use tokio::sync::Notify;
 
 #[path = "model_info_overrides_tests.rs"]
 mod model_info_overrides_tests;
@@ -83,13 +82,6 @@ struct TestModelsEndpoint {
     responses: Mutex<VecDeque<Vec<ModelInfo>>>,
     fetch_count: AtomicUsize,
     observed_proxy_policy: Mutex<Option<OutboundProxyPolicy>>,
-    first_fetch_gate: Option<Arc<FirstFetchGate>>,
-}
-
-#[derive(Debug)]
-struct FirstFetchGate {
-    started: Notify,
-    release: Notify,
 }
 
 impl TestModelsEndpoint {
@@ -100,7 +92,6 @@ impl TestModelsEndpoint {
             responses: Mutex::new(responses.into()),
             fetch_count: AtomicUsize::new(0),
             observed_proxy_policy: Mutex::new(None),
-            first_fetch_gate: None,
         })
     }
 
@@ -111,26 +102,7 @@ impl TestModelsEndpoint {
             responses: Mutex::new(responses.into()),
             fetch_count: AtomicUsize::new(0),
             observed_proxy_policy: Mutex::new(None),
-            first_fetch_gate: None,
         })
-    }
-
-    fn with_blocked_first_fetch(
-        responses: Vec<Vec<ModelInfo>>,
-    ) -> (Arc<Self>, Arc<FirstFetchGate>) {
-        let gate = Arc::new(FirstFetchGate {
-            started: Notify::new(),
-            release: Notify::new(),
-        });
-        let endpoint = Arc::new(Self {
-            has_command_auth: false,
-            uses_codex_backend: true,
-            responses: Mutex::new(responses.into()),
-            fetch_count: AtomicUsize::new(0),
-            observed_proxy_policy: Mutex::new(None),
-            first_fetch_gate: Some(Arc::clone(&gate)),
-        });
-        (endpoint, gate)
     }
 
     fn fetch_count(&self) -> usize {
@@ -145,13 +117,7 @@ impl TestModelsEndpoint {
     }
 
     async fn list_models(&self) -> CoreResult<(Vec<ModelInfo>, Option<String>)> {
-        let fetch_index = self.fetch_count.fetch_add(1, Ordering::SeqCst);
-        if fetch_index == 0
-            && let Some(gate) = self.first_fetch_gate.as_ref()
-        {
-            gate.started.notify_one();
-            gate.release.notified().await;
-        }
+        self.fetch_count.fetch_add(1, Ordering::SeqCst);
         let models = self
             .responses
             .lock()
@@ -271,96 +237,6 @@ async fn manager_without_disk_cache_fetches_and_retains_models_in_memory() {
     assert_eq!(catalog.models, remote_models);
     assert_eq!(cached_catalog, catalog);
     assert_eq!(manager.get_remote_models().await, remote_models);
-    assert_eq!(endpoint.fetch_count(), 1);
-}
-
-#[tokio::test]
-async fn manager_without_disk_cache_refetches_when_stale() {
-    let remote_models = vec![remote_model("remote", "Remote", /*priority*/ 0)];
-    let endpoint = TestModelsEndpoint::new(vec![remote_models.clone(), remote_models]);
-    let mut manager = OpenAiModelsManager::new_without_disk_cache(
-        endpoint.clone(),
-        Some(AuthManager::from_auth_for_testing(
-            CodexAuth::create_dummy_chatgpt_auth_for_testing(),
-        )),
-    );
-    manager.cache_manager.set_ttl(Duration::ZERO);
-
-    for _ in 0..2 {
-        let _ = manager
-            .raw_model_catalog(
-                RefreshStrategy::OnlineIfUncached,
-                DEFAULT_HTTP_CLIENT_FACTORY,
-            )
-            .await;
-    }
-
-    assert_eq!(endpoint.fetch_count(), 2);
-}
-
-#[tokio::test]
-async fn manager_without_disk_cache_online_always_refetches() {
-    let remote_models = vec![remote_model("remote", "Remote", /*priority*/ 0)];
-    let endpoint = TestModelsEndpoint::new(vec![remote_models.clone(), remote_models]);
-    let manager = OpenAiModelsManager::new_without_disk_cache(
-        endpoint.clone(),
-        Some(AuthManager::from_auth_for_testing(
-            CodexAuth::create_dummy_chatgpt_auth_for_testing(),
-        )),
-    );
-
-    for _ in 0..2 {
-        let _ = manager
-            .raw_model_catalog(RefreshStrategy::Online, DEFAULT_HTTP_CLIENT_FACTORY)
-            .await;
-    }
-
-    assert_eq!(endpoint.fetch_count(), 2);
-}
-
-#[tokio::test]
-async fn concurrent_memory_cache_misses_share_one_fetch() {
-    let remote_models = vec![remote_model("remote", "Remote", /*priority*/ 0)];
-    let (endpoint, gate) =
-        TestModelsEndpoint::with_blocked_first_fetch(vec![remote_models.clone(), remote_models]);
-    let manager = Arc::new(OpenAiModelsManager::new_without_disk_cache(
-        endpoint.clone(),
-        Some(AuthManager::from_auth_for_testing(
-            CodexAuth::create_dummy_chatgpt_auth_for_testing(),
-        )),
-    ));
-
-    let first_refresh = tokio::spawn({
-        let manager = Arc::clone(&manager);
-        async move {
-            manager
-                .raw_model_catalog(
-                    RefreshStrategy::OnlineIfUncached,
-                    DEFAULT_HTTP_CLIENT_FACTORY,
-                )
-                .await
-        }
-    });
-    gate.started.notified().await;
-    let second_refresh = tokio::spawn({
-        let manager = Arc::clone(&manager);
-        async move {
-            manager
-                .raw_model_catalog(
-                    RefreshStrategy::OnlineIfUncached,
-                    DEFAULT_HTTP_CLIENT_FACTORY,
-                )
-                .await
-        }
-    });
-    tokio::task::yield_now().await;
-    gate.release.notify_one();
-
-    let (first_catalog, second_catalog) = tokio::join!(first_refresh, second_refresh);
-    assert_eq!(
-        first_catalog.expect("first refresh should complete"),
-        second_catalog.expect("second refresh should complete")
-    );
     assert_eq!(endpoint.fetch_count(), 1);
 }
 
@@ -800,7 +676,6 @@ async fn refresh_available_models_keeps_merging_for_api_auth() {
         responses: Mutex::new(vec![remote_models.clone()].into()),
         fetch_count: AtomicUsize::new(0),
         observed_proxy_policy: Mutex::new(None),
-        first_fetch_gate: None,
     });
     let manager = openai_manager_for_tests_with_auth(
         codex_home.path().to_path_buf(),

--- a/codex-rs/models-manager/src/manager_tests.rs
+++ b/codex-rs/models-manager/src/manager_tests.rs
@@ -210,6 +210,36 @@ fn static_manager_for_tests(model_catalog: ModelsResponse) -> StaticModelsManage
     StaticModelsManager::new(/*auth_manager*/ None, model_catalog)
 }
 
+#[tokio::test]
+async fn manager_without_disk_cache_fetches_and_retains_models_in_memory() {
+    let remote_models = vec![remote_model("remote", "Remote", /*priority*/ 0)];
+    let endpoint = TestModelsEndpoint::new(vec![remote_models.clone()]);
+    let manager = OpenAiModelsManager::new_without_disk_cache(
+        endpoint.clone(),
+        Some(AuthManager::from_auth_for_testing(
+            CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+        )),
+    );
+
+    let catalog = manager
+        .raw_model_catalog(
+            RefreshStrategy::OnlineIfUncached,
+            DEFAULT_HTTP_CLIENT_FACTORY,
+        )
+        .await;
+    let cached_catalog = manager
+        .raw_model_catalog(
+            RefreshStrategy::OnlineIfUncached,
+            DEFAULT_HTTP_CLIENT_FACTORY,
+        )
+        .await;
+
+    assert_eq!(catalog.models, remote_models);
+    assert_eq!(cached_catalog, catalog);
+    assert_eq!(manager.get_remote_models().await, remote_models);
+    assert_eq!(endpoint.fetch_count(), 1);
+}
+
 async fn chatgpt_auth_tokens_for_tests(codex_home: &Path) -> CodexAuth {
     let auth_dot_json = codex_login::AuthDotJson {
         auth_mode: Some(AuthMode::ChatgptAuthTokens),


### PR DESCRIPTION
## What

- add a bounded in-memory backend to `ModelsCacheManager`
- select it when `ThreadManager` is created with `SessionSource::Custom("codex-cloud-agent")`
- preserve the existing file-backed cache for local Codex and provider-specific static catalogs

## Why

Codex Cloud Agent is multi-tenant and should not write tenant-specific model catalogs to shared host storage. CCA also uses `OnlineIfUncached`, so removing persistence without retaining cache state would add a `/models` round trip to repeated requests.

The model catalog is less than 1 MiB. Each tenant-scoped CCA runtime now retains one complete `ModelsCache` snapshot—models, ETag, client version, and fetch time—and replaces it on refresh. The snapshot is released with its runtime and does not grow per request.

This is the cache-only v0 split from the broader pathless-runtime work in #31463. It does not make `codex_home` optional or change any other filesystem behavior.

## How

- local callers continue using `$CODEX_HOME/models_cache.json`
- CCA uses the same cache eligibility, TTL, ETag, and refresh logic against one in-memory snapshot
- `OnlineIfUncached` reuses a fresh snapshot; `Online` remains a forced network refresh
- provider implementations expose a named no-disk construction path, with a static in-memory fallback for providers that do not override it
- v0 deliberately does not add a global cache, freshness-only state, semaphore, singleflight, provider/config option, or broader filesystem abstraction

## Validation

- `just test -p codex-models-manager` (40 passed)
- `just test -p codex-model-provider` (53 passed)
- `just test -p codex-core cloud_agent_uses_memory_only_models_cache` (1 passed)
- `just fix -p codex-models-manager`
- `just fix -p codex-model-provider`
- `just fix -p codex-core`
- `just fmt`
- `git diff --check`
