### PR TITLE
Fix GPT-6-Astra Fast tier description for 0.153.2

### DIFF
--- a/codex-rs/models-manager/models.json
+++ b/codex-rs/models-manager/models.json
@@ -160,7 +160,7 @@
         {
           "id": "priority",
           "name": "Fast",
-          "description": "1.5x speed, increased usage"
+          "description": "2x speed, increased usage"
         }
       ],
       "additional_speed_tiers": [


### PR DESCRIPTION
## Why

Correct the bundled GPT-6-Astra Fast tier wording for the 0.153.2 patch release.

## What

Change the Fast tier description from `1.5x speed, increased usage` to `2x speed, increased usage`. No other catalog fields change.

## ELI5

This updates the text users see. It does not change how requests run or guarantee an exact speedup.

Manual validation: compared the complete parsed catalog against `release/0.153` and confirmed only this description changes; `git diff --check` passed. All 48 `codex-models-manager` library tests passed.
