### PR TITLE
Allow stable Python SDK releases

### DIFF
--- a/.github/workflows/python-sdk-release.yml
+++ b/.github/workflows/python-sdk-release.yml
@@ -38,10 +38,10 @@ jobs:
           from pathlib import Path
 
           sdk_version = os.environ["GITHUB_REF_NAME"].removeprefix("python-v")
-          if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+b[0-9]+", sdk_version):
+          if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", sdk_version):
               raise SystemExit(
-                  "Python SDK release tags must identify a beta release, "
-                  "for example python-v0.1.0b1."
+                  "Python SDK release tags must identify a stable release, "
+                  "for example python-v0.144.4."
               )
 
           pyproject = tomllib.loads(Path("sdk/python/pyproject.toml").read_text())
@@ -56,8 +56,14 @@ jobs:
                   f"Expected exactly one pinned {prefix} dependency, found {runtime_versions}"
               )
 
+          runtime_version = runtime_versions[0]
+          if sdk_version != runtime_version:
+              raise SystemExit(
+                  f"Python SDK version {sdk_version} must match pinned runtime {runtime_version}."
+              )
+
           with Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
-              print(f"runtime_version={runtime_versions[0]}", file=output)
+              print(f"runtime_version={runtime_version}", file=output)
               print(f"sdk_version={sdk_version}", file=output)
           PY
 


### PR DESCRIPTION
## Why

The Python SDK now declares stable package metadata and pins `openai-codex-cli-bin==0.144.4`, but the release workflow still accepts only beta tags. As a result, the `python-v0.144.4` release failed during tag validation:
https://github.com/openai/codex/actions/runs/29543104487

## What changed

- accept stable `python-vX.Y.Z` SDK release tags
- require the SDK release version to match the pinned Codex CLI runtime version before preparing or publishing artifacts

## Validation

Exercised the embedded release-validation script against the checked-in SDK pin:

- `python-v0.144.4` resolves `sdk_version=0.144.4` and `runtime_version=0.144.4`
- beta tags are rejected
- mismatched stable tags are rejected
- `git diff --check`

After this merges, recreate `python-v0.144.4` from the updated `main` commit to publish the stable SDK.