### PR TITLE
Backport retained-image compaction budgeting to 0.150

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -5,3 +5,4 @@ psuedo
 SOM
 te
 TE
+WRONLY

--- a/.github/scripts/verify_cargo_workspace_manifests.py
+++ b/.github/scripts/verify_cargo_workspace_manifests.py
@@ -26,7 +26,6 @@ UTILITY_NAME_EXCEPTIONS = {
     "path-utils": "codex-utils-path",
 }
 MANIFEST_FEATURE_EXCEPTIONS = {
-    "codex-rs/code-mode/Cargo.toml": {"sandbox": ("v8/v8_enable_sandbox",)},
     "codex-rs/v8-poc/Cargo.toml": {"sandbox": ("v8/v8_enable_sandbox",)},
 }
 OPTIONAL_DEPENDENCY_EXCEPTIONS = set()

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           target: x86_64-unknown-linux-gnu
 
-      - name: Build codex with Bazel
+      - name: Build codex and the code-mode host with Bazel
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         shell: bash
@@ -88,8 +88,8 @@ jobs:
           set -euo pipefail
           # Use the shared CI wrapper so fork PRs fall back cleanly when
           # BuildBuddy credentials are unavailable. This workflow needs the
-          # built `codex` binary on disk afterwards, so ask the wrapper to
-          # override CI's default remote_download_minimal behavior.
+          # built binaries on disk afterwards, so ask the wrapper to override
+          # CI's default remote_download_minimal behavior.
           ./.github/scripts/run-bazel-ci.sh \
             --remote-download-toplevel \
             -- \
@@ -97,42 +97,29 @@ jobs:
             --build_metadata=COMMIT_SHA=${GITHUB_SHA} \
             --build_metadata=TAG_job=sdk \
             -- \
-            //codex-rs/cli:codex
+            //codex-rs/cli:codex \
+            //codex-rs/code-mode-host:codex-code-mode-host
 
-          # Resolve the exact output file using the same wrapper/config path as
-          # the build instead of guessing which Bazel convenience symlink is
-          # available on the runner.
           cquery_output="$(
             ./.github/scripts/run-bazel-ci.sh \
               -- \
               cquery \
               --output=files \
               -- \
-              //codex-rs/cli:codex \
-              | grep -E '^(/|bazel-out/)' \
-              | tail -n 1
+              'set(//codex-rs/cli:codex //codex-rs/code-mode-host:codex-code-mode-host)' \
+              | grep -E '^(/|bazel-out/)'
           )"
-          if [[ "${cquery_output}" = /* ]]; then
-            codex_bazel_output_path="${cquery_output}"
-          else
-            codex_bazel_output_path="${GITHUB_WORKSPACE}/${cquery_output}"
-          fi
-          if [[ -z "${codex_bazel_output_path}" ]]; then
-            echo "Bazel did not report an output path for //codex-rs/cli:codex." >&2
-            exit 1
-          fi
-          if [[ ! -e "${codex_bazel_output_path}" ]]; then
-            echo "Unable to locate the Bazel-built codex binary at ${codex_bazel_output_path}." >&2
+          mapfile -t bazel_output_paths <<< "${cquery_output}"
+          if [[ ${#bazel_output_paths[@]} -ne 2 ]]; then
+            echo "Expected both Bazel-built binaries, found ${#bazel_output_paths[@]}." >&2
             exit 1
           fi
 
-          # Stage the binary into the workspace and point the SDK tests at that
-          # stable path. The tests spawn `codex` directly many times, so using a
-          # normal executable path is more reliable than invoking Bazel for each
-          # test process.
+          # Stage both binaries together so the CLI can discover its sibling
+          # code-mode host while the SDK tests spawn the CLI directly.
           install_dir="${GITHUB_WORKSPACE}/.tmp/sdk-ci"
           mkdir -p "${install_dir}"
-          install -m 755 "${codex_bazel_output_path}" "${install_dir}/codex"
+          install -m 755 "${bazel_output_paths[@]}" "${install_dir}"
           echo "CODEX_EXEC_PATH=${install_dir}/codex" >> "$GITHUB_ENV"
 
       - name: Warm up Bazel-built codex

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -1328,7 +1328,7 @@ async fn remote_manual_compact_chatgpt_auth_reuses_service_tier_and_prompt_cache
     Ok(())
 }
 
-#[test_case(None; "default_preserves_images")]
+#[test_case(None; "default_trims_images")]
 #[test_case(Some(false); "disabled_preserves_images")]
 #[test_case(Some(true); "enabled_trims_images")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1433,7 +1433,7 @@ async fn remote_compact_v2_charges_retained_images_to_token_budget(
             follow_up.inputs_of_type("compaction")[0]["encrypted_content"],
             "IMAGE_BUDGET_SUMMARY"
         );
-        let dropped = if image_budget_enabled == Some(true) {
+        let dropped = if image_budget_enabled.unwrap_or(true) {
             cycle
         } else {
             0

--- a/codex-rs/core/tests/suite/openai_file_mcp.rs
+++ b/codex-rs/core/tests/suite/openai_file_mcp.rs
@@ -44,7 +44,6 @@ use serde_json::json;
 use wiremock::Mock;
 use wiremock::MockServer;
 use wiremock::ResponseTemplate;
-use wiremock::matchers::body_json;
 use wiremock::matchers::body_partial_json;
 use wiremock::matchers::header;
 use wiremock::matchers::method;

--- a/codex-rs/features/src/lib.rs
+++ b/codex-rs/features/src/lib.rs
@@ -1576,8 +1576,8 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::CompactionImageBudget,
         key: "compaction_image_budget",
-        stage: Stage::UnderDevelopment,
-        default_enabled: false,
+        stage: Stage::Stable,
+        default_enabled: true,
     },
     FeatureSpec {
         id: Feature::RetainClientDeveloperMessages,


### PR DESCRIPTION
## Summary

Backport #40994 to the 0.150 stable release line. Enable `compaction_image_budget` by default so retained images count against the existing remote-compaction token budget and older images are trimmed as needed. Explicitly disabling the feature preserves the previous behavior.

The runtime change is a clean cherry-pick of `528fd7ace5ec0a1c2a387dcb9c76a09f3fa011ee`. The implementation is already present in 0.150.0; only the feature default/stability and the existing integration test expectations change.

CI-only corrections address failures already present in the public release base: recognize the valid `OFlags::WRONLY` identifier in codespell, remove the obsolete code-mode manifest-feature exception, remove an unused test import left by the public export, and stage the code-mode host beside the CLI in SDK tests. The SDK staging change matches the existing internal workflow. These changes do not alter CLI runtime behavior or dependencies.

## Validation

- Existing integration coverage exercises default/on/off behavior across repeated compactions and checks retained images in follow-up requests.
- `just test -p codex-features`: 39 passed, none skipped.
- `just test -p codex-core --test all remote_compact_v2_charges_retained_images_to_token_budget`: all three default/on/off cases passed.
- `just test -p codex-core --lib image_budget_tests`: 4 passed.
- `python3 .github/scripts/verify_cargo_workspace_manifests.py`, the pinned codespell check for the affected identifier, pinned `just fmt`, and `git diff --check` passed.
- CI must pass on the final head before release.

## Release

Targets `release/0.150`, based on the source commit for 0.150.0 (`076f17c114b0a82d7235552ccec5ff2d69f3266a`). Intended for the next 0.150 stable patch.
