### PR TITLE
[0.153 hotfix] Show Astra in bundled model picker

### DIFF
--- a/codex-rs/models-manager/models.json
+++ b/codex-rs/models-manager/models.json
@@ -64,7 +64,7 @@
         }
       ],
       "shell_type": "unified_exec",
-      "visibility": "hide",
+      "visibility": "list",
       "minimal_client_version": "0.153.0",
       "supported_in_api": true,
       "availability_nux": null,

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__model_selection_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__model_selection_popup.snap
@@ -5,12 +5,14 @@ expression: popup
   Select Model and Effort
   Access legacy models by running codex -m <model_name> or in your config.toml
 
-  1. gpt-5.6-sol (default)  Latest frontier agentic coding model.
-  2. gpt-5.6-terra          Balanced agentic coding model for everyday work.
-  3. gpt-5.6-luna           Fast and affordable agentic coding model.
-  4. gpt-5.5                Frontier model for complex coding, research, and
+  1. gpt-6-astra (default)  Our most capable model for complex, demanding
+                            work.
+  2. gpt-5.6-sol            Latest frontier agentic coding model.
+  3. gpt-5.6-terra          Balanced agentic coding model for everyday work.
+  4. gpt-5.6-luna           Fast and affordable agentic coding model.
+  5. gpt-5.5                Frontier model for complex coding, research, and
                             real-world work.
-› 5. gpt-5.2 (current)      Optimized for professional work and long-running
+› 6. gpt-5.2 (current)      Optimized for professional work and long-running
                             agents.
 
   Press enter to confirm or esc to go back


### PR DESCRIPTION
The 0.153 bundled catalog hides `gpt-6-astra`, omitting it from catalog-backed model selection. Change its visibility to `list` and update the existing picker snapshot. Its existing priority makes Astra the bundled default when no model is explicitly configured.

## Validation

- `just test -p codex-models-manager --lib`: 48 passed.
- `just fmt` and `git diff --check` passed.
- Parsed the release catalog and verified its only semantic change is Astra visibility from `hide` to `list`.
- Reviewed the picker snapshot against the release-line rendering sources; TUI tests were not rerun on this release branch.
